### PR TITLE
fix: remove auto-created sponsors when event tag is removed

### DIFF
--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -204,6 +204,15 @@ export async function removePartnerFromParty(
       data: { coHosts: filtered },
     });
   }
+
+  // Also remove auto-created sponsor records for this tag
+  const autoNote = `Auto-created from partner tag "${tag}"`;
+  await prisma.sponsor.deleteMany({
+    where: {
+      partyId,
+      notes: autoNote,
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- `removePartnerFromParty()` now also deletes auto-created `Sponsor` records (matched by `notes` field) when a tag is removed from an event
- Previously only co-host entries were cleaned up, leaving orphaned sponsor records visible on event pages
- Only affects auto-created sponsors (notes = `Auto-created from partner tag "..."`) — manually added sponsors are never touched

## Root cause
When a tag like `brave` was removed from an event, `removePartnerFromParty()` removed the co-host JSON entry but did not delete the corresponding `Sponsor` row. This left Brave (and potentially other auto-sponsors) visible on events that no longer have the `brave` tag.

## Test plan
- [ ] Add `brave` tag to a test event → Brave auto-creates as sponsor
- [ ] Remove `brave` tag → Brave sponsor record is deleted
- [ ] Manually-added sponsors are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)