### PR TITLE
prosciutto-62495: Separate Invited / RSVP'd / Checked-In counts

### DIFF
--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -388,6 +388,22 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       });
 
       if (existingGuest) {
+        // Determine new status for INVITED guests completing RSVP
+        let newStatus = existingGuest.status;
+        let newWaitlistPosition: number | null = null;
+        if (existingGuest.status === 'INVITED') {
+          if (isAtCapacity) {
+            newStatus = 'WAITLISTED';
+            const maxPos = await prisma.guest.aggregate({
+              where: { partyId: party.id, status: 'WAITLISTED' },
+              _max: { waitlistPosition: true },
+            });
+            newWaitlistPosition = (maxPos._max.waitlistPosition || 0) + 1;
+          } else {
+            newStatus = party.requireApproval ? 'PENDING' : 'CONFIRMED';
+          }
+        }
+
         // Update the existing guest record
         const updatedGuest = await prisma.guest.update({
           where: { id: existingGuest.id },
@@ -410,6 +426,9 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             dislikedBeverages: dislikedBeverages || [],
             pizzeriaRankings: pizzeriaRankings || [],
             suggestedPizzerias: suggestedPizzerias || [],
+            status: newStatus,
+            ...(newWaitlistPosition !== null ? { waitlistPosition: newWaitlistPosition } : {}),
+            submittedVia: existingGuest.status === 'INVITED' ? 'rsvp' : existingGuest.submittedVia,
           },
         });
 

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -544,7 +544,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       include: {
         user: { select: { name: true, email: true, profilePictureUrl: true, website: true, twitter: true, instagram: true } },
         guests: {
-          select: { id: true, approved: true, checkedInAt: true },
+          select: { id: true, approved: true, checkedInAt: true, status: true },
         },
         budgetItems: {
           select: { id: true, cost: true, status: true },
@@ -687,8 +687,8 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
     const uniqueViewMap = new Map(uniqueViewStats.map(r => [r.party_id, Number(r.unique_count)]));
 
     const formattedEvents = events.map(event => {
-      const guestCount = event._count.guests;
-      const approvedCount = event.guests.filter(g => g.approved !== false).length;
+      const guestCount = event.guests.filter(g => g.status !== 'INVITED').length;
+      const approvedCount = event.guests.filter(g => g.approved !== false && g.status !== 'INVITED').length;
 
       // Budget summary
       let budget = null;
@@ -775,6 +775,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         } : null,
         coHosts,
         rsvpCount: guestCount,
+        invitedCount: event.guests.filter(g => g.status === 'INVITED').length,
         approvedCount,
         maxGuests: event.maxGuests,
         expectedGuests: event.expectedGuests || null,

--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -255,7 +255,7 @@ router.post('/', requireApiKey(SCOPES.GUESTS_WRITE), async (req: ApiKeyRequest, 
 
     // Check max guests
     if (party.maxGuests) {
-      const guestCount = await prisma.guest.count({ where: { partyId } });
+      const guestCount = await prisma.guest.count({ where: { partyId, status: { not: 'INVITED' } } });
       if (guestCount >= party.maxGuests) {
         throw new AppError('Party has reached maximum guests', 400, 'MAX_GUESTS_REACHED');
       }
@@ -704,7 +704,7 @@ router.post('/bulk-invite', requireAuth, async (req: AuthRequest, res: Response,
                   partyId,
                   name,
                   email: normalizedEmail,
-                  status: 'PENDING',
+                  status: 'INVITED',
                   submittedVia: 'invite',
                   approved: null,
                   roles: [],

--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { usePizza } from '../contexts/PizzaContext';
 import { TableRow } from './TableRow';
-import { UserRoundX, Users, Clock, Search, CheckCircle2, Download } from 'lucide-react';
+import { UserRoundX, Users, Clock, Search, CheckCircle2, Download, Mail } from 'lucide-react';
 import { IconInput } from './IconInput';
 import { checkInGuest, getNotableGuestIds, addNotableAttendee, deleteNotableAttendeeByGuestId } from '../lib/api';
 
@@ -101,10 +101,11 @@ export const GuestList: React.FC = () => {
   const requireApproval = party?.requireApproval || false;
 
   const exportCSV = () => {
-    const headers = ['Name', 'Email', 'RSVP Date', 'Dietary Restrictions', 'Liked Toppings', 'Disliked Toppings', 'Wallet Address'];
+    const headers = ['Name', 'Email', 'Status', 'RSVP Date', 'Dietary Restrictions', 'Liked Toppings', 'Disliked Toppings', 'Wallet Address'];
     const rows = guests.map(g => [
       g.name,
       g.email || '',
+      g.status || 'CONFIRMED',
       g.submittedAt ? new Date(g.submittedAt).toLocaleDateString() : '',
       g.dietaryRestrictions.join('; '),
       g.toppings.join('; '),
@@ -143,7 +144,8 @@ export const GuestList: React.FC = () => {
   };
 
   // Separate guests by status
-  const confirmedGuests = filteredGuests.filter(g => g.status !== 'WAITLISTED');
+  const invitedGuests = filteredGuests.filter(g => g.status === 'INVITED');
+  const confirmedGuests = filteredGuests.filter(g => g.status !== 'WAITLISTED' && g.status !== 'INVITED');
   const waitlistedGuests = filteredGuests.filter(g => g.status === 'WAITLISTED')
     .sort((a, b) => (a.waitlistPosition || 0) - (b.waitlistPosition || 0));
 
@@ -159,6 +161,12 @@ export const GuestList: React.FC = () => {
               {confirmedGuests.length}
               {party?.maxGuests && ` / ${party.maxGuests}`}
             </span>
+            {invitedGuests.length > 0 && (
+              <span className="bg-blue-500/20 text-blue-400 text-sm font-medium px-3 py-1 rounded-full border border-blue-500/30 flex items-center gap-1">
+                <Mail size={14} />
+                {invitedGuests.length} invited
+              </span>
+            )}
             {checkedInCount > 0 && (
               <span className="bg-green-500/20 text-green-400 text-sm font-medium px-3 py-1 rounded-full border border-green-500/30 flex items-center gap-1">
                 <CheckCircle2 size={14} />
@@ -222,6 +230,31 @@ export const GuestList: React.FC = () => {
           </div>
         )}
       </div>
+
+      {/* Invited Section */}
+      {invitedGuests.length > 0 && (
+        <div className="card p-6">
+          <div className="flex justify-between items-center mb-4">
+            <div className="flex items-center gap-3">
+              <Mail size={20} className="text-theme-text-secondary" />
+              <h2 className="text-xl font-bold text-theme-text">Invited</h2>
+              <span className="bg-blue-500/20 text-blue-400 text-sm font-medium px-3 py-1 rounded-full border border-blue-500/30">
+                {invitedGuests.length}
+              </span>
+            </div>
+          </div>
+          <div className="divide-y divide-theme-stroke">
+            {invitedGuests.map(guest => (
+              <TableRow
+                key={guest.id}
+                guest={guest}
+                variant="basic"
+                onRemove={removeGuest}
+              />
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Waitlist Section */}
       {waitlistedGuests.length > 0 && (

--- a/frontend/src/components/PartyHeader.tsx
+++ b/frontend/src/components/PartyHeader.tsx
@@ -232,13 +232,23 @@ export const PartyHeader: React.FC = () => {
                 )}
                 <p className="text-sm text-theme-text-muted">
                   {party.hostName && `Hosted by ${party.hostName} • `}
-                  {party.maxGuests ? (
-                    <span>
-                      {party.guests.length} of {party.maxGuests} guests responded
-                    </span>
-                  ) : (
-                    <span>{party.guests.length} guest{party.guests.length !== 1 ? 's' : ''}</span>
-                  )}
+                  {(() => {
+                    const invited = party.guests.filter(g => g.status === 'INVITED').length;
+                    const rsvpd = party.guests.filter(g => g.status !== 'INVITED').length;
+                    const checkedIn = party.guests.filter(g => g.checkedInAt).length;
+                    if (invited > 0) {
+                      return (
+                        <span>
+                          {invited} invited · {rsvpd} RSVP'd{party.maxGuests ? ` / ${party.maxGuests}` : ''} · {checkedIn} checked in
+                        </span>
+                      );
+                    }
+                    return party.maxGuests ? (
+                      <span>{rsvpd} of {party.maxGuests} guests responded</span>
+                    ) : (
+                      <span>{rsvpd} guest{rsvpd !== 1 ? 's' : ''}{checkedIn > 0 ? ` · ${checkedIn} checked in` : ''}</span>
+                    );
+                  })()}
                 </p>
               </div>
 

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -156,9 +156,17 @@ export const GPPDashboardTab: React.FC = () => {
   return (
     <div className="space-y-6">
       {/* Quick stats */}
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <div className="card p-4 text-center">
-          <div className="text-2xl font-bold text-theme-text">{guests.length}</div>
+          <div className="text-2xl font-bold text-theme-text">
+            {guests.filter(g => g.status === 'INVITED').length}
+          </div>
+          <div className="text-xs text-theme-text-muted">Invited</div>
+        </div>
+        <div className="card p-4 text-center">
+          <div className="text-2xl font-bold text-theme-text">
+            {guests.filter(g => g.status !== 'INVITED').length}
+          </div>
           <div className="text-xs text-theme-text-muted">RSVPs</div>
         </div>
         <div className="card p-4 text-center">

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -376,7 +376,8 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
     // Generate wave-based recommendations (handles both single and multi-wave)
     // Pass orderExpectedGuests as override if set
-    const waves = generateWaveRecommendations(guests, pizzaSettings.style, party, availableBeverages, orderExpectedGuests);
+    const activeGuests = guests.filter(g => g.status !== 'INVITED');
+    const waves = generateWaveRecommendations(activeGuests, pizzaSettings.style, party, availableBeverages, orderExpectedGuests);
     setWaveRecommendations(waves);
 
     // Also update single recommendations for backward compatibility

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -937,6 +937,12 @@ function EventCard({ event, onToggleChecklist, cityChats }: EventCardProps) {
               <span className="text-lg font-bold text-theme-text">{event.rsvpCount}</span>
               <span className="text-xs text-theme-text-muted">RSVPs</span>
             </div>
+            {event.invitedCount > 0 && (
+              <div className="flex items-center gap-1.5">
+                <span className="text-lg font-bold text-blue-400">{event.invitedCount}</span>
+                <span className="text-xs text-theme-text-muted">Invited</span>
+              </div>
+            )}
             {(event.photoCount + gppCount > 0) && (
               <button
                 onClick={togglePhotos}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,7 +10,7 @@ export interface Beverage {
   type: 'soda' | 'juice' | 'water' | 'other' | 'alcohol';
 }
 
-export type GuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
+export type GuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED' | 'INVITED';
 
 export interface Guest {
   id?: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1200,6 +1200,7 @@ export interface SponsorDashboardEvent {
   } | null;
   coHosts: CoHost[];
   rsvpCount: number;
+  invitedCount: number;
   approvedCount: number;
   maxGuests: number | null;
   expectedGuests?: number | null;


### PR DESCRIPTION
## Summary
- Add `INVITED` guest status for bulk-invited guests who haven't RSVP'd yet
- Dashboard shows three separate counts: Invited, RSVP'd, Checked In
- INVITED guests excluded from capacity checks and pizza recommendations
- GuestList shows Invited section with blue theme
- CSV export includes Status column
- GPP dashboard adds Invited stat card

## Test plan
- [ ] Bulk-invite guests → appear as "Invited" not "Pending"
- [ ] RSVP as invited email → status transitions to Confirmed
- [ ] Invited guests don't count toward maxGuests capacity
- [ ] PartyHeader shows X invited · X RSVP'd · X checked in
- [ ] GuestList shows Invited section with blue badge
- [ ] GPP dashboard shows 4 stat cards including Invited
- [ ] Pizza recommendations exclude invited-only guests
- [ ] CSV export includes Status column

🤖 Generated with [Claude Code](https://claude.com/claude-code)