### PR TITLE
crust-64388: Unified partner reorder (underboss + event)

### DIFF
--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -47,6 +47,193 @@ router.get('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Resp
   }
 });
 
+// GET /api/parties/:partyId/sponsors/unified - List unified partners (event + underboss)
+router.get('/:partyId/sponsors/unified', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    // Verify ownership or super admin
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    // Verify co-host has access to sponsors tab
+    const canAccessSponsors = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccessSponsors) {
+      throw new AppError('You do not have access to the sponsors tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    // 1. Fetch confirmed event sponsors with brand descriptions
+    const eventSponsors = await prisma.sponsor.findMany({
+      where: {
+        partyId,
+        brandDescription: { not: null },
+        status: { in: ['yes', 'billed', 'paid'] },
+      },
+      orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+    });
+
+    // 2. Get the party's eventTags
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { eventTags: true },
+    });
+
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // 3. Fetch tag-matched SponsorUsers with brand descriptions
+    let underbossPartners: any[] = [];
+    if (party.eventTags.length > 0) {
+      underbossPartners = await prisma.sponsorUser.findMany({
+        where: {
+          tag: { in: party.eventTags },
+          isActive: true,
+          brandDescription: { not: null },
+        },
+        orderBy: [{ descriptionSortOrder: 'asc' }, { createdAt: 'asc' }],
+      });
+    }
+
+    // 4. Deduplicate: collect emails of event sponsors
+    const eventSponsorEmails = new Set(
+      eventSponsors
+        .filter(s => s.contactEmail)
+        .map(s => s.contactEmail!.toLowerCase())
+    );
+
+    // 5. Build unified list
+    const partners: any[] = [];
+
+    // Add event sponsors
+    for (const s of eventSponsors) {
+      partners.push({
+        id: s.id,
+        sponsorId: s.id,
+        sponsorUserId: undefined,
+        source: 'event',
+        name: s.name,
+        brandDescription: s.brandDescription,
+        logoUrl: s.logoUrl,
+        website: s.website,
+        sortOrder: s.sortOrder ?? 0,
+      });
+    }
+
+    // Add underboss partners that don't have a matching Sponsor record
+    for (const su of underbossPartners) {
+      if (eventSponsorEmails.has(su.email.toLowerCase())) {
+        // Already has a Sponsor record — mark the existing entry with the sponsorUserId
+        const existing = partners.find(
+          p => p.source === 'event' && eventSponsors.find(
+            es => es.id === p.sponsorId && es.contactEmail?.toLowerCase() === su.email.toLowerCase()
+          )
+        );
+        if (existing) {
+          existing.sponsorUserId = su.id;
+          existing.source = 'event'; // keep as event since it has a Sponsor record
+        }
+        continue;
+      }
+
+      partners.push({
+        id: `su-${su.id}`,
+        sponsorId: undefined,
+        sponsorUserId: su.id,
+        source: 'underboss',
+        name: su.coHostName || su.name || su.email,
+        brandDescription: su.brandDescription,
+        logoUrl: su.coHostLogoUrl,
+        website: su.coHostWebsite,
+        sortOrder: 9999 + su.descriptionSortOrder,
+      });
+    }
+
+    // Sort by sortOrder, then by name as tiebreaker
+    partners.sort((a, b) => a.sortOrder - b.sortOrder);
+
+    res.json({ partners });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/sponsors/ensure-from-underboss - Create Sponsor records for underboss partners
+router.post('/:partyId/sponsors/ensure-from-underboss', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { sponsorUserIds } = req.body;
+
+    // Verify ownership or super admin
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+    }
+
+    // Verify co-host has access to sponsors tab
+    const canAccessSponsors = await canUserAccessTab(partyId, req.userEmail, req.userId, 'partners');
+    if (!canAccessSponsors) {
+      throw new AppError('You do not have access to the sponsors tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    if (!Array.isArray(sponsorUserIds) || sponsorUserIds.length === 0) {
+      throw new AppError('sponsorUserIds must be a non-empty array', 400, 'VALIDATION_ERROR');
+    }
+
+    const createdSponsorIds: string[] = [];
+
+    for (const suId of sponsorUserIds) {
+      // Fetch the SponsorUser
+      const sponsorUser = await prisma.sponsorUser.findUnique({
+        where: { id: suId },
+      });
+
+      if (!sponsorUser) {
+        continue; // Skip unknown IDs
+      }
+
+      // Check if a Sponsor record already exists for this party + email
+      const existingSponsor = await prisma.sponsor.findFirst({
+        where: {
+          partyId,
+          contactEmail: sponsorUser.email,
+        },
+      });
+
+      if (existingSponsor) {
+        createdSponsorIds.push(existingSponsor.id);
+        continue;
+      }
+
+      // Create a Sponsor record, reusing partnerSync logic
+      const created = await prisma.sponsor.create({
+        data: {
+          partyId,
+          name: sponsorUser.coHostName || sponsorUser.name || sponsorUser.email,
+          website: sponsorUser.coHostWebsite || null,
+          brandTwitter: sponsorUser.coHostTwitter || null,
+          brandInstagram: sponsorUser.coHostInstagram || null,
+          brandDescription: sponsorUser.brandDescription || null,
+          logoUrl: sponsorUser.coHostLogoUrl || null,
+          category: sponsorUser.category || null,
+          contactEmail: sponsorUser.email,
+          status: 'yes',
+          sortOrder: sponsorUser.descriptionSortOrder,
+          notes: `Auto-created from partner tag "${sponsorUser.tag}"`,
+        },
+      });
+
+      createdSponsorIds.push(created.id);
+    }
+
+    res.json({ createdSponsorIds });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // GET /api/parties/:partyId/sponsors/stats - Get pipeline statistics
 router.get('/:partyId/sponsors/stats', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Plus, RefreshCw, GripVertical, FileText } from 'lucide-react';
-import { Sponsor, SponsorStats } from '../../types';
+import { Plus, RefreshCw, GripVertical, FileText, Globe } from 'lucide-react';
+import { Sponsor, SponsorStats, UnifiedPartner } from '../../types';
 import {
   getSponsors,
   getSponsorStats,
@@ -9,6 +9,8 @@ import {
   deleteSponsor,
   updateFundraisingGoal,
   reorderSponsors,
+  getUnifiedSponsors,
+  ensureUnderbossSponsors,
 } from '../../lib/api';
 import { SponsorPipeline } from './SponsorPipeline';
 import { SponsorList } from './SponsorList';
@@ -31,9 +33,10 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
   const [editingSponsor, setEditingSponsor] = useState<Sponsor | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Description reorder state
+  // Unified description reorder state
   const [descDragIndex, setDescDragIndex] = useState<number | null>(null);
-  const [descOrderSponsors, setDescOrderSponsors] = useState<Sponsor[]>([]);
+  const [unifiedPartners, setUnifiedPartners] = useState<UnifiedPartner[]>([]);
+  const [isSavingOrder, setIsSavingOrder] = useState(false);
 
   // Load sponsors and stats
   const loadData = useCallback(async (showRefresh = false) => {
@@ -60,18 +63,28 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
     }
   }, [partyId]);
 
+  // Load unified partners for description ordering
+  const loadUnifiedPartners = useCallback(async () => {
+    try {
+      const result = await getUnifiedSponsors(partyId);
+      if (result) {
+        setUnifiedPartners(result.partners);
+      }
+    } catch (err) {
+      console.error('Failed to load unified partners:', err);
+      // Fall back silently — the old behavior still works via sponsors list
+    }
+  }, [partyId]);
+
   useEffect(() => {
     loadData();
-  }, [loadData]);
+    loadUnifiedPartners();
+  }, [loadData, loadUnifiedPartners]);
 
-  // Keep description-order sponsors in sync with main sponsors list
+  // Reload unified partners when sponsors change
   useEffect(() => {
-    setDescOrderSponsors(
-      sponsors
-        .filter(s => s.brandDescription && ['yes', 'billed', 'paid'].includes(s.status))
-        .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-    );
-  }, [sponsors]);
+    loadUnifiedPartners();
+  }, [sponsors, loadUnifiedPartners]);
 
   // Handle form submission
   const handleFormSubmit = async (formData: PartnerFormData) => {
@@ -146,22 +159,57 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
     e.preventDefault();
     if (descDragIndex === null || descDragIndex === index) return;
 
-    const newOrder = [...descOrderSponsors];
+    const newOrder = [...unifiedPartners];
     const draggedItem = newOrder[descDragIndex];
     newOrder.splice(descDragIndex, 1);
     newOrder.splice(index, 0, draggedItem);
 
-    setDescOrderSponsors(newOrder);
+    setUnifiedPartners(newOrder);
     setDescDragIndex(index);
   };
 
   const handleDescDragEnd = async () => {
     setDescDragIndex(null);
+    setIsSavingOrder(true);
+
     try {
-      await reorderSponsors(partyId, descOrderSponsors.map(s => s.id));
+      // Check if any underboss-only partners need Sponsor records created
+      const underbossOnly = unifiedPartners.filter(
+        p => p.source === 'underboss' && !p.sponsorId && p.sponsorUserId
+      );
+
+      let sponsorIdMap: Record<string, string> = {};
+
+      if (underbossOnly.length > 0) {
+        const result = await ensureUnderbossSponsors(
+          partyId,
+          underbossOnly.map(p => p.sponsorUserId!)
+        );
+
+        // Map sponsorUserIds to newly created sponsor IDs
+        underbossOnly.forEach((p, i) => {
+          if (result.createdSponsorIds[i]) {
+            sponsorIdMap[p.id] = result.createdSponsorIds[i];
+          }
+        });
+      }
+
+      // Build the final sponsor IDs list for reorder
+      const sponsorIds = unifiedPartners.map(p => {
+        if (p.sponsorId) return p.sponsorId;
+        // Use the newly created sponsor ID
+        return sponsorIdMap[p.id] || p.id;
+      });
+
+      await reorderSponsors(partyId, sponsorIds);
+
+      // Reload data to get fresh state
+      await loadData();
     } catch (err) {
       console.error('Failed to save sponsor description order:', err);
       await loadData();
+    } finally {
+      setIsSavingOrder(false);
     }
   };
 
@@ -226,18 +274,21 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
         isLoading={isRefreshing}
       />
 
-      {/* Brand Description Order */}
-      {descOrderSponsors.length > 1 && (
+      {/* Brand Description Order (Unified) */}
+      {unifiedPartners.length > 1 && (
         <div className="card bg-theme-header border-theme-stroke p-4">
           <div className="flex items-center gap-2 mb-3">
             <FileText size={16} className="text-theme-text-muted" />
             <h3 className="text-sm font-semibold text-theme-text">Brand Description Order</h3>
             <span className="text-xs text-theme-text-faint">(drag to reorder on event page)</span>
+            {isSavingOrder && (
+              <RefreshCw size={12} className="animate-spin text-theme-text-muted ml-auto" />
+            )}
           </div>
           <div className="space-y-1.5">
-            {descOrderSponsors.map((sponsor, index) => (
+            {unifiedPartners.map((partner, index) => (
               <div
-                key={sponsor.id}
+                key={partner.id}
                 draggable
                 onDragStart={() => handleDescDragStart(index)}
                 onDragOver={(e) => handleDescDragOver(e, index)}
@@ -249,12 +300,18 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
                 <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0">
                   <GripVertical size={16} />
                 </div>
-                {sponsor.logoUrl && (
-                  <img src={sponsor.logoUrl} alt="" className="w-6 h-6 rounded object-cover shrink-0" />
+                {partner.logoUrl && (
+                  <img src={partner.logoUrl} alt="" className="w-6 h-6 rounded object-cover shrink-0" />
                 )}
-                <span className="text-sm text-theme-text font-medium truncate">{sponsor.name}</span>
+                <span className="text-sm text-theme-text font-medium truncate">{partner.name}</span>
+                {partner.source === 'underboss' && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded-md border bg-purple-500/20 text-purple-400 border-purple-500/30 shrink-0 flex items-center gap-1">
+                    <Globe size={10} />
+                    Global
+                  </span>
+                )}
                 <span className="text-xs text-theme-text-faint truncate ml-auto max-w-[50%]">
-                  {sponsor.brandDescription?.substring(0, 60)}...
+                  {partner.brandDescription?.substring(0, 60)}...
                 </span>
               </div>
             ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -982,6 +982,24 @@ export async function reorderSponsors(
     body: { sponsorIds },
     requireAuth: true,
   });
+}
+
+// Unified sponsors (event + underboss partners)
+export async function getUnifiedSponsors(partyId: string): Promise<{ partners: UnifiedPartner[] }> {
+  return apiRequest<{ partners: UnifiedPartner[] }>(`/api/parties/${partyId}/sponsors/unified`);
+}
+
+export async function ensureUnderbossSponsors(
+  partyId: string,
+  sponsorUserIds: string[]
+): Promise<{ createdSponsorIds: string[] }> {
+  return apiRequest<{ createdSponsorIds: string[] }>(
+    `/api/parties/${partyId}/sponsors/ensure-from-underboss`,
+    {
+      method: 'POST',
+      body: { sponsorUserIds },
+    }
+  );
 }
 
 // Partner Intake Form API functions

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1225,3 +1225,16 @@ export interface SponsorDashboardData {
   tag: string | null;
   events: SponsorDashboardEvent[];
 }
+
+// Unified partner (merges event-level Sponsor with underboss SponsorUser)
+export interface UnifiedPartner {
+  id: string;
+  sponsorId?: string;
+  sponsorUserId?: string;
+  source: 'event' | 'underboss';
+  name: string;
+  brandDescription: string;
+  logoUrl: string | null;
+  website: string | null;
+  sortOrder: number;
+}


### PR DESCRIPTION
## Summary
- New GET /api/parties/:partyId/sponsors/unified endpoint merging event sponsors with tag-matched underboss partners
- New POST /api/parties/:partyId/sponsors/ensure-from-underboss to create Sponsor records for underboss partners
- SponsorCRM Brand Description Order now shows all partners from both sources
- Visual badges distinguish Global Partner vs Event Partner
- On reorder, auto-creates missing Sponsor records then persists sort order

## Test plan
- [ ] Open SponsorCRM on an event with both event-level and underboss partners
- [ ] Verify both sources appear in the drag list with badges
- [ ] Drag to reorder - underboss partners without Sponsor records get auto-created
- [ ] Refresh - order persists
- [ ] Check public event page - all partners display in correct order
- [ ] Event with no tags - list shows only event-level sponsors (unchanged behavior)