### PR TITLE
dough-22622: partner dashboard expected guests field

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -858,6 +858,9 @@ model Sponsor {
   intakeSubmittedAt DateTime? @map("intake_submitted_at") @db.Timestamptz
   sponsorMessage    String?   @map("sponsor_message")
 
+  // Per-partner expected guest count (entered on /partner dashboard)
+  expectedGuests Int? @map("expected_guests")
+
   // Metadata
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -334,6 +334,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
     const queryTag = req.query.tag as string | undefined;
     const tag = queryTag?.trim().toLowerCase() || req.sponsorUser?.tag;
     const sponsorUserId = req.sponsorUser?.id;
+    const sponsorEmail = req.sponsorUser?.email?.toLowerCase() || null;
 
     // Build where clause — admins without a tag filter see all events that have any eventTags
     const where: any = {};
@@ -375,6 +376,25 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       },
       orderBy: { date: 'asc' },
     });
+
+    // Batch-fetch this partner's expectedGuests per event (matched by contactEmail)
+    let expectedGuestsByPartyId: Record<string, number | null> = {};
+    if (sponsorEmail && events.length > 0) {
+      const sponsorRows = await prisma.sponsor.findMany({
+        where: {
+          partyId: { in: events.map(e => e.id) },
+          contactEmail: sponsorEmail,
+        },
+        select: { partyId: true, expectedGuests: true, createdAt: true },
+        orderBy: { createdAt: 'asc' },
+      });
+      // If multiple rows exist for the same party + email, the first (oldest) wins
+      for (const row of sponsorRows) {
+        if (!(row.partyId in expectedGuestsByPartyId)) {
+          expectedGuestsByPartyId[row.partyId] = row.expectedGuests;
+        }
+      }
+    }
 
     // Batch-fetch all co-host profile data upfront (avoid await inside .map)
     const allCoHostEmails = new Set<string>();
@@ -483,6 +503,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         rsvpCount: guestCount,
         approvedCount,
         maxGuests: event.maxGuests,
+        expectedGuests: sponsorEmail ? (expectedGuestsByPartyId[event.id] ?? null) : null,
         budget,
         progress,
         sponsorStatuses,
@@ -549,6 +570,98 @@ sponsorDashboardRouter.post('/checklist/:itemId/toggle', requireAuth, requireSpo
     });
 
     res.json({ item: updated });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/sponsor/me/events/:partyId/expected-guests - Set this partner's expected guest count for an event
+sponsorDashboardRouter.patch('/me/events/:partyId/expected-guests', requireAuth, requireSponsorAuth, async (req: SponsorRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const sponsorUser = req.sponsorUser;
+
+    if (!sponsorUser) {
+      throw new AppError('Sponsor account required', 403, 'FORBIDDEN');
+    }
+
+    const sponsorEmail = sponsorUser.email?.toLowerCase();
+    if (!sponsorEmail) {
+      throw new AppError('Sponsor account missing email', 400, 'VALIDATION_ERROR');
+    }
+
+    // Validate body
+    const { expectedGuests } = req.body ?? {};
+    let normalized: number | null;
+    if (expectedGuests === null || expectedGuests === undefined || expectedGuests === '') {
+      normalized = null;
+    } else if (
+      typeof expectedGuests !== 'number' ||
+      !Number.isFinite(expectedGuests) ||
+      !Number.isInteger(expectedGuests) ||
+      expectedGuests < 0 ||
+      expectedGuests > 10000
+    ) {
+      throw new AppError('expectedGuests must be null or a non-negative integer <= 10000', 400, 'VALIDATION_ERROR');
+    } else {
+      normalized = expectedGuests;
+    }
+
+    // Find party and verify partner has access via tag
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, eventTags: true },
+    });
+    if (!party) {
+      throw new AppError('Event not found', 404, 'NOT_FOUND');
+    }
+    if (!party.eventTags?.includes(sponsorUser.tag)) {
+      throw new AppError('You do not have access to this event', 403, 'FORBIDDEN');
+    }
+
+    // Find existing Sponsor row matching this partner (by contactEmail) for this event
+    const existing = await prisma.sponsor.findFirst({
+      where: { partyId, contactEmail: sponsorEmail },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    let updated;
+    if (existing) {
+      updated = await prisma.sponsor.update({
+        where: { id: existing.id },
+        data: { expectedGuests: normalized },
+      });
+    } else {
+      // Look up the full SponsorUser record to get coHostName for the display name
+      const fullSponsorUser = await prisma.sponsorUser.findUnique({
+        where: { id: sponsorUser.id },
+        select: { coHostName: true, name: true, email: true },
+      });
+      const displayName =
+        fullSponsorUser?.coHostName?.trim() ||
+        fullSponsorUser?.name?.trim() ||
+        sponsorUser.name?.trim() ||
+        sponsorEmail;
+      updated = await prisma.sponsor.create({
+        data: {
+          partyId,
+          name: displayName,
+          contactEmail: sponsorEmail,
+          status: 'yes',
+          notes: 'Auto-created from partner dashboard expected guests entry',
+          expectedGuests: normalized,
+        },
+      });
+    }
+
+    res.json({
+      sponsor: {
+        id: updated.id,
+        partyId: updated.partyId,
+        contactEmail: updated.contactEmail,
+        expectedGuests: updated.expectedGuests,
+      },
+    });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2860,6 +2860,18 @@ export async function toggleSponsorChecklistItem(itemId: string): Promise<{ item
   });
 }
 
+// Update this partner's expected guest count for a specific event.
+// Stored on the Sponsor table (per partner-event), upserted on first save.
+export async function updateSponsorExpectedGuests(
+  partyId: string,
+  expectedGuests: number | null,
+): Promise<{ sponsor: { id: string; partyId: string; contactEmail: string | null; expectedGuests: number | null } }> {
+  return apiRequest(`/api/sponsor/me/events/${partyId}/expected-guests`, {
+    method: 'PATCH',
+    body: { expectedGuests },
+  });
+}
+
 // ============================================
 // Sponsor User Admin API
 // ============================================

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -5,7 +5,7 @@ import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
 import { IconInput } from '../components/IconInput';
 import { useAuth } from '../contexts/AuthContext';
-import { fetchSponsorMe, fetchSponsorEvents, toggleSponsorChecklistItem } from '../lib/api';
+import { fetchSponsorMe, fetchSponsorEvents, toggleSponsorChecklistItem, updateSponsorExpectedGuests } from '../lib/api';
 import {
   Loader2, Shield, Tag, ExternalLink, Users,
   Search, ThumbsUp, ThumbsDown, BarChart3, Calendar, MapPin,
@@ -553,6 +553,26 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
   // Filter co-hosts to show only visible ones
   const visibleCoHosts = event.coHosts.filter((h: CoHost) => h.showOnEvent !== false);
 
+  // Per-partner expected guest count (local optimistic state)
+  const [localExpected, setLocalExpected] = useState<number | null>(event.expectedGuests ?? null);
+
+  // Keep local state in sync if the parent re-renders with a fresh value
+  useEffect(() => {
+    setLocalExpected(event.expectedGuests ?? null);
+  }, [event.expectedGuests]);
+
+  async function saveExpectedGuests() {
+    const current = event.expectedGuests ?? null;
+    if (localExpected === current) return; // no change
+    try {
+      await updateSponsorExpectedGuests(event.id, localExpected);
+      // Optimistic — don't refetch
+    } catch (err) {
+      console.error('Failed to save expected guests:', err);
+      setLocalExpected(current); // revert
+    }
+  }
+
   return (
     <div className="bg-theme-card border border-theme-stroke rounded-2xl overflow-hidden flex flex-col md:flex-row hover:border-theme-stroke-hover transition-colors">
       {/* Flyer image — banner on mobile, left column on desktop */}
@@ -633,6 +653,21 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
             <Users size={14} className="text-theme-text-muted" />
             <span className="text-lg font-bold text-theme-text">{event.rsvpCount}</span>
             <span className="text-xs text-theme-text-muted">RSVPs</span>
+            <span className="text-theme-text-muted mx-1">·</span>
+            <input
+              type="number"
+              min={0}
+              max={10000}
+              value={localExpected ?? ''}
+              onChange={(e) => setLocalExpected(e.target.value === '' ? null : parseInt(e.target.value, 10))}
+              onBlur={saveExpectedGuests}
+              onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+              placeholder="—"
+              className="w-14 bg-theme-surface border border-theme-stroke rounded text-sm text-theme-text px-1.5 py-0.5 text-right focus:outline-none focus:border-theme-stroke-hover"
+              title="Your expected guests for this event"
+              aria-label="Your expected guests for this event"
+            />
+            <span className="text-xs text-theme-text-muted">expected</span>
           </div>
         </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1162,6 +1162,7 @@ export interface SponsorDashboardEvent {
   rsvpCount: number;
   approvedCount: number;
   maxGuests: number | null;
+  expectedGuests?: number | null;
   budget: {
     total: number;
     spent: number;

--- a/plans/dough-22622-partner-dashboard-expected-guests.md
+++ b/plans/dough-22622-partner-dashboard-expected-guests.md
@@ -1,0 +1,142 @@
+# dough-22622 — Partner dashboard: expected guests field
+
+**Priority**: Medium
+
+## Goal
+
+On `/partner` dashboard event cards, add a numeric "expected guests" input each partner can fill in for their own expected attendance contribution. Auto-saves on blur. Stored per (partner, event).
+
+## Data model
+
+Use the existing `Sponsor` table (which already represents partner-per-event records). Add a new column:
+
+```prisma
+model Sponsor {
+  ...
+  expectedGuests Int? @map("expected_guests")
+  ...
+}
+```
+
+DB migration:
+```sql
+ALTER TABLE sponsors ADD COLUMN IF NOT EXISTS expected_guests integer;
+```
+
+## Backend
+
+### 1. Read path — extend `fetchSponsorEvents`
+
+Find the route that powers the partner dashboard event list (in `backend/src/routes/sponsor-user.routes.ts` — it's the GET that returns `SponsorDashboardEvent[]`). Each returned event needs a new field `expectedGuests: number | null` — pulled from the Sponsor record matching the calling user's `sponsorUser.email` for that event.
+
+If multiple Sponsor records exist for that party + email (shouldn't but possible), use the first.
+
+### 2. Write path — new endpoint
+
+```
+PATCH /api/sponsor/me/events/:partyId/expected-guests
+Body: { expectedGuests: number | null }
+Auth: requireAuth + verify caller's sponsorUser.tag is in event.eventTags
+```
+
+Logic:
+- Find party. Verify the calling user has a `sponsorUser` record with `tag in party.eventTags`.
+- Upsert: if a Sponsor record already exists for `(partyId, contactEmail = sponsorUser.email)`, update `expectedGuests`. Otherwise insert one with `name = sponsorUser.coHostName || sponsorUser.name || sponsorUser.email`, `contactEmail = sponsorUser.email`, `status = 'yes'`, `notes = 'Auto-created from partner dashboard expected guests entry'`, plus the new `expectedGuests`.
+- Return updated row.
+
+Validation: `expectedGuests` must be `null` or a non-negative integer ≤ 10000. Reject otherwise with 400.
+
+## Frontend
+
+### 1. Type
+
+In `frontend/src/types.ts`, add `expectedGuests?: number | null;` to `SponsorDashboardEvent`.
+
+### 2. API helper
+
+In `frontend/src/lib/api.ts`, add:
+```ts
+export async function updateSponsorExpectedGuests(partyId: string, expectedGuests: number | null) {
+  // PATCH /api/sponsor/me/events/:partyId/expected-guests
+}
+```
+
+### 3. UI — `EventCard` in `PartnerDashboardPage.tsx`
+
+Add a small inline numeric input near the RSVP count (around line 632, `<div className="flex items-center gap-1.5 flex-shrink-0"> ... <Users size={14} ...> ... {event.rsvpCount} ... RSVPs</div>`).
+
+Suggested placement: a second row underneath the date/venue/RSVP row, OR inline next to the RSVP count. A clean version:
+
+```tsx
+<div className="flex items-center gap-1.5 flex-shrink-0">
+  <Users size={14} className="text-theme-text-muted" />
+  <span className="text-lg font-bold text-theme-text">{event.rsvpCount}</span>
+  <span className="text-xs text-theme-text-muted">RSVPs</span>
+  <span className="text-theme-text-muted mx-1">·</span>
+  <input
+    type="number"
+    min={0}
+    max={10000}
+    value={localExpected ?? ''}
+    onChange={(e) => setLocalExpected(e.target.value === '' ? null : parseInt(e.target.value, 10))}
+    onBlur={() => saveExpectedGuests()}
+    placeholder="—"
+    className="w-14 bg-theme-surface border border-theme-stroke rounded text-sm text-theme-text px-1.5 py-0.5 text-right focus:outline-none focus:border-theme-stroke-hover"
+    title="Your expected guests"
+  />
+  <span className="text-xs text-theme-text-muted">expected</span>
+</div>
+```
+
+Local state pattern (matches existing optimistic update pattern in this codebase):
+```ts
+const [localExpected, setLocalExpected] = useState<number | null>(event.expectedGuests ?? null);
+
+async function saveExpectedGuests() {
+  if (localExpected === (event.expectedGuests ?? null)) return; // no change
+  try {
+    await updateSponsorExpectedGuests(event.id, localExpected);
+    // Don't refetch — optimistic update is enough
+  } catch (err) {
+    setLocalExpected(event.expectedGuests ?? null); // revert on failure
+    console.error('Failed to save expected guests:', err);
+  }
+}
+```
+
+## Files to create/modify
+
+1. **DB migration** via `mcp__supabase-pizzadao__apply_migration` — add `expected_guests` column
+2. `backend/prisma/schema.prisma` — add `expectedGuests Int? @map("expected_guests")` to Sponsor model
+3. `backend/src/routes/sponsor-user.routes.ts` — extend GET response, add PATCH endpoint
+4. `frontend/src/types.ts` — add `expectedGuests?: number | null` to `SponsorDashboardEvent`
+5. `frontend/src/lib/api.ts` — add `updateSponsorExpectedGuests` helper
+6. `frontend/src/pages/PartnerDashboardPage.tsx` — add input to `EventCard`
+
+## Order of operations (CRITICAL)
+
+Per CLAUDE.md: "Preview deploys share production backend + DB. New DB columns must be applied to production BEFORE they'll work on preview branches."
+
+1. Apply DB migration to production Supabase first (column add — safe, additive only)
+2. Deploy backend to production (since preview frontend hits prod backend) — happens automatically when this branch merges to master
+3. Frontend Vercel preview will then work end-to-end
+
+For the PR: the agent should apply the DB migration immediately (additive, low risk). The backend changes won't take effect on the preview until merged to master. **The Vercel preview will only show the UI element — the read/write won't work until merge.** Note this in the PR description so Snax doesn't think it's broken.
+
+## Verification
+
+After merge to master + backend deploy:
+
+1. Open `/partner` dashboard logged in as a partner (e.g., ownthedoge → smoke@ownthedoge.com)
+2. Each event card shows the expected-guests input (empty if never set)
+3. Type a number → click outside → input persists
+4. Refresh page → number is still there
+5. Multiple partners on the same event each have their own number
+6. Negative numbers / non-integers / values >10000 are rejected by backend
+7. Logged-in admin viewing /underboss → can query DB to see the values (admin UI for these is a follow-up)
+
+## Notes
+
+- Don't modify the Sponsor `status` of existing rows. Only set `status='yes'` when CREATING a new Sponsor row from the partner dashboard (auto-created).
+- Don't surface this in the existing partner-intake flow — that's a different feature.
+- No CLAUDE.md "7-places" gotchas here since this is the Sponsor table, not the parties table — but verify the backend handler uses Prisma not Supabase client.


### PR DESCRIPTION
## Summary
- New numeric input on /partner event cards for partner-specific expected guest count
- Auto-saves on blur with optimistic update
- Stored on Sponsor table (new column expected_guests)
- Backend endpoint upserts the Sponsor record (creates if missing)

## DB migration applied
`ALTER TABLE sponsors ADD COLUMN IF NOT EXISTS expected_guests integer;` — applied to production already.

## Preview limitations
WARNING: The Vercel preview frontend hits the production backend. Until this PR merges, the new endpoint and the new field in the GET response don't exist on prod, so the UI will render but reads/writes won't work end-to-end until merge + backend deploy.

## Test plan (post-merge)
- [ ] Open `/partner` logged in as a partner (e.g., smoke@ownthedoge.com)
- [ ] Each event card shows the expected-guests input
- [ ] Type a number → click outside → persists across refresh
- [ ] Multiple partners on same event each have their own number
- [ ] Backend rejects negative / >10000 / non-integer values

Task: dough-22622
