### PR TITLE
feat: sponsor pricing suggestion in underboss

### DIFF
--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { Search, ArrowUpDown, ThumbsUp, ThumbsDown, ChevronDown, Check, X } from 'lucide-react';
+import { Search, ArrowUpDown, ThumbsUp, ThumbsDown, ChevronDown, Check, X, DollarSign } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { EventRow } from './EventRow';
 import { EventCard } from './EventCard';
 import { bulkApproveEvents, bulkDeleteEvents, bulkUpdateEventTags } from '../../lib/api';
 import type { UnderbossEvent, UnderbossEventProgress } from '../../types';
+import { calculateTagSponsorshipTotal } from '../../utils/sponsorshipPricing';
 
 interface EventTableProps {
   events: UnderbossEvent[];
@@ -219,6 +220,11 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     [events]
   );
 
+  const sponsorshipSuggestion = useMemo(() => {
+    if (tagFilter === 'all' || filteredEvents.length === 0) return null;
+    return calculateTagSponsorshipTotal(filteredEvents);
+  }, [tagFilter, filteredEvents]);
+
   function toggleSelectAll() {
     if (selectedIds.size === filteredEvents.length) {
       setSelectedIds(new Set());
@@ -336,6 +342,18 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           </button>
         )}
       </div>
+
+      {/* Sponsorship pricing suggestion banner */}
+      {sponsorshipSuggestion && (
+        <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-green-500/10 border border-green-500/20">
+          <DollarSign size={14} className="text-green-400" />
+          <span className="text-sm text-green-400">
+            Suggested sponsorship for "<span className="font-medium">{tagFilter}</span>"
+            ({sponsorshipSuggestion.eventCount} events):
+            <span className="font-bold ml-1">${sponsorshipSuggestion.total.toLocaleString()}</span>
+          </span>
+        </div>
+      )}
 
       {/* Bulk action bar — always visible */}
       <div className="sticky top-0 z-30 flex items-center gap-3 px-4 py-2 rounded-lg bg-theme-surface border border-theme-stroke">

--- a/frontend/src/utils/sponsorshipPricing.ts
+++ b/frontend/src/utils/sponsorshipPricing.ts
@@ -1,0 +1,57 @@
+import type { UnderbossEvent } from '../types';
+
+const TIER_1_CITIES = [
+  'new york', 'nyc', 'los angeles', 'san francisco', 'chicago', 'miami', 'toronto', 'mexico city',
+  'london', 'paris', 'berlin', 'amsterdam', 'barcelona', 'lisbon', 'milan',
+  'tokyo', 'singapore', 'hong kong', 'seoul', 'sydney', 'melbourne', 'bangkok', 'dubai', 'mumbai',
+  'sao paulo', 'buenos aires',
+];
+
+/**
+ * Check if a city name matches a tier-1 city.
+ * Normalizes by lowercasing and stripping hyphens/spaces, then checks
+ * if any tier-1 city string is contained in the normalized name.
+ */
+export function isTier1City(cityName: string): boolean {
+  const normalized = cityName.toLowerCase().replace(/[-\s]/g, '');
+  return TIER_1_CITIES.some((tier1) => {
+    const normalizedTier1 = tier1.replace(/[-\s]/g, '');
+    return normalized.includes(normalizedTier1);
+  });
+}
+
+/**
+ * Calculate the sponsorship price for a single event.
+ * Base price scales linearly from $2 (30 guests) to $500 (250 guests).
+ * Tier-1 cities get a 2x multiplier.
+ * Guest count is clamped to [30, 250].
+ */
+export function calculateEventPrice(guests: number, cityName: string): number {
+  const clamped = Math.max(30, Math.min(250, guests));
+  // Linear interpolation: $2 at 30 guests, $500 at 250 guests
+  const base = 2 + ((clamped - 30) / (250 - 30)) * (500 - 2);
+  const multiplier = isTier1City(cityName) ? 2 : 1;
+  return Math.round(base * multiplier);
+}
+
+/**
+ * Calculate the total sponsorship suggestion for a set of events.
+ * Extracts city name by stripping "Global Pizza Party " prefix from event name.
+ * Uses expectedGuests if available, falls back to guestCount, defaults to 30.
+ */
+export function calculateTagSponsorshipTotal(
+  events: UnderbossEvent[]
+): { total: number; eventCount: number } {
+  const prefix = 'Global Pizza Party ';
+  let total = 0;
+
+  for (const event of events) {
+    const cityName = event.name.startsWith(prefix)
+      ? event.name.slice(prefix.length)
+      : event.name;
+    const guests = event.expectedGuests ?? event.guestCount ?? 30;
+    total += calculateEventPrice(guests, cityName);
+  }
+
+  return { total, eventCount: events.length };
+}


### PR DESCRIPTION
## Summary
- Shows suggested sponsorship price when filtering events by tag in underboss
- Per-event price scales $2 (30 guests) to $500 (250 guests), 2x for major cities
- Green banner appears between filter pills and bulk actions

## Changes
- **New:** `frontend/src/utils/sponsorshipPricing.ts` — pricing logic + tier-1 city list
- **Edit:** `frontend/src/components/underboss/EventTable.tsx` — pricing banner UI

## Test plan
- [ ] Select a tag in underboss events → green pricing banner appears
- [ ] Select "All" tag → banner disappears
- [ ] Verify major cities (NYC, London) get higher per-event prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)