### PR TITLE
pepperoni-93577: inline tag pill writes to event_tags

### DIFF
--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
-import { updateHostStatus, updateHostTags, updateUnderbossNotes } from '../../lib/api';
+import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes } from '../../lib/api';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
 interface EventRowProps {
@@ -124,15 +124,19 @@ function HostStatusBadge({
   );
 }
 
-// Host tags pills with inline editor
+// Event tags pills with inline editor.
+// Writes to `parties.event_tags` via `bulkUpdateEventTags` so partner co-host /
+// sponsor sync runs (matches the bulk action menu's behavior).
 function HostTagsPills({
   tags,
   eventId,
   onUpdate,
+  partnerTags = [],
 }: {
   tags: string[];
   eventId: string;
   onUpdate: (tags: string[]) => void;
+  partnerTags?: string[];
 }) {
   const [isAdding, setIsAdding] = useState(false);
   const [newTag, setNewTag] = useState('');
@@ -147,7 +151,7 @@ function HostTagsPills({
     setNewTag('');
     setIsAdding(false);
     try {
-      await updateHostTags(eventId, newTags);
+      await bulkUpdateEventTags([eventId], [cleaned], 'add');
     } catch {
       onUpdate(tags);
     }
@@ -157,15 +161,17 @@ function HostTagsPills({
     const newTags = tags.filter((t) => t !== tag);
     onUpdate(newTags);
     try {
-      await updateHostTags(eventId, newTags);
+      await bulkUpdateEventTags([eventId], [tag], 'remove');
     } catch {
       onUpdate(tags);
     }
   }
 
-  const tagColors: Record<string, string> = {
-    swc: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-  };
+  function colorForTag(tag: string): string {
+    if (tag === 'swc') return 'bg-purple-500/20 text-purple-400 border-purple-500/30';
+    if (tag === 'global pizza party') return 'bg-orange-500/20 text-orange-400 border-orange-500/30';
+    return 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30';
+  }
 
   return (
     <div className="flex flex-wrap items-center gap-1 mt-0.5">
@@ -173,11 +179,12 @@ function HostTagsPills({
         <button
           key={tag}
           onClick={() => removeTag(tag)}
-          className={`text-[10px] px-1.5 py-0.5 rounded-md border transition-colors hover:opacity-70 ${
-            tagColors[tag] || 'bg-theme-surface text-theme-text-muted border-theme-stroke'
-          }`}
+          className={`text-[10px] px-1.5 py-0.5 rounded-md border transition-colors hover:opacity-70 inline-flex items-center gap-0.5 ${colorForTag(tag)}`}
           title={`Click to remove "${tag}"`}
         >
+          {partnerTags.includes(tag) && (
+            <Handshake size={9} className="shrink-0" />
+          )}
           {tag}
         </button>
       ))}
@@ -232,7 +239,7 @@ function HostTagsPills({
 export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggleSelect, partnerTags = [] }: EventRowProps) {
   // Local state for optimistic updates
   const [hostStatus, setHostStatus] = useState<HostStatus | null>(event.hostStatus);
-  const [hostTags, setHostTags] = useState<string[]>(event.hostTags || []);
+  const [eventTags, setEventTags] = useState<string[]>(event.eventTags || []);
   const [notesOpen, setNotesOpen] = useState(false);
   const [notesValue, setNotesValue] = useState(event.underbossNotes || '');
   const [notesSaving, setNotesSaving] = useState(false);
@@ -389,35 +396,14 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
           <div className="text-xs text-theme-text-faint truncate max-w-[150px]">{event.host.email}</div>
         )}
         <HostTagsPills
-          tags={hostTags}
+          tags={eventTags}
           eventId={event.id}
+          partnerTags={partnerTags}
           onUpdate={(tags) => {
-            setHostTags(tags);
-            onEventUpdate?.(event.id, { hostTags: tags });
+            setEventTags(tags);
+            onEventUpdate?.(event.id, { eventTags: tags });
           }}
         />
-        {/* Event tags (read-only) */}
-        {(event.eventTags || []).length > 0 && (
-          <div className="flex flex-wrap items-center gap-1 mt-0.5">
-            {event.eventTags.map((tag) => (
-              <span
-                key={tag}
-                className={`text-[10px] px-1.5 py-0.5 rounded-md border inline-flex items-center gap-0.5 ${
-                  tag === 'swc'
-                    ? 'bg-purple-500/20 text-purple-400 border-purple-500/30'
-                    : tag === 'global pizza party'
-                      ? 'bg-orange-500/20 text-orange-400 border-orange-500/30'
-                      : 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30'
-                }`}
-              >
-                {partnerTags.includes(tag) && (
-                  <Handshake size={9} className="shrink-0" />
-                )}
-                {tag}
-              </span>
-            ))}
-          </div>
-        )}
       </td>
 
       {/* Location */}

--- a/plans/pepperoni-93577-inline-tag-pill-fix.md
+++ b/plans/pepperoni-93577-inline-tag-pill-fix.md
@@ -1,0 +1,58 @@
+# pepperoni-93577 — Inline event tag pill writes to wrong column
+
+**Priority**: High (silently breaks partner sync)
+
+## Problem
+
+The per-row inline tag pill editor in `EventRow.tsx` (`HostTagsPills`) writes tags into `parties.host_tags` (a jsonb column). But:
+- The partner "events tagged" count in `PartnerManager` reads from `parties.event_tags` (text[]).
+- The bulk action menu (Actions → Add Tag) writes to `event_tags` and triggers partner co-host/sponsor sync.
+- The two columns silently diverged. Snax inline-tagged 6 events with `ownthedoge`; partner UI showed 0.
+
+## Root cause references
+
+- Inline editor: `frontend/src/components/underboss/EventRow.tsx:127-230` (`HostTagsPills`)
+- API: `frontend/src/lib/api.ts:2408` (`updateHostTags`)
+- Backend: `backend/src/routes/underboss.routes.ts:736-762` writes `hostTags`
+- Bulk editor: `frontend/src/components/underboss/EventTable.tsx:364-399` calls `bulkUpdateEventTags`
+- Bulk backend: `backend/src/routes/underboss.routes.ts:582-685` writes `eventTags` + runs partner sync
+- Count reader: `backend/src/routes/sponsor-user.routes.ts:48-58`
+
+## Fix
+
+Convert the inline pill editor to use `bulkUpdateEventTags([eventId], [tag], 'add'|'remove')`. This:
+- Writes to `event_tags` (the column the partner UI reads)
+- Triggers the existing partner-sync side effects (co-host/sponsor records)
+- Reuses the already-tested bulk endpoint — no new backend route needed
+
+## Files to modify
+
+1. **`frontend/src/components/underboss/EventRow.tsx`**
+   - In `HostTagsPills` (~lines 127–230):
+     - Change the data source from `event.hostTags` → `event.eventTags`
+     - In `addTag`: replace `await updateHostTags(eventId, newTags)` with `await bulkUpdateEventTags([eventId], [cleaned], 'add')`
+     - In `removeTag`: similar — `bulkUpdateEventTags([eventId], [tag], 'remove')`
+     - Update the imports: drop `updateHostTags`, add `bulkUpdateEventTags`
+   - In the EventRow JSX where `HostTagsPills` is rendered: change the `tags` prop to use `event.eventTags` instead of `event.hostTags`. Also update the tag-display line ~391 if it reads `hostTags`.
+
+2. **`frontend/src/components/underboss/EventTable.tsx`** (or wherever the events are loaded for the table)
+   - Likely no change; events already include `eventTags`. Verify the row data flowing into `EventRow` has `eventTags`.
+
+3. **`frontend/src/lib/api.ts`**
+   - Optional: deprecate or remove `updateHostTags` if no longer used. Grep first to be sure.
+
+4. **Do NOT delete the `host_tags` column or the backend route** in this PR — leave them as no-ops in case anything else still references them. Add a TODO comment noting the column can be dropped after a future cleanup.
+
+## Verification
+
+1. Open `/underboss` Vercel preview
+2. Find any event, click the inline tag pill, add a tag like `testtag-fix-verify`
+3. Refresh `/underboss` → in the Partners tab, create a partner with that same tag → should immediately show 1 event tagged
+4. Remove the tag via the inline pill → count drops to 0
+5. The bulk action menu (select rows → Actions → Add Tag) should still work as before
+6. Browser console should be clean
+
+## Notes
+
+- The DB backfill (host_tags → event_tags merge) was already applied in the same session as this task. Don't re-do it.
+- Tags should be lowercased on insert (already done in `HostTagsPills.addTag` via `tag.trim().toLowerCase()` — preserve that).


### PR DESCRIPTION
## Summary
- The inline tag pill on EventRow now writes to `event_tags` (not `host_tags`)
- Triggers partner co-host/sponsor sync just like the bulk action menu
- Fixes silent divergence where inline-tagged events were invisible to partner counts

## Test plan
- [ ] Open Vercel preview `/underboss` Events tab
- [ ] Add a tag via the inline pill on any event
- [ ] Refresh — partner with that tag in /underboss Partners shows updated count
- [ ] Removing the tag drops the count
- [ ] Bulk action menu still works as before

Task: pepperoni-93577
