### PR TITLE
feat: add notes field for events in underboss dashboard

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -155,6 +155,7 @@ model Party {
   hostStatus        String?  @map("host_status")
   underbossApproved Boolean  @default(false) @map("underboss_approved")
   hostTags          Json     @default("[]") @map("host_tags")
+  underbossNotes    String?  @map("underboss_notes")
 
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -203,6 +203,7 @@ function formatEvent(party: any, underbossEmails: string[] = []) {
     underbossApproved: party.underbossApproved || false,
     hostTags: party.hostTags || [],
     eventTags: party.eventTags || [],
+    underbossNotes: party.underbossNotes || null,
     createdAt: party.createdAt,
   };
 }
@@ -752,6 +753,28 @@ router.patch('/event/:partyId/tags', requireAuth, requireUnderbossAuth, async (r
       where: { id: partyId },
       data: { hostTags: cleanTags },
       select: { id: true, hostTags: true },
+    });
+
+    res.json({ party });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/underboss/event/:partyId/notes - Set underboss notes
+router.patch('/event/:partyId/notes', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { notes } = req.body;
+
+    if (notes !== null && typeof notes !== 'string') {
+      throw new AppError('notes must be a string or null', 400, 'VALIDATION_ERROR');
+    }
+
+    const party = await prisma.party.update({
+      where: { id: partyId },
+      data: { underbossNotes: notes || null },
+      select: { id: true, underbossNotes: true },
     });
 
     res.json({ party });

--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X } from 'lucide-react';
+import React, { useState, useRef, useCallback } from 'react';
+import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, StickyNote } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
-import { updateHostStatus, updateHostTags } from '../../lib/api';
+import { IconInput } from '../IconInput';
+import { updateHostStatus, updateHostTags, updateUnderbossNotes } from '../../lib/api';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
 interface EventCardProps {
@@ -204,6 +205,38 @@ function HostTagsPills({
 export function EventCard({ event, showRegion, onEventUpdate, isSelected, onToggleSelect }: EventCardProps) {
   const [hostStatus, setHostStatus] = useState<HostStatus | null>(event.hostStatus);
   const [hostTags, setHostTags] = useState<string[]>(event.hostTags || []);
+  const [notesOpen, setNotesOpen] = useState(false);
+  const [notesValue, setNotesValue] = useState(event.underbossNotes || '');
+  const [notesSaving, setNotesSaving] = useState(false);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveNotes = useCallback(async (value: string) => {
+    const trimmed = value.trim();
+    const newValue = trimmed || null;
+    setNotesSaving(true);
+    onEventUpdate?.(event.id, { underbossNotes: newValue });
+    try {
+      await updateUnderbossNotes(event.id, newValue);
+    } catch {
+      setNotesValue(event.underbossNotes || '');
+      onEventUpdate?.(event.id, { underbossNotes: event.underbossNotes });
+    } finally {
+      setNotesSaving(false);
+    }
+  }, [event.id, event.underbossNotes, onEventUpdate]);
+
+  const handleNotesChange = useCallback((value: string) => {
+    setNotesValue(value);
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    saveTimeoutRef.current = setTimeout(() => saveNotes(value), 1000);
+  }, [saveNotes]);
+
+  const handleNotesBlur = useCallback(() => {
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    saveNotes(notesValue);
+  }, [notesValue, saveNotes]);
+
+  const hasNotes = !!(event.underbossNotes || notesValue.trim());
 
   const eventUrl = event.customUrl ? `https://rsv.pizza/${event.customUrl}` : null;
   const relTime = formatRelativeTime(event.date);
@@ -236,6 +269,17 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
                 <ExternalLink size={12} />
               </a>
             )}
+            <button
+              onClick={() => setNotesOpen(!notesOpen)}
+              className={`transition-colors shrink-0 ${
+                hasNotes
+                  ? 'text-amber-400 hover:text-amber-300'
+                  : 'text-theme-text-faint hover:text-theme-text-secondary'
+              }`}
+              title={hasNotes ? 'Edit notes' : 'Add notes'}
+            >
+              <StickyNote size={12} />
+            </button>
           </div>
 
           {/* Date */}
@@ -253,6 +297,36 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
               </>
             )}
           </div>
+
+          {/* Inline notes editor */}
+          {notesOpen && (
+            <div className="mt-1.5">
+              <IconInput
+                icon={StickyNote}
+                iconSize={12}
+                placeholder="Underboss notes..."
+                value={notesValue}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleNotesChange(e.target.value)}
+                onBlur={handleNotesBlur}
+                multiline
+                rows={2}
+                className="bg-theme-surface border border-theme-stroke rounded-lg text-xs text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover !pl-8 py-1.5 pr-2"
+              />
+              {notesSaving && (
+                <span className="text-[10px] text-theme-text-faint mt-0.5 block">Saving...</span>
+              )}
+            </div>
+          )}
+          {/* Show notes preview when collapsed */}
+          {!notesOpen && hasNotes && (
+            <button
+              onClick={() => setNotesOpen(true)}
+              className="text-[11px] text-amber-400/70 truncate max-w-full mt-0.5 text-left hover:text-amber-400 transition-colors block"
+              title={notesValue}
+            >
+              {notesValue}
+            </button>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake } from 'lucide-react';
+import React, { useState, useRef, useCallback } from 'react';
+import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
-import { updateHostStatus, updateHostTags } from '../../lib/api';
+import { IconInput } from '../IconInput';
+import { updateHostStatus, updateHostTags, updateUnderbossNotes } from '../../lib/api';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
 interface EventRowProps {
@@ -232,6 +233,39 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
   // Local state for optimistic updates
   const [hostStatus, setHostStatus] = useState<HostStatus | null>(event.hostStatus);
   const [hostTags, setHostTags] = useState<string[]>(event.hostTags || []);
+  const [notesOpen, setNotesOpen] = useState(false);
+  const [notesValue, setNotesValue] = useState(event.underbossNotes || '');
+  const [notesSaving, setNotesSaving] = useState(false);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveNotes = useCallback(async (value: string) => {
+    const trimmed = value.trim();
+    const newValue = trimmed || null;
+    setNotesSaving(true);
+    onEventUpdate?.(event.id, { underbossNotes: newValue });
+    try {
+      await updateUnderbossNotes(event.id, newValue);
+    } catch {
+      // Revert on error
+      setNotesValue(event.underbossNotes || '');
+      onEventUpdate?.(event.id, { underbossNotes: event.underbossNotes });
+    } finally {
+      setNotesSaving(false);
+    }
+  }, [event.id, event.underbossNotes, onEventUpdate]);
+
+  const handleNotesChange = useCallback((value: string) => {
+    setNotesValue(value);
+    // Debounce auto-save
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    saveTimeoutRef.current = setTimeout(() => saveNotes(value), 1000);
+  }, [saveNotes]);
+
+  const handleNotesBlur = useCallback(() => {
+    // Save immediately on blur
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    saveNotes(notesValue);
+  }, [notesValue, saveNotes]);
 
   const eventUrl = event.customUrl
     ? `https://rsv.pizza/${event.customUrl}`
@@ -239,6 +273,8 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
 
   const relTime = formatRelativeTime(event.date);
   const fullDate = formatFullDate(event.date);
+
+  const hasNotes = !!(event.underbossNotes || notesValue.trim());
 
   return (
     <tr className="border-b border-theme-stroke hover:bg-theme-surface transition-colors">
@@ -276,6 +312,17 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                   <ExternalLink size={12} />
                 </a>
               )}
+              <button
+                onClick={() => setNotesOpen(!notesOpen)}
+                className={`transition-colors shrink-0 ${
+                  hasNotes
+                    ? 'text-amber-400 hover:text-amber-300'
+                    : 'text-theme-text-faint hover:text-theme-text-secondary'
+                }`}
+                title={hasNotes ? 'Edit notes' : 'Add notes'}
+              >
+                <StickyNote size={12} />
+              </button>
             </div>
             <div className="flex items-center gap-1.5 mt-0.5" title={fullDate}>
               <Calendar size={10} className="text-theme-text-faint" />
@@ -283,6 +330,35 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                 {relTime.text}
               </span>
             </div>
+            {/* Inline notes editor */}
+            {notesOpen && (
+              <div className="mt-1.5">
+                <IconInput
+                  icon={StickyNote}
+                  iconSize={12}
+                  placeholder="Underboss notes..."
+                  value={notesValue}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleNotesChange(e.target.value)}
+                  onBlur={handleNotesBlur}
+                  multiline
+                  rows={2}
+                  className="bg-theme-surface border border-theme-stroke rounded-lg text-xs text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover !pl-8 py-1.5 pr-2"
+                />
+                {notesSaving && (
+                  <span className="text-[10px] text-theme-text-faint mt-0.5 block">Saving...</span>
+                )}
+              </div>
+            )}
+            {/* Show notes preview when collapsed */}
+            {!notesOpen && hasNotes && (
+              <button
+                onClick={() => setNotesOpen(true)}
+                className="text-[11px] text-amber-400/70 truncate max-w-[180px] mt-0.5 text-left hover:text-amber-400 transition-colors block"
+                title={notesValue}
+              >
+                {notesValue}
+              </button>
+            )}
           </div>
         </div>
       </td>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2409,6 +2409,17 @@ export async function updateHostTags(
   });
 }
 
+// Update underboss notes on an event (underboss auth)
+export async function updateUnderbossNotes(
+  partyId: string,
+  notes: string | null
+): Promise<void> {
+  await apiRequest(`/api/underboss/event/${partyId}/notes`, {
+    method: 'PATCH',
+    body: { notes },
+  });
+}
+
 // Bulk approve events (underboss auth)
 export async function bulkApproveEvents(partyIds: string[], approved: boolean = true): Promise<void> {
   await apiRequest('/api/underboss/events/bulk-approve', {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -988,6 +988,7 @@ export interface UnderbossEvent {
   underbossApproved: boolean;
   hostTags: string[];
   eventTags: string[];
+  underbossNotes: string | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- Adds an editable **underboss notes** field per event in the `/underboss` dashboard
- Underbosses can click the sticky note icon next to any event name to expand an inline textarea
- Notes auto-save with a 1-second debounce and save immediately on blur
- When notes exist, the icon turns amber and a truncated preview appears below the event name
- Works on both desktop (table rows) and mobile (event cards)

## Changes
- **Prisma schema**: Added `underboss_notes` column to `Party` model
- **Backend**: New `PATCH /api/underboss/event/:partyId/notes` endpoint
- **Backend**: `formatEvent()` now includes `underbossNotes` in dashboard response
- **Frontend types**: Added `underbossNotes` to `UnderbossEvent` interface
- **Frontend API**: Added `updateUnderbossNotes()` function
- **EventRow.tsx**: Inline notes editor with debounced save, amber indicator
- **EventCard.tsx**: Same notes editor for mobile card view

## Important: DB Migration Required
This adds a new `underboss_notes` column to the `parties` table. The **Supabase migration must be applied** before this works:
```sql
ALTER TABLE parties ADD COLUMN underboss_notes TEXT;
```
And the **backend must be redeployed** to production for the preview to work (since previews share the production backend).

## Test plan
- [ ] Apply DB migration to add `underboss_notes` column
- [ ] Deploy backend to production
- [ ] Visit `/underboss` dashboard
- [ ] Click the sticky note icon on any event -- textarea should expand
- [ ] Type notes and click away -- should auto-save
- [ ] Refresh page -- notes should persist
- [ ] Verify amber icon appears for events with notes
- [ ] Verify truncated preview text shows below event name when notes panel is collapsed
- [ ] Test on mobile view (card layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)