### PR TITLE
feat: show GPP past-year photos in underboss dashboard

### DIFF
--- a/frontend/src/components/underboss/CitiesTable.tsx
+++ b/frontend/src/components/underboss/CitiesTable.tsx
@@ -4,9 +4,19 @@ import { Search, MapPin, Check, X, Clock, ExternalLink, ArrowUpDown, ChevronDown
 import { IconInput } from '../IconInput';
 import { fetchSheetCities, SheetCity } from '../../lib/cities';
 import { fetchCityStatuses, updateCityStatus, CityStatusMap, getPartyPhotos } from '../../lib/api';
+import { getGppPhotosForCity } from '../../lib/gppPhotos';
 import type { UnderbossMeResponse } from '../../lib/api';
 import { GPP_REGIONS } from '../../types';
-import type { UnderbossEvent, Photo } from '../../types';
+import type { UnderbossEvent } from '../../types';
+
+interface DisplayPhoto {
+  id: string;
+  url: string;
+  thumbnailUrl: string | null;
+  caption: string | null;
+  source: 'uploaded' | 'gpp';
+  year?: number;
+}
 
 type CityStatusValue = 'created' | 'skip' | 'todo';
 
@@ -598,7 +608,7 @@ function CityPhotoLightbox({
   onClose,
   onNavigate,
 }: {
-  photos: Photo[];
+  photos: DisplayPhoto[];
   currentIndex: number;
   onClose: () => void;
   onNavigate: (index: number) => void;
@@ -679,33 +689,55 @@ function CityRow({
   onToggleSelect: (key: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [displayPhotos, setDisplayPhotos] = useState<DisplayPhoto[]>([]);
   const [photosLoading, setPhotosLoading] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const loadPhotos = useCallback(async () => {
-    if (photos.length > 0 || city.matchedEventIds.length === 0) return;
+    if (displayPhotos.length > 0) return;
     setPhotosLoading(true);
     try {
-      const results = await Promise.all(
-        city.matchedEventIds.map(id => getPartyPhotos(id))
-      );
-      const allPhotos = results.flatMap(r => r?.photos || []);
-      setPhotos(allPhotos);
+      // Fetch uploaded photos from matched events + GPP manifest photos in parallel
+      const [uploadedResults, gppPhotos] = await Promise.all([
+        city.matchedEventIds.length > 0
+          ? Promise.all(city.matchedEventIds.map(id => getPartyPhotos(id)))
+          : Promise.resolve([]),
+        city.city ? getGppPhotosForCity(city.city) : Promise.resolve([]),
+      ]);
+
+      const uploaded: DisplayPhoto[] = (uploadedResults as any[]).flatMap(r => r?.photos || []).map((p: any) => ({
+        id: p.id,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        source: 'uploaded' as const,
+      }));
+
+      const gpp: DisplayPhoto[] = gppPhotos.map((p, i) => ({
+        id: `gpp-${i}`,
+        url: p.url,
+        thumbnailUrl: null,
+        caption: `GPP ${p.year}`,
+        source: 'gpp' as const,
+        year: p.year,
+      }));
+
+      setDisplayPhotos([...uploaded, ...gpp]);
     } catch (err) {
       console.error('Failed to load photos:', err);
     } finally {
       setPhotosLoading(false);
     }
-  }, [city.matchedEventIds, photos.length]);
+  }, [city.matchedEventIds, city.city, displayPhotos.length]);
 
   const toggleExpand = useCallback(() => {
-    if (city.photoCount === 0) return;
     const next = !expanded;
     setExpanded(next);
     if (next) loadPhotos();
-  }, [expanded, city.photoCount, loadPhotos]);
+  }, [expanded, loadPhotos]);
+
+  const displayedPhotos = showAll ? displayPhotos : displayPhotos.slice(0, 12);
 
   return (
     <>
@@ -746,12 +778,7 @@ function CityRow({
         <td className="py-2.5 px-3 text-center">
           <button
             onClick={toggleExpand}
-            disabled={city.photoCount === 0}
-            className={`inline-flex items-center gap-1 text-xs transition-colors ${
-              city.photoCount > 0
-                ? 'text-theme-text-muted hover:text-theme-text-secondary cursor-pointer'
-                : 'text-theme-text-faint/40 cursor-default'
-            }`}
+            className="inline-flex items-center gap-1 text-xs text-theme-text-muted hover:text-theme-text-secondary cursor-pointer transition-colors"
           >
             <Camera size={12} />
             <span>{city.photoCount}</span>
@@ -772,16 +799,16 @@ function CityRow({
                 <div className="animate-spin w-4 h-4 border-2 border-red-500 border-t-transparent rounded-full" />
                 <span className="text-xs text-theme-text-muted">Loading photos...</span>
               </div>
-            ) : photos.length === 0 ? (
+            ) : displayPhotos.length === 0 ? (
               <p className="text-xs text-theme-text-faint py-2">No photos found</p>
             ) : (
               <div className="space-y-2">
                 <div className="grid grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-2">
-                  {(showAll ? photos : photos.slice(0, 12)).map((photo, idx) => (
+                  {displayedPhotos.map((photo, idx) => (
                     <button
                       key={photo.id}
                       onClick={() => setLightboxIndex(idx)}
-                      className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all"
+                      className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all relative group"
                     >
                       <img
                         src={photo.thumbnailUrl || photo.url}
@@ -789,15 +816,20 @@ function CityRow({
                         className="w-full h-full object-cover"
                         loading="lazy"
                       />
+                      {photo.source === 'gpp' && photo.year && (
+                        <span className="absolute bottom-0.5 right-0.5 text-[9px] bg-black/60 text-white/80 px-1 rounded">
+                          {photo.year}
+                        </span>
+                      )}
                     </button>
                   ))}
                 </div>
-                {!showAll && photos.length > 12 && (
+                {!showAll && displayPhotos.length > 12 && (
                   <button
                     onClick={() => setShowAll(true)}
                     className="text-xs text-red-400 hover:text-red-300 transition-colors"
                   >
-                    Show all {photos.length} photos
+                    Show all {displayPhotos.length} photos
                   </button>
                 )}
               </div>
@@ -805,9 +837,9 @@ function CityRow({
           </td>
         </tr>
       )}
-      {lightboxIndex !== null && photos[lightboxIndex] && createPortal(
+      {lightboxIndex !== null && displayedPhotos[lightboxIndex] && createPortal(
         <CityPhotoLightbox
-          photos={showAll ? photos : photos.slice(0, 12)}
+          photos={displayedPhotos}
           currentIndex={lightboxIndex}
           onClose={() => setLightboxIndex(null)}
           onNavigate={setLightboxIndex}
@@ -831,33 +863,54 @@ function CityCard({
   onToggleSelect: (key: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [displayPhotos, setDisplayPhotos] = useState<DisplayPhoto[]>([]);
   const [photosLoading, setPhotosLoading] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const loadPhotos = useCallback(async () => {
-    if (photos.length > 0 || city.matchedEventIds.length === 0) return;
+    if (displayPhotos.length > 0) return;
     setPhotosLoading(true);
     try {
-      const results = await Promise.all(
-        city.matchedEventIds.map(id => getPartyPhotos(id))
-      );
-      const allPhotos = results.flatMap(r => r?.photos || []);
-      setPhotos(allPhotos);
+      const [uploadedResults, gppPhotos] = await Promise.all([
+        city.matchedEventIds.length > 0
+          ? Promise.all(city.matchedEventIds.map(id => getPartyPhotos(id)))
+          : Promise.resolve([]),
+        city.city ? getGppPhotosForCity(city.city) : Promise.resolve([]),
+      ]);
+
+      const uploaded: DisplayPhoto[] = (uploadedResults as any[]).flatMap(r => r?.photos || []).map((p: any) => ({
+        id: p.id,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        source: 'uploaded' as const,
+      }));
+
+      const gpp: DisplayPhoto[] = gppPhotos.map((p, i) => ({
+        id: `gpp-${i}`,
+        url: p.url,
+        thumbnailUrl: null,
+        caption: `GPP ${p.year}`,
+        source: 'gpp' as const,
+        year: p.year,
+      }));
+
+      setDisplayPhotos([...uploaded, ...gpp]);
     } catch (err) {
       console.error('Failed to load photos:', err);
     } finally {
       setPhotosLoading(false);
     }
-  }, [city.matchedEventIds, photos.length]);
+  }, [city.matchedEventIds, city.city, displayPhotos.length]);
 
   const toggleExpand = useCallback(() => {
-    if (city.photoCount === 0) return;
     const next = !expanded;
     setExpanded(next);
     if (next) loadPhotos();
-  }, [expanded, city.photoCount, loadPhotos]);
+  }, [expanded, loadPhotos]);
+
+  const displayedPhotos = showAll ? displayPhotos : displayPhotos.slice(0, 12);
 
   return (
     <div className={`bg-theme-surface border border-theme-stroke rounded-xl p-3 space-y-2 ${isSelected ? 'ring-1 ring-red-500/30' : ''}`}>
@@ -889,12 +942,7 @@ function CityCard({
           <span>{city.country} &middot; {city.underboss || 'No underboss'}</span>
           <button
             onClick={toggleExpand}
-            disabled={city.photoCount === 0}
-            className={`inline-flex items-center gap-1 transition-colors ${
-              city.photoCount > 0
-                ? 'text-theme-text-muted hover:text-theme-text-secondary cursor-pointer'
-                : 'text-theme-text-faint/40 cursor-default'
-            }`}
+            className="inline-flex items-center gap-1 text-theme-text-muted hover:text-theme-text-secondary cursor-pointer transition-colors"
           >
             <Camera size={10} />
             <span>{city.photoCount}</span>
@@ -913,16 +961,16 @@ function CityCard({
               <div className="animate-spin w-4 h-4 border-2 border-red-500 border-t-transparent rounded-full" />
               <span className="text-xs text-theme-text-muted">Loading photos...</span>
             </div>
-          ) : photos.length === 0 ? (
+          ) : displayPhotos.length === 0 ? (
             <p className="text-xs text-theme-text-faint py-2">No photos found</p>
           ) : (
             <div className="space-y-2">
               <div className="grid grid-cols-3 gap-1.5">
-                {(showAll ? photos : photos.slice(0, 12)).map((photo, idx) => (
+                {displayedPhotos.map((photo, idx) => (
                   <button
                     key={photo.id}
                     onClick={() => setLightboxIndex(idx)}
-                    className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all"
+                    className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all relative group"
                   >
                     <img
                       src={photo.thumbnailUrl || photo.url}
@@ -930,24 +978,29 @@ function CityCard({
                       className="w-full h-full object-cover"
                       loading="lazy"
                     />
+                    {photo.source === 'gpp' && photo.year && (
+                      <span className="absolute bottom-0.5 right-0.5 text-[9px] bg-black/60 text-white/80 px-1 rounded">
+                        {photo.year}
+                      </span>
+                    )}
                   </button>
                 ))}
               </div>
-              {!showAll && photos.length > 12 && (
+              {!showAll && displayPhotos.length > 12 && (
                 <button
                   onClick={() => setShowAll(true)}
                   className="text-xs text-red-400 hover:text-red-300 transition-colors"
                 >
-                  Show all {photos.length} photos
+                  Show all {displayPhotos.length} photos
                 </button>
               )}
             </div>
           )}
         </div>
       )}
-      {lightboxIndex !== null && photos[lightboxIndex] && createPortal(
+      {lightboxIndex !== null && displayedPhotos[lightboxIndex] && createPortal(
         <CityPhotoLightbox
-          photos={showAll ? photos : photos.slice(0, 12)}
+          photos={displayedPhotos}
           currentIndex={lightboxIndex}
           onClose={() => setLightboxIndex(null)}
           onNavigate={setLightboxIndex}

--- a/frontend/src/components/underboss/CitiesTable.tsx
+++ b/frontend/src/components/underboss/CitiesTable.tsx
@@ -4,7 +4,7 @@ import { Search, MapPin, Check, X, Clock, ExternalLink, ArrowUpDown, ChevronDown
 import { IconInput } from '../IconInput';
 import { fetchSheetCities, SheetCity } from '../../lib/cities';
 import { fetchCityStatuses, updateCityStatus, CityStatusMap, getPartyPhotos } from '../../lib/api';
-import { getGppPhotosForCity } from '../../lib/gppPhotos';
+import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
 import type { UnderbossMeResponse } from '../../lib/api';
 import { GPP_REGIONS } from '../../types';
 import type { UnderbossEvent } from '../../types';
@@ -63,6 +63,12 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [showActionDropdown, setShowActionDropdown] = useState(false);
+  const [gppCounts, setGppCounts] = useState<Record<string, number>>({});
+
+  // Load GPP photo counts (cached at module level)
+  useEffect(() => {
+    getGppPhotoCounts().then(setGppCounts);
+  }, []);
 
   // Load sheet cities and DB statuses
   useEffect(() => {
@@ -121,6 +127,8 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
         status = 'todo';
       }
 
+      const gppKey = sc.city.toLowerCase().replace(/\s+/g, '');
+
       return {
         key,
         city: sc.city,
@@ -131,11 +139,11 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
         status,
         isAuto,
         matchedEventUrl: matchedEvent ? `/${matchedEvent}` : null,
-        photoCount: matchedEvents.reduce((sum, e) => sum + (e.photoCount || 0), 0),
+        photoCount: matchedEvents.reduce((sum, e) => sum + (e.photoCount || 0), 0) + (gppCounts[gppKey] || 0),
         matchedEventIds: matchedEvents.map(e => e.id),
       };
     });
-  }, [sheetCities, cityStatuses, eventCityMap]);
+  }, [sheetCities, cityStatuses, eventCityMap, gppCounts]);
 
   // Apply filters + sorting
   const filteredCities = useMemo(() => {

--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -4,7 +4,17 @@ import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, StickyNo
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, getPartyPhotos } from '../../lib/api';
-import type { UnderbossEvent, HostStatus, Photo } from '../../types';
+import { getGppPhotosForCity } from '../../lib/gppPhotos';
+import type { UnderbossEvent, HostStatus } from '../../types';
+
+interface DisplayPhoto {
+  id: string;
+  url: string;
+  thumbnailUrl: string | null;
+  caption: string | null;
+  source: 'uploaded' | 'gpp';
+  year?: number;
+}
 
 interface EventCardProps {
   event: UnderbossEvent;
@@ -209,7 +219,7 @@ function PhotoLightbox({
   onClose,
   onNavigate,
 }: {
-  photos: Photo[];
+  photos: DisplayPhoto[];
   currentIndex: number;
   onClose: () => void;
   onNavigate: (index: number) => void;
@@ -286,30 +296,52 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [photosExpanded, setPhotosExpanded] = useState(false);
-  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [displayPhotos, setDisplayPhotos] = useState<DisplayPhoto[]>([]);
   const [photosLoading, setPhotosLoading] = useState(false);
   const [showAllPhotos, setShowAllPhotos] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const loadPhotos = useCallback(async () => {
-    if (photos.length > 0 || !event.id) return;
+    if (displayPhotos.length > 0 || !event.id) return;
     setPhotosLoading(true);
     try {
-      const result = await getPartyPhotos(event.id);
-      setPhotos(result?.photos || []);
+      const cityName = event.name.replace(/^Global Pizza Party\s*/i, '').trim();
+
+      const [uploadedResult, gppPhotos] = await Promise.all([
+        getPartyPhotos(event.id),
+        cityName ? getGppPhotosForCity(cityName) : Promise.resolve([]),
+      ]);
+
+      const uploaded: DisplayPhoto[] = (uploadedResult?.photos || []).map((p) => ({
+        id: p.id,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        source: 'uploaded' as const,
+      }));
+
+      const gpp: DisplayPhoto[] = gppPhotos.map((p, i) => ({
+        id: `gpp-${i}`,
+        url: p.url,
+        thumbnailUrl: null,
+        caption: `GPP ${p.year}`,
+        source: 'gpp' as const,
+        year: p.year,
+      }));
+
+      setDisplayPhotos([...uploaded, ...gpp]);
     } catch (err) {
       console.error('Failed to load photos:', err);
     } finally {
       setPhotosLoading(false);
     }
-  }, [event.id, photos.length]);
+  }, [event.id, event.name, displayPhotos.length]);
 
   const togglePhotos = useCallback(() => {
-    if (event.photoCount === 0) return;
     const next = !photosExpanded;
     setPhotosExpanded(next);
     if (next) loadPhotos();
-  }, [photosExpanded, event.photoCount, loadPhotos]);
+  }, [photosExpanded, loadPhotos]);
 
   const saveNotes = useCallback(async (value: string) => {
     const trimmed = value.trim();
@@ -471,12 +503,7 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
         </div>
         <button
           onClick={togglePhotos}
-          disabled={event.photoCount === 0}
-          className={`flex items-center gap-1 transition-colors ${
-            event.photoCount > 0
-              ? 'text-theme-text-muted hover:text-theme-text-secondary cursor-pointer'
-              : 'text-theme-text-faint/40 cursor-default'
-          }`}
+          className="flex items-center gap-1 text-theme-text-muted hover:text-theme-text-secondary cursor-pointer transition-colors"
         >
           <Camera size={12} />
           <span className="text-xs">{event.photoCount}</span>
@@ -491,16 +518,16 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
               <div className="animate-spin w-4 h-4 border-2 border-red-500 border-t-transparent rounded-full" />
               <span className="text-xs text-theme-text-muted">Loading photos...</span>
             </div>
-          ) : photos.length === 0 ? (
+          ) : displayPhotos.length === 0 ? (
             <p className="text-xs text-theme-text-faint py-2">No photos found</p>
           ) : (
             <div className="space-y-2">
               <div className="grid grid-cols-3 gap-1.5">
-                {(showAllPhotos ? photos : photos.slice(0, 12)).map((photo, idx) => (
+                {(showAllPhotos ? displayPhotos : displayPhotos.slice(0, 12)).map((photo, idx) => (
                   <button
                     key={photo.id}
                     onClick={() => setLightboxIndex(idx)}
-                    className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all"
+                    className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all relative group"
                   >
                     <img
                       src={photo.thumbnailUrl || photo.url}
@@ -508,15 +535,20 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
                       className="w-full h-full object-cover"
                       loading="lazy"
                     />
+                    {photo.source === 'gpp' && photo.year && (
+                      <span className="absolute bottom-0.5 right-0.5 text-[9px] bg-black/60 text-white/80 px-1 rounded">
+                        {photo.year}
+                      </span>
+                    )}
                   </button>
                 ))}
               </div>
-              {!showAllPhotos && photos.length > 12 && (
+              {!showAllPhotos && displayPhotos.length > 12 && (
                 <button
                   onClick={() => setShowAllPhotos(true)}
                   className="text-xs text-red-400 hover:text-red-300 transition-colors"
                 >
-                  Show all {photos.length} photos
+                  Show all {displayPhotos.length} photos
                 </button>
               )}
             </div>
@@ -537,9 +569,9 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
         <ProgressIndicator done={event.progress.hasThrown} label="Thrown" />
       </div>
 
-      {lightboxIndex !== null && (showAllPhotos ? photos : photos.slice(0, 12))[lightboxIndex] && createPortal(
+      {lightboxIndex !== null && (showAllPhotos ? displayPhotos : displayPhotos.slice(0, 12))[lightboxIndex] && createPortal(
         <PhotoLightbox
-          photos={showAllPhotos ? photos : photos.slice(0, 12)}
+          photos={showAllPhotos ? displayPhotos : displayPhotos.slice(0, 12)}
           currentIndex={lightboxIndex}
           onClose={() => setLightboxIndex(null)}
           onNavigate={setLightboxIndex}

--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -4,7 +4,7 @@ import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, StickyNo
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, getPartyPhotos } from '../../lib/api';
-import { getGppPhotosForCity } from '../../lib/gppPhotos';
+import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
 interface DisplayPhoto {
@@ -301,6 +301,18 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
   const [showAllPhotos, setShowAllPhotos] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
+  // GPP photo count for the badge (fetched once, cached at module level)
+  const [gppCount, setGppCount] = useState(0);
+
+  useEffect(() => {
+    const cityName = event.name.replace(/^Global Pizza Party\s*/i, '').trim();
+    if (!cityName) return;
+    getGppPhotoCounts().then(counts => {
+      const key = cityName.toLowerCase().replace(/\s+/g, '');
+      setGppCount(counts[key] || 0);
+    });
+  }, [event.name]);
+
   const loadPhotos = useCallback(async () => {
     if (displayPhotos.length > 0 || !event.id) return;
     setPhotosLoading(true);
@@ -506,7 +518,7 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
           className="flex items-center gap-1 text-theme-text-muted hover:text-theme-text-secondary cursor-pointer transition-colors"
         >
           <Camera size={12} />
-          <span className="text-xs">{event.photoCount}</span>
+          <span className="text-xs">{event.photoCount + gppCount}</span>
         </button>
       </div>
 

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -4,7 +4,17 @@ import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshak
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
-import type { UnderbossEvent, HostStatus, Photo } from '../../types';
+import { getGppPhotosForCity } from '../../lib/gppPhotos';
+import type { UnderbossEvent, HostStatus } from '../../types';
+
+interface DisplayPhoto {
+  id: string;
+  url: string;
+  thumbnailUrl: string | null;
+  caption: string | null;
+  source: 'uploaded' | 'gpp';
+  year?: number;
+}
 
 interface EventRowProps {
   event: UnderbossEvent;
@@ -243,7 +253,7 @@ function PhotoLightbox({
   onClose,
   onNavigate,
 }: {
-  photos: Photo[];
+  photos: DisplayPhoto[];
   currentIndex: number;
   onClose: () => void;
   onNavigate: (index: number) => void;
@@ -321,30 +331,57 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [photosExpanded, setPhotosExpanded] = useState(false);
-  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [displayPhotos, setDisplayPhotos] = useState<DisplayPhoto[]>([]);
   const [photosLoading, setPhotosLoading] = useState(false);
   const [showAllPhotos, setShowAllPhotos] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const loadPhotos = useCallback(async () => {
-    if (photos.length > 0 || !event.id) return;
+    if (displayPhotos.length > 0 || !event.id) return;
     setPhotosLoading(true);
     try {
-      const result = await getPartyPhotos(event.id);
-      setPhotos(result?.photos || []);
+      // Extract city name from event name (strip "Global Pizza Party " prefix)
+      const cityName = event.name.replace(/^Global Pizza Party\s*/i, '').trim();
+
+      // Fetch both sources in parallel
+      const [uploadedResult, gppPhotos] = await Promise.all([
+        getPartyPhotos(event.id),
+        cityName ? getGppPhotosForCity(cityName) : Promise.resolve([]),
+      ]);
+
+      // Convert uploaded photos to DisplayPhoto
+      const uploaded: DisplayPhoto[] = (uploadedResult?.photos || []).map((p) => ({
+        id: p.id,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        source: 'uploaded' as const,
+      }));
+
+      // Convert GPP photos to DisplayPhoto
+      const gpp: DisplayPhoto[] = gppPhotos.map((p, i) => ({
+        id: `gpp-${i}`,
+        url: p.url,
+        thumbnailUrl: null,
+        caption: `GPP ${p.year}`,
+        source: 'gpp' as const,
+        year: p.year,
+      }));
+
+      // Uploaded first, then GPP
+      setDisplayPhotos([...uploaded, ...gpp]);
     } catch (err) {
       console.error('Failed to load photos:', err);
     } finally {
       setPhotosLoading(false);
     }
-  }, [event.id, photos.length]);
+  }, [event.id, event.name, displayPhotos.length]);
 
   const togglePhotos = useCallback(() => {
-    if (event.photoCount === 0) return;
     const next = !photosExpanded;
     setPhotosExpanded(next);
     if (next) loadPhotos();
-  }, [photosExpanded, event.photoCount, loadPhotos]);
+  }, [photosExpanded, loadPhotos]);
 
   // Expected guests state
   const [expectedGuestsValue, setExpectedGuestsValue] = useState(
@@ -416,7 +453,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
 
   const hasNotes = !!(event.underbossNotes || notesValue.trim());
 
-  const displayedPhotos = showAllPhotos ? photos : photos.slice(0, 12);
+  const displayedPhotos = showAllPhotos ? displayPhotos : displayPhotos.slice(0, 12);
 
   return (
     <>
@@ -585,12 +622,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
         <td className="py-3 px-3 text-center">
           <button
             onClick={togglePhotos}
-            disabled={event.photoCount === 0}
-            className={`inline-flex items-center justify-center gap-1 transition-colors ${
-              event.photoCount > 0
-                ? 'text-theme-text-muted hover:text-theme-text-secondary cursor-pointer'
-                : 'text-theme-text-faint/40 cursor-default'
-            }`}
+            className="inline-flex items-center justify-center gap-1 text-theme-text-muted hover:text-theme-text-secondary cursor-pointer transition-colors"
           >
             <Camera size={12} />
             <span className="text-xs">{event.photoCount}</span>
@@ -620,7 +652,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                 <div className="animate-spin w-4 h-4 border-2 border-red-500 border-t-transparent rounded-full" />
                 <span className="text-xs text-theme-text-muted">Loading photos...</span>
               </div>
-            ) : photos.length === 0 ? (
+            ) : displayPhotos.length === 0 ? (
               <p className="text-xs text-theme-text-faint py-2">No photos found</p>
             ) : (
               <div className="space-y-2">
@@ -629,7 +661,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                     <button
                       key={photo.id}
                       onClick={() => setLightboxIndex(idx)}
-                      className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all"
+                      className="aspect-square rounded-lg overflow-hidden hover:ring-2 hover:ring-red-500/50 transition-all relative group"
                     >
                       <img
                         src={photo.thumbnailUrl || photo.url}
@@ -637,15 +669,20 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                         className="w-full h-full object-cover"
                         loading="lazy"
                       />
+                      {photo.source === 'gpp' && photo.year && (
+                        <span className="absolute bottom-0.5 right-0.5 text-[9px] bg-black/60 text-white/80 px-1 rounded">
+                          {photo.year}
+                        </span>
+                      )}
                     </button>
                   ))}
                 </div>
-                {!showAllPhotos && photos.length > 12 && (
+                {!showAllPhotos && displayPhotos.length > 12 && (
                   <button
                     onClick={() => setShowAllPhotos(true)}
                     className="text-xs text-red-400 hover:text-red-300 transition-colors"
                   >
-                    Show all {photos.length} photos
+                    Show all {displayPhotos.length} photos
                   </button>
                 )}
               </div>

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -4,7 +4,7 @@ import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshak
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
-import { getGppPhotosForCity } from '../../lib/gppPhotos';
+import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
 interface DisplayPhoto {
@@ -336,6 +336,18 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
   const [showAllPhotos, setShowAllPhotos] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
+  // GPP photo count for the badge (fetched once, cached at module level)
+  const [gppCount, setGppCount] = useState(0);
+
+  useEffect(() => {
+    const cityName = event.name.replace(/^Global Pizza Party\s*/i, '').trim();
+    if (!cityName) return;
+    getGppPhotoCounts().then(counts => {
+      const key = cityName.toLowerCase().replace(/\s+/g, '');
+      setGppCount(counts[key] || 0);
+    });
+  }, [event.name]);
+
   const loadPhotos = useCallback(async () => {
     if (displayPhotos.length > 0 || !event.id) return;
     setPhotosLoading(true);
@@ -625,7 +637,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
             className="inline-flex items-center justify-center gap-1 text-theme-text-muted hover:text-theme-text-secondary cursor-pointer transition-colors"
           >
             <Camera size={12} />
-            <span className="text-xs">{event.photoCount}</span>
+            <span className="text-xs">{event.photoCount + gppCount}</span>
           </button>
         </td>
 

--- a/frontend/src/lib/gppPhotos.ts
+++ b/frontend/src/lib/gppPhotos.ts
@@ -1,0 +1,79 @@
+const GPP_PHOTOS_URL = 'https://app.gpp.day/api/photos.json';
+const GPP_BASE_URL = 'https://app.gpp.day';
+
+interface GppCity {
+  slug: string;
+  name: string;
+  lat: number;
+  lng: number;
+  countryCode: string;
+  years: {
+    year: number;
+    photos: { src: string }[];
+  }[];
+}
+
+interface GppManifest {
+  cities: GppCity[];
+}
+
+// Module-level cache — fetch once, reuse across all components
+let manifestCache: GppManifest | null = null;
+let manifestPromise: Promise<GppManifest | null> | null = null;
+
+async function fetchManifest(): Promise<GppManifest | null> {
+  if (manifestCache) return manifestCache;
+  if (manifestPromise) return manifestPromise;
+
+  manifestPromise = fetch(GPP_PHOTOS_URL)
+    .then((res) => {
+      if (!res.ok) throw new Error(`Failed to fetch photos manifest: ${res.status}`);
+      return res.json() as Promise<GppManifest>;
+    })
+    .then((data) => {
+      manifestCache = data;
+      return data;
+    })
+    .catch((err) => {
+      console.error('Error fetching GPP photos manifest:', err);
+      manifestPromise = null;
+      return null;
+    });
+
+  return manifestPromise;
+}
+
+export interface GppPhoto {
+  src: string;
+  url: string;
+  year: number;
+}
+
+/**
+ * Get GPP manifest photos for a city, matched by customUrl or city name.
+ * Returns photos sorted most-recent-year first.
+ */
+export async function getGppPhotosForCity(cityNameOrUrl: string): Promise<GppPhoto[]> {
+  const manifest = await fetchManifest();
+  if (!manifest) return [];
+
+  const normalized = cityNameOrUrl.toLowerCase().replace(/\s+/g, '');
+  const city = manifest.cities.find(
+    (c) => c.name.toLowerCase().replace(/\s+/g, '') === normalized
+  );
+
+  if (!city || city.years.length === 0) return [];
+
+  const sortedYears = [...city.years].sort((a, b) => b.year - a.year);
+  const photos: GppPhoto[] = [];
+  for (const yearData of sortedYears) {
+    for (const photo of yearData.photos) {
+      photos.push({
+        src: photo.src,
+        url: `${GPP_BASE_URL}${photo.src}`,
+        year: yearData.year,
+      });
+    }
+  }
+  return photos;
+}

--- a/frontend/src/lib/gppPhotos.ts
+++ b/frontend/src/lib/gppPhotos.ts
@@ -53,6 +53,26 @@ export interface GppPhoto {
  * Get GPP manifest photos for a city, matched by customUrl or city name.
  * Returns photos sorted most-recent-year first.
  */
+/**
+ * Get a map of normalized city name → total GPP photo count.
+ * Fetches manifest if not cached yet.
+ */
+export async function getGppPhotoCounts(): Promise<Record<string, number>> {
+  const manifest = await fetchManifest();
+  if (!manifest) return {};
+
+  const counts: Record<string, number> = {};
+  for (const city of manifest.cities) {
+    const key = city.name.toLowerCase().replace(/\s+/g, '');
+    let total = 0;
+    for (const year of city.years) {
+      total += year.photos.length;
+    }
+    if (total > 0) counts[key] = total;
+  }
+  return counts;
+}
+
 export async function getGppPhotosForCity(cityNameOrUrl: string): Promise<GppPhoto[]> {
   const manifest = await fetchManifest();
   if (!manifest) return [];


### PR DESCRIPTION
## Summary
- Add shared `gppPhotos.ts` module with cached manifest fetch + city matching logic
- Merge GPP past-year photos alongside uploaded photos in EventRow, EventCard, and CitiesTable components
- Photo expand buttons are now always clickable (cities may have GPP photos even with 0 uploaded photos)
- GPP photos display a small year badge overlay (e.g. "2024", "2023") in the bottom-right corner of each thumbnail
- Uploaded photos appear first in the grid, followed by GPP manifest photos sorted most-recent-year-first

## Test plan
- [ ] Open underboss dashboard Events tab, expand photos for a GPP event that has a city name matching the manifest -- verify GPP photos appear after any uploaded photos
- [ ] Verify year badges show on GPP photo thumbnails
- [ ] Verify lightbox navigation works across both uploaded and GPP photos
- [ ] Expand photos for an event with 0 uploaded photos but a matching GPP city -- verify GPP photos still appear
- [ ] Open the Cities tab, expand photos for a city -- verify GPP manifest photos appear alongside uploaded ones
- [ ] Test on mobile (EventCard) -- same behavior as desktop
- [ ] Verify the manifest is only fetched once (check Network tab -- single request to `app.gpp.day/api/photos.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)