### PR TITLE
fix: CDN cache immutable → revalidating

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -15,7 +15,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=86400, s-maxage=31536000, immutable"
+          "value": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- CDN (`/cdn/*`) cache changed from `immutable` (1 year) to revalidating (1 day + stale-while-revalidate)
- Fixes broken images that get permanently stuck when a Vercel edge POP caches an error response
- Browser cache reduced from 24h to 1h so broken images self-heal faster
- `/assets/*` cache left unchanged (content-hashed files, `immutable` is correct there)

## Test plan
- [ ] Deploy and verify previously broken images (ENS avatar, DSC avatar on SF event, São Paulo flyer on partner dashboard) now load
- [ ] Verify images still load fast (CDN still caches for 24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)