### PR TITLE
forno-84630: shrink Google logo on VenueMap thumbnails

### DIFF
--- a/frontend/src/components/VenueMap.tsx
+++ b/frontend/src/components/VenueMap.tsx
@@ -132,7 +132,7 @@ export default function VenueMap({
   if (!address) {
     return (
       <div
-        className={`${className ?? ''} rounded-[inherit] bg-gradient-to-br from-[#ff393a]/20 to-[#ff6b35]/20 flex items-center justify-center`}
+        className={`${className ?? ''} venue-map-thumbnail rounded-[inherit] bg-gradient-to-br from-[#ff393a]/20 to-[#ff6b35]/20 flex items-center justify-center`}
       >
         <MapPin className="w-12 h-12 text-theme-text" />
       </div>
@@ -144,7 +144,7 @@ export default function VenueMap({
   if (error) {
     return (
       <div
-        className={`${className ?? ''} rounded-[inherit] bg-gradient-to-br from-[#ff393a]/20 to-[#ff6b35]/20 flex items-center justify-center`}
+        className={`${className ?? ''} venue-map-thumbnail rounded-[inherit] bg-gradient-to-br from-[#ff393a]/20 to-[#ff6b35]/20 flex items-center justify-center`}
       >
         <div className="text-center">
           <MapPin className="w-12 h-12 text-theme-text mx-auto mb-2" />
@@ -158,7 +158,7 @@ export default function VenueMap({
     <div
       ref={containerRef}
       data-testid="venue-map"
-      className={`${className ?? ''} rounded-[inherit] overflow-hidden bg-theme-surface`}
+      className={`${className ?? ''} venue-map-thumbnail rounded-[inherit] overflow-hidden bg-theme-surface`}
     />
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -695,3 +695,20 @@ body.gpp-theme-active .pac-item-query {
   letter-spacing: 0.1px;
   pointer-events: none;
 }
+
+/* VenueMap thumbnails — shrink Google attribution so it stays legible without
+   dominating the small (~120-200px) map area on the public event page. The
+   Google logo sits at bottom-left as an <a href="https://maps.google.com/...">
+   and the "Map Data / Terms / Report a map error" links are inside
+   .gm-style-cc at bottom-right. We scale both to 70% toward their anchor
+   corners so attribution remains visible + clickable per Google Maps ToS 10.5.
+   Scoped to .venue-map-thumbnail so the larger ParticipatingPizzeriasMap is
+   unaffected. */
+.venue-map-thumbnail .gm-style-cc {
+  transform: scale(0.7);
+  transform-origin: bottom right;
+}
+.venue-map-thumbnail a[href^="https://maps.google.com/maps"] {
+  transform: scale(0.7);
+  transform-origin: bottom left;
+}


### PR DESCRIPTION
## Summary
- Scales the Google logo and map attribution (.gm-style-cc) to 70% on the small VenueMap thumbnails rendered on the public event page.
- Adds a scoped `venue-map-thumbnail` class on the VenueMap container so overrides don't leak.
- Larger `ParticipatingPizzeriasMap` is unaffected — its attribution stays at full size.
- Attribution remains visible and clickable per Google Maps ToS 10.5 (not hidden, not moved off-screen).

## Implementation
- `frontend/src/components/VenueMap.tsx`: added `venue-map-thumbnail` class to the map container div (plus the no-address / error fallback states for consistency).
- `frontend/src/index.css`: added two scoped rules near the existing `pizzeria-pin-label` map CSS:
  - `.venue-map-thumbnail .gm-style-cc` → `scale(0.7)` anchored bottom-right
  - `.venue-map-thumbnail a[href^="https://maps.google.com/maps"]` → `scale(0.7)` anchored bottom-left

## Test plan
- [ ] Load the public event page with a venue address
- [ ] Verify the Google logo (bottom-left) on VenueMap thumbnails looks ~70% smaller
- [ ] Verify the "Map Data / Terms / Report a map error" links (bottom-right) also look ~70% smaller
- [ ] Verify the Participating Pizzerias map still shows full-size Google attribution
- [ ] Click the Google logo and the Terms link — both should still be interactive

Closes forno-84630.