### PR TITLE
Fix: All Tags shows per-partner click breakdown

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -515,7 +515,9 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
   try {
     // Admins can pass ?tag= to filter, or see all tagged events
     const queryTag = req.query.tag as string | undefined;
-    const tag = queryTag?.trim().toLowerCase() || req.sponsorUser?.tag;
+    const tag = req.isAdminViewing
+      ? (queryTag?.trim().toLowerCase() || undefined)
+      : (queryTag?.trim().toLowerCase() || req.sponsorUser?.tag);
     const sponsorUserId = req.sponsorUser?.id;
 
     // Build where clause — admins without a tag filter see all events that have any eventTags

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -566,6 +566,17 @@ export function PartnerDashboardPage() {
               clicksByPlatformAgg[platform].uniqueClickers += link.uniqueClickers;
             }
           }
+          // Aggregate clicks by partner name (for All Tags view)
+          const clicksByPartnerAgg: Record<string, { clicks: number; uniqueClickers: number }> = {};
+          for (const e of allEvents) {
+            for (const link of e.clickStats?.byLink || []) {
+              // Extract base partner name: "PizzaDAO_twitter" -> "PizzaDAO"
+              const baseName = (link.linkLabel || 'Unknown').replace(/_[^_]+$/, '');
+              if (!clicksByPartnerAgg[baseName]) clicksByPartnerAgg[baseName] = { clicks: 0, uniqueClickers: 0 };
+              clicksByPartnerAgg[baseName].clicks += link.clicks;
+              clicksByPartnerAgg[baseName].uniqueClickers += link.uniqueClickers;
+            }
+          }
           const isSwc = dashboardData?.tag === 'swc';
           const withVenue = allEvents.filter(e => e.progress?.hasVenue).length;
           const withBudget = allEvents.filter(e => e.progress?.hasBudget).length;
@@ -604,21 +615,36 @@ export function PartnerDashboardPage() {
                   </div>
                   <div className="text-2xl font-bold text-theme-text">{totalClicks.toLocaleString()}</div>
                   <div className="text-xs text-theme-text-muted mt-1">{totalUniqueClickers.toLocaleString()} unique</div>
-                  {Object.keys(clicksByPlatformAgg).length > 0 && (
-                    <div className="flex flex-wrap gap-2 mt-2">
-                      {Object.entries(clicksByPlatformAgg)
-                        .sort((a, b) => b[1].clicks - a[1].clicks)
-                        .map(([platform, data]) => (
-                        <span
-                          key={platform}
-                          className="inline-flex items-center gap-1 text-xs text-theme-text-muted"
-                          title={`${platform}: ${data.clicks} clicks (${data.uniqueClickers} unique)`}
-                        >
-                          <PlatformIcon platform={platform} size={14} />
-                          <span className="font-semibold text-theme-text">{data.clicks}</span>
-                        </span>
-                      ))}
-                    </div>
+                  {!selectedTag && dashboardData?.isAdmin ? (
+                    Object.keys(clicksByPartnerAgg).length > 0 && (
+                      <div className="flex flex-col gap-1 mt-2">
+                        {Object.entries(clicksByPartnerAgg)
+                          .sort((a, b) => b[1].clicks - a[1].clicks)
+                          .map(([partner, data]) => (
+                            <div key={partner} className="flex items-center justify-between text-xs">
+                              <span className="text-theme-text-secondary">{partner}</span>
+                              <span className="text-theme-text font-semibold">{data.clicks} <span className="text-theme-text-muted font-normal">({data.uniqueClickers} unique)</span></span>
+                            </div>
+                          ))}
+                      </div>
+                    )
+                  ) : (
+                    Object.keys(clicksByPlatformAgg).length > 0 && (
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {Object.entries(clicksByPlatformAgg)
+                          .sort((a, b) => b[1].clicks - a[1].clicks)
+                          .map(([platform, data]) => (
+                          <span
+                            key={platform}
+                            className="inline-flex items-center gap-1 text-xs text-theme-text-muted"
+                            title={`${platform}: ${data.clicks} clicks (${data.uniqueClickers} unique)`}
+                          >
+                            <PlatformIcon platform={platform} size={14} />
+                            <span className="font-semibold text-theme-text">{data.clicks}</span>
+                          </span>
+                        ))}
+                      </div>
+                    )
                   )}
                 </div>
                 {isSwc && (


### PR DESCRIPTION
## Summary
- Fixed backend tag fallback that caused All Tags to only show PizzaDAO data
- Added per-partner click aggregation in the Partner Link Clicks stats tile when viewing All Tags

## Changes
- `backend/src/routes/sponsor-user.routes.ts`: Don't fall back to admin's own tag when no tag query param is provided
- `frontend/src/pages/PartnerDashboardPage.tsx`: Aggregate and display clicks by partner name instead of platform when in All Tags view

## Test plan
- [ ] Admin selects "All Tags" → sees events from all partner tags
- [ ] Partner Link Clicks tile shows per-partner rows with click totals
- [ ] Selecting a specific tag still shows platform breakdown as before
- [ ] Non-admin partners still see only their own data

🤖 Generated with [Claude Code](https://claude.com/claude-code)