### PR TITLE
Unify check-in QR flow with email QR + peer vouching

### DIFF
--- a/backend/src/routes/checkin.routes.ts
+++ b/backend/src/routes/checkin.routes.ts
@@ -185,6 +185,11 @@ router.post('/:inviteCode/vouch', requireAuth, async (req: AuthRequest, res: Res
       throw new AppError('You must be an RSVPd guest to vouch for others', 403, 'NOT_A_GUEST');
     }
 
+    // Prevent self-vouch
+    if (voucher.id === targetGuestId) {
+      throw new AppError("You can't check yourself in!", 400, 'SELF_VOUCH');
+    }
+
     // Voucher must be checked in
     if (!voucher.checkedInAt) {
       throw new AppError('You must be checked in to vouch for others', 403, 'NOT_CHECKED_IN');
@@ -249,10 +254,33 @@ router.get('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: R
       throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
     }
 
-    // Verify user can check in guests for this party
-    const canCheck = await canUserCheckIn(party.id, req.userId, req.userEmail);
-    if (!canCheck) {
-      throw new AppError('You are not authorized to view check-in status for this event', 403, 'UNAUTHORIZED');
+    // Allow: hosts/co-hosts, the target guest themselves, or any checked-in guest
+    const isHostOrCohost = await canUserCheckIn(party.id, req.userId, req.userEmail);
+
+    let isTargetGuest = false;
+    let isCheckedInGuest = false;
+
+    if (!isHostOrCohost) {
+      // Check if caller is the target guest
+      const callerGuest = await prisma.guest.findFirst({
+        where: {
+          partyId: party.id,
+          email: req.userEmail?.toLowerCase(),
+        },
+        select: { id: true, checkedInAt: true },
+      });
+
+      if (callerGuest) {
+        if (callerGuest.id === guestId) {
+          isTargetGuest = true;
+        } else if (callerGuest.checkedInAt) {
+          isCheckedInGuest = true;
+        }
+      }
+
+      if (!isTargetGuest && !isCheckedInGuest) {
+        throw new AppError('You are not authorized to view check-in status for this event', 403, 'UNAUTHORIZED');
+      }
     }
 
     // Find the guest
@@ -277,6 +305,8 @@ router.get('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: R
     res.json({
       guest,
       isCheckedIn: !!guest.checkedInAt,
+      callerIsTarget: isTargetGuest,
+      callerIsHost: isHostOrCohost,
     });
   } catch (error) {
     next(error);

--- a/frontend/src/components/CheckInButton.tsx
+++ b/frontend/src/components/CheckInButton.tsx
@@ -26,12 +26,24 @@ export function CheckInButton({
   const [showQR, setShowQR] = useState(false);
   const [showScanner, setShowScanner] = useState(false);
   const [localCheckedInAt, setLocalCheckedInAt] = useState<string | null>(checkedInAt);
+  const [showCheckedInToast, setShowCheckedInToast] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const prevCheckedInRef = useRef<string | null>(checkedInAt);
 
   // Sync prop changes
   useEffect(() => {
     setLocalCheckedInAt(checkedInAt);
   }, [checkedInAt]);
+
+  // Detect transition from not-checked-in to checked-in
+  useEffect(() => {
+    if (prevCheckedInRef.current === null && localCheckedInAt !== null) {
+      setShowCheckedInToast(true);
+      const timer = setTimeout(() => setShowCheckedInToast(false), 4000);
+      return () => clearTimeout(timer);
+    }
+    prevCheckedInRef.current = localCheckedInAt;
+  }, [localCheckedInAt]);
 
   // Poll for check-in status while QR is shown (guest waiting to be vouched)
   const startPolling = useCallback(() => {
@@ -120,9 +132,15 @@ export function CheckInButton({
         >
           Checked In
         </button>
+        {showCheckedInToast && (
+          <p className="text-xs text-green-400 mt-1 text-center animate-pulse">
+            Now you can check in other guests!
+          </p>
+        )}
         {showScanner && (
           <CheckInScanner
             inviteCode={inviteCode}
+            currentGuestId={guestId}
             onVouchSuccess={handleVouchSuccess}
             onClose={() => setShowScanner(false)}
           />

--- a/frontend/src/components/CheckInQRDisplay.tsx
+++ b/frontend/src/components/CheckInQRDisplay.tsx
@@ -10,7 +10,7 @@ interface CheckInQRDisplayProps {
 }
 
 export function CheckInQRDisplay({ inviteCode, guestId, guestName, onClose }: CheckInQRDisplayProps) {
-  const qrData = `checkin:${inviteCode}:${guestId}`;
+  const qrData = `https://rsv.pizza/checkin/${inviteCode}/${guestId}`;
   const qrSrc = `https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=${encodeURIComponent(qrData)}`;
 
   return createPortal(

--- a/frontend/src/components/CheckInScanner.tsx
+++ b/frontend/src/components/CheckInScanner.tsx
@@ -6,11 +6,12 @@ import { vouchForGuest } from '../lib/api';
 
 interface CheckInScannerProps {
   inviteCode: string;
+  currentGuestId?: string;
   onVouchSuccess: (guestName: string) => void;
   onClose: () => void;
 }
 
-export function CheckInScanner({ inviteCode, onVouchSuccess, onClose }: CheckInScannerProps) {
+export function CheckInScanner({ inviteCode, currentGuestId, onVouchSuccess, onClose }: CheckInScannerProps) {
   const scannerRef = useRef<Html5Qrcode | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<string>('Starting camera...');
@@ -25,11 +26,21 @@ export function CheckInScanner({ inviteCode, onVouchSuccess, onClose }: CheckInS
     toastTimerRef.current = setTimeout(() => setToast(null), durationMs);
   }, []);
 
-  // Parse QR data: "checkin:{inviteCode}:{guestId}"
   const parseQR = useCallback((data: string): { inviteCode: string; guestId: string } | null => {
+    // Format 1: checkin:{inviteCode}:{guestId}  (legacy on-screen QR)
     const parts = data.split(':');
-    if (parts.length !== 3 || parts[0] !== 'checkin') return null;
-    return { inviteCode: parts[1], guestId: parts[2] };
+    if (parts.length === 3 && parts[0] === 'checkin') {
+      return { inviteCode: parts[1], guestId: parts[2] };
+    }
+    // Format 2: https://rsv.pizza/checkin/{inviteCode}/{guestId}  (email QR / unified)
+    try {
+      const url = new URL(data);
+      const segments = url.pathname.split('/').filter(Boolean);
+      if (segments.length === 3 && segments[0] === 'checkin') {
+        return { inviteCode: segments[1], guestId: segments[2] };
+      }
+    } catch {}
+    return null;
   }, []);
 
   const handleScan = useCallback(async (decodedText: string) => {
@@ -38,6 +49,11 @@ export function CheckInScanner({ inviteCode, onVouchSuccess, onClose }: CheckInS
     const parsed = parseQR(decodedText);
     if (!parsed) {
       showToast('Invalid QR code');
+      return;
+    }
+
+    if (currentGuestId && parsed.guestId === currentGuestId) {
+      showToast("You can't check yourself in!");
       return;
     }
 

--- a/frontend/src/pages/CheckInPage.tsx
+++ b/frontend/src/pages/CheckInPage.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Layout } from '../components/Layout';
-import { Loader2, CheckCircle2, XCircle, Clock, AlertCircle } from 'lucide-react';
+import { Loader2, CheckCircle2, XCircle, AlertCircle, QrCode } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-import { checkInGuest, CheckInResponse } from '../lib/api';
+import { vouchForGuest } from '../lib/api';
+import { CheckInQRDisplay } from '../components/CheckInQRDisplay';
 
-type CheckInState = 'loading' | 'success' | 'already-checked-in' | 'unauthorized' | 'error' | 'not-found';
+type CheckInState = 'loading' | 'show-qr' | 'vouching' | 'success' | 'already-checked-in' | 'not-checked-in' | 'unauthorized' | 'error' | 'not-found';
 
 export function CheckInPage() {
   const { inviteCode, guestId } = useParams<{ inviteCode: string; guestId: string }>();
@@ -16,60 +17,104 @@ export function CheckInPage() {
   const [guestName, setGuestName] = useState<string>('');
   const [checkedInAt, setCheckedInAt] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [hasAttemptedCheckIn, setHasAttemptedCheckIn] = useState(false);
+  const [hasAttempted, setHasAttempted] = useState(false);
 
   // Redirect to login if not authenticated
   useEffect(() => {
     if (!authLoading && !user) {
-      // Store the current URL to redirect back after login
       const currentUrl = `/checkin/${inviteCode}/${guestId}`;
       sessionStorage.setItem('authReturnUrl', currentUrl);
       navigate(`/login?redirect=${encodeURIComponent(currentUrl)}`);
     }
   }, [authLoading, user, inviteCode, guestId, navigate]);
 
-  // Auto check-in when authenticated
+  // Determine what to show
   useEffect(() => {
-    if (authLoading || !user || hasAttemptedCheckIn || !inviteCode || !guestId) {
-      return;
-    }
+    if (authLoading || !user || hasAttempted || !inviteCode || !guestId) return;
 
-    const performCheckIn = async () => {
-      setHasAttemptedCheckIn(true);
+    const determine = async () => {
+      setHasAttempted(true);
       setState('loading');
 
       try {
-        const response: CheckInResponse = await checkInGuest(inviteCode, guestId);
+        const apiUrl = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
+        const token = localStorage.getItem('authToken');
 
-        setGuestName(response.guest.name);
+        // Fetch target guest status
+        const resp = await fetch(`${apiUrl}/api/checkin/${inviteCode}/${guestId}`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
 
-        if (response.alreadyCheckedIn) {
+        if (!resp.ok) {
+          const errData = await resp.json().catch(() => ({}));
+          if (resp.status === 403) {
+            // User is not host, not target guest, and not checked in
+            setState('not-checked-in');
+            return;
+          }
+          if (resp.status === 404) {
+            setState('not-found');
+            setErrorMessage(errData.message || 'Guest or event not found');
+            return;
+          }
+          throw new Error(errData.message || 'Failed to fetch check-in status');
+        }
+
+        const data = await resp.json();
+        setGuestName(data.guest?.name || 'Guest');
+
+        // If the target guest is already checked in
+        if (data.isCheckedIn) {
           setState('already-checked-in');
-          setCheckedInAt(response.guest.checkedInAt);
-        } else {
-          setState('success');
-          setCheckedInAt(response.guest.checkedInAt);
+          setCheckedInAt(data.guest?.checkedInAt);
+          return;
+        }
+
+        // If caller IS the target guest — show QR code
+        if (data.callerIsTarget) {
+          setState('show-qr');
+          return;
+        }
+
+        // If caller is host or checked-in guest — vouch for them
+        if (data.callerIsHost || !data.callerIsTarget) {
+          setState('vouching');
+          try {
+            const result = await vouchForGuest(inviteCode, guestId);
+            if (result.success) {
+              setGuestName(result.guest?.name || guestName);
+              if (result.alreadyCheckedIn) {
+                setState('already-checked-in');
+                setCheckedInAt(result.guest?.checkedInAt || null);
+              } else {
+                setState('success');
+                setCheckedInAt(result.guest?.checkedInAt || null);
+              }
+            } else {
+              setState('error');
+              setErrorMessage(result.message || 'Check-in failed');
+            }
+          } catch (err: any) {
+            if (err.message?.includes('SELF_VOUCH') || err.message?.includes("can't check yourself")) {
+              setState('show-qr');
+            } else if (err.message?.includes('NOT_CHECKED_IN') || err.message?.includes('must be checked in')) {
+              setState('not-checked-in');
+            } else {
+              setState('error');
+              setErrorMessage(err.message || 'Check-in failed');
+            }
+          }
         }
       } catch (error: any) {
-        console.error('Check-in error:', error);
-
-        if (error.message?.includes('not authorized') || error.message?.includes('UNAUTHORIZED')) {
-          setState('unauthorized');
-          setErrorMessage('You are not authorized to check in guests for this event. Only hosts and co-hosts can check in guests.');
-        } else if (error.message?.includes('not found') || error.message?.includes('NOT_FOUND')) {
-          setState('not-found');
-          setErrorMessage(error.message || 'Guest or event not found');
-        } else {
-          setState('error');
-          setErrorMessage(error.message || 'An error occurred during check-in');
-        }
+        console.error('Check-in page error:', error);
+        setState('error');
+        setErrorMessage(error.message || 'An error occurred');
       }
     };
 
-    performCheckIn();
-  }, [authLoading, user, inviteCode, guestId, hasAttemptedCheckIn]);
+    determine();
+  }, [authLoading, user, inviteCode, guestId, hasAttempted]);
 
-  // Format the check-in time
   const formatCheckInTime = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleString('en-US', {
@@ -82,13 +127,41 @@ export function CheckInPage() {
     });
   };
 
-  // Render content based on state
   const renderContent = () => {
-    if (authLoading || state === 'loading') {
+    if (authLoading || state === 'loading' || state === 'vouching') {
       return (
         <div className="flex flex-col items-center justify-center py-12">
           <Loader2 size={48} className="animate-spin text-[#ff393a] mb-4" />
-          <p className="text-theme-text-secondary">Checking in guest...</p>
+          <p className="text-theme-text-secondary">
+            {state === 'vouching' ? 'Checking in guest...' : 'Loading...'}
+          </p>
+        </div>
+      );
+    }
+
+    if (state === 'show-qr' && inviteCode && guestId) {
+      return (
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <div className="w-16 h-16 rounded-full bg-[#ff393a]/20 flex items-center justify-center mb-4">
+            <QrCode size={32} className="text-[#ff393a]" />
+          </div>
+          <h2 className="text-xl font-bold text-theme-text mb-2">Show Your QR Code</h2>
+          <p className="text-theme-text-secondary text-sm mb-6 max-w-xs">
+            Show this QR code to a host or checked-in guest to verify your attendance
+          </p>
+          <div className="bg-white rounded-xl p-4 inline-block mb-4">
+            <img
+              src={`https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=${encodeURIComponent(`https://rsv.pizza/checkin/${inviteCode}/${guestId}`)}`}
+              alt="Check-in QR code"
+              width={250}
+              height={250}
+              className="block"
+            />
+          </div>
+          <p className="text-theme-text-muted text-xs">
+            {guestName && <span className="block text-theme-text-secondary mb-1">{guestName}</span>}
+            A host or checked-in guest needs to scan this to check you in
+          </p>
         </div>
       );
     }
@@ -103,16 +176,9 @@ export function CheckInPage() {
           <p className="text-xl text-theme-text mb-4">{guestName}</p>
           {checkedInAt && (
             <p className="text-theme-text-muted text-sm flex items-center gap-2">
-              <Clock size={14} />
-              {formatCheckInTime(checkedInAt)}
+              <span>{formatCheckInTime(checkedInAt)}</span>
             </p>
           )}
-          <button
-            onClick={() => navigate(`/host/${inviteCode}`)}
-            className="mt-8 btn-secondary"
-          >
-            Back to Event Dashboard
-          </button>
         </div>
       );
     }
@@ -127,34 +193,23 @@ export function CheckInPage() {
           <p className="text-xl text-theme-text mb-4">{guestName}</p>
           {checkedInAt && (
             <p className="text-theme-text-muted text-sm flex items-center gap-2">
-              <Clock size={14} />
-              Checked in at {formatCheckInTime(checkedInAt)}
+              <span>Checked in at {formatCheckInTime(checkedInAt)}</span>
             </p>
           )}
-          <button
-            onClick={() => navigate(`/host/${inviteCode}`)}
-            className="mt-8 btn-secondary"
-          >
-            Back to Event Dashboard
-          </button>
         </div>
       );
     }
 
-    if (state === 'unauthorized') {
+    if (state === 'not-checked-in') {
       return (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <div className="w-20 h-20 rounded-full bg-yellow-500/20 flex items-center justify-center mb-6">
             <AlertCircle size={48} className="text-yellow-500" />
           </div>
-          <h2 className="text-2xl font-bold text-theme-text mb-2">Unauthorized</h2>
-          <p className="text-theme-text-secondary mb-4 max-w-md">{errorMessage}</p>
-          <button
-            onClick={() => navigate('/')}
-            className="mt-4 btn-secondary"
-          >
-            Go Home
-          </button>
+          <h2 className="text-2xl font-bold text-theme-text mb-2">Not Checked In Yet</h2>
+          <p className="text-theme-text-secondary mb-4 max-w-md">
+            You must be checked in first before you can check in other guests.
+          </p>
         </div>
       );
     }
@@ -167,12 +222,20 @@ export function CheckInPage() {
           </div>
           <h2 className="text-2xl font-bold text-theme-text mb-2">Not Found</h2>
           <p className="text-theme-text-secondary mb-4 max-w-md">{errorMessage}</p>
-          <button
-            onClick={() => navigate('/')}
-            className="mt-4 btn-secondary"
-          >
-            Go Home
-          </button>
+          <button onClick={() => navigate('/')} className="mt-4 btn-secondary">Go Home</button>
+        </div>
+      );
+    }
+
+    if (state === 'unauthorized') {
+      return (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="w-20 h-20 rounded-full bg-yellow-500/20 flex items-center justify-center mb-6">
+            <AlertCircle size={48} className="text-yellow-500" />
+          </div>
+          <h2 className="text-2xl font-bold text-theme-text mb-2">Unauthorized</h2>
+          <p className="text-theme-text-secondary mb-4 max-w-md">{errorMessage}</p>
+          <button onClick={() => navigate('/')} className="mt-4 btn-secondary">Go Home</button>
         </div>
       );
     }
@@ -187,20 +250,12 @@ export function CheckInPage() {
         <p className="text-theme-text-secondary mb-4 max-w-md">{errorMessage}</p>
         <div className="flex gap-4 mt-4">
           <button
-            onClick={() => {
-              setHasAttemptedCheckIn(false);
-              setState('loading');
-            }}
+            onClick={() => { setHasAttempted(false); setState('loading'); }}
             className="btn-primary"
           >
             Try Again
           </button>
-          <button
-            onClick={() => navigate('/')}
-            className="btn-secondary"
-          >
-            Go Home
-          </button>
+          <button onClick={() => navigate('/')} className="btn-secondary">Go Home</button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Scanner accepts both `checkin:` and URL format QR codes (email QR + in-app QR unified)
- Guests clicking their own email QR link see their QR code instead of auto-check-in
- Hosts/checked-in guests visiting the link vouch for the target guest
- Self-scan/self-vouch prevention on both frontend and backend
- On-screen QR codes now use URL format so any phone camera can scan them
- "Now you can check in other guests" message after getting checked in

## Test plan
- [ ] Host opens event page, taps Check In, self-checks in, sees "Now you can check in other guests"
- [ ] Host taps "Checked In" button, scanner opens, scans guest email QR → guest checked in
- [ ] Guest clicks email QR link → sees their QR code (NOT auto-checked-in)
- [ ] Checked-in guest scans another guest's QR → that guest gets checked in
- [ ] Self-scan shows "You can't check yourself in!" toast
- [ ] On-screen QR encodes URL format (scannable by any phone camera)

🤖 Generated with [Claude Code](https://claude.com/claude-code)