### PR TITLE
feat: PostHog analytics for RSVP funnel

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "date-fns": "^4.1.0",
     "html5-qrcode": "^2.3.8",
     "lucide-react": "^0.344.0",
+    "posthog-js": "^1.372.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,9 +3,19 @@ import { createRoot } from 'react-dom/client';
 import { WagmiProvider } from 'wagmi';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConnectKitProvider } from 'connectkit';
+import posthog from 'posthog-js';
 import { wagmiConfig } from './lib/wagmiConfig';
 import App from './App.tsx';
 import './index.css';
+
+// Initialize PostHog (production only)
+const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
+if (posthogKey) {
+  posthog.init(posthogKey, {
+    api_host: 'https://us.i.posthog.com',
+    autocapture: true,
+  });
+}
 
 const queryClient = new QueryClient();
 

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { MapPin, Users, Pizza, Loader2, Lock, AlertCircle, Settings, Heart, Camera, Link2, LogIn } from 'lucide-react';
+import posthog from 'posthog-js';
 import { verifyPartyPassword, isUserGuestAtParty, getExistingGuest, ExistingGuestData } from '../lib/supabase';
 import { getEventBySlug, PublicEvent, getPhotoStats, verifyTweet, trackLinkClick } from '../lib/api';
 import { IconInput } from '../components/IconInput';
@@ -114,6 +115,13 @@ export function EventPage() {
         const foundEvent = result;
         if (foundEvent) {
           setEvent(foundEvent);
+
+          // Track event page view for funnel analysis
+          posthog.capture('event_page_viewed', {
+            eventName: foundEvent.name,
+            inviteCode: foundEvent.inviteCode,
+          });
+
           setCanEditAsCoHost(false);
 
           // Check if logged-in user has already RSVP'd and fetch their data

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Check, AlertCircle, Loader2, Lock, X, ChevronRight, Heart } from 'lucide-react';
+import posthog from 'posthog-js';
 import { getPartyByInviteCodeOrCustomUrl, verifyPartyPassword, isUserGuestAtParty, DbParty } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import { DonationForm } from '../components/DonationForm';
@@ -53,6 +54,12 @@ export function RSVPPage() {
         const foundParty = await getPartyByInviteCodeOrCustomUrl(inviteCode);
         if (foundParty) {
           setParty(foundParty);
+
+          // Track RSVP page view for funnel analysis
+          posthog.capture('rsvp_page_viewed', {
+            eventName: foundParty.name,
+            inviteCode: foundParty.invite_code,
+          });
 
           // Check if donations are enabled
           const stats = await getDonationStats(foundParty.id);
@@ -124,6 +131,24 @@ export function RSVPPage() {
       if (isGPP) fireFromCenter();
     },
   });
+
+  // Track RSVP step 2 reached
+  useEffect(() => {
+    if (form.step === 2 && party) {
+      posthog.capture('rsvp_step2_reached', { eventName: party.name });
+    }
+  }, [form.step, party]);
+
+  // Track RSVP submission success
+  useEffect(() => {
+    if (form.submitted && party) {
+      posthog.capture('rsvp_submitted', {
+        eventName: party.name,
+        alreadyRegistered: form.alreadyRegistered,
+        pendingApproval: form.pendingApproval,
+      });
+    }
+  }, [form.submitted, party, form.alreadyRegistered, form.pendingApproval]);
 
   const handlePasswordSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Adds PostHog JS SDK for RSVP funnel tracking
- Tracks: event_page_viewed → rsvp_page_viewed → rsvp_step2_reached → rsvp_submitted
- Dormant until `VITE_POSTHOG_KEY` env var is set in Vercel

## Changes
- `frontend/package.json` — added `posthog-js`
- `frontend/src/main.tsx` — PostHog init (guarded by env var)
- `frontend/src/pages/RSVPPage.tsx` — 3 funnel events
- `frontend/src/pages/EventPage.tsx` — page view event

## To activate
Set `VITE_POSTHOG_KEY` in Vercel env vars (Preview + Production) with your PostHog project API key.

## Test plan
- [ ] Without env var: no errors, no network calls to PostHog
- [ ] With env var: events fire on page load and form progression
- [ ] PostHog dashboard shows funnel: page view → step 1 → step 2 → submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)