### PR TITLE
marinara-22521: Delete audit log with Postgres triggers

### DIFF
--- a/backend/src/helpers/auditContext.ts
+++ b/backend/src/helpers/auditContext.ts
@@ -1,0 +1,19 @@
+import { PrismaClient, Prisma } from '@prisma/client';
+
+/**
+ * Sets Postgres session variables so the deletion trigger can record
+ * who performed the delete and from what context.
+ *
+ * Must be called inside an interactive $transaction with the delete.
+ * Uses SET LOCAL so the variables are scoped to the current transaction.
+ */
+export async function setDeleteContext(
+  tx: Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>,
+  userEmail: string | undefined,
+  context: string
+): Promise<void> {
+  const safeEmail = userEmail || 'unknown';
+  const safeContext = context;
+  await tx.$executeRaw(Prisma.sql`SELECT set_config('app.current_user', ${safeEmail}, true)`);
+  await tx.$executeRaw(Prisma.sql`SELECT set_config('app.delete_context', ${safeContext}, true)`);
+}

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -2,6 +2,7 @@ import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest, isAdmin, isSuperAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
+import { setDeleteContext } from '../helpers/auditContext.js';
 
 const router = Router();
 
@@ -117,7 +118,10 @@ router.delete('/:id', requireAuth, async (req: AuthRequest, res: Response, next:
       throw new AppError('Cannot remove yourself', 400, 'SELF_REMOVAL');
     }
 
-    await prisma.admin.delete({ where: { id } });
+    await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, req.userEmail, 'admin');
+      await tx.admin.delete({ where: { id } });
+    });
 
     res.json({ success: true, message: 'Admin removed' });
   } catch (error) {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -5,6 +5,7 @@ import { AppError } from '../middleware/error.js';
 import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS } from '../helpers/partyAccess.js';
+import { setDeleteContext } from '../helpers/auditContext.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -561,7 +562,10 @@ router.delete('/:id', async (req: AuthRequest, res: Response, next: NextFunction
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
 
-    await prisma.party.delete({ where: { id } });
+    await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, req.userEmail, 'host_dashboard');
+      await tx.party.delete({ where: { id } });
+    });
 
     // Trigger webhook for party deletion
     await triggerWebhook('party.deleted', { id }, req.userId!);
@@ -725,8 +729,11 @@ router.delete('/:partyId/guests/:guestId', async (req: AuthRequest, res: Respons
       throw new AppError('You do not have access to the guests tab', 403, 'TAB_ACCESS_DENIED');
     }
 
-    await prisma.guest.delete({
-      where: { id: guestId, partyId },
+    await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, req.userEmail, 'host_dashboard');
+      await tx.guest.delete({
+        where: { id: guestId, partyId },
+      });
     });
 
     // Trigger webhook for guest removal

--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -3,6 +3,7 @@ import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
+import { setDeleteContext } from '../helpers/auditContext.js';
 
 const router = Router();
 
@@ -605,8 +606,11 @@ router.delete('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthRequ
       throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
     }
 
-    await prisma.sponsor.delete({
-      where: { id: sponsorId },
+    await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, req.userEmail, 'host_dashboard');
+      await tx.sponsor.delete({
+        where: { id: sponsorId },
+      });
     });
 
     res.json({ success: true });

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -4,6 +4,7 @@ import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import crypto from 'crypto';
 import { addPartnerToParty, removePartnerFromParty, getAutoCoHostPartners } from '../helpers/partnerSync.js';
+import { setDeleteContext } from '../helpers/auditContext.js';
 
 // Extend Request to include underboss
 interface UnderbossRequest extends AuthRequest {
@@ -571,8 +572,11 @@ router.delete('/events/bulk-delete', requireAuth, requireUnderbossAuth, async (r
       throw new AppError('partyIds must be a non-empty array', 400, 'VALIDATION_ERROR');
     }
 
-    const result = await prisma.party.deleteMany({
-      where: { id: { in: partyIds } },
+    const result = await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, req.userEmail, 'underboss_bulk');
+      return tx.party.deleteMany({
+        where: { id: { in: partyIds } },
+      });
     });
 
     res.json({ deleted: result.count });

--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -4,6 +4,7 @@ import { requireApiKey, ApiKeyRequest, SCOPES } from '../../middleware/apiKey.js
 import { requireAuth, AuthRequest } from '../../middleware/auth.js';
 import { AppError } from '../../middleware/error.js';
 import { triggerWebhook } from '../../services/webhook.service.js';
+import { setDeleteContext } from '../../helpers/auditContext.js';
 
 const router = Router({ mergeParams: true }); // mergeParams to access :partyId
 
@@ -434,7 +435,10 @@ router.delete('/:guestId', requireApiKey(SCOPES.GUESTS_WRITE), async (req: ApiKe
       throw new AppError('Guest not found', 404, 'NOT_FOUND');
     }
 
-    await prisma.guest.delete({ where: { id: guestId } });
+    await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, `api_key:${req.apiKey!.userId}`, 'api_v1');
+      await tx.guest.delete({ where: { id: guestId } });
+    });
 
     // Trigger webhook
     await triggerWebhook('guest.removed', { guestId, partyId }, req.apiKey!.userId);

--- a/backend/src/routes/v1/parties.ts
+++ b/backend/src/routes/v1/parties.ts
@@ -3,6 +3,7 @@ import { prisma } from '../../config/database.js';
 import { requireApiKey, ApiKeyRequest, SCOPES } from '../../middleware/apiKey.js';
 import { AppError } from '../../middleware/error.js';
 import { triggerWebhook } from '../../services/webhook.service.js';
+import { setDeleteContext } from '../../helpers/auditContext.js';
 import guestsRouter from './guests.js';
 
 const router = Router();
@@ -339,7 +340,10 @@ router.delete('/:id', requireApiKey(SCOPES.PARTIES_WRITE), async (req: ApiKeyReq
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
 
-    await prisma.party.delete({ where: { id } });
+    await prisma.$transaction(async (tx) => {
+      await setDeleteContext(tx, `api_key:${req.apiKey!.userId}`, 'api_v1');
+      await tx.party.delete({ where: { id } });
+    });
 
     // Trigger webhook
     await triggerWebhook('party.deleted', { id }, req.apiKey!.userId);

--- a/supabase/migrations/20260429_create_deletion_log.sql
+++ b/supabase/migrations/20260429_create_deletion_log.sql
@@ -1,0 +1,75 @@
+-- ============================================
+-- Deletion Audit Log
+-- ============================================
+-- Captures full row snapshots before any DELETE.
+-- Postgres BEFORE DELETE triggers on high-priority tables.
+-- Backend sets session vars (app.current_user, app.delete_context)
+-- inside interactive transactions so the trigger can record who
+-- performed the delete and from what context.
+-- ============================================
+
+-- 1. Create the deletion_log table
+CREATE TABLE deletion_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  table_name TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  record_data JSONB NOT NULL,
+  deleted_by TEXT,
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  context TEXT
+);
+
+CREATE INDEX idx_deletion_log_table_name ON deletion_log (table_name);
+CREATE INDEX idx_deletion_log_deleted_at ON deletion_log (deleted_at);
+CREATE INDEX idx_deletion_log_record_id ON deletion_log (record_id);
+
+-- 2. Generic trigger function
+CREATE OR REPLACE FUNCTION log_deletion()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO deletion_log (table_name, record_id, record_data, deleted_by, context)
+  VALUES (
+    TG_TABLE_NAME,
+    OLD.id::TEXT,
+    to_jsonb(OLD),
+    current_setting('app.current_user', true),
+    current_setting('app.delete_context', true)
+  );
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Triggers on high-priority tables (direct deletes)
+CREATE TRIGGER trg_deletion_log_parties BEFORE DELETE ON parties FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_guests BEFORE DELETE ON guests FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_photos BEFORE DELETE ON photos FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_sponsors BEFORE DELETE ON sponsors FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_raffles BEFORE DELETE ON raffles FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_raffle_prizes BEFORE DELETE ON raffle_prizes FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_raffle_entries BEFORE DELETE ON raffle_entries FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_raffle_winners BEFORE DELETE ON raffle_winners FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_displays BEFORE DELETE ON displays FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_staff BEFORE DELETE ON staff FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_performers BEFORE DELETE ON performers FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_venues BEFORE DELETE ON venues FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_venue_photos BEFORE DELETE ON venue_photos FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_budget_items BEFORE DELETE ON budget_items FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_checklist_items BEFORE DELETE ON checklist_items FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_party_kits BEFORE DELETE ON party_kits FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_social_posts BEFORE DELETE ON social_posts FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_notable_attendees BEFORE DELETE ON notable_attendees FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_admins BEFORE DELETE ON admins FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_checklist_defaults BEFORE DELETE ON checklist_defaults FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_quiz_questions BEFORE DELETE ON quiz_questions FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_quiz_question_templates BEFORE DELETE ON quiz_question_templates FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_quiz_answers BEFORE DELETE ON quiz_answers FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_webhooks BEFORE DELETE ON webhooks FOR EACH ROW EXECUTE FUNCTION log_deletion();
+
+-- 4. Triggers on cascade-only targets (important child data)
+CREATE TRIGGER trg_deletion_log_orders BEFORE DELETE ON orders FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_donations BEFORE DELETE ON donations FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_sponsor_checklist_items BEFORE DELETE ON sponsor_checklist_items FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_partner_event_notes BEFORE DELETE ON partner_event_notes FOR EACH ROW EXECUTE FUNCTION log_deletion();
+
+-- 5. Permissions: audit log is backend/service-role only
+REVOKE ALL ON deletion_log FROM anon, authenticated;


### PR DESCRIPTION
## Summary
- New deletion_log table captures full row snapshots before any delete
- Postgres BEFORE DELETE triggers on 28 tables (direct deletes + cascade targets)
- High-impact delete routes wrapped in transactions to record deleted_by and context
- No frontend changes — purely backend/DB

## Test plan
- [ ] Apply migration - triggers are active
- [ ] Delete a guest - check deletion_log has full guest record
- [ ] Delete a party - cascade children (guests, sponsors, etc.) all logged
- [ ] Verify deleted_by shows user email on high-impact routes
- [ ] Verify context shows correct source (host_dashboard, underboss_bulk, etc.)
- [ ] All existing delete operations continue to work normally

Generated with Claude Code