### PR TITLE
feat: bulk CSV invites in promo app

### DIFF
--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -1,6 +1,7 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../../config/database.js';
 import { requireApiKey, ApiKeyRequest, SCOPES } from '../../middleware/apiKey.js';
+import { requireAuth, AuthRequest } from '../../middleware/auth.js';
 import { AppError } from '../../middleware/error.js';
 import { triggerWebhook } from '../../services/webhook.service.js';
 
@@ -15,6 +16,82 @@ async function verifyPartyOwnership(partyId: string, userId: string) {
     throw new AppError('Party not found', 404, 'NOT_FOUND');
   }
   return party;
+}
+
+// Build the invite email subject + HTML for a given party + guest. Optionally
+// inject a custom host message above the CTA button. Shared by the single
+// `/send-invite` and bulk `/bulk-invite` endpoints.
+export function buildInviteEmail(
+  party: {
+    name: string;
+    date: Date | null;
+    address: string | null;
+    inviteCode: string;
+    customUrl: string | null;
+    timezone: string | null;
+  },
+  guest: { name: string; email: string },
+  customMessage?: string
+): { subject: string; html: string } {
+  const baseUrl = 'https://rsv.pizza';
+  const eventUrl = party.customUrl
+    ? `${baseUrl}/${party.customUrl}`
+    : `${baseUrl}/${party.inviteCode}`;
+
+  const dateText = party.date
+    ? new Date(party.date).toLocaleDateString('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : 'Date TBD';
+
+  // Escape user-provided content to avoid HTML injection
+  const escape = (s: string) =>
+    s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const customMessageBlock = customMessage && customMessage.trim().length > 0
+    ? `
+          <div style="background: #fff; border-left: 4px solid #ff393a; padding: 16px 20px; border-radius: 6px; margin: 20px 0; white-space: pre-wrap;">
+            <p style="margin: 0; color: #333; font-size: 15px;">${escape(customMessage.trim()).replace(/\n/g, '<br>')}</p>
+          </div>`
+    : '';
+
+  const subject = `You're invited to ${party.name}!`;
+
+  const html = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>You're invited!</title>
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #ffffff; font-size: 32px; margin: 0;">You're Invited!</h1>
+          </div>
+          <div style="background: #f9f9f9; padding: 30px; border-radius: 12px; margin-bottom: 20px;">
+            <h2 style="color: #1a1a2e; margin-top: 0;">${escape(party.name)}</h2>
+            <p><strong>When:</strong> ${escape(dateText)}</p>
+            <p><strong>Where:</strong> ${escape(party.address || 'Location TBD')}</p>
+          </div>
+          ${customMessageBlock}
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${eventUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600;">RSVP Now</a>
+          </div>
+        </body>
+      </html>
+    `;
+
+  return { subject, html };
 }
 
 /**
@@ -483,44 +560,17 @@ router.post('/:guestId/send-invite', requireApiKey(SCOPES.GUESTS_WRITE), async (
       throw new AppError('Email service not configured', 500, 'CONFIG_ERROR');
     }
 
-    const baseUrl = 'https://rsv.pizza';
-    const eventUrl = party.customUrl
-      ? `${baseUrl}/${party.customUrl}`
-      : `${baseUrl}/${party.inviteCode}`;
-
-    const dateText = party.date
-      ? new Date(party.date).toLocaleDateString('en-US', {
-          weekday: 'long',
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-        })
-      : 'Date TBD';
-
-    const emailHtml = `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta charset="utf-8">
-          <title>You're invited!</title>
-        </head>
-        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-          <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
-            <h1 style="color: #ffffff; font-size: 32px; margin: 0;">You're Invited!</h1>
-          </div>
-          <div style="background: #f9f9f9; padding: 30px; border-radius: 12px; margin-bottom: 20px;">
-            <h2 style="color: #1a1a2e; margin-top: 0;">${party.name}</h2>
-            <p><strong>When:</strong> ${dateText}</p>
-            <p><strong>Where:</strong> ${party.address || 'Location TBD'}</p>
-          </div>
-          <div style="text-align: center; margin: 30px 0;">
-            <a href="${eventUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600;">RSVP Now</a>
-          </div>
-        </body>
-      </html>
-    `;
+    const { subject, html } = buildInviteEmail(
+      {
+        name: party.name,
+        date: party.date,
+        address: party.address,
+        inviteCode: party.inviteCode,
+        customUrl: party.customUrl,
+        timezone: party.timezone,
+      },
+      { name: guest.name, email: guest.email }
+    );
 
     const response = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -531,8 +581,8 @@ router.post('/:guestId/send-invite', requireApiKey(SCOPES.GUESTS_WRITE), async (
       body: JSON.stringify({
         from: 'RSV.Pizza <noreply@rsv.pizza>',
         to: [guest.email],
-        subject: `You're invited to ${party.name}!`,
-        html: emailHtml,
+        subject,
+        html,
       }),
     });
 
@@ -542,6 +592,176 @@ router.post('/:guestId/send-invite', requireApiKey(SCOPES.GUESTS_WRITE), async (
     }
 
     res.json({ success: true, message: 'Invite sent' });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * POST /api/v1/parties/:partyId/guests/bulk-invite
+ *
+ * User-authenticated (Bearer token) bulk invite endpoint used by the Promo
+ * app in the host dashboard. Creates a `Guest` row per entry with status
+ * PENDING / submittedVia 'invite' and sends an invite email via Resend.
+ *
+ * Body: { guests: Array<{name, email}>, customMessage?: string }
+ * Response: { sent, failed, skipped, createdGuestIds }
+ */
+router.post('/bulk-invite', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const userId = req.userId;
+    if (!userId) {
+      throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+    }
+
+    // Verify party ownership (user must own the party to bulk-invite)
+    const party = await prisma.party.findFirst({
+      where: { id: partyId, userId },
+    });
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    const { guests, customMessage } = req.body as {
+      guests?: Array<{ name?: string; email?: string }>;
+      customMessage?: string;
+    };
+
+    if (!Array.isArray(guests) || guests.length === 0) {
+      throw new AppError('guests must be a non-empty array', 400, 'VALIDATION_ERROR');
+    }
+    if (guests.length > 500) {
+      throw new AppError('Max 500 guests per request', 400, 'VALIDATION_ERROR');
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    const results = {
+      sent: [] as string[],
+      failed: [] as Array<{ email: string; reason: string }>,
+      skipped: [] as Array<{ email: string; reason: string }>,
+      createdGuestIds: [] as string[],
+    };
+
+    // Prefetch existing guest emails for this party (case-insensitive compare)
+    const existing = await prisma.guest.findMany({
+      where: { partyId },
+      select: { email: true },
+    });
+    const existingEmails = new Set(
+      existing
+        .map((g) => (g.email ? g.email.toLowerCase() : null))
+        .filter((e): e is string => !!e)
+    );
+
+    const resendApiKey = process.env.RESEND_API_KEY;
+
+    // Process in batches of 10 with a 500ms delay between batches.
+    const BATCH_SIZE = 10;
+    for (let i = 0; i < guests.length; i += BATCH_SIZE) {
+      const batch = guests.slice(i, i + BATCH_SIZE);
+
+      await Promise.all(
+        batch.map(async (g) => {
+          const rawEmail = (g.email || '').trim();
+          const normalizedEmail = rawEmail.toLowerCase();
+          const displayEmail = rawEmail || '(no email)';
+
+          if (!rawEmail || !emailRegex.test(rawEmail)) {
+            results.failed.push({ email: displayEmail, reason: 'invalid email' });
+            return;
+          }
+
+          if (existingEmails.has(normalizedEmail)) {
+            results.skipped.push({ email: displayEmail, reason: 'already invited' });
+            return;
+          }
+          // Reserve this email so duplicates within the same batch are also skipped
+          existingEmails.add(normalizedEmail);
+
+          const name = (g.name || '').trim() || normalizedEmail.split('@')[0];
+
+          let newGuest;
+          try {
+            newGuest = await prisma.guest.create({
+              data: {
+                partyId,
+                name,
+                email: normalizedEmail,
+                status: 'PENDING',
+                submittedVia: 'invite',
+                approved: null,
+                roles: [],
+              },
+            });
+            results.createdGuestIds.push(newGuest.id);
+          } catch (err: any) {
+            results.failed.push({
+              email: displayEmail,
+              reason: err?.message || 'failed to create guest',
+            });
+            return;
+          }
+
+          // Send invite email (if Resend configured). If email fails, keep the
+          // guest row but report the failure so the host knows to retry.
+          if (resendApiKey) {
+            try {
+              const { subject, html } = buildInviteEmail(
+                {
+                  name: party.name,
+                  date: party.date,
+                  address: party.address,
+                  inviteCode: party.inviteCode,
+                  customUrl: party.customUrl,
+                  timezone: party.timezone,
+                },
+                { name, email: normalizedEmail },
+                customMessage
+              );
+
+              const resp = await fetch('https://api.resend.com/emails', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Authorization: `Bearer ${resendApiKey}`,
+                },
+                body: JSON.stringify({
+                  from: 'RSV.Pizza <noreply@rsv.pizza>',
+                  to: [normalizedEmail],
+                  subject,
+                  html,
+                }),
+              });
+
+              if (!resp.ok) {
+                const body = await resp.text().catch(() => '');
+                results.failed.push({
+                  email: displayEmail,
+                  reason: `resend ${resp.status}${body ? ': ' + body.slice(0, 120) : ''}`,
+                });
+                return;
+              }
+            } catch (err: any) {
+              results.failed.push({
+                email: displayEmail,
+                reason: err?.message || 'email send error',
+              });
+              return;
+            }
+          }
+
+          results.sent.push(displayEmail);
+        })
+      );
+
+      if (i + BATCH_SIZE < guests.length) {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+
+    res.json(results);
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/promo/BulkInvite.tsx
+++ b/frontend/src/components/promo/BulkInvite.tsx
@@ -1,0 +1,500 @@
+import React, { useState, useMemo, useRef, useCallback } from 'react';
+import {
+  Upload,
+  FileText,
+  MessageSquare,
+  Send,
+  Loader2,
+  CheckCircle,
+  AlertTriangle,
+  RotateCcw,
+  ChevronDown,
+  ChevronUp,
+  Users,
+} from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
+import { Party } from '../../types';
+import { usePizza } from '../../contexts/PizzaContext';
+import { parseCsv, ParsedCsvRow } from '../../lib/csvParser';
+import { bulkInviteGuests, BulkInviteResult } from '../../lib/api';
+
+interface BulkInviteProps {
+  party: Party;
+}
+
+type Stage = 'upload' | 'preview' | 'sending' | 'results';
+
+type RowStatus = 'valid' | 'invalid-email' | 'duplicate-db' | 'duplicate-csv';
+
+interface PreviewRow extends ParsedCsvRow {
+  status: RowStatus;
+  checked: boolean;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_ROWS = 500;
+
+function statusLabel(status: RowStatus): string {
+  switch (status) {
+    case 'valid':
+      return 'Valid';
+    case 'invalid-email':
+      return 'Invalid email';
+    case 'duplicate-db':
+      return 'Already invited';
+    case 'duplicate-csv':
+      return 'Duplicate in file';
+  }
+}
+
+function statusBadgeClass(status: RowStatus): string {
+  switch (status) {
+    case 'valid':
+      return 'bg-green-500/10 text-green-400 border border-green-500/20';
+    case 'invalid-email':
+      return 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20';
+    case 'duplicate-db':
+    case 'duplicate-csv':
+      return 'bg-theme-surface text-theme-text-muted border border-theme-stroke';
+  }
+}
+
+export const BulkInvite: React.FC<BulkInviteProps> = ({ party }) => {
+  const { guests, loadParty } = usePizza();
+
+  const [stage, setStage] = useState<Stage>('upload');
+  const [dragActive, setDragActive] = useState(false);
+  const [previewRows, setPreviewRows] = useState<PreviewRow[]>([]);
+  const [customMessage, setCustomMessage] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [results, setResults] = useState<BulkInviteResult | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [showSkipped, setShowSkipped] = useState(false);
+  const [showFailed, setShowFailed] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Pre-compute existing emails on the party, case-insensitive
+  const existingEmails = useMemo(() => {
+    const s = new Set<string>();
+    for (const g of guests) {
+      if (g.email) s.add(g.email.trim().toLowerCase());
+    }
+    return s;
+  }, [guests]);
+
+  const classifyRows = useCallback(
+    (parsed: ParsedCsvRow[]): PreviewRow[] => {
+      const seenInFile = new Set<string>();
+      return parsed.map((row) => {
+        const email = row.email.trim().toLowerCase();
+        let status: RowStatus = 'valid';
+        if (!email || !EMAIL_REGEX.test(email)) {
+          status = 'invalid-email';
+        } else if (existingEmails.has(email)) {
+          status = 'duplicate-db';
+        } else if (seenInFile.has(email)) {
+          status = 'duplicate-csv';
+        } else {
+          seenInFile.add(email);
+        }
+        return {
+          ...row,
+          status,
+          checked: status === 'valid',
+        };
+      });
+    },
+    [existingEmails]
+  );
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      setParseError(null);
+      try {
+        const text = await file.text();
+        const parsed = parseCsv(text);
+        if (parsed.length === 0) {
+          setParseError('No rows found in CSV. Make sure the file has name and email columns.');
+          return;
+        }
+        if (parsed.length > MAX_ROWS) {
+          setParseError(`Too many rows (${parsed.length}). Max is ${MAX_ROWS} per upload.`);
+          return;
+        }
+        const classified = classifyRows(parsed);
+        setPreviewRows(classified);
+        setStage('preview');
+      } catch (err: any) {
+        setParseError(err?.message || 'Failed to read file.');
+      }
+    },
+    [classifyRows]
+  );
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleFile(file);
+    // Reset so selecting the same file again still triggers change
+    e.target.value = '';
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) void handleFile(file);
+  };
+
+  const toggleRow = (idx: number) => {
+    setPreviewRows((rows) =>
+      rows.map((r, i) => (i === idx ? { ...r, checked: !r.checked } : r))
+    );
+  };
+
+  const resetToUpload = () => {
+    setStage('upload');
+    setPreviewRows([]);
+    setCustomMessage('');
+    setParseError(null);
+    setResults(null);
+    setSendError(null);
+    setShowSkipped(false);
+    setShowFailed(false);
+  };
+
+  const counts = useMemo(() => {
+    let valid = 0;
+    let duplicates = 0;
+    let invalid = 0;
+    let checked = 0;
+    for (const r of previewRows) {
+      if (r.status === 'valid') valid++;
+      else if (r.status === 'invalid-email') invalid++;
+      else duplicates++;
+      if (r.checked) checked++;
+    }
+    return { total: previewRows.length, valid, duplicates, invalid, checked };
+  }, [previewRows]);
+
+  const handleSend = async () => {
+    const toSend = previewRows
+      .filter((r) => r.checked)
+      .map((r) => ({
+        name: r.name,
+        email: r.email.trim(),
+      }));
+
+    if (toSend.length === 0) return;
+
+    setStage('sending');
+    setSendError(null);
+
+    try {
+      const res = await bulkInviteGuests(
+        party.id,
+        toSend,
+        customMessage.trim() || undefined
+      );
+      setResults(res);
+      setStage('results');
+      // Refresh guest list so new pending guests appear in the host dashboard
+      if (party.inviteCode) {
+        void loadParty(party.inviteCode);
+      }
+    } catch (err: any) {
+      setSendError(err?.message || 'Failed to send invites.');
+      setStage('preview');
+    }
+  };
+
+  // ---------------- Upload stage ----------------
+  if (stage === 'upload') {
+    return (
+      <div className="space-y-4">
+        <div
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragActive(true);
+          }}
+          onDragLeave={() => setDragActive(false)}
+          onDrop={onDrop}
+          onClick={() => fileInputRef.current?.click()}
+          className={`cursor-pointer border-2 border-dashed rounded-xl p-8 text-center transition-colors ${
+            dragActive
+              ? 'border-[#ff393a] bg-[#ff393a]/5'
+              : 'border-theme-stroke hover:border-theme-stroke-hover bg-theme-surface'
+          }`}
+        >
+          <Upload size={32} className="mx-auto mb-3 text-theme-text-muted" />
+          <p className="text-theme-text font-medium mb-1">
+            Drop a CSV or click to select
+          </p>
+          <p className="text-xs text-theme-text-muted">
+            CSV should have name and email columns. Max {MAX_ROWS} rows.
+          </p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={onFileChange}
+            className="hidden"
+          />
+        </div>
+
+        {parseError && (
+          <div className="flex items-start gap-2 bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3">
+            <AlertTriangle size={16} className="text-yellow-500 flex-shrink-0 mt-0.5" />
+            <span className="text-xs text-yellow-500/80">{parseError}</span>
+          </div>
+        )}
+
+        <p className="text-xs text-theme-text-faint">
+          Invited guests are added as pending RSVPs. They receive an email with
+          the event details and an RSVP link.
+        </p>
+      </div>
+    );
+  }
+
+  // ---------------- Preview stage ----------------
+  if (stage === 'preview') {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <div className="flex items-center gap-2">
+            <FileText size={14} className="text-theme-text-muted" />
+            <span className="text-xs text-theme-text-muted">
+              Found {counts.total} row{counts.total !== 1 ? 's' : ''} ·{' '}
+              <span className="text-green-400">{counts.valid} valid</span> ·{' '}
+              <span className="text-theme-text-secondary">{counts.duplicates} duplicate</span> ·{' '}
+              <span className="text-yellow-500/90">{counts.invalid} invalid</span>
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={resetToUpload}
+            className="text-xs text-theme-text-muted hover:text-theme-text-secondary flex items-center gap-1 transition-colors"
+          >
+            <RotateCcw size={12} />
+            Start over
+          </button>
+        </div>
+
+        <div className="border border-theme-stroke rounded-lg overflow-hidden">
+          <div className="max-h-96 overflow-y-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-theme-surface sticky top-0">
+                <tr>
+                  <th className="w-10 p-2"></th>
+                  <th className="text-left p-2 text-xs font-medium text-theme-text-muted">Name</th>
+                  <th className="text-left p-2 text-xs font-medium text-theme-text-muted">Email</th>
+                  <th className="text-left p-2 text-xs font-medium text-theme-text-muted">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {previewRows.map((row, idx) => {
+                  const dimmed = row.status !== 'valid';
+                  return (
+                    <tr
+                      key={idx}
+                      className={`border-t border-theme-stroke ${
+                        dimmed ? 'opacity-50' : ''
+                      }`}
+                    >
+                      <td className="p-2 align-middle">
+                        <Checkbox
+                          checked={row.checked}
+                          onChange={() => toggleRow(idx)}
+                          label=""
+                          size={16}
+                        />
+                      </td>
+                      <td className="p-2 text-theme-text truncate max-w-xs" title={row.name}>
+                        {row.name || <span className="text-theme-text-muted italic">—</span>}
+                      </td>
+                      <td className="p-2 text-theme-text-secondary truncate max-w-xs" title={row.email}>
+                        {row.email || <span className="text-theme-text-muted italic">—</span>}
+                      </td>
+                      <td className="p-2">
+                        <span className={`inline-block px-2 py-0.5 rounded text-xs ${statusBadgeClass(row.status)}`}>
+                          {statusLabel(row.status)}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <IconInput
+          icon={MessageSquare}
+          multiline
+          rows={3}
+          value={customMessage}
+          onChange={(e) => setCustomMessage(e.target.value)}
+          placeholder="Optional custom message (shown in invite email)"
+        />
+
+        {sendError && (
+          <div className="flex items-start gap-2 bg-red-500/10 border border-red-500/20 rounded-lg p-3">
+            <AlertTriangle size={16} className="text-red-400 flex-shrink-0 mt-0.5" />
+            <span className="text-xs text-red-300">{sendError}</span>
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={resetToUpload}
+            className="flex-1 flex items-center justify-center gap-2 bg-theme-surface hover:bg-theme-surface-hover text-theme-text font-medium py-2.5 rounded-lg transition-colors text-sm border border-theme-stroke"
+          >
+            <RotateCcw size={16} />
+            Start over
+          </button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={counts.checked === 0}
+            className="flex-1 flex items-center justify-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm"
+          >
+            <Send size={16} />
+            Send {counts.checked} invite{counts.checked !== 1 ? 's' : ''}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------- Sending stage ----------------
+  if (stage === 'sending') {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 gap-3">
+        <Loader2 size={32} className="text-[#ff393a] animate-spin" />
+        <p className="text-theme-text font-medium">Sending invites...</p>
+        <p className="text-xs text-theme-text-muted">
+          This may take a moment for large batches.
+        </p>
+      </div>
+    );
+  }
+
+  // ---------------- Results stage ----------------
+  if (stage === 'results' && results) {
+    const sentCount = results.sent.length;
+    const skippedCount = results.skipped.length;
+    const failedCount = results.failed.length;
+    const success = sentCount > 0;
+
+    return (
+      <div className="space-y-4">
+        <div
+          className={`flex items-start gap-3 rounded-lg p-4 ${
+            success
+              ? 'bg-green-500/10 border border-green-500/20'
+              : 'bg-yellow-500/10 border border-yellow-500/20'
+          }`}
+        >
+          {success ? (
+            <CheckCircle size={20} className="text-green-400 flex-shrink-0 mt-0.5" />
+          ) : (
+            <AlertTriangle size={20} className="text-yellow-500 flex-shrink-0 mt-0.5" />
+          )}
+          <div className="flex-1">
+            <p className={`font-medium ${success ? 'text-green-400' : 'text-yellow-500'}`}>
+              {success
+                ? `Sent ${sentCount} invite${sentCount !== 1 ? 's' : ''}`
+                : 'Failed to send any invites'}
+            </p>
+            <div className="flex flex-wrap gap-3 mt-1 text-xs text-theme-text-muted">
+              <span className="flex items-center gap-1">
+                <Users size={12} />
+                {sentCount} sent
+              </span>
+              {skippedCount > 0 && <span>{skippedCount} skipped</span>}
+              {failedCount > 0 && <span className="text-red-300">{failedCount} failed</span>}
+            </div>
+          </div>
+        </div>
+
+        {skippedCount > 0 && (
+          <div className="border border-theme-stroke rounded-lg overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setShowSkipped((v) => !v)}
+              className="w-full flex items-center justify-between p-3 text-left hover:bg-theme-surface transition-colors"
+            >
+              <span className="text-sm text-theme-text">
+                {skippedCount} skipped
+              </span>
+              {showSkipped ? (
+                <ChevronUp size={16} className="text-theme-text-muted" />
+              ) : (
+                <ChevronDown size={16} className="text-theme-text-muted" />
+              )}
+            </button>
+            {showSkipped && (
+              <div className="border-t border-theme-stroke max-h-48 overflow-y-auto">
+                {results.skipped.map((s, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between gap-2 p-2 text-xs border-b border-theme-stroke last:border-b-0"
+                  >
+                    <span className="text-theme-text-secondary truncate">{s.email}</span>
+                    <span className="text-theme-text-muted flex-shrink-0">{s.reason}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {failedCount > 0 && (
+          <div className="border border-red-500/20 rounded-lg overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setShowFailed((v) => !v)}
+              className="w-full flex items-center justify-between p-3 text-left hover:bg-red-500/5 transition-colors"
+            >
+              <span className="text-sm text-red-300">
+                {failedCount} failed
+              </span>
+              {showFailed ? (
+                <ChevronUp size={16} className="text-red-300" />
+              ) : (
+                <ChevronDown size={16} className="text-red-300" />
+              )}
+            </button>
+            {showFailed && (
+              <div className="border-t border-red-500/20 max-h-48 overflow-y-auto">
+                {results.failed.map((f, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between gap-2 p-2 text-xs border-b border-red-500/10 last:border-b-0"
+                  >
+                    <span className="text-theme-text-secondary truncate">{f.email}</span>
+                    <span className="text-red-300/80 flex-shrink-0">{f.reason}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={resetToUpload}
+          className="w-full flex items-center justify-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium py-2.5 rounded-lg transition-colors text-sm"
+        >
+          <Upload size={16} />
+          Invite more
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/frontend/src/components/promo/PromoWidget.tsx
+++ b/frontend/src/components/promo/PromoWidget.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Share2, Globe, Mail } from 'lucide-react';
+import { Share2, Globe, Mail, UserPlus } from 'lucide-react';
 import { usePizza } from '../../contexts/PizzaContext';
 import { SocialComposer } from './SocialComposer';
 import { PlatformPublisher } from './PlatformPublisher';
 import { EmailOutreach } from './EmailOutreach';
+import { BulkInvite } from './BulkInvite';
 
-type PromoSection = 'social' | 'publish' | 'email';
+type PromoSection = 'social' | 'publish' | 'email' | 'invite';
 
 interface SectionConfig {
   id: PromoSection;
@@ -32,6 +33,12 @@ const SECTIONS: SectionConfig[] = [
     label: 'Email Guests',
     description: 'Send updates to your guest list',
     icon: Mail,
+  },
+  {
+    id: 'invite',
+    label: 'Invite Guests',
+    description: 'Upload a CSV to send bulk invites',
+    icon: UserPlus,
   },
 ];
 
@@ -90,6 +97,7 @@ export const PromoWidget: React.FC = () => {
                 {section.id === 'social' && <SocialComposer party={party} />}
                 {section.id === 'publish' && <PlatformPublisher party={party} />}
                 {section.id === 'email' && <EmailOutreach party={party} guests={guests} />}
+                {section.id === 'invite' && <BulkInvite party={party} />}
               </div>
             )}
           </div>

--- a/frontend/src/components/promo/index.ts
+++ b/frontend/src/components/promo/index.ts
@@ -2,3 +2,4 @@ export { PromoWidget } from './PromoWidget';
 export { SocialComposer } from './SocialComposer';
 export { PlatformPublisher } from './PlatformPublisher';
 export { EmailOutreach } from './EmailOutreach';
+export { BulkInvite } from './BulkInvite';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -287,6 +287,28 @@ export async function promoteGuestApi(partyId: string, guestId: string) {
   });
 }
 
+// Bulk CSV invites (Promo app → POST /api/v1/parties/:partyId/guests/bulk-invite)
+export interface BulkInviteResult {
+  sent: string[];
+  failed: Array<{ email: string; reason: string }>;
+  skipped: Array<{ email: string; reason: string }>;
+  createdGuestIds: string[];
+}
+
+export async function bulkInviteGuests(
+  partyId: string,
+  guests: Array<{ name: string; email: string }>,
+  customMessage?: string
+): Promise<BulkInviteResult> {
+  return apiRequest<BulkInviteResult>(
+    `/api/v1/parties/${partyId}/guests/bulk-invite`,
+    {
+      method: 'POST',
+      body: { guests, customMessage },
+    }
+  );
+}
+
 // Public RSVP API (no auth required)
 export async function submitRsvpApi(
   inviteCode: string,

--- a/frontend/src/lib/csvParser.ts
+++ b/frontend/src/lib/csvParser.ts
@@ -1,0 +1,114 @@
+/**
+ * Minimal CSV parser for the bulk-invite Promo widget.
+ *
+ * - Handles quoted fields with embedded commas and escaped quotes (`""`)
+ * - Handles CRLF or LF line endings
+ * - Trims whitespace on each cell
+ * - Detects a header row when a cell matches `name` or `email` variants
+ *   (case-insensitive); otherwise assumes column 0 = name, column 1 = email
+ * - Falls back to the email local-part for `name` when a row has no name
+ *
+ * The parser is lenient — it returns every data row, valid or not. The UI
+ * component handles validation (invalid email, duplicate, etc.).
+ */
+
+export interface ParsedCsvRow {
+  name: string;
+  email: string;
+  /** The raw line from the CSV, for display in debug/error UI. */
+  _raw: string;
+}
+
+// Split a single CSV line into cells, respecting quoted fields.
+function splitCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        // Escaped quote (`""`) -> literal `"`
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ',') {
+        cells.push(current);
+        current = '';
+      } else {
+        current += ch;
+      }
+    }
+  }
+  cells.push(current);
+
+  return cells.map((c) => c.trim());
+}
+
+const NAME_HEADERS = new Set(['name', 'full name', 'full_name', 'fullname']);
+const EMAIL_HEADERS = new Set(['email', 'e-mail', 'e_mail', 'email address', 'email_address']);
+
+function isNameHeader(cell: string): boolean {
+  return NAME_HEADERS.has(cell.trim().toLowerCase());
+}
+function isEmailHeader(cell: string): boolean {
+  return EMAIL_HEADERS.has(cell.trim().toLowerCase());
+}
+
+export function parseCsv(text: string): ParsedCsvRow[] {
+  // Strip a BOM if present
+  const cleaned = text.replace(/^\uFEFF/, '');
+
+  // Normalize line endings and split
+  const lines = cleaned
+    .split(/\r\n|\n|\r/)
+    .map((l) => l)
+    .filter((l) => l.trim().length > 0);
+
+  if (lines.length === 0) return [];
+
+  // Detect header row: does the first line have a name header AND an email header?
+  const firstCells = splitCsvLine(lines[0]);
+  const hasNameHeader = firstCells.some(isNameHeader);
+  const hasEmailHeader = firstCells.some(isEmailHeader);
+  const headerDetected = hasNameHeader && hasEmailHeader;
+
+  let nameIdx = 0;
+  let emailIdx = 1;
+  let dataStart = 0;
+
+  if (headerDetected) {
+    nameIdx = firstCells.findIndex(isNameHeader);
+    emailIdx = firstCells.findIndex(isEmailHeader);
+    dataStart = 1;
+  }
+
+  const rows: ParsedCsvRow[] = [];
+  for (let i = dataStart; i < lines.length; i++) {
+    const raw = lines[i];
+    const cells = splitCsvLine(raw);
+
+    const email = (cells[emailIdx] || '').trim();
+    let name = (cells[nameIdx] || '').trim();
+
+    // Fallback: if we don't have a name, use the local part of the email
+    if (!name && email.includes('@')) {
+      name = email.split('@')[0];
+    }
+
+    rows.push({ name, email, _raw: raw });
+  }
+
+  return rows;
+}

--- a/plans/bulk-csv-invites.md
+++ b/plans/bulk-csv-invites.md
@@ -1,0 +1,118 @@
+# Bulk CSV Invites
+
+## Feature
+Hosts can upload a `.csv` of email addresses to bulk-invite people to their party. CSV rows are parsed into guests (created in DB as pending/invited) and each gets an invite email.
+
+## User Flow
+1. Host opens the **Promo app** (`PromoWidget`) on the host page
+2. Expands the new **"Invite Guests"** section
+3. Drops a `.csv` file (or clicks to select)
+4. **Preview table** inline in the section shows parsed rows (name, email) with checkboxes — host can uncheck bad rows
+5. Invalid rows (malformed email, missing email) are visually flagged and auto-unchecked
+6. Duplicates (already existing in guest list) flagged and auto-unchecked
+7. Optional custom message textarea
+8. Host clicks "Send X invites"
+9. Progress indicator shows as invites send
+10. Results summary: "Sent X, failed Y, skipped Z (duplicates)"
+
+## CSV Parsing Rules
+- **Flexible headers**: case-insensitive match for `name`/`full name`/`full_name` and `email`/`email address`/`e-mail`
+- **If no header row detected** (first row looks like data): assume first column = name, second = email
+- **Required**: email must be valid format (basic regex)
+- **Optional**: name — if missing, use the local part of email (before `@`) as fallback
+- **Dedup**: skip rows where email already exists in this party's guests (case-insensitive)
+- **Dedup within CSV**: skip duplicate emails within the file
+
+## Backend Changes
+
+### New endpoint: `POST /api/v1/parties/:partyId/guests/bulk-invite`
+- **Auth**: requires party ownership
+- **Body**: `{ guests: Array<{ name: string; email: string }>, customMessage?: string }`
+- **Logic**:
+  1. For each guest in the input array:
+     - Check if a guest with this email already exists on the party → skip (return as "skipped")
+     - Create a new `Guest` row: `name`, `email`, `status: 'PENDING'`, `submittedVia: 'invite'`, `approved: null`
+     - Send invite email via Resend using existing template from `/send-invite` endpoint (extract into shared helper)
+     - Track success/failure per row
+  2. Return `{ sent: number, failed: Array<{email, reason}>, skipped: Array<{email, reason}>, createdGuestIds: string[] }`
+- **Rate limiting**: Send in batches of 10 with a 500ms delay between batches to stay under Resend limits
+- **Backend location**: `backend/src/routes/v1/guests.ts` — add new route
+
+### Refactor
+- Extract the invite email HTML builder from `/send-invite` (lines 462-548) into a shared helper function `buildInviteEmail(party, guestName, guestEmail, customMessage?)` so both single and bulk endpoints use the same template.
+
+## Frontend Changes
+
+### New component: `frontend/src/components/promo/BulkInvite.tsx`
+Inline component (not a modal — lives inside the PromoWidget's expanded section). Single scrollable view with 4 states, controlled by component-local state:
+
+**State 1 — Upload (initial)**:
+- Drag-and-drop zone + file picker for `.csv`
+- Helper text: "CSV should have `name` and `email` columns. Max 500 rows."
+
+**State 2 — Preview (after parse)**:
+- Summary: "Found X rows, Y will be invited" with counts of valid/invalid/duplicate
+- Scrollable table of rows: checkbox, name, email, status indicator (✓ valid, ⚠ invalid email, ↻ duplicate)
+- Invalid/duplicate rows auto-unchecked and visually dimmed
+- Optional `IconInput` (multiline) for custom message
+- "Clear / pick different file" link and "Send X invites" button (disabled when 0 checked)
+
+**State 3 — Sending**:
+- Spinner with "Sending X/Y..."
+
+**State 4 — Results**:
+- "Sent X invites, Y skipped (duplicates), Z failed"
+- Collapsible details of skipped/failed rows
+- "Invite more" button — returns to State 1
+- Triggers parent guest list refresh (via `loadParty` from `usePizza()`)
+
+### Integration into `PromoWidget.tsx`
+Add a new section to the `SECTIONS` array:
+```typescript
+{
+  id: 'invite',
+  label: 'Invite Guests',
+  description: 'Upload a CSV to send bulk invites',
+  icon: UserPlus, // from lucide-react
+},
+```
+
+Add `PromoSection` type: `'social' | 'publish' | 'email' | 'invite'`
+
+Render `<BulkInvite party={party} />` when `section.id === 'invite'`.
+
+### CSV parsing
+- Use native `FileReader` + string splitting (no library needed for simple CSV)
+- Handle: comma separator, optional quoted fields, CRLF or LF line endings, trim whitespace
+- Keep it in a utility function: `frontend/src/lib/csvParser.ts`
+
+## Files to Create
+- `frontend/src/components/promo/BulkInvite.tsx`
+- `frontend/src/lib/csvParser.ts`
+
+## Files to Modify
+- `backend/src/routes/v1/guests.ts` — new bulk-invite route + refactor email builder into helper
+- `frontend/src/components/promo/PromoWidget.tsx` — add "Invite Guests" section
+- `frontend/src/components/promo/index.ts` — export `BulkInvite`
+- `frontend/src/lib/api.ts` (or wherever guest API calls live) — add `bulkInviteGuests(partyId, rows, customMessage?)` function
+
+## DB Changes
+**None**. The existing `Guest` table supports this — `status: 'PENDING'`, `submittedVia: 'invite'`.
+
+## Edge Cases to Handle
+- Empty CSV
+- CSV with only headers, no data rows
+- CSV with unrecognized columns (show error, don't crash)
+- Emails with whitespace / mixed case → normalize to lowercase-trimmed
+- Extremely large CSV (>1000 rows) → show warning, enforce max 500/upload
+- Network failure mid-send → allow retry of just the failed ones
+
+## Verification
+1. Create a test CSV with 5 valid rows, 1 invalid email, 1 duplicate
+2. Upload → preview shows all 7, last 2 flagged
+3. Send → 5 invites sent, 2 skipped
+4. Check guests tab → 5 new pending guests appear
+5. Check email inbox → invite received with correct party details and RSVP link
+6. Re-upload same CSV → all 5 should show as "duplicate" in preview
+7. Test with CSV that has no header row
+8. Test with CSV that uses "Full Name" / "E-mail" column headers


### PR DESCRIPTION
## Summary
- Adds "Invite Guests" section to Promo app (PromoWidget)
- Hosts upload a CSV with name+email columns → preview → send
- Creates guests as PENDING status with submittedVia: 'invite'
- Reuses existing invite email template via shared helper
- Batches of 10 with 500ms delay for Resend rate limiting
- Unchecked rows (manually or auto-flagged invalid/duplicate) are ignored

## Backend Changes
- New endpoint: `POST /api/v1/parties/:partyId/guests/bulk-invite` (user Bearer auth)
- Refactored invite email HTML into `buildInviteEmail()` shared helper with HTML-escaping and optional `customMessage` block above the CTA
- Existing `/send-invite` route updated to use the shared helper
- Max 500 guests per request, validates email format server-side, deduplicates against existing party guests and within the batch

## Frontend Changes
- New `BulkInvite` component in `frontend/src/components/promo/` with 4 stages: upload, preview, sending, results
- New `parseCsv` utility in `frontend/src/lib/csvParser.ts` (handles quoted fields, CRLF/LF, BOM, detects `name` / `full name` / `email` / `e-mail` headers, falls back to positional columns)
- New `bulkInviteGuests()` API function in `frontend/src/lib/api.ts`
- Integrates into `PromoWidget` as a new collapsible section

## Deploy Order
- **Backend must merge to master first** for the bulk-invite endpoint to work. The preview frontend talks to production backend, so during PR review the CSV upload/preview UI will work but the actual send will 404 until backend merges and auto-deploys from master.

## Preview
https://rsvpizza-git-bulk-csv-invites-pizza-dao.vercel.app

## Test plan
- [ ] Upload CSV with valid rows → preview shows rows with Valid badges
- [ ] Upload CSV with invalid emails → flagged with Invalid email badge & auto-unchecked
- [ ] Upload CSV with existing guest emails → flagged as Already invited & auto-unchecked
- [ ] Upload CSV with in-file duplicates → second occurrence flagged as Duplicate in file
- [ ] Custom message text appears in invite email (above RSVP button)
- [ ] Send → results summary shows accurate sent/skipped/failed counts
- [ ] Guest list refreshes with new pending guests after send
- [ ] Re-upload same CSV → all rows show as already invited
- [ ] Test with `Full Name` / `E-mail` headers
- [ ] Test with no header row (assumes col 0 = name, col 1 = email)
- [ ] Test with > 500 rows → parse error shown, no upload attempted
- [ ] Manually uncheck a valid row → not sent

Generated with [Claude Code](https://claude.com/claude-code)
