### PR TITLE
feat: Previous-year photos host management

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -157,6 +157,10 @@ model Party {
   hostTags          Json     @default("[]") @map("host_tags")
   underbossNotes    String?  @map("underboss_notes")
 
+  // GPP (Global Pizza Party/Previous year) photo management
+  hiddenGppPhotos  Json  @default("[]") @map("hidden_gpp_photos")  // Array of hidden app.gpp.day photo src paths
+  extraGppPhotos   Json  @default("[]") @map("extra_gpp_photos")   // Array of host-uploaded previous year photo URLs
+
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -48,6 +48,8 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         nftChain: true,
         photosEnabled: true,
         photosPublic: true,
+        hiddenGppPhotos: true,
+        extraGppPhotos: true,
         password: true, // Just to check if it exists
         userId: true,
         user: {
@@ -222,6 +224,8 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         nftChain: party.nftChain,
         photosEnabled: party.photosEnabled,
         photosPublic: party.photosPublic,
+        hiddenGppPhotos: party.hiddenGppPhotos || [],
+        extraGppPhotos: party.extraGppPhotos || [],
         hasPassword: !!party.password,
         hostName: party.eventType === 'gpp' ? 'PizzaDAO' : (party.user?.name || null),
         hostProfile,

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -393,7 +393,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       nftEnabled, nftChain,
       pinnedApps,
       region,
-      venueReportTitle, venueReportNotes
+      venueReportTitle, venueReportNotes,
+      hiddenGppPhotos, extraGppPhotos
     } = req.body;
 
     // Verify ownership or super admin
@@ -485,6 +486,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(region !== undefined && { region: region || null }),
         ...(venueReportTitle !== undefined && { venueReportTitle: venueReportTitle || null }),
         ...(venueReportNotes !== undefined && { venueReportNotes: venueReportNotes || null }),
+        ...(hiddenGppPhotos !== undefined && { hiddenGppPhotos }),
+        ...(extraGppPhotos !== undefined && { extraGppPhotos }),
       },
       include: {
         user: { select: { name: true } },

--- a/frontend/src/components/LastYearPhotos.tsx
+++ b/frontend/src/components/LastYearPhotos.tsx
@@ -48,6 +48,7 @@ async function fetchManifest(): Promise<GppManifest | null> {
 }
 
 interface PhotoItem {
+  src: string; // Raw src path (manifest) or URL (extra) — used as identifier for hiding
   url: string;
   year: number;
   index: number;
@@ -55,10 +56,12 @@ interface PhotoItem {
 
 interface LastYearPhotosProps {
   customUrl: string;
+  hiddenGppPhotos?: string[];
+  extraGppPhotos?: string[];
 }
 
-export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
-  const [photos, setPhotos] = useState<PhotoItem[]>([]);
+export function LastYearPhotos({ customUrl, hiddenGppPhotos = [], extraGppPhotos = [] }: LastYearPhotosProps) {
+  const [rawManifestPhotos, setRawManifestPhotos] = useState<PhotoItem[]>([]);
   const [cityName, setCityName] = useState('');
   const [loading, setLoading] = useState(true);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
@@ -73,7 +76,7 @@ export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
         return;
       }
 
-      // Match city: normalize DOW name to lowercase-no-spaces, compare with customUrl
+      // Match city: normalize name to lowercase-no-spaces, compare with customUrl
       const normalizedCustomUrl = customUrl.toLowerCase().replace(/\s+/g, '');
       const city = manifest.cities.find(
         (c) => c.name.toLowerCase().replace(/\s+/g, '') === normalizedCustomUrl
@@ -84,19 +87,23 @@ export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
         return;
       }
 
-      // Use the most recent year's photos
+      // Collect ALL years' photos (sorted most recent first)
       const sortedYears = [...city.years].sort((a, b) => b.year - a.year);
-      const latestYear = sortedYears[0];
-
-      const photoItems: PhotoItem[] = latestYear.photos.map((p, i) => ({
-        url: `${GPP_BASE_URL}${p.src}`,
-        year: latestYear.year,
-        index: i + 1,
-      }));
+      const allPhotos: PhotoItem[] = [];
+      for (const yearData of sortedYears) {
+        for (let i = 0; i < yearData.photos.length; i++) {
+          allPhotos.push({
+            src: yearData.photos[i].src,
+            url: `${GPP_BASE_URL}${yearData.photos[i].src}`,
+            year: yearData.year,
+            index: i + 1,
+          });
+        }
+      }
 
       if (!cancelled) {
         setCityName(city.name);
-        setPhotos(photoItems);
+        setRawManifestPhotos(allPhotos);
         setLoading(false);
       }
     })();
@@ -105,6 +112,22 @@ export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
       cancelled = true;
     };
   }, [customUrl]);
+
+  // Filter at render time — avoids stale closure over hiddenGppPhotos
+  const hiddenSet = new Set(hiddenGppPhotos);
+
+  const manifestPhotos = rawManifestPhotos.filter((p) => !hiddenSet.has(p.src));
+
+  const extraPhotoItems: PhotoItem[] = extraGppPhotos
+    .filter((url) => !hiddenSet.has(url))
+    .map((url, i) => ({
+      src: url,
+      url,
+      year: 0,
+      index: i + 1,
+    }));
+
+  const photos = [...manifestPhotos, ...extraPhotoItems];
 
   // Lightbox navigation
   const openLightbox = useCallback((index: number) => {
@@ -163,7 +186,7 @@ export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
     <div className="space-y-4">
       {/* Header */}
       <h2 className="text-lg font-semibold text-theme-text">
-        Last Year's Party{cityName ? ` in ${cityName}` : ''}
+        Previous Years' Parties{cityName ? ` in ${cityName}` : ''}
         <span className="text-theme-text-muted font-normal text-sm ml-2">
           ({photos.length})
         </span>
@@ -173,13 +196,13 @@ export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
         {photos.map((photo, index) => (
           <div
-            key={`${photo.year}-${photo.index}`}
+            key={`${photo.year}-${photo.index}-${photo.url}`}
             className="group relative aspect-square rounded-xl overflow-hidden bg-theme-surface cursor-pointer"
             onClick={() => openLightbox(index)}
           >
             <img
               src={photo.url}
-              alt={`${cityName} pizza party ${photo.year} — photo ${photo.index}`}
+              alt={`${cityName} pizza party ${photo.year > 0 ? photo.year : 'previous year'} — photo ${photo.index}`}
               loading="lazy"
               className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
             />
@@ -240,7 +263,7 @@ export function LastYearPhotos({ customUrl }: LastYearPhotosProps) {
             >
               <img
                 src={photos[lightboxIndex].url}
-                alt={`${cityName} pizza party ${photos[lightboxIndex].year} — photo ${photos[lightboxIndex].index}`}
+                alt={`${cityName} pizza party ${photos[lightboxIndex].year > 0 ? photos[lightboxIndex].year : 'previous year'} — photo ${photos[lightboxIndex].index}`}
                 className="max-w-full max-h-[85vh] object-contain rounded-lg"
               />
             </div>

--- a/frontend/src/components/PreviousYearPhotos.tsx
+++ b/frontend/src/components/PreviousYearPhotos.tsx
@@ -1,0 +1,654 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  ChevronLeft,
+  ChevronRight,
+  X,
+  Eye,
+  EyeOff,
+  Upload,
+  Loader2,
+  Trash2,
+  Image as ImageIcon,
+} from 'lucide-react';
+import { usePizza } from '../contexts/PizzaContext';
+import { updateParty, uploadEventPhoto } from '../lib/supabase';
+
+const GPP_PHOTOS_URL = 'https://app.gpp.day/api/photos.json';
+const GPP_BASE_URL = 'https://app.gpp.day';
+
+interface GppCity {
+  slug: string;
+  name: string;
+  lat: number;
+  lng: number;
+  countryCode: string;
+  years: {
+    year: number;
+    photos: { src: string }[];
+  }[];
+}
+
+interface GppManifest {
+  cities: GppCity[];
+}
+
+// Module-level cache so we only fetch once across all instances
+let manifestCache: GppManifest | null = null;
+let manifestPromise: Promise<GppManifest | null> | null = null;
+
+async function fetchManifest(): Promise<GppManifest | null> {
+  if (manifestCache) return manifestCache;
+  if (manifestPromise) return manifestPromise;
+
+  manifestPromise = fetch(GPP_PHOTOS_URL)
+    .then((res) => {
+      if (!res.ok) throw new Error(`Failed to fetch photos manifest: ${res.status}`);
+      return res.json() as Promise<GppManifest>;
+    })
+    .then((data) => {
+      manifestCache = data;
+      return data;
+    })
+    .catch((err) => {
+      console.error('Error fetching GPP photos manifest:', err);
+      manifestPromise = null;
+      return null;
+    });
+
+  return manifestPromise;
+}
+
+interface PhotoItem {
+  src: string; // The raw src path from manifest (used as identifier)
+  url: string; // Full URL for display
+  year: number;
+  index: number;
+  isExtra?: boolean; // Host-uploaded photo
+}
+
+export function PreviousYearPhotos() {
+  const { party, loadParty } = usePizza();
+  const [photos, setPhotos] = useState<PhotoItem[]>([]);
+  const [cityName, setCityName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [hiddenSrcs, setHiddenSrcs] = useState<Set<string>>(new Set());
+  const [extraPhotos, setExtraPhotos] = useState<string[]>([]);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [showUploadArea, setShowUploadArea] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Initialize from party data
+  useEffect(() => {
+    if (party) {
+      setHiddenSrcs(new Set(party.hiddenGppPhotos || []));
+      setExtraPhotos(party.extraGppPhotos || []);
+    }
+  }, [party?.hiddenGppPhotos, party?.extraGppPhotos]);
+
+  // Fetch manifest photos
+  useEffect(() => {
+    if (!party?.customUrl) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      const manifest = await fetchManifest();
+      if (cancelled || !manifest) {
+        if (!cancelled) setLoading(false);
+        return;
+      }
+
+      const normalizedCustomUrl = party.customUrl!.toLowerCase().replace(/\s+/g, '');
+      const city = manifest.cities.find(
+        (c) => c.name.toLowerCase().replace(/\s+/g, '') === normalizedCustomUrl
+      );
+
+      if (!city || city.years.length === 0) {
+        if (!cancelled) setLoading(false);
+        return;
+      }
+
+      // Collect all years' photos, sorted by year (most recent first)
+      const sortedYears = [...city.years].sort((a, b) => b.year - a.year);
+      const allPhotos: PhotoItem[] = [];
+      for (const yearData of sortedYears) {
+        for (let i = 0; i < yearData.photos.length; i++) {
+          allPhotos.push({
+            src: yearData.photos[i].src,
+            url: `${GPP_BASE_URL}${yearData.photos[i].src}`,
+            year: yearData.year,
+            index: i + 1,
+          });
+        }
+      }
+
+      if (!cancelled) {
+        setCityName(city.name);
+        setPhotos(allPhotos);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [party?.customUrl]);
+
+  // Build the combined list of all photos (manifest + extra)
+  const allPhotos: PhotoItem[] = [
+    ...photos,
+    ...extraPhotos.map((url, i) => ({
+      src: url, // Use URL as identifier for extras
+      url,
+      year: 0,
+      index: i + 1,
+      isExtra: true,
+    })),
+  ];
+
+  const visibleCount = allPhotos.filter((p) => !hiddenSrcs.has(p.src)).length;
+  const hiddenCount = allPhotos.filter((p) => hiddenSrcs.has(p.src)).length;
+
+  // Toggle visibility
+  const togglePhoto = useCallback(
+    async (src: string) => {
+      if (!party) return;
+
+      const newHidden = new Set(hiddenSrcs);
+      if (newHidden.has(src)) {
+        newHidden.delete(src);
+      } else {
+        newHidden.add(src);
+      }
+
+      // Optimistic update
+      setHiddenSrcs(newHidden);
+
+      setSaving(true);
+      const success = await updateParty(party.id, {
+        hidden_gpp_photos: Array.from(newHidden),
+      });
+      setSaving(false);
+
+      if (!success) {
+        // Revert on failure
+        setHiddenSrcs(hiddenSrcs);
+        if (party.inviteCode) {
+          loadParty(party.inviteCode);
+        }
+      }
+    },
+    [party, hiddenSrcs, loadParty]
+  );
+
+  // Remove an extra photo
+  const removeExtraPhoto = useCallback(
+    async (url: string) => {
+      if (!party) return;
+
+      const newExtras = extraPhotos.filter((u) => u !== url);
+
+      // Also remove from hidden if it was hidden
+      const newHidden = new Set(hiddenSrcs);
+      newHidden.delete(url);
+
+      // Optimistic update
+      setExtraPhotos(newExtras);
+      setHiddenSrcs(newHidden);
+
+      setSaving(true);
+      const success = await updateParty(party.id, {
+        extra_gpp_photos: newExtras,
+        hidden_gpp_photos: Array.from(newHidden),
+      });
+      setSaving(false);
+
+      if (!success) {
+        // Revert
+        setExtraPhotos(extraPhotos);
+        setHiddenSrcs(hiddenSrcs);
+        if (party.inviteCode) {
+          loadParty(party.inviteCode);
+        }
+      }
+    },
+    [party, extraPhotos, hiddenSrcs, loadParty]
+  );
+
+  // Upload handler
+  const handleUploadFiles = useCallback(
+    async (files: FileList | File[]) => {
+      if (!party) return;
+
+      setUploading(true);
+      const newUrls: string[] = [];
+
+      for (const file of Array.from(files)) {
+        if (!file.type.startsWith('image/')) continue;
+        if (file.size > 10 * 1024 * 1024) continue;
+
+        const result = await uploadEventPhoto(file, party.id);
+        if (result) {
+          newUrls.push(result.url);
+        }
+      }
+
+      if (newUrls.length > 0) {
+        const updatedExtras = [...extraPhotos, ...newUrls];
+        setExtraPhotos(updatedExtras);
+
+        const success = await updateParty(party.id, {
+          extra_gpp_photos: updatedExtras,
+        });
+
+        if (!success) {
+          setExtraPhotos(extraPhotos);
+          if (party.inviteCode) {
+            loadParty(party.inviteCode);
+          }
+        }
+      }
+
+      setUploading(false);
+      setShowUploadArea(false);
+    },
+    [party, extraPhotos, loadParty]
+  );
+
+  // Lightbox navigation
+  const openLightbox = useCallback((index: number) => {
+    setLightboxIndex(index);
+  }, []);
+
+  const closeLightbox = useCallback(() => {
+    setLightboxIndex(null);
+  }, []);
+
+  const navigateLightbox = useCallback(
+    (direction: 'prev' | 'next') => {
+      setLightboxIndex((current) => {
+        if (current === null) return null;
+        if (direction === 'prev') return current > 0 ? current - 1 : current;
+        return current < allPhotos.length - 1 ? current + 1 : current;
+      });
+    },
+    [allPhotos.length]
+  );
+
+  // Keyboard navigation for lightbox
+  useEffect(() => {
+    if (lightboxIndex === null) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeLightbox();
+      else if (e.key === 'ArrowLeft') navigateLightbox('prev');
+      else if (e.key === 'ArrowRight') navigateLightbox('next');
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [lightboxIndex, closeLightbox, navigateLightbox]);
+
+  // Lock body scroll when lightbox is open
+  useEffect(() => {
+    if (lightboxIndex !== null) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [lightboxIndex]);
+
+  // Only show for GPP events with a customUrl
+  if (!party || party.eventType !== 'gpp' || !party.customUrl) return null;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 text-[#ff393a] animate-spin" />
+      </div>
+    );
+  }
+
+  // Show even if no manifest photos — host might want to upload extras
+  if (allPhotos.length === 0 && !showUploadArea) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-theme-text">
+            Photos from Previous Years
+          </h2>
+          <button
+            onClick={() => setShowUploadArea(true)}
+            className="flex items-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-4 py-2 rounded-lg transition-colors text-sm"
+          >
+            <Upload size={16} />
+            Upload
+          </button>
+        </div>
+
+        <div className="text-center py-8 bg-theme-surface rounded-xl">
+          <ImageIcon className="w-10 h-10 text-theme-text-faint mx-auto mb-3" />
+          <p className="text-theme-text-secondary text-sm">
+            {photos.length === 0
+              ? 'No previous year photos found for this city. Upload your own!'
+              : 'No photos to display.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h2 className="text-lg font-semibold text-theme-text">
+          Photos from Previous Years{cityName ? ` in ${cityName}` : ''}
+          <span className="text-theme-text-muted font-normal text-sm ml-2">
+            ({visibleCount} visible{hiddenCount > 0 ? `, ${hiddenCount} hidden` : ''})
+          </span>
+        </h2>
+
+        <div className="flex items-center gap-2">
+          {saving && (
+            <span className="text-theme-text-muted text-xs flex items-center gap-1">
+              <Loader2 size={12} className="animate-spin" />
+              Saving...
+            </span>
+          )}
+          <button
+            onClick={() => setShowUploadArea(true)}
+            className="flex items-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-4 py-2 rounded-lg transition-colors text-sm"
+          >
+            <Upload size={16} />
+            <span className="hidden sm:inline">Upload</span>
+          </button>
+        </div>
+      </div>
+
+      <p className="text-theme-text-muted text-xs">
+        Click the eye icon to show/hide photos on your public event page. Hidden photos will not be visible to guests.
+      </p>
+
+      {/* Photo Grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+        {allPhotos.map((photo, index) => {
+          const isHidden = hiddenSrcs.has(photo.src);
+          return (
+            <div
+              key={photo.src}
+              className={`group relative aspect-square rounded-xl overflow-hidden bg-theme-surface ${
+                isHidden ? 'opacity-40' : ''
+              }`}
+            >
+              {/* Image */}
+              <img
+                src={photo.url}
+                alt={
+                  photo.isExtra
+                    ? `Uploaded photo ${photo.index}`
+                    : `${cityName} ${photo.year} - photo ${photo.index}`
+                }
+                loading="lazy"
+                className="w-full h-full object-cover cursor-pointer"
+                onClick={() => openLightbox(index)}
+              />
+
+              {/* Overlay gradient */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+
+              {/* Year badge */}
+              {photo.year > 0 && (
+                <span className="absolute top-2 left-2 text-[10px] font-medium bg-black/60 text-white/80 px-2 py-0.5 rounded-full">
+                  {photo.year}
+                </span>
+              )}
+              {photo.isExtra && (
+                <span className="absolute top-2 left-2 text-[10px] font-medium bg-[#ff393a]/80 text-white px-2 py-0.5 rounded-full">
+                  Uploaded
+                </span>
+              )}
+
+              {/* Action buttons */}
+              <div className="absolute bottom-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    togglePhoto(photo.src);
+                  }}
+                  className={`p-1.5 rounded-full transition-colors ${
+                    isHidden
+                      ? 'bg-red-500/80 text-white hover:bg-red-500'
+                      : 'bg-white/20 text-white hover:bg-white/30'
+                  }`}
+                  title={isHidden ? 'Show on event page' : 'Hide from event page'}
+                >
+                  {isHidden ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
+
+                {photo.isExtra && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeExtraPhoto(photo.url);
+                    }}
+                    className="p-1.5 rounded-full bg-white/20 text-white hover:bg-red-500/80 transition-colors"
+                    title="Remove uploaded photo"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Upload Modal */}
+      {showUploadArea &&
+        createPortal(
+          <UploadModal
+            uploading={uploading}
+            dragging={dragging}
+            setDragging={setDragging}
+            fileInputRef={fileInputRef}
+            onFiles={handleUploadFiles}
+            onClose={() => setShowUploadArea(false)}
+          />,
+          document.body
+        )}
+
+      {/* Lightbox Modal */}
+      {lightboxIndex !== null &&
+        allPhotos[lightboxIndex] &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-50 bg-black/95 flex items-center justify-center"
+            onClick={closeLightbox}
+          >
+            <button
+              onClick={closeLightbox}
+              className="absolute top-4 right-4 text-white/60 hover:text-white p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
+              aria-label="Close"
+            >
+              <X size={24} />
+            </button>
+
+            {lightboxIndex > 0 && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigateLightbox('prev');
+                }}
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-white/60 hover:text-white p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
+                aria-label="Previous photo"
+              >
+                <ChevronLeft size={32} />
+              </button>
+            )}
+
+            {lightboxIndex < allPhotos.length - 1 && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigateLightbox('next');
+                }}
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-white/60 hover:text-white p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
+                aria-label="Next photo"
+              >
+                <ChevronRight size={32} />
+              </button>
+            )}
+
+            <div
+              className="max-w-[90vw] max-h-[90vh] flex items-center justify-center"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <img
+                src={allPhotos[lightboxIndex].url}
+                alt={`Photo ${lightboxIndex + 1} of ${allPhotos.length}`}
+                className="max-w-full max-h-[85vh] object-contain rounded-lg"
+              />
+            </div>
+
+            <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-4">
+              <p className="text-white/60 text-sm">
+                {lightboxIndex + 1} of {allPhotos.length}
+                {allPhotos[lightboxIndex].year > 0 && ` - ${allPhotos[lightboxIndex].year}`}
+                {allPhotos[lightboxIndex].isExtra && ' - Uploaded'}
+              </p>
+
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  togglePhoto(allPhotos[lightboxIndex!].src);
+                }}
+                className={`p-2 rounded-full transition-colors ${
+                  hiddenSrcs.has(allPhotos[lightboxIndex].src)
+                    ? 'bg-red-500/80 text-white hover:bg-red-500'
+                    : 'bg-white/20 text-white hover:bg-white/30'
+                }`}
+                title={
+                  hiddenSrcs.has(allPhotos[lightboxIndex].src)
+                    ? 'Show on event page'
+                    : 'Hide from event page'
+                }
+              >
+                {hiddenSrcs.has(allPhotos[lightboxIndex].src) ? (
+                  <EyeOff size={18} />
+                ) : (
+                  <Eye size={18} />
+                )}
+              </button>
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}
+
+// Upload modal sub-component
+function UploadModal({
+  uploading,
+  dragging,
+  setDragging,
+  fileInputRef,
+  onFiles,
+  onClose,
+}: {
+  uploading: boolean;
+  dragging: boolean;
+  setDragging: (v: boolean) => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFiles: (files: FileList | File[]) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-start justify-center pt-20 p-4 z-50 overflow-y-auto"
+      onClick={onClose}
+    >
+      <div
+        className="max-w-lg w-full bg-theme-header border border-theme-stroke rounded-2xl p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-theme-text">
+            Upload Previous Year Photos
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-theme-text-secondary hover:text-theme-text transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <p className="text-theme-text-muted text-xs mb-4">
+          Upload your own photos from previous years. These will appear alongside the
+          app.gpp.day photos on your public event page.
+        </p>
+
+        <div
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragging(false);
+            onFiles(e.dataTransfer.files);
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragging(true);
+          }}
+          onDragLeave={(e) => {
+            e.preventDefault();
+            setDragging(false);
+          }}
+          onClick={() => fileInputRef.current?.click()}
+          className={`border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-all ${
+            dragging
+              ? 'border-[#ff393a] bg-[#ff393a]/10'
+              : 'border-theme-stroke-hover hover:border-[#ff393a]/50 hover:bg-theme-surface'
+          }`}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            multiple
+            onChange={(e) => e.target.files && onFiles(e.target.files)}
+            className="hidden"
+          />
+
+          {uploading ? (
+            <>
+              <Loader2 className="w-10 h-10 text-[#ff393a] mx-auto mb-3 animate-spin" />
+              <p className="text-theme-text-secondary">Uploading...</p>
+            </>
+          ) : (
+            <>
+              <Upload className="w-10 h-10 text-theme-text-muted mx-auto mb-3" />
+              <p className="text-theme-text-secondary mb-1">
+                Drag and drop photos here
+              </p>
+              <p className="text-theme-text-muted text-sm">or click to select files</p>
+              <p className="text-theme-text-faint text-xs mt-2">
+                Max 10MB per photo. JPEG, PNG, WebP, GIF
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -122,6 +122,8 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     eventTags: dbParty.event_tags || [],
     canEdit: dbParty.can_edit || false,
     allowedTabs: dbParty.allowed_tabs,
+    hiddenGppPhotos: (dbParty.hidden_gpp_photos as string[]) || [],
+    extraGppPhotos: (dbParty.extra_gpp_photos as string[]) || [],
     guests,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -153,6 +153,8 @@ export interface UpdatePartyData {
   venueReportNotes?: string | null;
   pinnedApps?: string[];
   region?: string | null;
+  hiddenGppPhotos?: string[];
+  extraGppPhotos?: string[];
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -235,6 +237,8 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       venueReportNotes: data.venueReportNotes,
       pinnedApps: data.pinnedApps,
       region: data.region,
+      hiddenGppPhotos: data.hiddenGppPhotos,
+      extraGppPhotos: data.extraGppPhotos,
     },
   });
 }
@@ -362,6 +366,8 @@ export interface PublicEvent {
   photoModeration?: boolean;
   nftEnabled?: boolean;
   nftChain?: string | null;
+  hiddenGppPhotos?: string[];
+  extraGppPhotos?: string[];
 }
 
 // Public Event API (no auth required)

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -431,6 +431,8 @@ export interface DbParty {
   event_tags?: string[];
   can_edit?: boolean;
   allowed_tabs?: string[];
+  hidden_gpp_photos?: string[];
+  extra_gpp_photos?: string[];
 }
 
 export type DbGuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
@@ -481,7 +483,8 @@ export const SAFE_PARTY_COLUMNS = `
   report_published, report_public_slug,
   venue_report_published, venue_report_slug, venue_report_title, venue_report_notes,
   pinned_apps,
-  region
+  region,
+  hidden_gpp_photos, extra_gpp_photos
 `;
 
 /**
@@ -1316,6 +1319,8 @@ export async function updateParty(
     venue_report_notes?: string | null;
     pinned_apps?: string[];
     region?: string | null;
+    hidden_gpp_photos?: string[];
+    extra_gpp_photos?: string[];
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -1368,6 +1373,8 @@ export async function updateParty(
         venueReportNotes: updates.venue_report_notes,
         pinnedApps: updates.pinned_apps,
         region: updates.region,
+        hiddenGppPhotos: updates.hidden_gpp_photos,
+        extraGppPhotos: updates.extra_gpp_photos,
       });
       return true;
     } catch (error) {

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1085,7 +1085,13 @@ export function EventPage() {
                 )}
 
                 {/* Last Year's Party Photos — GPP events only */}
-                {event.eventType === 'gpp' && event.customUrl && <LastYearPhotos customUrl={event.customUrl} />}
+                {event.eventType === 'gpp' && event.customUrl && (
+                  <LastYearPhotos
+                    customUrl={event.customUrl}
+                    hiddenGppPhotos={event.hiddenGppPhotos}
+                    extraGppPhotos={event.extraGppPhotos}
+                  />
+                )}
 
                 {/* Photo Gallery Section - only for confirmed guests */}
                 {photoStats?.photosEnabled && existingGuestData?.status === 'CONFIRMED' && (

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -29,6 +29,7 @@ import { BudgetTab } from '../components/budget';
 import { ChecklistTab } from '../components/checklist';
 import { PartyKitWidget } from '../components/kit';
 import { PromoWidget } from '../components/promo';
+import { PreviousYearPhotos } from '../components/PreviousYearPhotos';
 import { PINNABLE_APPS } from '../lib/appDefinitions';
 import { GPPDashboardTab } from '../components/gpp-dashboard';
 // tabPermissions is used by HostsManager for the permission picker UI
@@ -374,14 +375,23 @@ function HostPageContent() {
               )}
 
               {activeTab === 'photos' && party && (
-                <div className="card p-6 space-y-4">
-                  <PhotoGallery
-                    partyId={party.id}
-                    isHost={true}
-                    uploaderName={user?.name || undefined}
-                    uploaderEmail={user?.email}
-                    photoModeration={true}
-                  />
+                <div className="space-y-4">
+                  <div className="card p-6 space-y-4">
+                    <PhotoGallery
+                      partyId={party.id}
+                      isHost={true}
+                      uploaderName={user?.name || undefined}
+                      uploaderEmail={user?.email}
+                      photoModeration={true}
+                    />
+                  </div>
+
+                  {/* Previous Year Photos — GPP events only */}
+                  {party.eventType === 'gpp' && party.customUrl && (
+                    <div className="card p-6">
+                      <PreviousYearPhotos />
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -265,6 +265,8 @@ export interface Party {
   region?: string | null;
   canEdit?: boolean;
   allowedTabs?: string[];
+  hiddenGppPhotos?: string[];
+  extraGppPhotos?: string[];
 }
 
 export interface Donation {

--- a/migrations/add-gpp-photo-fields.sql
+++ b/migrations/add-gpp-photo-fields.sql
@@ -1,0 +1,11 @@
+-- Add fields for managing "Photos from Previous Years" on the host dashboard
+-- hidden_gpp_photos: array of photo src paths (from app.gpp.day) that the host has hidden
+-- extra_gpp_photos: array of URLs for host-uploaded historical photos
+
+ALTER TABLE parties
+  ADD COLUMN IF NOT EXISTS hidden_gpp_photos jsonb DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS extra_gpp_photos jsonb DEFAULT '[]'::jsonb;
+
+-- Add a comment for documentation
+COMMENT ON COLUMN parties.hidden_gpp_photos IS 'Array of app.gpp.day photo src paths hidden by the host';
+COMMENT ON COLUMN parties.extra_gpp_photos IS 'Array of host-uploaded previous year photo URLs';


### PR DESCRIPTION
## Summary
- Hosts can show/hide individual app.gpp.day manifest photos per event
- Upload additional historical photos from the Photos tab
- Public `LastYearPhotos` component respects hidden state and shows all years
- Two new JSONB columns: `hidden_gpp_photos`, `extra_gpp_photos`

## DB Migration Required
```sql
ALTER TABLE parties
  ADD COLUMN IF NOT EXISTS hidden_gpp_photos jsonb DEFAULT '[]'::jsonb,
  ADD COLUMN IF NOT EXISTS extra_gpp_photos jsonb DEFAULT '[]'::jsonb;
```
Apply via Supabase before merging since previews share prod DB.

## Test plan
- [ ] Apply DB migration to Supabase
- [ ] Verify host Photos tab shows "Previous Years' Photos" section
- [ ] Toggle hide/show on manifest photos, confirm public page reflects changes
- [ ] Upload an extra historical photo, verify it appears on public page
- [ ] Remove an extra photo, verify it disappears
- [ ] Verify public EventPage shows all years (not just latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)