### PR TITLE
margherita-96072: External event links in promo section

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -131,6 +131,9 @@ model Party {
   farcasterViews     Int?      @map("farcaster_views")    // Farcaster view count
   lumaUrl            String?   @map("luma_url")           // Luma event URL
   lumaViews          Int?      @map("luma_views")         // Luma page views
+  meetupUrl          String?   @map("meetup_url")         // Meetup event URL
+  eventbriteUrl      String?   @map("eventbrite_url")     // Eventbrite event URL
+  externalLinks      Json?     @default("[]") @map("external_links") // Custom external links [{label, url}]
   poapEventId        String?   @map("poap_event_id")      // POAP event ID
   poapMints          Int?      @map("poap_mints")         // POAP mint count
   poapMoments        Int?      @map("poap_moments")       // POAP moments count

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -395,7 +395,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       pinnedApps,
       region,
       venueReportTitle, venueReportNotes,
-      hiddenGppPhotos, extraGppPhotos
+      hiddenGppPhotos, extraGppPhotos,
+      lumaUrl, meetupUrl, eventbriteUrl, externalLinks
     } = req.body;
 
     // Verify ownership or super admin
@@ -411,6 +412,21 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
       if (customUrl.length < 3 || customUrl.length > 50) {
         throw new AppError('Custom URL must be between 3 and 50 characters', 400, 'VALIDATION_ERROR');
+      }
+    }
+
+    // Validate externalLinks if provided
+    if (externalLinks !== undefined && externalLinks !== null) {
+      if (!Array.isArray(externalLinks)) {
+        throw new AppError('externalLinks must be an array', 400, 'VALIDATION_ERROR');
+      }
+      if (externalLinks.length > 10) {
+        throw new AppError('Maximum 10 external links allowed', 400, 'VALIDATION_ERROR');
+      }
+      for (const link of externalLinks) {
+        if (typeof link.label !== 'string' || typeof link.url !== 'string') {
+          throw new AppError('Each external link must have a label and url string', 400, 'VALIDATION_ERROR');
+        }
       }
     }
 
@@ -492,6 +508,10 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(venueReportNotes !== undefined && { venueReportNotes: venueReportNotes || null }),
         ...(hiddenGppPhotos !== undefined && { hiddenGppPhotos }),
         ...(extraGppPhotos !== undefined && { extraGppPhotos }),
+        ...(lumaUrl !== undefined && { lumaUrl: lumaUrl || null }),
+        ...(meetupUrl !== undefined && { meetupUrl: meetupUrl || null }),
+        ...(eventbriteUrl !== undefined && { eventbriteUrl: eventbriteUrl || null }),
+        ...(externalLinks !== undefined && { externalLinks }),
       },
       include: {
         user: { select: { name: true } },

--- a/frontend/src/__tests__/field-sync.test.ts
+++ b/frontend/src/__tests__/field-sync.test.ts
@@ -186,7 +186,7 @@ describe('Field Mapping Consistency', () => {
       'kit_enabled', 'kit_deadline',
       'fundraising_goal', 'report_recap', 'report_video_url', 'report_photos_url',
       'flyer_artist', 'x_post_url', 'x_post_views', 'farcaster_post_url', 'farcaster_views',
-      'luma_url', 'luma_views', 'poap_event_id', 'poap_mints', 'poap_moments',
+      'luma_views', 'poap_event_id', 'poap_mints', 'poap_moments',
       'report_published', 'report_public_slug',
     ]);
 
@@ -237,6 +237,10 @@ describe('Field Mapping Consistency', () => {
       region: null,
       event_type: null,
       event_tags: [],
+      luma_url: null,
+      meetup_url: null,
+      eventbrite_url: null,
+      external_links: [],
     };
 
     const party = dbPartyToParty(sampleDbParty as any, []);

--- a/frontend/src/components/promo/PlatformPublisher.tsx
+++ b/frontend/src/components/promo/PlatformPublisher.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
-import { Copy, ExternalLink, Check, MessageSquare } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Copy, ExternalLink, Check, MessageSquare, Link, Tag, X, Plus, Loader2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Party } from '../../types';
+import { usePizza } from '../../contexts/PizzaContext';
+import { updateParty } from '../../lib/supabase';
 import {
   EventPlatform,
   EVENT_PLATFORMS,
@@ -11,11 +13,21 @@ import {
   getLocationString,
 } from './promoUtils';
 
-interface PlatformPublisherProps {
-  party: Party;
-}
-
 const PLATFORM_ORDER: EventPlatform[] = ['luma', 'meetup', 'eventbrite'];
+
+// Map platform to party field name (snake_case for updateParty)
+const PLATFORM_URL_FIELD: Record<EventPlatform, 'luma_url' | 'meetup_url' | 'eventbrite_url'> = {
+  luma: 'luma_url',
+  meetup: 'meetup_url',
+  eventbrite: 'eventbrite_url',
+};
+
+// Map platform to Party property name (camelCase)
+const PLATFORM_PARTY_KEY: Record<EventPlatform, 'lumaUrl' | 'meetupUrl' | 'eventbriteUrl'> = {
+  luma: 'lumaUrl',
+  meetup: 'meetupUrl',
+  eventbrite: 'eventbriteUrl',
+};
 
 // Simple platform logos
 function LumaLogo() {
@@ -50,10 +62,39 @@ function getPlatformLogo(platform: EventPlatform) {
   }
 }
 
-export const PlatformPublisher: React.FC<PlatformPublisherProps> = ({ party }) => {
+export const PlatformPublisher: React.FC = () => {
+  const { party, loadParty } = usePizza();
   const [expandedPlatform, setExpandedPlatform] = useState<EventPlatform | null>(null);
   const [description, setDescription] = useState('');
   const [copied, setCopied] = useState<string | null>(null);
+
+  // Local URL state for each platform
+  const [platformUrls, setPlatformUrls] = useState<Record<EventPlatform, string>>({
+    luma: '',
+    meetup: '',
+    eventbrite: '',
+  });
+
+  // Saving state per field
+  const [savingField, setSavingField] = useState<string | null>(null);
+  const [savedField, setSavedField] = useState<string | null>(null);
+
+  // Custom links local state
+  const [customLinks, setCustomLinks] = useState<Array<{label: string; url: string}>>([]);
+
+  // Sync from party to local state
+  useEffect(() => {
+    if (party) {
+      setPlatformUrls({
+        luma: party.lumaUrl || '',
+        meetup: party.meetupUrl || '',
+        eventbrite: party.eventbriteUrl || '',
+      });
+      setCustomLinks(party.externalLinks || []);
+    }
+  }, [party]);
+
+  if (!party) return null;
 
   const handleExpand = (platform: EventPlatform) => {
     if (expandedPlatform === platform) {
@@ -79,13 +120,100 @@ export const PlatformPublisher: React.FC<PlatformPublisherProps> = ({ party }) =
     window.open(config.createUrl, '_blank', 'noopener,noreferrer');
   };
 
+  const savePlatformUrl = async (platform: EventPlatform) => {
+    const fieldName = PLATFORM_URL_FIELD[platform];
+    const value = platformUrls[platform].trim();
+    const partyKey = PLATFORM_PARTY_KEY[platform];
+
+    // Skip if unchanged
+    if (value === (party[partyKey] || '')) return;
+
+    setSavingField(fieldName);
+    setSavedField(null);
+
+    try {
+      const success = await updateParty(party.id, { [fieldName]: value || null });
+      if (success) {
+        setSavedField(fieldName);
+        setTimeout(() => setSavedField(null), 2000);
+      } else if (party.inviteCode) {
+        await loadParty(party.inviteCode);
+      }
+    } catch (error) {
+      console.error(`Error saving ${fieldName}:`, error);
+      if (party.inviteCode) {
+        await loadParty(party.inviteCode);
+      }
+    } finally {
+      setSavingField(null);
+    }
+  };
+
+  const saveCustomLinks = async (links: Array<{label: string; url: string}>) => {
+    setSavingField('external_links');
+    setSavedField(null);
+
+    try {
+      const success = await updateParty(party.id, { external_links: links });
+      if (success) {
+        setSavedField('external_links');
+        setTimeout(() => setSavedField(null), 2000);
+      } else if (party.inviteCode) {
+        await loadParty(party.inviteCode);
+      }
+    } catch (error) {
+      console.error('Error saving custom links:', error);
+      if (party.inviteCode) {
+        await loadParty(party.inviteCode);
+      }
+    } finally {
+      setSavingField(null);
+    }
+  };
+
+  const addCustomLink = () => {
+    if (customLinks.length >= 10) return;
+    setCustomLinks([...customLinks, { label: '', url: '' }]);
+  };
+
+  const removeCustomLink = (index: number) => {
+    const updated = customLinks.filter((_, i) => i !== index);
+    setCustomLinks(updated);
+    saveCustomLinks(updated);
+  };
+
+  const updateCustomLink = (index: number, field: 'label' | 'url', value: string) => {
+    const updated = customLinks.map((link, i) =>
+      i === index ? { ...link, [field]: value } : link
+    );
+    setCustomLinks(updated);
+  };
+
+  const handleCustomLinkBlur = () => {
+    // Filter out completely empty rows before saving
+    const nonEmpty = customLinks.filter(link => link.label.trim() || link.url.trim());
+    saveCustomLinks(nonEmpty);
+  };
+
   const rsvpUrl = getRsvpUrl(party);
+
+  const renderSaveIndicator = (fieldName: string) => {
+    if (savingField === fieldName) {
+      return <Loader2 size={12} className="animate-spin text-theme-text-muted" />;
+    }
+    if (savedField === fieldName) {
+      return <Check size={12} className="text-green-400" />;
+    }
+    return null;
+  };
 
   return (
     <div className="space-y-3">
       {PLATFORM_ORDER.map((platform) => {
         const config = EVENT_PLATFORMS[platform];
         const isExpanded = expandedPlatform === platform;
+        const partyKey = PLATFORM_PARTY_KEY[platform];
+        const hasUrl = !!(party[partyKey]);
 
         return (
           <div key={platform} className="border border-theme-stroke rounded-xl overflow-hidden">
@@ -102,19 +230,40 @@ export const PlatformPublisher: React.FC<PlatformPublisherProps> = ({ party }) =
                   <p className="text-theme-text-muted text-xs">Create event listing</p>
                 </div>
               </div>
-              <svg
-                className={`w-5 h-5 text-theme-text-muted transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-              </svg>
+              <div className="flex items-center gap-2">
+                {hasUrl && (
+                  <Check size={16} className="text-green-400" />
+                )}
+                <svg
+                  className={`w-5 h-5 text-theme-text-muted transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </div>
             </button>
 
             {/* Expanded Content */}
             {isExpanded && (
               <div className="border-t border-theme-stroke p-4 space-y-3">
+                {/* URL Input */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs text-theme-text-muted">{config.name} Event URL</span>
+                    {renderSaveIndicator(PLATFORM_URL_FIELD[platform])}
+                  </div>
+                  <IconInput
+                    icon={Link}
+                    type="url"
+                    value={platformUrls[platform]}
+                    onChange={(e) => setPlatformUrls(prev => ({ ...prev, [platform]: e.target.value }))}
+                    onBlur={() => savePlatformUrl(platform)}
+                    placeholder={`Paste your ${config.name} event URL`}
+                  />
+                </div>
+
                 {/* Quick Copy Fields */}
                 <div className="space-y-2">
                   <div className="flex items-center justify-between bg-theme-surface rounded-lg px-3 py-2">
@@ -228,6 +377,73 @@ export const PlatformPublisher: React.FC<PlatformPublisherProps> = ({ party }) =
           </div>
         );
       })}
+
+      {/* Custom External Links */}
+      <div className="border border-theme-stroke rounded-xl overflow-hidden">
+        <div className="p-4">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <Link size={16} className="text-theme-text-muted" />
+              <span className="text-theme-text font-medium text-sm">Custom Links</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {renderSaveIndicator('external_links')}
+              {customLinks.length > 0 && (
+                <span className="text-xs text-theme-text-muted">{customLinks.length}/10</span>
+              )}
+            </div>
+          </div>
+          <p className="text-xs text-theme-text-muted mb-3">
+            Add links to other platforms where your event is listed
+          </p>
+
+          {customLinks.length > 0 && (
+            <div className="space-y-2 mb-3">
+              {customLinks.map((link, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <div className="flex-1 min-w-0">
+                    <IconInput
+                      icon={Tag}
+                      value={link.label}
+                      onChange={(e) => updateCustomLink(index, 'label', e.target.value)}
+                      onBlur={handleCustomLinkBlur}
+                      placeholder="Label (e.g. Facebook)"
+                    />
+                  </div>
+                  <div className="flex-[2] min-w-0">
+                    <IconInput
+                      icon={Link}
+                      type="url"
+                      value={link.url}
+                      onChange={(e) => updateCustomLink(index, 'url', e.target.value)}
+                      onBlur={handleCustomLinkBlur}
+                      placeholder="https://..."
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeCustomLink(index)}
+                    className="text-theme-text-muted hover:text-red-400 transition-colors flex-shrink-0 p-1"
+                  >
+                    <X size={16} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {customLinks.length < 10 && (
+            <button
+              type="button"
+              onClick={addCustomLink}
+              className="flex items-center gap-1.5 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
+            >
+              <Plus size={14} />
+              Add link
+            </button>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/promo/PromoWidget.tsx
+++ b/frontend/src/components/promo/PromoWidget.tsx
@@ -95,7 +95,7 @@ export const PromoWidget: React.FC = () => {
             {isExpanded && (
               <div className="border-t border-theme-stroke p-4">
                 {section.id === 'social' && <SocialComposer party={party} />}
-                {section.id === 'publish' && <PlatformPublisher party={party} />}
+                {section.id === 'publish' && <PlatformPublisher />}
                 {section.id === 'email' && <EmailOutreach party={party} guests={guests} />}
                 {section.id === 'invite' && <BulkInvite party={party} />}
               </div>

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -127,6 +127,10 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     allowedTabs: dbParty.allowed_tabs,
     hiddenGppPhotos: (dbParty.hidden_gpp_photos as string[]) || [],
     extraGppPhotos: (dbParty.extra_gpp_photos as string[]) || [],
+    lumaUrl: dbParty.luma_url || null,
+    meetupUrl: dbParty.meetup_url || null,
+    eventbriteUrl: dbParty.eventbrite_url || null,
+    externalLinks: dbParty.external_links || [],
     guests,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -157,6 +157,10 @@ export interface UpdatePartyData {
   region?: string | null;
   hiddenGppPhotos?: string[];
   extraGppPhotos?: string[];
+  lumaUrl?: string | null;
+  meetupUrl?: string | null;
+  eventbriteUrl?: string | null;
+  externalLinks?: Array<{label: string; url: string}>;
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -243,6 +247,10 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       region: data.region,
       hiddenGppPhotos: data.hiddenGppPhotos,
       extraGppPhotos: data.extraGppPhotos,
+      lumaUrl: data.lumaUrl,
+      meetupUrl: data.meetupUrl,
+      eventbriteUrl: data.eventbriteUrl,
+      externalLinks: data.externalLinks,
     },
   });
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -436,6 +436,11 @@ export interface DbParty {
   allowed_tabs?: string[];
   hidden_gpp_photos?: string[];
   extra_gpp_photos?: string[];
+  // External event links
+  luma_url?: string | null;
+  meetup_url?: string | null;
+  eventbrite_url?: string | null;
+  external_links?: Array<{label: string; url: string}>;
 }
 
 export type DbGuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
@@ -482,7 +487,8 @@ export const SAFE_PARTY_COLUMNS = `
   kit_enabled, kit_deadline,
   fundraising_goal, report_recap, report_video_url, report_photos_url,
   flyer_artist, x_post_url, x_post_views, farcaster_post_url, farcaster_views,
-  luma_url, luma_views, poap_event_id, poap_mints, poap_moments,
+  luma_url, luma_views, meetup_url, eventbrite_url, external_links,
+  poap_event_id, poap_mints, poap_moments,
   report_published, report_public_slug,
   venue_report_published, venue_report_slug, venue_report_title, venue_report_notes,
   pinned_apps,
@@ -1327,6 +1333,10 @@ export async function updateParty(
     region?: string | null;
     hidden_gpp_photos?: string[];
     extra_gpp_photos?: string[];
+    luma_url?: string | null;
+    meetup_url?: string | null;
+    eventbrite_url?: string | null;
+    external_links?: Array<{label: string; url: string}>;
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -1384,6 +1394,10 @@ export async function updateParty(
         region: updates.region,
         hiddenGppPhotos: updates.hidden_gpp_photos,
         extraGppPhotos: updates.extra_gpp_photos,
+        lumaUrl: updates.luma_url,
+        meetupUrl: updates.meetup_url,
+        eventbriteUrl: updates.eventbrite_url,
+        externalLinks: updates.external_links,
       });
       return true;
     } catch (error) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -270,6 +270,11 @@ export interface Party {
   allowedTabs?: string[];
   hiddenGppPhotos?: string[];
   extraGppPhotos?: string[];
+  // External event links
+  lumaUrl?: string | null;
+  meetupUrl?: string | null;
+  eventbriteUrl?: string | null;
+  externalLinks?: Array<{label: string; url: string}>;
 }
 
 export interface Donation {

--- a/supabase/migrations/20260424_add_external_event_links.sql
+++ b/supabase/migrations/20260424_add_external_event_links.sql
@@ -1,0 +1,8 @@
+-- Add external event link columns to parties table
+ALTER TABLE parties
+  ADD COLUMN IF NOT EXISTS meetup_url TEXT,
+  ADD COLUMN IF NOT EXISTS eventbrite_url TEXT,
+  ADD COLUMN IF NOT EXISTS external_links JSONB DEFAULT '[]';
+
+-- Column-level SELECT grants (required because project uses column-level grants)
+GRANT SELECT (meetup_url, eventbrite_url, external_links) ON parties TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Adds URL input fields for Luma, Meetup, and Eventbrite in the PlatformPublisher component
- Adds custom links section (label + URL pairs) for arbitrary external platforms (max 10)
- Save on blur with saving/saved indicator, green checkmark when URL is saved in collapsed header
- Full field chain: DB migration -> Prisma -> backend routes -> frontend types/api/context -> UI

## Database
- New columns: `meetup_url`, `eventbrite_url`, `external_links` on `parties`
- Column-level SELECT grants applied for anon/authenticated
- Migration file: `supabase/migrations/20260424_add_external_event_links.sql`

## Files Changed
- `supabase/migrations/20260424_add_external_event_links.sql` -- DB migration
- `backend/prisma/schema.prisma` -- New Prisma fields
- `backend/src/routes/party.routes.ts` -- PATCH handler with externalLinks validation
- `frontend/src/types.ts` -- Party interface additions
- `frontend/src/lib/supabase.ts` -- DbParty, SAFE_PARTY_COLUMNS, updateParty
- `frontend/src/lib/api.ts` -- UpdatePartyData, updatePartyApi body
- `frontend/src/contexts/PizzaContext.tsx` -- dbPartyToParty mapper
- `frontend/src/components/promo/PlatformPublisher.tsx` -- Main UI (URL inputs + custom links)
- `frontend/src/components/promo/PromoWidget.tsx` -- Updated PlatformPublisher usage
- `frontend/src/__tests__/field-sync.test.ts` -- Updated test data

## Test plan
- [ ] Apply DB migration to production Supabase
- [ ] Deploy backend (`cd backend && vercel --prod --scope pizza-dao`)
- [ ] Open host dashboard -> Promo tab -> Publish Event section
- [ ] Paste a URL into the Luma field, blur -> verify it saves (reload page, value persists)
- [ ] Paste URLs for Meetup and Eventbrite -> verify they save
- [ ] Verify green checkmark appears in collapsed header when URL is saved
- [ ] Add a custom link with label "Facebook" and a URL -> verify it saves
- [ ] Delete a custom link -> verify removal
- [ ] Verify max 10 custom links limit
- [ ] Verify saving indicator appears during save

🤖 Generated with [Claude Code](https://claude.com/claude-code)