### PR TITLE
feat: partner description ordering + PizzaDAO default

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1122,7 +1122,8 @@ model SponsorUser {
   category        String?
 
   // Brand info (synced to Sponsor records)
-  brandDescription String? @map("brand_description")
+  brandDescription     String? @map("brand_description")
+  descriptionSortOrder Int     @default(0) @map("description_sort_order")
 
   // Granular co-host permissions (applied when autoCoHost adds them to events)
   coHostShowOnEvent Boolean @default(true)  @map("co_host_show_on_event")

--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -27,6 +27,7 @@ interface SponsorUserLike {
   name: string | null;
   email: string;
   brandDescription: string | null;
+  descriptionSortOrder: number;
 }
 
 interface PartyLike {
@@ -95,6 +96,7 @@ export async function addPartnerToParty(
       brandDescription: sponsorUser.brandDescription || null,
       logoUrl: sponsorUser.coHostLogoUrl || null,
       category: sponsorUser.category || null,
+      sortOrder: sponsorUser.descriptionSortOrder,
     };
 
     const existingSponsor = await prisma.sponsor.findFirst({

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -156,7 +156,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         logoUrl: true,
         brandTwitter: true,
       },
-      orderBy: { createdAt: 'asc' },
+      orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
     });
 
     // Enrich coHosts with user profile data (avatar, socials) then strip emails

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -18,7 +18,7 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
     }
 
     const sponsorUsers = await prisma.sponsorUser.findMany({
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ descriptionSortOrder: 'asc' }, { createdAt: 'desc' }],
       select: {
         id: true,
         email: true,
@@ -42,6 +42,7 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
         coHostCanEdit: true,
         coHostAllowedTabs: true,
         brandDescription: true,
+        descriptionSortOrder: true,
       },
     });
 
@@ -77,6 +78,7 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
       coHostShowOnEvent, coHostCanEdit, coHostAllowedTabs,
       category,
       brandDescription,
+      descriptionSortOrder,
     } = req.body;
 
     if (!email || !tag) {
@@ -108,6 +110,7 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
         autoCoHost: autoCoHost || false,
         autoSponsor: autoSponsor || false,
         brandDescription: brandDescription?.trim() || null,
+        descriptionSortOrder: typeof descriptionSortOrder === 'number' ? descriptionSortOrder : 0,
         coHostShowOnEvent: coHostShowOnEvent !== undefined ? !!coHostShowOnEvent : true,
         coHostCanEdit: !!coHostCanEdit,
         coHostAllowedTabs: Array.isArray(coHostAllowedTabs) ? coHostAllowedTabs : Prisma.JsonNull,
@@ -131,6 +134,35 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
   }
 });
 
+// PATCH /api/sponsor-users/reorder - Reorder sponsor users by descriptionSortOrder (admin only)
+// NOTE: Must be registered before /:id to avoid Express matching 'reorder' as an id
+sponsorUserAdminRouter.patch('/reorder', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const { sponsorUserIds } = req.body;
+
+    if (!Array.isArray(sponsorUserIds) || sponsorUserIds.length === 0) {
+      throw new AppError('sponsorUserIds must be a non-empty array', 400, 'VALIDATION_ERROR');
+    }
+
+    await prisma.$transaction(
+      sponsorUserIds.map((id: string, index: number) =>
+        prisma.sponsorUser.update({
+          where: { id },
+          data: { descriptionSortOrder: index },
+        })
+      )
+    );
+
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // PATCH /api/sponsor-users/:id - Update a sponsor user (super admin only)
 sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
@@ -146,6 +178,7 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
       coHostShowOnEvent, coHostCanEdit, coHostAllowedTabs,
       category,
       brandDescription,
+      descriptionSortOrder,
     } = req.body;
 
     // Fetch old state for sync reconciliation
@@ -169,6 +202,7 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
     if (coHostAvatarUrl !== undefined) updateData.coHostAvatarUrl = coHostAvatarUrl?.trim() || null;
     if (coHostLogoUrl !== undefined) updateData.coHostLogoUrl = coHostLogoUrl?.trim() || null;
     if (brandDescription !== undefined) updateData.brandDescription = brandDescription?.trim() || null;
+    if (descriptionSortOrder !== undefined) updateData.descriptionSortOrder = typeof descriptionSortOrder === 'number' ? descriptionSortOrder : 0;
     if (autoCoHost !== undefined) updateData.autoCoHost = autoCoHost;
     if (autoSponsor !== undefined) updateData.autoSponsor = autoSponsor;
     if (category !== undefined) updateData.category = category?.trim() || null;

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -148,6 +148,14 @@ sponsorUserAdminRouter.patch('/reorder', requireAuth, async (req: AuthRequest, r
       throw new AppError('sponsorUserIds must be a non-empty array', 400, 'VALIDATION_ERROR');
     }
 
+    // Capture old global order BEFORE updating
+    const oldSponsorUsers = await prisma.sponsorUser.findMany({
+      where: { id: { in: sponsorUserIds }, autoSponsor: true, isActive: true },
+      select: { id: true, email: true, descriptionSortOrder: true, tag: true },
+      orderBy: { descriptionSortOrder: 'asc' },
+    });
+
+    // Apply the new order
     await prisma.$transaction(
       sponsorUserIds.map((id: string, index: number) =>
         prisma.sponsorUser.update({
@@ -156,6 +164,81 @@ sponsorUserAdminRouter.patch('/reorder', requireAuth, async (req: AuthRequest, r
         })
       )
     );
+
+    // Smart sync: propagate new order to events that haven't been host-customized
+    try {
+      // Build old order: email -> old descriptionSortOrder
+      const oldOrderByEmail = new Map(oldSponsorUsers.map(su => [su.email, su.descriptionSortOrder]));
+
+      // Build new order: email -> new descriptionSortOrder (index)
+      const newSponsorUsers = await prisma.sponsorUser.findMany({
+        where: { id: { in: sponsorUserIds }, autoSponsor: true, isActive: true },
+        select: { id: true, email: true, descriptionSortOrder: true, tag: true },
+      });
+      const newOrderByEmail = new Map(newSponsorUsers.map(su => [su.email, su.descriptionSortOrder]));
+
+      // Find all auto-created sponsors across all events
+      const autoSponsors = await prisma.sponsor.findMany({
+        where: {
+          contactEmail: { in: Array.from(oldOrderByEmail.keys()) },
+          notes: { startsWith: 'Auto-created from partner tag' },
+        },
+        select: { id: true, partyId: true, contactEmail: true, sortOrder: true },
+      });
+
+      if (autoSponsors.length > 0) {
+        // Group by event
+        const byEvent = new Map<string, typeof autoSponsors>();
+        for (const sp of autoSponsors) {
+          const list = byEvent.get(sp.partyId) || [];
+          list.push(sp);
+          byEvent.set(sp.partyId, list);
+        }
+
+        const updates: { id: string; sortOrder: number }[] = [];
+
+        for (const [, eventSponsors] of byEvent) {
+          // Current event order (by sortOrder)
+          const currentOrder = [...eventSponsors]
+            .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+            .map(s => s.contactEmail);
+
+          // Old global order for the same emails
+          const oldGlobalOrder = [...eventSponsors]
+            .sort((a, b) => (oldOrderByEmail.get(a.contactEmail!) ?? 0) - (oldOrderByEmail.get(b.contactEmail!) ?? 0))
+            .map(s => s.contactEmail);
+
+          // Compare sequences — if they match, event hasn't been host-customized
+          const isCustomized = currentOrder.length !== oldGlobalOrder.length ||
+            currentOrder.some((email, i) => email !== oldGlobalOrder[i]);
+
+          if (!isCustomized) {
+            // Safe to sync — update each sponsor's sortOrder to new global value
+            for (const sp of eventSponsors) {
+              const newOrder = newOrderByEmail.get(sp.contactEmail!);
+              if (newOrder !== undefined) {
+                updates.push({ id: sp.id, sortOrder: newOrder });
+              }
+            }
+          }
+        }
+
+        // Batch update
+        if (updates.length > 0) {
+          await prisma.$transaction(
+            updates.map(u =>
+              prisma.sponsor.update({
+                where: { id: u.id },
+                data: { sortOrder: u.sortOrder },
+              })
+            )
+          );
+        }
+      }
+    } catch (syncError) {
+      console.error('Failed to sync sponsor sort order to events:', syncError);
+      // Non-fatal: the global reorder succeeded, event sync is best-effort
+    }
 
     res.json({ success: true });
   } catch (error) {

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Plus, RefreshCw } from 'lucide-react';
+import { Plus, RefreshCw, GripVertical, FileText } from 'lucide-react';
 import { Sponsor, SponsorStats } from '../../types';
 import {
   getSponsors,
@@ -8,6 +8,7 @@ import {
   updateSponsor,
   deleteSponsor,
   updateFundraisingGoal,
+  reorderSponsors,
 } from '../../lib/api';
 import { SponsorPipeline } from './SponsorPipeline';
 import { SponsorList } from './SponsorList';
@@ -29,6 +30,10 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
   const [showForm, setShowForm] = useState(false);
   const [editingSponsor, setEditingSponsor] = useState<Sponsor | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Description reorder state
+  const [descDragIndex, setDescDragIndex] = useState<number | null>(null);
+  const [descOrderSponsors, setDescOrderSponsors] = useState<Sponsor[]>([]);
 
   // Load sponsors and stats
   const loadData = useCallback(async (showRefresh = false) => {
@@ -58,6 +63,13 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // Keep description-order sponsors in sync with main sponsors list
+  useEffect(() => {
+    setDescOrderSponsors(
+      sponsors.filter(s => s.brandDescription && ['yes', 'billed', 'paid'].includes(s.status))
+    );
+  }, [sponsors]);
 
   // Handle form submission
   const handleFormSubmit = async (formData: PartnerFormData) => {
@@ -123,6 +135,34 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
     setEditingSponsor(null);
   };
 
+  // Description reorder handlers
+  const handleDescDragStart = (index: number) => {
+    setDescDragIndex(index);
+  };
+
+  const handleDescDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (descDragIndex === null || descDragIndex === index) return;
+
+    const newOrder = [...descOrderSponsors];
+    const draggedItem = newOrder[descDragIndex];
+    newOrder.splice(descDragIndex, 1);
+    newOrder.splice(index, 0, draggedItem);
+
+    setDescOrderSponsors(newOrder);
+    setDescDragIndex(index);
+  };
+
+  const handleDescDragEnd = async () => {
+    setDescDragIndex(null);
+    try {
+      await reorderSponsors(partyId, descOrderSponsors.map(s => s.id));
+    } catch (err) {
+      console.error('Failed to save sponsor description order:', err);
+      await loadData();
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="space-y-4">
@@ -183,6 +223,42 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
         onSponsorUpdate={(updated) => setSponsors(prev => prev.map(s => s.id === updated.id ? updated : s))}
         isLoading={isRefreshing}
       />
+
+      {/* Brand Description Order */}
+      {descOrderSponsors.length > 1 && (
+        <div className="card bg-theme-header border-theme-stroke p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <FileText size={16} className="text-theme-text-muted" />
+            <h3 className="text-sm font-semibold text-theme-text">Brand Description Order</h3>
+            <span className="text-xs text-theme-text-faint">(drag to reorder on event page)</span>
+          </div>
+          <div className="space-y-1.5">
+            {descOrderSponsors.map((sponsor, index) => (
+              <div
+                key={sponsor.id}
+                draggable
+                onDragStart={() => handleDescDragStart(index)}
+                onDragOver={(e) => handleDescDragOver(e, index)}
+                onDragEnd={handleDescDragEnd}
+                className={`flex items-center gap-2 p-2 rounded-lg bg-theme-surface border border-theme-stroke cursor-move transition-opacity ${
+                  descDragIndex === index ? 'opacity-50' : 'opacity-100'
+                }`}
+              >
+                <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0">
+                  <GripVertical size={16} />
+                </div>
+                {sponsor.logoUrl && (
+                  <img src={sponsor.logoUrl} alt="" className="w-6 h-6 rounded object-cover shrink-0" />
+                )}
+                <span className="text-sm text-theme-text font-medium truncate">{sponsor.name}</span>
+                <span className="text-xs text-theme-text-faint truncate ml-auto max-w-[50%]">
+                  {sponsor.brandDescription?.substring(0, 60)}...
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Form Modal */}
       {showForm && (

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -67,7 +67,9 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
   // Keep description-order sponsors in sync with main sponsors list
   useEffect(() => {
     setDescOrderSponsors(
-      sponsors.filter(s => s.brandDescription && ['yes', 'billed', 'paid'].includes(s.status))
+      sponsors
+        .filter(s => s.brandDescription && ['yes', 'billed', 'paid'].includes(s.status))
+        .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
     );
   }, [sponsors]);
 

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Handshake, Plus, Edit2, Trash2, RefreshCw, Check, AlertCircle } from 'lucide-react';
-import { fetchSponsorUsers, createSponsorUser, updateSponsorUser, deleteSponsorUser } from '../../lib/api';
+import { Handshake, Plus, Edit2, Trash2, RefreshCw, Check, AlertCircle, GripVertical } from 'lucide-react';
+import { fetchSponsorUsers, createSponsorUser, updateSponsorUser, deleteSponsorUser, reorderSponsorUsers } from '../../lib/api';
 import type { SponsorUser } from '../../types';
 import { PartnerForm } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
@@ -18,6 +18,7 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
 
   const loadPartners = useCallback(async () => {
     try {
@@ -109,6 +110,35 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
     }
   };
 
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (draggedIndex === null || draggedIndex === index) return;
+
+    const newPartners = [...partners];
+    const draggedItem = newPartners[draggedIndex];
+    newPartners.splice(draggedIndex, 1);
+    newPartners.splice(index, 0, draggedItem);
+
+    setPartners(newPartners);
+    setDraggedIndex(index);
+  };
+
+  const handleDragEnd = async () => {
+    setDraggedIndex(null);
+    // Persist new order to backend
+    try {
+      await reorderSponsorUsers(partners.map(p => p.id));
+    } catch (err) {
+      console.error('Failed to save partner order:', err);
+      // Reload to get correct order from server
+      await loadPartners();
+    }
+  };
+
   const handleDelete = async (id: string) => {
     if (!confirm('Deactivate this partner? This will remove their co-host entries from all events.')) return;
     try {
@@ -163,16 +193,25 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
         </p>
       ) : (
         <div className="space-y-2">
-          {partners.map((partner) => (
+          {partners.map((partner, index) => (
             <div
               key={partner.id}
-              className={`p-3 rounded-xl border transition-colors ${
+              draggable
+              onDragStart={() => handleDragStart(index)}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDragEnd={handleDragEnd}
+              className={`p-3 rounded-xl border transition-colors cursor-move ${
                 partner.isActive
                   ? 'bg-theme-surface border-theme-stroke'
                   : 'bg-theme-surface/50 border-theme-stroke/50 opacity-60'
-              }`}
+              } ${draggedIndex === index ? 'opacity-50' : 'opacity-100'}`}
             >
               <div className="flex items-start gap-3">
+                {/* Drag handle */}
+                <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0 pt-1">
+                  <GripVertical size={16} />
+                </div>
+
                 {/* Avatar */}
                 {partner.coHostAvatarUrl ? (
                   <img

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -964,6 +964,18 @@ export async function deleteSponsor(partyId: string, sponsorId: string): Promise
   }
 }
 
+// Reorder sponsors for a party (host)
+export async function reorderSponsors(
+  partyId: string,
+  sponsorIds: string[]
+): Promise<{ sponsors: Sponsor[] }> {
+  return apiRequest<{ sponsors: Sponsor[] }>(`/api/parties/${partyId}/sponsors/reorder`, {
+    method: 'PATCH',
+    body: { sponsorIds },
+    requireAuth: true,
+  });
+}
+
 // Partner Intake Form API functions
 
 export interface PartnerIntakeData {
@@ -2927,6 +2939,14 @@ export async function updateSponsorUser(id: string, data: SponsorUserUpdateData)
 
 export async function deleteSponsorUser(id: string): Promise<void> {
   await apiRequest(`/api/sponsor-users/${id}`, { method: 'DELETE' });
+}
+
+// Reorder sponsor users (admin) — updates descriptionSortOrder based on array position
+export async function reorderSponsorUsers(sponsorUserIds: string[]): Promise<void> {
+  await apiRequest('/api/sponsor-users/reorder', {
+    method: 'PATCH',
+    body: { sponsorUserIds },
+  });
 }
 
 // User Sponsorship Profile

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -968,7 +968,7 @@ export function EventPage() {
                 )}
 
                 {/* Description + Sponsor Blurbs */}
-                {(event.description || (event.sponsors && event.sponsors.filter(s => s.brandDescription).length > 0)) && (
+                {(event.description || true) && (
                   <div className="border-t border-theme-stroke pt-4 mt-4">
                     <div className="text-theme-text leading-relaxed prose prose-invert prose-lg max-w-none">
                       {event.description && (
@@ -1026,31 +1026,43 @@ export function EventPage() {
                           {event.description}
                         </ReactMarkdown>
                       )}
-                      {event.sponsors && event.sponsors.filter(s => s.brandDescription).length > 0 && (
-                        <div className={event.description ? 'mt-4 pt-4 border-t border-theme-stroke/50' : ''}>
-                          {event.sponsors
-                            .filter(s => s.brandDescription)
-                            .map(sponsor => (
-                              <p key={sponsor.id} className="mb-2 last:mb-0 text-base">
-                                <strong>
-                                  {sponsor.website ? (
-                                    <a
-                                      href={sponsor.website}
-                                      className="text-[#ff393a] hover:text-[#ff5a5b] font-semibold no-underline"
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                    >
-                                      {sponsor.name}
-                                    </a>
-                                  ) : (
-                                    sponsor.name
-                                  )}
-                                </strong>{' '}
-                                {sponsor.brandDescription}
-                              </p>
-                            ))}
-                        </div>
-                      )}
+                      <div className={event.description ? 'mt-4 pt-4 border-t border-theme-stroke/50' : ''}>
+                        {/* PizzaDAO — always first */}
+                        <p className="mb-2 last:mb-0 text-base">
+                          <strong>
+                            <a
+                              href="https://pizzadao.org"
+                              className="text-[#ff393a] hover:text-[#ff5a5b] font-semibold no-underline"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              PizzaDAO
+                            </a>
+                          </strong>{' '}
+                          PizzaDAO is an international pizza co-op that's bringing the pizza industry onchain. We throw a global pizza party every year, arrange conference events every month, and support other organizers' meetups with pizza.
+                        </p>
+                        {event.sponsors && event.sponsors
+                          .filter(s => s.brandDescription)
+                          .map(sponsor => (
+                            <p key={sponsor.id} className="mb-2 last:mb-0 text-base">
+                              <strong>
+                                {sponsor.website ? (
+                                  <a
+                                    href={sponsor.website}
+                                    className="text-[#ff393a] hover:text-[#ff5a5b] font-semibold no-underline"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    {sponsor.name}
+                                  </a>
+                                ) : (
+                                  sponsor.name
+                                )}
+                              </strong>{' '}
+                              {sponsor.brandDescription}
+                            </p>
+                          ))}
+                      </div>
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1039,7 +1039,7 @@ export function EventPage() {
                               PizzaDAO
                             </a>
                           </strong>{' '}
-                          PizzaDAO is an international pizza co-op that's bringing the pizza industry onchain. We throw a global pizza party every year, arrange conference events every month, and support other organizers' meetups with pizza.
+                          is an international pizza co-op that's bringing the pizza industry onchain. We throw a global pizza party every year, arrange conference events every month, and support other organizers' meetups with pizza.
                         </p>
                         {event.sponsors && event.sponsors
                           .filter(s => s.brandDescription)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -460,6 +460,7 @@ export interface Sponsor {
   logoUrl: string | null;
   category: string | null;
   notes: string | null;
+  sortOrder: number;
   lastContactedAt: string | null;
   intakeToken: string | null;
   intakeSubmittedAt: string | null;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1139,6 +1139,7 @@ export interface SponsorUser {
   autoSponsor: boolean;
   category: string | null;
   brandDescription: string | null;
+  descriptionSortOrder: number;
 }
 
 export interface SponsorChecklistItem {

--- a/supabase/migrations/20260421_partner_description_ordering.sql
+++ b/supabase/migrations/20260421_partner_description_ordering.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sponsor_users ADD COLUMN IF NOT EXISTS description_sort_order INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary
- PizzaDAO brand description hardcoded as first entry on all event pages (linked to pizzadao.org)
- Underboss can drag-to-reorder partner descriptions globally
- Hosts can drag-to-reorder per-event sponsor descriptions
- New `descriptionSortOrder` field on SponsorUser
- Event route respects sortOrder for sponsor brand descriptions

## Test plan
- [ ] Every event page shows PizzaDAO description first, linked to pizzadao.org
- [ ] Underboss: drag partners to reorder → event pages reflect new order
- [ ] Host: drag sponsors to reorder → that event reflects override
- [ ] No duplicate PizzaDAO if also a sponsor on the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)