### PR TITLE
feat: show timezone abbrev instead of IANA city name

### DIFF
--- a/frontend/src/components/TimezonePickerInput.tsx
+++ b/frontend/src/components/TimezonePickerInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { formatTimezoneDisplay } from '../utils/dateUtils';
 
 interface TimezonePickerInputProps {
   value: string; // IANA timezone like "America/New_York"
@@ -68,11 +69,6 @@ export function TimezonePickerInput({ value, onChange }: TimezonePickerInputProp
     return { offset, city, fullName: tz };
   };
 
-  const getTimezoneDisplay = () => {
-    if (!value) return { offset: '', city: '' };
-    return formatTimezone(value);
-  };
-
   // Filter timezones based on search
   const filterTimezones = (timezones: string[]) => {
     if (!searchText) return timezones;
@@ -109,7 +105,7 @@ export function TimezonePickerInput({ value, onChange }: TimezonePickerInputProp
     setSearchText('');
   };
 
-  const display = getTimezoneDisplay();
+  const selectedDisplay = value ? formatTimezoneDisplay(value) : '';
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -121,10 +117,7 @@ export function TimezonePickerInput({ value, onChange }: TimezonePickerInputProp
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        <div className="text-right">
-          <div className="font-medium">{display.offset}</div>
-          <div>{display.city}</div>
-        </div>
+        <div className="text-right font-medium">{selectedDisplay}</div>
       </button>
 
       {isOpen && (

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -253,21 +253,32 @@ export function formatTimeDisplay(time: string): string {
 }
 
 /**
- * Format a timezone for display matching the timepicker modal.
- * e.g., "America/Denver" → "GMT-7 / Denver"
+ * Format a timezone for display as "{abbreviation} / {offset}".
+ * e.g., "America/New_York" → "EDT / GMT-4" (or "EST / GMT-5" in winter)
+ * Falls back to just the offset when the zone has no real letter abbreviation
+ * (e.g., "Asia/Kolkata" → "GMT+5:30").
  */
 export function formatTimezoneDisplay(timezone: string): string {
   if (!timezone) return '';
   try {
-    const formatter = new Intl.DateTimeFormat('en-US', {
+    const now = new Date();
+    const shortFmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: 'short',
+    });
+    const offsetFmt = new Intl.DateTimeFormat('en-US', {
       timeZone: timezone,
       timeZoneName: 'shortOffset',
     });
-    const parts = formatter.formatToParts(new Date());
-    const offsetPart = parts.find(p => p.type === 'timeZoneName');
-    const offset = offsetPart?.value || '';
-    const city = timezone.split('/').pop()?.replace(/_/g, ' ') || '';
-    return city ? `${offset} / ${city}` : offset;
+    const short = shortFmt.formatToParts(now).find(p => p.type === 'timeZoneName')?.value ?? '';
+    const offset = offsetFmt.formatToParts(now).find(p => p.type === 'timeZoneName')?.value ?? '';
+
+    // If "short" is just a GMT offset or equals the shortOffset value, it's not a real
+    // letter abbreviation (e.g., Asia/Kolkata → "GMT+5:30"). Fall back to just the offset
+    // so we don't render a duplicate like "GMT+5:30 / GMT+5:30".
+    const hasRealAbbrev = short && !short.startsWith('GMT') && short !== offset;
+    if (hasRealAbbrev) return `${short} / ${offset}`;
+    return offset;
   } catch {
     return '';
   }


### PR DESCRIPTION
## Summary
- Replace `"{offset} / {city}"` timezone display with `"{abbreviation} / {offset}"` so Detroit events show `"EDT / GMT-4"` instead of the confusing `"GMT-4 / New York"` (Detroit's IANA zone is `America/New_York`).
- Falls back to just the offset when the zone has no letter abbreviation (e.g., `Asia/Kolkata` → `"GMT+5:30"`).
- Picker dropdown list items still show city + offset so users can search by city.

## Test plan
- [ ] Event page header shows `"EDT / GMT-4"` for a Detroit / NYC event in May
- [ ] In January, same event shows `"EST / GMT-5"`
- [ ] Indian event (`Asia/Kolkata`) shows `"GMT+5:30"` (no duplicate)
- [ ] Timezone picker selected-value display shows abbrev + offset
- [ ] Timezone picker list items unchanged (still city + offset)