### PR TITLE
feat: show PizzaDAO clicks on partner dashboard

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -52,7 +52,7 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
     if (uniqueTags.length > 0) {
       for (const tag of uniqueTags) {
         const count = await prisma.party.count({
-          where: { eventTags: { has: tag } },
+          where: tag === 'pizzadao' ? {} : { eventTags: { has: tag } },
         });
         tagCounts[tag] = count;
       }
@@ -480,8 +480,10 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
 
     // Build where clause — admins without a tag filter see all events that have any eventTags
     const where: any = {};
-    if (tag) {
+    if (tag && tag !== 'pizzadao') {
       where.eventTags = { has: tag };
+    } else if (tag === 'pizzadao') {
+      // PizzaDAO is a co-host on all events — no eventTags filter needed
     } else if (req.isAdminViewing) {
       // Admin with no tag filter — show events that have at least one eventTag
       where.NOT = { eventTags: { equals: [] } };


### PR DESCRIPTION
## Summary
- Special-case the `pizzadao` tag in the partner dashboard backend so PizzaDAO click stats are visible to admins.
- **Event query** (`GET /api/sponsor/events`): When `tag` is `"pizzadao"`, skip the `eventTags` filter since PizzaDAO is a co-host on all events and events don't carry a `"pizzadao"` eventTag.
- **Tag counts** (`GET /api/sponsor-users/list`): When counting events for the `"pizzadao"` tag, count all events instead of filtering by `eventTags`.

## Changes
Only `backend/src/routes/sponsor-user.routes.ts` was modified (2 targeted changes, 4 lines added / 2 removed).

## Test plan
- [ ] Log in as admin, navigate to partner dashboard, select PizzaDAO tag
- [ ] Verify events list shows all events (not an empty list)
- [ ] Verify tag count for PizzaDAO reflects total event count
- [ ] Verify other partner tags still filter correctly by eventTags

🤖 Generated with [Claude Code](https://claude.com/claude-code)