### PR TITLE
feat: GPP default description admin editor

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1154,3 +1154,15 @@ model SponsorChecklistItem {
   @@index([partyId])
   @@map("sponsor_checklist_items")
 }
+
+// ============================================
+// App Config (key-value store)
+// ============================================
+
+model AppConfig {
+  key       String   @id
+  value     String
+  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz
+
+  @@map("app_config")
+}

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -391,8 +391,115 @@ router.post('/checklist-defaults', requireAuth, async (req: AuthRequest, res: Re
   }
 });
 
+// ============================================
+// GPP Default Description
+// ============================================
+
+const GPP_HARDCODED_DESCRIPTION = `Join us for the Global Pizza Party, a worldwide celebration of pizza and bitcoin, where communities around the world come together to share pizza and good vibes.
+
+What to expect:
+- Free pizza
+- Crypto enthusiasts
+- Good conversations
+
+RSVP to secure your slice!`;
+
+// GET /api/admin/gpp-description — Read current default + event stats
+router.get('/gpp-description', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await rawIsSuperAdmin(req.userEmail))) {
+      throw new AppError('Super admin access required', 403, 'FORBIDDEN');
+    }
+
+    // Read current default from app_config
+    const configRow = await prisma.appConfig.findUnique({ where: { key: 'gpp_default_description' } });
+    const defaultDescription = configRow?.value ?? GPP_HARDCODED_DESCRIPTION;
+
+    // Count all GPP events
+    const totalGppEvents = await prisma.party.count({ where: { eventType: 'gpp' } });
+
+    // Count events still on default
+    const defaultCount = await prisma.party.count({
+      where: { eventType: 'gpp', description: defaultDescription },
+    });
+
+    // Find events with custom descriptions
+    const customEvents = await prisma.party.findMany({
+      where: {
+        eventType: 'gpp',
+        NOT: { description: defaultDescription },
+      },
+      select: {
+        id: true,
+        name: true,
+        customUrl: true,
+        inviteCode: true,
+        description: true,
+      },
+      orderBy: { name: 'asc' },
+    });
+
+    const customizedEvents = customEvents.map(e => ({
+      id: e.id,
+      name: e.name,
+      customUrl: e.customUrl,
+      inviteCode: e.inviteCode,
+      descriptionPreview: (e.description || '').slice(0, 100),
+    }));
+
+    res.json({ defaultDescription, totalGppEvents, defaultCount, customizedEvents });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/admin/gpp-description — Update default + bulk-apply to events on old default
+router.patch('/gpp-description', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await rawIsSuperAdmin(req.userEmail))) {
+      throw new AppError('Super admin access required', 403, 'FORBIDDEN');
+    }
+
+    const { description } = req.body;
+    if (!description || typeof description !== 'string' || description.trim().length === 0) {
+      throw new AppError('description is required', 400, 'VALIDATION_ERROR');
+    }
+
+    const newDescription = description.trim();
+
+    // Read old default
+    const configRow = await prisma.appConfig.findUnique({ where: { key: 'gpp_default_description' } });
+    const oldDefault = configRow?.value ?? GPP_HARDCODED_DESCRIPTION;
+
+    // Upsert the new default
+    await prisma.appConfig.upsert({
+      where: { key: 'gpp_default_description' },
+      update: { value: newDescription, updatedAt: new Date() },
+      create: { key: 'gpp_default_description', value: newDescription },
+    });
+
+    // Bulk-update events that still have the old default
+    const result = await prisma.party.updateMany({
+      where: { eventType: 'gpp', description: oldDefault },
+      data: { description: newDescription },
+    });
+
+    const totalGppEvents = await prisma.party.count({ where: { eventType: 'gpp' } });
+    const skippedCount = totalGppEvents - result.count;
+
+    res.json({
+      success: true,
+      updatedCount: result.count,
+      skippedCount,
+      newDefault: newDescription,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // PATCH /api/admin/:id — Update admin role/name (super_admin only, can't downgrade self)
-// IMPORTANT: This wildcard route must be LAST to avoid matching named routes like /checklist-defaults
+// IMPORTANT: This wildcard route must be LAST to avoid matching named routes like /checklist-defaults, /gpp-description
 router.patch('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     if (!(await isSuperAdmin(req.userEmail))) {

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -303,11 +303,15 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
       }));
     }
 
+    // Read DB-stored default description, fall back to hardcoded
+    const configRow = await prisma.appConfig.findUnique({ where: { key: 'gpp_default_description' } });
+    const gppDescription = configRow?.value ?? GPP_DEFAULTS.description;
+
     // Create the party with GPP defaults
     const party = await prisma.party.create({
       data: {
         name: eventName,
-        description: GPP_DEFAULTS.description,
+        description: gppDescription,
         eventType: GPP_DEFAULTS.eventType,
         eventTags: GPP_DEFAULTS.eventTags,
         requireApproval: GPP_DEFAULTS.requireApproval,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2954,3 +2954,34 @@ export async function getUserSponsorships(): Promise<UserSponsorshipEntry[]> {
   return apiRequest<UserSponsorshipEntry[]>('/api/user/sponsorships');
 }
 
+// GPP Default Description Admin API
+
+export interface GppDescriptionData {
+  defaultDescription: string;
+  totalGppEvents: number;
+  defaultCount: number;
+  customizedEvents: Array<{
+    id: string;
+    name: string;
+    customUrl: string | null;
+    inviteCode: string;
+    descriptionPreview: string;
+  }>;
+}
+
+export async function fetchGppDescription(): Promise<GppDescriptionData> {
+  return apiRequest<GppDescriptionData>('/api/admin/gpp-description');
+}
+
+export async function updateGppDescription(description: string): Promise<{
+  success: boolean;
+  updatedCount: number;
+  skippedCount: number;
+  newDefault: string;
+}> {
+  return apiRequest('/api/admin/gpp-description', {
+    method: 'PATCH',
+    body: { description },
+  });
+}
+

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -6,7 +6,7 @@ import { GPPClouds } from '../components/GPPClouds';
 import { IconInput } from '../components/IconInput';
 import {
   Shield, ShieldCheck, UserPlus, Trash2, Loader2,
-  Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag,
+  Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp,
 } from 'lucide-react';
 import {
   fetchAdminMe, fetchAdminList, addAdmin, removeAdmin,
@@ -14,8 +14,9 @@ import {
   fetchGppNftSettings, updateGppNftSettings,
   fetchChecklistDefaults, updateChecklistDefaults, addChecklistDefault, deleteChecklistDefault,
   fetchSponsorUsers, createSponsorUser, deleteSponsorUser,
+  fetchGppDescription, updateGppDescription,
 } from '../lib/api';
-import type { ChecklistDefault } from '../lib/api';
+import type { ChecklistDefault, GppDescriptionData } from '../lib/api';
 import { GPP_REGIONS } from '../types';
 import type { AdminUser, UnderbossAdmin, SponsorUser } from '../types';
 
@@ -72,6 +73,16 @@ export function AdminPage() {
   const [addingSponsor, setAddingSponsor] = useState(false);
   const [sponsorMessage, setSponsorMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
+  // GPP Default Description state
+  const [gppDescription, setGppDescription] = useState('');
+  const [gppDescOriginal, setGppDescOriginal] = useState('');
+  const [gppCustomEvents, setGppCustomEvents] = useState<GppDescriptionData['customizedEvents']>([]);
+  const [gppTotalEvents, setGppTotalEvents] = useState(0);
+  const [gppDefaultCount, setGppDefaultCount] = useState(0);
+  const [savingDesc, setSavingDesc] = useState(false);
+  const [descMessage, setDescMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [showCustomized, setShowCustomized] = useState(false);
+
   const isSuperAdmin = currentRole === 'super_admin';
 
   // Set body class for elements outside React tree
@@ -93,12 +104,14 @@ export function AdminPage() {
         setCurrentRole(me.role || '');
         setCurrentEmail(me.email || '');
 
-        const [adminList, ubList, nftSettings, clDefaults, spList] = await Promise.all([
+        const isSA = me.role === 'super_admin';
+        const [adminList, ubList, nftSettings, clDefaults, spList, gppDescData] = await Promise.all([
           fetchAdminList(),
           fetchUnderbossList(),
           fetchGppNftSettings(),
           fetchChecklistDefaults(),
           fetchSponsorUsers(),
+          isSA ? fetchGppDescription().catch(() => null) : Promise.resolve(null),
         ]);
         setAdmins(adminList);
         setUnderbosses(ubList);
@@ -106,6 +119,13 @@ export function AdminPage() {
         setGppNftChain(nftSettings.nftChain || 'base');
         setChecklistItems(clDefaults.items);
         setSponsorUsers(spList.sponsorUsers);
+        if (gppDescData) {
+          setGppDescription(gppDescData.defaultDescription);
+          setGppDescOriginal(gppDescData.defaultDescription);
+          setGppCustomEvents(gppDescData.customizedEvents);
+          setGppTotalEvents(gppDescData.totalGppEvents);
+          setGppDefaultCount(gppDescData.defaultCount);
+        }
       } catch (err: any) {
         setError(err.message || 'Failed to check admin status');
       } finally {
@@ -149,6 +169,35 @@ export function AdminPage() {
       return () => clearTimeout(t);
     }
   }, [sponsorMessage]);
+
+  useEffect(() => {
+    if (descMessage) {
+      const t = setTimeout(() => setDescMessage(null), 4000);
+      return () => clearTimeout(t);
+    }
+  }, [descMessage]);
+
+  async function handleSaveGppDescription() {
+    setSavingDesc(true);
+    setDescMessage(null);
+    try {
+      const result = await updateGppDescription(gppDescription);
+      setGppDescOriginal(result.newDefault);
+      setDescMessage({
+        type: 'success',
+        text: `Updated ${result.updatedCount} events. ${result.skippedCount} skipped (customized).`,
+      });
+      // Refresh stats
+      const fresh = await fetchGppDescription();
+      setGppCustomEvents(fresh.customizedEvents);
+      setGppTotalEvents(fresh.totalGppEvents);
+      setGppDefaultCount(fresh.defaultCount);
+    } catch (err: any) {
+      setDescMessage({ type: 'error', text: err.message || 'Failed to update' });
+    } finally {
+      setSavingDesc(false);
+    }
+  }
 
   async function handleAddSponsor(e: React.FormEvent) {
     e.preventDefault();
@@ -811,7 +860,7 @@ export function AdminPage() {
 
           {/* Event Setup Checklist — super admin only */}
           {isSuperAdmin && (
-            <section className="card p-6">
+            <section className="card p-6 mt-6">
               <div className="flex items-center gap-2 mb-4">
                 <ListChecks size={20} className="text-theme-text-secondary" />
                 <h2 className="text-lg font-semibold text-theme-text">Event Setup Checklist</h2>
@@ -892,9 +941,81 @@ export function AdminPage() {
             </section>
           )}
 
+          {/* GPP Default Description — super admin only */}
+          {isSuperAdmin && (
+            <section className="card p-6 mt-6">
+              <div className="flex items-center gap-2 mb-4">
+                <FileText size={20} className="text-theme-text-secondary" />
+                <h2 className="text-lg font-semibold text-theme-text">GPP Default Description</h2>
+              </div>
+
+              <p className="text-sm text-theme-text-muted mb-4">
+                {gppDefaultCount} of {gppTotalEvents} events use the default
+              </p>
+
+              {descMessage && (
+                <div className={`mb-4 px-4 py-2 rounded-lg text-sm ${
+                  descMessage.type === 'success' ? 'bg-green-100 text-green-700 border border-green-300' : 'bg-red-100 text-red-700 border border-red-300'
+                }`}>
+                  {descMessage.text}
+                </div>
+              )}
+
+              <IconInput
+                icon={FileText}
+                multiline
+                rows={8}
+                placeholder="Default description for new GPP events..."
+                value={gppDescription}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setGppDescription(e.target.value)}
+              />
+
+              <button
+                onClick={handleSaveGppDescription}
+                disabled={gppDescription === gppDescOriginal || savingDesc}
+                className="mt-4 px-6 py-2 bg-[#E52828] text-white rounded-xl text-sm font-medium hover:bg-[#CC2020] transition-colors disabled:opacity-50"
+              >
+                {savingDesc ? 'Saving...' : 'Save & Apply to Default Events'}
+              </button>
+
+              {gppCustomEvents.length > 0 && (
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    onClick={() => setShowCustomized(!showCustomized)}
+                    className="flex items-center gap-1.5 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
+                  >
+                    {showCustomized ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                    {gppCustomEvents.length} event{gppCustomEvents.length !== 1 ? 's' : ''} with custom descriptions
+                  </button>
+
+                  {showCustomized && (
+                    <div className="mt-2 space-y-2">
+                      {gppCustomEvents.map((ev) => (
+                        <div key={ev.id} className="flex flex-col gap-0.5 py-2 px-3 rounded-lg bg-white/30 border border-theme-stroke">
+                          <a
+                            href={`/host/${ev.inviteCode}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-sm font-medium text-theme-text hover:underline"
+                          >
+                            {ev.name}
+                          </a>
+                          <span className="text-xs text-theme-text-muted truncate">
+                            {ev.descriptionPreview}{ev.descriptionPreview.length >= 100 ? '...' : ''}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </section>
+          )}
+
           {/* GPP NFT Settings — super admin only */}
           {isSuperAdmin && (
-            <section className="card p-6">
+            <section className="card p-6 mt-6">
               <div className="flex items-center gap-2 mb-4">
                 <Shield size={20} className="text-theme-text-secondary" />
                 <h2 className="text-lg font-semibold text-theme-text">GPP NFT Settings</h2>

--- a/supabase/migrations/20260421_app_config.sql
+++ b/supabase/migrations/20260421_app_config.sql
@@ -1,0 +1,12 @@
+-- App-level configuration key-value store
+CREATE TABLE IF NOT EXISTS app_config (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed the GPP default description
+INSERT INTO app_config (key, value) VALUES (
+  'gpp_default_description',
+  E'Join us for the Global Pizza Party, a worldwide celebration of pizza and bitcoin, where communities around the world come together to share pizza and good vibes.\n\nWhat to expect:\n- Free pizza\n- Crypto enthusiasts\n- Good conversations\n\nRSVP to secure your slice!'
+) ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- New `app_config` table for storing app-level configuration
- Admin page section to edit GPP default event description
- "Save & Apply" bulk-updates events still on old default, skips customized
- Shows count + list of events with custom descriptions
- GPP event creation reads default from DB (falls back to hardcode)

## Test plan
- [ ] Admin page shows GPP Description section with current default
- [ ] Edit description and save -- shows correct updated/skipped counts
- [ ] Customized events list shows correct events with preview text
- [ ] Create new GPP event -- uses DB-stored default
- [ ] Non-admin cannot access the endpoint

Generated with [Claude Code](https://claude.com/claude-code)