### PR TITLE
feat: underboss review tag preset

### DIFF
--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -137,7 +137,7 @@ function HostTagsPills({
 }) {
   const [isAdding, setIsAdding] = useState(false);
   const [newTag, setNewTag] = useState('');
-  const presetTags = ['swc'];
+  const presetTags = ['review', 'swc'];
 
   async function addTag(tag: string) {
     const cleaned = tag.trim().toLowerCase();
@@ -156,6 +156,7 @@ function HostTagsPills({
   }
 
   const tagColors: Record<string, string> = {
+    review: 'bg-red-500/20 text-red-400 border-red-500/30',
     swc: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
   };
 

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -152,7 +152,7 @@ function HostTagsPills({
   const [isAdding, setIsAdding] = useState(false);
   const [newTag, setNewTag] = useState('');
 
-  const presetTags = ['swc'];
+  const presetTags = ['review', 'swc'];
 
   async function addTag(tag: string) {
     const cleaned = tag.trim().toLowerCase();
@@ -179,6 +179,7 @@ function HostTagsPills({
   }
 
   function colorForTag(tag: string): string {
+    if (tag === 'review') return 'bg-red-500/20 text-red-400 border-red-500/30';
     if (tag === 'swc') return 'bg-purple-500/20 text-purple-400 border-purple-500/30';
     if (tag === 'global pizza party') return 'bg-orange-500/20 text-orange-400 border-orange-500/30';
     return 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30';

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -425,7 +425,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                     </button>
                     {showTagSubmenu === 'add' && (
                       <div className="absolute left-full top-0 ml-1 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[160px]">
-                        {['swc', 'Global Pizza Party'].map((tag) => (
+                        {['review', 'swc', 'Global Pizza Party'].map((tag) => (
                           <button
                             key={tag}
                             onClick={async () => {


### PR DESCRIPTION
## Summary
- Adds a **review** preset tag to the underboss dashboard across all three view components (table row, mobile card, bulk action menu)
- The review tag renders with red styling (`bg-red-500/20 text-red-400 border-red-500/30`) to stand out as a call-to-action
- Frontend-only change — no backend or database modifications

## Changes
- **EventRow.tsx** — Added `'review'` to `presetTags` array and red color mapping in `colorForTag`
- **EventCard.tsx** — Added `'review'` to `presetTags` array and red color entry in `tagColors` record
- **EventTable.tsx** — Added `'review'` to the bulk "Add Tag" submenu preset list

## Test plan
- [ ] Open underboss dashboard in table view, click "+" on any event's tag area, verify "review" appears as a preset option
- [ ] Add "review" tag to an event, verify it renders with red styling
- [ ] Open underboss dashboard on mobile, verify the card view also shows the "review" preset
- [ ] Select multiple events, open Actions > Add Tag, verify "review" appears in the submenu
- [ ] Click "review" in bulk add tag, verify it applies to all selected events

🤖 Generated with [Claude Code](https://claude.com/claude-code)