### PR TITLE
Add partner category dropdown (host-facing)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -853,6 +853,9 @@ model Sponsor {
   // Assets (for confirmed sponsors)
   logoUrl String? @map("logo_url")
 
+  // Category
+  category String? // hardware_wallet, software_wallet, cex, blockchain, dex, community, custom
+
   // Tracking
   notes           String? // Communication history, notes
   lastContactedAt DateTime? @map("last_contacted_at") @db.Timestamptz

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1115,6 +1115,7 @@ model SponsorUser {
   coHostLogoUrl   String?   @map("co_host_logo_url")
   autoCoHost      Boolean   @default(false) @map("auto_co_host")
   autoSponsor     Boolean   @default(false) @map("auto_sponsor")
+  category        String?
 
   // Granular co-host permissions (applied when autoCoHost adds them to events)
   coHostShowOnEvent Boolean @default(true)  @map("co_host_show_on_event")

--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -20,6 +20,7 @@ interface SponsorUserLike {
   coHostLogoUrl: string | null;
   autoCoHost: boolean;
   autoSponsor: boolean;
+  category: string | null;
   coHostShowOnEvent?: boolean;
   coHostCanEdit?: boolean;
   coHostAllowedTabs?: any;
@@ -91,6 +92,7 @@ export async function addPartnerToParty(
       brandTwitter: sponsorUser.coHostTwitter || null,
       brandInstagram: sponsorUser.coHostInstagram || null,
       logoUrl: sponsorUser.coHostLogoUrl || null,
+      category: sponsorUser.category || null,
     };
 
     const existingSponsor = await prisma.sponsor.findFirst({

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -39,6 +39,7 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
         coHostLogoUrl: true,
         autoCoHost: true,
         autoSponsor: true,
+        category: true,
         coHostShowOnEvent: true,
         coHostCanEdit: true,
         coHostAllowedTabs: true,
@@ -75,6 +76,7 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
       coHostName, coHostWebsite, coHostTwitter, coHostInstagram,
       coHostAvatarUrl, coHostLogoUrl, autoCoHost, autoSponsor,
       coHostShowOnEvent, coHostCanEdit, coHostAllowedTabs,
+      category,
     } = req.body;
 
     if (!email || !tag) {
@@ -108,6 +110,7 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
         coHostShowOnEvent: coHostShowOnEvent !== undefined ? !!coHostShowOnEvent : true,
         coHostCanEdit: !!coHostCanEdit,
         coHostAllowedTabs: Array.isArray(coHostAllowedTabs) ? coHostAllowedTabs : Prisma.JsonNull,
+        category: category?.trim() || null,
       },
     });
 
@@ -140,6 +143,7 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
       coHostName, coHostWebsite, coHostTwitter, coHostInstagram,
       coHostAvatarUrl, coHostLogoUrl, autoCoHost, autoSponsor,
       coHostShowOnEvent, coHostCanEdit, coHostAllowedTabs,
+      category,
     } = req.body;
 
     // Fetch old state for sync reconciliation
@@ -164,6 +168,7 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
     if (coHostLogoUrl !== undefined) updateData.coHostLogoUrl = coHostLogoUrl?.trim() || null;
     if (autoCoHost !== undefined) updateData.autoCoHost = autoCoHost;
     if (autoSponsor !== undefined) updateData.autoSponsor = autoSponsor;
+    if (category !== undefined) updateData.category = category?.trim() || null;
     if (coHostShowOnEvent !== undefined) updateData.coHostShowOnEvent = !!coHostShowOnEvent;
     if (coHostCanEdit !== undefined) updateData.coHostCanEdit = !!coHostCanEdit;
     if (coHostAllowedTabs !== undefined) {

--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -141,6 +141,7 @@ router.post('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Res
       notes,
       lastContactedAt,
       sponsorMessage,
+      category,
     } = req.body;
 
     // Validate required fields
@@ -172,6 +173,12 @@ router.post('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Res
       throw new AppError(`Invalid sponsorship type. Must be one of: ${validTypes.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
 
+    // Validate category if provided
+    const validCategories = ['hardware_wallet', 'software_wallet', 'cex', 'blockchain', 'dex', 'community', 'custom'];
+    if (category && !validCategories.includes(category)) {
+      throw new AppError(`Invalid category. Must be one of: ${validCategories.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+
     const sponsor = await prisma.sponsor.create({
       data: {
         partyId,
@@ -194,6 +201,7 @@ router.post('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Res
         notes: notes?.trim() || null,
         lastContactedAt: lastContactedAt ? new Date(lastContactedAt) : null,
         sponsorMessage: sponsorMessage?.trim() || null,
+        category: category?.trim() || null,
       },
     });
 
@@ -258,6 +266,7 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
       notes,
       lastContactedAt,
       sponsorMessage,
+      category,
     } = req.body;
 
     // Verify ownership or super admin
@@ -293,6 +302,12 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
       throw new AppError(`Invalid sponsorship type. Must be one of: ${validTypes.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
 
+    // Validate category if provided
+    const validCategories = ['hardware_wallet', 'software_wallet', 'cex', 'blockchain', 'dex', 'community', 'custom'];
+    if (category && !validCategories.includes(category)) {
+      throw new AppError(`Invalid category. Must be one of: ${validCategories.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+
     const sponsor = await prisma.sponsor.update({
       where: { id: sponsorId },
       data: {
@@ -315,6 +330,7 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
         ...(notes !== undefined && { notes: notes?.trim() || null }),
         ...(lastContactedAt !== undefined && { lastContactedAt: lastContactedAt ? new Date(lastContactedAt) : null }),
         ...(sponsorMessage !== undefined && { sponsorMessage: sponsorMessage?.trim() || null }),
+        ...(category !== undefined && { category: category?.trim() || null }),
       },
     });
 

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -163,6 +163,7 @@ function sponsorUserToFormData(su: SponsorUser): PartnerFormData {
     autoCoHost: su.autoCoHost,
     autoSponsor: su.autoSponsor,
     notes: su.notes || '',
+    category: (su.category as SponsorCategory) || null,
   };
 }
 
@@ -463,6 +464,26 @@ export function PartnerForm({
               <span className="text-xs text-theme-text-muted">Avatar preview</span>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Category — Partner mode */}
+      {isPartner && (
+        <div className="relative">
+          <Building2 size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />
+          <select
+            value={formData.category || ''}
+            onChange={e => handleChange('category', (e.target.value as SponsorCategory) || null)}
+            className="w-full !pl-14 bg-theme-input border border-theme-stroke rounded-xl text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
+            style={{ colorScheme: 'dark' }}
+          >
+            <option value="" className="bg-theme-header text-theme-text-muted">Category</option>
+            {SPONSOR_CATEGORIES.map(opt => (
+              <option key={opt.id} value={opt.id} className="bg-theme-header text-theme-text">
+                {opt.label}
+              </option>
+            ))}
+          </select>
         </div>
       )}
 

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { X, Building2, User, Mail, Phone, DollarSign, FileText, Calendar, Globe, Upload, Image, Instagram, Settings, Check, MessageSquare, Loader2 } from 'lucide-react';
-import { Sponsor, SponsorStatus, SponsorshipType, SponsorUser } from '../../types';
+import { Sponsor, SponsorStatus, SponsorshipType, SponsorCategory, SPONSOR_CATEGORIES, SponsorUser } from '../../types';
 import { CreateSponsorData, PartnerIntakeResponse } from '../../lib/api';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
@@ -48,6 +48,7 @@ export interface PartnerFormData {
   status: SponsorStatus;
   amount: number | null;
   lastContactedAt: string | null;
+  category: SponsorCategory | null;
 
   // Partner-only
   email: string;
@@ -79,6 +80,7 @@ export function extractSponsorData(data: PartnerFormData): CreateSponsorData {
     logoUrl: data.logoUrl || undefined,
     notes: data.notes || undefined,
     lastContactedAt: data.lastContactedAt,
+    category: data.category || undefined,
   };
 }
 
@@ -114,7 +116,7 @@ function getDefaultFormData(): PartnerFormData {
     contactTwitter: '', telegram: '',
     sponsorshipType: null, productService: '', sponsorMessage: '',
     pointPerson: '', status: 'todo' as SponsorStatus,
-    amount: null, lastContactedAt: null,
+    amount: null, lastContactedAt: null, category: null,
     email: '', tag: '', contactPersonName: '', coHostAvatarUrl: '',
     autoCoHost: false, autoSponsor: false,
   };
@@ -142,6 +144,7 @@ function sponsorToFormData(s: Sponsor): PartnerFormData {
     productService: s.productService || '',
     sponsorMessage: s.sponsorMessage || '',
     lastContactedAt: s.lastContactedAt ? s.lastContactedAt.split('T')[0] : null,
+    category: (s.category as SponsorCategory) || null,
   };
 }
 
@@ -537,6 +540,22 @@ export function PartnerForm({
               >
                 {STATUS_OPTIONS.map(opt => (
                   <option key={opt.value} value={opt.value} className="bg-theme-header text-theme-text">
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="relative">
+              <Building2 size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />
+              <select
+                value={formData.category || ''}
+                onChange={e => handleChange('category', (e.target.value as SponsorCategory) || null)}
+                className="w-full !pl-14 bg-theme-input border border-theme-stroke rounded-xl text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
+                style={{ colorScheme: 'dark' }}
+              >
+                <option value="" className="bg-theme-header text-theme-text-muted">Category</option>
+                {SPONSOR_CATEGORIES.map(opt => (
+                  <option key={opt.id} value={opt.id} className="bg-theme-header text-theme-text">
                     {opt.label}
                   </option>
                 ))}

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -3,7 +3,7 @@ import {
   ChevronUp, ChevronDown, Edit2, Trash2, ExternalLink,
   Mail, Phone, User, Building2, Calendar
 } from 'lucide-react';
-import { Sponsor, SponsorStatus } from '../../types';
+import { Sponsor, SponsorStatus, SPONSOR_CATEGORIES } from '../../types';
 import { PartnerIntakeButton } from './PartnerIntakeButton';
 
 interface SponsorListProps {
@@ -257,6 +257,14 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                               <ExternalLink size={12} />
                             </a>
                           )}
+                          {sponsor.category && (() => {
+                            const cat = SPONSOR_CATEGORIES.find(c => c.id === sponsor.category);
+                            return cat ? (
+                              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-500/20 text-indigo-300 border border-indigo-500/30">
+                                {cat.label}
+                              </span>
+                            ) : null;
+                          })()}
                         </div>
                         {sponsor.organization && (
                           <div className="text-xs text-theme-text-muted truncate">{sponsor.organization}</div>

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -74,6 +74,7 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
         coHostLogoUrl: data.logoUrl || undefined,
         autoCoHost: data.autoCoHost,
         autoSponsor: data.autoSponsor,
+        category: data.category || undefined,
       };
 
       let newSyncMessage: string | null = null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2921,6 +2921,7 @@ export interface SponsorUserCreateData {
   coHostLogoUrl?: string;
   autoCoHost?: boolean;
   autoSponsor?: boolean;
+  category?: string;
 }
 
 export async function createSponsorUser(data: SponsorUserCreateData): Promise<{ sponsorUser: SponsorUser; syncedCount: number }> {
@@ -2944,6 +2945,7 @@ export interface SponsorUserUpdateData {
   coHostLogoUrl?: string;
   autoCoHost?: boolean;
   autoSponsor?: boolean;
+  category?: string;
 }
 
 export async function updateSponsorUser(id: string, data: SponsorUserUpdateData): Promise<{ sponsorUser: SponsorUser; syncedCount: number }> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -708,6 +708,7 @@ export interface CreateSponsorData {
   logoUrl?: string;
   notes?: string;
   lastContactedAt?: string | null;
+  category?: string;
 }
 
 export interface UpdateSponsorData extends Partial<CreateSponsorData> {}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1145,6 +1145,7 @@ export interface SponsorUser {
   coHostLogoUrl: string | null;
   autoCoHost: boolean;
   autoSponsor: boolean;
+  category: string | null;
 }
 
 export interface SponsorChecklistItem {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -427,6 +427,17 @@ export interface PhotoStats {
 // Sponsor CRM types
 export type SponsorStatus = 'todo' | 'asked' | 'yes' | 'billed' | 'paid' | 'stuck' | 'alum' | 'skip';
 export type SponsorshipType = 'cash' | 'in-kind' | 'venue' | 'pizza' | 'drinks' | 'other';
+export type SponsorCategory = 'hardware_wallet' | 'software_wallet' | 'cex' | 'blockchain' | 'dex' | 'community' | 'custom';
+
+export const SPONSOR_CATEGORIES: { id: SponsorCategory; label: string }[] = [
+  { id: 'hardware_wallet', label: 'Hardware Wallet' },
+  { id: 'software_wallet', label: 'Software Wallet' },
+  { id: 'cex', label: 'CEX' },
+  { id: 'blockchain', label: 'Blockchain' },
+  { id: 'dex', label: 'DEX' },
+  { id: 'community', label: 'Community' },
+  { id: 'custom', label: 'Custom' },
+];
 
 export interface Sponsor {
   id: string;
@@ -447,6 +458,7 @@ export interface Sponsor {
   sponsorshipType: SponsorshipType | null;
   productService: string | null;
   logoUrl: string | null;
+  category: string | null;
   notes: string | null;
   lastContactedAt: string | null;
   intakeToken: string | null;


### PR DESCRIPTION
## Summary
- Adds a category dropdown to the sponsor CRM form (host-facing only)
- Categories: Hardware Wallet, Software Wallet, CEX, Blockchain, DEX, Community, Custom
- NOT shown on the partner intake form
- Shows category badge in sponsor list view

## Changes
- DB migration: `category` column on `sponsors` table
- Backend: create/update sponsor routes handle `category`
- Frontend: category dropdown in CRM form, badge in list view

## Test plan
- [ ] Open host dashboard → Partners tab → Add/edit a sponsor → verify category dropdown appears
- [ ] Open a partner intake link → verify category does NOT appear
- [ ] Save a sponsor with a category → reload → verify it persists
- [ ] Check sponsor list → verify category badge shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)