### PR TITLE
feat: multi-tag partner emails

### DIFF
--- a/backend/prisma/migrations/20260508_multi_tag_partner_email.sql
+++ b/backend/prisma/migrations/20260508_multi_tag_partner_email.sql
@@ -1,0 +1,16 @@
+-- Allow the same email to appear on multiple sponsor_user rows (one per tag)
+-- Remove the unique constraint on email alone
+ALTER TABLE sponsor_users DROP CONSTRAINT IF EXISTS sponsor_users_email_key;
+
+-- Add composite unique constraint on (email, tag)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'sponsor_users_email_tag_key'
+  ) THEN
+    ALTER TABLE sponsor_users ADD CONSTRAINT sponsor_users_email_tag_key UNIQUE (email, tag);
+  END IF;
+END $$;
+
+-- Add index on email for fast lookups
+CREATE INDEX IF NOT EXISTS idx_sponsor_users_email ON sponsor_users(email);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1133,7 +1133,7 @@ model Admin {
 
 model SponsorUser {
   id        String   @id @default(uuid()) @db.Uuid
-  email     String   @unique
+  email     String
   name      String?
   tag       String
   isActive  Boolean  @default(true) @map("is_active")
@@ -1166,6 +1166,8 @@ model SponsorUser {
   quizQuestionTemplates QuizQuestionTemplate[]
   partnerEventNotes     PartnerEventNote[]
 
+  @@unique([email, tag])
+  @@index([email])
   @@index([tag])
   @@map("sponsor_users")
 }

--- a/backend/src/middleware/sponsorAuth.ts
+++ b/backend/src/middleware/sponsorAuth.ts
@@ -32,18 +32,22 @@ export async function requireSponsorAuth(
     if (await isAdmin(email)) {
       req.isAdminViewing = true;
       // Still check if admin is also a sponsor
-      const sponsorUser = await prisma.sponsorUser.findFirst({
+      const sponsorUsers = await prisma.sponsorUser.findMany({
         where: { email: email.toLowerCase(), isActive: true },
         select: { id: true, email: true, name: true, tag: true, isActive: true },
       });
-      if (sponsorUser) {
-        req.sponsorUser = sponsorUser;
+      if (sponsorUsers.length > 0) {
+        const requestedTag = (req.query?.tag as string)?.trim().toLowerCase();
+        const match = requestedTag
+          ? sponsorUsers.find(s => s.tag === requestedTag)
+          : sponsorUsers[0];
+        req.sponsorUser = match || sponsorUsers[0];
       }
       return next();
     }
 
     // Look up sponsor by email
-    const sponsorUser = await prisma.sponsorUser.findFirst({
+    const sponsorUsers = await prisma.sponsorUser.findMany({
       where: { email: email.toLowerCase(), isActive: true },
       select: {
         id: true,
@@ -54,13 +58,23 @@ export async function requireSponsorAuth(
       },
     });
 
-    if (sponsorUser) {
+    if (sponsorUsers.length > 0) {
+      const requestedTag = (req.query?.tag as string)?.trim().toLowerCase();
+      const match = requestedTag
+        ? sponsorUsers.find(s => s.tag === requestedTag)
+        : sponsorUsers[0];
+
+      if (requestedTag && !match) {
+        throw new AppError('Not authorized for this tag', 403, 'FORBIDDEN');
+      }
+
+      const selected = match || sponsorUsers[0];
       req.sponsorUser = {
-        id: sponsorUser.id,
-        email: sponsorUser.email,
-        name: sponsorUser.name,
-        tag: sponsorUser.tag,
-        isActive: sponsorUser.isActive,
+        id: selected.id,
+        email: selected.email,
+        name: selected.name,
+        tag: selected.tag,
+        isActive: selected.isActive,
       };
       return next();
     }

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -14,15 +14,17 @@ async function canUserViewReport(partyId: string, userId?: string, userEmail?: s
 
   // Check if user is a sponsor tagged on this event
   if (userEmail) {
-    const sponsorUser = await prisma.sponsorUser.findFirst({
+    const sponsorUsers = await prisma.sponsorUser.findMany({
       where: { email: userEmail.toLowerCase(), isActive: true },
+      select: { tag: true },
     });
-    if (sponsorUser) {
+    if (sponsorUsers.length > 0) {
+      const sponsorTags = sponsorUsers.map(s => s.tag);
       const party = await prisma.party.findUnique({
         where: { id: partyId },
         select: { eventTags: true },
       });
-      if (party && party.eventTags && Array.isArray(party.eventTags) && party.eventTags.includes(sponsorUser.tag)) {
+      if (party && party.eventTags && Array.isArray(party.eventTags) && (party.eventTags as string[]).some(t => sponsorTags.includes(t))) {
         return true;
       }
     }
@@ -339,12 +341,14 @@ async function findPartyBySlug(slug: string) {
 // Helper: check if user is a sponsor tagged on an event (by any slug)
 async function isSponsorForReport(slug: string, userEmail?: string): Promise<boolean> {
   if (!userEmail) return false;
-  const sponsorUser = await prisma.sponsorUser.findFirst({
+  const sponsorUsers = await prisma.sponsorUser.findMany({
     where: { email: userEmail.toLowerCase(), isActive: true },
+    select: { tag: true },
   });
-  if (!sponsorUser) return false;
+  if (sponsorUsers.length === 0) return false;
+  const sponsorTags = sponsorUsers.map(s => s.tag);
   const party = await findPartyBySlug(slug);
-  return !!(party?.eventTags && Array.isArray(party.eventTags) && (party.eventTags as string[]).includes(sponsorUser.tag));
+  return !!(party?.eventTags && Array.isArray(party.eventTags) && (party.eventTags as string[]).some(t => sponsorTags.includes(t)));
 }
 
 // GET /api/reports/:publicSlug/check - Check if report requires password (public, optionalAuth)

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -96,13 +96,13 @@ sponsorUserAdminRouter.post('/', requireAuth, async (req: AuthRequest, res: Resp
       throw new AppError('Email and tag are required', 400, 'VALIDATION_ERROR');
     }
 
-    // Check for existing sponsor with same email
-    const existing = await prisma.sponsorUser.findUnique({
-      where: { email: email.toLowerCase() },
+    // Check for existing sponsor with same email+tag combo
+    const existing = await prisma.sponsorUser.findFirst({
+      where: { email: email.toLowerCase(), tag: tag.trim().toLowerCase() },
     });
 
     if (existing) {
-      throw new AppError('A sponsor user with this email already exists', 409, 'CONFLICT');
+      throw new AppError('This email is already registered for this tag', 409, 'CONFLICT');
     }
 
     // Underboss: always set createdBy to their email (prevent spoofing)
@@ -467,7 +467,7 @@ sponsorDashboardRouter.get('/me', requireAuth, async (req: AuthRequest, res: Res
 
     const adminUser = await isAdmin(email);
 
-    const sponsorUser = await prisma.sponsorUser.findFirst({
+    const sponsorUsers = await prisma.sponsorUser.findMany({
       where: { email: email.toLowerCase(), isActive: true },
       select: {
         id: true,
@@ -478,16 +478,22 @@ sponsorDashboardRouter.get('/me', requireAuth, async (req: AuthRequest, res: Res
       },
     });
 
-    if (sponsorUser) {
+    if (sponsorUsers.length > 0) {
       return res.json({
         isSponsor: true,
         isAdmin: adminUser,
         sponsor: {
-          id: sponsorUser.id,
-          email: sponsorUser.email,
-          name: sponsorUser.name,
-          tag: sponsorUser.tag,
+          id: sponsorUsers[0].id,
+          email: sponsorUsers[0].email,
+          name: sponsorUsers[0].name,
+          tag: sponsorUsers[0].tag,
         },
+        sponsors: sponsorUsers.map(s => ({
+          id: s.id,
+          email: s.email,
+          name: s.name,
+          tag: s.tag,
+        })),
       });
     }
 

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -221,8 +221,13 @@ export function PartnerDashboardPage() {
           return;
         }
 
-        // If admin, load all events first to get available tags
-        const tag = me.isAdmin ? selectedTag : me.sponsor?.tag;
+        // Determine which tag to fetch events for
+        const isMultiTag = !me.isAdmin && me.sponsors && me.sponsors.length > 1;
+        const tag = me.isAdmin
+          ? selectedTag
+          : isMultiTag
+            ? (selectedTag || me.sponsors![0].tag)
+            : me.sponsor?.tag;
         const data = await fetchSponsorEvents(tag);
         setDashboardData(data);
 
@@ -240,6 +245,14 @@ export function PartnerDashboardPage() {
             result.sponsorUsers.forEach(su => tags.add(su.tag));
           } catch { /* admin-only, ok to fail */ }
           setAvailableTags(Array.from(tags).sort());
+        }
+
+        // For multi-tag partners (non-admin), set available tags from their sponsors
+        if (isMultiTag && availableTags.length === 0) {
+          setAvailableTags(me.sponsors!.map(s => s.tag).sort());
+          if (!selectedTag) {
+            setSelectedTag(me.sponsors![0].tag);
+          }
         }
       } catch (err: any) {
         setError(err.message || 'Failed to load partner dashboard');
@@ -435,18 +448,20 @@ export function PartnerDashboardPage() {
           </div>
 
           {/* Admin tag filter */}
-          {dashboardData?.isAdmin && availableTags.length > 0 && (
+          {(dashboardData?.isAdmin || (meData?.sponsors && meData.sponsors.length > 1)) && availableTags.length > 0 && (
             <div className="mt-4 flex flex-wrap gap-2">
-              <button
-                onClick={() => setSelectedTag(undefined)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border ${
-                  !selectedTag
-                    ? 'border-[#E52828] text-theme-text bg-[#E52828]/20'
-                    : 'border-theme-stroke text-theme-text-muted hover:text-theme-text-secondary'
-                }`}
-              >
-                All tags
-              </button>
+              {dashboardData?.isAdmin && (
+                <button
+                  onClick={() => setSelectedTag(undefined)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border ${
+                    !selectedTag
+                      ? 'border-[#E52828] text-theme-text bg-[#E52828]/20'
+                      : 'border-theme-stroke text-theme-text-muted hover:text-theme-text-secondary'
+                  }`}
+                >
+                  All tags
+                </button>
+              )}
               {availableTags.map(tag => (
                 <button
                   key={tag}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1250,6 +1250,12 @@ export interface SponsorMeResponse {
     name: string | null;
     tag: string;
   } | null;
+  sponsors?: {
+    id: string;
+    email: string;
+    name: string | null;
+    tag: string;
+  }[];
 }
 
 export interface SponsorDashboardData {


### PR DESCRIPTION
## Summary
- Remove @unique on sponsor_users.email, add composite @@unique([email, tag]) so the same email can belong to multiple tags
- /api/sponsor/me returns all sponsor records in a sponsors array (backward-compatible sponsor field preserved)
- sponsorAuth middleware selects the correct sponsor record based on ?tag= query param
- Report access checks now use findMany + some() to match ANY of the users tags
- Partner dashboard shows a tag picker when the user has multiple tags

## Test plan
- [ ] Admin creates same email with two different tags should succeed
- [ ] Admin creates duplicate email+tag should get 409 error
- [ ] Partner with 1 tag dashboard loads normally, no tag picker
- [ ] Partner with 2+ tags tag picker appears, switching tags reloads events
- [ ] Notes/checklist scoped to correct sponsor_user_id per tag
- [ ] Reports: partner with tags A B can view events tagged with either
- [ ] Admin tag picker still works as before