### PR TITLE
fix: single dropdown arrow + show partner avatars

### DIFF
--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -125,6 +125,7 @@ router.get('/:partyId/sponsors/unified', requireAuth, async (req: AuthRequest, r
         name: s.name,
         brandDescription: s.brandDescription,
         logoUrl: s.logoUrl,
+        avatarUrl: null,
         website: s.website,
         sortOrder: s.sortOrder ?? 0,
       });
@@ -142,6 +143,7 @@ router.get('/:partyId/sponsors/unified', requireAuth, async (req: AuthRequest, r
         if (existing) {
           existing.sponsorUserId = su.id;
           existing.source = 'event'; // keep as event since it has a Sponsor record
+          existing.avatarUrl = su.coHostAvatarUrl;
         }
         continue;
       }
@@ -154,6 +156,7 @@ router.get('/:partyId/sponsors/unified', requireAuth, async (req: AuthRequest, r
         name: su.coHostName || su.name || su.email,
         brandDescription: su.brandDescription,
         logoUrl: su.coHostLogoUrl,
+        avatarUrl: su.coHostAvatarUrl,
         website: su.coHostWebsite,
         sortOrder: 9999 + su.descriptionSortOrder,
       });

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus, RefreshCw, GripVertical, FileText, Globe } from 'lucide-react';
 import { Sponsor, SponsorStats, SponsorStatus, UnifiedPartner } from '../../types';
 import {
@@ -37,6 +37,17 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
   const [descDragIndex, setDescDragIndex] = useState<number | null>(null);
   const [unifiedPartners, setUnifiedPartners] = useState<UnifiedPartner[]>([]);
   const [isSavingOrder, setIsSavingOrder] = useState(false);
+
+  // Build avatar URL map from unified partners for the sponsor table
+  const sponsorAvatarUrls = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of unifiedPartners) {
+      if (p.sponsorId && p.avatarUrl) {
+        map[p.sponsorId] = p.avatarUrl;
+      }
+    }
+    return map;
+  }, [unifiedPartners]);
 
   // Load sponsors and stats
   const loadData = useCallback(async (showRefresh = false) => {
@@ -301,6 +312,7 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
         onSponsorUpdate={(updated) => setSponsors(prev => prev.map(s => s.id === updated.id ? updated : s))}
         onStatusChange={handleStatusChange}
         isLoading={isRefreshing}
+        avatarUrls={sponsorAvatarUrls}
       />
 
       {/* Brand Description Order (Unified) */}
@@ -329,8 +341,8 @@ export function SponsorCRM({ partyId }: SponsorCRMProps) {
                 <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0">
                   <GripVertical size={16} />
                 </div>
-                {partner.logoUrl && (
-                  <img src={partner.logoUrl} alt="" className="w-6 h-6 rounded object-cover shrink-0" />
+                {(partner.avatarUrl || partner.logoUrl) && (
+                  <img src={partner.avatarUrl || partner.logoUrl!} alt="" className="w-6 h-6 rounded-full object-cover shrink-0" />
                 )}
                 <span className="text-sm text-theme-text font-medium truncate">{partner.name}</span>
                 {partner.source === 'underboss' && (

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -14,6 +14,7 @@ interface SponsorListProps {
   onSponsorUpdate: (sponsor: Sponsor) => void;
   onStatusChange: (sponsor: Sponsor, newStatus: SponsorStatus) => void;
   isLoading?: boolean;
+  avatarUrls?: Record<string, string>;
 }
 
 type SortField = 'name' | 'status' | 'amount' | 'lastContactedAt' | 'createdAt';
@@ -41,7 +42,7 @@ const STATUS_ORDER: Record<SponsorStatus, number> = {
   skip: 7,
 };
 
-export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpdate, onStatusChange, isLoading }: SponsorListProps) {
+export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpdate, onStatusChange, isLoading, avatarUrls }: SponsorListProps) {
   const [sortField, setSortField] = useState<SortField>('createdAt');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [filterStatus, setFilterStatus] = useState<SponsorStatus | 'all'>('all');
@@ -233,7 +234,7 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                         value={sponsor.status}
                         onChange={(e) => onStatusChange(sponsor, e.target.value as SponsorStatus)}
                         className={`appearance-none rounded-full px-2.5 py-0.5 pr-6 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-[#ff393a] cursor-pointer ${statusConfig.bgColor} ${statusConfig.color}`}
-                        style={{ WebkitAppearance: 'none', MozAppearance: 'none' }}
+                        style={{ WebkitAppearance: 'none', MozAppearance: 'none', backgroundImage: 'none' }}
                       >
                         {Object.entries(STATUS_CONFIG).map(([status, config]) => (
                           <option key={status} value={status} className="bg-theme-header text-theme-text">
@@ -248,11 +249,11 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                   {/* Sponsor Name & Organization */}
                   <td className="p-3">
                     <div className="flex items-start gap-2">
-                      {sponsor.logoUrl && (
+                      {(avatarUrls?.[sponsor.id] || sponsor.logoUrl) && (
                         <img
-                          src={sponsor.logoUrl}
+                          src={avatarUrls?.[sponsor.id] || sponsor.logoUrl!}
                           alt=""
-                          className="w-8 h-8 rounded object-cover flex-shrink-0"
+                          className="w-8 h-8 rounded-full object-cover flex-shrink-0"
                         />
                       )}
                       <div className="min-w-0">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1257,6 +1257,7 @@ export interface UnifiedPartner {
   name: string;
   brandDescription: string;
   logoUrl: string | null;
+  avatarUrl: string | null;
   website: string | null;
   sortOrder: number;
 }


### PR DESCRIPTION
## Summary
- **Dropdown arrows**: Fixed double chevron on status dropdown selects in the partner table. The global CSS adds a background-image arrow to all `<select>` elements, and a custom `<ChevronDown>` icon was also overlaid — now the CSS arrow is suppressed with `backgroundImage: 'none'`.
- **Partner avatars**: Partner thumbnails in both the CRM table and the Brand Description Order section now show the partner's avatar (`coHostAvatarUrl`) instead of their logo (`coHostLogoUrl`). Falls back to logo if no avatar is set. Images are now `rounded-full` for circular style.

## Changes
- `backend/src/routes/sponsor.routes.ts` — Added `avatarUrl` field to unified partners response
- `frontend/src/types.ts` — Added `avatarUrl` to `UnifiedPartner` interface
- `frontend/src/components/sponsors/SponsorCRM.tsx` — Build avatar URL map, pass to SponsorList, use avatar in brand order thumbnails
- `frontend/src/components/sponsors/SponsorList.tsx` — Fix double dropdown arrow, accept/use avatar URLs, circular thumbnails

## Test plan
- [ ] Open a host page with partners → verify status dropdowns show only one arrow
- [ ] Verify partner table thumbnails show circular avatars (not rectangular logos)
- [ ] Verify Brand Description Order thumbnails show circular avatars
- [ ] Partners without avatars should fall back to showing their logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)