### PR TITLE
feat: CDN proxy for Supabase Storage images

### DIFF
--- a/frontend/src/components/HostsList.tsx
+++ b/frontend/src/components/HostsList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { User, Globe, Instagram, Youtube, Linkedin } from 'lucide-react';
+import { cdnUrl } from '../lib/supabase';
 
 interface CoHost {
   id: string;
@@ -94,7 +95,7 @@ export const HostsList: React.FC<HostsListProps> = ({
           <div className={`flex items-center ${config.gap}`}>
             {hostProfile?.avatar_url ? (
               <img
-                src={hostProfile.avatar_url}
+                src={cdnUrl(hostProfile.avatar_url)}
                 alt={displayHostName}
                 className={`${config.avatar} rounded-full object-cover flex-shrink-0`}
               />
@@ -182,7 +183,7 @@ export const HostsList: React.FC<HostsListProps> = ({
           <div key={coHost.id} className={`flex items-center ${config.gap}`}>
             {coHost.avatar_url ? (
               <img
-                src={coHost.avatar_url}
+                src={cdnUrl(coHost.avatar_url)}
                 alt={coHost.name}
                 className={`${config.avatar} rounded-full object-cover flex-shrink-0`}
               />
@@ -263,7 +264,7 @@ export const HostsAvatars: React.FC<HostsAvatarsProps> = ({
         {displayHostName && (
           hostProfile?.avatar_url ? (
             <img
-              src={hostProfile.avatar_url}
+              src={cdnUrl(hostProfile.avatar_url)}
               alt={displayHostName}
               className="w-8 min-w-8 h-8 min-h-8 rounded-full object-cover flex-shrink-0 border-2 border-theme-card"
               style={{ zIndex: 10, marginLeft: '-8px' }}
@@ -282,7 +283,7 @@ export const HostsAvatars: React.FC<HostsAvatarsProps> = ({
           <div key={coHost.id} className="flex-shrink-0" style={{ zIndex: 9 - index, marginLeft: '-8px' }}>
             {coHost.avatar_url ? (
               <img
-                src={coHost.avatar_url}
+                src={cdnUrl(coHost.avatar_url)}
                 alt={coHost.name}
                 className="w-8 min-w-8 h-8 min-h-8 rounded-full object-cover border-2 border-theme-card"
               />

--- a/frontend/src/components/PartyHeader.tsx
+++ b/frontend/src/components/PartyHeader.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePizza } from '../contexts/PizzaContext';
 import { PartyPopper, Link2, Copy, Check, X, Calendar, User, Loader2, Users, MapPin, Lock, Image, FileText, Link as LinkIcon, Upload, Trash2, ChevronDown, ChevronUp, ExternalLink, Pizza } from 'lucide-react';
-import { uploadEventImage } from '../lib/supabase';
+import { uploadEventImage, cdnUrl } from '../lib/supabase';
 import { IconInput } from './IconInput';
 
 export const PartyHeader: React.FC = () => {
@@ -194,7 +194,7 @@ export const PartyHeader: React.FC = () => {
             <div className="w-48 h-48 flex-shrink-0 rounded-xl overflow-hidden">
               {party.eventImageUrl ? (
                 <img
-                  src={party.eventImageUrl}
+                  src={cdnUrl(party.eventImageUrl)}
                   alt={party.name}
                   className="w-full h-full object-cover"
                 />
@@ -612,7 +612,7 @@ export const PartyHeader: React.FC = () => {
                 {party.eventImageUrl ? (
                   <div className="sm:w-48 sm:h-48 w-full aspect-square flex-shrink-0 bg-black/30">
                     <img
-                      src={party.eventImageUrl}
+                      src={cdnUrl(party.eventImageUrl)}
                       alt={party.name}
                       className="w-full h-full object-cover"
                     />

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -7,7 +7,7 @@ import { Download, Loader2, RotateCcw, Move, Plus, ChevronLeft, ChevronRight, Im
 import { useFlyerDrag, DEFAULT_POSITIONS, FlyerPositions } from './useFlyerDrag';
 import { PartnerForm, extractSponsorData } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
-import { uploadEventImage, updateParty } from '../../lib/supabase';
+import { uploadEventImage, updateParty, cdnUrl } from '../../lib/supabase';
 import {
   fitText, loadImg, uses12Hour, formatFlyerTime,
   CITY_FONT, TEXT_FONT, CITY_COLOR, TIME_COLOR, VENUE_COLOR,
@@ -1164,7 +1164,7 @@ export function FlyerGenerator() {
                     style={{ position: 'relative', display: 'inline-block' }}
                   >
                     <img
-                      src={s.logoUrl!}
+                      src={cdnUrl(s.logoUrl!)}
                       alt={s.name}
                       crossOrigin="anonymous"
                       onDoubleClick={(e) => handleLogoDoubleClick(s.id, e)}
@@ -1331,7 +1331,7 @@ export function FlyerGenerator() {
               }}
             >
               <img
-                src={s.logoUrl!}
+                src={cdnUrl(s.logoUrl!)}
                 alt={s.name}
                 crossOrigin="anonymous"
                 onMouseDown={(e) => handleLogoDragStart(s.id, e)}

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { Sponsor, SponsorStatus, SPONSOR_CATEGORIES } from '../../types';
 import { PartnerIntakeButton } from './PartnerIntakeButton';
+import { cdnUrl } from '../../lib/supabase';
 
 interface SponsorListProps {
   sponsors: Sponsor[];
@@ -247,7 +248,7 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                     <div className="flex items-start gap-2">
                       {(avatarUrls?.[sponsor.id] || sponsor.logoUrl) && (
                         <img
-                          src={avatarUrls?.[sponsor.id] || sponsor.logoUrl!}
+                          src={cdnUrl(avatarUrls?.[sponsor.id] || sponsor.logoUrl!)}
                           alt=""
                           className="w-8 h-8 rounded-full object-cover flex-shrink-0"
                         />

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -20,6 +20,20 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
+const SUPABASE_STORAGE_PREFIX = 'https://znpiwdvvsqaxuskpfleo.supabase.co/storage/v1/object/public/';
+
+/**
+ * Rewrite a Supabase Storage public URL to go through the Vercel edge CDN.
+ * Non-matching URLs pass through unchanged.
+ */
+export function cdnUrl(url: string): string {
+  if (!url) return url;
+  if (url.startsWith(SUPABASE_STORAGE_PREFIX)) {
+    return '/cdn/' + url.slice(SUPABASE_STORAGE_PREFIX.length);
+  }
+  return url;
+}
+
 // Helper to check if user is authenticated
 function isAuthenticated(): boolean {
   return !!localStorage.getItem('authToken');

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -11,6 +11,7 @@ import {
   Search, ThumbsUp, ThumbsDown, BarChart3, Calendar, MapPin,
   Wallet, TrendingUp, StickyNote, MessageCircle, MousePointerClick, Eye,
 } from 'lucide-react';
+import { cdnUrl } from '../lib/supabase';
 import type { SponsorDashboardEvent, SponsorMeResponse, SponsorDashboardData, CoHost } from '../types';
 import { GPP_REGIONS } from '../types';
 
@@ -632,7 +633,7 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
       {event.eventImageUrl && (
         <div className="md:w-44 flex-shrink-0 self-stretch bg-black/40 flex items-center justify-center">
           <img
-            src={event.eventImageUrl}
+            src={cdnUrl(event.eventImageUrl)}
             alt=""
             className="w-full h-32 md:h-full object-contain"
           />
@@ -758,7 +759,7 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
                   className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-theme-surface text-xs text-theme-text-secondary"
                 >
                   {host.avatar_url && (
-                    <img src={host.avatar_url} alt="" className="w-3.5 h-3.5 rounded-full" />
+                    <img src={cdnUrl(host.avatar_url)} alt="" className="w-3.5 h-3.5 rounded-full" />
                   )}
                   {host.name}
                 </span>

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,11 +1,24 @@
 {
   "rewrites": [
     {
-      "source": "/((?!assets/).*)",
+      "source": "/cdn/:path*",
+      "destination": "https://znpiwdvvsqaxuskpfleo.supabase.co/storage/v1/object/public/:path*"
+    },
+    {
+      "source": "/((?!assets/|cdn/).*)",
       "destination": "/index.html"
     }
   ],
   "headers": [
+    {
+      "source": "/cdn/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, s-maxage=31536000, immutable"
+        }
+      ]
+    },
     {
       "source": "/assets/(.*)",
       "headers": [


### PR DESCRIPTION
## Summary
- Proxy `/cdn/*` requests through Vercel's edge network to Supabase Storage, caching images for 1 year at edge / 1 day in browser
- Add `cdnUrl()` helper that rewrites Supabase Storage URLs → `/cdn/...` at render time
- Wrap image `src` attributes in high-traffic components: HostsList, PartyHeader, SponsorList, FlyerGenerator, PartnerDashboardPage

## Why
Regenerating 362 flyers exceeded Supabase Storage egress quota, causing 402 errors on ALL images site-wide. This CDN layer ensures repeated image loads hit Vercel's edge cache instead of Supabase bandwidth.

## What stays the same
- DB stores original Supabase URLs (no migration)
- Upload functions still upload directly to Supabase
- Backend unchanged

## Test plan
- [ ] Images load via `/cdn/` URLs (check DevTools Network tab)
- [ ] Verify `x-vercel-cache: HIT` header on repeat image loads
- [ ] Original Supabase URLs still work as fallback
- [ ] Event images, host avatars, co-host avatars, sponsor logos all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)