### PR TITLE
Add donation field support to backend

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -69,12 +69,20 @@ model Party {
   eventType  String?  @map("event_type")  // 'standard', 'gpp', 'private', etc.
   eventTags  String[] @default([]) @map("event_tags")  // Tags for filtering/grouping
 
+  // Donation settings
+  donationEnabled    Boolean   @default(false) @map("donation_enabled")
+  donationGoal       Decimal?  @db.Decimal(10, 2) @map("donation_goal")
+  donationMessage    String?   @map("donation_message")
+  suggestedAmounts   Json      @default("[500, 1000, 2500, 5000]") @map("suggested_amounts") // cents
+  donationRecipient  String?   @map("donation_recipient")
+
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  guests Guest[]
-  orders Order[]
-  photos Photo[]
+  guests    Guest[]
+  orders    Order[]
+  photos    Photo[]
+  donations Donation[]
 
   @@map("parties")
 }
@@ -106,8 +114,32 @@ model Guest {
 
   pizzaMappings GuestPizzaMapping[]
   photos        Photo[]
+  donations     Donation[]
 
   @@map("guests")
+}
+
+model Donation {
+  id              String   @id @default(cuid())
+  amount          Decimal  @db.Decimal(10, 2)
+  currency        String   @default("usd")
+  status          String   @default("pending") // pending, succeeded, failed, refunded
+  paymentIntentId String?  @map("payment_intent_id")
+  chargeId        String?  @map("charge_id")
+  donorName       String?  @map("donor_name")
+  donorEmail      String?  @map("donor_email")
+  isAnonymous     Boolean  @default(false) @map("is_anonymous")
+  message         String?
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  partyId String @map("party_id") @db.Uuid
+  party   Party  @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  guestId String? @map("guest_id") @db.Uuid
+  guest   Guest?  @relation(fields: [guestId], references: [id], onDelete: SetNull)
+
+  @@map("donations")
 }
 
 model Order {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -244,7 +244,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
     const {
       name, date, endTime, duration, pizzaStyle, address, venueName, maxGuests,
       availableBeverages, availableToppings, password, eventImageUrl, description,
-      customUrl, timezone, hideGuests, requireApproval, coHosts, selectedPizzerias
+      customUrl, timezone, hideGuests, requireApproval, coHosts, selectedPizzerias,
+      donationEnabled, donationGoal, donationMessage, suggestedAmounts, donationRecipient
     } = req.body;
 
     // Verify ownership or super admin
@@ -285,6 +286,11 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(customUrl !== undefined && { customUrl: customUrl || null }),
         ...(coHosts !== undefined && { coHosts }),
         ...(selectedPizzerias !== undefined && { selectedPizzerias }),
+        ...(donationEnabled !== undefined && { donationEnabled }),
+        ...(donationGoal !== undefined && { donationGoal: donationGoal || null }),
+        ...(donationMessage !== undefined && { donationMessage: donationMessage || null }),
+        ...(suggestedAmounts !== undefined && { suggestedAmounts }),
+        ...(donationRecipient !== undefined && { donationRecipient: donationRecipient || null }),
       },
       include: {
         user: { select: { name: true } },


### PR DESCRIPTION
## Summary
- Adds donation fields (donationEnabled, donationGoal, donationMessage, suggestedAmounts, donationRecipient) to the Party model in Prisma schema
- Adds Donation model for tracking payment intents and donation records
- Updates PATCH /api/parties/:id handler to accept and persist donation fields

This unblocks the donation feature branch preview which calls the production backend.

## Test plan
- [ ] Verify PATCH /api/parties/:id accepts donation fields without error
- [ ] Verify existing party update functionality is not broken