### PR TITLE
fix: bump API rate limit to 500/15min

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -76,8 +76,8 @@ app.use(express.json());
 // Rate limiting
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
-  message: { error: 'Too many requests, please try again later' },
+  max: 500, // limit each IP to 500 requests per windowMs
+  message: { error: 'You\'ve been rate limited. Please wait a few minutes before trying again.' },
   standardHeaders: true,
   legacyHeaders: false,
   // Skip rate limit validation errors


### PR DESCRIPTION
## Summary
- Bumps global API rate limit from 100 to 500 requests per 15 minutes
- Improves the error message to explain rate limiting to the user
- Fixes 429 errors that hosts were hitting during active dashboard usage (e.g. Ljubljana)

🤖 Generated with [Claude Code](https://claude.com/claude-code)