### PR TITLE
prosciutto-62495: Add invited count to underboss dashboard

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -132,10 +132,14 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
   let eventsWithBudget = 0;
   let eventsWithKit = 0;
 
-  for (const event of events) {
-    const guestCount = event._count?.guests || 0;
-    const approvedCount = event.guests?.filter((g: any) => g.approved !== false).length || 0;
+  let totalInvited = 0;
 
+  for (const event of events) {
+    const invited = event.guests?.filter((g: any) => g.status === 'INVITED').length || 0;
+    const guestCount = (event._count?.guests || 0) - invited;
+    const approvedCount = event.guests?.filter((g: any) => g.approved !== false && g.status !== 'INVITED').length || 0;
+
+    totalInvited += invited;
     totalRsvps += guestCount;
     totalApproved += approvedCount;
 
@@ -148,6 +152,7 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
   return {
     totalEvents,
     totalRsvps,
+    totalInvited,
     totalApproved,
     eventsWithVenue,
     eventsWithBudget,
@@ -163,8 +168,9 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
 
 // Helper: format event for response
 function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMap?: Map<string, Date>) {
-  const guestCount = party._count?.guests || 0;
-  const approvedCount = party.guests?.filter((g: any) => g.approved !== false).length || 0;
+  const invitedCount = party.guests?.filter((g: any) => g.status === 'INVITED').length || 0;
+  const guestCount = (party._count?.guests || 0) - invitedCount;
+  const approvedCount = party.guests?.filter((g: any) => g.approved !== false && g.status !== 'INVITED').length || 0;
   const checkedInCount = party.guests?.filter((g: any) => g.checkedInAt).length || 0;
   const photoCount = party._count?.photos || 0;
 
@@ -203,6 +209,7 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
     coHosts: party.coHosts || [],
     progress: computeProgress(party, underbossEmails),
     guestCount,
+    invitedCount,
     approvedCount,
     checkedInCount,
     photoCount,
@@ -373,7 +380,7 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
       include: {
         user: { select: { name: true, email: true } },
         guests: {
-          select: { id: true, approved: true, checkedInAt: true },
+          select: { id: true, approved: true, checkedInAt: true, status: true },
         },
         partyKit: { select: { status: true } },
         sponsors: { select: { status: true, amount: true } },
@@ -440,7 +447,7 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
         include: {
           user: { select: { name: true, email: true } },
           guests: {
-            select: { id: true, approved: true, checkedInAt: true },
+            select: { id: true, approved: true, checkedInAt: true, status: true },
           },
           partyKit: { select: { status: true } },
           sponsors: { select: { status: true, amount: true } },
@@ -565,7 +572,7 @@ router.get('/:region/stats', requireAuth, requireUnderbossAuth, async (req: Unde
         include: {
           user: { select: { name: true, email: true } },
           guests: {
-            select: { id: true, approved: true, checkedInAt: true },
+            select: { id: true, approved: true, checkedInAt: true, status: true },
           },
           partyKit: { select: { status: true } },
           _count: { select: { guests: true, photos: true } },

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -637,6 +637,9 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
             <Users size={12} className="text-theme-text-faint" />
             <span className="text-sm text-theme-text-secondary">{event.guestCount}</span>
           </div>
+          {event.invitedCount > 0 && (
+            <div className="text-xs text-blue-400/60">{event.invitedCount} invited</div>
+          )}
           {event.checkedInCount > 0 && (
             <div className="text-xs text-green-400/60">{event.checkedInCount} checked in</div>
           )}

--- a/frontend/src/components/underboss/RegionStats.tsx
+++ b/frontend/src/components/underboss/RegionStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Users, MapPin, Wallet, BarChart3, TrendingUp } from 'lucide-react';
+import { Users, MapPin, Wallet, BarChart3, TrendingUp, Mail } from 'lucide-react';
 import type { UnderbossStats } from '../../types';
 
 interface RegionStatsProps {
@@ -52,7 +52,7 @@ export function RegionStats({ stats }: RegionStatsProps) {
   return (
     <div className="space-y-4">
       {/* Top stats grid */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-3">
         <StatCard
           icon={BarChart3}
           label="Events"
@@ -65,6 +65,12 @@ export function RegionStats({ stats }: RegionStatsProps) {
           value={stats.totalRsvps}
           subValue={`~${stats.avgRsvpsPerEvent} per event`}
           color="bg-purple-500/20 text-purple-400"
+        />
+        <StatCard
+          icon={Mail}
+          label="Invited"
+          value={stats.totalInvited}
+          color="bg-blue-500/20 text-blue-400"
         />
         <StatCard
           icon={Users}

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -17,12 +17,14 @@ import type { UnderbossDashboardData, UnderbossStats, UnderbossEvent } from '../
 function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStats {
   const totalEvents = events.length;
   let totalRsvps = 0;
+  let totalInvited = 0;
   let totalApproved = 0;
   let eventsWithVenue = 0;
   let eventsWithBudget = 0;
 
   for (const e of events) {
     totalRsvps += e.guestCount;
+    totalInvited += e.invitedCount || 0;
     totalApproved += e.approvedCount;
     if (e.progress.hasVenue) eventsWithVenue++;
     if (e.progress.hasBudget) eventsWithBudget++;
@@ -31,6 +33,7 @@ function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStat
   return {
     totalEvents,
     totalRsvps,
+    totalInvited,
     totalApproved,
     eventsWithVenue,
     eventsWithBudget,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1015,6 +1015,7 @@ export interface UnderbossEvent {
   coHosts: any[];
   progress: UnderbossEventProgress;
   guestCount: number;
+  invitedCount: number;
   approvedCount: number;
   checkedInCount: number;
   photoCount: number;
@@ -1037,6 +1038,7 @@ export interface UnderbossEvent {
 export interface UnderbossStats {
   totalEvents: number;
   totalRsvps: number;
+  totalInvited: number;
   totalApproved: number;
   eventsWithVenue: number;
   eventsWithBudget: number;


### PR DESCRIPTION
## Summary
- Underboss dashboard now shows separate Invited count alongside RSVPs
- `guestCount` excludes INVITED guests so RSVP numbers are accurate
- New "Invited" stat card in RegionStats
- Event rows show "X invited" in blue below the RSVP count
- Follows up on #230 which added INVITED status

## Test plan
- [ ] Underboss dashboard shows Invited stat card with correct total
- [ ] Event rows show invited count per event
- [ ] Total RSVPs excludes invited guests
- [ ] Approved count excludes invited guests

🤖 Generated with [Claude Code](https://claude.com/claude-code)