### PR TITLE
feat: rejected/hidden event host messaging + List My Event

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -515,6 +515,7 @@ function formatGppEvent(event: any) {
     guestCount: event._count?.guests ?? 0,
     underbossStatus: event.underbossStatus || 'pending',
     approved: event.underbossStatus === 'approved',
+    community: event.underbossStatus === 'listed',
     rsvpOpen: !event.rsvpClosedAt,
   };
 }
@@ -565,7 +566,7 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
   try {
     const { limit = '500', offset = '0', city, country, region } = req.query;
 
-    const where: any = { eventType: 'gpp', underbossStatus: { not: 'rejected' } };
+    const where: any = { eventType: 'gpp', underbossStatus: { notIn: ['rejected', 'hidden'] } };
     if (city) {
       where.name = { contains: city as string, mode: 'insensitive' };
     }

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -605,7 +605,7 @@ router.patch('/events/bulk-status', requireAuth, requireUnderbossAuth, async (re
     if (!Array.isArray(partyIds) || partyIds.length === 0) {
       throw new AppError('partyIds must be a non-empty array', 400, 'VALIDATION_ERROR');
     }
-    const validStatuses = ['pending', 'approved', 'rejected'];
+    const validStatuses = ['pending', 'approved', 'rejected', 'listed', 'hidden'];
     if (!validStatuses.includes(status)) {
       throw new AppError(`status must be one of: ${validStatuses.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
@@ -776,23 +776,72 @@ router.patch('/event/:partyId/host-status', requireAuth, requireUnderbossAuth, a
 });
 
 // PATCH /api/underboss/event/:partyId/status - Update underboss status
-router.patch('/event/:partyId/status', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+// Allows both underbosses (all statuses) and event owners (listed/hidden only from rejected/listed/hidden)
+router.patch('/event/:partyId/status', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId } = req.params;
     const { status } = req.body;
+    const email = req.userEmail;
 
-    const validStatuses = ['pending', 'approved', 'rejected'];
-    if (!validStatuses.includes(status)) {
-      throw new AppError(`status must be one of: ${validStatuses.join(', ')}`, 400, 'VALIDATION_ERROR');
+    if (!email) {
+      throw new AppError('Authentication required', 401, 'UNAUTHORIZED');
     }
 
-    const party = await prisma.party.update({
+    const allValidStatuses = ['pending', 'approved', 'rejected', 'listed', 'hidden'];
+    if (!allValidStatuses.includes(status)) {
+      throw new AppError(`status must be one of: ${allValidStatuses.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+
+    // Check if user is an underboss or admin
+    const isAdminUser = await isAdmin(email);
+    const underboss = isAdminUser ? { id: 'admin' } : await prisma.underboss.findFirst({
+      where: { email: email.toLowerCase(), isActive: true },
+      select: { id: true },
+    });
+
+    if (underboss) {
+      // Underboss/admin: allow all statuses
+      const party = await prisma.party.update({
+        where: { id: partyId },
+        data: { underbossStatus: status },
+        select: { id: true, underbossStatus: true },
+      });
+      return res.json({ party });
+    }
+
+    // Not an underboss — check if user is the event owner
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, underbossStatus: true, user: { select: { email: true } } },
+    });
+
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    if (party.user?.email?.toLowerCase() !== email.toLowerCase()) {
+      throw new AppError('Not authorized', 403, 'FORBIDDEN');
+    }
+
+    // Event owner: only allow listed/hidden transitions from rejected/listed/hidden
+    const ownerAllowedStatuses = ['listed', 'hidden'];
+    const ownerAllowedFromStatuses = ['rejected', 'listed', 'hidden'];
+
+    if (!ownerAllowedStatuses.includes(status)) {
+      throw new AppError('Event owners can only set status to listed or hidden', 403, 'FORBIDDEN');
+    }
+
+    if (!ownerAllowedFromStatuses.includes(party.underbossStatus || '')) {
+      throw new AppError('Cannot change status from current state', 403, 'FORBIDDEN');
+    }
+
+    const updated = await prisma.party.update({
       where: { id: partyId },
       data: { underbossStatus: status },
       select: { id: true, underbossStatus: true },
     });
 
-    res.json({ party });
+    res.json({ party: updated });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/PartyHeader.tsx
+++ b/frontend/src/components/PartyHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePizza } from '../contexts/PizzaContext';
-import { PartyPopper, Link2, Copy, Check, X, Calendar, User, Loader2, Users, MapPin, Lock, Image, FileText, Link as LinkIcon, Upload, Trash2, ChevronDown, ChevronUp, ExternalLink, Pizza } from 'lucide-react';
+import { PartyPopper, Link2, Copy, Check, X, Calendar, User, Loader2, Users, MapPin, Lock, Image, FileText, Link as LinkIcon, Upload, Trash2, ChevronDown, ChevronUp, ExternalLink, Pizza, Globe, EyeOff } from 'lucide-react';
 import { uploadEventImage, cdnUrl } from '../lib/supabase';
 import { IconInput } from './IconInput';
 
@@ -216,10 +216,16 @@ export const PartyHeader: React.FC = () => {
                       Approved
                     </span>
                   )}
-                  {party.eventType === 'gpp' && party.underbossStatus === 'rejected' && (
-                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-500/20 text-red-400 border border-red-500/30">
-                      <X size={12} />
-                      Not Approved
+                  {party.eventType === 'gpp' && party.underbossStatus === 'listed' && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-400 border border-blue-500/30">
+                      <Globe size={12} />
+                      Community Event
+                    </span>
+                  )}
+                  {party.eventType === 'gpp' && party.underbossStatus === 'hidden' && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-500/20 text-gray-400 border border-gray-500/30">
+                      <EyeOff size={12} />
+                      Not Listed
                     </span>
                   )}
                 </div>

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X } from 'lucide-react';
 import { usePizza } from '../../contexts/PizzaContext';
-import { getChecklist, seedChecklist } from '../../lib/api';
+import { getChecklist, seedChecklist, updateUnderbossStatus } from '../../lib/api';
 import { AutoCompleteStates, ChecklistItem } from '../../types';
 import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
@@ -17,6 +17,7 @@ export const GPPDashboardTab: React.FC = () => {
   const [hostsExpanded, setHostsExpanded] = useState(false);
   const [coHostCount, setCoHostCount] = useState(party?.coHosts?.length ?? 0);
   const [showCompleted, setShowCompleted] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!party?.id) return;
@@ -193,16 +194,71 @@ export const GPPDashboardTab: React.FC = () => {
             <div className="text-xs text-theme-text-muted mt-1">Event Status</div>
           </div>
         )}
-        {party.underbossStatus === 'rejected' && (
-          <div className="card p-4 text-center border border-red-500/30">
-            <div className="flex items-center justify-center gap-1.5 text-red-400">
-              <X size={20} />
-              <span className="text-sm font-medium">Not Approved</span>
-            </div>
-            <div className="text-xs text-theme-text-muted mt-1">Event Status</div>
-          </div>
-        )}
       </div>
+
+      {/* Rejected status callout */}
+      {party.underbossStatus === 'rejected' && (
+        <div className="card p-6 border border-amber-500/30 bg-amber-500/5">
+          <p className="text-sm text-theme-text mb-4">
+            We can't support your event financially this year, but we're happy to list your event on the site!
+          </p>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={async () => {
+                setSaving(true);
+                try {
+                  await updateUnderbossStatus(party.id, 'listed');
+                  window.location.reload();
+                } catch (err) {
+                  console.error('Failed to update status:', err);
+                } finally {
+                  setSaving(false);
+                }
+              }}
+              disabled={saving}
+              className="btn-primary flex items-center gap-2"
+            >
+              {saving ? <Loader2 size={16} className="animate-spin" /> : null}
+              List My Event
+            </button>
+            <button
+              onClick={async () => {
+                setSaving(true);
+                try {
+                  await updateUnderbossStatus(party.id, 'hidden');
+                  window.location.reload();
+                } catch (err) {
+                  console.error('Failed to update status:', err);
+                } finally {
+                  setSaving(false);
+                }
+              }}
+              disabled={saving}
+              className="btn-secondary flex items-center gap-2"
+            >
+              Maybe Next Year
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Hidden status callout */}
+      {party.underbossStatus === 'hidden' && (
+        <div className="card p-6 border border-theme-stroke">
+          <p className="text-sm text-theme-text-muted">
+            Your event is currently not listed on the site.
+          </p>
+        </div>
+      )}
+
+      {/* Listed status callout */}
+      {party.underbossStatus === 'listed' && (
+        <div className="card p-6 border border-green-500/30 bg-green-500/5">
+          <p className="text-sm text-green-400">
+            Your event is listed as a Community event on the site.
+          </p>
+        </div>
+      )}
 
       {/* Checklist progress */}
       <div className="card p-6">

--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -412,6 +412,12 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
             {event.underbossStatus === 'rejected' && (
               <span className="w-2 h-2 rounded-full bg-red-400 shrink-0" title="Rejected" />
             )}
+            {event.underbossStatus === 'hidden' && (
+              <span className="w-2 h-2 rounded-full bg-gray-400 shrink-0" title="Hidden" />
+            )}
+            {event.underbossStatus === 'listed' && (
+              <span className="w-2 h-2 rounded-full bg-blue-400 shrink-0" title="Community Listed" />
+            )}
             <span className="text-sm font-medium text-theme-text truncate">{event.name.replace(/^Global Pizza Party\s*/i, '')}</span>
             {eventUrl && (
               <a href={eventUrl} target="_blank" rel="noopener noreferrer" className="text-theme-text-faint hover:text-theme-text-secondary transition-colors shrink-0">

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -507,6 +507,12 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                 {event.underbossStatus === 'rejected' && (
                   <span className="w-2 h-2 rounded-full bg-red-400 shrink-0" title="Rejected" />
                 )}
+                {event.underbossStatus === 'hidden' && (
+                  <span className="w-2 h-2 rounded-full bg-gray-400 shrink-0" title="Hidden" />
+                )}
+                {event.underbossStatus === 'listed' && (
+                  <span className="w-2 h-2 rounded-full bg-blue-400 shrink-0" title="Community Listed" />
+                )}
                 <span className="text-sm font-medium text-theme-text truncate">{event.name.replace(/^Global Pizza Party\s*/i, '')}</span>
                 {eventUrl && (
                   <a

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -167,6 +167,8 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         progressIncludes.every((key) => {
           if (key === 'approved') return e.underbossStatus === 'approved';
           if (key === 'rejected') return e.underbossStatus === 'rejected';
+          if (key === 'hidden') return e.underbossStatus === 'hidden';
+          if (key === 'listed') return e.underbossStatus === 'listed';
           return e.progress[key as keyof typeof e.progress];
         })
       );
@@ -178,6 +180,8 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         progressExcludes.every((key) => {
           if (key === 'approved') return e.underbossStatus !== 'approved';
           if (key === 'rejected') return e.underbossStatus !== 'rejected';
+          if (key === 'hidden') return e.underbossStatus !== 'hidden';
+          if (key === 'listed') return e.underbossStatus !== 'listed';
           return !e.progress[key as keyof typeof e.progress];
         })
       );
@@ -312,6 +316,20 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           onToggle={(newState) => setFilterState('rejected', newState)}
         />
 
+        {/* Hidden filter */}
+        <FilterPill
+          label="Hidden"
+          state={getFilterState('hidden')}
+          onToggle={(newState) => setFilterState('hidden', newState)}
+        />
+
+        {/* Listed filter */}
+        <FilterPill
+          label="Listed"
+          state={getFilterState('listed')}
+          onToggle={(newState) => setFilterState('listed', newState)}
+        />
+
         {/* Country filter -- only when showRegion */}
         {showRegion && (
           <select
@@ -442,6 +460,21 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                     className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-theme-surface transition-colors"
                   >
                     Reject
+                  </button>
+                  <button
+                    onClick={async () => {
+                      setShowActionDropdown(false);
+                      setBulkLoading(true);
+                      try {
+                        await bulkUpdateUnderbossStatus(Array.from(selectedIds), 'hidden');
+                        setSelectedIds(new Set());
+                        onBulkAction?.();
+                      } catch (err) { console.error('Bulk hide failed', err); }
+                      setBulkLoading(false);
+                    }}
+                    className="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-surface transition-colors"
+                  >
+                    Hide
                   </button>
                   <button
                     onClick={() => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2501,7 +2501,7 @@ export async function updateHostStatus(
 // Update underboss status on an event (underboss auth)
 export async function updateUnderbossStatus(
   partyId: string,
-  status: 'pending' | 'approved' | 'rejected'
+  status: 'pending' | 'approved' | 'rejected' | 'listed' | 'hidden'
 ): Promise<void> {
   await apiRequest(`/api/underboss/event/${partyId}/status`, {
     method: 'PATCH',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,7 +10,7 @@ export interface Beverage {
   type: 'soda' | 'juice' | 'water' | 'other' | 'alcohol';
 }
 
-export type UnderbossStatus = 'pending' | 'approved' | 'rejected';
+export type UnderbossStatus = 'pending' | 'approved' | 'rejected' | 'listed' | 'hidden';
 
 export type GuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED' | 'INVITED';
 


### PR DESCRIPTION
## Summary
- Adds `listed` and `hidden` underboss_status values alongside existing `pending`/`approved`/`rejected`
- When an event is rejected, hosts see a friendly callout with **List My Event** (marks as community event) and **Maybe Next Year** (hides from site) buttons
- Event owners can self-transition between listed/hidden without underboss auth
- Public GPP API excludes hidden events and flags listed events with `community: true`
- Underboss dashboard gains Hide bulk action and Hidden/Listed filter pills
- Community badge shown on public GPP page for listed events

## Test plan
- [ ] Underboss can approve, reject, hide events
- [ ] Host sees rejection callout with working buttons
- [ ] List My Event → status becomes listed, dashboard shows Community Event pill
- [ ] Maybe Next Year → status becomes hidden, dashboard shows Not Listed pill  
- [ ] Public GPP API excludes rejected + hidden, includes listed with community flag
- [ ] GPP landing page shows Community badge on listed events

🤖 Generated with [Claude Code](https://claude.com/claude-code)