### PR TITLE
spinach-58515: Kit contents modal on /shipping

### DIFF
--- a/frontend/src/components/shipping/KitContentsModal.tsx
+++ b/frontend/src/components/shipping/KitContentsModal.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { X, Gift, Package, Star, Check } from 'lucide-react';
+import { KIT_TIERS } from '../../types';
+import type { KitTier } from '../../types';
+
+interface KitContentsModalProps {
+  tier: KitTier;
+  onClose: () => void;
+}
+
+const TIER_ICONS: Record<string, React.ReactNode> = {
+  basic: <Gift size={18} />,
+  large: <Package size={18} />,
+  deluxe: <Star size={18} />,
+};
+
+export function KitContentsModal({ tier, onClose }: KitContentsModalProps) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-card border border-theme-stroke rounded-2xl w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-theme-stroke">
+          <h3 className="text-lg font-semibold text-theme-text">Kit Tiers</h3>
+          <button
+            onClick={onClose}
+            className="text-theme-text-faint hover:text-theme-text-secondary transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Tier list */}
+        <div className="p-5 space-y-3">
+          {KIT_TIERS.map((t) => {
+            const isActive = t.id === tier;
+            return (
+              <div
+                key={t.id}
+                className={`rounded-xl p-4 transition-colors ${
+                  isActive
+                    ? 'bg-[#ff393a]/10 border border-[#ff393a]/30'
+                    : 'bg-theme-surface border border-transparent'
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span className={isActive ? 'text-[#ff393a]' : 'text-theme-text-muted'}>
+                    {TIER_ICONS[t.id]}
+                  </span>
+                  <span className="text-sm font-medium text-theme-text">{t.name}</span>
+                  {isActive && (
+                    <span className="ml-auto text-xs font-medium text-[#ff393a] bg-[#ff393a]/15 px-2 py-0.5 rounded-full">
+                      Current
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-theme-text-muted mb-2">{t.description}</p>
+                <div className="flex flex-wrap gap-1">
+                  {t.contents.map((item, index) => (
+                    <span
+                      key={index}
+                      className="inline-flex items-center gap-1 text-xs bg-theme-surface-hover text-theme-text-secondary px-2 py-0.5 rounded"
+                    >
+                      <Check size={10} className="text-[#ff393a]" />
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/shipping/KitDetailModal.tsx
+++ b/frontend/src/components/shipping/KitDetailModal.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Package, MapPin, Truck, User, Calendar, FileText, ExternalLink } from 'lucide-react';
+import { X, Package, MapPin, Truck, User, Calendar, FileText, ExternalLink, Gift, Star, Check } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type { ShippingKit, KitStatus, KitTier } from '../../types';
-import { GPP_REGIONS } from '../../types';
+import { GPP_REGIONS, KIT_TIERS } from '../../types';
 import { detectCarrier, detectTrackingUrl } from '../../lib/trackingUtils';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -179,6 +179,32 @@ export function KitDetailModal({ kit, onClose, onUpdate }: KitDetailModalProps) 
                 )}
               </div>
             </div>
+
+            {/* Kit Contents */}
+            {(() => {
+              const tierInfo = KIT_TIERS.find((t) => t.id === allocatedTier);
+              const tierIcon = allocatedTier === 'deluxe' ? <Star size={16} className="text-theme-text-muted" /> : allocatedTier === 'large' ? <Package size={16} className="text-theme-text-muted" /> : <Gift size={16} className="text-theme-text-muted" />;
+              return tierInfo ? (
+                <div className="bg-theme-surface rounded-xl p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    {tierIcon}
+                    <p className="text-sm font-medium text-theme-text">Kit Contents ({tierInfo.name})</p>
+                  </div>
+                  <p className="text-xs text-theme-text-muted mb-3">{tierInfo.description}</p>
+                  <div className="flex flex-wrap gap-1">
+                    {tierInfo.contents.map((item, index) => (
+                      <span
+                        key={index}
+                        className="inline-flex items-center gap-1 text-xs bg-theme-surface-hover text-theme-text-secondary px-2 py-0.5 rounded"
+                      >
+                        <Check size={10} className="text-[#ff393a]" />
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null;
+            })()}
 
             <div>
               <IconInput

--- a/frontend/src/components/shipping/KitRow.tsx
+++ b/frontend/src/components/shipping/KitRow.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ExternalLink, Eye } from 'lucide-react';
+import { ExternalLink, Eye, Info } from 'lucide-react';
+import { KitContentsModal } from './KitContentsModal';
 import type { ShippingKit, KitStatus, KitTier } from '../../types';
 import { GPP_REGIONS } from '../../types';
 import { detectTrackingUrl } from '../../lib/trackingUtils';
@@ -37,6 +38,7 @@ export function KitRow({
   showRegion,
 }: KitRowProps) {
   const [showTracking, setShowTracking] = useState(false);
+  const [showContents, setShowContents] = useState(false);
   const [trackingNum, setTrackingNum] = useState(kit.trackingNumber || '');
   const [trackingLink, setTrackingLink] = useState(kit.trackingUrl || '');
 
@@ -115,7 +117,7 @@ export function KitRow({
 
       {/* Tier */}
       <td className="px-3 py-3 hidden lg:table-cell">
-        <div className="relative">
+        <div className="flex items-center gap-1">
           <select
             value={kit.allocatedTier || kit.requestedTier}
             onChange={(e) => onTierChange(kit.id, e.target.value)}
@@ -125,6 +127,13 @@ export function KitRow({
               <option key={t} value={t}>{t}</option>
             ))}
           </select>
+          <button
+            onClick={() => setShowContents(true)}
+            className="p-1 rounded hover:bg-theme-surface transition-colors text-theme-text-faint hover:text-theme-text-muted"
+            title="View tier contents"
+          >
+            <Info size={14} />
+          </button>
         </div>
         {kit.allocatedTier && kit.allocatedTier !== kit.requestedTier && (
           <div className="text-xs text-theme-text-faint mt-0.5">req: {kit.requestedTier}</div>
@@ -199,6 +208,13 @@ export function KitRow({
           <Eye size={16} />
         </button>
       </td>
+
+      {showContents && (
+        <KitContentsModal
+          tier={kit.allocatedTier || kit.requestedTier}
+          onClose={() => setShowContents(false)}
+        />
+      )}
     </tr>
   );
 }

--- a/frontend/src/components/shipping/index.ts
+++ b/frontend/src/components/shipping/index.ts
@@ -3,6 +3,7 @@ export { KitFilters } from './KitFilters';
 export { KitRow } from './KitRow';
 export { KitTable } from './KitTable';
 export { KitDetailModal } from './KitDetailModal';
+export { KitContentsModal } from './KitContentsModal';
 export { CsvImportModal } from './CsvImportModal';
 export { CoordinatorManager } from './CoordinatorManager';
 export { CoordinatorModal } from './CoordinatorModal';

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^6.8.2",
-        "@supabase/supabase-js": "*",
+        "@supabase/supabase-js": "^2.49.1",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",


### PR DESCRIPTION
## Summary
- New lightweight KitContentsModal showing all 3 tier contents with current tier highlighted
- Info icon button on each kit row for quick tier contents reference
- Kit Contents section added to existing KitDetailModal

## Test plan
- [ ] Navigate to /shipping as admin
- [ ] Click Info icon next to tier dropdown → modal shows all 3 tiers
- [ ] Open full kit detail modal → Kit Contents section visible
- [ ] Change tier dropdown → contents update dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)