### PR TITLE
security: RLS lockdown on parties and guests

### DIFF
--- a/supabase/migrations/20260421_rls_lockdown.sql
+++ b/supabase/migrations/20260421_rls_lockdown.sql
@@ -1,0 +1,40 @@
+-- RLS Lockdown: Drop dangerous permissive policies on parties and guests
+--
+-- The app routes all writes through the backend API which uses service_role
+-- (bypasses RLS). These wide-open policies allowed any anonymous Supabase
+-- client to UPDATE any party or DELETE any guest — a serious security hole.
+--
+-- Policies dropped:
+--   parties: "Anyone can update parties"  (FOR UPDATE USING (true))
+--   parties: "Anyone can create parties"  (FOR INSERT WITH CHECK (true))
+--   guests:  "Anyone can delete guests"   (FOR DELETE USING (true))
+--   guests:  "Anyone can add guests"      (FOR INSERT WITH CHECK (true))
+--
+-- Policies kept:
+--   parties: "Anyone can read parties"    (FOR SELECT — needed by public event pages)
+--   guests:  "Anyone can read guests"     (FOR SELECT — needed by host guest lists)
+--
+-- Frontend fallback paths that hit Supabase directly will stop working.
+-- These only fire when the user is NOT authenticated (edge case), and all
+-- normal flows go through the authenticated backend API.
+
+-- ============================================================
+-- parties table
+-- ============================================================
+
+-- Drop the permissive UPDATE policy (backend handles all party updates)
+DROP POLICY IF EXISTS "Anyone can update parties" ON parties;
+
+-- Drop the permissive INSERT policy (backend handles all party creation)
+DROP POLICY IF EXISTS "Anyone can create parties" ON parties;
+
+-- ============================================================
+-- guests table
+-- ============================================================
+
+-- Drop the permissive DELETE policy (backend handles all guest removals)
+DROP POLICY IF EXISTS "Anyone can delete guests" ON guests;
+
+-- Drop the permissive INSERT policy (backend handles all guest creation,
+-- including public RSVP submissions via /api/rsvp/:inviteCode/guest)
+DROP POLICY IF EXISTS "Anyone can add guests" ON guests;


### PR DESCRIPTION
## Summary
- Drops permissive `"Anyone can update parties"` UPDATE policy
- Drops permissive `"Anyone can create parties"` INSERT policy  
- Drops permissive `"Anyone can delete guests"` DELETE policy
- Drops permissive `"Anyone can add guests"` INSERT policy
- All writes already go through backend API (service_role bypasses RLS)
- SELECT policies kept intact for public event pages and guest list reads

## Frontend fallback paths affected
The frontend has Supabase-direct fallback code for unauthenticated users in `supabase.ts`:
- `createParty` fallback INSERT on parties (line ~588)
- `updateParty` fallback UPDATE on parties (line ~1396)
- `deleteParty` fallback DELETE on parties (line ~1421)
- `addGuestByHost` fallback INSERT on guests (line ~1101)
- `removeGuest` fallback DELETE on guests (line ~1138)
- `updateGuestApproval` fallback UPDATE on guests (line ~1163)

These fallbacks only trigger when the user is NOT authenticated. All normal authenticated flows use the backend API and are unaffected.

## Test plan
- [ ] RSVP flow still works (guest creation via backend API `/api/rsvp/:inviteCode/guest`)
- [ ] Host can still edit event details (party updates via backend API `PATCH /api/parties/:id`)
- [ ] Guest list management still works (delete via backend API `DELETE /api/parties/:partyId/guests/:guestId`)
- [ ] Public event pages still load (SELECT policies unchanged)
- [ ] Co-host adding guests works (backend API `POST /api/parties/:id/guests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)