### PR TITLE
feat: GPP slug sync + old-slug redirects

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -196,6 +196,7 @@ model Party {
   sponsorChecklistItems SponsorChecklistItem[]
   partnerEventNotes     PartnerEventNote[]
   quizQuestions         QuizQuestion[]
+  slugAliases           SlugAlias[]
 
   @@map("parties")
 }
@@ -1268,4 +1269,14 @@ model QuizAnswer {
   @@index([questionId])
   @@index([guestId])
   @@map("quiz_answers")
+}
+
+model SlugAlias {
+  oldSlug   String   @id @map("old_slug")
+  partyId   String   @map("party_id") @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  party Party @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  @@map("slug_aliases")
 }

--- a/backend/src/routes/checkin.routes.ts
+++ b/backend/src/routes/checkin.routes.ts
@@ -62,6 +62,25 @@ async function findPartyByCode(inviteCode: string) {
     });
   }
 
+  // Alias fallback: silently resolve old slugs
+  if (!party) {
+    const alias = await prisma.slugAlias.findUnique({
+      where: { oldSlug: inviteCode },
+      select: { partyId: true },
+    });
+    if (alias) {
+      party = await prisma.party.findUnique({
+        where: { id: alias.partyId },
+        select: {
+          id: true,
+          name: true,
+          userId: true,
+          coHosts: true,
+        },
+      });
+    }
+  }
+
   return party;
 }
 

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -141,6 +141,18 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
       });
     }
 
+    // If not found by either method, check slug_aliases for a redirect
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { party: { select: { customUrl: true, inviteCode: true } } },
+      });
+      if (alias?.party) {
+        const newSlug = alias.party.customUrl || alias.party.inviteCode;
+        return res.status(301).json({ redirect: true, slug: newSlug, url: `/${newSlug}` });
+      }
+    }
+
     if (!party) {
       throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
     }
@@ -292,6 +304,19 @@ router.post('/:slug/check-host', async (req: Request, res: Response, next: NextF
         select: { coHosts: true, userId: true },
       });
     }
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { coHosts: true, userId: true },
+        });
+      }
+    }
     if (!party) {
       return res.json({ isHost: false });
     }
@@ -327,6 +352,19 @@ router.post('/:slug/verify-tweet', async (req: Request, res: Response, next: Nex
     let party = await prisma.party.findUnique({ where: { inviteCode: slug }, select: { id: true, shareToUnlock: true } });
     if (!party) {
       party = await prisma.party.findUnique({ where: { customUrl: slug }, select: { id: true, shareToUnlock: true } });
+    }
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true, shareToUnlock: true },
+        });
+      }
     }
     if (!party) {
       throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -198,8 +198,12 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
     const normalizedHostName = hostName.trim();
     const normalizedTelegram = telegram?.trim().replace(/^@/, '') || null;
 
-    // Generate custom URL from city name (lowercase, no spaces)
-    const customUrl = normalizedCity.toLowerCase().replace(/\s+/g, '');
+    // Generate custom URL from city name (strip diacritics, lowercase, no spaces/special chars)
+    const customUrl = normalizedCity
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '');
 
     // Check for existing GPP event in this city
     const existingEvent = await prisma.party.findFirst({
@@ -506,13 +510,30 @@ router.get('/events/by-city/:citySlug', async (req: Request, res: Response, next
   try {
     const { citySlug } = req.params;
 
-    const event = await prisma.party.findFirst({
+    let event = await prisma.party.findFirst({
       where: {
         eventType: 'gpp',
         customUrl: citySlug.toLowerCase(),
       },
       select: gppEventSelect,
     });
+
+    // Alias fallback: check if this is an old slug
+    if (!event) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: citySlug.toLowerCase() },
+        select: { partyId: true },
+      });
+      if (alias) {
+        event = await prisma.party.findFirst({
+          where: {
+            id: alias.partyId,
+            eventType: 'gpp',
+          },
+          select: gppEventSelect,
+        });
+      }
+    }
 
     if (!event) {
       return res.status(404).json({ error: 'GPP event not found for this city' });

--- a/backend/src/routes/linkclick.routes.ts
+++ b/backend/src/routes/linkclick.routes.ts
@@ -28,6 +28,19 @@ router.post('/:slug/click', async (req: Request, res: Response, _next: NextFunct
         select: { id: true },
       });
     }
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true },
+        });
+      }
+    }
 
     if (!party) {
       res.status(204).end();

--- a/backend/src/routes/pageview.routes.ts
+++ b/backend/src/routes/pageview.routes.ts
@@ -22,6 +22,19 @@ router.post('/:slug/view', async (req: Request, res: Response, _next: NextFuncti
         select: { id: true },
       });
     }
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true },
+        });
+      }
+    }
 
     if (!party) {
       res.status(204).end();

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -48,6 +48,32 @@ router.get('/:inviteCode', async (req: Request, res: Response, next: NextFunctio
       });
     }
 
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: inviteCode },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: {
+            id: true,
+            name: true,
+            date: true,
+            eventType: true,
+            availableBeverages: true,
+            rsvpClosedAt: true,
+            maxGuests: true,
+            user: { select: { name: true } },
+            guests: {
+              select: { status: true },
+            },
+          },
+        });
+      }
+    }
+
     if (!party) {
       throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
     }
@@ -119,6 +145,20 @@ router.post('/:inviteCode/verify-password', async (req: Request, res: Response, 
       });
     }
 
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: inviteCode },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true, password: true },
+        });
+      }
+    }
+
     if (!party) {
       throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
     }
@@ -146,6 +186,20 @@ router.get('/:inviteCode/guest/:email', async (req: Request, res: Response, next
         where: { customUrl: inviteCode },
         select: { id: true },
       });
+    }
+
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: inviteCode },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true },
+        });
+      }
     }
 
     if (!party) {
@@ -268,6 +322,33 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
           _count: { select: { guests: true } },
         },
       });
+    }
+
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: inviteCode },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: {
+            id: true,
+            name: true,
+            date: true,
+            timezone: true,
+            address: true,
+            customUrl: true,
+            rsvpClosedAt: true,
+            maxGuests: true,
+            requireApproval: true,
+            userId: true,
+            user: { select: { name: true } },
+            _count: { select: { guests: true } },
+          },
+        });
+      }
     }
 
     if (!party) {
@@ -479,6 +560,27 @@ router.post('/:inviteCode/send-confirmation', async (req: Request, res: Response
           customUrl: true,
         },
       });
+    }
+
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: inviteCode },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: {
+            id: true,
+            name: true,
+            date: true,
+            timezone: true,
+            address: true,
+            customUrl: true,
+          },
+        });
+      }
     }
 
     if (!party) {

--- a/frontend/api/event/[slug].ts
+++ b/frontend/api/event/[slug].ts
@@ -63,6 +63,39 @@ async function getPartyBySlug(slug: string) {
     }
   }
 
+  // Alias fallback: check slug_aliases table
+  const aliasResponse = await fetch(
+    `${SUPABASE_URL}/rest/v1/slug_aliases?old_slug=eq.${encodeURIComponent(slug)}&select=party_id`,
+    {
+      headers: {
+        'apikey': SUPABASE_ANON_KEY,
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+    }
+  );
+
+  if (aliasResponse.ok) {
+    const aliasData = await aliasResponse.json();
+    if (aliasData && aliasData.length > 0) {
+      const partyResponse = await fetch(
+        `${SUPABASE_URL}/rest/v1/parties?id=eq.${encodeURIComponent(aliasData[0].party_id)}&select=*`,
+        {
+          headers: {
+            'apikey': SUPABASE_ANON_KEY,
+            'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+          },
+        }
+      );
+
+      if (partyResponse.ok) {
+        const partyData = await partyResponse.json();
+        if (partyData && partyData.length > 0) {
+          return partyData[0];
+        }
+      }
+    }
+  }
+
   return null;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -418,16 +418,25 @@ export interface PublicEvent {
 }
 
 // Public Event API (no auth required)
-export async function getEventBySlug(slug: string): Promise<PublicEvent | null> {
+export async function getEventBySlug(slug: string): Promise<PublicEvent | { redirect: true; slug: string } | null> {
   try {
-    const response = await apiRequest<{ event: PublicEvent }>(
-      `/api/events/${slug}`,
-      {
-        method: 'GET',
-        requireAuth: false,
-      }
-    );
-    return response.event;
+    const response = await fetch(`${API_URL}/api/events/${slug}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json();
+
+    // Handle redirect response from slug aliases
+    if (data.redirect) {
+      return { redirect: true, slug: data.slug };
+    }
+
+    return data.event || null;
   } catch (error) {
     console.error('Error fetching event:', error);
     return null;

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -701,15 +701,36 @@ export async function getPartyByCustomUrl(customUrl: string): Promise<DbParty | 
     .eq('custom_url', customUrl.toLowerCase())
     .single();
 
-  if (error) {
+  if (error && error.code !== 'PGRST116') {
     console.error('Error fetching party by custom URL:', error);
     return null;
   }
-  if (data) {
-    normalizePartyCoHosts(data);
-    data.co_hosts = sanitizeCoHosts(data.co_hosts);
+
+  let party = data;
+
+  // Alias fallback: check slug_aliases if not found by custom_url
+  if (!party) {
+    const { data: aliasData } = await supabase
+      .from('slug_aliases')
+      .select('party_id')
+      .eq('old_slug', customUrl.toLowerCase())
+      .maybeSingle();
+
+    if (aliasData) {
+      const { data: partyData } = await supabase
+        .from('parties')
+        .select(SAFE_PARTY_COLUMNS)
+        .eq('id', aliasData.party_id)
+        .single();
+      party = partyData;
+    }
   }
-  return data;
+
+  if (party) {
+    normalizePartyCoHosts(party);
+    party.co_hosts = sanitizeCoHosts(party.co_hosts);
+  }
+  return party;
 }
 
 // Reserved slugs that can't be used as custom party URLs
@@ -820,8 +841,29 @@ export async function getPartyByInviteCodeOrCustomUrl(slug: string): Promise<DbP
     if (inviteCodeData) {
       party = inviteCodeData as DbParty;
     } else {
-      if (customUrlError) error = customUrlError;
-      if (inviteCodeError) error = inviteCodeError;
+      // Alias fallback: check slug_aliases
+      const { data: aliasData } = await supabase
+        .from('slug_aliases')
+        .select('party_id')
+        .eq('old_slug', normalizedSlug)
+        .maybeSingle();
+
+      if (aliasData) {
+        const { data: aliasPartyData } = await supabase
+          .from('parties')
+          .select(SAFE_PARTY_COLUMNS)
+          .eq('id', aliasData.party_id)
+          .maybeSingle();
+
+        if (aliasPartyData) {
+          party = aliasPartyData as DbParty;
+        }
+      }
+
+      if (!party) {
+        if (customUrlError) error = customUrlError;
+        if (inviteCodeError) error = inviteCodeError;
+      }
     }
   }
 
@@ -857,7 +899,25 @@ export async function getPartyWithGuests(inviteCode: string): Promise<{ party: D
     console.error('Error fetching party:', partyError);
   }
 
-  const party: DbParty | null = partyData;
+  let party: DbParty | null = partyData;
+
+  // Alias fallback: check slug_aliases if not found
+  if (!party) {
+    const { data: aliasData } = await supabase
+      .from('slug_aliases')
+      .select('party_id')
+      .eq('old_slug', inviteCode)
+      .maybeSingle();
+
+    if (aliasData) {
+      const { data: aliasPartyData } = await supabase
+        .from('parties')
+        .select(SAFE_PARTY_COLUMNS)
+        .eq('id', aliasData.party_id)
+        .maybeSingle();
+      party = aliasPartyData;
+    }
+  }
 
   if (!party) {
     return null;

--- a/frontend/src/pages/DJPage.tsx
+++ b/frontend/src/pages/DJPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { Loader2, AlertCircle, Music, Calendar, MapPin, Mic2, Disc3, ListMusic, ExternalLink, Clock, Instagram } from 'lucide-react';
 import { getEventBySlug, PublicEvent, getPerformers } from '../lib/api';
@@ -54,6 +54,7 @@ function formatDuration(minutes: number | null): string {
 
 export function DJPage() {
   const { inviteCode } = useParams<{ inviteCode: string }>();
+  const navigate = useNavigate();
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -72,7 +73,15 @@ export function DJPage() {
 
       try {
         // Load event details
-        const foundEvent = await getEventBySlug(inviteCode);
+        const result = await getEventBySlug(inviteCode);
+
+        // Handle redirect from old slug alias
+        if (result && 'redirect' in result) {
+          navigate(`/dj/${result.slug}`, { replace: true });
+          return;
+        }
+
+        const foundEvent = result;
         if (!foundEvent) {
           setError('Event not found. The link may be invalid or expired.');
           setLoading(false);

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -103,7 +103,15 @@ export function EventPage() {
   useEffect(() => {
     async function loadEvent() {
       if (slug) {
-        const foundEvent = await getEventBySlug(slug);
+        const result = await getEventBySlug(slug);
+
+        // Handle redirect from old slug alias
+        if (result && 'redirect' in result) {
+          navigate(`/${result.slug}`, { replace: true });
+          return;
+        }
+
+        const foundEvent = result;
         if (foundEvent) {
           setEvent(foundEvent);
           setCanEditAsCoHost(false);

--- a/scripts/migrate-gpp-slugs.js
+++ b/scripts/migrate-gpp-slugs.js
@@ -1,0 +1,102 @@
+/**
+ * Migrate GPP event slugs to match English city names.
+ * - Strips diacritics
+ * - Updates custom_url
+ * - Inserts old slug into slug_aliases for redirects
+ *
+ * Run: node scripts/migrate-gpp-slugs.js          (dry run)
+ * Run: node scripts/migrate-gpp-slugs.js --apply   (real run)
+ */
+
+const { PrismaClient } = require('@prisma/client');
+const p = new PrismaClient();
+const DRY_RUN = !process.argv.includes('--apply');
+
+function generateSlug(cityName) {
+  return cityName
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '')
+    .trim();
+}
+
+async function main() {
+  const events = await p.party.findMany({
+    where: { eventType: 'gpp' },
+    select: { id: true, name: true, customUrl: true },
+  });
+
+  const changes = [];
+  const newSlugSet = new Set(); // Track new slugs to detect collisions among changes
+
+  // Collect existing slugs for collision detection
+  const existingSlugs = new Set(events.map(e => e.customUrl).filter(Boolean));
+
+  for (const e of events) {
+    const match = e.name.match(/Global Pizza Party\s+(.+)/);
+    if (!match) continue;
+
+    const city = match[1].trim();
+    const newSlug = generateSlug(city);
+
+    if (!newSlug || newSlug === e.customUrl) continue;
+
+    // Check for collision among new slugs
+    if (newSlugSet.has(newSlug)) {
+      console.log(`  COLLISION (dup new slug): ${e.name} -> ${newSlug} (already taken by another change)`);
+      continue;
+    }
+    newSlugSet.add(newSlug);
+
+    changes.push({
+      id: e.id,
+      name: e.name,
+      oldSlug: e.customUrl,
+      newSlug,
+    });
+  }
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`  GPP Slug Migration -- ${DRY_RUN ? 'DRY RUN' : 'APPLYING'}`);
+  console.log(`${'='.repeat(60)}\n`);
+  console.log(`Total GPP events: ${events.length}`);
+  console.log(`Slugs to change: ${changes.length}\n`);
+
+  for (const c of changes) {
+    const collision = existingSlugs.has(c.newSlug) && c.newSlug !== c.oldSlug;
+    console.log(`  ${c.name}`);
+    console.log(`    ${c.oldSlug} -> ${c.newSlug}${collision ? ' ** COLLISION' : ''}`);
+  }
+
+  // Filter out collisions with existing slugs
+  const safeChanges = changes.filter(c => !existingSlugs.has(c.newSlug) || c.newSlug === c.oldSlug);
+  const skipped = changes.length - safeChanges.length;
+  if (skipped > 0) {
+    console.log(`\n  Skipping ${skipped} changes due to collisions with existing slugs.`);
+  }
+
+  if (!DRY_RUN && safeChanges.length > 0) {
+    console.log(`\nApplying ${safeChanges.length} changes...`);
+    for (const c of safeChanges) {
+      // Insert alias for old slug
+      await p.slugAlias.create({
+        data: { oldSlug: c.oldSlug, partyId: c.id },
+      });
+      // Update custom_url
+      await p.party.update({
+        where: { id: c.id },
+        data: { customUrl: c.newSlug },
+      });
+      console.log(`  OK ${c.oldSlug} -> ${c.newSlug}`);
+    }
+    console.log(`\nApplied ${safeChanges.length} slug changes.`);
+  } else if (DRY_RUN) {
+    console.log(`\nRun with --apply to execute these changes.`);
+  }
+
+  await p.$disconnect();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/migrate-gpp-slugs.js
+++ b/scripts/migrate-gpp-slugs.js
@@ -17,9 +17,19 @@ function generateSlug(cityName) {
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '')
-    .trim();
+    .replace(/[^a-z0-9]/g, '');
+}
+
+// Extract just the city name from the event name, stripping sponsors/suffixes
+function extractCity(eventName) {
+  const match = eventName.match(/Global Pizza Party\s+[-–—]?\s*(.+)/);
+  if (!match) return null;
+  let city = match[1].trim();
+  // Strip trailing sponsor/venue info after " - " (keep first segment only)
+  city = city.split(/\s+[-–—]\s+/)[0].trim();
+  // Strip leading dashes
+  city = city.replace(/^[-–—\s]+/, '');
+  return city || null;
 }
 
 async function main() {
@@ -35,13 +45,16 @@ async function main() {
   const existingSlugs = new Set(events.map(e => e.customUrl).filter(Boolean));
 
   for (const e of events) {
-    const match = e.name.match(/Global Pizza Party\s+(.+)/);
-    if (!match) continue;
+    const city = extractCity(e.name);
+    if (!city) continue;
 
-    const city = match[1].trim();
     const newSlug = generateSlug(city);
 
     if (!newSlug || newSlug === e.customUrl) continue;
+
+    // Skip if new slug is longer and already contains the old slug as-is
+    // (means old slug is already the clean city, event name has extra info)
+    if (newSlug.length > e.customUrl.length && newSlug.includes(e.customUrl)) continue;
 
     // Check for collision among new slugs
     if (newSlugSet.has(newSlug)) {

--- a/supabase/migrations/20260430_create_slug_aliases.sql
+++ b/supabase/migrations/20260430_create_slug_aliases.sql
@@ -1,0 +1,13 @@
+-- Create slug_aliases table for old-slug -> new-slug redirects
+CREATE TABLE slug_aliases (
+  old_slug   TEXT PRIMARY KEY,
+  party_id   UUID NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_slug_aliases_party_id ON slug_aliases(party_id);
+
+ALTER TABLE slug_aliases ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "slug_aliases_select" ON slug_aliases FOR SELECT USING (true);
+
+GRANT SELECT ON slug_aliases TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Creates a `slug_aliases` table to map old GPP slugs to their updated parties, enabling seamless redirects when slugs change (e.g., `lussemburgo` -> `luxembourg`)
- Adds alias fallback lookups to all backend routes (event, RSVP, GPP by-city, check-in, page views, link clicks) and frontend Supabase queries
- Fixes GPP event creation to strip diacritics from city names going forward (e.g., `Sao Paulo` -> `saopaulo` instead of `sãopaulo`)
- Includes a migration script (`scripts/migrate-gpp-slugs.js`) with dry-run mode to rename existing slugs and populate the aliases table

## Changes
- **Supabase migration**: `slug_aliases` table with RLS + anon/authenticated SELECT grant
- **Prisma schema**: `SlugAlias` model with Party relation
- **Backend routes**: Alias fallback in `event.routes.ts` (JSON redirect for GET /:slug), `rsvp.routes.ts`, `gpp.routes.ts`, `checkin.routes.ts`, `pageview.routes.ts`, `linkclick.routes.ts`
- **Frontend**: `getEventBySlug` detects redirect responses; `EventPage` and `DJPage` navigate to new slug; `supabase.ts` functions fall back to `slug_aliases`; OG tag serverless function checks aliases for crawler previews

## Test plan
- [ ] Apply Supabase migration to create `slug_aliases` table
- [ ] Run `npx prisma generate` in backend
- [ ] Run migration script in dry-run mode: `node scripts/migrate-gpp-slugs.js`
- [ ] Verify output shows correct old -> new slug mappings
- [ ] Run with `--apply` to execute the migration
- [ ] Test visiting an old slug URL (e.g., `/lussemburgo`) — should redirect to new slug
- [ ] Test RSVP flow on old slug — should resolve silently
- [ ] Test creating a new GPP event with diacritics in the city name — slug should be stripped
- [ ] Verify OG tags work for old slug URLs (social media preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)