### PR TITLE
fix(stromboli-94160): include website URL in nearby pizzeria search

### DIFF
--- a/supabase/functions/search-pizzerias/index.ts
+++ b/supabase/functions/search-pizzerias/index.ts
@@ -36,7 +36,7 @@ async function searchGooglePlaces(lat: number, lng: number, radius: number): Pro
     headers: {
       'Content-Type': 'application/json',
       'X-Goog-Api-Key': GOOGLE_PLACES_API_KEY,
-      'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.location,places.rating,places.userRatingCount,places.priceLevel,places.currentOpeningHours,places.nationalPhoneNumber'
+      'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.location,places.rating,places.userRatingCount,places.priceLevel,places.currentOpeningHours,places.nationalPhoneNumber,places.websiteUri'
     },
     body: JSON.stringify(requestBody)
   });
@@ -71,6 +71,7 @@ async function searchGooglePlaces(lat: number, lng: number, radius: number): Pro
       name: place.displayName?.text || 'Unknown',
       address: place.formattedAddress || '',
       phone: place.nationalPhoneNumber,
+      url: place.websiteUri,
       rating: place.rating,
       reviewCount: place.userRatingCount,
       priceLevel: priceLevelMap[place.priceLevel] || undefined,


### PR DESCRIPTION
## Summary

- The `search-pizzerias` Supabase edge function's Google Places API field mask was missing `places.websiteUri`, so nearby-searched pizzerias came back with `url === undefined` and the Website link never rendered (e.g. Angelo's Pizzeria, Pizzeria Beddia). The custom "Add Custom Pizzeria" flow in `PlaceAutocomplete.tsx` was already requesting `website` correctly, which is why Tacconelli's worked.
- Fix: add `places.websiteUri` to the `X-Goog-FieldMask` header and map `place.websiteUri` -> `url` on the returned `Pizzeria` object. The frontend already renders `pizzeria.url` (see `PizzeriaSelection.tsx:341-366`) and the `Pizzeria` type already has `url?: string`, so no other changes are needed.

## DEPLOYMENT REQUIRED

Edge functions do **not** auto-deploy from git. After merging this PR, manually deploy:

```bash
SUPABASE_ACCESS_TOKEN=<token> npx supabase functions deploy search-pizzerias --project-ref znpiwdvvsqaxuskpfleo
```

(Or, from the project root, pulling the token from `secrets.md`:)

```bash
SUPABASE_ACCESS_TOKEN=$(grep -o 'sbp_[a-zA-Z0-9]*' secrets.md | head -1) \
  npx supabase functions deploy search-pizzerias --project-ref znpiwdvvsqaxuskpfleo
```

## Note for existing data

Existing selected pizzerias (e.g., Angelo's Pizzeria, Pizzeria Beddia on Snax's GPP event) **won't retroactively** get websites — the `url` field is captured at selection time. To pick up the website on already-selected pizzerias, remove them and re-select from the nearby-search results after the edge function is deployed.

## Test plan

- [ ] Merge PR and run the deploy command above.
- [ ] On the host Pizza & drinks tab, run a nearby-pizzeria search.
- [ ] Verify pizzerias that have a website on Google show a "Website" link in their card.
- [ ] Re-select Angelo's Pizzeria / Pizzeria Beddia on Snax's GPP event and confirm the Website link now appears.
- [ ] Confirm custom-added pizzerias (Tacconelli's flow) still show websites — no regression.