### PR TITLE
fix(calzone-39692): pizzeria selection reload

### DIFF
--- a/frontend/src/components/PizzeriaSelection.tsx
+++ b/frontend/src/components/PizzeriaSelection.tsx
@@ -17,7 +17,7 @@ interface PizzeriaSelectionProps {
 }
 
 export const PizzeriaSelection: React.FC<PizzeriaSelectionProps> = ({ embedded = false }) => {
-  const { party, loadParty, guests, recommendations } = usePizza();
+  const { party, guests, recommendations } = usePizza();
 
   // AI order state
   const [orderPizzeria, setOrderPizzeria] = useState<Pizzeria | null>(null);
@@ -93,7 +93,8 @@ export const PizzeriaSelection: React.FC<PizzeriaSelectionProps> = ({ embedded =
     fetchNearbyPizzerias();
   }, [party?.address]);
 
-  // Save field helper
+  // Save field helper — optimistic: caller updates local state first, we only persist.
+  // On failure, revert local selectedPizzerias to whatever party has.
   const saveField = async (fieldName: string, updates: Record<string, any>) => {
     if (!party) return false;
 
@@ -102,15 +103,14 @@ export const PizzeriaSelection: React.FC<PizzeriaSelectionProps> = ({ embedded =
     try {
       const success = await updateParty(party.id, updates);
       if (success) {
-        if (party?.inviteCode) {
-          await loadParty(party.inviteCode);
-        }
         return true;
       } else {
         throw new Error('Failed to save');
       }
     } catch (error) {
       console.error(`Error saving ${fieldName}:`, error);
+      // Revert optimistic local state on failure
+      setSelectedPizzerias(party?.selectedPizzerias || []);
       return false;
     } finally {
       setSavingField(null);


### PR DESCRIPTION
## Summary
- Removes unnecessary `loadParty()` call in `PizzeriaSelection.saveField` that re-triggered the address-geocoding `useEffect` and re-ran `searchPizzerias`, causing the visible "reload" of the nearby pizzerias list when selecting a pizzeria
- Optimistic local state update was already in place, so `loadParty` was pure overhead
- On save failure, revert local `selectedPizzerias` to `party.selectedPizzerias` (matches the existing optimistic pattern in `EventDetailsTab`, `BeverageSettings`, `PizzaStyleAndToppings`)

## Root cause
`saveField` called `loadParty(party.inviteCode)` after every save → re-fetched the party → `useEffect([party])` reset local `selectedPizzerias` + `useEffect([party?.address])` re-geocoded and re-ran `searchPizzerias` → the whole nearby pizzerias list rebuilt visibly.

## Test plan
- [ ] Open host page → Pizza & drinks tab → click a nearby pizzeria to select it
- [ ] Verify: it's added to selected list instantly, the nearby list does NOT flash/reload, and no network trip to re-geocode the address
- [ ] Remove a selected pizzeria → same behavior
- [ ] Add a manual pizzeria via the modal → verifies the non-`selectPizzeria` path still saves cleanly

Closes: calzone-39692