### PR TITLE
feat: Show approval status and event address on shipping dashboard

### DIFF
--- a/backend/src/routes/shipping.routes.ts
+++ b/backend/src/routes/shipping.routes.ts
@@ -180,6 +180,9 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
             name: true,
             region: true,
             date: true,
+            address: true,
+            venueName: true,
+            underbossApproved: true,
             user: { select: { name: true, email: true } },
           },
         },
@@ -200,7 +203,7 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
     }
 
     // Build CSV
-    const headers = ['Event Name', 'Region', 'Host Name', 'Host Email', 'Recipient', 'Address 1', 'Address 2', 'City', 'State', 'Postal Code', 'Country', 'Phone', 'Requested Tier', 'Allocated Tier', 'Status', 'Notes'];
+    const headers = ['Event Name', 'Region', 'Host Name', 'Host Email', 'Event Venue', 'Event Address', 'Event Approved', 'Recipient', 'Address 1', 'Address 2', 'City', 'State', 'Postal Code', 'Country', 'Phone', 'Requested Tier', 'Allocated Tier', 'Status', 'Notes'];
     const csvRows = [headers.join(',')];
 
     for (const kit of filtered) {
@@ -209,6 +212,9 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
         escapeCSV(kit.party.region || ''),
         escapeCSV(kit.party.user?.name || ''),
         escapeCSV(kit.party.user?.email || ''),
+        escapeCSV(kit.party.venueName || ''),
+        escapeCSV(kit.party.address || ''),
+        escapeCSV(kit.party.underbossApproved ? 'Yes' : 'No'),
         escapeCSV(kit.recipientName),
         escapeCSV(kit.addressLine1),
         escapeCSV(kit.addressLine2 || ''),
@@ -337,6 +343,9 @@ router.get('/kits', requireAuth, requireShippingAuth, async (req: ShippingReques
             name: true,
             region: true,
             date: true,
+            address: true,
+            venueName: true,
+            underbossApproved: true,
             user: { select: { name: true, email: true } },
           },
         },
@@ -366,6 +375,9 @@ router.get('/kits', requireAuth, requireShippingAuth, async (req: ShippingReques
       region: kit.party.region || null,
       hostName: kit.party.user?.name || null,
       hostEmail: kit.party.user?.email || null,
+      eventAddress: kit.party.address || null,
+      eventVenue: kit.party.venueName || null,
+      underbossApproved: kit.party.underbossApproved || false,
       requestedTier: kit.requestedTier,
       allocatedTier: kit.allocatedTier,
       recipientName: kit.recipientName,
@@ -412,6 +424,7 @@ router.get('/kits/:kitId', requireAuth, requireShippingAuth, async (req: Shippin
             date: true,
             address: true,
             venueName: true,
+            underbossApproved: true,
             user: { select: { name: true, email: true } },
           },
         },
@@ -433,6 +446,7 @@ router.get('/kits/:kitId', requireAuth, requireShippingAuth, async (req: Shippin
         hostEmail: kit.party.user?.email || null,
         eventAddress: kit.party.address || null,
         eventVenue: kit.party.venueName || null,
+        underbossApproved: kit.party.underbossApproved || false,
         requestedTier: kit.requestedTier,
         allocatedTier: kit.allocatedTier,
         recipientName: kit.recipientName,
@@ -515,6 +529,9 @@ router.patch('/kits/:kitId', requireAuth, requireShippingAuth, async (req: Shipp
             name: true,
             region: true,
             date: true,
+            address: true,
+            venueName: true,
+            underbossApproved: true,
             user: { select: { name: true, email: true } },
           },
         },
@@ -530,6 +547,9 @@ router.patch('/kits/:kitId', requireAuth, requireShippingAuth, async (req: Shipp
         region: updatedKit.party.region || null,
         hostName: updatedKit.party.user?.name || null,
         hostEmail: updatedKit.party.user?.email || null,
+        eventAddress: updatedKit.party.address || null,
+        eventVenue: updatedKit.party.venueName || null,
+        underbossApproved: updatedKit.party.underbossApproved || false,
         requestedTier: updatedKit.requestedTier,
         allocatedTier: updatedKit.allocatedTier,
         recipientName: updatedKit.recipientName,

--- a/frontend/src/components/shipping/KitDetailModal.tsx
+++ b/frontend/src/components/shipping/KitDetailModal.tsx
@@ -101,7 +101,27 @@ export function KitDetailModal({ kit, onClose, onUpdate }: KitDetailModalProps) 
               <p className="text-sm text-theme-text">{kit.hostName || '--'}</p>
               {kit.hostEmail && <p className="text-xs text-theme-text-faint">{kit.hostEmail}</p>}
             </div>
+            <div>
+              <p className="text-xs text-theme-text-muted mb-1">Event Approved</p>
+              <p className={`text-sm font-medium ${kit.underbossApproved ? 'text-green-500' : 'text-yellow-500'}`}>
+                {kit.underbossApproved ? 'Yes' : 'Pending'}
+              </p>
+            </div>
           </div>
+
+          {/* Event Location */}
+          {(kit.eventVenue || kit.eventAddress) && (
+            <div className="bg-theme-surface rounded-xl p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <MapPin size={16} className="text-theme-text-muted" />
+                <p className="text-sm font-medium text-theme-text">Event Location</p>
+              </div>
+              <div className="text-sm text-theme-text space-y-0.5">
+                {kit.eventVenue && <p className="font-medium">{kit.eventVenue}</p>}
+                {kit.eventAddress && <p className="text-theme-text-muted">{kit.eventAddress}</p>}
+              </div>
+            </div>
+          )}
 
           {/* Shipping address */}
           <div className="bg-theme-surface rounded-xl p-4">

--- a/frontend/src/components/shipping/KitRow.tsx
+++ b/frontend/src/components/shipping/KitRow.tsx
@@ -69,10 +69,16 @@ export function KitRow({
 
       {/* Event */}
       <td className="px-3 py-3">
-        <div className="text-sm font-medium text-theme-text truncate max-w-[180px]" title={kit.partyName}>
-          {kit.partyName}
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${kit.underbossApproved ? 'bg-green-500' : 'bg-yellow-500'}`}
+            title={kit.underbossApproved ? 'Event Approved' : 'Pending Approval'}
+          />
+          <span className="text-sm font-medium text-theme-text truncate max-w-[168px]" title={kit.partyName}>
+            {kit.partyName}
+          </span>
         </div>
-        <div className="text-xs text-theme-text-muted">{eventDate}</div>
+        <div className="text-xs text-theme-text-muted ml-3.5">{eventDate}</div>
       </td>
 
       {/* Region */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1053,6 +1053,9 @@ export interface ShippingKit {
   region: string | null;
   hostName: string | null;
   hostEmail: string | null;
+  eventAddress: string | null;
+  eventVenue: string | null;
+  underbossApproved: boolean;
   requestedTier: KitTier;
   allocatedTier: KitTier | null;
   recipientName: string;


### PR DESCRIPTION
## Summary
- Add `underbossApproved`, `eventAddress`, and `eventVenue` fields to all shipping API endpoints (GET list, GET detail, PATCH, CSV export)
- Show a green/yellow approval dot next to event names in the kit list rows
- Add "Event Approved" status field and "Event Location" section (venue name + address) to the kit detail modal
- Include Event Venue, Event Address, and Event Approved columns in CSV exports

## Test plan
- [ ] Open /shipping dashboard and verify green/yellow dots appear next to event names
- [ ] Hover over the dot to confirm tooltip shows "Event Approved" or "Pending Approval"
- [ ] Click a kit to open the detail modal — verify "Event Approved" shows Yes/Pending in green/yellow
- [ ] Verify "Event Location" section appears when venue/address data exists
- [ ] Export CSV and verify new columns (Event Venue, Event Address, Event Approved) are present
- [ ] Verify PATCH response includes the new fields after updating a kit

🤖 Generated with [Claude Code](https://claude.com/claude-code)