### PR TITLE
feat: Co-Host Profile section in CRM mode

### DIFF
--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -209,7 +209,7 @@ interface PartnerFormProps {
   submitLabel?: string;
   wasPreviouslySubmitted?: boolean;
   defaultStatus?: SponsorStatus;
-  onAddAsCoHost?: (data: { name: string; website: string; twitter: string; instagram: string; logoUrl: string }) => void;
+  onAddAsCoHost?: (data: { name: string; website: string; twitter: string; instagram: string; logoUrl: string; avatarUrl?: string }) => void;
 }
 
 /* ---------- Component ---------- */
@@ -356,6 +356,7 @@ export function PartnerForm({
           twitter: formData.brandTwitter.trim(),
           instagram: formData.brandInstagram.trim(),
           logoUrl,
+          avatarUrl: formData.coHostAvatarUrl.trim() || undefined,
         });
       }
     } catch (err) {
@@ -470,8 +471,8 @@ export function PartnerForm({
         />
       )}
 
-      {/* Co-Host Profile (avatar) — Partner mode only */}
-      {isPartner && (
+      {/* Co-Host Profile (avatar) — Partner + CRM (when adding as co-host) */}
+      {(isPartner || (isCrm && addAsCoHost)) && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <User size={16} />

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -21,7 +21,7 @@ import { triggerFlyerRegen } from '../flyer/autoRegenFlyer';
 
 interface SponsorCRMProps {
   partyId: string;
-  onAddAsCoHost?: (data: { name: string; website: string; twitter: string; instagram: string; logoUrl: string }) => void;
+  onAddAsCoHost?: (data: { name: string; website: string; twitter: string; instagram: string; logoUrl: string; avatarUrl?: string }) => void;
 }
 
 export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -405,14 +405,18 @@ function HostPageContent() {
                 <SponsorCRM
                   partyId={party.id}
                   onAddAsCoHost={async (data) => {
-                    // Build avatar from X handle or Instagram
+                    // Use manually-provided avatar if available, otherwise auto-fetch from socials
                     let avatarUrl: string | undefined;
-                    const xAvatar = data.twitter ? getXAvatarUrl(data.twitter) : null;
-                    if (xAvatar) {
-                      avatarUrl = await proxyAvatarToStorage(xAvatar);
-                    } else if (data.instagram) {
-                      const igAvatar = `https://unavatar.io/instagram/${data.instagram}`;
-                      avatarUrl = await proxyAvatarToStorage(igAvatar);
+                    if (data.avatarUrl) {
+                      avatarUrl = await proxyAvatarToStorage(data.avatarUrl);
+                    } else {
+                      const xAvatar = data.twitter ? getXAvatarUrl(data.twitter) : null;
+                      if (xAvatar) {
+                        avatarUrl = await proxyAvatarToStorage(xAvatar);
+                      } else if (data.instagram) {
+                        const igAvatar = `https://unavatar.io/instagram/${data.instagram}`;
+                        avatarUrl = await proxyAvatarToStorage(igAvatar);
+                      }
                     }
 
                     const newCoHost: CoHost = {


### PR DESCRIPTION
## Summary
- Shows the Co-Host Profile section (avatar URL input + preview) when adding a partner in CRM mode with 'Also add as event host' checked
- If a manual avatar URL is provided, it is used for the co-host instead of auto-fetching from X/Instagram
- Falls back to existing auto-fetch behavior when no manual avatar is provided
- No regression to Partner (underboss) mode behavior

## Test plan
- [ ] Host Page > Partners tab > Add Partner > check 'Also add as event host' > Co-Host Profile section appears
- [ ] Uncheck the checkbox > section disappears
- [ ] Fill avatar URL, submit > co-host uses provided avatar
- [ ] Leave avatar URL empty, submit > falls back to X/Instagram auto-fetch
- [ ] Underboss > Partners > Add/Edit > Co-Host Profile section still works

Generated with [Claude Code](https://claude.com/claude-code)