### PR TITLE
feat: tag partners on X in shareable RSVP post

### DIFF
--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -154,6 +154,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         website: true,
         brandDescription: true,
         logoUrl: true,
+        brandTwitter: true,
       },
       orderBy: { createdAt: 'asc' },
     });

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -264,14 +264,29 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
             </p>
           )}
           {/* Share Section */}
-          {(!form.alreadyRegistered || form.wasUpdated) && (
-            <ShareRSVP
-              eventName={event.name}
-              eventImageUrl={event.eventImageUrl}
-              customUrl={event.customUrl}
-              inviteCode={event.inviteCode}
-            />
-          )}
+          {(!form.alreadyRegistered || form.wasUpdated) && (() => {
+            const twitterHandles: string[] = [];
+            if (event.hostProfile?.twitter) twitterHandles.push(event.hostProfile.twitter);
+            if (event.coHosts) {
+              for (const host of event.coHosts) {
+                if (host.twitter && host.showOnEvent !== false) twitterHandles.push(host.twitter);
+              }
+            }
+            if (event.sponsors) {
+              for (const sponsor of event.sponsors) {
+                if (sponsor.brandTwitter) twitterHandles.push(sponsor.brandTwitter);
+              }
+            }
+            return (
+              <ShareRSVP
+                eventName={event.name}
+                eventImageUrl={event.eventImageUrl}
+                customUrl={event.customUrl}
+                inviteCode={event.inviteCode}
+                twitterHandles={twitterHandles}
+              />
+            );
+          })()}
           {/* NFT Minting Status */}
           {event.nftEnabled && form.ethereumAddress.trim() && event.eventImageUrl && (
             <div className="mt-4 pt-4 border-t border-theme-stroke">

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -6,6 +6,7 @@ interface ShareRSVPProps {
   eventImageUrl: string | null;
   customUrl: string | null;
   inviteCode: string;
+  twitterHandles?: string[];
 }
 
 // X (Twitter) icon
@@ -15,13 +16,48 @@ const XIcon: React.FC<{ size: number }> = ({ size }) => (
   </svg>
 );
 
-export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode }: ShareRSVPProps) {
+/** Normalize a twitter handle: strip @, strip full URL prefixes */
+function normalizeHandle(raw: string): string {
+  return raw
+    .replace(/^https?:\/\/(www\.)?(twitter\.com|x\.com)\//i, '')
+    .replace(/^@/, '')
+    .replace(/\/.*$/, '')
+    .trim();
+}
+
+/** Build share text that fits within maxLen chars */
+function buildShareText(base: string, handles: string[], maxLen: number): string {
+  let mentions = handles.map(h => `@${h}`);
+  let text = `${base}\n\n${mentions.join(' ')}`;
+  if (text.length <= maxLen) return text;
+  // Drop handles from end but always keep @Pizza_DAO (first)
+  while (mentions.length > 1 && text.length > maxLen) {
+    mentions.pop();
+    text = `${base}\n\n${mentions.join(' ')}`;
+  }
+  return text;
+}
+
+export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode, twitterHandles = [] }: ShareRSVPProps) {
   const [copied, setCopied] = useState(false);
   const [downloading, setDownloading] = useState(false);
 
   const city = eventName.replace(/^Global Pizza Party\s*/i, '') || eventName;
   const eventUrl = `https://rsv.pizza/${customUrl || inviteCode}`;
-  const shareText = `\u{1F5FA}\uFE0F\u{1F355}\u{1F973}\nI'm going to the Global Pizza Party in ${city}!`;
+  const baseText = `\u{1F5FA}\uFE0F\u{1F355}\u{1F973}\nI'm going to the Global Pizza Party in ${city}!`;
+
+  // Build deduplicated handles list, always starting with Pizza_DAO
+  const allHandles = ['Pizza_DAO', ...twitterHandles];
+  const seen = new Set<string>();
+  const uniqueHandles: string[] = [];
+  for (const raw of allHandles) {
+    const normalized = normalizeHandle(raw);
+    if (normalized && !seen.has(normalized.toLowerCase())) {
+      seen.add(normalized.toLowerCase());
+      uniqueHandles.push(normalized);
+    }
+  }
+  const shareText = buildShareText(baseText, uniqueHandles, 250);
 
   const handleShareX = () => {
     const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(eventUrl)}`;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -359,6 +359,7 @@ export interface PublicEventSponsor {
   website: string | null;
   brandDescription: string | null;
   logoUrl: string | null;
+  brandTwitter: string | null;
 }
 
 export interface PublicEvent {

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -303,14 +303,23 @@ export function RSVPPage() {
               Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
             </p>
           )}
-          {!form.alreadyRegistered && !form.pendingApproval && (
-            <ShareRSVP
-              eventName={party?.name || ''}
-              eventImageUrl={party?.event_image_url || null}
-              customUrl={party?.custom_url || null}
-              inviteCode={inviteCode || ''}
-            />
-          )}
+          {!form.alreadyRegistered && !form.pendingApproval && (() => {
+            const twitterHandles: string[] = [];
+            if (party?.co_hosts) {
+              for (const host of party.co_hosts as any[]) {
+                if (host.twitter && host.showOnEvent !== false) twitterHandles.push(host.twitter);
+              }
+            }
+            return (
+              <ShareRSVP
+                eventName={party?.name || ''}
+                eventImageUrl={party?.event_image_url || null}
+                customUrl={party?.custom_url || null}
+                inviteCode={inviteCode || ''}
+                twitterHandles={twitterHandles}
+              />
+            );
+          })()}
           <button
             onClick={handleClose}
             className="btn-secondary"


### PR DESCRIPTION
## Summary
- Always tags @Pizza_DAO in the Share on X tweet text after RSVP
- Collects twitter handles from the event host, co-hosts, and sponsors and includes them as @mentions
- Handles are normalized, deduplicated, and trimmed to fit within 250 chars
- Backend now returns brandTwitter in the public sponsor response

## Test plan
- [ ] RSVP to an event with partners that have X handles set
- [ ] RSVP to an event with no partners - verify @Pizza_DAO still appears
- [ ] Test with many handles to verify 250-char truncation