### PR TITLE
Auto-fill avatar from X username

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -11,7 +11,7 @@ import { TimezonePickerInput } from './TimezonePickerInput';
 import { CoHost } from '../types';
 import { Checkbox } from './Checkbox';
 import { getDateTimeInTimezone, parseDateTimeInTimezone } from '../utils/dateUtils';
-import { getXAvatarUrl } from '../utils/avatarUtils';
+import { getXAvatarUrl, isAutoFilledXAvatar } from '../utils/avatarUtils';
 
 export const EventDetailsTab: React.FC = () => {
   const { party } = usePizza();
@@ -1424,11 +1424,11 @@ export const EventDetailsTab: React.FC = () => {
                       onChange={(e) => {
                         const val = e.target.value;
                         setEditHostTwitter(val);
-                        if (!editHostAvatarUrl) {
+                        if (!editHostAvatarUrl.trim() || isAutoFilledXAvatar(editHostAvatarUrl)) {
                           const avatarUrl = getXAvatarUrl(val);
                           if (avatarUrl) setEditHostAvatarUrl(avatarUrl);
                         }
-                      }}
+                      }
                       placeholder="Twitter (no @)"
                       className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                     />
@@ -1525,7 +1525,7 @@ export const EventDetailsTab: React.FC = () => {
                   onChange={(e) => {
                     const val = e.target.value;
                     setNewCoHostTwitter(val);
-                    if (!newCoHostAvatarUrl) {
+                    if (!newCoHostAvatarUrl.trim() || isAutoFilledXAvatar(newCoHostAvatarUrl)) {
                       const avatarUrl = getXAvatarUrl(val);
                       if (avatarUrl) setNewCoHostAvatarUrl(avatarUrl);
                     }

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -6,7 +6,7 @@ import { Loader2, Upload, Instagram, Youtube, Linkedin, Globe, LogOut, Trash2, A
 import { IconInput } from '../components/IconInput';
 import { uploadProfilePicture, getUserPreferences, saveUserPreferences, UserPreferences } from '../lib/supabase';
 import { DIETARY_OPTIONS, TOPPINGS, DRINKS } from '../constants/options';
-import { getXAvatarUrl } from '../utils/avatarUtils';
+import { getXAvatarUrl, isAutoFilledXAvatar } from '../utils/avatarUtils';
 
 export function AccountPage() {
   const { user, loading: authLoading, signOut, updateProfile } = useAuth();
@@ -419,7 +419,7 @@ export function AccountPage() {
                     value={twitter}
                     onChange={(e) => setTwitter(e.target.value)}
                     onBlur={() => {
-                      if (twitter.trim() && !profilePicture && !profilePictureFile) {
+                      if (twitter.trim() && !profilePictureFile && (!profilePicture || isAutoFilledXAvatar(profilePicture))) {
                         const avatarUrl = getXAvatarUrl(twitter);
                         if (avatarUrl) setProfilePicture(avatarUrl);
                       }

--- a/frontend/src/utils/avatarUtils.ts
+++ b/frontend/src/utils/avatarUtils.ts
@@ -7,3 +7,10 @@ export function getXAvatarUrl(username: string): string | null {
   if (!/^[a-zA-Z0-9_]{1,15}$/.test(cleaned)) return null;
   return `https://unavatar.io/x/${cleaned}`;
 }
+
+/**
+ * Check if a URL is an auto-filled unavatar.io X avatar
+ */
+export function isAutoFilledXAvatar(url: string): boolean {
+  return url.trim().startsWith('https://unavatar.io/x/');
+}


### PR DESCRIPTION
## Summary\n- Adds `getXAvatarUrl()` utility that generates unavatar.io URLs from X/Twitter usernames\n- **Add Host Modal**: Typing an X username auto-fills the avatar URL field (if empty) and shows a circular preview thumbnail\n- **Edit Host Modal**: Same auto-fill behavior and avatar preview\n- **Account Page**: On blur of the X username field, auto-fills profile picture if no picture exists (handles URL-based profile pictures in save flow without requiring a file upload)\n\n## Files Changed\n- `frontend/src/utils/avatarUtils.ts` (new) -- utility to generate unavatar.io URLs\n- `frontend/src/components/EventDetailsTab.tsx` -- auto-fill + preview in Add/Edit Host modals\n- `frontend/src/pages/AccountPage.tsx` -- auto-fill on blur + save flow for URL-based profile pictures\n\n## Test plan\n- [ ] In host dashboard, open Add Host modal, type a valid X username (e.g. `elonmusk`) -- avatar URL should auto-fill and show circular preview\n- [ ] Clear the avatar URL, type a new X username -- should auto-fill again\n- [ ] If avatar URL already has a value, typing X username should NOT overwrite it\n- [ ] Edit an existing host, change their X username with empty avatar -- should auto-fill\n- [ ] On Account page, enter an X username and tab out -- profile picture should update if previously empty\n- [ ] Save profile with auto-filled avatar -- should persist the unavatar.io URL