### PR TITLE
Allow underbosses to access Partners tab (scoped)

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -22,6 +22,16 @@ export async function isSuperAdmin(email?: string): Promise<boolean> {
   return admin?.role === 'super_admin';
 }
 
+// Check if the user is an active underboss (DB-backed)
+export async function isUnderboss(email?: string): Promise<boolean> {
+  if (!email) return false;
+  const ub = await prisma.underboss.findFirst({
+    where: { email: email.toLowerCase(), isActive: true },
+    select: { id: true },
+  });
+  return !!ub;
+}
+
 // Optional auth: tries to parse the JWT but doesn't error if missing/invalid
 export const optionalAuth = (
   req: AuthRequest,

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1,7 +1,7 @@
 import { Router, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isAdmin, isUnderboss } from '../middleware/auth.js';
 import { requireSponsorAuth, SponsorRequest } from '../middleware/sponsorAuth.js';
 import { AppError } from '../middleware/error.js';
 import { syncPartnerToAllEvents, syncAutoSponsorsToAllEvents, removePartnerFromAllEvents, removeAutoSponsorsFromAllEvents } from '../helpers/partnerSync.js';
@@ -10,14 +10,23 @@ import { syncPartnerToAllEvents, syncAutoSponsorsToAllEvents, removePartnerFromA
 
 export const sponsorUserAdminRouter = Router();
 
-// GET /api/sponsor-users/list - List all sponsor users (admin only)
+// GET /api/sponsor-users/list - List sponsor users (admin: all, underboss: own)
 sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    if (!(await isAdmin(req.userEmail))) {
-      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    const adminUser = await isAdmin(req.userEmail);
+    const underbossUser = !adminUser ? await isUnderboss(req.userEmail) : false;
+    if (!adminUser && !underbossUser) {
+      throw new AppError('Admin or underboss access required', 403, 'FORBIDDEN');
+    }
+
+    const whereClause: any = {};
+    if (!adminUser) {
+      // Underboss: only see partners they created
+      whereClause.createdBy = req.userEmail;
     }
 
     const sponsorUsers = await prisma.sponsorUser.findMany({
+      where: whereClause,
       orderBy: [{ descriptionSortOrder: 'asc' }, { createdAt: 'desc' }],
       select: {
         id: true,
@@ -64,11 +73,13 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
   }
 });
 
-// POST /api/sponsor-users - Create a sponsor user (super admin only)
+// POST /api/sponsor-users - Create a sponsor user (admin or underboss)
 sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    if (!(await isAdmin(req.userEmail))) {
-      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    const adminUser = await isAdmin(req.userEmail);
+    const underbossUser = !adminUser ? await isUnderboss(req.userEmail) : false;
+    if (!adminUser && !underbossUser) {
+      throw new AppError('Admin or underboss access required', 403, 'FORBIDDEN');
     }
 
     const {
@@ -94,13 +105,16 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
       throw new AppError('A sponsor user with this email already exists', 409, 'CONFLICT');
     }
 
+    // Underboss: always set createdBy to their email (prevent spoofing)
+    const createdBy = underbossUser ? req.userEmail : (req.userEmail || null);
+
     const sponsorUser = await prisma.sponsorUser.create({
       data: {
         email: email.toLowerCase(),
         tag: tag.trim().toLowerCase(),
         name: name?.trim() || null,
         notes: notes?.trim() || null,
-        createdBy: req.userEmail || null,
+        createdBy,
         coHostName: coHostName?.trim() || null,
         coHostWebsite: coHostWebsite?.trim() || null,
         coHostTwitter: coHostTwitter?.trim() || null,
@@ -134,18 +148,30 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
   }
 });
 
-// PATCH /api/sponsor-users/reorder - Reorder sponsor users by descriptionSortOrder (admin only)
+// PATCH /api/sponsor-users/reorder - Reorder sponsor users by descriptionSortOrder (admin or underboss)
 // NOTE: Must be registered before /:id to avoid Express matching 'reorder' as an id
 sponsorUserAdminRouter.patch('/reorder', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    if (!(await isAdmin(req.userEmail))) {
-      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    const adminUser = await isAdmin(req.userEmail);
+    const underbossUser = !adminUser ? await isUnderboss(req.userEmail) : false;
+    if (!adminUser && !underbossUser) {
+      throw new AppError('Admin or underboss access required', 403, 'FORBIDDEN');
     }
 
     const { sponsorUserIds } = req.body;
 
     if (!Array.isArray(sponsorUserIds) || sponsorUserIds.length === 0) {
       throw new AppError('sponsorUserIds must be a non-empty array', 400, 'VALIDATION_ERROR');
+    }
+
+    // Underboss: verify all IDs belong to them
+    if (!adminUser) {
+      const ownedCount = await prisma.sponsorUser.count({
+        where: { id: { in: sponsorUserIds }, createdBy: req.userEmail },
+      });
+      if (ownedCount !== sponsorUserIds.length) {
+        throw new AppError('You can only reorder your own partners', 403, 'FORBIDDEN');
+      }
     }
 
     // Capture old global order BEFORE updating
@@ -246,11 +272,13 @@ sponsorUserAdminRouter.patch('/reorder', requireAuth, async (req: AuthRequest, r
   }
 });
 
-// PATCH /api/sponsor-users/:id - Update a sponsor user (super admin only)
+// PATCH /api/sponsor-users/:id - Update a sponsor user (admin or underboss)
 sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    if (!(await isAdmin(req.userEmail))) {
-      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    const adminUser = await isAdmin(req.userEmail);
+    const underbossUser = !adminUser ? await isUnderboss(req.userEmail) : false;
+    if (!adminUser && !underbossUser) {
+      throw new AppError('Admin or underboss access required', 403, 'FORBIDDEN');
     }
 
     const { id } = req.params;
@@ -270,6 +298,11 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
     });
     if (!oldSponsorUser) {
       throw new AppError('Sponsor user not found', 404, 'NOT_FOUND');
+    }
+
+    // Underboss: verify ownership
+    if (!adminUser && oldSponsorUser.createdBy !== req.userEmail) {
+      throw new AppError('You can only edit your own partners', 403, 'FORBIDDEN');
     }
 
     const updateData: any = {};
@@ -371,11 +404,13 @@ sponsorUserAdminRouter.patch('/:id', requireAuth, async (req: AuthRequest, res: 
   }
 });
 
-// DELETE /api/sponsor-users/:id - Deactivate a sponsor user (super admin only)
+// DELETE /api/sponsor-users/:id - Deactivate a sponsor user (admin or underboss)
 sponsorUserAdminRouter.delete('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    if (!(await isAdmin(req.userEmail))) {
-      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    const adminUser = await isAdmin(req.userEmail);
+    const underbossUser = !adminUser ? await isUnderboss(req.userEmail) : false;
+    if (!adminUser && !underbossUser) {
+      throw new AppError('Admin or underboss access required', 403, 'FORBIDDEN');
     }
 
     const { id } = req.params;
@@ -384,6 +419,11 @@ sponsorUserAdminRouter.delete('/:id', requireAuth, async (req: AuthRequest, res:
     const sponsorUser = await prisma.sponsorUser.findUnique({
       where: { id },
     });
+
+    // Underboss: verify ownership
+    if (!adminUser && sponsorUser?.createdBy !== req.userEmail) {
+      throw new AppError('You can only deactivate your own partners', 403, 'FORBIDDEN');
+    }
 
     await prisma.sponsorUser.update({
       where: { id },

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -7,11 +7,12 @@ import { PartnerForm } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
 
 interface PartnerManagerProps {
+  isAdmin?: boolean;
   onSyncComplete?: () => void;
   onFlyerRegenNeeded?: (tag: string) => void;
 }
 
-export function PartnerManager({ onSyncComplete, onFlyerRegenNeeded }: PartnerManagerProps) {
+export function PartnerManager({ isAdmin, onSyncComplete, onFlyerRegenNeeded }: PartnerManagerProps) {
   const [partners, setPartners] = useState<SponsorUser[]>([]);
   const [tagCounts, setTagCounts] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
@@ -208,21 +209,23 @@ export function PartnerManager({ onSyncComplete, onFlyerRegenNeeded }: PartnerMa
           {partners.map((partner, index) => (
             <div
               key={partner.id}
-              draggable
-              onDragStart={() => handleDragStart(index)}
-              onDragOver={(e) => handleDragOver(e, index)}
-              onDragEnd={handleDragEnd}
-              className={`p-3 rounded-xl border transition-colors cursor-move ${
+              draggable={!!isAdmin}
+              onDragStart={isAdmin ? () => handleDragStart(index) : undefined}
+              onDragOver={isAdmin ? (e) => handleDragOver(e, index) : undefined}
+              onDragEnd={isAdmin ? handleDragEnd : undefined}
+              className={`p-3 rounded-xl border transition-colors ${isAdmin ? 'cursor-move' : ''} ${
                 partner.isActive
                   ? 'bg-theme-surface border-theme-stroke'
                   : 'bg-theme-surface/50 border-theme-stroke/50 opacity-60'
               } ${draggedIndex === index ? 'opacity-50' : 'opacity-100'}`}
             >
               <div className="flex items-start gap-3">
-                {/* Drag handle */}
-                <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0 pt-1">
-                  <GripVertical size={16} />
-                </div>
+                {/* Drag handle (admin only) */}
+                {isAdmin && (
+                  <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0 pt-1">
+                    <GripVertical size={16} />
+                  </div>
+                )}
 
                 {/* Avatar */}
                 {partner.coHostAvatarUrl ? (

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -416,21 +416,19 @@ export function UnderbossDashboard() {
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}
             </button>
-            {isAdmin && (
-              <button
-                onClick={() => setActiveTab('partners')}
-                className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
-                  activeTab === 'partners'
-                    ? 'text-theme-text'
-                    : 'text-theme-text-muted hover:text-theme-text-secondary'
-                }`}
-              >
-                Partners
-                {activeTab === 'partners' && (
-                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
-                )}
-              </button>
-            )}
+            <button
+              onClick={() => setActiveTab('partners')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'partners'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              Partners
+              {activeTab === 'partners' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
           </div>
 
           {activeTab === 'events' && (
@@ -441,8 +439,8 @@ export function UnderbossDashboard() {
             <CitiesTable events={filteredData.events} selectedRegions={selectedRegions} meData={meData} onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }} />
           )}
 
-          {activeTab === 'partners' && isAdmin && (
-            <PartnerManager onSyncComplete={loadDashboard} onFlyerRegenNeeded={handleFlyerRegenForTag} />
+          {activeTab === 'partners' && (
+            <PartnerManager isAdmin={isAdmin} onSyncComplete={loadDashboard} onFlyerRegenNeeded={handleFlyerRegenForTag} />
           )}
         </section>
         </div>


### PR DESCRIPTION
## Summary
- Adds `isUnderboss()` helper to auth middleware
- Relaxes admin-only gate on sponsor-user routes to allow underboss access with `createdBy`-based scoping
- Shows Partners tab for all underbosses on the underboss dashboard
- Hides drag-to-reorder for non-admin users (global ordering only makes sense for admins)

## Scoping Details
- **GET /list**: Admins see all, underbosses see only `createdBy: their email`
- **POST /**: Underbosses can create, `createdBy` always set to their email
- **PATCH /:id**: Underbosses can only edit their own partners
- **DELETE /:id**: Underbosses can only deactivate their own partners
- **PATCH /reorder**: Underbosses can only reorder their own partners

## Test plan
- [ ] Log in as underboss → Partners tab visible
- [ ] Add a partner as underboss → appears in list
- [ ] Log in as different underboss → should NOT see first underboss's partner
- [ ] Log in as admin → should see ALL partners
- [ ] As underboss, attempt edit/delete of another's partner via dev tools → 403
- [ ] Partner auto-sync to tagged events still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)