### PR TITLE
Add Facebook & LinkedIn social post platforms

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -247,7 +247,7 @@ model SocialPost {
   partyId      String   @map("party_id") @db.Uuid
   party        Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
 
-  platform     String   // "twitter", "farcaster", "instagram"
+  platform     String   // "twitter", "farcaster", "instagram", "facebook", "linkedin"
   url          String   // Full URL to the post
   authorHandle String?  @map("author_handle")
   title        String?  // Title/description of what the post is about

--- a/frontend/src/components/report/SocialPostsList.tsx
+++ b/frontend/src/components/report/SocialPostsList.tsx
@@ -8,6 +8,8 @@ const PLATFORMS = {
   twitter: { name: 'X (Twitter)', color: 'bg-blue-500', icon: 'X' },
   farcaster: { name: 'Farcaster', color: 'bg-purple-500', icon: 'F' },
   instagram: { name: 'Instagram', color: 'bg-pink-500', icon: 'IG' },
+  facebook: { name: 'Facebook', color: 'bg-blue-600', icon: 'FB' },
+  linkedin: { name: 'LinkedIn', color: 'bg-sky-700', icon: 'LI' },
 };
 
 interface SocialPostsListProps {
@@ -156,6 +158,10 @@ export function SocialPostsList({ posts, onAdd, onDelete, editable = true }: Soc
       setNewPlatform('farcaster');
     } else if (url.includes('instagram.com')) {
       setNewPlatform('instagram');
+    } else if (url.includes('facebook.com') || url.includes('fb.com') || url.includes('fb.watch')) {
+      setNewPlatform('facebook');
+    } else if (url.includes('linkedin.com')) {
+      setNewPlatform('linkedin');
     }
   };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -541,7 +541,7 @@ export interface Playlist {
 export interface SocialPost {
   id: string;
   partyId: string;
-  platform: 'twitter' | 'farcaster' | 'instagram';
+  platform: 'twitter' | 'farcaster' | 'instagram' | 'facebook' | 'linkedin';
   url: string;
   authorHandle: string | null;
   title: string | null;


### PR DESCRIPTION
## Summary
- Add Facebook and LinkedIn as supported platforms for social posts in event reports
- Auto-detect platform from pasted URLs (facebook.com, fb.com, fb.watch, linkedin.com)
- No DB changes needed (platform is a plain string field)

## Test plan
- [ ] Add a Facebook post URL → platform auto-detected, icon shows FB
- [ ] Add a LinkedIn post URL → platform auto-detected, icon shows LI
- [ ] Existing Twitter/Farcaster/Instagram posts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)