### PR TITLE
slice-63335: filter underboss events by partner tag

### DIFF
--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -88,6 +88,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   const [sortField, setSortField] = useState<SortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [regionFilter, setRegionFilter] = useState<string>('all');
+  const [tagFilter, setTagFilter] = useState<string>('all');
 
   // Selection state for bulk actions
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -169,6 +170,11 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
       });
     }
 
+    // Tag filter
+    if (tagFilter !== 'all') {
+      result = result.filter((e) => e.eventTags?.includes(tagFilter));
+    }
+
     result = [...result].sort((a, b) => {
       let cmp = 0;
       switch (sortField) {
@@ -192,7 +198,12 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     });
 
     return result;
-  }, [events, search, sortField, sortDir, progressIncludes, progressExcludes, regionFilter, showRegion]);
+  }, [events, search, sortField, sortDir, progressIncludes, progressExcludes, regionFilter, showRegion, tagFilter]);
+
+  const availableTags = useMemo(
+    () => Array.from(new Set(events.flatMap((e) => e.eventTags ?? []))).sort(),
+    [events]
+  );
 
   function toggleSelectAll() {
     if (selectedIds.size === filteredEvents.length) {
@@ -228,7 +239,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     );
   }
 
-  const hasActiveFilters = progressIncludes.length > 0 || progressExcludes.length > 0 || regionFilter !== 'all';
+  const hasActiveFilters = progressIncludes.length > 0 || progressExcludes.length > 0 || regionFilter !== 'all' || tagFilter !== 'all';
 
   return (
     <div className="space-y-3">
@@ -277,6 +288,20 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           </select>
         )}
 
+        {/* Tag filter */}
+        {availableTags.length > 0 && (
+          <select
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
+            className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-1.5 text-sm text-theme-text-secondary focus:outline-none focus:border-theme-stroke-hover"
+          >
+            <option value="all">Tag: All</option>
+            {availableTags.map((tag) => (
+              <option key={tag} value={tag}>Tag: {tag}</option>
+            ))}
+          </select>
+        )}
+
         {/* Clear filters link */}
         {hasActiveFilters && (
           <button
@@ -284,6 +309,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
               setProgressIncludes([]);
               setProgressExcludes([]);
               setRegionFilter('all');
+              setTagFilter('all');
             }}
             className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
           >

--- a/plans/slice-63335-underboss-tag-filter.md
+++ b/plans/slice-63335-underboss-tag-filter.md
@@ -1,0 +1,64 @@
+# slice-63335 — Underboss Events tab: filter by partner tag
+
+**Priority**: Medium
+
+## Goal
+
+Add a tag filter to the /underboss Events tab so admins can filter the event list to only events with a chosen partner tag (or set of tags).
+
+## Existing patterns to mirror
+
+- Filter pill row lives in `frontend/src/components/underboss/EventTable.tsx:248-293`
+- Existing filters use the three-state `FilterPill` (include / exclude / neutral) at lines 42-84
+- A simpler `<select>` dropdown is used for country (line ~270)
+- Filter state is held in `EventTable` and applied in the filter logic block at lines 100-162
+
+## Recommended UI
+
+A compact dropdown labeled `Tag: All` next to the country dropdown — same look. Multi-select would be nicer but the country dropdown sets the precedent for a single-pick `<select>`. Keep it single-select for v1.
+
+Options come from the union of all distinct `event_tags` across the loaded events (computed client-side from the events array — no extra API needed).
+
+```tsx
+<select
+  value={tagFilter}
+  onChange={(e) => setTagFilter(e.target.value)}
+  className="..."  /* match country select styling */
+>
+  <option value="all">Tag: All</option>
+  {availableTags.map(tag => (
+    <option key={tag} value={tag}>Tag: {tag}</option>
+  ))}
+</select>
+```
+
+`availableTags` is computed via `useMemo` from `events.flatMap(e => e.eventTags)` deduped + sorted alphabetically.
+
+## Filter logic
+
+In the existing filter pipeline (around lines 100–162), add:
+```ts
+if (tagFilter !== 'all' && !event.eventTags?.includes(tagFilter)) return false;
+```
+
+## "Clear filters" handling
+
+The existing `hasActiveFilters` and "Clear filters" button at the end of the filter row should also clear `tagFilter` back to `'all'`.
+
+## Files to modify
+
+- `frontend/src/components/underboss/EventTable.tsx` — add `tagFilter` state, `availableTags` memo, the `<select>` in the filter row, the filter check, and the clear-filters reset
+
+## Verification
+
+1. Open `/underboss` Vercel preview Events tab
+2. Tag dropdown should list all tags currently assigned to events
+3. Pick `swc` → only `swc`-tagged events visible
+4. Pick `ownthedoge` → only ownthedoge events visible
+5. "Clear filters" link resets the tag dropdown to "All"
+6. Combining with country / progress filters should still work
+
+## Notes
+
+- This must be merged AFTER pepperoni-93577 (inline tag pill fix) so that inline-tagged events show up properly in the dropdown options. (It still works without that fix, but only inline-tagged events would be invisible — which is the bug being fixed elsewhere.)
+- No backend changes required.


### PR DESCRIPTION
## Summary
- New "Tag" dropdown on /underboss Events tab filter row
- Options derived from all distinct event_tags across loaded events
- Combines with existing progress, country, and approval filters
- Cleared by the existing "Clear filters" link

## Test plan
- [ ] Open Vercel preview `/underboss` Events tab
- [ ] Tag dropdown lists all assigned tags (swc, ownthedoge, Global Pizza Party, etc.)
- [ ] Selecting a tag filters the table
- [ ] Combining with country filter works
- [ ] "Clear filters" resets the tag filter

Task: slice-63335