### PR TITLE
zucchini-67857: logo file upload in Add Partner form

### DIFF
--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -236,6 +236,7 @@ export function PartnerForm({
   const [logoPreview, setLogoPreview] = useState<string | null>(() => {
     if (isCrm && sponsor?.logoUrl) return sponsor.logoUrl;
     if (isIntake && intakeInitialData?.logoUrl) return intakeInitialData.logoUrl;
+    if (isPartner && partnerData?.coHostLogoUrl) return partnerData.coHostLogoUrl;
     return null;
   });
   const [uploadingLogo, setUploadingLogo] = useState(false);
@@ -253,6 +254,7 @@ export function PartnerForm({
   useEffect(() => {
     if (isPartner && partnerData) {
       setFormData(sponsorUserToFormData(partnerData));
+      if (partnerData.coHostLogoUrl) setLogoPreview(partnerData.coHostLogoUrl);
     }
   }, [partnerData, isPartner]);
 
@@ -312,8 +314,8 @@ export function PartnerForm({
     try {
       let logoUrl = formData.logoUrl;
 
-      // Upload logo if a new file was selected (CRM and intake modes)
-      if ((isCrm || isIntake) && logoFile) {
+      // Upload logo if a new file was selected (CRM, intake, and partner modes)
+      if ((isCrm || isIntake || isPartner) && logoFile) {
         setUploadingLogo(true);
         const uploadedUrl = await uploadSponsorLogo(logoFile);
         if (uploadedUrl) {
@@ -644,74 +646,54 @@ export function PartnerForm({
         </div>
       )}
 
-      {/* Logo — CRM + Intake have file upload, partner has URL only */}
+      {/* Logo — file upload + URL fallback (shared across CRM, Intake, Partner) */}
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
           <Image size={16} />
           Logo
         </h3>
-        {(isCrm || isIntake) ? (
-          logoPreview ? (
-            <div className="flex items-center gap-4">
-              <img
-                src={logoPreview}
-                alt="Logo preview"
-                className="w-16 h-16 object-contain rounded-lg border border-theme-stroke bg-theme-surface"
-              />
-              <button
-                type="button"
-                onClick={removeLogo}
-                className="text-sm text-red-400 hover:text-red-300 transition-colors"
-              >
-                Remove
-              </button>
-            </div>
-          ) : (
-            <div className="flex gap-3">
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleLogoChange}
-                className="hidden"
-              />
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="flex items-center gap-2 px-4 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
-              >
-                <Upload size={16} />
-                Upload Logo
-              </button>
-              <div className="flex-1">
-                <IconInput
-                  icon={Globe}
-                  type="url"
-                  value={formData.logoUrl}
-                  onChange={e => handleChange('logoUrl', e.target.value)}
-                  placeholder="Or paste logo URL"
-                />
-              </div>
-            </div>
-          )
-        ) : (
-          <>
-            <IconInput
-              icon={Globe}
-              type="url"
-              value={formData.logoUrl}
-              onChange={e => handleChange('logoUrl', e.target.value)}
-              placeholder="Logo URL (for sponsor records)"
+        {logoPreview ? (
+          <div className="flex items-center gap-4">
+            <img
+              src={logoPreview}
+              alt="Logo preview"
+              className="w-16 h-16 object-contain rounded-lg border border-theme-stroke bg-theme-surface"
             />
-            {formData.logoUrl && (
-              <img
-                src={formData.logoUrl}
-                alt="Logo preview"
-                className="w-16 h-16 object-contain rounded-lg border border-theme-stroke bg-theme-surface"
-                onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+            <button
+              type="button"
+              onClick={removeLogo}
+              className="text-sm text-red-400 hover:text-red-300 transition-colors"
+            >
+              Remove
+            </button>
+          </div>
+        ) : (
+          <div className="flex gap-3">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleLogoChange}
+              className="hidden"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center gap-2 px-4 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
+            >
+              <Upload size={16} />
+              Upload Logo
+            </button>
+            <div className="flex-1">
+              <IconInput
+                icon={Globe}
+                type="url"
+                value={formData.logoUrl}
+                onChange={e => handleChange('logoUrl', e.target.value)}
+                placeholder="Or paste logo URL"
               />
-            )}
-          </>
+            </div>
+          </div>
         )}
       </div>
 

--- a/plans/zucchini-67857-partner-logo-upload.md
+++ b/plans/zucchini-67857-partner-logo-upload.md
@@ -1,0 +1,66 @@
+# zucchini-67857 — Add Partner form: logo file upload
+
+**Priority**: Low (UX polish)
+
+## Goal
+
+On the /underboss Add Partner form, replace (or augment) the URL-only Logo input with a file upload, mirroring the pattern already used in CRM/Intake modes.
+
+## File
+
+`frontend/src/components/sponsors/PartnerForm.tsx`
+
+## Current state
+
+Around lines 698-715, partner mode has only a URL `IconInput`:
+```tsx
+<>
+  <IconInput
+    icon={Globe}
+    type="url"
+    value={formData.logoUrl}
+    onChange={e => handleChange('logoUrl', e.target.value)}
+    placeholder="Logo URL (for sponsor records)"
+  />
+  {formData.logoUrl && (
+    <img
+      src={formData.logoUrl}
+      alt="Logo preview"
+      className="w-16 h-16 object-contain rounded-lg border border-theme-stroke bg-theme-surface"
+      onError={...}
+    />
+  )}
+</>
+```
+
+CRM/Intake modes (around lines 653-696) already have the file-upload pattern using `uploadSponsorLogo` from `lib/supabase.ts`. The submit handler (lines 299-338) already conditionally calls `uploadSponsorLogo(logoFile)` if `(isCrm || isIntake) && logoFile`.
+
+## Change
+
+Use the same file-upload UI in partner mode that's used in CRM/Intake modes. Two approaches:
+
+### Option A (recommended, minimal change)
+
+Change the gating condition to include partner mode:
+1. **Submit handler (line ~308)**: Change `if ((isCrm || isIntake) && logoFile)` → `if ((isCrm || isIntake || isPartner) && logoFile)`.
+2. **Logo input section**: Replace the partner-mode-only block (lines 698-715) with the same JSX block CRM/Intake mode uses (lines 653-696). Or — refactor: extract the file-upload JSX to a common block that all three modes render.
+
+### Option B (cleaner)
+
+Just remove the partner-mode-specific branch entirely and let the existing CRM/Intake branch render in partner mode too. If the surrounding `{(isCrm || isIntake) && (...)}` wrapper exists, change it to `{(isCrm || isIntake || isPartner) && (...)}`.
+
+Pick whichever is simpler given the surrounding code. Read lines 640-720 first to decide.
+
+## Notes
+
+- `uploadSponsorLogo` uploads to the `event-images` bucket under `sponsor-logos/`. No new storage config needed.
+- Partner mode should keep accepting a manually-pasted URL too (the existing pattern offers both file upload and URL input as a fallback).
+- Do not change anything else on the form (account, partner info, automation, notes).
+
+## Verification
+
+1. Open Vercel preview `/underboss` → Partners tab → click "Add Partner"
+2. The Logo section should show the file upload UI (drag/drop or click to upload) AND optionally a URL input as fallback (whatever the CRM/Intake pattern provides)
+3. Pick an image file → preview displays the local image
+4. Fill in the rest and Submit → image uploads to Supabase storage → partner is created with the public URL stored in `coHostLogoUrl`
+5. Edit the same partner → the logo loads from the stored URL and can be replaced


### PR DESCRIPTION
## Summary
- Add Partner form now accepts a logo file upload (in addition to URL)
- Reuses existing uploadSponsorLogo helper and CRM/Intake upload UI
- Public URL stored in coHostLogoUrl as before

## Test plan
- [ ] Open Vercel preview `/underboss` Partners tab → Add Partner
- [ ] Logo section shows file upload UI
- [ ] Upload an image → preview displays
- [ ] Save partner → logo URL persisted in DB
- [ ] Edit existing partner → logo loads and can be replaced

Task: zucchini-67857