### PR TITLE
Tracking auto-detect + CSV bulk import

### DIFF
--- a/backend/src/routes/shipping.routes.ts
+++ b/backend/src/routes/shipping.routes.ts
@@ -2,6 +2,7 @@ import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
+import { detectTrackingUrl } from '../utils/trackingUtils.js';
 
 // Valid kit statuses and tiers
 const VALID_STATUSES = ['pending', 'approved', 'shipped', 'delivered', 'declined'];
@@ -203,11 +204,12 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
     }
 
     // Build CSV
-    const headers = ['Event Name', 'Region', 'Host Name', 'Host Email', 'Event Venue', 'Event Address', 'Event Approved', 'Recipient', 'Address 1', 'Address 2', 'City', 'State', 'Postal Code', 'Country', 'Phone', 'Requested Tier', 'Allocated Tier', 'Status', 'Notes'];
+    const headers = ['Kit ID', 'Event Name', 'Region', 'Host Name', 'Host Email', 'Event Venue', 'Event Address', 'Event Approved', 'Recipient', 'Address 1', 'Address 2', 'City', 'State', 'Postal Code', 'Country', 'Phone', 'Requested Tier', 'Allocated Tier', 'Status', 'Notes', 'Tracking Number', 'Tracking URL'];
     const csvRows = [headers.join(',')];
 
     for (const kit of filtered) {
       const row = [
+        escapeCSV(kit.id),
         escapeCSV(kit.party.name),
         escapeCSV(kit.party.region || ''),
         escapeCSV(kit.party.user?.name || ''),
@@ -227,6 +229,8 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
         escapeCSV(kit.allocatedTier || ''),
         escapeCSV(kit.status),
         escapeCSV(kit.notes || ''),
+        escapeCSV(kit.trackingNumber || ''),
+        escapeCSV(kit.trackingUrl || ''),
       ];
       csvRows.push(row.join(','));
     }
@@ -288,6 +292,77 @@ router.patch('/kits/bulk-update', requireAuth, requireShippingAuth, async (req: 
     });
 
     res.json({ updated: result.count });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ============================================
+// POST /api/shipping/kits/import-tracking - Bulk import tracking numbers from CSV
+// ============================================
+router.post('/kits/import-tracking', requireAuth, requireShippingAuth, async (req: ShippingRequest, res: Response, next: NextFunction) => {
+  try {
+    const { items } = req.body;
+
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new AppError('items must be a non-empty array', 400, 'VALIDATION_ERROR');
+    }
+    if (items.length > 500) {
+      throw new AppError('Maximum 500 items per import', 400, 'VALIDATION_ERROR');
+    }
+
+    const regionFilter = buildRegionFilter(req.shippingRegions!);
+    let updated = 0;
+    let skipped = 0;
+    const notFound: string[] = [];
+
+    for (const item of items) {
+      const { kitId, trackingNumber, trackingUrl } = item;
+
+      if (!kitId) {
+        skipped++;
+        continue;
+      }
+
+      // Skip rows with no tracking data
+      if (!trackingNumber && !trackingUrl) {
+        skipped++;
+        continue;
+      }
+
+      // Verify kit exists and user has access
+      const kit = await prisma.partyKit.findFirst({
+        where: { id: kitId, ...regionFilter },
+      });
+
+      if (!kit) {
+        notFound.push(kitId);
+        continue;
+      }
+
+      const updateData: any = {};
+      if (trackingNumber) updateData.trackingNumber = trackingNumber;
+
+      if (trackingUrl) {
+        updateData.trackingUrl = trackingUrl;
+      } else if (trackingNumber) {
+        // Auto-detect URL from tracking number
+        const detected = detectTrackingUrl(trackingNumber);
+        if (detected) updateData.trackingUrl = detected;
+      }
+
+      if (Object.keys(updateData).length > 0) {
+        await prisma.partyKit.update({
+          where: { id: kitId },
+          data: updateData,
+        });
+        updated++;
+      } else {
+        skipped++;
+      }
+    }
+
+    res.json({ updated, skipped, notFound });
   } catch (error) {
     next(error);
   }
@@ -519,6 +594,12 @@ router.patch('/kits/:kitId', requireAuth, requireShippingAuth, async (req: Shipp
     if (trackingNumber !== undefined) updateData.trackingNumber = trackingNumber;
     if (trackingUrl !== undefined) updateData.trackingUrl = trackingUrl;
     if (adminNotes !== undefined) updateData.adminNotes = adminNotes;
+
+    // Auto-detect tracking URL if tracking number provided but URL is missing/empty
+    if (updateData.trackingNumber && !updateData.trackingUrl && trackingUrl === undefined) {
+      const detected = detectTrackingUrl(updateData.trackingNumber);
+      if (detected) updateData.trackingUrl = detected;
+    }
 
     const updatedKit = await prisma.partyKit.update({
       where: { id: kitId },

--- a/backend/src/utils/trackingUtils.ts
+++ b/backend/src/utils/trackingUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Carrier detection utility for shipping tracking numbers.
+ *
+ * Priority order: UPS → USPS → DHL → FedEx
+ */
+
+const CARRIERS: { name: string; test: (num: string) => boolean; url: (num: string) => string }[] = [
+  {
+    name: 'UPS',
+    test: (num) => /^1Z/i.test(num),
+    url: (num) => `https://www.ups.com/track?tracknum=${encodeURIComponent(num)}`,
+  },
+  {
+    name: 'USPS',
+    test: (num) => /^94\d{18,}$/.test(num) || /^\d{20,22}$/.test(num),
+    url: (num) => `https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(num)}`,
+  },
+  {
+    name: 'DHL',
+    test: (num) => /^JJD/i.test(num) || /^\d{10}$/.test(num),
+    url: (num) => `https://www.dhl.com/us-en/home/tracking.html?tracking-id=${encodeURIComponent(num)}`,
+  },
+  {
+    name: 'FedEx',
+    test: (num) => /^\d{12,22}$/.test(num),
+    url: (num) => `https://www.fedex.com/fedextrack/?trknbr=${encodeURIComponent(num)}`,
+  },
+];
+
+/**
+ * Detect the carrier name from a tracking number.
+ * Returns the carrier name (e.g. "UPS") or null if not detected.
+ */
+export function detectCarrier(trackingNumber: string): string | null {
+  const trimmed = trackingNumber.trim();
+  if (!trimmed) return null;
+
+  for (const carrier of CARRIERS) {
+    if (carrier.test(trimmed)) return carrier.name;
+  }
+  return null;
+}
+
+/**
+ * Detect a tracking URL from a tracking number.
+ * Returns a full URL for the carrier tracking page, or null if not detected.
+ */
+export function detectTrackingUrl(trackingNumber: string): string | null {
+  const trimmed = trackingNumber.trim();
+  if (!trimmed) return null;
+
+  for (const carrier of CARRIERS) {
+    if (carrier.test(trimmed)) return carrier.url(trimmed);
+  }
+  return null;
+}

--- a/frontend/src/components/shipping/CsvImportModal.tsx
+++ b/frontend/src/components/shipping/CsvImportModal.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Upload, FileText, CheckCircle, AlertCircle } from 'lucide-react';
+import { splitCsvLine } from '../../lib/csvParser';
+import { detectCarrier, detectTrackingUrl } from '../../lib/trackingUtils';
+import { importShippingTracking } from '../../lib/api';
+
+interface ParsedRow {
+  kitId: string;
+  recipient: string;
+  trackingNumber: string;
+  trackingUrl: string;
+  detectedCarrier: string | null;
+  autoUrl: string | null;
+  hasTracking: boolean;
+}
+
+interface ImportResult {
+  updated: number;
+  skipped: number;
+  notFound: string[];
+}
+
+interface CsvImportModalProps {
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [rows, setRows] = useState<ParsedRow[]>([]);
+  const [fileName, setFileName] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setFileName(file.name);
+    setParseError(null);
+    setResult(null);
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const text = (event.target?.result as string).replace(/^\uFEFF/, '');
+        const lines = text.split(/\r\n|\n|\r/).filter((l) => l.trim().length > 0);
+
+        if (lines.length < 2) {
+          setParseError('CSV must have a header row and at least one data row.');
+          return;
+        }
+
+        const headerCells = splitCsvLine(lines[0]);
+        const headerMap: Record<string, number> = {};
+        headerCells.forEach((cell, idx) => {
+          headerMap[cell.trim().toLowerCase()] = idx;
+        });
+
+        // Find Kit ID column (required)
+        const kitIdIdx = headerMap['kit id'] ?? headerMap['kitid'] ?? headerMap['kit_id'] ?? -1;
+        if (kitIdIdx === -1) {
+          setParseError('CSV must have a "Kit ID" column header.');
+          return;
+        }
+
+        // Find optional columns
+        const recipientIdx = headerMap['recipient'] ?? headerMap['recipient name'] ?? headerMap['name'] ?? -1;
+        const trackingNumIdx = headerMap['tracking number'] ?? headerMap['tracking_number'] ?? headerMap['trackingnumber'] ?? headerMap['tracking #'] ?? headerMap['tracking'] ?? -1;
+        const trackingUrlIdx = headerMap['tracking url'] ?? headerMap['tracking_url'] ?? headerMap['trackingurl'] ?? -1;
+
+        const parsed: ParsedRow[] = [];
+        for (let i = 1; i < lines.length; i++) {
+          const cells = splitCsvLine(lines[i]);
+          const kitId = (cells[kitIdIdx] || '').trim();
+          if (!kitId) continue;
+
+          const recipient = recipientIdx >= 0 ? (cells[recipientIdx] || '').trim() : '';
+          const trackingNumber = trackingNumIdx >= 0 ? (cells[trackingNumIdx] || '').trim() : '';
+          const trackingUrl = trackingUrlIdx >= 0 ? (cells[trackingUrlIdx] || '').trim() : '';
+
+          const detectedCarrier = trackingNumber ? detectCarrier(trackingNumber) : null;
+          const autoUrl = trackingNumber && !trackingUrl ? detectTrackingUrl(trackingNumber) : null;
+          const hasTracking = !!(trackingNumber || trackingUrl);
+
+          parsed.push({
+            kitId,
+            recipient,
+            trackingNumber,
+            trackingUrl,
+            detectedCarrier,
+            autoUrl,
+            hasTracking,
+          });
+        }
+
+        if (parsed.length === 0) {
+          setParseError('No valid data rows found in CSV.');
+          return;
+        }
+
+        setRows(parsed);
+      } catch {
+        setParseError('Failed to parse CSV file.');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const trackingRows = rows.filter((r) => r.hasTracking);
+
+  const handleApply = async () => {
+    if (trackingRows.length === 0) return;
+
+    setImporting(true);
+    try {
+      const items = trackingRows.map((r) => ({
+        kitId: r.kitId,
+        trackingNumber: r.trackingNumber || undefined,
+        trackingUrl: r.trackingUrl || r.autoUrl || undefined,
+      }));
+
+      const res = await importShippingTracking(items);
+      setResult(res);
+      if (res.updated > 0) {
+        onSuccess();
+      }
+    } catch (err: any) {
+      setParseError(err.message || 'Import failed.');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
+      <div
+        className="bg-theme-card border border-theme-stroke rounded-2xl w-full max-w-3xl mx-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-theme-stroke">
+          <div>
+            <h3 className="text-lg font-semibold text-theme-text">Import Tracking Numbers</h3>
+            <p className="text-sm text-theme-text-muted">Upload a CSV with Kit ID and tracking data</p>
+          </div>
+          <button onClick={onClose} className="text-theme-text-faint hover:text-theme-text-secondary transition-colors">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-5">
+          {/* File picker */}
+          {!result && (
+            <div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-2 px-4 py-3 bg-theme-surface border border-dashed border-theme-stroke-hover rounded-xl text-sm text-theme-text hover:bg-theme-surface/80 transition-colors w-full justify-center"
+              >
+                <Upload size={16} />
+                {fileName || 'Choose CSV file...'}
+              </button>
+              <p className="text-xs text-theme-text-faint mt-2">
+                CSV must include a "Kit ID" column. Optional: "Tracking Number", "Tracking URL", "Recipient".
+              </p>
+            </div>
+          )}
+
+          {/* Parse error */}
+          {parseError && (
+            <div className="flex items-center gap-2 text-sm text-red-500 bg-red-500/10 rounded-lg px-4 py-3">
+              <AlertCircle size={16} />
+              {parseError}
+            </div>
+          )}
+
+          {/* Preview table */}
+          {rows.length > 0 && !result && (
+            <>
+              <div className="text-sm text-theme-text-muted">
+                {rows.length} rows parsed, <span className="text-theme-text font-medium">{trackingRows.length}</span> with tracking data
+              </div>
+              <div className="overflow-x-auto border border-theme-stroke rounded-xl">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-theme-stroke bg-theme-surface/50">
+                      <th className="px-3 py-2 text-left text-xs font-medium text-theme-text-muted">Kit ID</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-theme-text-muted">Recipient</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-theme-text-muted">Tracking #</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-theme-text-muted">Carrier</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-theme-text-muted">URL</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, idx) => (
+                      <tr
+                        key={idx}
+                        className={`border-b border-theme-stroke last:border-b-0 ${
+                          row.hasTracking ? 'bg-green-500/5' : 'opacity-50'
+                        }`}
+                      >
+                        <td className="px-3 py-2 text-theme-text font-mono text-xs">{row.kitId.slice(0, 12)}...</td>
+                        <td className="px-3 py-2 text-theme-text-muted">{row.recipient || '--'}</td>
+                        <td className="px-3 py-2 text-theme-text">
+                          {row.trackingNumber ? (
+                            <span className="font-mono text-xs">{row.trackingNumber.length > 20 ? row.trackingNumber.slice(0, 20) + '...' : row.trackingNumber}</span>
+                          ) : (
+                            <span className="text-theme-text-faint">--</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2">
+                          {row.detectedCarrier ? (
+                            <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-600">{row.detectedCarrier}</span>
+                          ) : (
+                            <span className="text-theme-text-faint text-xs">--</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-xs text-theme-text-muted truncate max-w-[200px]">
+                          {row.trackingUrl || row.autoUrl ? (
+                            <span title={row.trackingUrl || row.autoUrl || ''}>
+                              {row.trackingUrl ? 'provided' : 'auto-detected'}
+                            </span>
+                          ) : (
+                            <span className="text-theme-text-faint">--</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+
+          {/* Result summary */}
+          {result && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-green-600">
+                <CheckCircle size={20} />
+                <span className="text-sm font-medium">Import complete</span>
+              </div>
+              <div className="bg-theme-surface rounded-xl p-4 space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-theme-text-muted">Updated</span>
+                  <span className="text-theme-text font-medium">{result.updated}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-theme-text-muted">Skipped</span>
+                  <span className="text-theme-text">{result.skipped}</span>
+                </div>
+                {result.notFound.length > 0 && (
+                  <div>
+                    <div className="flex justify-between text-red-500">
+                      <span>Not found</span>
+                      <span className="font-medium">{result.notFound.length}</span>
+                    </div>
+                    <div className="mt-1 text-xs text-theme-text-faint font-mono">
+                      {result.notFound.slice(0, 10).map((id) => id.slice(0, 12) + '...').join(', ')}
+                      {result.notFound.length > 10 && ` (+${result.notFound.length - 10} more)`}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 p-6 border-t border-theme-stroke">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
+          >
+            {result ? 'Close' : 'Cancel'}
+          </button>
+          {!result && rows.length > 0 && (
+            <button
+              onClick={handleApply}
+              disabled={importing || trackingRows.length === 0}
+              className="px-6 py-2 bg-red-500 hover:bg-red-600 text-white rounded-xl text-sm font-medium transition-colors disabled:opacity-50"
+            >
+              {importing ? 'Importing...' : `Apply ${trackingRows.length} Update${trackingRows.length !== 1 ? 's' : ''}`}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/shipping/KitDetailModal.tsx
+++ b/frontend/src/components/shipping/KitDetailModal.tsx
@@ -4,6 +4,7 @@ import { X, Package, MapPin, Truck, User, Calendar, FileText, ExternalLink } fro
 import { IconInput } from '../IconInput';
 import type { ShippingKit, KitStatus, KitTier } from '../../types';
 import { GPP_REGIONS } from '../../types';
+import { detectCarrier, detectTrackingUrl } from '../../lib/trackingUtils';
 
 const STATUS_COLORS: Record<string, string> = {
   pending: 'bg-yellow-500/20 text-yellow-700',
@@ -185,7 +186,16 @@ export function KitDetailModal({ kit, onClose, onUpdate }: KitDetailModalProps) 
                 placeholder="Tracking number"
                 value={trackingNumber}
                 onChange={(e) => setTrackingNumber((e.target as HTMLInputElement).value)}
+                onBlur={() => {
+                  if (trackingNumber && !trackingUrl) {
+                    const detected = detectTrackingUrl(trackingNumber);
+                    if (detected) setTrackingUrl(detected);
+                  }
+                }}
               />
+              {trackingNumber && detectCarrier(trackingNumber) && (
+                <p className="text-xs text-theme-text-muted mt-1 ml-1">Detected: {detectCarrier(trackingNumber)}</p>
+              )}
             </div>
 
             <div>

--- a/frontend/src/components/shipping/KitFilters.tsx
+++ b/frontend/src/components/shipping/KitFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Search, Download } from 'lucide-react';
+import { Search, Download, Upload } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type { KitStatus } from '../../types';
 
@@ -30,6 +30,7 @@ interface KitFiltersProps {
   countries: string[];
   onExport: () => void;
   exporting?: boolean;
+  onImport?: () => void;
 }
 
 export function KitFilters({
@@ -42,6 +43,7 @@ export function KitFilters({
   countries,
   onExport,
   exporting,
+  onImport,
 }: KitFiltersProps) {
   return (
     <div className="space-y-3">
@@ -100,6 +102,16 @@ export function KitFilters({
           <Download size={14} />
           {exporting ? 'Exporting...' : 'Export CSV'}
         </button>
+
+        {onImport && (
+          <button
+            onClick={onImport}
+            className="flex items-center gap-2 px-4 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-sm text-theme-text hover:border-theme-stroke-hover transition-colors"
+          >
+            <Upload size={14} />
+            Import Tracking
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/shipping/KitRow.tsx
+++ b/frontend/src/components/shipping/KitRow.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { ExternalLink, Eye } from 'lucide-react';
 import type { ShippingKit, KitStatus, KitTier } from '../../types';
 import { GPP_REGIONS } from '../../types';
+import { detectTrackingUrl } from '../../lib/trackingUtils';
 
 const STATUS_COLORS: Record<string, string> = {
   pending: 'bg-yellow-500/20 text-yellow-700',
@@ -50,8 +51,17 @@ export function KitRow({
   const requestedDate = new Date(kit.requestedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
   const handleTrackingBlur = () => {
-    if (trackingNum !== (kit.trackingNumber || '') || trackingLink !== (kit.trackingUrl || '')) {
-      onTrackingChange(kit.id, trackingNum, trackingLink);
+    // Auto-fill tracking URL if the tracking number changed and URL is empty
+    let url = trackingLink;
+    if (trackingNum && !url) {
+      const detected = detectTrackingUrl(trackingNum);
+      if (detected) {
+        url = detected;
+        setTrackingLink(detected);
+      }
+    }
+    if (trackingNum !== (kit.trackingNumber || '') || url !== (kit.trackingUrl || '')) {
+      onTrackingChange(kit.id, trackingNum, url);
     }
   };
 

--- a/frontend/src/components/shipping/index.ts
+++ b/frontend/src/components/shipping/index.ts
@@ -3,5 +3,6 @@ export { KitFilters } from './KitFilters';
 export { KitRow } from './KitRow';
 export { KitTable } from './KitTable';
 export { KitDetailModal } from './KitDetailModal';
+export { CsvImportModal } from './CsvImportModal';
 export { CoordinatorManager } from './CoordinatorManager';
 export { CoordinatorModal } from './CoordinatorModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2569,6 +2569,14 @@ export async function bulkUpdateShippingKits(kitIds: string[], updates: {
   });
 }
 
+// Import tracking numbers in bulk from CSV
+export async function importShippingTracking(items: { kitId: string; trackingNumber?: string; trackingUrl?: string }[]): Promise<{ updated: number; skipped: number; notFound: string[] }> {
+  return apiRequest<{ updated: number; skipped: number; notFound: string[] }>('/api/shipping/kits/import-tracking', {
+    method: 'POST',
+    body: { items },
+  });
+}
+
 // Export shipping kits CSV
 export async function exportShippingKitsCsv(filters?: ShippingKitFilters): Promise<Blob> {
   const params = new URLSearchParams();

--- a/frontend/src/lib/csvParser.ts
+++ b/frontend/src/lib/csvParser.ts
@@ -20,7 +20,7 @@ export interface ParsedCsvRow {
 }
 
 // Split a single CSV line into cells, respecting quoted fields.
-function splitCsvLine(line: string): string[] {
+export function splitCsvLine(line: string): string[] {
   const cells: string[] = [];
   let current = '';
   let inQuotes = false;

--- a/frontend/src/lib/trackingUtils.ts
+++ b/frontend/src/lib/trackingUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Carrier detection utility for shipping tracking numbers.
+ *
+ * Priority order: UPS → USPS → DHL → FedEx
+ */
+
+const CARRIERS: { name: string; test: (num: string) => boolean; url: (num: string) => string }[] = [
+  {
+    name: 'UPS',
+    test: (num) => /^1Z/i.test(num),
+    url: (num) => `https://www.ups.com/track?tracknum=${encodeURIComponent(num)}`,
+  },
+  {
+    name: 'USPS',
+    test: (num) => /^94\d{18,}$/.test(num) || /^\d{20,22}$/.test(num),
+    url: (num) => `https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodeURIComponent(num)}`,
+  },
+  {
+    name: 'DHL',
+    test: (num) => /^JJD/i.test(num) || /^\d{10}$/.test(num),
+    url: (num) => `https://www.dhl.com/us-en/home/tracking.html?tracking-id=${encodeURIComponent(num)}`,
+  },
+  {
+    name: 'FedEx',
+    test: (num) => /^\d{12,22}$/.test(num),
+    url: (num) => `https://www.fedex.com/fedextrack/?trknbr=${encodeURIComponent(num)}`,
+  },
+];
+
+/**
+ * Detect the carrier name from a tracking number.
+ * Returns the carrier name (e.g. "UPS") or null if not detected.
+ */
+export function detectCarrier(trackingNumber: string): string | null {
+  const trimmed = trackingNumber.trim();
+  if (!trimmed) return null;
+
+  for (const carrier of CARRIERS) {
+    if (carrier.test(trimmed)) return carrier.name;
+  }
+  return null;
+}
+
+/**
+ * Detect a tracking URL from a tracking number.
+ * Returns a full URL for the carrier tracking page, or null if not detected.
+ */
+export function detectTrackingUrl(trackingNumber: string): string | null {
+  const trimmed = trackingNumber.trim();
+  if (!trimmed) return null;
+
+  for (const carrier of CARRIERS) {
+    if (carrier.test(trimmed)) return carrier.url(trimmed);
+  }
+  return null;
+}

--- a/frontend/src/pages/ShippingDashboard.tsx
+++ b/frontend/src/pages/ShippingDashboard.tsx
@@ -4,7 +4,7 @@ import { Loader2, Shield, AlertCircle, Truck, ChevronDown, LogIn, Check } from '
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { KitStats, KitFilters, KitTable, KitDetailModal, CoordinatorManager } from '../components/shipping';
+import { KitStats, KitFilters, KitTable, KitDetailModal, CsvImportModal, CoordinatorManager } from '../components/shipping';
 import {
   fetchShippingMe,
   fetchShippingKits,
@@ -52,6 +52,9 @@ export function ShippingDashboard() {
 
   // Exporting
   const [exporting, setExporting] = useState(false);
+
+  // CSV import modal
+  const [showImportModal, setShowImportModal] = useState(false);
 
   // Available regions based on role
   const availableRegions = useMemo(() => {
@@ -424,6 +427,7 @@ export function ShippingDashboard() {
               countries={countries}
               onExport={handleExport}
               exporting={exporting}
+              onImport={() => setShowImportModal(true)}
             />
           </section>
 
@@ -459,6 +463,14 @@ export function ShippingDashboard() {
           kit={detailKit}
           onClose={() => setDetailKit(null)}
           onUpdate={handleDetailUpdate}
+        />
+      )}
+
+      {/* CSV Import Modal */}
+      {showImportModal && (
+        <CsvImportModal
+          onClose={() => setShowImportModal(false)}
+          onSuccess={() => loadData()}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Auto-detect carrier and tracking URL from tracking number (UPS, USPS, DHL, FedEx)
- CSV bulk import for tracking numbers on shipping dashboard
- Backend fallback auto-detection on PATCH
- Added Kit ID, Tracking Number, Tracking URL columns to CSV export

## Test plan
- [ ] Enter UPS tracking number -> URL auto-fills
- [ ] Enter FedEx number in detail modal -> shows carrier hint
- [ ] Export CSV, add tracking numbers, re-import -> kits updated
- [ ] Import with invalid Kit IDs -> shows in notFound