### PR TITLE
romana-28787: remove MapPin icon from Participating Pizzerias heading

### DIFF
--- a/frontend/src/components/ParticipatingPizzerias.tsx
+++ b/frontend/src/components/ParticipatingPizzerias.tsx
@@ -107,7 +107,6 @@ export function ParticipatingPizzerias({
       <div className="card p-4 sm:p-6">
         {/* Header — matches MusicWidget header style */}
         <div className="flex items-center gap-3 mb-4">
-          <MapPin size={20} className="text-[#ff393a]" />
           <h2 className="text-lg font-semibold text-theme-text">{sectionLabel}</h2>
         </div>
 


### PR DESCRIPTION
## Summary
- Removes the `MapPin` location pin icon from the "Participating {city} Pizzerias" section heading on the public event page (per Snax).
- Heading text is unchanged.
- `MapPin` import is kept because it is still used inside each individual pizzeria card avatar.

## Test plan
- [ ] Vercel preview renders the event page with the section heading and no pin icon in front of "Participating Pizzerias"
- [ ] Pizzeria cards still render with their `MapPin` avatar unchanged

Task: romana-28787