### PR TITLE
basil-20144: Sponsor Widget

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,12 +65,17 @@ model Party {
   photosEnabled Boolean @default(true) @map("photos_enabled")
   photosPublic  Boolean @default(true) @map("photos_public")
 
+  // Sponsor settings
+  sponsorsEnabled      Boolean @default(false) @map("sponsors_enabled")
+  sponsorSectionTitle  String? @map("sponsor_section_title") // Custom title like "Thanks to our sponsors"
+
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  guests Guest[]
-  orders Order[]
-  photos Photo[]
+  guests   Guest[]
+  orders   Order[]
+  photos   Photo[]
+  sponsors Sponsor[]
 
   @@map("parties")
 }
@@ -306,4 +311,32 @@ model Photo {
   @@index([partyId, createdAt])
   @@index([partyId, starred])
   @@map("photos")
+}
+
+// ============================================
+// Sponsor Models
+// ============================================
+
+model Sponsor {
+  id          String  @id @default(uuid()) @db.Uuid
+  partyId     String  @map("party_id") @db.Uuid
+  party       Party   @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  // Sponsor info
+  name        String
+  tier        String  @default("partner") // gold, silver, bronze, partner
+  logoUrl     String? @map("logo_url")
+  websiteUrl  String? @map("website_url")
+  description String?
+
+  // Display settings
+  displayOrder Int     @default(0) @map("display_order")
+  visible      Boolean @default(true)
+
+  // Metadata
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([partyId, displayOrder])
+  @@map("sponsors")
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import userRoutes from './routes/user.routes.js';
 import eventRoutes from './routes/event.routes.js';
 import nftRoutes from './routes/nft.routes.js';
 import photoRoutes from './routes/photo.routes.js';
+import sponsorRoutes from './routes/sponsor.routes.js';
 import v1Routes from './routes/v1/index.js';
 import { setupSwagger } from './swagger.js';
 
@@ -72,6 +73,7 @@ app.use('/api/rsvp', rsvpLimiter);
 // Routes
 app.use('/api/auth', authRoutes);
 app.use('/api/parties', photoRoutes); // Photo routes first (some are public)
+app.use('/api/parties', sponsorRoutes); // Sponsor routes (some are public)
 app.use('/api/parties', partyRoutes); // Party routes have global auth
 app.use('/api/rsvp', rsvpRoutes);
 app.use('/api/user', userRoutes);

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -207,7 +207,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
     const {
       name, date, endTime, duration, pizzaStyle, address, venueName, maxGuests,
       availableBeverages, availableToppings, password, eventImageUrl, description,
-      customUrl, timezone, hideGuests, requireApproval, coHosts, selectedPizzerias
+      customUrl, timezone, hideGuests, requireApproval, coHosts, selectedPizzerias,
+      sponsorsEnabled, sponsorSectionTitle
     } = req.body;
 
     // Verify ownership or super admin
@@ -248,6 +249,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(customUrl !== undefined && { customUrl: customUrl || null }),
         ...(coHosts !== undefined && { coHosts }),
         ...(selectedPizzerias !== undefined && { selectedPizzerias }),
+        ...(sponsorsEnabled !== undefined && { sponsorsEnabled }),
+        ...(sponsorSectionTitle !== undefined && { sponsorSectionTitle: sponsorSectionTitle || null }),
       },
       include: {
         user: { select: { name: true } },

--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -1,0 +1,276 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isSuperAdmin } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+
+// Helper function to check if user can access/edit a party
+async function canUserEditParty(partyId: string, userId?: string, userEmail?: string): Promise<boolean> {
+  // Super admin can edit any party
+  if (isSuperAdmin(userEmail)) {
+    return true;
+  }
+
+  // Otherwise, must be the party owner
+  const party = await prisma.party.findFirst({
+    where: { id: partyId, userId },
+  });
+
+  return !!party;
+}
+
+const router = Router();
+
+// GET /api/parties/:partyId/sponsors - List all sponsors for a party (public if sponsors enabled)
+router.get('/:partyId/sponsors', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    // Get party to check if sponsors are enabled
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, sponsorsEnabled: true, sponsorSectionTitle: true, userId: true },
+    });
+
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // For public access, only return visible sponsors if sponsors are enabled
+    const isHost = await canUserEditParty(partyId, req.userId, req.userEmail);
+
+    // Build query - hosts see all, public only sees visible
+    const where: any = { partyId };
+    if (!isHost) {
+      if (!party.sponsorsEnabled) {
+        // Return empty if sponsors not enabled for public
+        return res.json({
+          sponsors: [],
+          sponsorsEnabled: false,
+          sponsorSectionTitle: null,
+        });
+      }
+      where.visible = true;
+    }
+
+    const sponsors = await prisma.sponsor.findMany({
+      where,
+      orderBy: [
+        { displayOrder: 'asc' },
+        { createdAt: 'asc' },
+      ],
+    });
+
+    res.json({
+      sponsors,
+      sponsorsEnabled: party.sponsorsEnabled,
+      sponsorSectionTitle: party.sponsorSectionTitle,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/sponsors - Create a new sponsor (host only)
+router.post('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { name, tier, logoUrl, websiteUrl, description, visible } = req.body;
+
+    // Verify ownership or super admin
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    // Validate required fields
+    if (!name || !name.trim()) {
+      throw new AppError('Sponsor name is required', 400, 'VALIDATION_ERROR');
+    }
+
+    // Validate tier if provided
+    const validTiers = ['gold', 'silver', 'bronze', 'partner'];
+    if (tier && !validTiers.includes(tier)) {
+      throw new AppError(`Invalid tier. Must be one of: ${validTiers.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+
+    // Get the next display order
+    const maxOrderSponsor = await prisma.sponsor.findFirst({
+      where: { partyId },
+      orderBy: { displayOrder: 'desc' },
+      select: { displayOrder: true },
+    });
+    const nextOrder = (maxOrderSponsor?.displayOrder ?? -1) + 1;
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        partyId,
+        name: name.trim(),
+        tier: tier || 'partner',
+        logoUrl: logoUrl?.trim() || null,
+        websiteUrl: websiteUrl?.trim() || null,
+        description: description?.trim() || null,
+        displayOrder: nextOrder,
+        visible: visible !== false,
+      },
+    });
+
+    res.status(201).json({ sponsor });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/parties/:partyId/sponsors/:sponsorId - Get single sponsor details
+router.get('/:partyId/sponsors/:sponsorId', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, sponsorId } = req.params;
+
+    // Get party to check existence
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, sponsorsEnabled: true, userId: true },
+    });
+
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, partyId },
+    });
+
+    if (!sponsor) {
+      throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
+    }
+
+    // Check visibility for non-hosts
+    const isHost = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!isHost && (!party.sponsorsEnabled || !sponsor.visible)) {
+      throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
+    }
+
+    res.json({ sponsor });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/parties/:partyId/sponsors/:sponsorId - Update sponsor (host only)
+router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, sponsorId } = req.params;
+    const { name, tier, logoUrl, websiteUrl, description, displayOrder, visible } = req.body;
+
+    // Verify ownership or super admin
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    // Check if sponsor exists
+    const existingSponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, partyId },
+    });
+
+    if (!existingSponsor) {
+      throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
+    }
+
+    // Validate tier if provided
+    const validTiers = ['gold', 'silver', 'bronze', 'partner'];
+    if (tier !== undefined && !validTiers.includes(tier)) {
+      throw new AppError(`Invalid tier. Must be one of: ${validTiers.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+
+    const sponsor = await prisma.sponsor.update({
+      where: { id: sponsorId },
+      data: {
+        ...(name !== undefined && { name: name.trim() }),
+        ...(tier !== undefined && { tier }),
+        ...(logoUrl !== undefined && { logoUrl: logoUrl?.trim() || null }),
+        ...(websiteUrl !== undefined && { websiteUrl: websiteUrl?.trim() || null }),
+        ...(description !== undefined && { description: description?.trim() || null }),
+        ...(displayOrder !== undefined && { displayOrder }),
+        ...(visible !== undefined && { visible }),
+      },
+    });
+
+    res.json({ sponsor });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/parties/:partyId/sponsors/:sponsorId - Delete a sponsor (host only)
+router.delete('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, sponsorId } = req.params;
+
+    // Verify ownership or super admin
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    // Get the sponsor first
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, partyId },
+    });
+
+    if (!sponsor) {
+      throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
+    }
+
+    await prisma.sponsor.delete({
+      where: { id: sponsorId },
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/sponsors/reorder - Reorder sponsors (host only)
+router.post('/:partyId/sponsors/reorder', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { sponsorIds } = req.body;
+
+    // Verify ownership or super admin
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    // Validate sponsorIds is an array
+    if (!Array.isArray(sponsorIds)) {
+      throw new AppError('sponsorIds must be an array', 400, 'VALIDATION_ERROR');
+    }
+
+    // Update display order for each sponsor
+    await Promise.all(
+      sponsorIds.map((sponsorId: string, index: number) =>
+        prisma.sponsor.updateMany({
+          where: { id: sponsorId, partyId },
+          data: { displayOrder: index },
+        })
+      )
+    );
+
+    // Return updated sponsors
+    const sponsors = await prisma.sponsor.findMany({
+      where: { partyId },
+      orderBy: [
+        { displayOrder: 'asc' },
+        { createdAt: 'asc' },
+      ],
+    });
+
+    res.json({ sponsors });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -11,6 +11,7 @@ import { TimezonePickerInput } from './TimezonePickerInput';
 import { CoHost } from '../types';
 import { Checkbox } from './Checkbox';
 import { getDateTimeInTimezone, parseDateTimeInTimezone } from '../utils/dateUtils';
+import { SponsorSettings } from './SponsorSettings';
 
 export const EventDetailsTab: React.FC = () => {
   const { party, loadParty } = usePizza();
@@ -968,6 +969,20 @@ export const EventDetailsTab: React.FC = () => {
             </div>
           )}
         </div>
+
+        {/* Sponsors Section */}
+        {party && (
+          <div className="border-t border-white/10 pt-4">
+            <SponsorSettings
+              partyId={party.id}
+              onUpdate={() => {
+                if (party?.inviteCode) {
+                  loadParty(party.inviteCode);
+                }
+              }}
+            />
+          </div>
+        )}
 
         {/* Hosts Section */}
         <div>

--- a/frontend/src/components/SponsorCard.tsx
+++ b/frontend/src/components/SponsorCard.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { ExternalLink, GripVertical, Eye, EyeOff, Pencil, Trash2 } from 'lucide-react';
+import { Sponsor, SponsorTier } from '../types';
+
+interface SponsorCardProps {
+  sponsor: Sponsor;
+  isEditable?: boolean;
+  isDragging?: boolean;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onToggleVisibility?: () => void;
+  onDragStart?: () => void;
+  onDragOver?: (e: React.DragEvent) => void;
+  onDragEnd?: () => void;
+}
+
+const tierColors: Record<SponsorTier, { bg: string; border: string; text: string; badge: string }> = {
+  gold: {
+    bg: 'bg-amber-500/10',
+    border: 'border-amber-500/30',
+    text: 'text-amber-400',
+    badge: 'bg-amber-500/20 text-amber-400',
+  },
+  silver: {
+    bg: 'bg-slate-300/10',
+    border: 'border-slate-300/30',
+    text: 'text-slate-300',
+    badge: 'bg-slate-300/20 text-slate-300',
+  },
+  bronze: {
+    bg: 'bg-orange-700/10',
+    border: 'border-orange-700/30',
+    text: 'text-orange-400',
+    badge: 'bg-orange-700/20 text-orange-400',
+  },
+  partner: {
+    bg: 'bg-white/5',
+    border: 'border-white/10',
+    text: 'text-white/60',
+    badge: 'bg-white/10 text-white/60',
+  },
+};
+
+const tierLabels: Record<SponsorTier, string> = {
+  gold: 'Gold',
+  silver: 'Silver',
+  bronze: 'Bronze',
+  partner: 'Partner',
+};
+
+export const SponsorCard: React.FC<SponsorCardProps> = ({
+  sponsor,
+  isEditable = false,
+  isDragging = false,
+  onEdit,
+  onDelete,
+  onToggleVisibility,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
+}) => {
+  const colors = tierColors[sponsor.tier];
+
+  const CardContent = (
+    <>
+      {/* Logo */}
+      {sponsor.logoUrl ? (
+        <div className="w-16 h-16 flex-shrink-0 rounded-lg overflow-hidden bg-white/10 flex items-center justify-center">
+          <img
+            src={sponsor.logoUrl}
+            alt={`${sponsor.name} logo`}
+            className="max-w-full max-h-full object-contain"
+          />
+        </div>
+      ) : (
+        <div className={`w-16 h-16 flex-shrink-0 rounded-lg ${colors.bg} ${colors.border} border flex items-center justify-center`}>
+          <span className={`text-2xl font-bold ${colors.text}`}>
+            {sponsor.name.charAt(0).toUpperCase()}
+          </span>
+        </div>
+      )}
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <h3 className="font-medium text-white truncate">{sponsor.name}</h3>
+          <span className={`text-xs px-2 py-0.5 rounded-full ${colors.badge}`}>
+            {tierLabels[sponsor.tier]}
+          </span>
+        </div>
+        {sponsor.description && (
+          <p className="text-sm text-white/60 line-clamp-2">{sponsor.description}</p>
+        )}
+        {sponsor.websiteUrl && (
+          <a
+            href={sponsor.websiteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs text-[#ff393a] hover:text-[#ff5a5b] mt-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ExternalLink size={12} />
+            Visit website
+          </a>
+        )}
+      </div>
+    </>
+  );
+
+  if (isEditable) {
+    return (
+      <div
+        draggable
+        onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
+        className={`flex items-center gap-4 p-4 rounded-xl border transition-all ${
+          isDragging ? 'opacity-50' : 'opacity-100'
+        } ${!sponsor.visible ? 'bg-white/5 border-white/10' : `${colors.bg} ${colors.border}`}`}
+      >
+        {/* Drag Handle */}
+        <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60">
+          <GripVertical size={18} />
+        </div>
+
+        {CardContent}
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <button
+            type="button"
+            onClick={onToggleVisibility}
+            className={`p-2 rounded-lg transition-colors ${
+              sponsor.visible
+                ? 'text-white/40 hover:text-white hover:bg-white/10'
+                : 'text-white/30 hover:text-white/60 hover:bg-white/10'
+            }`}
+            title={sponsor.visible ? 'Hide from guests' : 'Show to guests'}
+          >
+            {sponsor.visible ? <Eye size={18} /> : <EyeOff size={18} />}
+          </button>
+          <button
+            type="button"
+            onClick={onEdit}
+            className="p-2 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+            title="Edit sponsor"
+          >
+            <Pencil size={18} />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="p-2 text-[#ff393a]/60 hover:text-[#ff393a] hover:bg-[#ff393a]/10 rounded-lg transition-colors"
+            title="Delete sponsor"
+          >
+            <Trash2 size={18} />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Guest-facing card (non-editable)
+  return (
+    <div className={`flex items-center gap-4 p-4 rounded-xl border ${colors.bg} ${colors.border}`}>
+      {CardContent}
+    </div>
+  );
+};

--- a/frontend/src/components/SponsorDisplay.tsx
+++ b/frontend/src/components/SponsorDisplay.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect } from 'react';
+import { Loader2, ExternalLink, Award } from 'lucide-react';
+import { Sponsor, SponsorTier } from '../types';
+import { getPartySponsors } from '../lib/api';
+
+interface SponsorDisplayProps {
+  partyId: string;
+}
+
+const tierColors: Record<SponsorTier, { bg: string; border: string; text: string }> = {
+  gold: {
+    bg: 'bg-amber-500/10',
+    border: 'border-amber-500/30',
+    text: 'text-amber-400',
+  },
+  silver: {
+    bg: 'bg-slate-300/10',
+    border: 'border-slate-300/30',
+    text: 'text-slate-300',
+  },
+  bronze: {
+    bg: 'bg-orange-700/10',
+    border: 'border-orange-700/30',
+    text: 'text-orange-400',
+  },
+  partner: {
+    bg: 'bg-white/5',
+    border: 'border-white/10',
+    text: 'text-white/60',
+  },
+};
+
+// Group sponsors by tier
+const tierOrder: SponsorTier[] = ['gold', 'silver', 'bronze', 'partner'];
+
+export const SponsorDisplay: React.FC<SponsorDisplayProps> = ({ partyId }) => {
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [sectionTitle, setSectionTitle] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    async function loadSponsors() {
+      try {
+        const response = await getPartySponsors(partyId);
+        if (response) {
+          setSponsors(response.sponsors);
+          setSectionTitle(response.sponsorSectionTitle);
+          setEnabled(response.sponsorsEnabled);
+        }
+      } catch (error) {
+        console.error('Error loading sponsors:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadSponsors();
+  }, [partyId]);
+
+  // Don't render if loading, not enabled, or no sponsors
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Loader2 className="w-5 h-5 animate-spin text-[#ff393a]" />
+      </div>
+    );
+  }
+
+  if (!enabled || sponsors.length === 0) {
+    return null;
+  }
+
+  // Group sponsors by tier for display
+  const sponsorsByTier = tierOrder.reduce((acc, tier) => {
+    const tierSponsors = sponsors.filter((s) => s.tier === tier);
+    if (tierSponsors.length > 0) {
+      acc[tier] = tierSponsors;
+    }
+    return acc;
+  }, {} as Record<SponsorTier, Sponsor[]>);
+
+  return (
+    <div className="border-t border-white/10 pt-6 mt-6">
+      {/* Section Header */}
+      <div className="flex items-center gap-2 mb-4">
+        <Award size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-white">
+          {sectionTitle || 'Our Sponsors'}
+        </h3>
+      </div>
+
+      {/* Sponsors Grid */}
+      <div className="space-y-4">
+        {Object.entries(sponsorsByTier).map(([tier, tierSponsors]) => (
+          <div key={tier} className="space-y-2">
+            {/* Render sponsors in a responsive grid */}
+            <div className={`grid gap-3 ${
+              tier === 'gold'
+                ? 'grid-cols-1 md:grid-cols-2'
+                : tier === 'silver'
+                  ? 'grid-cols-2 md:grid-cols-3'
+                  : 'grid-cols-2 md:grid-cols-4'
+            }`}>
+              {tierSponsors.map((sponsor) => {
+                const colors = tierColors[sponsor.tier as SponsorTier];
+                const isLargeTier = tier === 'gold' || tier === 'silver';
+
+                return (
+                  <a
+                    key={sponsor.id}
+                    href={sponsor.websiteUrl || undefined}
+                    target={sponsor.websiteUrl ? '_blank' : undefined}
+                    rel={sponsor.websiteUrl ? 'noopener noreferrer' : undefined}
+                    className={`block p-4 rounded-xl border transition-all ${colors.bg} ${colors.border} ${
+                      sponsor.websiteUrl ? 'hover:scale-[1.02] cursor-pointer' : ''
+                    }`}
+                  >
+                    <div className={`flex ${isLargeTier ? 'items-start gap-4' : 'flex-col items-center text-center gap-2'}`}>
+                      {/* Logo */}
+                      {sponsor.logoUrl ? (
+                        <div className={`flex-shrink-0 rounded-lg overflow-hidden bg-white/10 flex items-center justify-center ${
+                          isLargeTier ? 'w-16 h-16' : 'w-12 h-12'
+                        }`}>
+                          <img
+                            src={sponsor.logoUrl}
+                            alt={`${sponsor.name} logo`}
+                            className="max-w-full max-h-full object-contain"
+                          />
+                        </div>
+                      ) : (
+                        <div className={`flex-shrink-0 rounded-lg border flex items-center justify-center ${colors.bg} ${colors.border} ${
+                          isLargeTier ? 'w-16 h-16' : 'w-12 h-12'
+                        }`}>
+                          <span className={`font-bold ${colors.text} ${isLargeTier ? 'text-2xl' : 'text-lg'}`}>
+                            {sponsor.name.charAt(0).toUpperCase()}
+                          </span>
+                        </div>
+                      )}
+
+                      {/* Info */}
+                      <div className={`${isLargeTier ? 'flex-1 min-w-0' : ''}`}>
+                        <div className="flex items-center gap-1.5 justify-center md:justify-start">
+                          <h4 className={`font-medium text-white ${isLargeTier ? '' : 'text-sm'} truncate`}>
+                            {sponsor.name}
+                          </h4>
+                          {sponsor.websiteUrl && (
+                            <ExternalLink size={12} className="text-white/40 flex-shrink-0" />
+                          )}
+                        </div>
+                        {isLargeTier && sponsor.description && (
+                          <p className="text-sm text-white/60 mt-1 line-clamp-2">
+                            {sponsor.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </a>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/SponsorModal.tsx
+++ b/frontend/src/components/SponsorModal.tsx
@@ -1,0 +1,266 @@
+import React, { useState, useEffect } from 'react';
+import { X, Loader2, Image as ImageIcon, Globe, FileText } from 'lucide-react';
+import { Sponsor, SponsorTier } from '../types';
+
+interface SponsorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: SponsorFormData) => Promise<void>;
+  sponsor?: Sponsor | null; // If provided, we're editing
+  saving?: boolean;
+}
+
+export interface SponsorFormData {
+  name: string;
+  tier: SponsorTier;
+  logoUrl: string;
+  websiteUrl: string;
+  description: string;
+  visible: boolean;
+}
+
+const tierOptions: { value: SponsorTier; label: string; description: string }[] = [
+  { value: 'gold', label: 'Gold', description: 'Top-tier sponsors' },
+  { value: 'silver', label: 'Silver', description: 'Major sponsors' },
+  { value: 'bronze', label: 'Bronze', description: 'Supporting sponsors' },
+  { value: 'partner', label: 'Partner', description: 'Community partners' },
+];
+
+export const SponsorModal: React.FC<SponsorModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  sponsor,
+  saving = false,
+}) => {
+  const [name, setName] = useState('');
+  const [tier, setTier] = useState<SponsorTier>('partner');
+  const [logoUrl, setLogoUrl] = useState('');
+  const [websiteUrl, setWebsiteUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [visible, setVisible] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset form when modal opens/closes or sponsor changes
+  useEffect(() => {
+    if (isOpen) {
+      if (sponsor) {
+        setName(sponsor.name);
+        setTier(sponsor.tier);
+        setLogoUrl(sponsor.logoUrl || '');
+        setWebsiteUrl(sponsor.websiteUrl || '');
+        setDescription(sponsor.description || '');
+        setVisible(sponsor.visible);
+      } else {
+        setName('');
+        setTier('partner');
+        setLogoUrl('');
+        setWebsiteUrl('');
+        setDescription('');
+        setVisible(true);
+      }
+      setError(null);
+    }
+  }, [isOpen, sponsor]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.trim()) {
+      setError('Sponsor name is required');
+      return;
+    }
+
+    try {
+      await onSave({
+        name: name.trim(),
+        tier,
+        logoUrl: logoUrl.trim(),
+        websiteUrl: websiteUrl.trim(),
+        description: description.trim(),
+        visible,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save sponsor');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[#1a1a2e] border border-white/10 rounded-2xl shadow-xl max-w-md w-full p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">
+            {sponsor ? 'Edit Sponsor' : 'Add Sponsor'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-white/40 hover:text-white transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium text-white/80 mb-1.5">
+              Sponsor Name *
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Company or organization name"
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
+              autoFocus
+            />
+          </div>
+
+          {/* Tier */}
+          <div>
+            <label className="block text-sm font-medium text-white/80 mb-1.5">
+              Tier
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {tierOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setTier(option.value)}
+                  className={`p-2 rounded-lg border text-left transition-all ${
+                    tier === option.value
+                      ? 'bg-[#ff393a]/20 border-[#ff393a]/50 text-white'
+                      : 'bg-white/5 border-white/10 text-white/60 hover:bg-white/10'
+                  }`}
+                >
+                  <div className="font-medium text-sm">{option.label}</div>
+                  <div className="text-xs opacity-60">{option.description}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Logo URL */}
+          <div>
+            <label className="block text-sm font-medium text-white/80 mb-1.5">
+              <ImageIcon size={14} className="inline mr-1" />
+              Logo URL
+            </label>
+            <input
+              type="url"
+              value={logoUrl}
+              onChange={(e) => setLogoUrl(e.target.value)}
+              placeholder="https://example.com/logo.png"
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
+            />
+            {logoUrl && (
+              <div className="mt-2 p-2 bg-white/5 rounded-lg border border-white/10">
+                <img
+                  src={logoUrl}
+                  alt="Logo preview"
+                  className="max-h-16 max-w-full object-contain mx-auto"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = 'none';
+                  }}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Website URL */}
+          <div>
+            <label className="block text-sm font-medium text-white/80 mb-1.5">
+              <Globe size={14} className="inline mr-1" />
+              Website URL
+            </label>
+            <input
+              type="url"
+              value={websiteUrl}
+              onChange={(e) => setWebsiteUrl(e.target.value)}
+              placeholder="https://example.com"
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-white/80 mb-1.5">
+              <FileText size={14} className="inline mr-1" />
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Brief description of the sponsor..."
+              rows={2}
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a] resize-none"
+            />
+          </div>
+
+          {/* Visibility Toggle */}
+          <label className="flex items-center gap-3 cursor-pointer">
+            <div
+              className={`w-10 h-6 rounded-full p-0.5 transition-colors ${
+                visible ? 'bg-[#ff393a]' : 'bg-white/20'
+              }`}
+              onClick={() => setVisible(!visible)}
+            >
+              <div
+                className={`w-5 h-5 rounded-full bg-white shadow-md transition-transform ${
+                  visible ? 'translate-x-4' : 'translate-x-0'
+                }`}
+              />
+            </div>
+            <span className="text-sm text-white/80">
+              Show on event page
+            </span>
+          </label>
+
+          {/* Error */}
+          {error && (
+            <div className="p-3 rounded-lg text-sm bg-[#ff393a]/10 border border-[#ff393a]/30 text-[#ff393a]">
+              {error}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-white/10 hover:bg-white/20 text-white font-medium py-2.5 rounded-lg transition-colors text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !name.trim()}
+              className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
+            >
+              {saving ? (
+                <>
+                  <Loader2 size={16} className="animate-spin" />
+                  Saving...
+                </>
+              ) : sponsor ? (
+                'Save Changes'
+              ) : (
+                'Add Sponsor'
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/SponsorSettings.tsx
+++ b/frontend/src/components/SponsorSettings.tsx
@@ -1,0 +1,314 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Plus, Loader2, Award } from 'lucide-react';
+import { Sponsor } from '../types';
+import { SponsorCard } from './SponsorCard';
+import { SponsorModal, SponsorFormData } from './SponsorModal';
+import { Checkbox } from './Checkbox';
+import {
+  getPartySponsors,
+  createSponsor,
+  updateSponsor,
+  deleteSponsor,
+  reorderSponsors,
+} from '../lib/api';
+import { updateParty } from '../lib/supabase';
+
+interface SponsorSettingsProps {
+  partyId: string;
+  onUpdate?: () => void;
+}
+
+export const SponsorSettings: React.FC<SponsorSettingsProps> = ({ partyId, onUpdate }) => {
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [sponsorsEnabled, setSponsorsEnabled] = useState(false);
+  const [sponsorSectionTitle, setSponsorSectionTitle] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [editingSponsor, setEditingSponsor] = useState<Sponsor | null>(null);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
+  const [savingField, setSavingField] = useState<string | null>(null);
+
+  // Load sponsors
+  const loadSponsors = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await getPartySponsors(partyId);
+      if (response) {
+        setSponsors(response.sponsors);
+        setSponsorsEnabled(response.sponsorsEnabled);
+        setSponsorSectionTitle(response.sponsorSectionTitle || '');
+      }
+    } catch (error) {
+      console.error('Error loading sponsors:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [partyId]);
+
+  useEffect(() => {
+    loadSponsors();
+  }, [loadSponsors]);
+
+  // Toggle sponsors enabled
+  const handleToggleEnabled = async () => {
+    setSavingField('enabled');
+    const newValue = !sponsorsEnabled;
+    setSponsorsEnabled(newValue);
+    try {
+      await updateParty(partyId, { sponsors_enabled: newValue });
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error updating sponsors enabled:', error);
+      setSponsorsEnabled(!newValue); // Revert on error
+    } finally {
+      setSavingField(null);
+    }
+  };
+
+  // Save section title
+  const handleSaveSectionTitle = async () => {
+    setSavingField('title');
+    try {
+      await updateParty(partyId, { sponsor_section_title: sponsorSectionTitle.trim() || null });
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error updating section title:', error);
+    } finally {
+      setSavingField(null);
+    }
+  };
+
+  // Create or update sponsor
+  const handleSaveSponsor = async (data: SponsorFormData) => {
+    setSaving(true);
+    try {
+      if (editingSponsor) {
+        // Update existing sponsor
+        const result = await updateSponsor(partyId, editingSponsor.id, {
+          name: data.name,
+          tier: data.tier,
+          logoUrl: data.logoUrl || null,
+          websiteUrl: data.websiteUrl || null,
+          description: data.description || null,
+          visible: data.visible,
+        });
+        if (result) {
+          setSponsors((prev) =>
+            prev.map((s) => (s.id === editingSponsor.id ? result.sponsor : s))
+          );
+        }
+      } else {
+        // Create new sponsor
+        const result = await createSponsor(partyId, {
+          name: data.name,
+          tier: data.tier,
+          logoUrl: data.logoUrl || undefined,
+          websiteUrl: data.websiteUrl || undefined,
+          description: data.description || undefined,
+          visible: data.visible,
+        });
+        if (result) {
+          setSponsors((prev) => [...prev, result.sponsor]);
+        }
+      }
+      setShowModal(false);
+      setEditingSponsor(null);
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error saving sponsor:', error);
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Delete sponsor
+  const handleDeleteSponsor = async (sponsorId: string) => {
+    try {
+      const success = await deleteSponsor(partyId, sponsorId);
+      if (success) {
+        setSponsors((prev) => prev.filter((s) => s.id !== sponsorId));
+        onUpdate?.();
+      }
+    } catch (error) {
+      console.error('Error deleting sponsor:', error);
+    } finally {
+      setShowDeleteConfirm(null);
+    }
+  };
+
+  // Toggle sponsor visibility
+  const handleToggleVisibility = async (sponsor: Sponsor) => {
+    const newVisible = !sponsor.visible;
+    // Optimistic update
+    setSponsors((prev) =>
+      prev.map((s) => (s.id === sponsor.id ? { ...s, visible: newVisible } : s))
+    );
+    try {
+      await updateSponsor(partyId, sponsor.id, { visible: newVisible });
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error toggling visibility:', error);
+      // Revert on error
+      setSponsors((prev) =>
+        prev.map((s) => (s.id === sponsor.id ? { ...s, visible: !newVisible } : s))
+      );
+    }
+  };
+
+  // Drag and drop handlers
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (draggedIndex === null || draggedIndex === index) return;
+
+    const newSponsors = [...sponsors];
+    const draggedItem = newSponsors[draggedIndex];
+    newSponsors.splice(draggedIndex, 1);
+    newSponsors.splice(index, 0, draggedItem);
+
+    setSponsors(newSponsors);
+    setDraggedIndex(index);
+  };
+
+  const handleDragEnd = async () => {
+    if (draggedIndex !== null) {
+      // Save new order to server
+      const sponsorIds = sponsors.map((s) => s.id);
+      await reorderSponsors(partyId, sponsorIds);
+      onUpdate?.();
+    }
+    setDraggedIndex(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 animate-spin text-[#ff393a]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Award size={18} className="text-[#ff393a]" />
+          <h3 className="text-sm font-medium text-white/80">Sponsors</h3>
+        </div>
+        <Checkbox
+          checked={sponsorsEnabled}
+          onChange={handleToggleEnabled}
+          label={savingField === 'enabled' ? 'Saving...' : 'Show on event page'}
+          size={16}
+          labelClassName="text-xs font-medium text-white/60"
+        />
+      </div>
+
+      {sponsorsEnabled && (
+        <>
+          {/* Section Title */}
+          <div className="relative">
+            <input
+              type="text"
+              value={sponsorSectionTitle}
+              onChange={(e) => setSponsorSectionTitle(e.target.value)}
+              onBlur={handleSaveSectionTitle}
+              placeholder="Section title (e.g., 'Thanks to our sponsors')"
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
+            />
+            {savingField === 'title' && (
+              <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                <Loader2 size={14} className="animate-spin text-white/40" />
+              </div>
+            )}
+          </div>
+
+          {/* Sponsors List */}
+          <div className="space-y-2">
+            {sponsors.length === 0 ? (
+              <div className="text-center py-6 text-white/40 text-sm">
+                No sponsors yet. Add your first sponsor to display on the event page.
+              </div>
+            ) : (
+              sponsors.map((sponsor, index) => (
+                <SponsorCard
+                  key={sponsor.id}
+                  sponsor={sponsor}
+                  isEditable
+                  isDragging={draggedIndex === index}
+                  onEdit={() => {
+                    setEditingSponsor(sponsor);
+                    setShowModal(true);
+                  }}
+                  onDelete={() => setShowDeleteConfirm(sponsor.id)}
+                  onToggleVisibility={() => handleToggleVisibility(sponsor)}
+                  onDragStart={() => handleDragStart(index)}
+                  onDragOver={(e) => handleDragOver(e, index)}
+                  onDragEnd={handleDragEnd}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Add Sponsor Button */}
+          <button
+            type="button"
+            onClick={() => {
+              setEditingSponsor(null);
+              setShowModal(true);
+            }}
+            className="w-full btn-secondary flex items-center justify-center gap-2"
+          >
+            <Plus size={16} />
+            Add Sponsor
+          </button>
+        </>
+      )}
+
+      {/* Sponsor Modal */}
+      <SponsorModal
+        isOpen={showModal}
+        onClose={() => {
+          setShowModal(false);
+          setEditingSponsor(null);
+        }}
+        onSave={handleSaveSponsor}
+        sponsor={editingSponsor}
+        saving={saving}
+      />
+
+      {/* Delete Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-[#1a1a2e] border border-white/10 rounded-2xl shadow-xl p-6 w-full max-w-md">
+            <h2 className="text-xl font-bold text-white mb-3">Delete Sponsor?</h2>
+            <p className="text-white/60 mb-6">
+              This will permanently remove this sponsor from your event.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(null)}
+                className="flex-1 btn-secondary"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleDeleteSponsor(showDeleteConfirm)}
+                className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-6 py-3 rounded-xl transition-all"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Photo, PhotoStats } from '../types';
+import { Pizzeria, Photo, PhotoStats, Sponsor, SponsorsResponse } from '../types';
 
 // Authenticated API helper functions
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3006';
@@ -85,6 +85,9 @@ export interface UpdatePartyData {
   description?: string | null;
   customUrl?: string | null;
   coHosts?: any[];
+  // Sponsor settings
+  sponsorsEnabled?: boolean;
+  sponsorSectionTitle?: string | null;
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -134,6 +137,8 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       description: data.description,
       customUrl: data.customUrl,
       coHosts: data.coHosts,
+      sponsorsEnabled: data.sponsorsEnabled,
+      sponsorSectionTitle: data.sponsorSectionTitle,
     },
   });
 }
@@ -396,6 +401,124 @@ export async function getPhotoStats(partyId: string): Promise<PhotoStats | null>
     });
   } catch (error) {
     console.error('Error fetching photo stats:', error);
+    return null;
+  }
+}
+
+// ============================================
+// Sponsor API functions
+// ============================================
+
+export interface SponsorCreateData {
+  name: string;
+  tier?: 'gold' | 'silver' | 'bronze' | 'partner';
+  logoUrl?: string;
+  websiteUrl?: string;
+  description?: string;
+  visible?: boolean;
+}
+
+export interface SponsorUpdateData {
+  name?: string;
+  tier?: 'gold' | 'silver' | 'bronze' | 'partner';
+  logoUrl?: string | null;
+  websiteUrl?: string | null;
+  description?: string | null;
+  displayOrder?: number;
+  visible?: boolean;
+}
+
+// Get sponsors for a party (public endpoint)
+export async function getPartySponsors(partyId: string): Promise<SponsorsResponse | null> {
+  try {
+    return await apiRequest<SponsorsResponse>(`/api/parties/${partyId}/sponsors`, {
+      method: 'GET',
+      requireAuth: false,
+    });
+  } catch (error) {
+    console.error('Error fetching sponsors:', error);
+    return null;
+  }
+}
+
+// Create a sponsor (host only)
+export async function createSponsor(
+  partyId: string,
+  data: SponsorCreateData
+): Promise<{ sponsor: Sponsor } | null> {
+  try {
+    return await apiRequest<{ sponsor: Sponsor }>(`/api/parties/${partyId}/sponsors`, {
+      method: 'POST',
+      body: data,
+      requireAuth: true,
+    });
+  } catch (error) {
+    console.error('Error creating sponsor:', error);
+    return null;
+  }
+}
+
+// Get single sponsor details
+export async function getSponsor(
+  partyId: string,
+  sponsorId: string
+): Promise<{ sponsor: Sponsor } | null> {
+  try {
+    return await apiRequest<{ sponsor: Sponsor }>(`/api/parties/${partyId}/sponsors/${sponsorId}`, {
+      method: 'GET',
+      requireAuth: false,
+    });
+  } catch (error) {
+    console.error('Error fetching sponsor:', error);
+    return null;
+  }
+}
+
+// Update sponsor (host only)
+export async function updateSponsor(
+  partyId: string,
+  sponsorId: string,
+  data: SponsorUpdateData
+): Promise<{ sponsor: Sponsor } | null> {
+  try {
+    return await apiRequest<{ sponsor: Sponsor }>(`/api/parties/${partyId}/sponsors/${sponsorId}`, {
+      method: 'PATCH',
+      body: data,
+      requireAuth: true,
+    });
+  } catch (error) {
+    console.error('Error updating sponsor:', error);
+    return null;
+  }
+}
+
+// Delete sponsor (host only)
+export async function deleteSponsor(partyId: string, sponsorId: string): Promise<boolean> {
+  try {
+    await apiRequest<{ success: boolean }>(`/api/parties/${partyId}/sponsors/${sponsorId}`, {
+      method: 'DELETE',
+      requireAuth: true,
+    });
+    return true;
+  } catch (error) {
+    console.error('Error deleting sponsor:', error);
+    return false;
+  }
+}
+
+// Reorder sponsors (host only)
+export async function reorderSponsors(
+  partyId: string,
+  sponsorIds: string[]
+): Promise<{ sponsors: Sponsor[] } | null> {
+  try {
+    return await apiRequest<{ sponsors: Sponsor[] }>(`/api/parties/${partyId}/sponsors/reorder`, {
+      method: 'POST',
+      body: { sponsorIds },
+      requireAuth: true,
+    });
+  } catch (error) {
+    console.error('Error reordering sponsors:', error);
     return null;
   }
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -954,6 +954,9 @@ export async function updateParty(
     timezone?: string | null;
     available_beverages?: string[];
     available_toppings?: string[];
+    // Sponsor settings
+    sponsors_enabled?: boolean;
+    sponsor_section_title?: string | null;
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -976,6 +979,8 @@ export async function updateParty(
         description: updates.description,
         customUrl: updates.custom_url,
         coHosts: updates.co_hosts,
+        sponsorsEnabled: updates.sponsors_enabled,
+        sponsorSectionTitle: updates.sponsor_section_title,
       });
       return true;
     } catch (error) {

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -13,6 +13,7 @@ import { Footer } from '../components/Footer';
 import { CornerLinks } from '../components/CornerLinks';
 import { useAuth } from '../contexts/AuthContext';
 import { RSVPModal } from '../components/RSVPModal';
+import { SponsorDisplay } from '../components/SponsorDisplay';
 
 export function EventPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -712,6 +713,9 @@ export function EventPage() {
                     </div>
                   </div>
                 )}
+
+                {/* Sponsors Section */}
+                <SponsorDisplay partyId={event.id} />
 
                 {/* Mobile: Location Section */}
                 {event.address && googleMapsUrl && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -250,3 +250,26 @@ export interface PhotoStats {
   uniqueUploadersCount: number;
   photosEnabled: boolean;
 }
+
+// Sponsor types
+export type SponsorTier = 'gold' | 'silver' | 'bronze' | 'partner';
+
+export interface Sponsor {
+  id: string;
+  partyId: string;
+  name: string;
+  tier: SponsorTier;
+  logoUrl: string | null;
+  websiteUrl: string | null;
+  description: string | null;
+  displayOrder: number;
+  visible: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SponsorsResponse {
+  sponsors: Sponsor[];
+  sponsorsEnabled: boolean;
+  sponsorSectionTitle: string | null;
+}


### PR DESCRIPTION
## Summary

- Add sponsor management feature to RSV.Pizza events
- Hosts can add, edit, reorder, and toggle visibility of sponsors
- Sponsors are displayed on the guest-facing event page with tier-based styling
- Four sponsor tiers: Gold, Silver, Bronze, Partner

## Changes

### Backend
- **Prisma Schema**: Added `Sponsor` model and sponsor settings to `Party`
- **sponsor.routes.ts**: New CRUD routes for sponsor management
- **party.routes.ts**: Handle sponsor settings in party updates

### Frontend
- **SponsorCard**: Display component for individual sponsors
- **SponsorModal**: Add/edit sponsor form with tier selection
- **SponsorSettings**: Host management UI with drag-and-drop reordering
- **SponsorDisplay**: Guest-facing section with responsive tier-grouped layout
- **EventDetailsTab**: Integration of sponsor settings
- **EventPage**: Integration of sponsor display

## Test plan

- [ ] Create a new event and enable sponsors
- [ ] Add sponsors with different tiers (Gold, Silver, Bronze, Partner)
- [ ] Test logo URL and website link display
- [ ] Drag to reorder sponsors
- [ ] Toggle sponsor visibility
- [ ] Verify guest-facing display shows only visible sponsors
- [ ] Test responsive layout on mobile and desktop

---

Generated with [Claude Code](https://claude.com/claude-code)