### PR TITLE
fix: correct days-until-event timezone calc

### DIFF
--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -146,9 +146,12 @@ export const GPPDashboardTab: React.FC = () => {
   // Days until event
   const daysUntil = useMemo(() => {
     if (!party?.date) return null;
-    const diff = new Date(party.date).getTime() - Date.now();
+    const eventDate = new Date(party.date + 'T00:00:00');
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const diff = eventDate.getTime() - today.getTime();
     if (diff < 0) return null;
-    return Math.ceil(diff / (1000 * 60 * 60 * 24));
+    return Math.round(diff / (1000 * 60 * 60 * 24));
   }, [party?.date]);
 
   if (!party) return null;


### PR DESCRIPTION
## Summary
- Fixed the GPP dashboard "Days Until Event" showing 15 instead of 14
- Root cause: `new Date("2026-05-22")` parses as midnight UTC, but `Date.now()` is local time (EDT), so `Math.ceil` on the fractional day count rounded up incorrectly
- Fix: normalize both dates to local midnight before computing the difference, and use `Math.round` instead of `Math.ceil`

## Test plan
- [ ] Verify Philadelphia dashboard shows 14 days (May 22 - May 8)
- [ ] Check other city dashboards for correct countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)