### PR TITLE
fix: cosmetic tweaks — Hosted by + pizzeria card boxes

### DIFF
--- a/frontend/src/components/HostsList.tsx
+++ b/frontend/src/components/HostsList.tsx
@@ -85,7 +85,7 @@ export const HostsList: React.FC<HostsListProps> = ({
   return (
     <div>
       {showTitle && (
-        <h3 className="text-sm font-semibold text-theme-text-secondary mb-3">Hosted By</h3>
+        <h3 className="text-sm font-semibold text-theme-text-secondary mb-3">Hosted by</h3>
       )}
 
       <div className="space-y-3">

--- a/frontend/src/components/ParticipatingPizzerias.tsx
+++ b/frontend/src/components/ParticipatingPizzerias.tsx
@@ -30,7 +30,7 @@ export function ParticipatingPizzerias({
         {pizzerias.map((pizzeria) => (
           <div
             key={pizzeria.id}
-            className="flex items-start gap-3 p-3 bg-theme-surface rounded-xl border border-theme-stroke"
+            className="flex items-start gap-3 p-3"
           >
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">


### PR DESCRIPTION
## Summary
- **garlic-27599**: Changed "Hosted By" to "Hosted by" (lowercase 'b') in `HostsList.tsx` for consistent English casing
- **zucchini-38201**: Removed gray background, rounded border, and stroke from pizzeria card rows in `ParticipatingPizzerias.tsx` — keeps the layout (`flex items-start gap-3 p-3`) but drops the box styling

## Test plan
- [ ] Verify "Hosted by" label on event pages shows lowercase 'b'
- [ ] Verify participating pizzerias section no longer shows gray bordered boxes around each pizzeria name
- [ ] Verify layout/spacing of pizzeria list still looks correct without the card containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)