### PR TITLE
Fix: Respect hideGuests flag on public EventPage

### DIFF
--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -461,15 +461,17 @@ export function EventPage() {
                 />
 
                 {/* Guest Count */}
-                <div className="pt-4 border-t border-white/10 mt-4">
-                  <div className="flex items-center gap-2 text-white/60 text-sm">
-                    <Users className="w-4 h-4" />
-                    <span>
-                      {event.guestCount} {event.guestCount === 1 ? 'guest' : 'guests'}
-                      {event.maxGuests && ` • ${event.maxGuests} expected`}
-                    </span>
+                {!event.hideGuests && (
+                  <div className="pt-4 border-t border-white/10 mt-4">
+                    <div className="flex items-center gap-2 text-white/60 text-sm">
+                      <Users className="w-4 h-4" />
+                      <span>
+                        {event.guestCount} {event.guestCount === 1 ? 'guest' : 'guests'}
+                        {event.maxGuests && ` • ${event.maxGuests} expected`}
+                      </span>
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
             </div>
 
@@ -668,15 +670,17 @@ export function EventPage() {
                 </div>
 
                 {/* Guest Count - Mobile */}
-                <div className="md:hidden pt-4 border-t border-white/10">
-                  <div className="flex items-center gap-2 text-white/60 text-sm">
-                    <Users className="w-4 h-4" />
-                    <span>
-                      {event.guestCount} {event.guestCount === 1 ? 'guest' : 'guests'}
-                      {event.maxGuests && ` • ${event.maxGuests} expected`}
-                    </span>
+                {!event.hideGuests && (
+                  <div className="md:hidden pt-4 border-t border-white/10">
+                    <div className="flex items-center gap-2 text-white/60 text-sm">
+                      <Users className="w-4 h-4" />
+                      <span>
+                        {event.guestCount} {event.guestCount === 1 ? 'guest' : 'guests'}
+                        {event.maxGuests && ` • ${event.maxGuests} expected`}
+                      </span>
+                    </div>
                   </div>
-                </div>
+                )}
 
                 {/* Description */}
                 {event.description && (


### PR DESCRIPTION
## Summary
- Guest count was always shown on event pages regardless of the `hideGuests` setting
- Wrapped both desktop and mobile guest count sections with `{!event.hideGuests && ( ... )}` conditional
- Now properly hidden when host enables "Hide Guests"

## Test plan
- [ ] Open an event page where hideGuests is enabled -- guest count should NOT appear
- [ ] Open an event page where hideGuests is disabled -- guest count should appear as before
- [ ] Verify on both desktop and mobile viewports