### PR TITLE
feat: add Telegram chat links to underboss events table

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -215,6 +215,7 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
     eventTags: party.eventTags || [],
     underbossNotes: party.underbossNotes || null,
     expectedGuests: party.expectedGuests || null,
+    telegramGroup: party.telegramGroup || null,
     createdAt: party.createdAt,
     flyerGeneratedAt,
     latestSponsorAt: latestSponsorAtStr,

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote, ChevronLeft, ChevronRight, MessageCircle } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
@@ -521,6 +521,17 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                 >
                   <StickyNote size={12} />
                 </button>
+                {event.telegramGroup && (
+                  <a
+                    href={event.telegramGroup}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[#29B6F6] hover:text-[#4FC3F7] transition-colors shrink-0"
+                    title="Telegram group"
+                  >
+                    <MessageCircle size={12} />
+                  </a>
+                )}
               </div>
               <div className="flex items-center gap-1.5 mt-0.5" title={fullDate}>
                 <Calendar size={10} className="text-theme-text-faint" />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1026,6 +1026,7 @@ export interface UnderbossEvent {
   eventTags: string[];
   underbossNotes: string | null;
   expectedGuests: number | null;
+  telegramGroup?: string | null;
   createdAt: string;
   flyerGeneratedAt: string | null;
   latestSponsorAt: string | null;


### PR DESCRIPTION
## Summary
- Surface `telegramGroup` field from the Prisma model in the underboss `formatEvent()` API response
- Add `telegramGroup` to the `UnderbossEvent` TypeScript interface
- Render a blue MessageCircle icon link next to event names in the underboss table when a Telegram group URL is set

## Test plan
- [ ] Verify the underboss events API response includes `telegramGroup` for events that have one
- [ ] Verify events with a Telegram group show a blue chat icon in the name cell
- [ ] Verify events without a Telegram group do not show the icon
- [ ] Verify clicking the icon opens the Telegram link in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)