### PR TITLE
Avatar image proxy — store external avatars in Supabase storage

### DIFF
--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp } from 'lucide-react';
 import { CoHost } from '../types';
 import { Checkbox } from './Checkbox';
-import { updateParty, addGuestByHost } from '../lib/supabase';
+import { updateParty, addGuestByHost, proxyAvatarToStorage } from '../lib/supabase';
 import { getXAvatarUrl, isAutoFilledXAvatar } from '../utils/avatarUtils';
 import { uuid } from '../lib/utils';
 import { ALL_HOST_TABS } from '../lib/tabPermissions';
@@ -109,6 +109,11 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   const addCoHost = async () => {
     if (!newCoHostName.trim()) return;
 
+    // Proxy external avatar to storage
+    const avatarUrl = newCoHostAvatarUrl.trim()
+      ? await proxyAvatarToStorage(newCoHostAvatarUrl.trim())
+      : undefined;
+
     const newCoHost: CoHost = {
       id: uuid(),
       name: newCoHostName.trim(),
@@ -116,7 +121,7 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
       website: newCoHostWebsite.trim() || undefined,
       twitter: newCoHostTwitter.trim() || undefined,
       instagram: newCoHostInstagram.trim() || undefined,
-      avatar_url: newCoHostAvatarUrl.trim() || undefined,
+      avatar_url: avatarUrl,
       showOnEvent: true,
     };
 
@@ -159,6 +164,11 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   const saveHostEdit = async () => {
     if (!editHostName.trim()) return;
 
+    // Proxy external avatar to storage
+    const avatarUrl = editHostAvatarUrl.trim()
+      ? await proxyAvatarToStorage(editHostAvatarUrl.trim())
+      : undefined;
+
     const newCoHosts = coHosts.map(h =>
       h.id === editingHostId
         ? {
@@ -168,7 +178,7 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
           website: editHostWebsite.trim() || undefined,
           twitter: editHostTwitter.trim() || undefined,
           instagram: editHostInstagram.trim() || undefined,
-          avatar_url: editHostAvatarUrl.trim() || undefined,
+          avatar_url: avatarUrl,
         }
         : h
     );

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Handshake, Plus, Edit2, Trash2, RefreshCw, Check, AlertCircle, GripVertical } from 'lucide-react';
 import { fetchSponsorUsers, createSponsorUser, updateSponsorUser, deleteSponsorUser, reorderSponsorUsers } from '../../lib/api';
+import { proxyAvatarToStorage } from '../../lib/supabase';
 import type { SponsorUser } from '../../types';
 import { PartnerForm } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
@@ -62,6 +63,11 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
     setSyncMessage(null);
 
     try {
+      // Proxy external avatar to storage
+      const proxiedAvatarUrl = data.coHostAvatarUrl
+        ? await proxyAvatarToStorage(data.coHostAvatarUrl)
+        : undefined;
+
       const payload = {
         email: data.email,
         tag: data.tag,
@@ -71,7 +77,7 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
         coHostWebsite: data.website || undefined,
         coHostTwitter: data.brandTwitter || undefined,
         coHostInstagram: data.brandInstagram || undefined,
-        coHostAvatarUrl: data.coHostAvatarUrl || undefined,
+        coHostAvatarUrl: proxiedAvatarUrl,
         coHostLogoUrl: data.logoUrl || undefined,
         autoCoHost: data.autoCoHost,
         autoSponsor: data.autoSponsor,

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -137,6 +137,59 @@ export async function uploadSponsorLogo(file: File): Promise<string | null> {
 }
 
 /**
+ * Proxy an external avatar image to Supabase Storage.
+ * Skips if already a Supabase URL. Falls back to original URL on failure.
+ */
+export async function proxyAvatarToStorage(externalUrl: string): Promise<string> {
+  // Skip if empty or already a Supabase storage URL
+  if (!externalUrl || externalUrl.includes('.supabase.co/storage/')) {
+    return externalUrl;
+  }
+
+  try {
+    const response = await fetch(externalUrl);
+    if (!response.ok) return externalUrl;
+
+    const blob = await response.blob();
+
+    // Determine extension from content-type
+    const contentType = response.headers.get('content-type') || 'image/png';
+    const extMap: Record<string, string> = {
+      'image/jpeg': 'jpg',
+      'image/png': 'png',
+      'image/gif': 'gif',
+      'image/webp': 'webp',
+      'image/svg+xml': 'svg',
+    };
+    const ext = extMap[contentType] || 'png';
+
+    const fileName = `co-host-avatars/${Date.now()}-${Math.random().toString(36).substring(7)}.${ext}`;
+
+    const { error } = await supabase.storage
+      .from('event-images')
+      .upload(fileName, blob, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType,
+      });
+
+    if (error) {
+      console.error('Error proxying avatar:', error);
+      return externalUrl;
+    }
+
+    const { data: urlData } = supabase.storage
+      .from('event-images')
+      .getPublicUrl(fileName);
+
+    return urlData.publicUrl;
+  } catch (error) {
+    console.error('Error proxying avatar:', error);
+    return externalUrl;
+  }
+}
+
+/**
  * Upload an image for use in event descriptions (Markdown).
  * Stored under `description-images/{partyId}/` in the event-images bucket.
  * @param file The image file to upload

--- a/scripts/backfill-avatar-proxy.js
+++ b/scripts/backfill-avatar-proxy.js
@@ -1,0 +1,119 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://znpiwdvvsqaxuskpfleo.supabase.co';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+if (!SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Set SUPABASE_SERVICE_ROLE_KEY env var');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const dryRun = !process.argv.includes('--apply');
+
+async function proxyAvatar(url) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error(`    Failed to fetch ${url}: ${response.status}`);
+      return url;
+    }
+
+    const blob = await response.blob();
+    const arrayBuffer = await blob.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Determine extension from content-type
+    const contentType = response.headers.get('content-type') || 'image/png';
+    const extMap = {
+      'image/jpeg': 'jpg',
+      'image/png': 'png',
+      'image/gif': 'gif',
+      'image/webp': 'webp',
+      'image/svg+xml': 'svg',
+    };
+    const ext = extMap[contentType] || 'png';
+
+    const fileName = `co-host-avatars/${Date.now()}-${Math.random().toString(36).substring(7)}.${ext}`;
+
+    const { error } = await supabase.storage
+      .from('event-images')
+      .upload(fileName, buffer, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType,
+      });
+
+    if (error) {
+      console.error(`    Upload error for ${url}:`, error.message);
+      return url;
+    }
+
+    const { data: urlData } = supabase.storage
+      .from('event-images')
+      .getPublicUrl(fileName);
+
+    console.log(`    -> ${urlData.publicUrl}`);
+    return urlData.publicUrl;
+  } catch (err) {
+    console.error(`    Error proxying ${url}:`, err.message);
+    return url;
+  }
+}
+
+async function main() {
+  console.log(dryRun ? 'DRY RUN — pass --apply to execute' : 'APPLYING changes...');
+
+  const { data: parties, error } = await supabase
+    .from('parties')
+    .select('id, co_hosts')
+    .not('co_hosts', 'is', null);
+
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  }
+
+  let totalProxied = 0;
+
+  for (const party of parties) {
+    const coHosts = party.co_hosts;
+    if (!Array.isArray(coHosts)) continue;
+
+    let changed = false;
+    const updatedHosts = [];
+
+    for (const host of coHosts) {
+      if (host.avatar_url && !host.avatar_url.includes('.supabase.co/storage/')) {
+        console.log(`  Party ${party.id}: ${host.name} -> ${host.avatar_url}`);
+
+        if (!dryRun) {
+          const newUrl = await proxyAvatar(host.avatar_url);
+          if (newUrl !== host.avatar_url) {
+            updatedHosts.push({ ...host, avatar_url: newUrl });
+            changed = true;
+            totalProxied++;
+            continue;
+          }
+        } else {
+          totalProxied++;
+        }
+      }
+      updatedHosts.push(host);
+    }
+
+    if (changed && !dryRun) {
+      const { error: updateError } = await supabase
+        .from('parties')
+        .update({ co_hosts: updatedHosts })
+        .eq('id', party.id);
+
+      if (updateError) console.error(`  Error updating party ${party.id}:`, updateError);
+      else console.log(`  Updated party ${party.id}`);
+    }
+  }
+
+  console.log(`\n${dryRun ? 'Would proxy' : 'Proxied'} ${totalProxied} avatar(s)`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- New `proxyAvatarToStorage()` utility fetches external images and re-uploads to Supabase storage
- Called automatically when saving co-hosts in HostsManager (add + edit)
- Called when saving partner avatar in PartnerManager
- Backfill script to proxy existing external avatar URLs
- Skips URLs already in Supabase storage (no double-proxy)
- Falls back to original URL on any failure

## Test plan
- [ ] Add co-host with Twitter handle → avatar auto-fills → on Save, URL changes to supabase storage
- [ ] Paste external URL for avatar → on Save, proxied to storage
- [ ] Edit co-host with existing Supabase avatar → URL unchanged
- [ ] Run backfill dry-run → shows URLs to proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)