### PR TITLE
feat: graphics admin access control

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1127,6 +1127,17 @@ model Admin {
   @@map("admins")
 }
 
+model GraphicsAdmin {
+  id        String   @id @default(uuid()) @db.Uuid
+  email     String   @unique
+  name      String?
+  createdBy String?  @map("created_by")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@map("graphics_admins")
+}
+
 // ============================================
 // Sponsor Dashboard Models
 // ============================================

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,6 +34,7 @@ import telegramRoutes from './routes/telegram.routes.js';
 import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
+import graphicsAdminRoutes from './routes/graphics-admin.routes.js';
 import { sponsorUserAdminRouter, sponsorDashboardRouter } from './routes/sponsor-user.routes.js';
 import preferencesRoutes from './routes/preferences.routes.js';
 import quizTemplateRoutes from './routes/quiz-template.routes.js';
@@ -99,6 +100,7 @@ app.use('/api/rsvp', rsvpLimiter);
 
 // Routes
 app.use('/api/admin', adminRoutes);          // Admin management routes
+app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/underboss/telegram', telegramRoutes); // Telegram broadcast (before underboss catch-all)
 app.use('/api/underboss', underbossRoutes); // Underboss dashboard (token auth + admin routes)
 app.use('/api/sponsor-users', sponsorUserAdminRouter); // Sponsor user admin management

--- a/backend/src/routes/graphics-admin.routes.ts
+++ b/backend/src/routes/graphics-admin.routes.ts
@@ -1,0 +1,95 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+
+const router = Router();
+
+// GET /api/graphics-admin/list — List all graphics admins (any admin can view)
+router.get('/list', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const admins = await prisma.graphicsAdmin.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        createdBy: true,
+        createdAt: true,
+      },
+    });
+
+    res.json({ admins });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/graphics-admin/add — Add a graphics admin (any admin can add)
+router.post('/add', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const { email, name } = req.body;
+
+    if (!email) {
+      throw new AppError('Email is required', 400, 'VALIDATION_ERROR');
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const existing = await prisma.graphicsAdmin.findUnique({ where: { email: normalizedEmail } });
+    if (existing) {
+      throw new AppError('Graphics admin with this email already exists', 400, 'DUPLICATE');
+    }
+
+    const admin = await prisma.graphicsAdmin.create({
+      data: {
+        email: normalizedEmail,
+        name: name?.trim() || null,
+        createdBy: req.userEmail || null,
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        createdBy: true,
+        createdAt: true,
+      },
+    });
+
+    res.status(201).json({ admin });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/graphics-admin/:id — Remove a graphics admin (any admin can remove)
+router.delete('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const { id } = req.params;
+
+    const admin = await prisma.graphicsAdmin.findUnique({ where: { id } });
+    if (!admin) {
+      throw new AppError('Graphics admin not found', 404, 'NOT_FOUND');
+    }
+
+    await prisma.graphicsAdmin.delete({ where: { id } });
+
+    res.json({ success: true, message: 'Graphics admin removed' });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -244,12 +244,19 @@ router.get('/me', requireAuth, async (req: UnderbossRequest, res: Response, next
       throw new AppError('Authentication required', 401, 'UNAUTHORIZED');
     }
 
+    // Check graphics admin status
+    const graphicsAdmin = await prisma.graphicsAdmin.findUnique({
+      where: { email: email.toLowerCase() },
+    });
+    const isGraphicsAdmin = !!graphicsAdmin;
+
     // Check admin first
     const adminStatus = await isAdmin(email);
     if (adminStatus) {
       return res.json({
         isAdmin: true,
         isUnderboss: false,
+        isGraphicsAdmin,
         region: null,
         regions: ['__admin__'],
         name: 'Admin',
@@ -268,6 +275,7 @@ router.get('/me', requireAuth, async (req: UnderbossRequest, res: Response, next
       return res.json({
         isAdmin: false,
         isUnderboss: true,
+        isGraphicsAdmin,
         region: underboss.region,
         regions,
         name: underboss.name,
@@ -279,6 +287,7 @@ router.get('/me', requireAuth, async (req: UnderbossRequest, res: Response, next
     return res.json({
       isAdmin: false,
       isUnderboss: false,
+      isGraphicsAdmin,
       region: null,
       regions: [],
       name: null,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -2470,6 +2470,7 @@ export async function deleteChecklistDefault(name: string): Promise<{ success: b
 export interface UnderbossMeResponse {
   isAdmin: boolean;
   isUnderboss: boolean;
+  isGraphicsAdmin?: boolean;
   region: string | null;
   regions: string[];
   name: string | null;
@@ -3134,5 +3135,24 @@ export async function vouchForGuest(inviteCode: string, targetGuestId: string): 
     method: 'POST',
     body: { targetGuestId },
   });
+}
+
+// ── Graphics Admin Management ──
+
+export async function fetchGraphicsAdminList(): Promise<GraphicsAdmin[]> {
+  const data = await apiRequest<{ admins: GraphicsAdmin[] }>('/api/graphics-admin/list');
+  return data.admins;
+}
+
+export async function addGraphicsAdmin(data: { email: string; name?: string }): Promise<GraphicsAdmin> {
+  const result = await apiRequest<{ admin: GraphicsAdmin }>('/api/graphics-admin/add', {
+    method: 'POST',
+    body: data,
+  });
+  return result.admin;
+}
+
+export async function removeGraphicsAdmin(id: string): Promise<void> {
+  await apiRequest(`/api/graphics-admin/${id}`, { method: 'DELETE' });
 }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -6,7 +6,7 @@ import { GPPClouds } from '../components/GPPClouds';
 import { IconInput } from '../components/IconInput';
 import {
   Shield, ShieldCheck, UserPlus, Trash2, Loader2,
-  Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp, Download,
+  Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp, Download, Palette,
 } from 'lucide-react';
 import {
   fetchAdminMe, fetchAdminList, addAdmin, removeAdmin,
@@ -16,10 +16,11 @@ import {
   fetchSponsorUsers, createSponsorUser, deleteSponsorUser,
   fetchGppDescription, updateGppDescription,
   fetchUnderbossDashboard,
+  fetchGraphicsAdminList, addGraphicsAdmin, removeGraphicsAdmin,
 } from '../lib/api';
 import type { ChecklistDefault, GppDescriptionData } from '../lib/api';
 import { GPP_REGIONS } from '../types';
-import type { AdminUser, UnderbossAdmin, SponsorUser } from '../types';
+import type { AdminUser, UnderbossAdmin, SponsorUser, GraphicsAdmin } from '../types';
 import { fetchSheetCities } from '../lib/cities';
 
 const themeClass = 'gpp-theme';
@@ -48,6 +49,13 @@ export function AdminPage() {
   const [newName, setNewName] = useState('');
   const [addingAdmin, setAddingAdmin] = useState(false);
   const [adminMessage, setAdminMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  // Graphics admin list state
+  const [graphicsAdmins, setGraphicsAdmins] = useState<GraphicsAdmin[]>([]);
+  const [gaEmail, setGaEmail] = useState('');
+  const [gaName, setGaName] = useState('');
+  const [addingGa, setAddingGa] = useState(false);
+  const [gaMessage, setGaMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   // Underboss list state
   const [underbosses, setUnderbosses] = useState<UnderbossAdmin[]>([]);
@@ -117,16 +125,18 @@ export function AdminPage() {
         setCurrentEmail(me.email || '');
 
         const isSA = me.role === 'super_admin';
-        const [adminList, ubList, nftSettings, clDefaults, spList, gppDescData] = await Promise.all([
+        const [adminList, ubList, nftSettings, clDefaults, spList, gppDescData, gaList] = await Promise.all([
           fetchAdminList(),
           fetchUnderbossList(),
           fetchGppNftSettings(),
           fetchChecklistDefaults(),
           fetchSponsorUsers(),
           isSA ? fetchGppDescription().catch(() => null) : Promise.resolve(null),
+          fetchGraphicsAdminList(),
         ]);
         setAdmins(adminList);
         setUnderbosses(ubList);
+        setGraphicsAdmins(gaList);
         setGppNftEnabled(nftSettings.nftEnabled);
         setGppNftChain(nftSettings.nftChain || 'base');
         setChecklistItems(sortByDueDate(clDefaults.items));
@@ -153,6 +163,13 @@ export function AdminPage() {
       return () => clearTimeout(t);
     }
   }, [adminMessage]);
+
+  useEffect(() => {
+    if (gaMessage) {
+      const t = setTimeout(() => setGaMessage(null), 4000);
+      return () => clearTimeout(t);
+    }
+  }, [gaMessage]);
 
   useEffect(() => {
     if (ubMessage) {
@@ -389,6 +406,35 @@ export function AdminPage() {
     }
   }
 
+  async function handleAddGraphicsAdmin(e: React.FormEvent) {
+    e.preventDefault();
+    if (!gaEmail.trim()) return;
+    setAddingGa(true);
+    setGaMessage(null);
+    try {
+      const ga = await addGraphicsAdmin({ email: gaEmail.trim(), name: gaName.trim() || undefined });
+      setGraphicsAdmins((prev) => [...prev, ga]);
+      setGaEmail('');
+      setGaName('');
+      setGaMessage({ type: 'success', text: `Added ${ga.email} as graphics admin` });
+    } catch (err: any) {
+      setGaMessage({ type: 'error', text: err.message || 'Failed to add graphics admin' });
+    } finally {
+      setAddingGa(false);
+    }
+  }
+
+  async function handleRemoveGraphicsAdmin(id: string, email: string) {
+    if (!confirm(`Remove ${email} as graphics admin?`)) return;
+    try {
+      await removeGraphicsAdmin(id);
+      setGraphicsAdmins((prev) => prev.filter((ga) => ga.id !== id));
+      setGaMessage({ type: 'success', text: `Removed ${email}` });
+    } catch (err: any) {
+      setGaMessage({ type: 'error', text: err.message || 'Failed to remove graphics admin' });
+    }
+  }
+
   async function handleAddUnderboss(e: React.FormEvent) {
     e.preventDefault();
     if (!ubName.trim() || !ubEmail.trim() || ubRegions.length === 0) return;
@@ -611,6 +657,98 @@ export function AdminPage() {
                     <tr>
                       <td colSpan={5} className="px-4 py-8 text-center text-theme-text-faint">
                         No admins found
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* Graphics Admin Management */}
+          <section className="mb-10">
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <Palette size={18} className="text-theme-text-secondary" />
+              Graphics Admins ({graphicsAdmins.length})
+            </h2>
+
+            {gaMessage && (
+              <div
+                className={`mb-4 px-4 py-2 rounded-lg text-sm ${
+                  gaMessage.type === 'success'
+                    ? 'bg-green-100 text-green-700 border border-green-300'
+                    : 'bg-red-100 text-red-700 border border-red-300'
+                }`}
+              >
+                {gaMessage.text}
+              </div>
+            )}
+
+            <form onSubmit={handleAddGraphicsAdmin} className="bg-theme-surface border border-theme-stroke rounded-xl p-4 mb-4">
+              <div className="flex flex-col sm:flex-row gap-3">
+                <div className="flex-1">
+                  <IconInput
+                    icon={Mail}
+                    type="email"
+                    placeholder="Email address"
+                    value={gaEmail}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setGaEmail(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="flex-1">
+                  <IconInput
+                    icon={User}
+                    type="text"
+                    placeholder="Name (optional)"
+                    value={gaName}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setGaName(e.target.value)}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={addingGa || !gaEmail.trim()}
+                  className="flex items-center gap-2 bg-theme-surface-hover hover:bg-theme-surface-hover disabled:opacity-50 rounded-lg px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap"
+                >
+                  {addingGa ? <Loader2 size={16} className="animate-spin" /> : <UserPlus size={16} />}
+                  Add Graphics Admin
+                </button>
+              </div>
+            </form>
+
+            <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
+                    <th className="px-4 py-3 font-medium">Email</th>
+                    <th className="px-4 py-3 font-medium">Name</th>
+                    <th className="px-4 py-3 font-medium">Added</th>
+                    <th className="px-4 py-3 font-medium w-20"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {graphicsAdmins.map((ga) => (
+                    <tr key={ga.id} className="border-b border-theme-stroke hover:bg-theme-surface transition-colors">
+                      <td className="px-4 py-3 text-theme-text">{ga.email}</td>
+                      <td className="px-4 py-3 text-theme-text-secondary">{ga.name || '-'}</td>
+                      <td className="px-4 py-3 text-theme-text-muted">
+                        {new Date(ga.createdAt).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => handleRemoveGraphicsAdmin(ga.id, ga.email)}
+                          className="text-red-400/60 hover:text-red-400 transition-colors p-1"
+                          title="Remove graphics admin"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {graphicsAdmins.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-8 text-center text-theme-text-faint">
+                        No graphics admins yet
                       </td>
                     </tr>
                   )}

--- a/frontend/src/pages/GraphicsDashboard.tsx
+++ b/frontend/src/pages/GraphicsDashboard.tsx
@@ -35,7 +35,7 @@ export function GraphicsDashboard() {
     try {
       const me = await fetchUnderbossMe();
       setMeData(me);
-      if (!me.isUnderboss && !me.isAdmin) {
+      if (!me.isUnderboss && !me.isAdmin && !me.isGraphicsAdmin) {
         setLoading(false);
         return;
       }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1072,6 +1072,14 @@ export interface AdminUser {
   createdAt: string;
 }
 
+export interface GraphicsAdmin {
+  id: string;
+  email: string;
+  name: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
 export interface UnderbossAdmin {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- Adds a `graphics_admins` table for granting `/graphics` dashboard access to specific emails
- New CRUD API at `/api/graphics-admin/*` (admin-only)
- New "Graphics Admins" section on the admin page with add/remove UI
- `/api/underboss/me` now returns `isGraphicsAdmin` flag
- GraphicsDashboard access check updated to allow graphics admins

## Test plan
- [ ] Add an email as a graphics admin from `/admin`
- [ ] Log in with that email — verify `/graphics` is accessible
- [ ] Remove the email — verify access is denied
- [ ] Verify existing admin/underboss access still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)