### PR TITLE
feat: confirmed venue shortcut on venue tab

### DIFF
--- a/frontend/src/components/venue/VenueForm.tsx
+++ b/frontend/src/components/venue/VenueForm.tsx
@@ -10,6 +10,7 @@ interface VenueFormProps {
   venue?: Venue;
   onSave: (data: VenueCreateData) => Promise<void>;
   onClose: () => void;
+  initialStatus?: VenueStatus;
 }
 
 const venueStatusOptions: { value: VenueStatus; label: string }[] = [
@@ -53,7 +54,7 @@ function fetchPlaceDetails(placeId: string): Promise<google.maps.places.PlaceRes
 // Shows only a LocationAutocomplete search. When a place is picked, auto-creates
 // the venue and closes the modal.
 
-const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: VenueFormProps['onClose'] }> = ({ onSave, onClose }) => {
+const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: VenueFormProps['onClose']; initialStatus?: VenueStatus }> = ({ onSave, onClose, initialStatus }) => {
   const [searchValue, setSearchValue] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -107,13 +108,14 @@ const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: Venue
         address: address.trim() || undefined,
         website,
         contactPhone,
+        ...(initialStatus ? { status: initialStatus } : {}),
       });
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add venue');
       setSaving(false);
     }
-  }, [saving, onSave, onClose]);
+  }, [saving, onSave, onClose, initialStatus]);
 
   return createPortal(
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={onClose}>
@@ -459,5 +461,5 @@ export const VenueForm: React.FC<VenueFormProps> = (props) => {
   if (props.venue) {
     return <EditVenueForm {...props} />;
   }
-  return <AddVenueModal onSave={props.onSave} onClose={props.onClose} />;
+  return <AddVenueModal onSave={props.onSave} onClose={props.onClose} initialStatus={props.initialStatus} />;
 };

--- a/frontend/src/components/venue/VenueWidget.tsx
+++ b/frontend/src/components/venue/VenueWidget.tsx
@@ -37,6 +37,7 @@ export const VenueWidget: React.FC<VenueWidgetProps> = ({ partyId, onVenueSelect
   const [venues, setVenues] = useState<Venue[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
+  const [confirmedMode, setConfirmedMode] = useState(false);
   const [editingVenue, setEditingVenue] = useState<Venue | null>(null);
   const [expandedVenue, setExpandedVenue] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -65,6 +66,12 @@ export const VenueWidget: React.FC<VenueWidgetProps> = ({ partyId, onVenueSelect
       if (venue) {
         setVenues(prev => [venue, ...prev]);
         setShowForm(false);
+
+        // In confirmed mode, auto-select the venue
+        if (confirmedMode) {
+          setConfirmedMode(false);
+          await handleSelect(venue.id);
+        }
       }
     } catch (error) {
       throw error;
@@ -166,7 +173,7 @@ export const VenueWidget: React.FC<VenueWidgetProps> = ({ partyId, onVenueSelect
         </div>
         <button
           type="button"
-          onClick={() => setShowForm(true)}
+          onClick={() => { setConfirmedMode(false); setShowForm(true); }}
           className="flex items-center gap-1.5 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-3 py-1.5 rounded-lg transition-colors text-sm"
         >
           <Plus size={16} />
@@ -178,15 +185,25 @@ export const VenueWidget: React.FC<VenueWidgetProps> = ({ partyId, onVenueSelect
       {venues.length === 0 ? (
         <div className="card p-8 text-center">
           <MapPin size={32} className="mx-auto mb-3 text-theme-text-faint" />
-          <p className="text-theme-text-secondary mb-4">No venue options yet</p>
-          <button
-            type="button"
-            onClick={() => setShowForm(true)}
-            className="inline-flex items-center gap-2 bg-theme-surface-hover hover:bg-theme-surface-hover text-theme-text font-medium px-4 py-2 rounded-lg transition-colors"
-          >
-            <Plus size={18} />
-            Add Your First Venue
-          </button>
+          <p className="text-theme-text-secondary mb-4">Where's the party?</p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => { setConfirmedMode(true); setShowForm(true); }}
+              className="inline-flex items-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-5 py-2.5 rounded-lg transition-colors"
+            >
+              <Check size={18} />
+              I Have My Venue
+            </button>
+            <button
+              type="button"
+              onClick={() => { setConfirmedMode(false); setShowForm(true); }}
+              className="inline-flex items-center gap-2 bg-theme-surface-hover hover:bg-theme-surface text-theme-text-secondary font-medium px-5 py-2.5 rounded-lg transition-colors"
+            >
+              <Plus size={18} />
+              Still Exploring
+            </button>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">
@@ -440,7 +457,9 @@ export const VenueWidget: React.FC<VenueWidgetProps> = ({ partyId, onVenueSelect
           onClose={() => {
             setShowForm(false);
             setEditingVenue(null);
+            setConfirmedMode(false);
           }}
+          initialStatus={confirmedMode ? 'confirmed' : undefined}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds a two-option empty state on the venue tab: **"I Have My Venue"** vs **"Still Exploring"**
- "I Have My Venue" creates the venue with `confirmed` status and auto-selects it in one step
- Saves hosts from navigating the full multi-option tracker when they already have their venue locked in

## Changes
- `VenueWidget.tsx` — new empty state UI, `confirmedMode` state, auto-select after creation
- `VenueForm.tsx` — `initialStatus` prop passed through to AddVenueModal

## Test plan
- [ ] Go to venue tab on a party with no venues → see two buttons
- [ ] Click "I Have My Venue" → search and select a place → venue created as confirmed + auto-selected
- [ ] Click "Still Exploring" → same as before (researching status, no auto-select)
- [ ] Header "Add Venue" button still works normally
- [ ] Closing modal without selecting resets state

🤖 Generated with [Claude Code](https://claude.com/claude-code)