### PR TITLE
tomato-38768: Telegram group links on partner dashboard

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -134,6 +134,7 @@ model Party {
   meetupUrl          String?   @map("meetup_url")         // Meetup event URL
   eventbriteUrl      String?   @map("eventbrite_url")     // Eventbrite event URL
   externalLinks      Json?     @default("[]") @map("external_links") // Custom external links [{label, url}]
+  telegramGroup      String?   @map("telegram_group") @db.VarChar     // City Telegram group link
   poapEventId        String?   @map("poap_event_id")      // POAP event ID
   poapMints          Int?      @map("poap_mints")         // POAP mint count
   poapMoments        Int?      @map("poap_moments")       // POAP moments count

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -53,6 +53,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         photosPublic: true,
         hiddenGppPhotos: true,
         extraGppPhotos: true,
+        telegramGroup: true,
         password: true, // Just to check if it exists
         userId: true,
         user: {
@@ -118,6 +119,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
           photosPublic: true,
           hiddenGppPhotos: true,
           extraGppPhotos: true,
+          telegramGroup: true,
           password: true,
           userId: true,
           user: {
@@ -255,6 +257,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         photosPublic: party.photosPublic,
         hiddenGppPhotos: party.hiddenGppPhotos || [],
         extraGppPhotos: party.extraGppPhotos || [],
+        telegramGroup: party.telegramGroup || null,
         hasPassword: !!party.password,
         hostName: party.eventType === 'gpp' ? 'PizzaDAO' : (party.user?.name || null),
         hostProfile,

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -394,7 +394,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       venueReportTitle, venueReportNotes,
       hiddenGppPhotos, extraGppPhotos,
       lumaUrl, meetupUrl, eventbriteUrl, externalLinks,
-      quizEnabled
+      quizEnabled,
+      telegramGroup
     } = req.body;
 
     // Verify ownership or super admin
@@ -512,6 +513,7 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(eventbriteUrl !== undefined && { eventbriteUrl: eventbriteUrl || null }),
         ...(externalLinks !== undefined && { externalLinks }),
         ...(quizEnabled !== undefined && { quizEnabled }),
+        ...(telegramGroup !== undefined && { telegramGroup: telegramGroup || null }),
       },
       include: {
         user: { select: { name: true } },

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -618,6 +618,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         address: event.address,
         venueName: event.venueName,
         region: event.region || null,
+        telegramGroup: event.telegramGroup || null,
         eventImageUrl: event.eventImageUrl,
         hostName: event.user?.name || null,
         hostProfile: event.user ? {

--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -1,7 +1,7 @@
 ﻿import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { User, Lock, Image as ImageIcon, FileText, Loader2, X, Square as SquareIcon, Trash2, Calendar, Play, DollarSign } from 'lucide-react';
+import { User, Lock, Image as ImageIcon, FileText, Loader2, X, Square as SquareIcon, Trash2, Calendar, Play, DollarSign, MessageCircle } from 'lucide-react';
 import { IconInput } from './IconInput';
 import { usePizza } from '../contexts/PizzaContext';
 import { updateParty, uploadEventImage, deleteParty } from '../lib/supabase';
@@ -44,6 +44,7 @@ export const EventDetailsTab: React.FC = () => {
   const [shareTweetText, setShareTweetText] = useState('');
   const [nftEnabled, setNftEnabled] = useState(false);
   const [nftChain, setNftChain] = useState<string>('base');
+  const [telegramGroup, setTelegramGroup] = useState('');
 
   const [showOptionalFields, setShowOptionalFields] = useState(false);
 
@@ -127,6 +128,7 @@ export const EventDetailsTab: React.FC = () => {
       const partyShareTweetText = party.shareTweetText || '';
       const partyNftEnabled = party.nftEnabled || false;
       const partyNftChain = party.nftChain || 'base';
+      const partyTelegramGroup = party.telegramGroup || '';
 
       // Set form values
       setName(partyName);
@@ -151,6 +153,7 @@ export const EventDetailsTab: React.FC = () => {
       setShareTweetText(partyShareTweetText);
       setNftEnabled(partyNftEnabled);
       setNftChain(partyNftChain);
+      setTelegramGroup(partyTelegramGroup);
 
       // Store original values
       setOriginalValues({
@@ -821,6 +824,17 @@ export const EventDetailsTab: React.FC = () => {
                     saveOptions({ custom_url: customUrl.trim() || null });
                   }
                 }}
+              />
+
+              <IconInput
+                icon={MessageCircle}
+                type="url"
+                value={telegramGroup}
+                onChange={(e) => setTelegramGroup(e.target.value)}
+                onBlur={() => {
+                  saveOptions({ telegram_group: telegramGroup.trim() || null });
+                }}
+                placeholder="Telegram group link (e.g. https://t.me/+abc123)"
               />
 
               {/* NFT Settings — hidden for GPP events (managed from /admin) */}

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -132,6 +132,7 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     meetupUrl: dbParty.meetup_url || null,
     eventbriteUrl: dbParty.eventbrite_url || null,
     externalLinks: dbParty.external_links || [],
+    telegramGroup: dbParty.telegram_group || null,
     guests,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -413,6 +413,7 @@ export interface PublicEvent {
   nftChain?: string | null;
   hiddenGppPhotos?: string[];
   extraGppPhotos?: string[];
+  telegramGroup?: string | null;
   sponsors?: PublicEventSponsor[];
 }
 

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -477,6 +477,8 @@ export interface DbParty {
   meetup_url?: string | null;
   eventbrite_url?: string | null;
   external_links?: Array<{label: string; url: string}>;
+  // Telegram group
+  telegram_group?: string | null;
 }
 
 export type DbGuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
@@ -530,7 +532,8 @@ export const SAFE_PARTY_COLUMNS = `
   pinned_apps,
   region,
   hidden_gpp_photos, extra_gpp_photos,
-  quiz_enabled
+  quiz_enabled,
+  telegram_group
 `;
 
 /**
@@ -1369,6 +1372,7 @@ export async function updateParty(
     meetup_url?: string | null;
     eventbrite_url?: string | null;
     external_links?: Array<{label: string; url: string}>;
+    telegram_group?: string | null;
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -1431,6 +1435,7 @@ export async function updateParty(
         meetupUrl: updates.meetup_url,
         eventbriteUrl: updates.eventbrite_url,
         externalLinks: updates.external_links,
+        telegramGroup: updates.telegram_group,
       });
       return true;
     } catch (error) {

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -9,7 +9,7 @@ import { fetchSponsorMe, fetchSponsorEvents, toggleSponsorChecklistItem, updateP
 import {
   Loader2, Shield, Tag, Users,
   Search, ThumbsUp, ThumbsDown, BarChart3, Calendar, MapPin,
-  Wallet, TrendingUp, StickyNote,
+  Wallet, TrendingUp, StickyNote, MessageCircle,
 } from 'lucide-react';
 import type { SponsorDashboardEvent, SponsorMeResponse, SponsorDashboardData, CoHost } from '../types';
 import { GPP_REGIONS } from '../types';
@@ -635,6 +635,18 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
             )}
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
+            {event.telegramGroup && (
+              <a
+                href={event.telegramGroup}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-[#29B6F6] hover:text-[#4FC3F7] border border-[#29B6F6]/30 hover:border-[#29B6F6]/50 rounded-md transition-colors"
+                title="Join city Telegram group"
+              >
+                <MessageCircle size={12} />
+                Telegram
+              </a>
+            )}
             {event.reportPublicSlug ? (
               <a
                 href={`/report/${event.reportPublicSlug}`}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -276,6 +276,7 @@ export interface Party {
   meetupUrl?: string | null;
   eventbriteUrl?: string | null;
   externalLinks?: Array<{label: string; url: string}>;
+  telegramGroup?: string | null;
 }
 
 export interface Donation {
@@ -1168,6 +1169,7 @@ export interface SponsorDashboardEvent {
   address: string | null;
   venueName: string | null;
   region: string | null;
+  telegramGroup: string | null;
   eventImageUrl: string | null;
   hostName: string | null;
   hostProfile: {

--- a/supabase/migrations/20260428_add_telegram_group.sql
+++ b/supabase/migrations/20260428_add_telegram_group.sql
@@ -1,0 +1,2 @@
+ALTER TABLE parties ADD COLUMN telegram_group VARCHAR;
+GRANT SELECT (telegram_group) ON parties TO anon, authenticated;


### PR DESCRIPTION
## Summary
- New telegram_group column on parties table (full 7-place wiring)
- Host can set Telegram group URL in event settings (Options section)
- Partner dashboard shows Telegram link button on each event card
- Public event API also returns telegramGroup field

## Migration needed
```sql
ALTER TABLE parties ADD COLUMN telegram_group VARCHAR;
GRANT SELECT (telegram_group) ON parties TO anon, authenticated;
```

## Test plan
- [ ] Apply migration, then set a Telegram group URL on an event via host dashboard
- [ ] Open partner dashboard - Telegram link appears on that event card
- [ ] Click link - opens Telegram group in new tab
- [ ] Events without Telegram group - no link shown
- [ ] Public event API includes telegramGroup field