### PR TITLE
feat: venue field UX improvements

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -586,32 +586,42 @@ export const EventDetailsTab: React.FC = () => {
         </div>
 
         {/* Address */}
-        <LocationAutocomplete
-          value={address}
-          onChange={(newAddress) => {
-            setAddress(newAddress);
-          }}
-          onVenueNameChange={(newVenueName) => {
-            setVenueName(newVenueName);
-          }}
-          onTimezoneChange={setTimezone}
-          onLocationSelected={(loc) => {
-            // Store coords in ref; saveLocation will consume them
-            pendingCoordsRef.current = loc;
-          }}
-          onCitySelected={(cityData) => {
-            // Store country in ref; saveLocation will consume it
-            pendingCountryRef.current = cityData.country || null;
-          }}
-          onPlaceSelected={(newAddress, newVenueName) => {
-            // Save when a place is selected from autocomplete
-            saveLocation(newAddress, newVenueName);
-          }}
-          placeholder="Add Event Location"
-        />
-        {venueName && (
-          <p className="text-xs text-white/40 -mt-1 ml-1">Venue: {venueName}</p>
-        )}
+        <div className="relative">
+          <LocationAutocomplete
+            value={venueName ? `${venueName}, ${address}` : address}
+            onChange={(newAddress) => {
+              setVenueName(null);
+              setAddress(newAddress);
+            }}
+            onVenueNameChange={(newVenueName) => {
+              setVenueName(newVenueName);
+            }}
+            onTimezoneChange={setTimezone}
+            onLocationSelected={(loc) => {
+              pendingCoordsRef.current = loc;
+            }}
+            onCitySelected={(cityData) => {
+              pendingCountryRef.current = cityData.country || null;
+            }}
+            onPlaceSelected={(newAddress, newVenueName) => {
+              saveLocation(newAddress, newVenueName);
+            }}
+            placeholder="Add Event Location"
+          />
+          {venueName && (
+            <button
+              type="button"
+              onClick={() => {
+                setVenueName(null);
+                saveLocation(address, null);
+              }}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-white/30 hover:text-white/60 transition-colors z-10"
+              title="Remove venue name"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
 
         {/* Change Date Button */}
         <button


### PR DESCRIPTION
## Summary
- Merge venue name into the location input as "Venue, Address" instead of showing a separate `Venue: {name}` label
- Add an X button to clear the venue name
- Manual typing clears the venue association automatically

## Test plan
- [ ] Open host dashboard → location shows "Venue Name, Address" when venue exists
- [ ] Click X → venue name removed, input shows just address, saved to DB
- [ ] Search a new place → venue auto-detected, prepended to address
- [ ] Manually type → venue name cleared
- [ ] Refresh → changes persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)