### PR TITLE
feat: auto-regen flyers from underboss tag/partner changes

### DIFF
--- a/frontend/src/components/flyer/autoRegenFlyer.ts
+++ b/frontend/src/components/flyer/autoRegenFlyer.ts
@@ -2,8 +2,9 @@
  * Auto-regenerate GPP event flyers when partner status or event details change.
  *
  * Exports:
- *   triggerFlyerRegen(party, loadParty?)  — debounced entry point (3 s per party)
- *   cancelFlyerRegen(partyId)             — cancel a pending regen
+ *   triggerFlyerRegen(party, loadParty?)        — debounced entry point (3 s per party)
+ *   triggerFlyerRegenForEvents(events)           — batch entry point for underboss context
+ *   cancelFlyerRegen(partyId)                    — cancel a pending regen
  */
 
 import { renderFlyer, uses12Hour, formatFlyerTime } from './renderFlyer';
@@ -11,6 +12,23 @@ import { getDateTimeInTimezone } from '../../utils/dateUtils';
 import { uploadEventImage, updateParty } from '../../lib/supabase';
 import { getSponsors } from '../../lib/api';
 import type { Party } from '../../types';
+
+/**
+ * Minimal data needed for flyer regeneration.
+ * Both `Party` (host dashboard) and `UnderbossEvent` data satisfy this shape.
+ */
+export interface FlyerRegenData {
+  id: string;
+  name: string;
+  venueName: string | null;
+  address: string | null;
+  date: string | null;
+  timezone: string | null;
+  duration: number | null;
+  customUrl: string | null;
+  inviteCode?: string | null;
+  eventType?: string | null;
+}
 
 // ---- Debounce map (partyId → timer handle) ----
 const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -63,8 +81,6 @@ export function triggerFlyerRegen(
   pendingTimers.set(party.id, timer);
 }
 
-// ---- Internal helpers ----
-
 /** Extract city name from the party name (strip "Global Pizza Party" prefix). */
 function parseCityFromName(name: string): string {
   return name.replace(/^Global Pizza Party\s*/i, '').trim() || name;
@@ -89,45 +105,90 @@ async function ensureFonts(): Promise<void> {
   }
 }
 
+/**
+ * Trigger flyer regen from underboss context where we have UnderbossEvent data
+ * instead of a full Party object. Accepts multiple events for batch operations.
+ * Regens sequentially with a small delay between each to avoid overwhelming the browser.
+ */
+export function triggerFlyerRegenForEvents(
+  events: FlyerRegenData[],
+): void {
+  // Filter out events with custom flyer positions (host-customized layouts)
+  const eligible = events.filter((e) => {
+    try {
+      if (localStorage.getItem(`flyer-${e.id}`)) return false;
+    } catch {
+      // localStorage unavailable — include the event
+    }
+    return true;
+  });
+
+  if (eligible.length === 0) return;
+
+  // Process sequentially with ~500ms delay between each
+  let idx = 0;
+  function processNext() {
+    if (idx >= eligible.length) return;
+    const event = eligible[idx];
+    idx++;
+
+    // Cancel any existing pending regen for this event
+    cancelFlyerRegen(event.id);
+
+    doRegen(event).catch((err) => {
+      console.error(`[autoRegenFlyer] batch regen failed for ${event.id}:`, err);
+    }).finally(() => {
+      if (idx < eligible.length) {
+        setTimeout(processNext, 500);
+      }
+    });
+  }
+
+  // Kick off after a short initial delay (like the debounce for single events)
+  setTimeout(processNext, 1000);
+}
+
+// ---- Internal helpers ----
+
 /** The actual render → upload → update pipeline. */
 async function doRegen(
-  party: Party,
+  data: FlyerRegenData,
   loadParty?: (inviteCode: string) => Promise<boolean>,
 ): Promise<void> {
   // 1. Load fonts
   await ensureFonts();
 
   // 2. Fetch sponsors with logo + yes/paid status
-  const sponsorResult = await getSponsors(party.id);
+  const sponsorResult = await getSponsors(data.id);
   const sponsors = (sponsorResult?.sponsors ?? []).filter(
     (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid'),
   );
 
   // 3. Derive flyer text fields from party data
-  const city = parseCityFromName(party.name);
-  const venueName = party.venueName || 'LOCATION TBA';
-  const streetAddress = party.address ? party.address.split(',')[0].trim() : '';
+  const city = parseCityFromName(data.name);
+  const venueName = data.venueName || 'LOCATION TBA';
+  const streetAddress = data.address ? data.address.split(',')[0].trim() : '';
 
   let dateDisplay = '';
   let timeDisplay = '';
-  const is12h = party.timezone ? uses12Hour(party.timezone) : false;
+  const is12h = data.timezone ? uses12Hour(data.timezone) : false;
 
-  if (party.date) {
-    const tz = party.timezone || 'UTC';
-    const start = getDateTimeInTimezone(party.date, tz);
+  if (data.date) {
+    const tz = data.timezone || 'UTC';
+    const start = getDateTimeInTimezone(data.date, tz);
     const startFormatted = formatFlyerTime(start.timeStr, is12h);
     timeDisplay = startFormatted;
 
-    if (party.duration) {
+    if (data.duration) {
       const endDate = new Date(
-        new Date(party.date).getTime() + party.duration * 3600000,
+        new Date(data.date).getTime() + data.duration * 3600000,
       );
       const end = getDateTimeInTimezone(endDate, tz);
       const endFormatted = formatFlyerTime(end.timeStr, is12h);
       timeDisplay = `${startFormatted} - ${endFormatted}`;
     }
 
-    const eventDate = new Date(party.date);
+    const eventDate = new Date(data.date);
     const monthFormatter = new Intl.DateTimeFormat('en-US', {
       timeZone: tz,
       month: 'short',
@@ -162,7 +223,7 @@ async function doRegen(
   // 6. Upload
   const file = new File(
     [blob],
-    `gpp-flyer-${party.customUrl || party.inviteCode || party.id}.png`,
+    `gpp-flyer-${data.customUrl || data.inviteCode || data.id}.png`,
     { type: 'image/png' },
   );
   const uploadedUrl = await uploadEventImage(file);
@@ -172,7 +233,7 @@ async function doRegen(
   }
 
   // 7. Update party with new image URL + timestamp
-  const success = await updateParty(party.id, {
+  const success = await updateParty(data.id, {
     event_image_url: uploadedUrl,
     flyer_generated_at: new Date().toISOString(),
   });
@@ -182,7 +243,7 @@ async function doRegen(
   }
 
   // 8. Optionally refresh UI
-  if (loadParty && party.inviteCode) {
-    await loadParty(party.inviteCode);
+  if (loadParty && data.inviteCode) {
+    await loadParty(data.inviteCode);
   }
 }

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -4,6 +4,7 @@ import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshak
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
+import { triggerFlyerRegenForEvents } from '../flyer/autoRegenFlyer';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
@@ -141,11 +142,13 @@ function HostStatusBadge({
 function HostTagsPills({
   tags,
   eventId,
+  event,
   onUpdate,
   partnerTags = [],
 }: {
   tags: string[];
   eventId: string;
+  event: UnderbossEvent;
   onUpdate: (tags: string[]) => void;
   partnerTags?: string[];
 }) {
@@ -163,6 +166,7 @@ function HostTagsPills({
     setIsAdding(false);
     try {
       await bulkUpdateEventTags([eventId], [cleaned], 'add');
+      triggerFlyerRegenForEvents([event]);
     } catch {
       onUpdate(tags);
     }
@@ -173,6 +177,7 @@ function HostTagsPills({
     onUpdate(newTags);
     try {
       await bulkUpdateEventTags([eventId], [tag], 'remove');
+      triggerFlyerRegenForEvents([event]);
     } catch {
       onUpdate(tags);
     }
@@ -584,6 +589,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
           <HostTagsPills
             tags={eventTags}
             eventId={event.id}
+            event={event}
             partnerTags={partnerTags}
             onUpdate={(tags) => {
               setEventTags(tags);

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -5,6 +5,7 @@ import { IconInput } from '../IconInput';
 import { EventRow } from './EventRow';
 import { EventCard } from './EventCard';
 import { bulkApproveEvents, bulkDeleteEvents, bulkUpdateEventTags } from '../../lib/api';
+import { triggerFlyerRegenForEvents } from '../flyer/autoRegenFlyer';
 import type { UnderbossEvent, UnderbossEventProgress } from '../../types';
 import { calculateTagSponsorshipTotal } from '../../utils/sponsorshipPricing';
 
@@ -462,6 +463,9 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                                     }
                                   }
                                 }
+                                // Trigger flyer regen for affected events
+                                const affected = events.filter(e => selectedIds.has(e.id));
+                                triggerFlyerRegenForEvents(affected);
                                 onBulkAction?.();
                               } catch (err) { console.error('Add tag failed', err); }
                               setBulkLoading(false);
@@ -494,6 +498,9 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                                       }
                                     }
                                   }
+                                  // Trigger flyer regen for affected events
+                                  const affected = events.filter(e2 => selectedIds.has(e2.id));
+                                  triggerFlyerRegenForEvents(affected);
                                   onBulkAction?.();
                                 } catch (err) { console.error('Add custom tag failed', err); }
                                 setBulkLoading(false);
@@ -541,6 +548,9 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                                       onEventUpdate?.(id, { eventTags: (evt.eventTags || []).filter(t => t !== tag) });
                                     }
                                   }
+                                  // Trigger flyer regen for affected events (partner logo may have been removed)
+                                  const affected = events.filter(e => selectedIds.has(e.id));
+                                  triggerFlyerRegenForEvents(affected);
                                   onBulkAction?.();
                                 } catch (err) { console.error('Remove tag failed', err); }
                                 setBulkLoading(false);

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -8,9 +8,10 @@ import type { PartnerFormData } from '../sponsors/PartnerForm';
 
 interface PartnerManagerProps {
   onSyncComplete?: () => void;
+  onFlyerRegenNeeded?: (tag: string) => void;
 }
 
-export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
+export function PartnerManager({ onSyncComplete, onFlyerRegenNeeded }: PartnerManagerProps) {
   const [partners, setPartners] = useState<SponsorUser[]>([]);
   const [tagCounts, setTagCounts] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
@@ -104,6 +105,8 @@ export function PartnerManager({ onSyncComplete }: PartnerManagerProps) {
 
       if (newSyncMessage) {
         setSyncMessage(newSyncMessage);
+        // Trigger flyer regen for events with this partner's tag
+        onFlyerRegenNeeded?.(data.tag);
       }
 
       await loadPartners();

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -6,6 +6,7 @@ import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
 import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager } from '../components/underboss';
+import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
@@ -188,6 +189,15 @@ export function UnderbossDashboard() {
     const allSelected = selectedRegions.length === availableRegions.length;
     setSelectedRegions(allSelected ? [] : [...availableRegions]);
   };
+
+  // Handle flyer regen when a partner is created/updated and synced to events
+  const handleFlyerRegenForTag = useCallback((tag: string) => {
+    if (!allData) return;
+    const affected = allData.events.filter(e => e.eventTags?.includes(tag));
+    if (affected.length > 0) {
+      triggerFlyerRegenForEvents(affected);
+    }
+  }, [allData]);
 
   // Handle optimistic event updates from EventRow (host status, approval, tags)
   const handleEventUpdate = useCallback((eventId: string, updates: Partial<UnderbossEvent>) => {
@@ -432,7 +442,7 @@ export function UnderbossDashboard() {
           )}
 
           {activeTab === 'partners' && isAdmin && (
-            <PartnerManager onSyncComplete={loadDashboard} />
+            <PartnerManager onSyncComplete={loadDashboard} onFlyerRegenNeeded={handleFlyerRegenForTag} />
           )}
         </section>
         </div>


### PR DESCRIPTION
## Summary
- Adds `triggerFlyerRegenForEvents()` to `autoRegenFlyer.ts` for batch flyer regeneration from the underboss context (accepts `UnderbossEvent` data instead of requiring a full `Party` object)
- Wires flyer regen into all underboss tag operations: bulk add/remove tags in `EventTable`, single tag add/remove in `EventRow`'s `HostTagsPills`, and partner create/update via `PartnerManager` -> `UnderbossDashboard` callback
- Refactors `doRegen` to accept a new `FlyerRegenData` interface that both `Party` and `UnderbossEvent` satisfy, keeping the existing host dashboard flow unchanged

## Test plan
- [ ] In underboss panel, select events and bulk-add a partner tag -> verify flyers regenerate for those events
- [ ] In underboss panel, select events and bulk-remove a tag -> verify flyers regenerate
- [ ] In underboss panel, click the + button on a single event's tag pills to add a tag -> verify that event's flyer regenerates
- [ ] In underboss panel, click a tag pill on a single event to remove it -> verify flyer regenerates
- [ ] In underboss Partners tab, create/update a partner that syncs to events -> verify flyers regenerate for tagged events
- [ ] On the host dashboard, verify existing `triggerFlyerRegen(party)` still works unchanged (edit event name, date, venue, or sponsor status)
- [ ] Verify events with custom flyer positions in localStorage are skipped (not overwritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)