### PR TITLE
arugula-29881: Use GPP country for underboss filter

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -150,6 +150,7 @@ model Party {
 
   // Region (for underboss dashboard)
   region  String?
+  country String?
 
   // Underboss dashboard fields
   hostStatus        String?  @map("host_status")

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -321,6 +321,7 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
         duration: 3,
         timezone: eventTimezone,
         region: inferredRegion,
+        country: country || null,
         availableBeverages: [],
         availableToppings: [],
         coHosts: [

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -183,6 +183,7 @@ function formatEvent(party: any, underbossEmails: string[] = []) {
     address: party.address,
     venueName: party.venueName,
     region: party.region || null,
+    country: party.country || null,
     eventImageUrl: party.eventImageUrl || null,
     timezone: party.timezone || null,
     duration: party.duration ? Number(party.duration) : null,

--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -288,11 +288,11 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
             <span className={`text-xs ${relTime.isPast ? 'text-red-400' : 'text-theme-text-muted'}`}>
               {relTime.text}
             </span>
-            {showRegion && event.address && (
+            {showRegion && event.country && (
               <>
                 <span className="text-theme-text-faint">·</span>
                 <span className="text-xs text-theme-text-muted">
-                  {event.address.split(',').pop()?.trim() || ''}
+                  {event.country || ''}
                 </span>
               </>
             )}

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -374,7 +374,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
       {showRegion && (
         <td className="py-3 px-3">
           <span className="text-xs text-theme-text-muted">
-            {event.address ? event.address.split(',').pop()?.trim() || '\u2014' : '\u2014'}
+            {event.country || '\u2014'}
           </span>
         </td>
       )}

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -179,7 +179,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     // Country filter (only when showRegion is active)
     if (showRegion && regionFilter !== 'all') {
       result = result.filter((e) => {
-        const country = e.address?.split(',').pop()?.trim() || '';
+        const country = e.country || '';
         return country === regionFilter;
       });
     }
@@ -296,7 +296,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
             className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-1.5 text-sm text-theme-text-secondary focus:outline-none focus:border-theme-stroke-hover"
           >
             <option value="all">Country: All</option>
-            {[...new Set(events.map(e => e.address?.split(',').pop()?.trim()).filter(Boolean))].sort().map((c) => (
+            {[...new Set(events.map(e => e.country).filter(Boolean))].sort().map((c) => (
               <option key={c} value={c}>{c}</option>
             ))}
           </select>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -977,6 +977,7 @@ export interface UnderbossEvent {
   address: string | null;
   venueName: string | null;
   region?: string | null;
+  country?: string | null;
   host: { name: string | null; email: string | null };
   coHosts: any[];
   progress: UnderbossEventProgress;

--- a/supabase/migrations/20260417_add_country_column.sql
+++ b/supabase/migrations/20260417_add_country_column.sql
@@ -1,0 +1,10 @@
+ALTER TABLE parties ADD COLUMN country TEXT;
+
+UPDATE parties SET country = 'Canada' WHERE region = 'canada' AND country IS NULL;
+UPDATE parties SET country = 'United States' WHERE region = 'usa' AND country IS NULL;
+UPDATE parties SET country = 'Mexico' WHERE region = 'central-america' AND country IS NULL;
+UPDATE parties SET country = 'India' WHERE region = 'india' AND country IS NULL;
+UPDATE parties SET country = 'China' WHERE region = 'china' AND country IS NULL;
+UPDATE parties SET country = 'Australia' WHERE region = 'oceania' AND country IS NULL;
+
+GRANT SELECT (country) ON parties TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Add country TEXT column to parties table with backfill from existing region values
- Save country from GPP LocationAutocomplete during event creation (was previously discarded)
- Underboss dashboard now reads event.country directly instead of parsing venue address strings

## Migration
The migration at supabase/migrations/20260417_add_country_column.sql must be applied to production before the backend deploy.

## Test plan
- [ ] Apply migration to production DB
- [ ] Deploy backend to pick up Prisma and route changes
- [ ] Verify underboss dashboard shows country column correctly
- [ ] Verify country filter dropdown populates from event.country
- [ ] Create a new GPP event and verify country is saved