### PR TITLE
feat: editable pizzeria taglines on host page

### DIFF
--- a/frontend/src/components/PizzeriaSelection.tsx
+++ b/frontend/src/components/PizzeriaSelection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { MapPin, Star, Plus, X, Phone, Link as LinkIcon, Loader2, Store, Users, Trophy, Bot } from 'lucide-react';
+import { MapPin, Star, Plus, X, Phone, Link as LinkIcon, Loader2, Store, Users, Trophy, Bot, Pencil } from 'lucide-react';
 import { usePizza } from '../contexts/PizzaContext';
 import { updateParty } from '../lib/supabase';
 import { searchPizzerias, geocodeAddress, calculateDistanceMiles, formatDistanceMiles } from '../lib/ordering';
@@ -42,6 +42,9 @@ export const PizzeriaSelection: React.FC<PizzeriaSelectionProps> = ({ embedded =
       localStorage.setItem(storageKey, JSON.stringify(existing));
     }
   };
+
+  // Tagline editing state
+  const [editingTaglineId, setEditingTaglineId] = useState<string | null>(null);
 
   // Pizzeria selection state
   const [selectedPizzerias, setSelectedPizzerias] = useState<Pizzeria[]>([]);
@@ -340,6 +343,48 @@ export const PizzeriaSelection: React.FC<PizzeriaSelectionProps> = ({ embedded =
                     </div>
                     {pizzeria.address && (
                       <p className="text-theme-text-muted text-xs truncate">{pizzeria.address}</p>
+                    )}
+                    {editingTaglineId === pizzeria.id ? (
+                      <div className="mt-1">
+                        <IconInput
+                          icon={Pencil}
+                          iconSize={12}
+                          multiline
+                          rows={2}
+                          defaultValue={pizzeria.description || ''}
+                          placeholder="Add tagline..."
+                          className="text-xs !py-1.5"
+                          autoFocus
+                          onBlur={(e: React.FocusEvent<HTMLTextAreaElement>) => {
+                            const newDescription = (e.target as HTMLTextAreaElement).value.trim();
+                            const updated = selectedPizzerias.map(p =>
+                              p.id === pizzeria.id ? { ...p, description: newDescription || undefined } : p
+                            );
+                            setSelectedPizzerias(updated);
+                            savePizzerias(updated);
+                            setEditingTaglineId(null);
+                          }}
+                          onKeyDown={(e: React.KeyboardEvent) => {
+                            if (e.key === 'Escape') {
+                              setEditingTaglineId(null);
+                            }
+                          }}
+                        />
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditingTaglineId(pizzeria.id);
+                        }}
+                        className="flex items-center gap-1 mt-0.5 text-xs text-theme-text-muted hover:text-theme-text-secondary transition-colors group"
+                      >
+                        <span className={pizzeria.description ? '' : 'italic opacity-50'}>
+                          {pizzeria.description || 'Add tagline...'}
+                        </span>
+                        <Pencil size={10} className="opacity-0 group-hover:opacity-60 transition-opacity flex-shrink-0" />
+                      </button>
                     )}
                     {hasVotes && scores && (
                       <div className="flex items-center gap-2 mt-0.5">

--- a/plans/pizzeria-tagline-edit.md
+++ b/plans/pizzeria-tagline-edit.md
@@ -1,0 +1,37 @@
+# Pizzeria Tagline Edit
+
+## Task
+Allow hosts to edit the description/tagline on their selected pizzerias from the host page.
+
+## Scope
+Frontend-only — no DB or backend changes needed. The `description` field already exists on the `Pizzeria` type and is persisted as part of the `selected_pizzerias` JSONB array.
+
+## File to Modify
+- `frontend/src/components/PizzeriaSelection.tsx`
+
+## Implementation
+
+In the selected pizzerias section (lines ~289-407), for each pizzeria card:
+
+1. Add a `Pencil` icon import from lucide-react
+2. Below the address line and above the votes/links, add an inline editable tagline area:
+   - If NOT editing: show the current `description` as muted text, or "Add tagline..." placeholder if empty. Show a small pencil icon on hover.
+   - If editing: show an `IconInput` with `multiline` prop, pre-filled with current description
+3. Track which pizzeria is being edited via `editingTaglineId` state (`string | null`)
+4. On blur: update the pizzeria's `description` in the local `selectedPizzerias` array and call `savePizzerias()`
+5. Keep it compact — use `text-xs` styling consistent with the rest of the card
+
+## Save Flow
+- Same optimistic pattern as the rest of PizzeriaSelection
+- Update local state immediately, call `savePizzerias(updated)` which calls `saveField('pizzerias', { selected_pizzerias: updated })`
+- On failure, reverts to `party.selectedPizzerias`
+
+## Display
+Already handled — `ParticipatingPizzerias.tsx` renders `pizzeria.description` on the public event page. No changes needed there.
+
+## Verification
+1. Select a pizzeria on the host page Pizza tab
+2. Click the tagline area → should open editable input
+3. Type a tagline, click away → should save
+4. Reload page → tagline persists
+5. Check event page → tagline appears under pizzeria name


### PR DESCRIPTION
## Summary
- Adds inline editing for pizzeria description/taglines on the host page Pizza tab
- Hosts can click the tagline area to edit, saves on blur
- Shows on the public event page via existing ParticipatingPizzerias component
- No DB or backend changes needed — description is already part of the JSONB array

## Test plan
- [ ] Select a pizzeria on host page Pizza tab
- [ ] Click tagline area → editable input appears
- [ ] Type a tagline, click away → saves
- [ ] Reload → tagline persists
- [ ] Check event page → tagline shows under pizzeria name

🤖 Generated with [Claude Code](https://claude.com/claude-code)