### PR TITLE
fix: graceful fallback for broken avatar URLs

### DIFF
--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -43,7 +43,7 @@ function buildPartnerCoHost(sponsorUser: SponsorUserLike): Record<string, any> {
     website: sponsorUser.coHostWebsite || undefined,
     twitter: sponsorUser.coHostTwitter || undefined,
     instagram: sponsorUser.coHostInstagram || undefined,
-    avatar_url: sponsorUser.coHostAvatarUrl || undefined,
+    avatar_url: sponsorUser.coHostAvatarUrl || sponsorUser.coHostLogoUrl || undefined,
     showOnEvent: sponsorUser.coHostShowOnEvent !== false,
     canEdit: !!sponsorUser.coHostCanEdit,
     isPartner: true,

--- a/frontend/src/components/HostsList.tsx
+++ b/frontend/src/components/HostsList.tsx
@@ -1,7 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { User, Globe, Instagram, Youtube, Linkedin } from 'lucide-react';
 import { cdnUrl } from '../lib/supabase';
 import { normalizeUrl } from '../lib/utils';
+
+// Avatar with onError fallback for broken image URLs
+const AvatarImg: React.FC<{
+  src: string;
+  alt: string;
+  className: string;
+  fallbackClassName: string;
+  iconClassName: string;
+  style?: React.CSSProperties;
+}> = ({ src, alt, className, fallbackClassName, iconClassName, style }) => {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div className={fallbackClassName} style={style}>
+        <User className={iconClassName} />
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={cdnUrl(src)}
+      alt={alt}
+      className={className}
+      style={style}
+      onError={() => setFailed(true)}
+    />
+  );
+};
 
 interface CoHost {
   id: string;
@@ -95,10 +125,12 @@ export const HostsList: React.FC<HostsListProps> = ({
         {displayHostName && (
           <div className={`flex items-center ${config.gap}`}>
             {hostProfile?.avatar_url ? (
-              <img
-                src={cdnUrl(hostProfile.avatar_url)}
+              <AvatarImg
+                src={hostProfile.avatar_url}
                 alt={displayHostName}
                 className={`${config.avatar} rounded-full object-cover flex-shrink-0`}
+                fallbackClassName={`${config.avatar} rounded-full bg-[#ff393a]/20 flex items-center justify-center flex-shrink-0`}
+                iconClassName={`${config.icon} text-[#ff393a]`}
               />
             ) : (
               <div className={`${config.avatar} rounded-full bg-[#ff393a]/20 flex items-center justify-center flex-shrink-0`}>
@@ -183,10 +215,12 @@ export const HostsList: React.FC<HostsListProps> = ({
         {visibleCoHosts.map((coHost) => (
           <div key={coHost.id} className={`flex items-center ${config.gap}`}>
             {coHost.avatar_url ? (
-              <img
-                src={cdnUrl(coHost.avatar_url)}
+              <AvatarImg
+                src={coHost.avatar_url}
                 alt={coHost.name}
                 className={`${config.avatar} rounded-full object-cover flex-shrink-0`}
+                fallbackClassName={`${config.avatar} rounded-full bg-[#ff393a]/20 flex items-center justify-center flex-shrink-0`}
+                iconClassName={`${config.icon} text-[#ff393a]`}
               />
             ) : (
               <div className={`${config.avatar} rounded-full bg-[#ff393a]/20 flex items-center justify-center flex-shrink-0`}>
@@ -264,10 +298,12 @@ export const HostsAvatars: React.FC<HostsAvatarsProps> = ({
         {/* Primary host avatar */}
         {displayHostName && (
           hostProfile?.avatar_url ? (
-            <img
-              src={cdnUrl(hostProfile.avatar_url)}
+            <AvatarImg
+              src={hostProfile.avatar_url}
               alt={displayHostName}
               className="w-8 min-w-8 h-8 min-h-8 rounded-full object-cover flex-shrink-0 border-2 border-theme-card"
+              fallbackClassName="w-8 min-w-8 h-8 min-h-8 rounded-full bg-[#ff393a] flex items-center justify-center flex-shrink-0 border-2 border-theme-card relative"
+              iconClassName="w-4 h-4 text-theme-text"
               style={{ zIndex: 10, marginLeft: '-8px' }}
             />
           ) : (
@@ -283,10 +319,12 @@ export const HostsAvatars: React.FC<HostsAvatarsProps> = ({
         {displayCoHosts.map((coHost, index) => (
           <div key={coHost.id} className="flex-shrink-0" style={{ zIndex: 9 - index, marginLeft: '-8px' }}>
             {coHost.avatar_url ? (
-              <img
-                src={cdnUrl(coHost.avatar_url)}
+              <AvatarImg
+                src={coHost.avatar_url}
                 alt={coHost.name}
                 className="w-8 min-w-8 h-8 min-h-8 rounded-full object-cover border-2 border-theme-card"
+                fallbackClassName="w-8 min-w-8 h-8 min-h-8 rounded-full bg-[#ff393a] flex items-center justify-center border-2 border-theme-card"
+                iconClassName="w-4 h-4 text-theme-text"
               />
             ) : (
               <div className="w-8 min-w-8 h-8 min-h-8 rounded-full bg-[#ff393a] flex items-center justify-center border-2 border-theme-card">


### PR DESCRIPTION
## Summary
- Add `AvatarImg` component with `onError` handler so broken image URLs (e.g. Instagram/X profile links pasted into avatar field) gracefully fall back to the default icon instead of showing broken alt text
- Fall back to `coHostLogoUrl` in partner sync when `coHostAvatarUrl` is empty

## Data fix (already applied)
- Cleared 3 bad avatar URLs on São Paulo event (Hall Skate Zn, Felipe Flip, Bless SkateshopBarbershop)
- Cleared 1 bad avatar URL on Victoria Falls event (IMan Afrikah)

## Test plan
- [ ] Verify São Paulo event hosts show fallback icons (not broken text)
- [ ] Verify other events with partner avatars still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)