### PR TITLE
olive-20002: new flyer template + MAY 22 date overlay + repositioned elements

### DIFF
--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -75,7 +75,7 @@ function uses12Hour(tz: string): boolean {
 
 /**
  * Format a 24-hour "HH:MM" time string to the appropriate display format.
- * - 12-hour mode: "6:00 PM"
+ * - 12-hour mode: "6 PM" (or "6:30 PM" when minutes are non-zero)
  * - 24-hour mode: "18:00"
  */
 function formatFlyerTime(timeStr: string, is12h: boolean): string {
@@ -83,7 +83,9 @@ function formatFlyerTime(timeStr: string, is12h: boolean): string {
   const [hours, minutes] = timeStr.split(':').map(Number);
   const period = hours >= 12 ? 'PM' : 'AM';
   const hours12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
-  return `${hours12}:${minutes.toString().padStart(2, '0')} ${period}`;
+  return minutes === 0
+    ? `${hours12} ${period}`
+    : `${hours12}:${minutes.toString().padStart(2, '0')} ${period}`;
 }
 
 const CITY_FONT = '"Hub 191 Display", "Hub 191", "Comic Sans MS", cursive';
@@ -95,7 +97,7 @@ const VENUE_COLOR = '#0497C1';
 // Bounding box dimensions (measured from boxes overlay at 1080px)
 const CITY_BOX = { width: 587, height: 72 };
 const VENUE_BOX = { width: 600, height: 110 };
-const TIME_BOX = { width: 600, height: 60 }; // sized for "MAY 22  6:00 PM - 9:00 PM"
+const TIME_BOX = { width: 600, height: 60 }; // sized for "MAY 22  6 PM - 9 PM"
 /** Default sponsor logo bounding box. Width/height are user-resizable at runtime. */
 const DEFAULT_SPONSOR_BOX = { width: 759, height: 171 };
 /** Min/max sponsor box dimensions in 1080px canvas units. */

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -1403,7 +1403,7 @@ export function FlyerGenerator() {
           ) : (
             <>
               <Download className="w-5 h-5" />
-              Download Flyer
+              Download
             </>
           )}
         </button>
@@ -1437,7 +1437,7 @@ export function FlyerGenerator() {
           ) : (
             <>
               <ImagePlus className="w-4 h-4" />
-              Use as Event Image
+              Use for Event
             </>
           )}
         </button>
@@ -1448,7 +1448,7 @@ export function FlyerGenerator() {
             title="Reset element positions to defaults"
           >
             <RotateCcw className="w-4 h-4" />
-            Reset Positions
+            Reset
           </button>
         )}
       </div>

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -63,7 +63,7 @@ const TIME_COLOR = '#FFFFFF';
 // Bounding box dimensions (measured from boxes overlay at 1080px)
 const CITY_BOX = { width: 587, height: 72 };
 const VENUE_BOX = { width: 600, height: 110 };
-const TIME_BOX = { width: 300, height: 60 }; // sized to match MAY 22 text height
+const TIME_BOX = { width: 600, height: 60 }; // sized for "MAY 22  6:00 PM - 9:00 PM"
 /** Default sponsor logo bounding box. Width/height are user-resizable at runtime. */
 const DEFAULT_SPONSOR_BOX = { width: 759, height: 171 };
 /** Min/max sponsor box dimensions in 1080px canvas units. */
@@ -413,6 +413,7 @@ export function FlyerGenerator() {
 
   // Format date and time
   let timeDisplay = '';
+  let dateDisplay = 'MAY 22'; // fallback if no event date
   if (party.date && party.timezone) {
     const start = getDateTimeInTimezone(party.date, party.timezone);
     timeDisplay = start.timeStr;
@@ -421,6 +422,13 @@ export function FlyerGenerator() {
       const end = getDateTimeInTimezone(endDate, party.timezone);
       timeDisplay = `${start.timeStr} - ${end.timeStr}`;
     }
+    // Derive "MAY 22" style date from event date in the event's timezone
+    const eventDate = new Date(party.date);
+    const monthFormatter = new Intl.DateTimeFormat('en-US', { timeZone: party.timezone, month: 'short' });
+    const dayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: party.timezone, day: 'numeric' });
+    const monthStr = monthFormatter.format(eventDate).toUpperCase();
+    const dayStr = dayFormatter.format(eventDate);
+    dateDisplay = `${monthStr} ${dayStr}`;
   }
 
   const defaultVenueName = party.venueName || 'YOUR VENUE';
@@ -440,7 +448,9 @@ export function FlyerGenerator() {
   const cityFontSize = fitText(city, 'Hub 191 Display', 64, CITY_BOX.width);
   const venueNameFontSize = fitText(venueName, 'Hub 191', 46, VENUE_BOX.width);
   const streetFontSize = streetAddress ? fitText(streetAddress, 'Hub 191', 46, VENUE_BOX.width) : 46;
-  const timeFontSize = fitText(timeDisplay || '6PM - 9PM', 'Hub 191', 55, TIME_BOX.width);
+  // Fit the combined "MAY 22  6:00 PM - 9:00 PM" string within TIME_BOX
+  const fullTimeDisplay = `${dateDisplay}  ${timeDisplay || '6PM - 9PM'}`;
+  const timeFontSize = fitText(fullTimeDisplay, 'Hub 191', 55, TIME_BOX.width);
 
   // Compute sponsor logo sizing to fit within bounding box
   const sponsorCount = Math.min(sponsors.length, 8);
@@ -482,11 +492,21 @@ export function FlyerGenerator() {
       ctx.fillText(streetAddress.toUpperCase(), venueX, positions.venue.y + venueNameFontSize + 4);
     }
 
-    // 4) Time — Hub 191 Regular, white
-    if (timeDisplay) {
-      ctx.fillStyle = TIME_COLOR;
+    // 4) Date + Time — "MAY 22" in red, then time in white
+    {
       ctx.font = `${timeFontSize}px "Hub 191"`;
-      ctx.fillText(timeDisplay, positions.time.x, positions.time.y);
+      // Draw date (e.g. "MAY 22") in red
+      ctx.fillStyle = CITY_COLOR;
+      const dateStr = dateDisplay.toUpperCase();
+      ctx.fillText(dateStr, positions.time.x, positions.time.y);
+      // Measure date width to position time to its right
+      const dateWidth = ctx.measureText(dateStr).width;
+      const gap = 15;
+      // Draw time in white
+      if (timeDisplay) {
+        ctx.fillStyle = TIME_COLOR;
+        ctx.fillText(timeDisplay, positions.time.x + dateWidth + gap, positions.time.y);
+      }
     }
 
     // 5) Sponsor logos — group logos in flex layout, popped logos at custom positions
@@ -816,8 +836,8 @@ export function FlyerGenerator() {
           );
         })()}
 
-        {/* Time - Hub 191 Regular, next to "MAY 22" on template */}
-        {timeDisplay && (() => {
+        {/* Date + Time - "MAY 22" in red, time in white, Hub 191 Regular */}
+        {(() => {
           const dragProps = getDragProps('time');
           return (
             <div
@@ -831,7 +851,6 @@ export function FlyerGenerator() {
                 left: positions.time.x,
                 width: TIME_BOX.width,
                 height: TIME_BOX.height,
-                color: TIME_COLOR,
                 fontSize: timeFontSize,
                 fontFamily: TEXT_FONT,
                 textTransform: 'uppercase',
@@ -841,7 +860,8 @@ export function FlyerGenerator() {
                 ...dragProps.style,
               }}
             >
-              {timeDisplay}
+              <span style={{ color: CITY_COLOR }}>{dateDisplay}</span>
+              {timeDisplay && <span style={{ marginLeft: '0.4em', color: TIME_COLOR }}>{timeDisplay}</span>}
             </div>
           );
         })()}

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -3,11 +3,10 @@ import { usePizza } from '../../contexts/PizzaContext';
 import { getSponsors, createSponsor, reorderSponsors } from '../../lib/api';
 import { getDateTimeInTimezone } from '../../utils/dateUtils';
 import { Sponsor } from '../../types';
-import { Download, Loader2, RotateCcw, Move, Plus, ChevronLeft, ChevronRight, MoveHorizontal, MoveVertical, ImagePlus, Check } from 'lucide-react';
+import { Download, Loader2, RotateCcw, Move, Plus, ChevronLeft, ChevronRight, ImagePlus, Check } from 'lucide-react';
 import { useFlyerDrag, DEFAULT_POSITIONS, FlyerPositions } from './useFlyerDrag';
 import { PartnerForm, extractSponsorData } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
-import { IconInput } from '../IconInput';
 import { uploadEventImage, updateParty } from '../../lib/supabase';
 
 function parseCityFromAddress(address: string): string {
@@ -153,24 +152,6 @@ export function FlyerGenerator() {
       try { localStorage.removeItem(storageKey); } catch {}
     }
   }, [storageKey]);
-
-  const handleSponsorBoxWidthChange = useCallback((value: string) => {
-    const n = parseInt(value, 10);
-    if (Number.isNaN(n)) return;
-    setSponsorBoxSize(prev => ({
-      ...prev,
-      width: Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, n)),
-    }));
-  }, []);
-
-  const handleSponsorBoxHeightChange = useCallback((value: string) => {
-    const n = parseInt(value, 10);
-    if (Number.isNaN(n)) return;
-    setSponsorBoxSize(prev => ({
-      ...prev,
-      height: Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, n)),
-    }));
-  }, []);
 
   /** Convert a client (screen) coordinate to 1080px canvas coordinate */
   const clientToCanvas = useCallback((clientX: number, clientY: number): { x: number; y: number } | null => {
@@ -904,27 +885,23 @@ export function FlyerGenerator() {
                   }}
                 />
               )}
-              {/* Group box corner resize handle — scales all group logos together */}
+              {/* Sponsor box resize handle — corner (resizes box width + height) */}
               {(() => {
-                const handleGroupResizeStart = (e: React.MouseEvent) => {
+                const handleBoxResizeStart = (e: React.MouseEvent) => {
                   e.preventDefault();
                   e.stopPropagation();
+                  const startX = e.clientX;
                   const startY = e.clientY;
-                  // Capture current sizes for all group logos
-                  const startSizes: Record<string, number> = {};
-                  groupLogos.forEach(s => {
-                    startSizes[s.id] = logoSizes[s.id] ?? Math.min(defaultLogoSize, autoLogoSize);
-                  });
+                  const startW = sponsorBoxSize.width;
+                  const startH = sponsorBoxSize.height;
                   const rect = canvasRef.current?.getBoundingClientRect();
                   const sc = rect ? rect.width / 1080 : 1;
                   const handleMove = (moveEvent: MouseEvent) => {
+                    const deltaX = (moveEvent.clientX - startX) / sc;
                     const deltaY = (moveEvent.clientY - startY) / sc;
-                    setLogoSizes(prev => {
-                      const next = { ...prev };
-                      groupLogos.forEach(s => {
-                        next[s.id] = Math.round(Math.max(20, Math.min(200, startSizes[s.id] + deltaY)));
-                      });
-                      return next;
+                    setSponsorBoxSize({
+                      width: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startW + deltaX))),
+                      height: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startH + deltaY))),
                     });
                   };
                   const handleUp = () => {
@@ -934,24 +911,21 @@ export function FlyerGenerator() {
                   document.addEventListener('mousemove', handleMove);
                   document.addEventListener('mouseup', handleUp);
                 };
-                const handleGroupTouchResizeStart = (e: React.TouchEvent) => {
+                const handleBoxTouchResizeStart = (e: React.TouchEvent) => {
                   e.stopPropagation();
+                  const startX = e.touches[0].clientX;
                   const startY = e.touches[0].clientY;
-                  const startSizes: Record<string, number> = {};
-                  groupLogos.forEach(s => {
-                    startSizes[s.id] = logoSizes[s.id] ?? Math.min(defaultLogoSize, autoLogoSize);
-                  });
+                  const startW = sponsorBoxSize.width;
+                  const startH = sponsorBoxSize.height;
                   const rect = canvasRef.current?.getBoundingClientRect();
                   const sc = rect ? rect.width / 1080 : 1;
                   const handleMove = (moveEvent: TouchEvent) => {
                     moveEvent.preventDefault();
+                    const deltaX = (moveEvent.touches[0].clientX - startX) / sc;
                     const deltaY = (moveEvent.touches[0].clientY - startY) / sc;
-                    setLogoSizes(prev => {
-                      const next = { ...prev };
-                      groupLogos.forEach(s => {
-                        next[s.id] = Math.round(Math.max(20, Math.min(200, startSizes[s.id] + deltaY)));
-                      });
-                      return next;
+                    setSponsorBoxSize({
+                      width: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startW + deltaX))),
+                      height: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startH + deltaY))),
                     });
                   };
                   const handleUp = () => {
@@ -963,18 +937,146 @@ export function FlyerGenerator() {
                 };
                 return (
                   <div
-                    onMouseDown={handleGroupResizeStart}
-                    onTouchStart={handleGroupTouchResizeStart}
+                    onMouseDown={handleBoxResizeStart}
+                    onTouchStart={handleBoxTouchResizeStart}
+                    title="Drag to resize sponsor area"
                     style={{
                       position: 'absolute',
-                      bottom: 0,
-                      right: 0,
-                      width: 18,
-                      height: 18,
+                      bottom: -4,
+                      right: -4,
+                      width: 14,
+                      height: 14,
                       cursor: 'nwse-resize',
-                      zIndex: 35,
-                      background: 'linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.4) 50%)',
-                      borderRadius: '0 0 4px 0',
+                      zIndex: 36,
+                      background: 'rgba(255,255,255,0.6)',
+                      border: '1.5px solid rgba(255,255,255,0.9)',
+                      borderRadius: 2,
+                    }}
+                  />
+                );
+              })()}
+              {/* Sponsor box resize handle — right edge (width only) */}
+              {(() => {
+                const handleRightEdgeStart = (e: React.MouseEvent) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const startX = e.clientX;
+                  const startW = sponsorBoxSize.width;
+                  const rect = canvasRef.current?.getBoundingClientRect();
+                  const sc = rect ? rect.width / 1080 : 1;
+                  const handleMove = (moveEvent: MouseEvent) => {
+                    const deltaX = (moveEvent.clientX - startX) / sc;
+                    setSponsorBoxSize(prev => ({
+                      ...prev,
+                      width: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startW + deltaX))),
+                    }));
+                  };
+                  const handleUp = () => {
+                    document.removeEventListener('mousemove', handleMove);
+                    document.removeEventListener('mouseup', handleUp);
+                  };
+                  document.addEventListener('mousemove', handleMove);
+                  document.addEventListener('mouseup', handleUp);
+                };
+                const handleRightEdgeTouchStart = (e: React.TouchEvent) => {
+                  e.stopPropagation();
+                  const startX = e.touches[0].clientX;
+                  const startW = sponsorBoxSize.width;
+                  const rect = canvasRef.current?.getBoundingClientRect();
+                  const sc = rect ? rect.width / 1080 : 1;
+                  const handleMove = (moveEvent: TouchEvent) => {
+                    moveEvent.preventDefault();
+                    const deltaX = (moveEvent.touches[0].clientX - startX) / sc;
+                    setSponsorBoxSize(prev => ({
+                      ...prev,
+                      width: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startW + deltaX))),
+                    }));
+                  };
+                  const handleUp = () => {
+                    document.removeEventListener('touchmove', handleMove);
+                    document.removeEventListener('touchend', handleUp);
+                  };
+                  document.addEventListener('touchmove', handleMove, { passive: false });
+                  document.addEventListener('touchend', handleUp);
+                };
+                return (
+                  <div
+                    onMouseDown={handleRightEdgeStart}
+                    onTouchStart={handleRightEdgeTouchStart}
+                    style={{
+                      position: 'absolute',
+                      top: '50%',
+                      right: -4,
+                      width: 6,
+                      height: 28,
+                      transform: 'translateY(-50%)',
+                      cursor: 'ew-resize',
+                      zIndex: 36,
+                      background: 'rgba(255,255,255,0.5)',
+                      borderRadius: 3,
+                    }}
+                  />
+                );
+              })()}
+              {/* Sponsor box resize handle — bottom edge (height only) */}
+              {(() => {
+                const handleBottomEdgeStart = (e: React.MouseEvent) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const startY = e.clientY;
+                  const startH = sponsorBoxSize.height;
+                  const rect = canvasRef.current?.getBoundingClientRect();
+                  const sc = rect ? rect.width / 1080 : 1;
+                  const handleMove = (moveEvent: MouseEvent) => {
+                    const deltaY = (moveEvent.clientY - startY) / sc;
+                    setSponsorBoxSize(prev => ({
+                      ...prev,
+                      height: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startH + deltaY))),
+                    }));
+                  };
+                  const handleUp = () => {
+                    document.removeEventListener('mousemove', handleMove);
+                    document.removeEventListener('mouseup', handleUp);
+                  };
+                  document.addEventListener('mousemove', handleMove);
+                  document.addEventListener('mouseup', handleUp);
+                };
+                const handleBottomEdgeTouchStart = (e: React.TouchEvent) => {
+                  e.stopPropagation();
+                  const startY = e.touches[0].clientY;
+                  const startH = sponsorBoxSize.height;
+                  const rect = canvasRef.current?.getBoundingClientRect();
+                  const sc = rect ? rect.width / 1080 : 1;
+                  const handleMove = (moveEvent: TouchEvent) => {
+                    moveEvent.preventDefault();
+                    const deltaY = (moveEvent.touches[0].clientY - startY) / sc;
+                    setSponsorBoxSize(prev => ({
+                      ...prev,
+                      height: Math.round(Math.max(SPONSOR_BOX_MIN, Math.min(SPONSOR_BOX_MAX, startH + deltaY))),
+                    }));
+                  };
+                  const handleUp = () => {
+                    document.removeEventListener('touchmove', handleMove);
+                    document.removeEventListener('touchend', handleUp);
+                  };
+                  document.addEventListener('touchmove', handleMove, { passive: false });
+                  document.addEventListener('touchend', handleUp);
+                };
+                return (
+                  <div
+                    onMouseDown={handleBottomEdgeStart}
+                    onTouchStart={handleBottomEdgeTouchStart}
+                    style={{
+                      position: 'absolute',
+                      bottom: -4,
+                      left: '50%',
+                      width: 28,
+                      height: 6,
+                      transform: 'translateX(-50%)',
+                      cursor: 'ns-resize',
+                      zIndex: 36,
+                      background: 'rgba(255,255,255,0.5)',
+                      borderRadius: 3,
                     }}
                   />
                 );
@@ -1276,35 +1378,6 @@ export function FlyerGenerator() {
           >
             {renderFlyerContent()}
           </div>
-        </div>
-      </div>
-
-      {/* Sponsor logo area size controls */}
-      <div className="mx-auto" style={{ maxWidth: 500 }}>
-        <p className="text-center text-xs text-white/40 mb-2">Sponsor logo area size (px)</p>
-        <div className="grid grid-cols-2 gap-3">
-          <IconInput
-            icon={MoveHorizontal}
-            type="number"
-            min={SPONSOR_BOX_MIN}
-            max={SPONSOR_BOX_MAX}
-            step={10}
-            value={sponsorBoxSize.width}
-            onChange={(e) => handleSponsorBoxWidthChange(e.target.value)}
-            placeholder="Width"
-            aria-label="Sponsor logo area width"
-          />
-          <IconInput
-            icon={MoveVertical}
-            type="number"
-            min={SPONSOR_BOX_MIN}
-            max={SPONSOR_BOX_MAX}
-            step={10}
-            value={sponsorBoxSize.height}
-            onChange={(e) => handleSponsorBoxHeightChange(e.target.value)}
-            placeholder="Height"
-            aria-label="Sponsor logo area height"
-          />
         </div>
       </div>
 

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -59,6 +59,7 @@ const CITY_FONT = '"Hub 191 Display", "Hub 191", "Comic Sans MS", cursive';
 const TEXT_FONT = '"Hub 191", "Comic Sans MS", "Comic Sans", cursive';
 const CITY_COLOR = '#FE332C';
 const TIME_COLOR = '#FFFFFF';
+const VENUE_COLOR = '#0497C1';
 
 // Bounding box dimensions (measured from boxes overlay at 1080px)
 const CITY_BOX = { width: 587, height: 72 };
@@ -484,7 +485,7 @@ export function FlyerGenerator() {
     // 3) Venue name + street address — Hub 191 Regular, black
     //    x locked to city.x so venue always left-aligns with city
     const venueX = positions.city.x;
-    ctx.fillStyle = '#000000';
+    ctx.fillStyle = VENUE_COLOR;
     ctx.font = `${venueNameFontSize}px "Hub 191"`;
     ctx.fillText(venueName.toUpperCase(), venueX, positions.venue.y);
     if (streetAddress) {
@@ -767,7 +768,7 @@ export function FlyerGenerator() {
                 left: positions.city.x,
                 width: VENUE_BOX.width,
                 height: VENUE_BOX.height,
-                color: '#000000',
+                color: VENUE_COLOR,
                 textTransform: 'uppercase',
                 fontFamily: TEXT_FONT,
                 overflow: 'hidden',

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -54,6 +54,38 @@ function loadImg(src: string): Promise<HTMLImageElement> {
   });
 }
 
+/**
+ * Determine whether the given IANA timezone's country conventionally uses
+ * 12-hour time (e.g. "6:00 PM") or 24-hour time (e.g. "18:00").
+ */
+function uses12Hour(tz: string): boolean {
+  const TWELVE_HOUR_ZONES = new Set([
+    'Asia/Kolkata', 'Asia/Calcutta',  // India
+    'Asia/Manila',                     // Philippines
+    'Asia/Riyadh', 'Asia/Jeddah',     // Saudi Arabia
+    'Asia/Dubai',                      // UAE
+  ]);
+  if (TWELVE_HOUR_ZONES.has(tz)) return true;
+  // America/ covers US, Canada, Mexico, Colombia, etc. — all 12-hour
+  // Australia/ — 12-hour
+  if (tz.startsWith('America/') || tz.startsWith('Australia/')) return true;
+  // Default: 24-hour (Europe, most of Asia, Africa)
+  return false;
+}
+
+/**
+ * Format a 24-hour "HH:MM" time string to the appropriate display format.
+ * - 12-hour mode: "6:00 PM"
+ * - 24-hour mode: "18:00"
+ */
+function formatFlyerTime(timeStr: string, is12h: boolean): string {
+  if (!is12h) return timeStr; // already "HH:MM"
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  const period = hours >= 12 ? 'PM' : 'AM';
+  const hours12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+  return `${hours12}:${minutes.toString().padStart(2, '0')} ${period}`;
+}
+
 const CITY_FONT = '"Hub 191 Display", "Hub 191", "Comic Sans MS", cursive';
 const TEXT_FONT = '"Hub 191", "Comic Sans MS", "Comic Sans", cursive';
 const CITY_COLOR = '#FE332C';
@@ -397,12 +429,15 @@ export function FlyerGenerator() {
   let timeDisplay = '';
   let dateDisplay = 'MAY 22'; // fallback if no event date
   if (party.date && party.timezone) {
+    const is12h = uses12Hour(party.timezone);
     const start = getDateTimeInTimezone(party.date, party.timezone);
-    timeDisplay = start.timeStr;
+    const startFormatted = formatFlyerTime(start.timeStr, is12h);
+    timeDisplay = startFormatted;
     if (party.duration) {
       const endDate = new Date(new Date(party.date).getTime() + party.duration * 3600000);
       const end = getDateTimeInTimezone(endDate, party.timezone);
-      timeDisplay = `${start.timeStr} - ${end.timeStr}`;
+      const endFormatted = formatFlyerTime(end.timeStr, is12h);
+      timeDisplay = `${startFormatted} - ${endFormatted}`;
     }
     // Derive "MAY 22" style date from event date in the event's timezone
     const eventDate = new Date(party.date);

--- a/frontend/src/components/flyer/useFlyerDrag.ts
+++ b/frontend/src/components/flyer/useFlyerDrag.ts
@@ -10,8 +10,8 @@ export interface FlyerPositions {
 /** Default positions (in 1080px canvas coordinates) matching the 2026 template layout */
 export const DEFAULT_POSITIONS: FlyerPositions = {
   city: { x: 50, y: 608 },
-  time: { x: 203, y: 806 },
-  venue: { x: 48, y: 709 },
+  time: { x: 50, y: 700 },
+  venue: { x: 50, y: 795 },
   sponsors: { x: 27, y: 884 },
 };
 

--- a/frontend/src/components/flyer/useFlyerDrag.ts
+++ b/frontend/src/components/flyer/useFlyerDrag.ts
@@ -9,9 +9,9 @@ export interface FlyerPositions {
 
 /** Default positions (in 1080px canvas coordinates) matching the 2026 template layout */
 export const DEFAULT_POSITIONS: FlyerPositions = {
-  city: { x: 50, y: 600 },
-  time: { x: 50, y: 680 },
-  venue: { x: 50, y: 750 },
+  city: { x: 50, y: 580 },
+  time: { x: 50, y: 650 },
+  venue: { x: 50, y: 700 },
   sponsors: { x: 27, y: 884 },
 };
 

--- a/frontend/src/components/flyer/useFlyerDrag.ts
+++ b/frontend/src/components/flyer/useFlyerDrag.ts
@@ -9,9 +9,9 @@ export interface FlyerPositions {
 
 /** Default positions (in 1080px canvas coordinates) matching the 2026 template layout */
 export const DEFAULT_POSITIONS: FlyerPositions = {
-  city: { x: 50, y: 608 },
-  time: { x: 50, y: 700 },
-  venue: { x: 50, y: 795 },
+  city: { x: 50, y: 600 },
+  time: { x: 50, y: 680 },
+  venue: { x: 50, y: 750 },
   sponsors: { x: 27, y: 884 },
 };
 

--- a/frontend/src/components/flyer/useFlyerDrag.ts
+++ b/frontend/src/components/flyer/useFlyerDrag.ts
@@ -9,9 +9,9 @@ export interface FlyerPositions {
 
 /** Default positions (in 1080px canvas coordinates) matching the 2026 template layout */
 export const DEFAULT_POSITIONS: FlyerPositions = {
-  city: { x: 50, y: 580 },
-  time: { x: 50, y: 650 },
-  venue: { x: 50, y: 700 },
+  city: { x: 50, y: 582 },
+  time: { x: 50, y: 660 },
+  venue: { x: 50, y: 720 },
   sponsors: { x: 27, y: 884 },
 };
 


### PR DESCRIPTION
## Summary
- Swaps template to new 2026 GPP artwork (no baked-in MAY 22)
- Adds dynamic date (e.g. MAY 22) as red text to left of time element
- Time moved from x:203/y:806 → x:50/y:700
- Venue moved from x:48/y:709 → x:50/y:795
- City, date+time, venue all left-aligned at x:50

## Files changed
- `frontend/public/gpp-flyer-2026-template.png` — new template image
- `frontend/src/components/flyer/FlyerGenerator.tsx` — MAY 22 date rendering in both canvas + preview
- `frontend/src/components/flyer/useFlyerDrag.ts` — repositioned defaults