### PR TITLE
feat: GPP global editor access

### DIFF
--- a/backend/src/helpers/partyAccess.ts
+++ b/backend/src/helpers/partyAccess.ts
@@ -2,6 +2,15 @@ import { prisma } from '../config/database.js';
 import { isSuperAdmin } from '../middleware/auth.js';
 
 /**
+ * Emails that automatically get editor access to ALL GPP events.
+ * These users don't appear in the co_hosts array, so they're invisible
+ * in host settings and on the public event page.
+ */
+export const GPP_GLOBAL_EDITORS = [
+  'hunter@rarepizzas.com',
+];
+
+/**
  * Valid tab IDs that can appear in a co-host's allowedTabs array.
  * Used for validation when saving co-host permissions.
  */
@@ -59,6 +68,13 @@ export async function canUserEditParty(
     return true;
   }
 
+  // Check if user is a GPP global editor
+  if (userEmail && (party as any).eventType === 'gpp') {
+    if (GPP_GLOBAL_EDITORS.some(e => e.toLowerCase() === userEmail.toLowerCase())) {
+      return true;
+    }
+  }
+
   // Check if user is a co-host with edit permissions
   if (userEmail) {
     const coHosts = party.coHosts as Array<{ email?: string; canEdit?: boolean }> | null;
@@ -101,7 +117,7 @@ export async function canUserAccessTab(
   // Fetch the party to check ownership and co-host permissions
   const party = await prisma.party.findUnique({
     where: { id: partyId },
-    select: { userId: true, coHosts: true },
+    select: { userId: true, coHosts: true, eventType: true },
   });
 
   if (!party) {
@@ -111,6 +127,13 @@ export async function canUserAccessTab(
   // Party owner can access all tabs
   if (party.userId === userId) {
     return true;
+  }
+
+  // GPP global editors can access all tabs
+  if (userEmail && party.eventType === 'gpp') {
+    if (GPP_GLOBAL_EDITORS.some(e => e.toLowerCase() === userEmail.toLowerCase())) {
+      return true;
+    }
   }
 
   // Check co-host tab permissions

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
+import { GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 
 const router = Router();
 
@@ -320,12 +321,12 @@ router.post('/:slug/check-host', async (req: Request, res: Response, next: NextF
     // Find party by invite code or custom URL
     let party = await prisma.party.findUnique({
       where: { inviteCode: slug },
-      select: { coHosts: true, userId: true },
+      select: { coHosts: true, userId: true, eventType: true },
     });
     if (!party) {
       party = await prisma.party.findUnique({
         where: { customUrl: slug },
-        select: { coHosts: true, userId: true },
+        select: { coHosts: true, userId: true, eventType: true },
       });
     }
     // Alias fallback: silently resolve old slugs
@@ -337,7 +338,7 @@ router.post('/:slug/check-host', async (req: Request, res: Response, next: NextF
       if (alias) {
         party = await prisma.party.findUnique({
           where: { id: alias.partyId },
-          select: { coHosts: true, userId: true },
+          select: { coHosts: true, userId: true, eventType: true },
         });
       }
     }
@@ -350,7 +351,18 @@ router.post('/:slug/check-host', async (req: Request, res: Response, next: NextF
       (h: any) => h.email?.toLowerCase() === email.toLowerCase()
     );
 
-    res.json({ isHost: !!matchedHost, canEdit: !!matchedHost?.canEdit });
+    // Check GPP global editor access
+    let isHost = !!matchedHost;
+    let canEdit = !!matchedHost?.canEdit;
+    if (!canEdit && (party as any).eventType === 'gpp' && email) {
+      const isGppEditor = GPP_GLOBAL_EDITORS.some(e => e.toLowerCase() === email.toLowerCase());
+      if (isGppEditor) {
+        isHost = true;
+        canEdit = true;
+      }
+    }
+
+    res.json({ isHost, canEdit });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -4,7 +4,7 @@ import { requireAuth, AuthRequest, isSuperAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
-import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS } from '../helpers/partyAccess.js';
+import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 
 // Helper function to get party with ownership check
@@ -28,6 +28,13 @@ async function getPartyWithOwnershipCheck(partyId: string, userId?: string, user
   // Check if user is the owner
   if (party.userId === userId) {
     return party;
+  }
+
+  // Check if user is a GPP global editor
+  if (userEmail && (party as any).eventType === 'gpp') {
+    if (GPP_GLOBAL_EDITORS.some(e => e.toLowerCase() === userEmail.toLowerCase())) {
+      return party;
+    }
   }
 
   // Check if user is a co-host with edit permissions
@@ -113,6 +120,16 @@ router.get('/my-events', async (req: AuthRequest, res: Response, next: NextFunct
       });
     }
 
+    // 4. GPP global editor parties (if user is a GPP global editor)
+    let gppEditorParties: typeof ownedParties = [];
+    if (userEmail && GPP_GLOBAL_EDITORS.some(e => e.toLowerCase() === userEmail!.toLowerCase())) {
+      gppEditorParties = await prisma.party.findMany({
+        where: { eventType: 'gpp' },
+        select: slimSelect,
+        orderBy: { date: 'asc' },
+      });
+    }
+
     // Deduplicate by party ID, assign roles (host > cohost > guest)
     const partyMap = new Map<string, any>();
 
@@ -120,6 +137,11 @@ router.get('/my-events', async (req: AuthRequest, res: Response, next: NextFunct
       partyMap.set(p.id, { ...p, role: 'host' as const });
     }
     for (const p of cohostParties) {
+      if (!partyMap.has(p.id)) {
+        partyMap.set(p.id, { ...p, role: 'cohost' as const });
+      }
+    }
+    for (const p of gppEditorParties) {
       if (!partyMap.has(p.id)) {
         partyMap.set(p.id, { ...p, role: 'cohost' as const });
       }


### PR DESCRIPTION
## Summary
- Adds a `GPP_GLOBAL_EDITORS` list in `partyAccess.ts` (currently just `hunter@rarepizzas.com`)
- Grants automatic edit access to all GPP events without being in the `co_hosts` array
- Hunter won't appear in host settings or on the public event page
- GPP events show in hunter's "My Events" list

## Changes
- `partyAccess.ts` — new constant + checks in `canUserEditParty()` and `canUserAccessTab()`
- `party.routes.ts` — checks in `getPartyWithOwnershipCheck()` and `my-events` endpoint
- `event.routes.ts` — check in `check-host` endpoint

## Test plan
- [ ] Hunter logs in and sees GPP events in My Events
- [ ] Hunter can access the host dashboard for any GPP event
- [ ] Hunter does NOT appear in host settings on any event
- [ ] Hunter does NOT appear on the public event page
- [ ] Non-GPP events are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)