### PR TITLE
pineapple-80595: Partner invoice generator

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -179,6 +179,7 @@ model Party {
   performers       Performer[]
   venues           Venue[]
   sponsors         Sponsor[]
+  invoices         Invoice[]
   budgetItems      BudgetItem[]
   checklistItems   ChecklistItem[]
   socialPosts      SocialPost[]
@@ -866,6 +867,8 @@ model Sponsor {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
+  invoices          Invoice[]
+
   @@index([partyId, status])
   @@index([partyId, createdAt])
   @@map("sponsors")
@@ -1142,4 +1145,54 @@ model SponsorChecklistItem {
   @@index([sponsorUserId])
   @@index([partyId])
   @@map("sponsor_checklist_items")
+}
+
+// ============================================
+// Invoice Models
+// ============================================
+
+model Invoice {
+  id             String    @id @default(uuid()) @db.Uuid
+  partyId        String    @map("party_id") @db.Uuid
+  party          Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  sponsorId      String    @map("sponsor_id") @db.Uuid
+  sponsor        Sponsor   @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+
+  invoiceNumber  String    @map("invoice_number")
+  viewToken      String    @unique @map("view_token")
+
+  billToCompany  String?   @map("bill_to_company")
+  billToContact  String?   @map("bill_to_contact")
+  billToAddress  String?   @map("bill_to_address")
+  billToEmail    String    @map("bill_to_email")
+  ccEmails       String[]  @map("cc_emails")
+
+  lineItems      Json      @default("[]") @map("line_items")
+  total          Int       @default(0)
+  currency       String    @default("usd")
+
+  paymentTerms   String?   @map("payment_terms")
+  paymentInstructions String? @map("payment_instructions")
+  dueDate        DateTime? @map("due_date") @db.Date
+  memo           String?
+
+  status         String    @default("draft")
+
+  paidAt         DateTime? @map("paid_at") @db.Timestamptz
+  paidAmount     Int?      @map("paid_amount")
+  paymentMethod  String?   @map("payment_method")
+  paymentRef     String?   @map("payment_ref")
+
+  sentAt         DateTime? @map("sent_at") @db.Timestamptz
+  viewedAt       DateTime? @map("viewed_at") @db.Timestamptz
+
+  attachments    Json      @default("[]")
+
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([partyId])
+  @@index([sponsorId])
+  @@index([partyId, status])
+  @@map("invoices")
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -35,6 +35,7 @@ import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
 import { sponsorUserAdminRouter, sponsorDashboardRouter } from './routes/sponsor-user.routes.js';
+import { invoiceHostRoutes, invoicePublicRoutes } from './routes/invoice.routes.js';
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -112,6 +113,8 @@ app.use('/api/parties', venuePhotoRoutes); // Venue photo routes (host only)
 app.use('/api/parties', venueReportRoutes); // Venue report routes (includes public)
 app.use('/api/parties', venueRoutes); // Venue routes (host only)
 app.use('/api/partner-intake', partnerIntakeRoutes); // Public partner intake form routes
+app.use('/api/invoice', invoicePublicRoutes); // Public invoice view routes (token-gated)
+app.use('/api/parties', invoiceHostRoutes); // Invoice host routes (before sponsorRoutes)
 app.use('/api/parties', sponsorRoutes); // Sponsor CRM routes (host only)
 app.use('/api/parties', budgetRoutes); // Budget routes (host only)
 app.use('/api/parties', checklistRoutes); // Checklist routes (host only)

--- a/backend/src/routes/invoice.routes.ts
+++ b/backend/src/routes/invoice.routes.ts
@@ -1,0 +1,759 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
+
+// ============================================
+// Host routes (mounted at /api/parties)
+// ============================================
+const hostRouter = Router();
+
+// GET /api/parties/:partyId/invoices - List all invoices for a party
+hostRouter.get('/:partyId/invoices', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const invoices = await prisma.invoice.findMany({
+      where: { partyId },
+      include: {
+        sponsor: {
+          select: { id: true, name: true, contactEmail: true, logoUrl: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({ invoices });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/parties/:partyId/invoices/:invoiceId - Get single invoice
+hostRouter.get('/:partyId/invoices/:invoiceId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, invoiceId } = req.params;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const invoice = await prisma.invoice.findFirst({
+      where: { id: invoiceId, partyId },
+      include: {
+        sponsor: {
+          select: { id: true, name: true, contactEmail: true, logoUrl: true },
+        },
+        party: {
+          select: { name: true },
+        },
+      },
+    });
+
+    if (!invoice) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    res.json({ invoice });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/invoices - Create invoice for a sponsor
+hostRouter.post('/:partyId/invoices', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const {
+      sponsorId,
+      billToCompany,
+      billToContact,
+      billToAddress,
+      billToEmail,
+      ccEmails,
+      lineItems,
+      total,
+      currency,
+      paymentTerms,
+      paymentInstructions,
+      dueDate,
+      memo,
+      attachments,
+    } = req.body;
+
+    if (!sponsorId) {
+      throw new AppError('Sponsor ID is required', 400, 'VALIDATION_ERROR');
+    }
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    // Verify sponsor exists and belongs to this party
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, partyId },
+    });
+
+    if (!sponsor) {
+      throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
+    }
+
+    // Auto-generate invoice number (count existing + 1, zero-padded to 3 digits)
+    const existingCount = await prisma.invoice.count({
+      where: { partyId },
+    });
+    const invoiceNumber = String(existingCount + 1).padStart(3, '0');
+
+    // Generate view token
+    const viewToken = crypto.randomBytes(32).toString('hex');
+
+    // Use sponsor data as defaults for bill-to fields
+    const finalBillToEmail = billToEmail || sponsor.contactEmail;
+    if (!finalBillToEmail) {
+      throw new AppError('Bill-to email is required (sponsor has no contact email)', 400, 'VALIDATION_ERROR');
+    }
+
+    // Pre-populate line items from sponsor amount if no line items provided
+    let finalLineItems = lineItems || [];
+    let finalTotal = total || 0;
+
+    if (finalLineItems.length === 0 && sponsor.amount) {
+      const amountInCents = Math.round(Number(sponsor.amount) * 100);
+      finalLineItems = [{
+        description: sponsor.sponsorshipType
+          ? `${sponsor.sponsorshipType.charAt(0).toUpperCase() + sponsor.sponsorshipType.slice(1)} Sponsorship`
+          : 'Sponsorship',
+        amount: amountInCents,
+      }];
+      finalTotal = amountInCents;
+    }
+
+    const invoice = await prisma.invoice.create({
+      data: {
+        partyId,
+        sponsorId,
+        invoiceNumber,
+        viewToken,
+        billToCompany: billToCompany || sponsor.name || null,
+        billToContact: billToContact || sponsor.contactName || null,
+        billToAddress: billToAddress || null,
+        billToEmail: finalBillToEmail,
+        ccEmails: ccEmails || [],
+        lineItems: finalLineItems,
+        total: finalTotal,
+        currency: currency || 'usd',
+        paymentTerms: paymentTerms || null,
+        paymentInstructions: paymentInstructions || null,
+        dueDate: dueDate ? new Date(dueDate) : null,
+        memo: memo || null,
+        attachments: attachments || [],
+      },
+      include: {
+        sponsor: {
+          select: { id: true, name: true, contactEmail: true, logoUrl: true },
+        },
+      },
+    });
+
+    res.status(201).json({ invoice });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/parties/:partyId/invoices/:invoiceId - Update invoice
+hostRouter.patch('/:partyId/invoices/:invoiceId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, invoiceId } = req.params;
+    const {
+      billToCompany,
+      billToContact,
+      billToAddress,
+      billToEmail,
+      ccEmails,
+      lineItems,
+      total,
+      currency,
+      paymentTerms,
+      paymentInstructions,
+      dueDate,
+      memo,
+      attachments,
+    } = req.body;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const existing = await prisma.invoice.findFirst({
+      where: { id: invoiceId, partyId },
+    });
+
+    if (!existing) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    const invoice = await prisma.invoice.update({
+      where: { id: invoiceId },
+      data: {
+        ...(billToCompany !== undefined && { billToCompany: billToCompany || null }),
+        ...(billToContact !== undefined && { billToContact: billToContact || null }),
+        ...(billToAddress !== undefined && { billToAddress: billToAddress || null }),
+        ...(billToEmail !== undefined && { billToEmail }),
+        ...(ccEmails !== undefined && { ccEmails }),
+        ...(lineItems !== undefined && { lineItems }),
+        ...(total !== undefined && { total }),
+        ...(currency !== undefined && { currency }),
+        ...(paymentTerms !== undefined && { paymentTerms: paymentTerms || null }),
+        ...(paymentInstructions !== undefined && { paymentInstructions: paymentInstructions || null }),
+        ...(dueDate !== undefined && { dueDate: dueDate ? new Date(dueDate) : null }),
+        ...(memo !== undefined && { memo: memo || null }),
+        ...(attachments !== undefined && { attachments }),
+      },
+      include: {
+        sponsor: {
+          select: { id: true, name: true, contactEmail: true, logoUrl: true },
+        },
+      },
+    });
+
+    res.json({ invoice });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/parties/:partyId/invoices/:invoiceId - Delete draft invoice
+hostRouter.delete('/:partyId/invoices/:invoiceId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, invoiceId } = req.params;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const existing = await prisma.invoice.findFirst({
+      where: { id: invoiceId, partyId },
+    });
+
+    if (!existing) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    if (existing.status !== 'draft') {
+      throw new AppError('Only draft invoices can be deleted', 400, 'VALIDATION_ERROR');
+    }
+
+    await prisma.invoice.delete({
+      where: { id: invoiceId },
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/invoices/:invoiceId/send - Send invoice email
+hostRouter.post('/:partyId/invoices/:invoiceId/send', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, invoiceId } = req.params;
+    const { resend: forceResend } = req.body;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const invoice = await prisma.invoice.findFirst({
+      where: { id: invoiceId, partyId },
+      include: {
+        party: { select: { name: true } },
+        sponsor: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!invoice) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    // Validate
+    const lineItems = invoice.lineItems as Array<{ description: string; amount: number }>;
+    if (!lineItems || lineItems.length === 0) {
+      throw new AppError('Invoice must have at least one line item', 400, 'VALIDATION_ERROR');
+    }
+
+    if (!invoice.billToEmail) {
+      throw new AppError('Invoice must have a bill-to email', 400, 'VALIDATION_ERROR');
+    }
+
+    // Prevent re-send unless explicitly forced
+    if (invoice.status === 'issued' && !forceResend) {
+      throw new AppError('Invoice already sent. Pass { resend: true } to re-send.', 400, 'ALREADY_SENT');
+    }
+
+    // Build invoice view URL
+    const invoiceViewUrl = `https://rsv.pizza/invoice/${invoice.viewToken}`;
+
+    // Format amounts for email
+    const formatAmount = (cents: number) => {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: (invoice.currency || 'usd').toUpperCase(),
+        minimumFractionDigits: 2,
+      }).format(cents / 100);
+    };
+
+    // Build line items HTML
+    const lineItemsHtml = lineItems.map(item => `
+      <tr>
+        <td style="padding: 12px 16px; border-bottom: 1px solid #e0e0e0; color: #333;">${item.description}</td>
+        <td style="padding: 12px 16px; border-bottom: 1px solid #e0e0e0; text-align: right; color: #333; white-space: nowrap;">${formatAmount(item.amount)}</td>
+      </tr>
+    `).join('');
+
+    const dueDateText = invoice.dueDate
+      ? new Date(invoice.dueDate).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+      : null;
+
+    // Build email HTML
+    const emailHtml = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Invoice #${invoice.invoiceNumber}</title>
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #ffffff; font-size: 28px; margin: 0 0 10px 0;">Invoice #${invoice.invoiceNumber}</h1>
+            <p style="color: rgba(255,255,255,0.8); font-size: 16px; margin: 0;">${invoice.party.name}</p>
+          </div>
+
+          <div style="background: #f9f9f9; padding: 24px; border-radius: 12px; margin-bottom: 20px;">
+            <p style="margin: 0 0 16px 0; font-size: 16px;">
+              Thanks for helping us pizza the planet!
+            </p>
+
+            <table style="width: 100%; border-collapse: collapse; margin-bottom: 16px;">
+              <thead>
+                <tr style="background: #1a1a2e;">
+                  <th style="padding: 12px 16px; text-align: left; color: #ffffff; font-size: 14px; border-radius: 6px 0 0 0;">Description</th>
+                  <th style="padding: 12px 16px; text-align: right; color: #ffffff; font-size: 14px; border-radius: 0 6px 0 0;">Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${lineItemsHtml}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td style="padding: 12px 16px; font-weight: bold; font-size: 16px; color: #1a1a2e;">Total</td>
+                  <td style="padding: 12px 16px; text-align: right; font-weight: bold; font-size: 16px; color: #1a1a2e;">${formatAmount(invoice.total)}</td>
+                </tr>
+              </tfoot>
+            </table>
+
+            ${invoice.paymentInstructions ? `
+              <div style="background: #fff; padding: 16px; border-radius: 8px; border: 1px solid #e0e0e0; margin-bottom: 12px;">
+                <p style="margin: 0 0 4px 0; font-size: 12px; color: #666; text-transform: uppercase; letter-spacing: 1px;">Payment Instructions</p>
+                <p style="margin: 0; font-size: 14px; color: #333; white-space: pre-wrap;">${invoice.paymentInstructions}</p>
+              </div>
+            ` : ''}
+
+            ${invoice.paymentTerms ? `
+              <p style="margin: 0 0 8px 0; font-size: 14px; color: #666;">
+                <strong>Terms:</strong> ${invoice.paymentTerms}
+              </p>
+            ` : ''}
+
+            ${dueDateText ? `
+              <p style="margin: 0 0 8px 0; font-size: 14px; color: #666;">
+                <strong>Due:</strong> ${dueDateText}
+              </p>
+            ` : ''}
+
+            ${invoice.memo ? `
+              <p style="margin: 8px 0 0 0; font-size: 14px; color: #666;">
+                <strong>Note:</strong> ${invoice.memo}
+              </p>
+            ` : ''}
+          </div>
+
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${invoiceViewUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600; font-size: 16px;">View Invoice Online</a>
+          </div>
+
+          <div style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 30px; text-align: center; color: #666; font-size: 14px;">
+            <p>Sent via <a href="https://rsv.pizza" style="color: #ff393a; text-decoration: none;">RSV.Pizza</a></p>
+          </div>
+        </body>
+      </html>
+    `;
+
+    // Send email via Resend
+    const resendApiKey = process.env.RESEND_API_KEY;
+
+    if (resendApiKey) {
+      const emailPayload: any = {
+        from: 'RSV.Pizza <noreply@rsv.pizza>',
+        to: [invoice.billToEmail],
+        subject: `Invoice #${invoice.invoiceNumber} - ${invoice.billToCompany || invoice.sponsor.name} - ${invoice.party.name}`,
+        html: emailHtml,
+      };
+
+      // Add CC recipients
+      if (invoice.ccEmails && invoice.ccEmails.length > 0) {
+        emailPayload.cc = invoice.ccEmails;
+      }
+
+      const response = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${resendApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(emailPayload),
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        console.error('Resend API error:', error);
+        throw new AppError(`Failed to send email: ${error}`, 500, 'EMAIL_ERROR');
+      }
+    } else {
+      console.warn('RESEND_API_KEY not configured, skipping email send');
+    }
+
+    // Update invoice status
+    const updatedInvoice = await prisma.invoice.update({
+      where: { id: invoiceId },
+      data: {
+        status: 'issued',
+        sentAt: new Date(),
+      },
+      include: {
+        sponsor: {
+          select: { id: true, name: true, contactEmail: true, logoUrl: true },
+        },
+      },
+    });
+
+    // Auto-update sponsor status to 'billed'
+    await prisma.sponsor.update({
+      where: { id: invoice.sponsorId },
+      data: { status: 'billed' },
+    });
+
+    res.json({ invoice: updatedInvoice, emailSent: !!resendApiKey });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/invoices/:invoiceId/mark-paid - Mark invoice as paid
+hostRouter.post('/:partyId/invoices/:invoiceId/mark-paid', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, invoiceId } = req.params;
+    const { paymentMethod, paymentRef, paidAmount } = req.body;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    const canAccess = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccess) {
+      throw new AppError('You do not have access to the partners tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const existing = await prisma.invoice.findFirst({
+      where: { id: invoiceId, partyId },
+    });
+
+    if (!existing) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    const validMethods = ['usdc', 'wire', 'stripe', 'check', 'manual'];
+    if (paymentMethod && !validMethods.includes(paymentMethod)) {
+      throw new AppError(`Invalid payment method. Must be one of: ${validMethods.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+
+    const invoice = await prisma.invoice.update({
+      where: { id: invoiceId },
+      data: {
+        status: 'paid',
+        paidAt: new Date(),
+        paidAmount: paidAmount ?? existing.total,
+        paymentMethod: paymentMethod || 'manual',
+        paymentRef: paymentRef || null,
+      },
+      include: {
+        sponsor: {
+          select: { id: true, name: true, contactEmail: true, logoUrl: true },
+        },
+      },
+    });
+
+    // Auto-update sponsor status to 'paid'
+    await prisma.sponsor.update({
+      where: { id: existing.sponsorId },
+      data: { status: 'paid' },
+    });
+
+    res.json({ invoice });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ============================================
+// Public routes (mounted at /api/invoice)
+// ============================================
+const publicRouter = Router();
+
+// GET /api/invoice/:viewToken - Public invoice view
+publicRouter.get('/:viewToken', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { viewToken } = req.params;
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { viewToken },
+      include: {
+        party: { select: { name: true, eventImageUrl: true } },
+        sponsor: { select: { name: true, logoUrl: true } },
+      },
+    });
+
+    if (!invoice) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    res.json({ invoice });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/invoice/:viewToken/pdf - Download invoice as printable HTML
+publicRouter.get('/:viewToken/pdf', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { viewToken } = req.params;
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { viewToken },
+      include: {
+        party: { select: { name: true } },
+        sponsor: { select: { name: true } },
+      },
+    });
+
+    if (!invoice) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    const formatAmount = (cents: number) => {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: (invoice.currency || 'usd').toUpperCase(),
+        minimumFractionDigits: 2,
+      }).format(cents / 100);
+    };
+
+    const lineItems = invoice.lineItems as Array<{ description: string; amount: number }>;
+    const lineItemsHtml = lineItems.map(item => `
+      <tr>
+        <td style="padding: 10px 0; border-bottom: 1px solid #eee;">${item.description}</td>
+        <td style="padding: 10px 0; border-bottom: 1px solid #eee; text-align: right; white-space: nowrap;">${formatAmount(item.amount)}</td>
+      </tr>
+    `).join('');
+
+    const invoiceDate = invoice.sentAt
+      ? new Date(invoice.sentAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+      : new Date(invoice.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+    const dueDateText = invoice.dueDate
+      ? new Date(invoice.dueDate).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+      : null;
+
+    // Address lines from semicolon-separated string
+    const addressLines = invoice.billToAddress
+      ? invoice.billToAddress.split(';').map(line => line.trim()).filter(Boolean)
+      : [];
+
+    const html = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Invoice #${invoice.invoiceNumber} - ${invoice.billToCompany || ''}</title>
+          <style>
+            @media print {
+              body { margin: 0; padding: 20px; }
+              .no-print { display: none !important; }
+            }
+            body {
+              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+              color: #333;
+              max-width: 800px;
+              margin: 0 auto;
+              padding: 40px;
+              line-height: 1.5;
+            }
+            .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 40px; }
+            .header-left h1 { margin: 0; font-size: 28px; color: #1a1a2e; }
+            .header-left p { margin: 4px 0 0; color: #666; font-size: 14px; }
+            .header-right { text-align: right; font-size: 14px; color: #666; }
+            .header-right strong { color: #333; display: block; }
+            .bill-to { margin-bottom: 32px; }
+            .bill-to h3 { margin: 0 0 8px; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: #999; }
+            .bill-to p { margin: 2px 0; font-size: 14px; }
+            table { width: 100%; border-collapse: collapse; margin-bottom: 24px; }
+            thead th { padding: 10px 0; border-bottom: 2px solid #1a1a2e; text-align: left; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: #666; }
+            thead th:last-child { text-align: right; }
+            .total-row td { padding: 12px 0; font-weight: bold; font-size: 18px; border-top: 2px solid #1a1a2e; }
+            .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #eee; font-size: 14px; color: #666; }
+            .footer p { margin: 6px 0; }
+            .footer strong { color: #333; }
+            .print-btn {
+              position: fixed; bottom: 20px; right: 20px;
+              background: #1a1a2e; color: white; border: none;
+              padding: 12px 24px; border-radius: 8px; cursor: pointer;
+              font-size: 14px; font-weight: 600;
+            }
+            .print-btn:hover { background: #16213e; }
+          </style>
+        </head>
+        <body>
+          <button class="print-btn no-print" onclick="window.print()">Print / Save as PDF</button>
+
+          <div class="header">
+            <div class="header-left">
+              <h1>INVOICE</h1>
+              <p>${invoice.party.name}</p>
+            </div>
+            <div class="header-right">
+              <strong>Invoice #${invoice.invoiceNumber}</strong>
+              <span>Date: ${invoiceDate}</span><br>
+              ${dueDateText ? `<span>Due: ${dueDateText}</span><br>` : ''}
+            </div>
+          </div>
+
+          <div class="bill-to">
+            <h3>Bill To</h3>
+            ${invoice.billToCompany ? `<p><strong>${invoice.billToCompany}</strong></p>` : ''}
+            ${invoice.billToContact ? `<p>ATTN: ${invoice.billToContact}</p>` : ''}
+            ${addressLines.map(line => `<p>${line}</p>`).join('')}
+            <p>${invoice.billToEmail}</p>
+          </div>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Description</th>
+                <th style="text-align: right;">Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${lineItemsHtml}
+            </tbody>
+            <tfoot>
+              <tr class="total-row">
+                <td>Total</td>
+                <td style="text-align: right;">${formatAmount(invoice.total)}</td>
+              </tr>
+            </tfoot>
+          </table>
+
+          <div class="footer">
+            ${invoice.paymentInstructions ? `
+              <p><strong>Payment Instructions:</strong></p>
+              <p style="white-space: pre-wrap;">${invoice.paymentInstructions}</p>
+            ` : ''}
+            ${invoice.paymentTerms ? `<p><strong>Terms:</strong> ${invoice.paymentTerms}</p>` : ''}
+            ${invoice.memo ? `<p><strong>Note:</strong> ${invoice.memo}</p>` : ''}
+          </div>
+        </body>
+      </html>
+    `;
+
+    res.setHeader('Content-Type', 'text/html');
+    res.send(html);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/invoice/:viewToken/record-view - Record first view timestamp
+publicRouter.post('/:viewToken/record-view', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { viewToken } = req.params;
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { viewToken },
+    });
+
+    if (!invoice) {
+      throw new AppError('Invoice not found', 404, 'NOT_FOUND');
+    }
+
+    // Only record first view
+    if (!invoice.viewedAt) {
+      await prisma.invoice.update({
+        where: { id: invoice.id },
+        data: {
+          viewedAt: new Date(),
+          status: invoice.status === 'issued' ? 'viewed' : invoice.status,
+        },
+      });
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { hostRouter as invoiceHostRoutes, publicRouter as invoicePublicRoutes };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { ShippingDashboard } from './pages/ShippingDashboard';
 import { AdminPage } from './pages/AdminPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
+import { InvoicePage } from './pages/InvoicePage';
 
 // Legacy redirect: /sponsor-intake/:token → /partner-intake/:token
 // <Navigate> doesn't forward path params, so we wrap useParams().
@@ -60,6 +61,7 @@ function App() {
             <Route path="/partner-dashboard" element={<PartnerDashboardPage />} />
             <Route path="/sponsor-dashboard" element={<Navigate to="/partner-dashboard" replace />} />
             <Route path="/partner-intake/:token" element={<PartnerIntakePage />} />
+            <Route path="/invoice/:viewToken" element={<InvoicePage />} />
             <Route path="/sponsor-intake/:token" element={<SponsorIntakeRedirect />} />
             {/* Catch-all route for custom URLs - must be last */}
             <Route path="/:slug" element={<EventPage />} />

--- a/frontend/src/components/sponsors/InvoiceButton.tsx
+++ b/frontend/src/components/sponsors/InvoiceButton.tsx
@@ -1,0 +1,333 @@
+import React, { useState } from 'react';
+import {
+  FileText, Check, Clock, ExternalLink, Copy, Send, DollarSign,
+  Loader2, X, MoreHorizontal
+} from 'lucide-react';
+import { Sponsor, Invoice } from '../../types';
+import { markInvoicePaid, sendInvoice } from '../../lib/api';
+import { InvoiceForm } from './InvoiceForm';
+
+interface InvoiceButtonProps {
+  sponsor: Sponsor;
+  partyId: string;
+  invoice?: Invoice | null;
+  onInvoiceUpdate: (invoice: Invoice) => void;
+  onSponsorUpdate: (sponsor: Sponsor) => void;
+}
+
+export function InvoiceButton({ sponsor, partyId, invoice, onInvoiceUpdate, onSponsorUpdate }: InvoiceButtonProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const [showMarkPaid, setShowMarkPaid] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Mark paid modal state
+  const [paymentMethod, setPaymentMethod] = useState('manual');
+  const [paymentRef, setPaymentRef] = useState('');
+
+  const invoiceUrl = invoice?.viewToken
+    ? `https://rsv.pizza/invoice/${invoice.viewToken}`
+    : null;
+
+  const handleCopyUrl = async () => {
+    if (!invoiceUrl) return;
+    try {
+      await navigator.clipboard.writeText(invoiceUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const textArea = document.createElement('textarea');
+      textArea.value = invoiceUrl;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!invoice) return;
+    setLoading(true);
+    try {
+      const result = await sendInvoice(partyId, invoice.id, true);
+      if (result) {
+        onInvoiceUpdate(result.invoice);
+      }
+    } catch (err) {
+      console.error('Failed to resend invoice:', err);
+    } finally {
+      setLoading(false);
+      setShowMenu(false);
+    }
+  };
+
+  const handleMarkPaid = async () => {
+    if (!invoice) return;
+    setLoading(true);
+    try {
+      const result = await markInvoicePaid(partyId, invoice.id, {
+        paymentMethod,
+        paymentRef: paymentRef.trim() || undefined,
+      });
+      if (result) {
+        onInvoiceUpdate(result.invoice);
+        onSponsorUpdate({ ...sponsor, status: 'paid' });
+      }
+    } catch (err) {
+      console.error('Failed to mark paid:', err);
+    } finally {
+      setLoading(false);
+      setShowMarkPaid(false);
+      setShowMenu(false);
+    }
+  };
+
+  const formatAmount = (cents: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(cents / 100);
+  };
+
+  // Loading state
+  if (loading) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-white/40">
+        <Loader2 size={12} className="animate-spin" />
+      </span>
+    );
+  }
+
+  // No invoice yet
+  if (!invoice) {
+    return (
+      <>
+        <button
+          onClick={() => setShowForm(true)}
+          className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-theme-text-muted hover:text-theme-text bg-theme-surface hover:bg-theme-surface-hover border border-theme-stroke rounded transition-colors"
+          title="Create invoice for this partner"
+        >
+          <FileText size={12} />
+          Invoice
+        </button>
+        {showForm && (
+          <InvoiceForm
+            sponsor={sponsor}
+            partyId={partyId}
+            onClose={() => setShowForm(false)}
+            onSave={(inv) => {
+              onInvoiceUpdate(inv);
+              setShowForm(false);
+            }}
+            onSponsorUpdate={onSponsorUpdate}
+          />
+        )}
+      </>
+    );
+  }
+
+  // Draft invoice
+  if (invoice.status === 'draft') {
+    return (
+      <>
+        <button
+          onClick={() => setShowForm(true)}
+          className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-yellow-300 bg-yellow-500/20 rounded cursor-pointer hover:bg-yellow-500/30 transition-colors"
+          title="Edit draft invoice"
+        >
+          <Clock size={12} />
+          Draft
+        </button>
+        {showForm && (
+          <InvoiceForm
+            sponsor={sponsor}
+            partyId={partyId}
+            existingInvoice={invoice}
+            onClose={() => setShowForm(false)}
+            onSave={(inv) => {
+              onInvoiceUpdate(inv);
+              setShowForm(false);
+            }}
+            onSponsorUpdate={onSponsorUpdate}
+          />
+        )}
+      </>
+    );
+  }
+
+  // Paid invoice
+  if (invoice.status === 'paid') {
+    return (
+      <div className="relative inline-flex items-center gap-1">
+        <button
+          onClick={() => setShowMenu(!showMenu)}
+          className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-green-300 bg-green-500/20 rounded cursor-pointer hover:bg-green-500/30 transition-colors"
+          title={`Paid${invoice.paymentMethod ? ` via ${invoice.paymentMethod}` : ''}`}
+        >
+          <Check size={12} />
+          Paid
+          {invoice.paidAmount ? ` ${formatAmount(invoice.paidAmount)}` : ''}
+        </button>
+        {showMenu && (
+          <div className="absolute top-full right-0 mt-1 z-10 bg-theme-header border border-theme-stroke rounded-lg shadow-lg py-1 min-w-[140px]">
+            {invoiceUrl && (
+              <button
+                onClick={() => { window.open(invoiceUrl, '_blank'); setShowMenu(false); }}
+                className="w-full px-3 py-1.5 text-xs text-left text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface transition-colors flex items-center gap-2"
+              >
+                <ExternalLink size={12} />
+                View Invoice
+              </button>
+            )}
+            <button
+              onClick={handleCopyUrl}
+              className="w-full px-3 py-1.5 text-xs text-left text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface transition-colors flex items-center gap-2"
+            >
+              {copied ? <Check size={12} className="text-green-400" /> : <Copy size={12} />}
+              {copied ? 'Copied!' : 'Copy Link'}
+            </button>
+          </div>
+        )}
+        {showMenu && (
+          <div className="fixed inset-0 z-[5]" onClick={() => setShowMenu(false)} />
+        )}
+      </div>
+    );
+  }
+
+  // Issued or viewed invoice
+  return (
+    <div className="relative inline-flex items-center gap-1">
+      <button
+        onClick={() => setShowMenu(!showMenu)}
+        className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-blue-300 bg-blue-500/20 rounded cursor-pointer hover:bg-blue-500/30 transition-colors"
+        title={invoice.status === 'viewed' ? 'Invoice viewed by recipient' : 'Invoice sent'}
+      >
+        <FileText size={12} />
+        {invoice.status === 'viewed' ? 'Viewed' : 'Issued'}
+      </button>
+      {showMenu && (
+        <div className="absolute top-full right-0 mt-1 z-10 bg-theme-header border border-theme-stroke rounded-lg shadow-lg py-1 min-w-[160px]">
+          {invoiceUrl && (
+            <button
+              onClick={() => { window.open(invoiceUrl, '_blank'); setShowMenu(false); }}
+              className="w-full px-3 py-1.5 text-xs text-left text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface transition-colors flex items-center gap-2"
+            >
+              <ExternalLink size={12} />
+              View Invoice
+            </button>
+          )}
+          <button
+            onClick={handleCopyUrl}
+            className="w-full px-3 py-1.5 text-xs text-left text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface transition-colors flex items-center gap-2"
+          >
+            {copied ? <Check size={12} className="text-green-400" /> : <Copy size={12} />}
+            {copied ? 'Copied!' : 'Copy Link'}
+          </button>
+          <button
+            onClick={handleResend}
+            className="w-full px-3 py-1.5 text-xs text-left text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface transition-colors flex items-center gap-2"
+          >
+            <Send size={12} />
+            Resend
+          </button>
+          <button
+            onClick={() => { setShowMenu(false); setShowForm(true); }}
+            className="w-full px-3 py-1.5 text-xs text-left text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface transition-colors flex items-center gap-2"
+          >
+            <FileText size={12} />
+            Edit Invoice
+          </button>
+          <button
+            onClick={() => { setShowMenu(false); setShowMarkPaid(true); }}
+            className="w-full px-3 py-1.5 text-xs text-left text-green-400 hover:bg-green-500/10 transition-colors flex items-center gap-2"
+          >
+            <DollarSign size={12} />
+            Mark Paid
+          </button>
+        </div>
+      )}
+      {showMenu && (
+        <div className="fixed inset-0 z-[5]" onClick={() => setShowMenu(false)} />
+      )}
+
+      {/* Edit form */}
+      {showForm && (
+        <InvoiceForm
+          sponsor={sponsor}
+          partyId={partyId}
+          existingInvoice={invoice}
+          onClose={() => setShowForm(false)}
+          onSave={(inv) => {
+            onInvoiceUpdate(inv);
+            setShowForm(false);
+          }}
+          onSponsorUpdate={onSponsorUpdate}
+        />
+      )}
+
+      {/* Mark Paid Modal */}
+      {showMarkPaid && (
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center">
+          <div
+            className="bg-theme-header border border-theme-stroke rounded-xl w-full max-w-sm mx-4 p-4 shadow-2xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold text-theme-text">Mark Invoice as Paid</h3>
+              <button onClick={() => setShowMarkPaid(false)} className="p-1 text-theme-text-muted hover:text-theme-text">
+                <X size={16} />
+              </button>
+            </div>
+
+            <div className="space-y-3 mb-4">
+              <div>
+                <select
+                  value={paymentMethod}
+                  onChange={e => setPaymentMethod(e.target.value)}
+                  className="w-full bg-theme-surface border border-theme-stroke rounded-xl px-4 py-2.5 text-sm text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a]"
+                >
+                  <option value="manual">Manual</option>
+                  <option value="usdc">USDC</option>
+                  <option value="wire">Wire Transfer</option>
+                  <option value="stripe">Stripe</option>
+                  <option value="check">Check</option>
+                </select>
+              </div>
+
+              <IconInput
+                icon={FileText}
+                value={paymentRef}
+                onChange={e => setPaymentRef(e.target.value)}
+                placeholder="Transaction hash, check #, etc."
+              />
+            </div>
+
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowMarkPaid(false)}
+                className="flex-1 px-3 py-2 text-sm text-theme-text-secondary hover:text-theme-text bg-theme-surface rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleMarkPaid}
+                disabled={loading}
+                className="flex-1 px-3 py-2 text-sm bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center justify-center gap-1"
+              >
+                {loading ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                Confirm
+              </button>
+            </div>
+          </div>
+          <div className="fixed inset-0 z-[-1]" onClick={() => setShowMarkPaid(false)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/sponsors/InvoiceForm.tsx
+++ b/frontend/src/components/sponsors/InvoiceForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import {
   X, Plus, Trash2, FileText, Send, Save, DollarSign, Building2,
   User, Mail, MapPin, Calendar, Loader2, AlertCircle
@@ -209,7 +210,7 @@ export function InvoiceForm({ sponsor, partyId, existingInvoice, onClose, onSave
     }
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-start justify-center overflow-y-auto py-8">
       <div ref={modalRef} className="bg-theme-header border border-theme-stroke rounded-xl w-full max-w-2xl mx-4 shadow-2xl">
         {/* Header */}
@@ -412,6 +413,7 @@ export function InvoiceForm({ sponsor, partyId, existingInvoice, onClose, onSave
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/frontend/src/components/sponsors/InvoiceForm.tsx
+++ b/frontend/src/components/sponsors/InvoiceForm.tsx
@@ -1,0 +1,417 @@
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  X, Plus, Trash2, FileText, Send, Save, DollarSign, Building2,
+  User, Mail, MapPin, Calendar, Loader2, AlertCircle
+} from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { Sponsor, Invoice, InvoiceLineItem, CreateInvoiceData, UpdateInvoiceData } from '../../types';
+import { createInvoice, updateInvoice, sendInvoice } from '../../lib/api';
+
+interface InvoiceFormProps {
+  sponsor: Sponsor;
+  partyId: string;
+  existingInvoice?: Invoice | null;
+  onClose: () => void;
+  onSave: (invoice: Invoice) => void;
+  onSponsorUpdate?: (sponsor: Sponsor) => void;
+}
+
+const PAYMENT_TERMS_OPTIONS = [
+  'Due on receipt',
+  'Net 15',
+  'Net 30',
+  'Net 60',
+];
+
+export function InvoiceForm({ sponsor, partyId, existingInvoice, onClose, onSave, onSponsorUpdate }: InvoiceFormProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showSendConfirm, setShowSendConfirm] = useState(false);
+
+  // Form state
+  const [billToCompany, setBillToCompany] = useState(existingInvoice?.billToCompany || sponsor.name || '');
+  const [billToContact, setBillToContact] = useState(existingInvoice?.billToContact || sponsor.contactName || '');
+  const [billToAddress, setBillToAddress] = useState(existingInvoice?.billToAddress || '');
+  const [billToEmail, setBillToEmail] = useState(existingInvoice?.billToEmail || sponsor.contactEmail || '');
+  const [ccEmails, setCcEmails] = useState(existingInvoice?.ccEmails?.join(', ') || '');
+  const [paymentTerms, setPaymentTerms] = useState(existingInvoice?.paymentTerms || '');
+  const [paymentInstructions, setPaymentInstructions] = useState(existingInvoice?.paymentInstructions || '');
+  const [dueDate, setDueDate] = useState(existingInvoice?.dueDate ? existingInvoice.dueDate.split('T')[0] : '');
+  const [memo, setMemo] = useState(existingInvoice?.memo || '');
+
+  // Line items
+  const getDefaultLineItems = (): InvoiceLineItem[] => {
+    if (existingInvoice?.lineItems && (existingInvoice.lineItems as InvoiceLineItem[]).length > 0) {
+      return existingInvoice.lineItems as InvoiceLineItem[];
+    }
+    // Pre-populate from sponsor amount
+    if (sponsor.amount) {
+      const amountInCents = Math.round(sponsor.amount * 100);
+      return [{
+        description: sponsor.sponsorshipType
+          ? `${sponsor.sponsorshipType.charAt(0).toUpperCase() + sponsor.sponsorshipType.slice(1)} Sponsorship`
+          : 'Sponsorship',
+        amount: amountInCents,
+      }];
+    }
+    return [{ description: '', amount: 0 }];
+  };
+
+  const [lineItems, setLineItems] = useState<InvoiceLineItem[]>(getDefaultLineItems);
+
+  // Auto-compute total
+  const total = lineItems.reduce((sum, item) => sum + (item.amount || 0), 0);
+
+  const formatDollarAmount = (cents: number) => {
+    return (cents / 100).toFixed(2);
+  };
+
+  const parseDollarAmount = (value: string): number => {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) return 0;
+    return Math.round(parsed * 100);
+  };
+
+  const handleLineItemChange = (index: number, field: 'description' | 'amount', value: string) => {
+    setLineItems(prev => prev.map((item, i) => {
+      if (i !== index) return item;
+      if (field === 'amount') {
+        return { ...item, amount: parseDollarAmount(value) };
+      }
+      return { ...item, [field]: value };
+    }));
+  };
+
+  const addLineItem = () => {
+    setLineItems(prev => [...prev, { description: '', amount: 0 }]);
+  };
+
+  const removeLineItem = (index: number) => {
+    if (lineItems.length <= 1) return;
+    setLineItems(prev => prev.filter((_, i) => i !== index));
+  };
+
+  // Click outside to close
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  const buildData = (): CreateInvoiceData & UpdateInvoiceData => ({
+    sponsorId: sponsor.id,
+    billToCompany: billToCompany.trim() || undefined,
+    billToContact: billToContact.trim() || undefined,
+    billToAddress: billToAddress.trim() || undefined,
+    billToEmail: billToEmail.trim(),
+    ccEmails: ccEmails.split(',').map(e => e.trim()).filter(Boolean),
+    lineItems: lineItems.filter(item => item.description.trim() || item.amount > 0),
+    total,
+    paymentTerms: paymentTerms || undefined,
+    paymentInstructions: paymentInstructions.trim() || undefined,
+    dueDate: dueDate || undefined,
+    memo: memo.trim() || undefined,
+    attachments: existingInvoice?.attachments || [],
+  });
+
+  const handleSaveDraft = async () => {
+    if (!billToEmail.trim()) {
+      setError('Recipient email is required');
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const data = buildData();
+      let result;
+
+      if (existingInvoice) {
+        result = await updateInvoice(partyId, existingInvoice.id, data);
+      } else {
+        result = await createInvoice(partyId, data);
+      }
+
+      if (result) {
+        onSave(result.invoice);
+        onClose();
+      } else {
+        setError('Failed to save invoice');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save invoice');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSendInvoice = async () => {
+    if (!billToEmail.trim()) {
+      setError('Recipient email is required');
+      return;
+    }
+
+    if (lineItems.filter(item => item.description.trim() && item.amount > 0).length === 0) {
+      setError('At least one line item with a description and amount is required');
+      return;
+    }
+
+    setIsSending(true);
+    setError(null);
+
+    try {
+      // Save first, then send
+      const data = buildData();
+      let invoice: Invoice;
+
+      if (existingInvoice) {
+        const updateResult = await updateInvoice(partyId, existingInvoice.id, data);
+        if (!updateResult) {
+          setError('Failed to save invoice');
+          return;
+        }
+        invoice = updateResult.invoice;
+      } else {
+        const createResult = await createInvoice(partyId, data);
+        if (!createResult) {
+          setError('Failed to create invoice');
+          return;
+        }
+        invoice = createResult.invoice;
+      }
+
+      // Send the invoice
+      const isResend = existingInvoice?.status === 'issued' || existingInvoice?.status === 'viewed';
+      const sendResult = await sendInvoice(partyId, invoice.id, isResend);
+
+      if (sendResult) {
+        onSave(sendResult.invoice);
+        // Update sponsor status to billed
+        if (onSponsorUpdate) {
+          onSponsorUpdate({ ...sponsor, status: 'billed' });
+        }
+        onClose();
+      } else {
+        setError('Failed to send invoice');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send invoice');
+    } finally {
+      setIsSending(false);
+      setShowSendConfirm(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-start justify-center overflow-y-auto py-8">
+      <div ref={modalRef} className="bg-theme-header border border-theme-stroke rounded-xl w-full max-w-2xl mx-4 shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-theme-stroke">
+          <div className="flex items-center gap-2">
+            <FileText size={20} className="text-theme-text-secondary" />
+            <h2 className="text-lg font-semibold text-theme-text">
+              {existingInvoice ? `Edit Invoice #${existingInvoice.invoiceNumber}` : 'New Invoice'}
+            </h2>
+          </div>
+          <button onClick={onClose} className="p-1.5 text-theme-text-muted hover:text-theme-text rounded transition-colors">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+              <AlertCircle size={16} />
+              {error}
+            </div>
+          )}
+
+          {/* Bill To Section */}
+          <div>
+            <h3 className="text-sm font-medium text-theme-text-secondary mb-2">Bill To</h3>
+            <div className="space-y-2">
+              <IconInput
+                icon={Building2}
+                value={billToCompany}
+                onChange={e => setBillToCompany(e.target.value)}
+                placeholder="Company name"
+              />
+              <IconInput
+                icon={User}
+                value={billToContact}
+                onChange={e => setBillToContact(e.target.value)}
+                placeholder="Contact person"
+              />
+              <IconInput
+                icon={MapPin}
+                multiline
+                rows={2}
+                value={billToAddress}
+                onChange={(e: any) => setBillToAddress(e.target.value)}
+                placeholder="Address (use semicolons for line breaks)"
+              />
+              <IconInput
+                icon={Mail}
+                type="email"
+                value={billToEmail}
+                onChange={e => setBillToEmail(e.target.value)}
+                placeholder="Invoice recipient email"
+                required
+              />
+              <IconInput
+                icon={Mail}
+                value={ccEmails}
+                onChange={e => setCcEmails(e.target.value)}
+                placeholder="CC emails, comma-separated"
+              />
+            </div>
+          </div>
+
+          {/* Line Items */}
+          <div>
+            <h3 className="text-sm font-medium text-theme-text-secondary mb-2">Line Items</h3>
+            <div className="space-y-2">
+              {lineItems.map((item, index) => (
+                <div key={index} className="flex gap-2 items-start">
+                  <div className="flex-1">
+                    <IconInput
+                      icon={FileText}
+                      value={item.description}
+                      onChange={e => handleLineItemChange(index, 'description', e.target.value)}
+                      placeholder="Sponsorship package"
+                    />
+                  </div>
+                  <div className="w-36">
+                    <IconInput
+                      icon={DollarSign}
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={item.amount ? formatDollarAmount(item.amount) : ''}
+                      onChange={e => handleLineItemChange(index, 'amount', e.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                  {lineItems.length > 1 && (
+                    <button
+                      onClick={() => removeLineItem(index)}
+                      className="p-2 text-theme-text-muted hover:text-red-400 transition-colors mt-0.5"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={addLineItem}
+              className="flex items-center gap-1 mt-2 px-3 py-1.5 text-xs text-theme-text-secondary hover:text-theme-text bg-theme-surface hover:bg-theme-surface-hover rounded transition-colors"
+            >
+              <Plus size={14} />
+              Add Line Item
+            </button>
+          </div>
+
+          {/* Total */}
+          <div className="flex items-center justify-between p-3 bg-theme-surface rounded-lg">
+            <span className="text-sm font-medium text-theme-text-secondary">Total</span>
+            <span className="text-lg font-bold text-theme-text">${formatDollarAmount(total)}</span>
+          </div>
+
+          {/* Payment Details */}
+          <div>
+            <h3 className="text-sm font-medium text-theme-text-secondary mb-2">Payment Details</h3>
+            <div className="space-y-2">
+              <IconInput
+                icon={FileText}
+                multiline
+                rows={2}
+                value={paymentInstructions}
+                onChange={(e: any) => setPaymentInstructions(e.target.value)}
+                placeholder="e.g. 500 USDC to dreadpizzaroberts.eth"
+              />
+
+              <div className="relative">
+                <select
+                  value={paymentTerms}
+                  onChange={e => setPaymentTerms(e.target.value)}
+                  className="w-full bg-theme-surface border border-theme-stroke rounded-xl px-4 py-2.5 text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none"
+                >
+                  <option value="">Payment terms...</option>
+                  {PAYMENT_TERMS_OPTIONS.map(term => (
+                    <option key={term} value={term}>{term}</option>
+                  ))}
+                </select>
+              </div>
+
+              <IconInput
+                icon={Calendar}
+                type="date"
+                value={dueDate}
+                onChange={e => setDueDate(e.target.value)}
+                placeholder="Due date"
+              />
+
+              <IconInput
+                icon={FileText}
+                multiline
+                rows={2}
+                value={memo}
+                onChange={(e: any) => setMemo(e.target.value)}
+                placeholder="Notes for the partner..."
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between p-4 border-t border-theme-stroke">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
+          >
+            Cancel
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleSaveDraft}
+              disabled={isSaving || isSending}
+              className="flex items-center gap-1.5 px-4 py-2 text-sm bg-theme-surface hover:bg-theme-surface-hover border border-theme-stroke text-theme-text rounded-lg transition-colors disabled:opacity-50"
+            >
+              {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+              Save Draft
+            </button>
+
+            {!showSendConfirm ? (
+              <button
+                onClick={() => setShowSendConfirm(true)}
+                disabled={isSaving || isSending}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm bg-[#ff393a] hover:bg-[#ff393a]/80 text-white rounded-lg transition-colors disabled:opacity-50"
+              >
+                <Send size={14} />
+                Send Invoice
+              </button>
+            ) : (
+              <button
+                onClick={handleSendInvoice}
+                disabled={isSaving || isSending}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors disabled:opacity-50 animate-pulse"
+              >
+                {isSending ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+                Confirm Send
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Plus, RefreshCw } from 'lucide-react';
-import { Sponsor, SponsorStats } from '../../types';
+import { Sponsor, SponsorStats, Invoice } from '../../types';
 import {
   getSponsors,
   getSponsorStats,
@@ -8,6 +8,7 @@ import {
   updateSponsor,
   deleteSponsor,
   updateFundraisingGoal,
+  getInvoices,
 } from '../../lib/api';
 import { SponsorPipeline } from './SponsorPipeline';
 import { SponsorList } from './SponsorList';
@@ -21,6 +22,7 @@ interface SponsorCRMProps {
 export function SponsorCRM({ partyId }: SponsorCRMProps) {
   const [sponsors, setSponsors] = useState<Sponsor[]>([]);
   const [stats, setStats] = useState<SponsorStats | null>(null);
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -36,9 +38,10 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
     setError(null);
 
     try {
-      const [sponsorsResult, statsResult] = await Promise.all([
+      const [sponsorsResult, statsResult, invoicesResult] = await Promise.all([
         getSponsors(partyId),
         getSponsorStats(partyId),
+        getInvoices(partyId),
       ]);
 
       if (sponsorsResult) {
@@ -46,6 +49,9 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
       }
       if (statsResult) {
         setStats(statsResult);
+      }
+      if (invoicesResult) {
+        setInvoices(invoicesResult.invoices);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load sponsors');
@@ -178,9 +184,17 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
       <SponsorList
         sponsors={sponsors}
         partyId={partyId}
+        invoices={invoices}
         onEdit={handleEdit}
         onDelete={handleDelete}
         onSponsorUpdate={(updated) => setSponsors(prev => prev.map(s => s.id === updated.id ? updated : s))}
+        onInvoiceUpdate={(invoice) => setInvoices(prev => {
+          const existing = prev.findIndex(i => i.id === invoice.id);
+          if (existing >= 0) {
+            return prev.map(i => i.id === invoice.id ? invoice : i);
+          }
+          return [invoice, ...prev];
+        })}
         isLoading={isRefreshing}
       />
 

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -3,15 +3,18 @@ import {
   ChevronUp, ChevronDown, Edit2, Trash2, ExternalLink,
   Mail, Phone, User, Building2, Calendar
 } from 'lucide-react';
-import { Sponsor, SponsorStatus } from '../../types';
+import { Sponsor, SponsorStatus, Invoice } from '../../types';
 import { PartnerIntakeButton } from './PartnerIntakeButton';
+import { InvoiceButton } from './InvoiceButton';
 
 interface SponsorListProps {
   sponsors: Sponsor[];
   partyId: string;
+  invoices?: Invoice[];
   onEdit: (sponsor: Sponsor) => void;
   onDelete: (sponsorId: string) => void;
   onSponsorUpdate: (sponsor: Sponsor) => void;
+  onInvoiceUpdate?: (invoice: Invoice) => void;
   isLoading?: boolean;
 }
 
@@ -40,7 +43,7 @@ const STATUS_ORDER: Record<SponsorStatus, number> = {
   skip: 7,
 };
 
-export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpdate, isLoading }: SponsorListProps) {
+export function SponsorList({ sponsors, partyId, invoices = [], onEdit, onDelete, onSponsorUpdate, onInvoiceUpdate, isLoading }: SponsorListProps) {
   const [sortField, setSortField] = useState<SortField>('createdAt');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [filterStatus, setFilterStatus] = useState<SponsorStatus | 'all'>('all');
@@ -325,6 +328,13 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                   {/* Actions */}
                   <td className="p-3">
                     <div className="flex items-center justify-end gap-1">
+                      <InvoiceButton
+                        sponsor={sponsor}
+                        partyId={partyId}
+                        invoice={invoices.find(inv => inv.sponsorId === sponsor.id) || null}
+                        onInvoiceUpdate={(inv) => onInvoiceUpdate?.(inv)}
+                        onSponsorUpdate={onSponsorUpdate}
+                      />
                       <PartnerIntakeButton
                         sponsor={sponsor}
                         partyId={partyId}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, Invoice, CreateInvoiceData, UpdateInvoiceData } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -953,6 +953,130 @@ export async function deleteSponsor(partyId: string, sponsorId: string): Promise
     return true;
   } catch (error) {
     console.error('Error deleting sponsor:', error);
+    return false;
+  }
+}
+
+// ============================================
+// Invoice API functions
+// ============================================
+
+// Get all invoices for a party
+export async function getInvoices(partyId: string): Promise<{ invoices: Invoice[] } | null> {
+  try {
+    return await apiRequest<{ invoices: Invoice[] }>(`/api/parties/${partyId}/invoices`, {
+      method: 'GET',
+    });
+  } catch (error) {
+    console.error('Error fetching invoices:', error);
+    return null;
+  }
+}
+
+// Get single invoice
+export async function getInvoice(partyId: string, invoiceId: string): Promise<{ invoice: Invoice } | null> {
+  try {
+    return await apiRequest<{ invoice: Invoice }>(`/api/parties/${partyId}/invoices/${invoiceId}`, {
+      method: 'GET',
+    });
+  } catch (error) {
+    console.error('Error fetching invoice:', error);
+    return null;
+  }
+}
+
+// Create a new invoice
+export async function createInvoice(partyId: string, data: CreateInvoiceData): Promise<{ invoice: Invoice } | null> {
+  try {
+    return await apiRequest<{ invoice: Invoice }>(`/api/parties/${partyId}/invoices`, {
+      method: 'POST',
+      body: data,
+    });
+  } catch (error) {
+    console.error('Error creating invoice:', error);
+    return null;
+  }
+}
+
+// Update an invoice
+export async function updateInvoice(partyId: string, invoiceId: string, data: UpdateInvoiceData): Promise<{ invoice: Invoice } | null> {
+  try {
+    return await apiRequest<{ invoice: Invoice }>(`/api/parties/${partyId}/invoices/${invoiceId}`, {
+      method: 'PATCH',
+      body: data,
+    });
+  } catch (error) {
+    console.error('Error updating invoice:', error);
+    return null;
+  }
+}
+
+// Delete a draft invoice
+export async function deleteInvoice(partyId: string, invoiceId: string): Promise<boolean> {
+  try {
+    await apiRequest<{ success: boolean }>(`/api/parties/${partyId}/invoices/${invoiceId}`, {
+      method: 'DELETE',
+    });
+    return true;
+  } catch (error) {
+    console.error('Error deleting invoice:', error);
+    return false;
+  }
+}
+
+// Send an invoice
+export async function sendInvoice(partyId: string, invoiceId: string, resend = false): Promise<{ invoice: Invoice; emailSent: boolean } | null> {
+  try {
+    return await apiRequest<{ invoice: Invoice; emailSent: boolean }>(`/api/parties/${partyId}/invoices/${invoiceId}/send`, {
+      method: 'POST',
+      body: { resend },
+    });
+  } catch (error) {
+    console.error('Error sending invoice:', error);
+    return null;
+  }
+}
+
+// Mark invoice as paid
+export async function markInvoicePaid(
+  partyId: string,
+  invoiceId: string,
+  data: { paymentMethod?: string; paymentRef?: string; paidAmount?: number }
+): Promise<{ invoice: Invoice } | null> {
+  try {
+    return await apiRequest<{ invoice: Invoice }>(`/api/parties/${partyId}/invoices/${invoiceId}/mark-paid`, {
+      method: 'POST',
+      body: data,
+    });
+  } catch (error) {
+    console.error('Error marking invoice paid:', error);
+    return null;
+  }
+}
+
+// Get public invoice by view token (no auth required)
+export async function getPublicInvoice(viewToken: string): Promise<{ invoice: Invoice } | null> {
+  try {
+    return await apiRequest<{ invoice: Invoice }>(`/api/invoice/${viewToken}`, {
+      method: 'GET',
+      requireAuth: false,
+    });
+  } catch (error) {
+    console.error('Error fetching public invoice:', error);
+    return null;
+  }
+}
+
+// Record invoice view (no auth required)
+export async function recordInvoiceView(viewToken: string): Promise<boolean> {
+  try {
+    await apiRequest<{ success: boolean }>(`/api/invoice/${viewToken}/record-view`, {
+      method: 'POST',
+      requireAuth: false,
+    });
+    return true;
+  } catch (error) {
+    console.error('Error recording invoice view:', error);
     return false;
   }
 }

--- a/frontend/src/pages/InvoicePage.tsx
+++ b/frontend/src/pages/InvoicePage.tsx
@@ -1,0 +1,250 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { Loader2, FileText, Download, AlertCircle } from 'lucide-react';
+import { Invoice, InvoiceLineItem } from '../types';
+import { getPublicInvoice, recordInvoiceView } from '../lib/api';
+
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
+
+export function InvoicePage() {
+  const { viewToken } = useParams<{ viewToken: string }>();
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!viewToken) return;
+
+    const loadInvoice = async () => {
+      setLoading(true);
+      try {
+        const result = await getPublicInvoice(viewToken);
+        if (result) {
+          setInvoice(result.invoice);
+          // Record view on first load
+          await recordInvoiceView(viewToken);
+        } else {
+          setError('Invoice not found');
+        }
+      } catch (err) {
+        setError('Failed to load invoice');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadInvoice();
+  }, [viewToken]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <Loader2 size={32} className="animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (error || !invoice) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="text-center">
+          <AlertCircle size={48} className="mx-auto text-gray-400 mb-4" />
+          <h1 className="text-xl font-semibold text-gray-800 mb-2">Invoice Not Found</h1>
+          <p className="text-gray-500">{error || 'This invoice link may be invalid or expired.'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const lineItems = (invoice.lineItems || []) as InvoiceLineItem[];
+
+  const formatAmount = (cents: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: (invoice.currency || 'usd').toUpperCase(),
+      minimumFractionDigits: 2,
+    }).format(cents / 100);
+  };
+
+  const invoiceDate = invoice.sentAt
+    ? new Date(invoice.sentAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+    : new Date(invoice.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  const dueDateText = invoice.dueDate
+    ? new Date(invoice.dueDate).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+    : null;
+
+  const addressLines = invoice.billToAddress
+    ? invoice.billToAddress.split(';').map(line => line.trim()).filter(Boolean)
+    : [];
+
+  const pdfUrl = `${API_URL}/api/invoice/${viewToken}/pdf`;
+
+  const statusBadge = () => {
+    switch (invoice.status) {
+      case 'paid':
+        return <span className="px-3 py-1 bg-green-100 text-green-700 text-sm font-medium rounded-full">Paid</span>;
+      case 'issued':
+      case 'viewed':
+        return <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm font-medium rounded-full">Outstanding</span>;
+      case 'draft':
+        return <span className="px-3 py-1 bg-gray-100 text-gray-600 text-sm font-medium rounded-full">Draft</span>;
+      case 'cancelled':
+        return <span className="px-3 py-1 bg-red-100 text-red-600 text-sm font-medium rounded-full">Cancelled</span>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      {/* Print styles */}
+      <style>{`
+        @media print {
+          .no-print { display: none !important; }
+          body { background: white !important; }
+          .invoice-container { box-shadow: none !important; border: none !important; max-width: 100% !important; }
+        }
+      `}</style>
+
+      <div className="min-h-screen bg-gray-50 py-8 px-4 print:bg-white print:py-0">
+        {/* Action bar */}
+        <div className="max-w-3xl mx-auto mb-4 flex items-center justify-between no-print">
+          <div className="flex items-center gap-2 text-gray-500 text-sm">
+            <FileText size={16} />
+            Invoice #{invoice.invoiceNumber}
+            {invoice.party?.name && <span>- {invoice.party.name}</span>}
+          </div>
+          <div className="flex items-center gap-2">
+            <a
+              href={pdfUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 px-4 py-2 text-sm bg-gray-800 hover:bg-gray-900 text-white rounded-lg transition-colors"
+            >
+              <Download size={14} />
+              Download PDF
+            </a>
+          </div>
+        </div>
+
+        {/* Invoice */}
+        <div className="invoice-container max-w-3xl mx-auto bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+          {/* Header */}
+          <div className="p-8 pb-6">
+            <div className="flex justify-between items-start">
+              <div>
+                <h1 className="text-3xl font-bold text-gray-900 mb-1">INVOICE</h1>
+                <p className="text-gray-500">{invoice.party?.name || ''}</p>
+              </div>
+              <div className="text-right">
+                <div className="flex items-center gap-3 justify-end mb-2">
+                  {statusBadge()}
+                </div>
+                <p className="text-gray-800 font-semibold">#{invoice.invoiceNumber}</p>
+                <p className="text-gray-500 text-sm">Date: {invoiceDate}</p>
+                {dueDateText && (
+                  <p className="text-gray-500 text-sm">Due: {dueDateText}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Bill To */}
+          <div className="px-8 pb-6">
+            <h3 className="text-xs uppercase tracking-wider text-gray-400 mb-2 font-medium">Bill To</h3>
+            <div className="text-gray-700">
+              {invoice.billToCompany && (
+                <p className="font-semibold text-gray-900">{invoice.billToCompany}</p>
+              )}
+              {invoice.billToContact && (
+                <p>ATTN: {invoice.billToContact}</p>
+              )}
+              {addressLines.map((line, i) => (
+                <p key={i}>{line}</p>
+              ))}
+              <p>{invoice.billToEmail}</p>
+            </div>
+          </div>
+
+          {/* Line Items Table */}
+          <div className="px-8 pb-6">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b-2 border-gray-900">
+                  <th className="py-3 text-left text-xs uppercase tracking-wider text-gray-500 font-medium">Description</th>
+                  <th className="py-3 text-right text-xs uppercase tracking-wider text-gray-500 font-medium">Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lineItems.map((item, index) => (
+                  <tr key={index} className="border-b border-gray-100">
+                    <td className="py-3 text-gray-700">{item.description}</td>
+                    <td className="py-3 text-right text-gray-700 whitespace-nowrap">{formatAmount(item.amount)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2 border-gray-900">
+                  <td className="py-4 font-bold text-lg text-gray-900">Total</td>
+                  <td className="py-4 text-right font-bold text-lg text-gray-900">{formatAmount(invoice.total)}</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          {/* Payment Info & Notes */}
+          {(invoice.paymentInstructions || invoice.paymentTerms || invoice.memo) && (
+            <div className="px-8 pb-8 space-y-4">
+              {invoice.paymentInstructions && (
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <h4 className="text-xs uppercase tracking-wider text-gray-400 mb-1 font-medium">Payment Instructions</h4>
+                  <p className="text-gray-700 whitespace-pre-wrap">{invoice.paymentInstructions}</p>
+                </div>
+              )}
+              {invoice.paymentTerms && (
+                <div>
+                  <span className="text-gray-500 text-sm font-medium">Terms: </span>
+                  <span className="text-gray-700 text-sm">{invoice.paymentTerms}</span>
+                </div>
+              )}
+              {invoice.memo && (
+                <div>
+                  <span className="text-gray-500 text-sm font-medium">Note: </span>
+                  <span className="text-gray-700 text-sm">{invoice.memo}</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Paid stamp */}
+          {invoice.status === 'paid' && (
+            <div className="px-8 pb-8">
+              <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
+                <p className="text-green-700 font-semibold text-lg">
+                  PAID
+                  {invoice.paidAt && (
+                    <span className="font-normal text-sm text-green-600 ml-2">
+                      on {new Date(invoice.paidAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                    </span>
+                  )}
+                </p>
+                {invoice.paymentMethod && (
+                  <p className="text-green-600 text-sm mt-1">
+                    via {invoice.paymentMethod}
+                    {invoice.paymentRef && ` (${invoice.paymentRef})`}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Footer */}
+          <div className="px-8 py-4 bg-gray-50 border-t border-gray-100 text-center text-xs text-gray-400">
+            Generated by <a href="https://rsv.pizza" className="text-gray-500 hover:text-gray-700">RSV.Pizza</a>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -463,6 +463,73 @@ export interface SponsorStats {
   statusCounts: Record<SponsorStatus, number>;
 }
 
+// Invoice types
+export type InvoiceStatus = 'draft' | 'issued' | 'viewed' | 'paid' | 'cancelled';
+
+export interface InvoiceLineItem {
+  description: string;
+  amount: number; // in cents
+}
+
+export interface Invoice {
+  id: string;
+  partyId: string;
+  sponsorId: string;
+  invoiceNumber: string;
+  viewToken: string;
+  billToCompany: string | null;
+  billToContact: string | null;
+  billToAddress: string | null;
+  billToEmail: string;
+  ccEmails: string[];
+  lineItems: InvoiceLineItem[];
+  total: number; // in cents
+  currency: string;
+  paymentTerms: string | null;
+  paymentInstructions: string | null;
+  dueDate: string | null;
+  memo: string | null;
+  status: InvoiceStatus;
+  paidAt: string | null;
+  paidAmount: number | null;
+  paymentMethod: string | null;
+  paymentRef: string | null;
+  sentAt: string | null;
+  viewedAt: string | null;
+  attachments: Array<{ name: string; url: string }>;
+  createdAt: string;
+  updatedAt: string;
+  sponsor?: {
+    id: string;
+    name: string;
+    contactEmail: string | null;
+    logoUrl: string | null;
+  };
+  party?: {
+    name: string;
+    eventImageUrl?: string | null;
+  };
+}
+
+export interface CreateInvoiceData {
+  sponsorId: string;
+  billToCompany?: string;
+  billToContact?: string;
+  billToAddress?: string;
+  billToEmail?: string;
+  ccEmails?: string[];
+  lineItems?: InvoiceLineItem[];
+  total?: number;
+  currency?: string;
+  paymentTerms?: string;
+  paymentInstructions?: string;
+  dueDate?: string;
+  memo?: string;
+  attachments?: Array<{ name: string; url: string }>;
+}
+
+export interface UpdateInvoiceData extends Partial<Omit<CreateInvoiceData, 'sponsorId'>> {}
+
 // Music/DJ Lineup types
 export type PerformerType = 'dj' | 'live_band' | 'solo' | 'playlist';
 export type PerformerStatus = 'pending' | 'confirmed' | 'cancelled';

--- a/supabase/migrations/20260413_create_invoices.sql
+++ b/supabase/migrations/20260413_create_invoices.sql
@@ -1,0 +1,63 @@
+-- Create invoices table for partner invoice management
+CREATE TABLE invoices (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id        UUID NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  sponsor_id      UUID NOT NULL REFERENCES sponsors(id) ON DELETE CASCADE,
+
+  -- Invoice identification
+  invoice_number  TEXT NOT NULL,
+  view_token      TEXT UNIQUE NOT NULL,
+
+  -- Bill-to (snapshot at invoice time)
+  bill_to_company TEXT,
+  bill_to_contact TEXT,
+  bill_to_address TEXT,
+  bill_to_email   TEXT NOT NULL,
+  cc_emails       TEXT[],
+
+  -- Line items (JSONB array)
+  -- Each: { description: string, amount: number (cents) }
+  line_items      JSONB NOT NULL DEFAULT '[]',
+
+  -- Totals (all in cents)
+  total           INTEGER NOT NULL DEFAULT 0,
+  currency        TEXT NOT NULL DEFAULT 'usd',
+
+  -- Payment info
+  payment_terms   TEXT,
+  payment_instructions TEXT,
+  due_date        DATE,
+  memo            TEXT,
+
+  -- Status: draft, issued, viewed, paid, cancelled
+  status          TEXT NOT NULL DEFAULT 'draft',
+
+  -- Payment tracking
+  paid_at         TIMESTAMPTZ,
+  paid_amount     INTEGER,
+  payment_method  TEXT,
+  payment_ref     TEXT,
+
+  -- Email tracking
+  sent_at         TIMESTAMPTZ,
+  viewed_at       TIMESTAMPTZ,
+
+  -- Extra document attachments (URLs)
+  attachments     JSONB DEFAULT '[]',
+
+  -- Metadata
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_invoices_party_id ON invoices(party_id);
+CREATE INDEX idx_invoices_sponsor_id ON invoices(sponsor_id);
+CREATE INDEX idx_invoices_view_token ON invoices(view_token);
+CREATE INDEX idx_invoices_status ON invoices(party_id, status);
+
+-- Prevent duplicate invoice numbers per party (only for active invoices)
+CREATE UNIQUE INDEX idx_invoices_unique_number
+  ON invoices(party_id, invoice_number)
+  WHERE status NOT IN ('cancelled');
+
+ALTER TABLE invoices ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- New invoices table with full CRUD API (draft, send, mark-paid)
- Invoice email via Resend with branded HTML template + line items summary
- Printable HTML invoice endpoint at /api/invoice/:token/pdf (browser print-to-PDF)
- InvoiceForm modal in Partner CRM with dynamic line items, auto-computed total
- InvoiceButton per-sponsor with status badges (Draft, Issued, Viewed, Paid) and action menus
- Public invoice view page at /invoice/:viewToken with professional layout + print CSS
- Auto-updates sponsor status: billed on send, paid on mark-paid
- Invoice number auto-generation (zero-padded per party, unique constraint)
- View token tracking (records viewed_at timestamp on first view)

## Test plan
- [ ] Create invoice from sponsor row in Partner CRM
- [ ] Verify bill-to fields pre-populate from sponsor data
- [ ] Add/remove line items, verify total auto-computes
- [ ] Save as draft, verify it persists
- [ ] Send invoice, verify email arrives with correct content
- [ ] View public invoice page via link
- [ ] Download PDF (print-to-PDF) from public page
- [ ] Mark paid, verify invoice and sponsor status updates
- [ ] Duplicate invoice number prevention (unique constraint)
- [ ] Only draft invoices can be deleted

Generated with Claude Code