### PR TITLE
zucchini-37507: Event description images

### DIFF
--- a/frontend/src/components/DescriptionEditor.tsx
+++ b/frontend/src/components/DescriptionEditor.tsx
@@ -1,0 +1,143 @@
+import React, { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Image as ImageIcon, Loader2 } from 'lucide-react';
+import { uploadDescriptionImage } from '../lib/supabase';
+
+interface DescriptionEditorProps {
+  value: string;
+  onChange: (val: string) => void;
+  onSave: () => void;
+  onClose: () => void;
+  saving: boolean;
+  partyId: string;
+}
+
+export const DescriptionEditor: React.FC<DescriptionEditorProps> = ({
+  value,
+  onChange,
+  onSave,
+  onClose,
+  saving,
+  partyId,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Reset file input so the same file can be selected again
+    e.target.value = '';
+
+    // Validate file type
+    if (!file.type.startsWith('image/')) {
+      alert('Please select an image file.');
+      return;
+    }
+
+    // Validate file size (5MB max)
+    if (file.size > 5 * 1024 * 1024) {
+      alert('Image must be under 5MB.');
+      return;
+    }
+
+    setUploading(true);
+
+    const url = await uploadDescriptionImage(file, partyId);
+
+    if (!url) {
+      alert('Failed to upload image. Please try again.');
+      setUploading(false);
+      return;
+    }
+
+    // Insert markdown image at cursor position
+    const textarea = textareaRef.current;
+    const cursorPos = textarea?.selectionStart ?? value.length;
+    const imageMarkdown = `\n![image](${url})\n`;
+    const newValue = value.slice(0, cursorPos) + imageMarkdown + value.slice(cursorPos);
+    onChange(newValue);
+
+    setUploading(false);
+
+    // Restore focus and set cursor after inserted text
+    requestAnimationFrame(() => {
+      if (textarea) {
+        textarea.focus();
+        const newPos = cursorPos + imageMarkdown.length;
+        textarea.selectionStart = newPos;
+        textarea.selectionEnd = newPos;
+      }
+    });
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl max-w-lg w-full p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-theme-text">Description</h2>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="flex items-center gap-1.5 text-xs text-white/60 hover:text-white/90 bg-theme-surface border border-theme-stroke rounded-lg px-2.5 py-1.5 transition-colors disabled:opacity-50"
+          >
+            {uploading ? (
+              <>
+                <Loader2 size={14} className="animate-spin" />
+                Uploading...
+              </>
+            ) : (
+              <>
+                <ImageIcon size={14} />
+                Add Image
+              </>
+            )}
+          </button>
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleImageUpload}
+        />
+
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Describe your event..."
+          className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-3 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a] min-h-[200px] resize-y"
+          autoFocus
+        />
+
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving || uploading}
+          className="w-full mt-4 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
+        >
+          {saving ? (
+            <>
+              <Loader2 size={14} className="animate-spin" />
+              Saving...
+            </>
+          ) : (
+            'Done'
+          )}
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -13,6 +13,7 @@ import { Checkbox } from './Checkbox';
 import { getDateTimeInTimezone, parseDateTimeInTimezone, formatDateDisplay, formatTimeDisplay, formatTimezoneDisplay } from '../utils/dateUtils';
 import { DonationSettings } from './DonationSettings';
 import { HostsManager } from './HostsManager';
+import { DescriptionEditor } from './DescriptionEditor';
 
 export const EventDetailsTab: React.FC = () => {
   const { party } = usePizza();
@@ -1125,40 +1126,18 @@ export const EventDetailsTab: React.FC = () => {
       )}
 
       {/* Description Modal */}
-      {showDescriptionModal && createPortal(
-        <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70" onClick={() => setShowDescriptionModal(false)}>
-          <div className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl max-w-lg w-full p-5" onClick={(e) => e.stopPropagation()}>
-            <h2 className="text-lg font-semibold text-theme-text mb-4">Description</h2>
-
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Describe your event..."
-              className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-3 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a] min-h-[200px] resize-y"
-              autoFocus
-            />
-
-            <button
-              type="button"
-              onClick={async () => {
-                await saveDescription();
-                setShowDescriptionModal(false);
-              }}
-              disabled={savingField === 'description'}
-              className="w-full mt-4 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
-            >
-              {savingField === 'description' ? (
-                <>
-                  <Loader2 size={14} className="animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                'Done'
-              )}
-            </button>
-          </div>
-        </div>,
-        document.body
+      {showDescriptionModal && (
+        <DescriptionEditor
+          value={description}
+          onChange={setDescription}
+          onSave={async () => {
+            await saveDescription();
+            setShowDescriptionModal(false);
+          }}
+          onClose={() => setShowDescriptionModal(false)}
+          saving={savingField === 'description'}
+          partyId={party!.id}
+        />
       )}
 
     </div>

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -137,6 +137,41 @@ export async function uploadSponsorLogo(file: File): Promise<string | null> {
 }
 
 /**
+ * Upload an image for use in event descriptions (Markdown).
+ * Stored under `description-images/{partyId}/` in the event-images bucket.
+ * @param file The image file to upload
+ * @param partyId The party ID for organizing uploads
+ * @returns The public URL of the uploaded image, or null if upload failed
+ */
+export async function uploadDescriptionImage(file: File, partyId: string): Promise<string | null> {
+  try {
+    const fileExt = file.name.split('.').pop();
+    const fileName = `description-images/${partyId}/${Date.now()}-${Math.random().toString(36).substring(7)}.${fileExt}`;
+
+    const { error } = await supabase.storage
+      .from('event-images')
+      .upload(fileName, file, {
+        cacheControl: '3600',
+        upsert: false
+      });
+
+    if (error) {
+      console.error('Error uploading description image:', error);
+      return null;
+    }
+
+    const { data: urlData } = supabase.storage
+      .from('event-images')
+      .getPublicUrl(fileName);
+
+    return urlData.publicUrl;
+  } catch (error) {
+    console.error('Error uploading description image:', error);
+    return null;
+  }
+}
+
+/**
  * Upload a receipt file (image or PDF) to Supabase Storage and return the public URL
  * @param file The receipt file to upload (JPEG, PNG, WebP, or PDF)
  * @param partyId The party ID for organizing uploads

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1021,6 +1021,14 @@ export function EventPage() {
                               ) : (
                                 <code {...props} className="block bg-theme-surface-hover p-3 rounded text-xs font-mono overflow-x-auto my-3" />
                               ),
+                            img: ({ node, ...props }) => (
+                              <img
+                                {...props}
+                                className="rounded-lg max-w-full h-auto my-3"
+                                loading="lazy"
+                                style={{ maxHeight: '400px', objectFit: 'contain' }}
+                              />
+                            ),
                           }}
                         >
                           {event.description}


### PR DESCRIPTION
## Summary
- Hosts can upload images from the description editor modal
- Images stored in Supabase Storage (event-images/description-images/)
- Inserted as Markdown image syntax, rendered via existing ReactMarkdown
- No DB or backend changes

## Test plan
- [ ] Open host dashboard -> Settings -> Description
- [ ] Click Add Image button, upload an image
- [ ] Verify markdown is inserted at cursor position
- [ ] Save and check public event page -- image renders inline
- [ ] Try uploading non-image file (should reject)
- [ ] Try uploading >5MB file (should reject)
- [ ] Verify multiple images work
- [ ] Check mobile layout

Generated with [Claude Code](https://claude.com/claude-code)