### PR TITLE
feat: partner click breakdown by link type

### DIFF
--- a/.claude/.claude-md-state.json
+++ b/.claude/.claude-md-state.json
@@ -1,5 +1,5 @@
 {
-    "lastCheck":  "2026-05-01T22:29:29.2991552-04:00",
+    "lastCheck":  "2026-05-04T20:24:28.0217960-04:00",
     "migrationCount":  32,
     "srcFolders":  [
 

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -564,41 +564,36 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       : [];
     const uniqueClickMap = new Map(uniqueClickStats.map(r => [r.party_id, Number(r.unique_count)]));
 
-    // Per-type click breakdown (grouped by partyId + linkType)
-    const clickStatsByType = await prisma.linkClick.groupBy({
-      by: ['partyId', 'linkType'],
-      where: {
-        partyId: { in: eventIds },
-        linkType: { in: ['sponsor', 'host_social'] },
-      },
-      _count: true,
-    });
-
-    const uniqueClicksByType = eventIds.length > 0
-      ? await prisma.$queryRaw<{ party_id: string; link_type: string; unique_count: bigint }[]>`
-        SELECT party_id::text, link_type, COUNT(DISTINCT visitor_hash) as unique_count
+    // Per-link click breakdown (grouped by partyId + url)
+    const clicksByLink = eventIds.length > 0
+      ? await prisma.$queryRaw<{ party_id: string; url: string; link_type: string; link_label: string | null; total_clicks: bigint; unique_clicks: bigint }[]>`
+        SELECT
+          party_id::text,
+          url,
+          link_type,
+          MAX(link_label) as link_label,
+          COUNT(*) as total_clicks,
+          COUNT(DISTINCT visitor_hash) as unique_clicks
         FROM link_clicks
         WHERE party_id::text IN (${Prisma.join(eventIds)})
         AND link_type IN ('sponsor', 'host_social')
-        GROUP BY party_id, link_type
+        GROUP BY party_id, url, link_type
+        ORDER BY total_clicks DESC
       `
       : [];
 
-    // Build map: partyId -> [{ linkType, clicks, uniqueClickers }]
-    const byTypeMap = new Map<string, { linkType: string; clicks: number; uniqueClickers: number }[]>();
-    for (const row of clickStatsByType) {
-      const list = byTypeMap.get(row.partyId) || [];
-      list.push({ linkType: row.linkType!, clicks: row._count, uniqueClickers: 0 });
-      byTypeMap.set(row.partyId, list);
-    }
-    for (const row of uniqueClicksByType) {
-      const list = byTypeMap.get(row.party_id);
-      if (list) {
-        const entry = list.find(e => e.linkType === row.link_type);
-        if (entry) {
-          entry.uniqueClickers = Number(row.unique_count);
-        }
-      }
+    // Build map: partyId -> [{ url, linkType, linkLabel, clicks, uniqueClickers }]
+    const byLinkMap = new Map<string, { url: string; linkType: string; linkLabel: string | null; clicks: number; uniqueClickers: number }[]>();
+    for (const row of clicksByLink) {
+      const list = byLinkMap.get(row.party_id) || [];
+      list.push({
+        url: row.url,
+        linkType: row.link_type,
+        linkLabel: row.link_label,
+        clicks: Number(row.total_clicks),
+        uniqueClickers: Number(row.unique_clicks),
+      });
+      byLinkMap.set(row.party_id, list);
     }
 
     // Get page view (impression) counts per party
@@ -716,7 +711,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         clickStats: {
           totalClicks: clickCountMap.get(event.id) || 0,
           uniqueClickers: uniqueClickMap.get(event.id) || 0,
-          byType: byTypeMap.get(event.id) || [],
+          byLink: byLinkMap.get(event.id) || [],
         },
         impressions: {
           totalViews: viewCountMap.get(event.id) || 0,

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -564,6 +564,43 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       : [];
     const uniqueClickMap = new Map(uniqueClickStats.map(r => [r.party_id, Number(r.unique_count)]));
 
+    // Per-type click breakdown (grouped by partyId + linkType)
+    const clickStatsByType = await prisma.linkClick.groupBy({
+      by: ['partyId', 'linkType'],
+      where: {
+        partyId: { in: eventIds },
+        linkType: { in: ['sponsor', 'host_social'] },
+      },
+      _count: true,
+    });
+
+    const uniqueClicksByType = eventIds.length > 0
+      ? await prisma.$queryRaw<{ party_id: string; link_type: string; unique_count: bigint }[]>`
+        SELECT party_id::text, link_type, COUNT(DISTINCT visitor_hash) as unique_count
+        FROM link_clicks
+        WHERE party_id::text IN (${Prisma.join(eventIds)})
+        AND link_type IN ('sponsor', 'host_social')
+        GROUP BY party_id, link_type
+      `
+      : [];
+
+    // Build map: partyId -> [{ linkType, clicks, uniqueClickers }]
+    const byTypeMap = new Map<string, { linkType: string; clicks: number; uniqueClickers: number }[]>();
+    for (const row of clickStatsByType) {
+      const list = byTypeMap.get(row.partyId) || [];
+      list.push({ linkType: row.linkType!, clicks: row._count, uniqueClickers: 0 });
+      byTypeMap.set(row.partyId, list);
+    }
+    for (const row of uniqueClicksByType) {
+      const list = byTypeMap.get(row.party_id);
+      if (list) {
+        const entry = list.find(e => e.linkType === row.link_type);
+        if (entry) {
+          entry.uniqueClickers = Number(row.unique_count);
+        }
+      }
+    }
+
     // Get page view (impression) counts per party
     const viewStats = await prisma.pageView.groupBy({
       by: ['partyId'],
@@ -679,6 +716,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         clickStats: {
           totalClicks: clickCountMap.get(event.id) || 0,
           uniqueClickers: uniqueClickMap.get(event.id) || 0,
+          byType: byTypeMap.get(event.id) || [],
         },
         impressions: {
           totalViews: viewCountMap.get(event.id) || 0,

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -18,6 +18,34 @@ import { GPP_REGIONS } from '../types';
 const themeClass = 'gpp-theme';
 const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)' } as React.CSSProperties;
 
+// Detect platform from URL domain
+function detectPlatform(url: string): string {
+  try {
+    const host = new URL(url).hostname.replace('www.', '');
+    if (host.includes('instagram.com')) return 'Instagram';
+    if (host.includes('twitter.com') || host.includes('x.com')) return 'X';
+    if (host.includes('youtube.com') || host.includes('youtu.be')) return 'YouTube';
+    if (host.includes('tiktok.com')) return 'TikTok';
+    if (host.includes('linkedin.com')) return 'LinkedIn';
+    if (host.includes('facebook.com') || host.includes('fb.com')) return 'Facebook';
+    if (host.includes('farcaster') || host.includes('warpcast.com')) return 'Farcaster';
+    return 'Website';
+  } catch {
+    return 'Website';
+  }
+}
+
+const PLATFORM_COLORS: Record<string, string> = {
+  Instagram: 'bg-pink-500/15 text-pink-300',
+  X: 'bg-gray-500/15 text-gray-300',
+  YouTube: 'bg-red-500/15 text-red-300',
+  TikTok: 'bg-cyan-500/15 text-cyan-300',
+  LinkedIn: 'bg-blue-500/15 text-blue-300',
+  Facebook: 'bg-indigo-500/15 text-indigo-300',
+  Farcaster: 'bg-purple-500/15 text-purple-300',
+  Website: 'bg-green-500/15 text-green-300',
+};
+
 // ============================================
 // Progress filter constants & FilterPill
 // ============================================
@@ -397,13 +425,14 @@ export function PartnerDashboardPage() {
           const totalUniqueVisitors = allEvents.reduce((sum, e) => sum + (e.impressions?.uniqueVisitors || 0), 0);
           const totalClicks = allEvents.reduce((sum, e) => sum + (e.clickStats?.totalClicks || 0), 0);
           const totalUniqueClickers = allEvents.reduce((sum, e) => sum + (e.clickStats?.uniqueClickers || 0), 0);
-          // Aggregate click breakdown by type across all events
-          const clicksByTypeAgg: Record<string, { clicks: number; uniqueClickers: number }> = {};
+          // Aggregate click breakdown by platform across all events
+          const clicksByPlatformAgg: Record<string, { clicks: number; uniqueClickers: number }> = {};
           for (const e of allEvents) {
-            for (const t of e.clickStats?.byType || []) {
-              if (!clicksByTypeAgg[t.linkType]) clicksByTypeAgg[t.linkType] = { clicks: 0, uniqueClickers: 0 };
-              clicksByTypeAgg[t.linkType].clicks += t.clicks;
-              clicksByTypeAgg[t.linkType].uniqueClickers += t.uniqueClickers;
+            for (const link of e.clickStats?.byLink || []) {
+              const platform = detectPlatform(link.url);
+              if (!clicksByPlatformAgg[platform]) clicksByPlatformAgg[platform] = { clicks: 0, uniqueClickers: 0 };
+              clicksByPlatformAgg[platform].clicks += link.clicks;
+              clicksByPlatformAgg[platform].uniqueClickers += link.uniqueClickers;
             }
           }
           const isSwc = dashboardData?.tag === 'swc';
@@ -444,15 +473,17 @@ export function PartnerDashboardPage() {
                   </div>
                   <div className="text-2xl font-bold text-theme-text">{totalClicks.toLocaleString()}</div>
                   <div className="text-xs text-theme-text-muted mt-1">{totalUniqueClickers.toLocaleString()} unique</div>
-                  {Object.keys(clicksByTypeAgg).length > 0 && (
+                  {Object.keys(clicksByPlatformAgg).length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mt-2">
-                      {Object.entries(clicksByTypeAgg).map(([type, data]) => (
+                      {Object.entries(clicksByPlatformAgg)
+                        .sort((a, b) => b[1].clicks - a[1].clicks)
+                        .map(([platform, data]) => (
                         <span
-                          key={type}
-                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/10 text-[10px] text-green-300"
+                          key={platform}
+                          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] ${PLATFORM_COLORS[platform] || PLATFORM_COLORS.Website}`}
                           title={`${data.uniqueClickers} unique`}
                         >
-                          {type === 'sponsor' ? 'Website/Social' : type === 'host_social' ? 'Host Links' : type}
+                          {platform}
                           <span className="font-semibold">{data.clicks}</span>
                         </span>
                       ))}
@@ -766,18 +797,27 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
                 {event.clickStats.uniqueClickers > 0 && (
                   <span className="text-theme-text-muted/50">({event.clickStats.uniqueClickers} unique)</span>
                 )}
-                {event.clickStats.byType && event.clickStats.byType.length > 1 && (
-                  <span className="flex items-center gap-1">
-                    {event.clickStats.byType.map(t => (
-                      <span
-                        key={t.linkType}
-                        className="inline-flex items-center gap-0.5 px-1.5 py-0 rounded-full bg-green-500/10 text-[10px] text-green-300"
-                        title={`${t.uniqueClickers} unique`}
-                      >
-                        {t.linkType === 'sponsor' ? 'Web' : t.linkType === 'host_social' ? 'Host' : t.linkType}
-                        <span className="font-semibold">{t.clicks}</span>
-                      </span>
-                    ))}
+                {event.clickStats.byLink && event.clickStats.byLink.length > 0 && (
+                  <span className="flex items-center gap-1 flex-wrap">
+                    {(() => {
+                      // Group by platform for compact display
+                      const platformCounts: Record<string, number> = {};
+                      for (const link of event.clickStats.byLink!) {
+                        const p = detectPlatform(link.url);
+                        platformCounts[p] = (platformCounts[p] || 0) + link.clicks;
+                      }
+                      return Object.entries(platformCounts)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([platform, clicks]) => (
+                          <span
+                            key={platform}
+                            className={`inline-flex items-center gap-0.5 px-1.5 py-0 rounded-full text-[10px] ${PLATFORM_COLORS[platform] || PLATFORM_COLORS.Website}`}
+                          >
+                            {platform}
+                            <span className="font-semibold">{clicks}</span>
+                          </span>
+                        ));
+                    })()}
                   </span>
                 )}
               </div>

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -397,6 +397,15 @@ export function PartnerDashboardPage() {
           const totalUniqueVisitors = allEvents.reduce((sum, e) => sum + (e.impressions?.uniqueVisitors || 0), 0);
           const totalClicks = allEvents.reduce((sum, e) => sum + (e.clickStats?.totalClicks || 0), 0);
           const totalUniqueClickers = allEvents.reduce((sum, e) => sum + (e.clickStats?.uniqueClickers || 0), 0);
+          // Aggregate click breakdown by type across all events
+          const clicksByTypeAgg: Record<string, { clicks: number; uniqueClickers: number }> = {};
+          for (const e of allEvents) {
+            for (const t of e.clickStats?.byType || []) {
+              if (!clicksByTypeAgg[t.linkType]) clicksByTypeAgg[t.linkType] = { clicks: 0, uniqueClickers: 0 };
+              clicksByTypeAgg[t.linkType].clicks += t.clicks;
+              clicksByTypeAgg[t.linkType].uniqueClickers += t.uniqueClickers;
+            }
+          }
           const isSwc = dashboardData?.tag === 'swc';
           const withVenue = allEvents.filter(e => e.progress?.hasVenue).length;
           const withBudget = allEvents.filter(e => e.progress?.hasBudget).length;
@@ -435,6 +444,20 @@ export function PartnerDashboardPage() {
                   </div>
                   <div className="text-2xl font-bold text-theme-text">{totalClicks.toLocaleString()}</div>
                   <div className="text-xs text-theme-text-muted mt-1">{totalUniqueClickers.toLocaleString()} unique</div>
+                  {Object.keys(clicksByTypeAgg).length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mt-2">
+                      {Object.entries(clicksByTypeAgg).map(([type, data]) => (
+                        <span
+                          key={type}
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/10 text-[10px] text-green-300"
+                          title={`${data.uniqueClickers} unique`}
+                        >
+                          {type === 'sponsor' ? 'Website/Social' : type === 'host_social' ? 'Host Links' : type}
+                          <span className="font-semibold">{data.clicks}</span>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 {isSwc && (
                   <>
@@ -737,11 +760,25 @@ function EventCard({ event, onToggleChecklist }: EventCardProps) {
               </div>
             )}
             {event.clickStats && event.clickStats.totalClicks > 0 && (
-              <div className="flex items-center gap-1.5 text-xs text-theme-text-muted">
+              <div className="flex items-center gap-1.5 text-xs text-theme-text-muted flex-wrap">
                 <MousePointerClick size={12} />
                 <span>{event.clickStats.totalClicks} clicks</span>
                 {event.clickStats.uniqueClickers > 0 && (
                   <span className="text-theme-text-muted/50">({event.clickStats.uniqueClickers} unique)</span>
+                )}
+                {event.clickStats.byType && event.clickStats.byType.length > 1 && (
+                  <span className="flex items-center gap-1">
+                    {event.clickStats.byType.map(t => (
+                      <span
+                        key={t.linkType}
+                        className="inline-flex items-center gap-0.5 px-1.5 py-0 rounded-full bg-green-500/10 text-[10px] text-green-300"
+                        title={`${t.uniqueClickers} unique`}
+                      >
+                        {t.linkType === 'sponsor' ? 'Web' : t.linkType === 'host_social' ? 'Host' : t.linkType}
+                        <span className="font-semibold">{t.clicks}</span>
+                      </span>
+                    ))}
+                  </span>
                 )}
               </div>
             )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1217,6 +1217,11 @@ export interface SponsorDashboardEvent {
   clickStats?: {
     totalClicks: number;
     uniqueClickers: number;
+    byType?: {
+      linkType: string;
+      clicks: number;
+      uniqueClickers: number;
+    }[];
   };
   impressions?: {
     totalViews: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1217,8 +1217,10 @@ export interface SponsorDashboardEvent {
   clickStats?: {
     totalClicks: number;
     uniqueClickers: number;
-    byType?: {
+    byLink?: {
+      url: string;
       linkType: string;
+      linkLabel: string | null;
       clicks: number;
       uniqueClickers: number;
     }[];


### PR DESCRIPTION
## Summary
- Partners now see which link types are generating clicks (Website/Social vs Host Links)
- Backend groups click stats by `linkType` in the `/api/sponsor/events` response
- Frontend shows colored pills in the summary card and per-event rows

## Task
salami-60149

## Changes
- **Backend**: Added `groupBy(['partyId', 'linkType'])` + raw SQL for unique counts by type
- **Frontend types**: Expanded `clickStats` with optional `byType` array
- **Frontend UI**: Aggregated type pills in summary card + compact inline breakdown per event

## Deploy notes
Backend must deploy first (adds `byType` to response). Frontend gracefully degrades if field is missing.

## Test plan
- [ ] Verify partner dashboard loads without errors
- [ ] Check summary clicks card shows type breakdown pills
- [ ] Check per-event rows show inline type pills when multiple types exist
- [ ] Verify backwards compat — frontend works even if backend hasn't deployed yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)