### PR TITLE
Update underboss price calculator

### DIFF
--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -6,6 +6,7 @@ import { IconInput } from '../IconInput';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
 import { triggerFlyerRegenForEvents } from '../flyer/autoRegenFlyer';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
+import { calculateEventPrice } from '../../utils/sponsorshipPricing';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
 interface DisplayPhoto {
@@ -469,6 +470,10 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
   const relTime = formatRelativeTime(event.date);
   const fullDate = formatFullDate(event.date);
 
+  const cityName = event.name.replace(/^Global Pizza Party\s*/i, '').trim();
+  const priceGuests = event.expectedGuests ?? event.guestCount ?? 30;
+  const price = calculateEventPrice(priceGuests, cityName);
+
   const hasNotes = !!(event.underbossNotes || notesValue.trim());
 
   const displayedPhotos = showAllPhotos ? displayPhotos : displayPhotos.slice(0, 12);
@@ -538,6 +543,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                 <span className={`text-xs ${relTime.isPast ? 'text-red-400' : 'text-theme-text-muted'}`}>
                   {relTime.text}
                 </span>
+                <span className="text-xs text-green-400/60 ml-1">&middot; ${price.toLocaleString()}</span>
               </div>
               {/* Inline notes editor */}
               {notesOpen && (

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -101,6 +101,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   const [customTag, setCustomTag] = useState('');
   const [showCopyCitiesModal, setShowCopyCitiesModal] = useState(false);
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
+  const [discount, setDiscount] = useState(0);
 
   // Alphabetized city names from the currently-selected events.
   // Reuses the same extraction logic as the Send Telegram action: strip
@@ -351,8 +352,27 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           <span className="text-sm text-green-400">
             Suggested sponsorship for "<span className="font-medium">{tagFilter}</span>"
             ({sponsorshipSuggestion.eventCount} events):
-            <span className="font-bold ml-1">${sponsorshipSuggestion.total.toLocaleString()}</span>
+            {discount > 0 ? (
+              <>
+                <span className="line-through opacity-50 ml-1">${sponsorshipSuggestion.total.toLocaleString()}</span>
+                <span className="font-bold ml-1">${Math.round(sponsorshipSuggestion.total * (1 - discount / 100)).toLocaleString()}</span>
+              </>
+            ) : (
+              <span className="font-bold ml-1">${sponsorshipSuggestion.total.toLocaleString()}</span>
+            )}
           </span>
+          <div className="flex items-center gap-1 ml-2">
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={discount || ''}
+              onChange={(e) => setDiscount(Math.max(0, Math.min(100, Number(e.target.value) || 0)))}
+              placeholder="0"
+              className="w-12 px-1.5 py-0.5 text-xs text-center rounded bg-black/30 border border-green-500/20 text-green-400 placeholder:text-green-400/30 focus:outline-none focus:border-green-500/40"
+            />
+            <span className="text-xs text-green-400/60">% off</span>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -373,6 +373,11 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
             />
             <span className="text-xs text-green-400/60">% off</span>
           </div>
+          {sponsorshipSuggestion.missingExpectedGuests > 0 && (
+            <span className="text-xs text-amber-400/70 ml-2">
+              ({sponsorshipSuggestion.missingExpectedGuests} without expected guests)
+            </span>
+          )}
         </div>
       )}
 

--- a/frontend/src/utils/sponsorshipPricing.ts
+++ b/frontend/src/utils/sponsorshipPricing.ts
@@ -22,16 +22,16 @@ export function isTier1City(cityName: string): boolean {
 
 /**
  * Calculate the sponsorship price for a single event.
- * Base price scales linearly from $2 (30 guests) to $500 (250 guests).
- * Tier-1 cities get a 2x multiplier.
+ * $200 minimum, linear interpolation up to $500 (non-tier-1) or $1,000 (tier-1).
  * Guest count is clamped to [30, 250].
  */
 export function calculateEventPrice(guests: number, cityName: string): number {
   const clamped = Math.max(30, Math.min(250, guests));
-  // Linear interpolation: $2 at 30 guests, $500 at 250 guests
-  const base = 2 + ((clamped - 30) / (250 - 30)) * (500 - 2);
-  const multiplier = isTier1City(cityName) ? 2 : 1;
-  return Math.round(base * multiplier);
+  const tier1 = isTier1City(cityName);
+  const min = 200;
+  const max = tier1 ? 1000 : 500;
+  const price = min + ((clamped - 30) / (250 - 30)) * (max - min);
+  return Math.round(price);
 }
 
 /**

--- a/frontend/src/utils/sponsorshipPricing.ts
+++ b/frontend/src/utils/sponsorshipPricing.ts
@@ -41,17 +41,19 @@ export function calculateEventPrice(guests: number, cityName: string): number {
  */
 export function calculateTagSponsorshipTotal(
   events: UnderbossEvent[]
-): { total: number; eventCount: number } {
+): { total: number; eventCount: number; missingExpectedGuests: number } {
   const prefix = 'Global Pizza Party ';
   let total = 0;
+  let missingExpectedGuests = 0;
 
   for (const event of events) {
     const cityName = event.name.startsWith(prefix)
       ? event.name.slice(prefix.length)
       : event.name;
+    if (event.expectedGuests == null) missingExpectedGuests++;
     const guests = event.expectedGuests ?? event.guestCount ?? 30;
     total += calculateEventPrice(guests, cityName);
   }
 
-  return { total, eventCount: events.length };
+  return { total, eventCount: events.length, missingExpectedGuests };
 }


### PR DESCRIPTION
## Summary
- Pricing formula updated: $200 minimum, scales to $500 (regular) or $1,000 (tier-1 cities like NYC)
- Per-city price shown on each event row next to the date (e.g. `· $350`)
- Optional discount % input added next to the sponsorship total banner
- Uses `expectedGuests` as priority in calculation

## Test plan
- [ ] Filter by a partner tag on /underboss and verify the sponsorship total reflects the new $200-$1,000 range
- [ ] Check a tier-1 city (e.g. New York) shows higher price than a non-tier-1 city
- [ ] Verify per-city price appears next to date on each event row
- [ ] Enter a discount % and confirm the total updates with strikethrough on original

🤖 Generated with [Claude Code](https://claude.com/claude-code)