### PR TITLE
Partner One Sheet page with interest form

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,6 +38,7 @@ import { sponsorUserAdminRouter, sponsorDashboardRouter } from './routes/sponsor
 import preferencesRoutes from './routes/preferences.routes.js';
 import quizTemplateRoutes from './routes/quiz-template.routes.js';
 import { quizHostRouter, quizPublicRouter } from './routes/quiz.routes.js';
+import onesheetRoutes from './routes/onesheet.routes.js';
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -128,6 +129,7 @@ app.use('/api/user', userRoutes);
 app.use('/api/events', pageviewRoutes); // Page view tracking (public, before eventRoutes)
 app.use('/api/events', linkclickRoutes); // Link click tracking (public, before eventRoutes)
 app.use('/api/events', quizPublicRouter); // Public quiz endpoints (before eventRoutes)
+app.use('/api/events', onesheetRoutes); // One Sheet interest form (public, before eventRoutes)
 app.use('/api/events', eventRoutes);
 app.use('/api/nft', nftRoutes);
 app.use('/api/gpp', gppRoutes);

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -159,12 +159,15 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
       throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
     }
 
-    // Fetch confirmed sponsors with descriptions for public display
+    // Fetch confirmed sponsors with descriptions or logos for public display
     const sponsors = await prisma.sponsor.findMany({
       where: {
         partyId: party.id,
         status: { in: ['yes', 'billed', 'paid'] },
-        brandDescription: { not: null },
+        OR: [
+          { brandDescription: { not: null } },
+          { logoUrl: { not: null } },
+        ],
       },
       select: {
         id: true,
@@ -176,6 +179,20 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
       },
       orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
     });
+
+    // Page view stats for one-sheet
+    const [totalViews, uniqueVisitorsResult] = await Promise.all([
+      prisma.pageView.count({ where: { partyId: party.id } }),
+      prisma.$queryRaw<[{ count: bigint }]>`
+        SELECT COUNT(DISTINCT visitor_hash) as count
+        FROM page_views
+        WHERE party_id = ${party.id}::uuid AND visitor_hash IS NOT NULL
+      `,
+    ]);
+    const pageViewStats = {
+      totalViews,
+      uniqueVisitors: Number(uniqueVisitorsResult[0]?.count ?? 0),
+    };
 
     // Enrich coHosts with user profile data (avatar, socials) then strip emails
     const rawCoHosts = (party.coHosts as any[] || []);
@@ -279,6 +296,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         guestCount: party._count.guests,
         userId: party.userId,
         sponsors,
+        pageViewStats,
       },
     });
   } catch (error) {

--- a/backend/src/routes/onesheet.routes.ts
+++ b/backend/src/routes/onesheet.routes.ts
@@ -1,0 +1,107 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { rateLimit } from 'express-rate-limit';
+import { prisma } from '../config/database.js';
+import { AppError } from '../middleware/error.js';
+
+const router = Router();
+
+// Strict rate limit for interest form submissions
+const interestLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 10, // 10 submissions per hour per IP
+  message: { error: 'Too many submissions, please try again later' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: false,
+});
+
+// POST /api/events/:slug/interest — submit partner interest (public, no auth)
+router.post('/:slug/interest', interestLimiter, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const slug = req.params.slug.toLowerCase();
+    const { name, email, company, message } = req.body;
+
+    // Validate required fields
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      throw new AppError('Name is required', 400, 'MISSING_NAME');
+    }
+    if (!email || typeof email !== 'string' || !email.trim()) {
+      throw new AppError('Email is required', 400, 'MISSING_EMAIL');
+    }
+    if (!company || typeof company !== 'string' || !company.trim()) {
+      throw new AppError('Company is required', 400, 'MISSING_COMPANY');
+    }
+
+    // Basic email validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email.trim())) {
+      throw new AppError('Invalid email address', 400, 'INVALID_EMAIL');
+    }
+
+    // Find party by inviteCode → customUrl → slugAlias
+    let party = await prisma.party.findUnique({
+      where: { inviteCode: slug },
+      select: { id: true },
+    });
+    if (!party) {
+      party = await prisma.party.findUnique({
+        where: { customUrl: slug },
+        select: { id: true },
+      });
+    }
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true },
+        });
+      }
+    }
+    if (!party) {
+      throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
+    }
+
+    // Check for duplicate by contactEmail on this event
+    const existing = await prisma.sponsor.findFirst({
+      where: {
+        partyId: party.id,
+        contactEmail: email.trim().toLowerCase(),
+      },
+    });
+    if (existing) {
+      throw new AppError('You have already expressed interest in partnering with this event', 409, 'DUPLICATE_INTEREST');
+    }
+
+    // Get next sortOrder
+    const maxSort = await prisma.sponsor.aggregate({
+      where: { partyId: party.id },
+      _max: { sortOrder: true },
+    });
+    const nextSortOrder = (maxSort._max.sortOrder ?? -1) + 1;
+
+    // Create Sponsor record
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        partyId: party.id,
+        name: company.trim(),
+        contactName: name.trim(),
+        contactEmail: email.trim().toLowerCase(),
+        sponsorMessage: message?.trim() || null,
+        status: 'asked',
+        notes: 'Submitted via One Sheet interest form',
+        intakeSubmittedAt: new Date(),
+        sortOrder: nextSortOrder,
+      },
+    });
+
+    res.status(201).json({ success: true, id: sponsor.id });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { AdminPage } from './pages/AdminPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
 import { PostComposerPage } from './pages/PostComposerPage';
+import { OneSheetPage } from './pages/OneSheetPage';
 
 // Legacy redirect: /sponsor-intake/:token → /partner-intake/:token
 // <Navigate> doesn't forward path params, so we wrap useParams().
@@ -66,6 +67,7 @@ function App() {
             <Route path="/sponsor-intake/:token" element={<SponsorIntakeRedirect />} />
             <Route path="/graphics" element={<Suspense fallback={null}><GraphicsDashboard /></Suspense>} />
             <Route path="/post" element={<PostComposerPage />} />
+            <Route path="/onesheet/:slug" element={<OneSheetPage />} />
             <Route path="/raleigh" element={<Navigate to="/durham" replace />} />
             <Route path="/cmohhr0640003jp047krjarz0" element={<Navigate to="/nashville" replace />} />
             {/* Catch-all route for custom URLs - must be last */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -418,6 +418,7 @@ export interface PublicEvent {
   telegramGroup?: string | null;
   turtleRolesEnabled?: boolean;
   sponsors?: PublicEventSponsor[];
+  pageViewStats?: { totalViews: number; uniqueVisitors: number };
 }
 
 // Public Event API (no auth required)
@@ -444,6 +445,31 @@ export async function getEventBySlug(slug: string): Promise<PublicEvent | { redi
     console.error('Error fetching event:', error);
     return null;
   }
+}
+
+// One Sheet interest form
+export interface OneSheetInterestData {
+  name: string;
+  email: string;
+  company: string;
+  message?: string;
+}
+
+export async function submitOneSheetInterest(slug: string, data: OneSheetInterestData): Promise<{ success: boolean; id: string }> {
+  const response = await fetch(`${API_URL}/api/events/${slug}/interest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: 'Request failed' }));
+    const err = new Error(error.message || error.error || `API error: ${response.status}`);
+    (err as any).status = response.status;
+    throw err;
+  }
+
+  return response.json();
 }
 
 // Donation API functions

--- a/frontend/src/pages/OneSheetPage.tsx
+++ b/frontend/src/pages/OneSheetPage.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import {
+  User, Mail, Building2, MessageCircle, MapPin, Calendar,
+  Users, Eye, Handshake, CheckCircle, Loader2,
+} from 'lucide-react';
+import { getEventBySlug, PublicEvent, submitOneSheetInterest } from '../lib/api';
+import { cdnUrl } from '../lib/supabase';
+import { IconInput } from '../components/IconInput';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+export function OneSheetPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(true);
+  const [event, setEvent] = useState<PublicEvent | null>(null);
+
+  // Form state
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [company, setCompany] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadEvent() {
+      if (!slug) return;
+      const result = await getEventBySlug(slug);
+
+      // Handle redirect from old slug alias
+      if (result && 'redirect' in result) {
+        navigate(`/onesheet/${result.slug}`, { replace: true });
+        return;
+      }
+
+      setEvent(result);
+      setLoading(false);
+    }
+    loadEvent();
+  }, [slug, navigate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!slug) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await submitOneSheetInterest(slug, { name, email, company, message: message || undefined });
+      setSubmitted(true);
+    } catch (err: any) {
+      if (err.status === 409) {
+        setError("You've already expressed interest in partnering with this event.");
+      } else {
+        setError(err.message || 'Something went wrong. Please try again.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Format date/time with timezone
+  const formatEventDateTime = () => {
+    if (!event?.date) return null;
+    const d = new Date(event.date);
+    const opts: Intl.DateTimeFormatOptions = {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short',
+      ...(event.timezone ? { timeZone: event.timezone } : {}),
+    };
+    return d.toLocaleDateString('en-US', opts);
+  };
+
+  // OG image URL
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+  const ogImageUrl = (() => {
+    if (!event?.eventImageUrl) return `${baseUrl}/logo.png`;
+    if (event.eventImageUrl.startsWith('http')) return event.eventImageUrl;
+    if (event.eventImageUrl.startsWith('/')) return `${baseUrl}${event.eventImageUrl}`;
+    return `${baseUrl}/${event.eventImageUrl}`;
+  })();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-white/40" />
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="min-h-screen bg-[#0a0a0a]">
+        <Header />
+        <div className="flex flex-col items-center justify-center py-32 text-center">
+          <h1 className="text-2xl font-bold text-white mb-2">Event Not Found</h1>
+          <p className="text-white/50">The event you're looking for doesn't exist or has been removed.</p>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  const rsvpCount = event.guestCount ?? 0;
+  const totalViews = event.pageViewStats?.totalViews ?? 0;
+  const partnerCount = event.sponsors?.length ?? 0;
+  const sponsorsWithLogos = (event.sponsors || []).filter(s => s.logoUrl);
+
+  const ogDescription = [
+    event.venueName,
+    event.address,
+    formatEventDateTime(),
+  ].filter(Boolean).join(' | ');
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a]">
+      <Helmet>
+        <title>{event.name} - Partner One Sheet</title>
+        <meta property="og:title" content={`${event.name} - Partner One Sheet`} />
+        <meta property="og:image" content={ogImageUrl} />
+        <meta property="og:description" content={ogDescription} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={`${event.name} - Partner One Sheet`} />
+        <meta name="twitter:image" content={ogImageUrl} />
+      </Helmet>
+
+      <Header />
+
+      <main className="max-w-3xl mx-auto px-4 py-8 space-y-8">
+        {/* Flyer Image */}
+        {event.eventImageUrl && (
+          <div className="rounded-xl overflow-hidden">
+            <img
+              src={cdnUrl(event.eventImageUrl)}
+              alt={event.name}
+              className="w-full object-contain"
+            />
+          </div>
+        )}
+
+        {/* Event Info */}
+        <div className="space-y-3">
+          <h1 className="text-3xl font-bold text-white">{event.name}</h1>
+
+          {(event.venueName || event.address) && (
+            <div className="flex items-start gap-2 text-white/70">
+              <MapPin size={18} className="mt-0.5 flex-shrink-0 text-white/40" />
+              <span>
+                {event.venueName}
+                {event.venueName && event.address ? ' — ' : ''}
+                {event.address}
+              </span>
+            </div>
+          )}
+
+          {event.date && (
+            <div className="flex items-center gap-2 text-white/70">
+              <Calendar size={18} className="flex-shrink-0 text-white/40" />
+              <span>{formatEventDateTime()}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Stats Cards */}
+        <div className="grid grid-cols-3 gap-4">
+          <div className="bg-white/5 border border-white/10 rounded-xl p-4 text-center">
+            <Users size={20} className="mx-auto mb-1 text-white/40" />
+            <div className="text-2xl font-bold text-white">{rsvpCount.toLocaleString()}</div>
+            <div className="text-xs text-white/40 mt-0.5">RSVPs</div>
+          </div>
+          <div className="bg-white/5 border border-white/10 rounded-xl p-4 text-center">
+            <Eye size={20} className="mx-auto mb-1 text-white/40" />
+            <div className="text-2xl font-bold text-white">{totalViews.toLocaleString()}</div>
+            <div className="text-xs text-white/40 mt-0.5">Page Views</div>
+          </div>
+          <div className="bg-white/5 border border-white/10 rounded-xl p-4 text-center">
+            <Handshake size={20} className="mx-auto mb-1 text-white/40" />
+            <div className="text-2xl font-bold text-white">{partnerCount.toLocaleString()}</div>
+            <div className="text-xs text-white/40 mt-0.5">Partners</div>
+          </div>
+        </div>
+
+        {/* Partner Logos */}
+        {sponsorsWithLogos.length > 0 && (
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-white/80">Partners</h2>
+            <div className="flex flex-wrap items-center gap-4">
+              {sponsorsWithLogos.map((sponsor) => {
+                const img = (
+                  <img
+                    key={sponsor.id}
+                    src={cdnUrl(sponsor.logoUrl!)}
+                    alt={sponsor.name}
+                    className="h-12 w-auto object-contain rounded"
+                  />
+                );
+                if (sponsor.website) {
+                  return (
+                    <a
+                      key={sponsor.id}
+                      href={sponsor.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={sponsor.name}
+                    >
+                      {img}
+                    </a>
+                  );
+                }
+                return img;
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Interest Form */}
+        <div className="bg-white/5 border border-white/10 rounded-xl p-6 space-y-5">
+          {submitted ? (
+            <div className="flex flex-col items-center py-8 text-center space-y-3">
+              <CheckCircle size={48} className="text-green-400" />
+              <h2 className="text-xl font-bold text-white">Thank you!</h2>
+              <p className="text-white/60">
+                We've received your interest and will be in touch soon.
+              </p>
+            </div>
+          ) : (
+            <>
+              <h2 className="text-xl font-semibold text-white">Interested in Partnering?</h2>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <IconInput
+                  icon={User}
+                  placeholder="Your name"
+                  required
+                  value={name}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+                />
+                <IconInput
+                  icon={Mail}
+                  placeholder="Email address"
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+                />
+                <IconInput
+                  icon={Building2}
+                  placeholder="Company / brand"
+                  required
+                  value={company}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCompany(e.target.value)}
+                />
+                <IconInput
+                  icon={MessageCircle}
+                  placeholder="Message (optional)"
+                  multiline
+                  rows={3}
+                  value={message}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setMessage(e.target.value)}
+                />
+
+                {error && (
+                  <p className="text-sm text-red-400">{error}</p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="w-full py-3 rounded-lg bg-white text-black font-semibold hover:bg-white/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                >
+                  {submitting ? (
+                    <>
+                      <Loader2 size={18} className="animate-spin" />
+                      Submitting...
+                    </>
+                  ) : (
+                    'Submit Interest'
+                  )}
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -10,7 +10,7 @@ import {
   Loader2, Shield, Tag, Users,
   Search, ThumbsUp, ThumbsDown, BarChart3, Calendar, MapPin,
   Wallet, TrendingUp, StickyNote, MessageCircle, MousePointerClick, Eye,
-  Instagram, Youtube, Linkedin, Globe, Facebook,
+  Instagram, Youtube, Linkedin, Globe, Facebook, Link2,
 } from 'lucide-react';
 import { cdnUrl } from '../lib/supabase';
 import { fetchSheetCities } from '../lib/cities';
@@ -680,6 +680,9 @@ function EventCard({ event, onToggleChecklist, cityChats }: EventCardProps) {
   // Filter co-hosts to show only visible ones
   const visibleCoHosts = event.coHosts.filter((h: CoHost) => h.showOnEvent !== false);
 
+  // One Sheet copy state
+  const [copied, setCopied] = useState(false);
+
   // Notes state with debounced auto-save
   const [notes, setNotes] = useState(event.partnerNotes || '');
   const [savingNotes, setSavingNotes] = useState(false);
@@ -797,6 +800,18 @@ function EventCard({ event, onToggleChecklist, cityChats }: EventCardProps) {
                 Report
               </span>
             )}
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(`https://rsv.pizza/onesheet/${event.slug}`);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+              }}
+              className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-theme-text-muted hover:text-theme-text-secondary border border-theme-stroke hover:border-theme-stroke-hover rounded-md transition-colors"
+              title="Copy One Sheet link"
+            >
+              <Link2 size={12} />
+              {copied ? 'Copied!' : 'One Sheet'}
+            </button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add `/onesheet/:slug` public page showing event flyer, details, stats, partner logos, and interest form
- Add `POST /api/events/:slug/interest` endpoint for partner interest submissions (rate limited, duplicate detection)
- Add page view stats (`totalViews`, `uniqueVisitors`) to public event response
- Broaden sponsor query to include sponsors with logos (not just descriptions)
- Add "One Sheet" copy link button to partner dashboard EventCard

## Test plan
- [ ] Visit `/onesheet/{any-event-slug}` — renders event info, stats, partner logos, and interest form
- [ ] Submit the form → check Supabase `sponsors` table for new row with `status: 'asked'`
- [ ] Submit same email again → should see 409 "already expressed interest"
- [ ] Partner dashboard → event card should show "One Sheet" copy button → clipboard has correct URL
- [ ] Social share: paste onesheet URL → should show og:title + og:image preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)