### PR TITLE
feat: auto-add WPC + ENS tags & partners on GPP event creation

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { randomBytes } from 'crypto';
 import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
+import { getAutoCoHostPartners, addPartnerToParty } from '../helpers/partnerSync.js';
 
 const router = Router();
 
@@ -75,7 +76,7 @@ What to expect:
 
 RSVP to secure your slice!`,
   eventType: 'gpp',
-  eventTags: ['Global Pizza Party'],
+  eventTags: ['Global Pizza Party', 'wpc', 'ens'],
   requireApproval: true,
   hideGuests: false,
   photosEnabled: true,
@@ -354,6 +355,16 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
         user: { select: { name: true } },
       },
     });
+
+    // Auto-sync partner co-hosts + sponsors for default tags
+    try {
+      const partners = await getAutoCoHostPartners(GPP_DEFAULTS.eventTags);
+      for (const partner of partners) {
+        await addPartnerToParty(party as any, partner);
+      }
+    } catch (err) {
+      console.error('Failed to sync auto partners:', err);
+    }
 
     // Add the host as a guest
     await prisma.guest.create({


### PR DESCRIPTION
## Summary
- Added `wpc` and `ens` to the default `eventTags` array for GPP events, so every new Global Pizza Party event is automatically tagged with these partner identifiers.
- Added an import for `getAutoCoHostPartners` and `addPartnerToParty` from the `partnerSync` helper.
- After party creation, automatically syncs partner co-hosts and sponsors that match the default event tags (`Global Pizza Party`, `wpc`, `ens`). Failures are caught and logged without blocking event creation.

## Why
Partner organizations (WPC, ENS) should be automatically associated with every GPP event at creation time, rather than requiring manual addition. This ensures consistent branding and co-host attribution across all Global Pizza Party events.

## Test plan
- [ ] Create a new GPP event via the `/api/gpp/events` endpoint
- [ ] Verify the created event has `eventTags` containing `['Global Pizza Party', 'wpc', 'ens']`
- [ ] Verify partner co-hosts and sponsors from matching tags are auto-added to the party
- [ ] Verify that if partner sync fails, the event is still created successfully (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)