### PR TITLE
feat: shareable social post after RSVP

### DIFF
--- a/frontend/src/components/RSVPModal.test.tsx
+++ b/frontend/src/components/RSVPModal.test.tsx
@@ -123,7 +123,7 @@ describe('RSVPModal', () => {
 
     // Wait for submission to complete and success screen to appear
     await waitFor(() => {
-      expect(screen.getByText('RSVP Updated!')).toBeInTheDocument();
+      expect(screen.getByText('RSVP Updated')).toBeInTheDocument();
     });
 
     // Now simulate what happens in EventPage.onRSVPSuccess:
@@ -144,7 +144,7 @@ describe('RSVPModal', () => {
 
     // BUG: The modal should STILL show the success screen,
     // not reset back to step 1
-    expect(screen.getByText('RSVP Updated!')).toBeInTheDocument();
+    expect(screen.getByText('RSVP Updated')).toBeInTheDocument();
     expect(screen.queryByText('Step 1 of 2')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -9,6 +9,7 @@ import { DonationStep } from './DonationStep';
 import { useRSVPForm, publicEventToRSVPData, RSVPSubmitResult } from '../hooks/useRSVPForm';
 import { RSVPFormStep1 } from './RSVPFormStep1';
 import { RSVPFormStep2 } from './RSVPFormStep2';
+import { ShareRSVP } from './ShareRSVP';
 import { useMintNFT, MintStatus, MintResult } from '../hooks/useMintNFT';
 import { getNFTViewUrl, getChainConfig, NFTChain } from '../lib/nftContract';
 import { useAccount } from 'wagmi';
@@ -261,6 +262,15 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
             <p className="text-theme-text-secondary mb-4">
               Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
             </p>
+          )}
+          {/* Share Section */}
+          {(!form.alreadyRegistered || form.wasUpdated) && !form.pendingApproval && (
+            <ShareRSVP
+              eventName={event.name}
+              eventImageUrl={event.eventImageUrl}
+              customUrl={event.customUrl}
+              inviteCode={event.inviteCode}
+            />
           )}
           {/* NFT Minting Status */}
           {event.nftEnabled && form.ethereumAddress.trim() && event.eventImageUrl && (

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -264,7 +264,7 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
             </p>
           )}
           {/* Share Section */}
-          {(!form.alreadyRegistered || form.wasUpdated) && !form.pendingApproval && (
+          {(!form.alreadyRegistered || form.wasUpdated) && (
             <ShareRSVP
               eventName={event.name}
               eventImageUrl={event.eventImageUrl}

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -206,7 +206,7 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
     };
 
     const getSuccessTitle = () => {
-      if (form.wasUpdated) return 'RSVP Updated!';
+      if (form.wasUpdated) return 'RSVP Updated';
       if (form.alreadyRegistered) return "You're already registered!";
       if (form.waitlisted) return "You're on the Waitlist!";
       if (form.pendingApproval) return 'RSVP Submitted!';

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -61,6 +61,7 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
 
   return (
     <div className="mt-6 pt-6 border-t border-theme-stroke">
+      <p className="text-theme-text font-medium text-center mb-3">Tell your friends about the party!</p>
       {eventImageUrl && (
         <div className="rounded-xl overflow-hidden mb-3">
           <img

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { Download, Link, Share2, Check } from 'lucide-react';
+
+interface ShareRSVPProps {
+  eventName: string;
+  eventImageUrl: string | null;
+  customUrl: string | null;
+  inviteCode: string;
+}
+
+// X (Twitter) icon
+const XIcon: React.FC<{ size: number }> = ({ size }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: ShareRSVPProps) {
+  const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  if (!eventImageUrl) return null;
+
+  const city = eventName.replace(/^Global Pizza Party\s*/i, '') || eventName;
+  const eventUrl = `https://rsv.pizza/${customUrl || inviteCode}`;
+  const shareText = `I'm going to the pizza party in ${city}!`;
+
+  const handleShareX = () => {
+    const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText + ' \u{1F355}')}&url=${encodeURIComponent(eventUrl)}`;
+    window.open(intentUrl, '_blank');
+  };
+
+  const handleDownload = async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      const res = await fetch(eventImageUrl);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${city.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase()}-pizza-party.jpg`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to download image:', err);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(eventUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy link:', err);
+    }
+  };
+
+  const handleNativeShare = async () => {
+    try {
+      await navigator.share({
+        title: shareText,
+        text: shareText + ' \u{1F355}',
+        url: eventUrl,
+      });
+    } catch (err) {
+      // User cancelled or share failed — ignore
+    }
+  };
+
+  const canNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
+
+  return (
+    <div className="mt-6 pt-6 border-t border-theme-stroke">
+      <p className="text-theme-text-secondary text-sm mb-3 text-center">Share the vibes</p>
+
+      <div className="rounded-xl overflow-hidden mb-3">
+        <img
+          src={eventImageUrl}
+          alt={eventName}
+          className="w-full rounded-xl"
+        />
+      </div>
+
+      <p className="text-theme-text font-medium text-center mb-4">
+        {shareText} {'\u{1F355}'}
+      </p>
+
+      <div className="flex gap-2">
+        <button
+          onClick={handleShareX}
+          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm"
+        >
+          <XIcon size={14} />
+          <span className="hidden sm:inline">Share on X</span>
+          <span className="sm:hidden">X</span>
+        </button>
+
+        <button
+          onClick={handleDownload}
+          disabled={downloading}
+          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm disabled:opacity-50"
+        >
+          <Download size={14} />
+          <span className="hidden sm:inline">Download</span>
+          <span className="sm:hidden">Save</span>
+        </button>
+
+        <button
+          onClick={handleCopyLink}
+          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-sm"
+        >
+          {copied ? (
+            <>
+              <Check size={14} className="text-[#39d98a]" />
+              <span className="text-[#39d98a]">Copied!</span>
+            </>
+          ) : (
+            <>
+              <Link size={14} className="text-theme-text" />
+              <span className="text-theme-text hidden sm:inline">Copy Link</span>
+              <span className="text-theme-text sm:hidden">Link</span>
+            </>
+          )}
+        </button>
+
+        {canNativeShare && (
+          <button
+            onClick={handleNativeShare}
+            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm"
+          >
+            <Share2 size={14} />
+            <span>Share</span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Download, Link, Share2, Check } from 'lucide-react';
+import { Download, Link, Check } from 'lucide-react';
 
 interface ShareRSVPProps {
   eventName: string;
@@ -59,24 +59,8 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
     }
   };
 
-  const handleNativeShare = async () => {
-    try {
-      await navigator.share({
-        title: shareText,
-        text: shareText + ' \u{1F355}',
-        url: eventUrl,
-      });
-    } catch (err) {
-      // User cancelled or share failed — ignore
-    }
-  };
-
-  const canNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
-
   return (
     <div className="mt-6 pt-6 border-t border-theme-stroke">
-      <p className="text-theme-text-secondary text-sm mb-3 text-center">Share the vibes</p>
-
       {eventImageUrl && (
         <div className="rounded-xl overflow-hidden mb-3">
           <img
@@ -94,7 +78,7 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
       <div className="flex gap-2">
         <button
           onClick={handleShareX}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm"
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm"
         >
           <XIcon size={14} />
           <span className="hidden sm:inline">Share on X</span>
@@ -105,7 +89,7 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
           <button
             onClick={handleDownload}
             disabled={downloading}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm disabled:opacity-50"
+            className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm disabled:opacity-50"
           >
             <Download size={14} />
             <span className="hidden sm:inline">Download</span>
@@ -115,7 +99,7 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
 
         <button
           onClick={handleCopyLink}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-sm"
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-sm"
         >
           {copied ? (
             <>
@@ -130,16 +114,6 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
             </>
           )}
         </button>
-
-        {canNativeShare && (
-          <button
-            onClick={handleNativeShare}
-            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm"
-          >
-            <Share2 size={14} />
-            <span>Share</span>
-          </button>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -19,11 +19,9 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
   const [copied, setCopied] = useState(false);
   const [downloading, setDownloading] = useState(false);
 
-  if (!eventImageUrl) return null;
-
   const city = eventName.replace(/^Global Pizza Party\s*/i, '') || eventName;
   const eventUrl = `https://rsv.pizza/${customUrl || inviteCode}`;
-  const shareText = `I'm going to the pizza party in ${city}!`;
+  const shareText = `I'm going to the Global Pizza Party in ${city}!`;
 
   const handleShareX = () => {
     const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText + ' \u{1F355}')}&url=${encodeURIComponent(eventUrl)}`;
@@ -31,7 +29,7 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
   };
 
   const handleDownload = async () => {
-    if (downloading) return;
+    if (downloading || !eventImageUrl) return;
     setDownloading(true);
     try {
       const res = await fetch(eventImageUrl);
@@ -79,13 +77,15 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
     <div className="mt-6 pt-6 border-t border-theme-stroke">
       <p className="text-theme-text-secondary text-sm mb-3 text-center">Share the vibes</p>
 
-      <div className="rounded-xl overflow-hidden mb-3">
-        <img
-          src={eventImageUrl}
-          alt={eventName}
-          className="w-full rounded-xl"
-        />
-      </div>
+      {eventImageUrl && (
+        <div className="rounded-xl overflow-hidden mb-3">
+          <img
+            src={eventImageUrl}
+            alt={eventName}
+            className="w-full rounded-xl"
+          />
+        </div>
+      )}
 
       <p className="text-theme-text font-medium text-center mb-4">
         {shareText} {'\u{1F355}'}
@@ -101,15 +101,17 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
           <span className="sm:hidden">X</span>
         </button>
 
-        <button
-          onClick={handleDownload}
-          disabled={downloading}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm disabled:opacity-50"
-        >
-          <Download size={14} />
-          <span className="hidden sm:inline">Download</span>
-          <span className="sm:hidden">Save</span>
-        </button>
+        {eventImageUrl && (
+          <button
+            onClick={handleDownload}
+            disabled={downloading}
+            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-theme-surface border border-theme-stroke rounded-xl hover:bg-theme-surface-hover transition-colors text-theme-text text-sm disabled:opacity-50"
+          >
+            <Download size={14} />
+            <span className="hidden sm:inline">Download</span>
+            <span className="sm:hidden">Save</span>
+          </button>
+        )}
 
         <button
           onClick={handleCopyLink}

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -71,10 +71,6 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
         </div>
       )}
 
-      <p className="text-theme-text font-medium text-center mb-4 whitespace-pre-line">
-        {shareText}
-      </p>
-
       <div className="flex gap-2">
         <button
           onClick={handleShareX}

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -21,10 +21,10 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
 
   const city = eventName.replace(/^Global Pizza Party\s*/i, '') || eventName;
   const eventUrl = `https://rsv.pizza/${customUrl || inviteCode}`;
-  const shareText = `I'm going to the Global Pizza Party in ${city}!`;
+  const shareText = `\u{1F5FA}\uFE0F\u{1F355}\u{1F973}\nI'm going to the Global Pizza Party in ${city}!`;
 
   const handleShareX = () => {
-    const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText + ' \u{1F355}')}&url=${encodeURIComponent(eventUrl)}`;
+    const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(eventUrl)}`;
     window.open(intentUrl, '_blank');
   };
 
@@ -71,8 +71,8 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: S
         </div>
       )}
 
-      <p className="text-theme-text font-medium text-center mb-4">
-        {shareText} {'\u{1F355}'}
+      <p className="text-theme-text font-medium text-center mb-4 whitespace-pre-line">
+        {shareText}
       </p>
 
       <div className="flex gap-2">

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -12,6 +12,7 @@ import { RSVPFormStep2 } from '../components/RSVPFormStep2';
 // GPP theme applied conditionally
 import { GPPClouds } from '../components/GPPClouds';
 import { useConfetti } from '../hooks/useConfetti';
+import { ShareRSVP } from '../components/ShareRSVP';
 
 export function RSVPPage() {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -301,6 +302,14 @@ export function RSVPPage() {
             <p className="text-theme-text-secondary mb-4">
               Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
             </p>
+          )}
+          {!form.alreadyRegistered && !form.pendingApproval && (
+            <ShareRSVP
+              eventName={party?.name || ''}
+              eventImageUrl={party?.event_image_url || null}
+              customUrl={party?.custom_url || null}
+              inviteCode={inviteCode || ''}
+            />
           )}
           <button
             onClick={handleClose}


### PR DESCRIPTION
## Summary
- Adds a share section to the RSVP success screen
- Shows event flyer with share buttons (X, Download, Copy Link, native share)
- Only appears for successful new RSVPs with an event image

## Test plan
- [ ] RSVP to an event with a flyer and see share section
- [ ] Share on X opens Twitter with pre-filled text and event URL
- [ ] Download saves the flyer image
- [ ] Copy Link copies event URL with Copied feedback
- [ ] RSVP to event without flyer shows no share section
- [ ] Mobile native share button appears and works