### PR TITLE
Fix: custom pizzeria add functionality

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updatePartyApi } from './api';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('updatePartyApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set auth token so the API function doesn't throw "Not authenticated"
+    localStorage.setItem('authToken', 'test-token');
+
+    // Mock successful fetch response
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ party: { id: 'party-1' } }),
+    });
+  });
+
+  it('should include selectedPizzerias in the request body when provided', async () => {
+    const testPizzerias = [
+      {
+        id: 'custom-abc123',
+        placeId: '',
+        name: 'Test Pizzeria',
+        address: '123 Main St',
+        phone: '555-1234',
+        url: 'https://testpizzeria.com',
+        location: { lat: 0, lng: 0 },
+        orderingOptions: [],
+      },
+    ];
+
+    await updatePartyApi('party-1', {
+      selectedPizzerias: testPizzerias,
+    });
+
+    // Verify fetch was called
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Get the request body that was sent
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    // The selectedPizzerias field MUST be present in the request body
+    // This is the core of the bug: selectedPizzerias was being dropped
+    expect(body.selectedPizzerias).toBeDefined();
+    expect(body.selectedPizzerias).toEqual(testPizzerias);
+    expect(body.selectedPizzerias[0].name).toBe('Test Pizzeria');
+  });
+
+  it('should not include selectedPizzerias when not provided', async () => {
+    await updatePartyApi('party-1', {
+      name: 'Updated Party Name',
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    // selectedPizzerias should be undefined (not sent) when not in the update data
+    expect(body.selectedPizzerias).toBeUndefined();
+  });
+
+  it('should preserve other fields alongside selectedPizzerias', async () => {
+    const testPizzerias = [
+      {
+        id: 'custom-xyz',
+        placeId: '',
+        name: 'My Custom Pizzeria',
+        address: '456 Oak Ave',
+        location: { lat: 40.7128, lng: -74.006 },
+        orderingOptions: [],
+      },
+    ];
+
+    await updatePartyApi('party-1', {
+      name: 'Pizza Night',
+      address: '789 Elm St',
+      selectedPizzerias: testPizzerias,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    // All fields should be present
+    expect(body.name).toBe('Pizza Night');
+    expect(body.address).toBe('789 Elm St');
+    expect(body.selectedPizzerias).toHaveLength(1);
+    expect(body.selectedPizzerias[0].name).toBe('My Custom Pizzeria');
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -94,6 +94,7 @@ export interface UpdatePartyData {
   requireApproval?: boolean;
   availableBeverages?: string[];
   availableToppings?: string[];
+  selectedPizzerias?: any[];
   password?: string | null;
   eventImageUrl?: string | null;
   description?: string | null;
@@ -147,6 +148,7 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       requireApproval: data.requireApproval,
       availableBeverages: data.availableBeverages,
       availableToppings: data.availableToppings,
+      selectedPizzerias: data.selectedPizzerias,
       password: data.password,
       eventImageUrl: data.eventImageUrl,
       description: data.description,


### PR DESCRIPTION
## Summary
- **Bug**: The "Add Custom Pizzeria" feature was broken for authenticated users. Pizzerias were silently dropped when saving because `selectedPizzerias` was missing from the `UpdatePartyData` interface and the `updatePartyApi` request body in `frontend/src/lib/api.ts`.
- **Root cause**: When the API layer was built, `selectedPizzerias` was included in `updateParty` (supabase.ts) and the backend PATCH handler (party.routes.ts), but was never added to the frontend API client (`api.ts`). The field was passed from `supabase.ts` to `updatePartyApi`, but `updatePartyApi` did not include it in the request body sent to the server.
- **Fix**: Added `selectedPizzerias` to the `UpdatePartyData` interface and the `updatePartyApi` function body (2 lines changed in `api.ts`).
- **Tests**: Added 3 unit tests proving the bug existed and verifying the fix.

## Files changed
- `frontend/src/lib/api.ts` — Added `selectedPizzerias` to interface and request body
- `frontend/src/lib/api.test.ts` — New test file with 3 tests

## Test plan
- [x] Tests written first (TDD) that fail without the fix
- [x] All 3 new tests pass after the fix
- [x] Existing test suite (RSVPModal.test.tsx) still passes
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify on Vercel preview: create an event, add a custom pizzeria, refresh, confirm it persists