### PR TITLE
feat: show partner descriptions on event page + underboss modal

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1113,6 +1113,9 @@ model SponsorUser {
   autoCoHost      Boolean   @default(false) @map("auto_co_host")
   autoSponsor     Boolean   @default(false) @map("auto_sponsor")
 
+  // Brand info (synced to Sponsor records)
+  brandDescription String? @map("brand_description")
+
   // Granular co-host permissions (applied when autoCoHost adds them to events)
   coHostShowOnEvent Boolean @default(true)  @map("co_host_show_on_event")
   coHostCanEdit     Boolean @default(false) @map("co_host_can_edit")

--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -25,6 +25,7 @@ interface SponsorUserLike {
   coHostAllowedTabs?: any;
   name: string | null;
   email: string;
+  brandDescription: string | null;
 }
 
 interface PartyLike {
@@ -90,6 +91,7 @@ export async function addPartnerToParty(
       website: sponsorUser.coHostWebsite || null,
       brandTwitter: sponsorUser.coHostTwitter || null,
       brandInstagram: sponsorUser.coHostInstagram || null,
+      brandDescription: sponsorUser.brandDescription || null,
       logoUrl: sponsorUser.coHostLogoUrl || null,
     };
 

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -141,6 +141,23 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
       throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
     }
 
+    // Fetch confirmed sponsors with descriptions for public display
+    const sponsors = await prisma.sponsor.findMany({
+      where: {
+        partyId: party.id,
+        status: { in: ['yes', 'billed', 'paid'] },
+        brandDescription: { not: null },
+      },
+      select: {
+        id: true,
+        name: true,
+        website: true,
+        brandDescription: true,
+        logoUrl: true,
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
     // Enrich coHosts with user profile data (avatar, socials) then strip emails
     const rawCoHosts = (party.coHosts as any[] || []);
     const coHostEmails = rawCoHosts.map((h: any) => h.email).filter(Boolean);
@@ -239,6 +256,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         hostProfile,
         guestCount: party._count.guests,
         userId: party.userId,
+        sponsors,
       },
     });
   } catch (error) {

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -42,6 +42,7 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
         coHostShowOnEvent: true,
         coHostCanEdit: true,
         coHostAllowedTabs: true,
+        brandDescription: true,
       },
     });
 
@@ -75,6 +76,7 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
       coHostName, coHostWebsite, coHostTwitter, coHostInstagram,
       coHostAvatarUrl, coHostLogoUrl, autoCoHost, autoSponsor,
       coHostShowOnEvent, coHostCanEdit, coHostAllowedTabs,
+      brandDescription,
     } = req.body;
 
     if (!email || !tag) {
@@ -105,6 +107,7 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
         coHostLogoUrl: coHostLogoUrl?.trim() || null,
         autoCoHost: autoCoHost || false,
         autoSponsor: autoSponsor || false,
+        brandDescription: brandDescription?.trim() || null,
         coHostShowOnEvent: coHostShowOnEvent !== undefined ? !!coHostShowOnEvent : true,
         coHostCanEdit: !!coHostCanEdit,
         coHostAllowedTabs: Array.isArray(coHostAllowedTabs) ? coHostAllowedTabs : Prisma.JsonNull,
@@ -140,6 +143,7 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
       coHostName, coHostWebsite, coHostTwitter, coHostInstagram,
       coHostAvatarUrl, coHostLogoUrl, autoCoHost, autoSponsor,
       coHostShowOnEvent, coHostCanEdit, coHostAllowedTabs,
+      brandDescription,
     } = req.body;
 
     // Fetch old state for sync reconciliation
@@ -162,6 +166,7 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
     if (coHostInstagram !== undefined) updateData.coHostInstagram = coHostInstagram?.trim() || null;
     if (coHostAvatarUrl !== undefined) updateData.coHostAvatarUrl = coHostAvatarUrl?.trim() || null;
     if (coHostLogoUrl !== undefined) updateData.coHostLogoUrl = coHostLogoUrl?.trim() || null;
+    if (brandDescription !== undefined) updateData.brandDescription = brandDescription?.trim() || null;
     if (autoCoHost !== undefined) updateData.autoCoHost = autoCoHost;
     if (autoSponsor !== undefined) updateData.autoSponsor = autoSponsor;
     if (coHostShowOnEvent !== undefined) updateData.coHostShowOnEvent = !!coHostShowOnEvent;

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -155,6 +155,7 @@ function sponsorUserToFormData(su: SponsorUser): PartnerFormData {
     website: su.coHostWebsite || '',
     brandTwitter: su.coHostTwitter || '',
     brandInstagram: su.coHostInstagram || '',
+    brandDescription: su.brandDescription || '',
     coHostAvatarUrl: su.coHostAvatarUrl || '',
     logoUrl: su.coHostLogoUrl || '',
     autoCoHost: su.autoCoHost,
@@ -423,14 +424,14 @@ export function PartnerForm({
             />
           )}
         </div>
-        {(isCrm || isIntake) && (
+        {(isCrm || isIntake || isPartner) && (
           <IconInput
             icon={FileText}
             multiline
             rows={2}
             value={formData.brandDescription}
             onChange={e => handleChange('brandDescription', (e.target as HTMLTextAreaElement).value)}
-            placeholder="1-2 sentence description"
+            placeholder="1-2 sentence brand description (shown on event page)"
           />
         )}
       </div>

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -74,6 +74,7 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
         coHostLogoUrl: data.logoUrl || undefined,
         autoCoHost: data.autoCoHost,
         autoSponsor: data.autoSponsor,
+        brandDescription: data.brandDescription || undefined,
       };
 
       let newSyncMessage: string | null = null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -353,6 +353,14 @@ export interface HostProfile {
 }
 
 // Public event data type
+export interface PublicEventSponsor {
+  id: string;
+  name: string;
+  website: string | null;
+  brandDescription: string | null;
+  logoUrl: string | null;
+}
+
 export interface PublicEvent {
   id: string;
   name: string;
@@ -396,6 +404,7 @@ export interface PublicEvent {
   nftChain?: string | null;
   hiddenGppPhotos?: string[];
   extraGppPhotos?: string[];
+  sponsors?: PublicEventSponsor[];
 }
 
 // Public Event API (no auth required)
@@ -2920,6 +2929,7 @@ export interface SponsorUserCreateData {
   coHostLogoUrl?: string;
   autoCoHost?: boolean;
   autoSponsor?: boolean;
+  brandDescription?: string;
 }
 
 export async function createSponsorUser(data: SponsorUserCreateData): Promise<{ sponsorUser: SponsorUser; syncedCount: number }> {
@@ -2943,6 +2953,7 @@ export interface SponsorUserUpdateData {
   coHostLogoUrl?: string;
   autoCoHost?: boolean;
   autoSponsor?: boolean;
+  brandDescription?: string;
 }
 
 export async function updateSponsorUser(id: string, data: SponsorUserUpdateData): Promise<{ sponsorUser: SponsorUser; syncedCount: number }> {

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -967,63 +967,91 @@ export function EventPage() {
                   </div>
                 )}
 
-                {/* Description */}
-                {event.description && (
+                {/* Description + Sponsor Blurbs */}
+                {(event.description || (event.sponsors && event.sponsors.filter(s => s.brandDescription).length > 0)) && (
                   <div className="border-t border-theme-stroke pt-4 mt-4">
                     <div className="text-theme-text leading-relaxed prose prose-invert prose-lg max-w-none">
-                      <ReactMarkdown
-                        remarkPlugins={[remarkGfm, remarkBreaks]}
-                        components={{
-                          a: ({ node, ...props }) => (
-                            <a
-                              {...props}
-                              className="text-[#ff393a] hover:text-[#ff5a5b] font-semibold no-underline"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              onClick={() => {
-                                if (slug && props.href) {
-                                  trackLinkClick(slug, props.href, 'description', typeof props.children === 'string' ? props.children : undefined);
-                                }
-                              }}
-                            />
-                          ),
-                          p: ({ node, ...props }) => (
-                            <p {...props} className="mb-3 last:mb-0" />
-                          ),
-                          ul: ({ node, ...props }) => (
-                            <ul {...props} className="list-disc list-inside mb-3 space-y-1" />
-                          ),
-                          ol: ({ node, ...props }) => (
-                            <ol {...props} className="list-decimal list-inside mb-3 space-y-1" />
-                          ),
-                          h1: ({ node, ...props }) => (
-                            <h1 {...props} className="text-xl font-bold text-theme-text mt-4 mb-2 first:mt-0" />
-                          ),
-                          h2: ({ node, ...props }) => (
-                            <h2 {...props} className="text-lg font-bold text-theme-text mt-4 mb-2 first:mt-0" />
-                          ),
-                          h3: ({ node, ...props }) => (
-                            <h3 {...props} className="text-base font-semibold text-theme-text mt-3 mb-2 first:mt-0" />
-                          ),
-                          strong: ({ node, ...props }) => (
-                            <strong {...props} className="font-semibold text-theme-text" />
-                          ),
-                          em: ({ node, ...props }) => (
-                            <em {...props} className="italic" />
-                          ),
-                          blockquote: ({ node, ...props }) => (
-                            <blockquote {...props} className="border-l-4 border-[#ff393a] pl-4 my-3 italic" />
-                          ),
-                          code: ({ node, inline, ...props }) =>
-                            inline ? (
-                              <code {...props} className="bg-theme-surface-hover px-1.5 py-0.5 rounded text-xs font-mono" />
-                            ) : (
-                              <code {...props} className="block bg-theme-surface-hover p-3 rounded text-xs font-mono overflow-x-auto my-3" />
+                      {event.description && (
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm, remarkBreaks]}
+                          components={{
+                            a: ({ node, ...props }) => (
+                              <a
+                                {...props}
+                                className="text-[#ff393a] hover:text-[#ff5a5b] font-semibold no-underline"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={() => {
+                                  if (slug && props.href) {
+                                    trackLinkClick(slug, props.href, 'description', typeof props.children === 'string' ? props.children : undefined);
+                                  }
+                                }}
+                              />
                             ),
-                        }}
-                      >
-                        {event.description}
-                      </ReactMarkdown>
+                            p: ({ node, ...props }) => (
+                              <p {...props} className="mb-3 last:mb-0" />
+                            ),
+                            ul: ({ node, ...props }) => (
+                              <ul {...props} className="list-disc list-inside mb-3 space-y-1" />
+                            ),
+                            ol: ({ node, ...props }) => (
+                              <ol {...props} className="list-decimal list-inside mb-3 space-y-1" />
+                            ),
+                            h1: ({ node, ...props }) => (
+                              <h1 {...props} className="text-xl font-bold text-theme-text mt-4 mb-2 first:mt-0" />
+                            ),
+                            h2: ({ node, ...props }) => (
+                              <h2 {...props} className="text-lg font-bold text-theme-text mt-4 mb-2 first:mt-0" />
+                            ),
+                            h3: ({ node, ...props }) => (
+                              <h3 {...props} className="text-base font-semibold text-theme-text mt-3 mb-2 first:mt-0" />
+                            ),
+                            strong: ({ node, ...props }) => (
+                              <strong {...props} className="font-semibold text-theme-text" />
+                            ),
+                            em: ({ node, ...props }) => (
+                              <em {...props} className="italic" />
+                            ),
+                            blockquote: ({ node, ...props }) => (
+                              <blockquote {...props} className="border-l-4 border-[#ff393a] pl-4 my-3 italic" />
+                            ),
+                            code: ({ node, inline, ...props }) =>
+                              inline ? (
+                                <code {...props} className="bg-theme-surface-hover px-1.5 py-0.5 rounded text-xs font-mono" />
+                              ) : (
+                                <code {...props} className="block bg-theme-surface-hover p-3 rounded text-xs font-mono overflow-x-auto my-3" />
+                              ),
+                          }}
+                        >
+                          {event.description}
+                        </ReactMarkdown>
+                      )}
+                      {event.sponsors && event.sponsors.filter(s => s.brandDescription).length > 0 && (
+                        <div className={event.description ? 'mt-4 pt-4 border-t border-theme-stroke/50' : ''}>
+                          {event.sponsors
+                            .filter(s => s.brandDescription)
+                            .map(sponsor => (
+                              <p key={sponsor.id} className="mb-2 last:mb-0 text-base">
+                                <strong>
+                                  {sponsor.website ? (
+                                    <a
+                                      href={sponsor.website}
+                                      className="text-[#ff393a] hover:text-[#ff5a5b] font-semibold no-underline"
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      {sponsor.name}
+                                    </a>
+                                  ) : (
+                                    sponsor.name
+                                  )}
+                                  :
+                                </strong>{' '}
+                                {sponsor.brandDescription}
+                              </p>
+                            ))}
+                        </div>
+                      )}
                     </div>
                   </div>
                 )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1133,6 +1133,7 @@ export interface SponsorUser {
   coHostLogoUrl: string | null;
   autoCoHost: boolean;
   autoSponsor: boolean;
+  brandDescription: string | null;
 }
 
 export interface SponsorChecklistItem {


### PR DESCRIPTION
## Summary
- Add `brandDescription` field to `SponsorUser` (Prisma + backend routes) so partners can enter a 1-2 sentence brand description from the underboss partner modal
- On public event pages, fetch confirmed sponsors (status: yes/billed/paid) that have a `brandDescription` and render their blurbs below the event description
- Partner sync (`partnerSync.ts`) propagates `brandDescription` to auto-created Sponsor records

## DB migration required
```sql
ALTER TABLE sponsor_users ADD COLUMN IF NOT EXISTS brand_description TEXT;
```

## Files changed
- `backend/prisma/schema.prisma` - add `brandDescription` to `SponsorUser` model
- `backend/src/routes/event.routes.ts` - query sponsors with descriptions, include in response
- `backend/src/routes/sponsor-user.routes.ts` - GET/POST/PATCH support for `brandDescription`
- `backend/src/helpers/partnerSync.ts` - sync `brandDescription` to Sponsor records
- `frontend/src/lib/api.ts` - add `PublicEventSponsor` type, update data interfaces
- `frontend/src/types.ts` - add `brandDescription` to `SponsorUser` interface
- `frontend/src/components/sponsors/PartnerForm.tsx` - show description field in partner mode
- `frontend/src/components/underboss/PartnerManager.tsx` - pass `brandDescription` in payload
- `frontend/src/pages/EventPage.tsx` - render sponsor blurbs below description

## Test plan
- [ ] Apply DB migration to add `brand_description` column to `sponsor_users`
- [ ] Edit a partner in the underboss dashboard and add a brand description
- [ ] Verify the description syncs to auto-created Sponsor records on tagged events
- [ ] View a public event page with confirmed sponsors that have descriptions
- [ ] Verify sponsor blurbs appear below the event description with correct formatting
- [ ] Verify events without sponsors/descriptions still render correctly

Generated with [Claude Code](https://claude.com/claude-code)