### PR TITLE
fix: sync venue coordinates to party on select

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -788,6 +788,8 @@ model Venue {
   capacity     Int?
   cost         Decimal?  @db.Decimal(10, 2)
   organization String?
+  latitude     Float?
+  longitude    Float?
 
   // Contact
   pointPerson   String?  @map("point_person")

--- a/backend/src/routes/venue.routes.ts
+++ b/backend/src/routes/venue.routes.ts
@@ -52,7 +52,7 @@ router.post('/:partyId/venues', async (req: AuthRequest, res: Response, next: Ne
     const {
       name, address, website, capacity, cost, organization,
       pointPerson, contactName, contactEmail, contactPhone,
-      status, notes, pros, cons
+      status, notes, pros, cons, latitude, longitude
     } = req.body;
 
     // Verify ownership or super admin
@@ -88,6 +88,8 @@ router.post('/:partyId/venues', async (req: AuthRequest, res: Response, next: Ne
         notes: notes?.trim() || null,
         pros: pros?.trim() || null,
         cons: cons?.trim() || null,
+        latitude: latitude != null ? parseFloat(latitude) : null,
+        longitude: longitude != null ? parseFloat(longitude) : null,
       },
     });
 
@@ -104,7 +106,7 @@ router.patch('/:partyId/venues/:venueId', async (req: AuthRequest, res: Response
     const {
       name, address, website, capacity, cost, organization,
       pointPerson, contactName, contactEmail, contactPhone,
-      status, notes, pros, cons
+      status, notes, pros, cons, latitude, longitude
     } = req.body;
 
     // Verify ownership or super admin
@@ -145,6 +147,8 @@ router.patch('/:partyId/venues/:venueId', async (req: AuthRequest, res: Response
         ...(notes !== undefined && { notes: notes?.trim() || null }),
         ...(pros !== undefined && { pros: pros?.trim() || null }),
         ...(cons !== undefined && { cons: cons?.trim() || null }),
+        ...(latitude !== undefined && { latitude: latitude != null ? parseFloat(latitude) : null }),
+        ...(longitude !== undefined && { longitude: longitude != null ? parseFloat(longitude) : null }),
       },
       include: {
         photos: {
@@ -224,7 +228,7 @@ router.patch('/:partyId/venues/:venueId/select', async (req: AuthRequest, res: R
     // Use a transaction to:
     // 1. Deselect all other venues for this party
     // 2. Select this venue
-    // 3. Copy venue name and address to party
+    // 3. Copy venue name, address, and coordinates to party
     const [, venue, party] = await prisma.$transaction([
       // Deselect all venues for this party
       prisma.venue.updateMany({
@@ -236,12 +240,14 @@ router.patch('/:partyId/venues/:venueId/select', async (req: AuthRequest, res: R
         where: { id: venueId },
         data: { isSelected: true },
       }),
-      // Update party with venue name and address
+      // Update party with venue name, address, and coordinates
       prisma.party.update({
         where: { id: partyId },
         data: {
           venueName: existingVenue.name,
           address: existingVenue.address,
+          latitude: existingVenue.latitude,
+          longitude: existingVenue.longitude,
         },
       }),
     ]);

--- a/frontend/src/components/venue/VenueForm.tsx
+++ b/frontend/src/components/venue/VenueForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Loader2, MapPin, Users, DollarSign, User, Phone, Mail, Globe, FileText, Building2, ThumbsUp, ThumbsDown } from 'lucide-react';
 import { Venue, VenueStatus } from '../../types';
@@ -58,6 +58,7 @@ const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: Venue
   const [searchValue, setSearchValue] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const pendingCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
 
   const handlePlaceSelected = useCallback(async (address: string, venueName: string | null) => {
     if (saving) return;
@@ -102,6 +103,9 @@ const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: Venue
       // Non-critical — we'll create the venue without extra details
     }
 
+    // Capture coordinates from the pending ref
+    const coords = pendingCoordsRef.current;
+
     try {
       await onSave({
         name: name.trim(),
@@ -109,6 +113,7 @@ const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: Venue
         website,
         contactPhone,
         ...(initialStatus ? { status: initialStatus } : {}),
+        ...(coords ? { latitude: coords.lat, longitude: coords.lng } : {}),
       });
       onClose();
     } catch (err) {
@@ -154,6 +159,9 @@ const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: Venue
                 value={searchValue}
                 onChange={setSearchValue}
                 onPlaceSelected={handlePlaceSelected}
+                onLocationSelected={(loc) => {
+                  pendingCoordsRef.current = loc;
+                }}
                 types={['establishment']}
                 fields={['formatted_address', 'name', 'place_id', 'geometry', 'website']}
                 placeholder="Search for a venue..."

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1158,6 +1158,8 @@ export interface VenueCreateData {
   notes?: string;
   pros?: string;
   cons?: string;
+  latitude?: number;
+  longitude?: number;
 }
 
 export interface VenueUpdateData extends Partial<VenueCreateData> {}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -160,6 +160,8 @@ export interface Venue {
   capacity: number | null;
   cost: number | null;
   organization: string | null;
+  latitude: number | null;
+  longitude: number | null;
   pointPerson: string | null;
   contactName: string | null;
   contactEmail: string | null;


### PR DESCRIPTION
## Summary
- Adds `latitude`/`longitude` fields to Venue model
- Captures coordinates from Google Places when adding a venue
- Syncs lat/lng to party record when venue is selected as location
- Fixes maps not showing on event pages after venue selection

## Root cause
The AddVenueModal used LocationAutocomplete (which provides coords) but never captured them. The venue select endpoint only synced name + address, not coordinates.

## Test plan
- [ ] Add a venue via venue tab → verify coordinates are stored on the venue
- [ ] Select venue as location → verify party has lat/lng and map shows on event page
- [ ] Edit a venue → coordinates preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)