### PR TITLE
fix: PizzaDAO avatar fallback for GPP events

### DIFF
--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -3,6 +3,8 @@ import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
 import { GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 
+const PIZZADAO_AVATAR_URL = 'https://znpiwdvvsqaxuskpfleo.supabase.co/storage/v1/object/public/profile-pictures/cmkgpzby50002f8y1d8md1dzn/1768937020563.jpg';
+
 const router = Router();
 
 // GET /api/events/:slug - Get public event details with host profile (public)
@@ -228,7 +230,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
       const pizzaCoHost = sanitizedCoHosts.find((h: any) => h.name === 'PizzaDAO');
       hostProfile = {
         name: 'PizzaDAO',
-        avatar_url: pizzaCoHost?.avatar_url || null,
+        avatar_url: pizzaCoHost?.avatar_url || PIZZADAO_AVATAR_URL,
         website: pizzaCoHost?.website || 'https://pizzadao.org',
         twitter: pizzaCoHost?.twitter || 'pizza_dao',
         instagram: pizzaCoHost?.instagram || 'pizza_dao',


### PR DESCRIPTION
## Summary
- 117 GPP events were showing a default avatar instead of the PizzaDAO logo because the PizzaDAO co-host entry in their `coHosts` array had no `avatar_url` set.
- The event API route (`backend/src/routes/event.routes.ts`) previously fell back to `null` when no avatar was found, which caused the frontend to render a generic default avatar.
- Added a `PIZZADAO_AVATAR_URL` constant and used it as the fallback so GPP events always display the correct PizzaDAO logo.
- A separate data backfill was run to fix the existing co-host entries in the database.

## Test plan
- [ ] Visit any GPP event page and confirm the PizzaDAO host avatar displays correctly
- [ ] Verify non-GPP events are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)