### PR TITLE
Add Connect Wallet button to RSVP form

### DIFF
--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -540,16 +540,18 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
                 {hasWallet && (
                   <button
                     type="button"
-                    onClick={connectWallet}
+                    onClick={ethereumAddress.trim() ? () => { setEthereumAddress(''); setWalletValidation('idle'); } : connectWallet}
                     disabled={walletConnecting}
                     className="px-3 py-2.5 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-white/60 hover:text-white text-sm whitespace-nowrap transition-colors disabled:opacity-50 flex items-center gap-1.5 flex-shrink-0"
                   >
                     {walletConnecting ? (
                       <Loader2 size={14} className="animate-spin" />
+                    ) : ethereumAddress.trim() ? (
+                      <X size={14} />
                     ) : (
                       <Wallet size={14} />
                     )}
-                    <span className="hidden sm:inline">{walletConnecting ? 'Connecting...' : 'Connect'}</span>
+                    <span className="hidden sm:inline">{walletConnecting ? 'Connecting...' : ethereumAddress.trim() ? 'Clear' : 'Connect'}</span>
                   </button>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Adds a Connect Wallet button next to the wallet address input on RSVP step 1
- Uses browser wallet (MetaMask etc.) via `window.ethereum` to auto-fill address
- Hides button entirely if no browser wallet detected
- Shows spinner while connecting, compact responsive design (icon-only on mobile, icon+text on desktop)

## Test Plan
- [ ] Button appears when MetaMask/browser wallet is installed
- [ ] Button hidden when no wallet extension
- [ ] Clicking connects and fills in the address
- [ ] Validation updates correctly after connect
- [ ] Manual entry still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)