### PR TITLE
feat: hide bulk partner contact emails from event hosts

### DIFF
--- a/backend/prisma/migrations/20260510_add_added_by_underboss.sql
+++ b/backend/prisma/migrations/20260510_add_added_by_underboss.sql
@@ -1,0 +1,6 @@
+-- Add addedByUnderboss boolean to Sponsor table
+-- When true, contact info is hidden from event hosts (only visible to admin/underboss)
+ALTER TABLE "Sponsor" ADD COLUMN IF NOT EXISTS "added_by_underboss" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill: mark existing auto-created sponsors as underboss-added
+UPDATE "Sponsor" SET "added_by_underboss" = true WHERE "notes" LIKE 'Auto-created from partner tag%';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -895,6 +895,9 @@ model Sponsor {
   intakeSubmittedAt DateTime? @map("intake_submitted_at") @db.Timestamptz
   sponsorMessage    String?   @map("sponsor_message")
 
+  // Whether this sponsor was bulk-added by an underboss (contact info hidden from hosts)
+  addedByUnderboss Boolean @default(false) @map("added_by_underboss")
+
   // Display order (for flyer logo row)
   sortOrder Int @default(0) @map("sort_order")
 

--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -139,6 +139,7 @@ export async function addPartnerToParty(
           contactEmail: sponsorUser.email,
           status: 'yes',
           notes: `Auto-created from partner tag "${sponsorUser.tag}"`,
+          addedByUnderboss: true,
         },
       });
       sponsorId = created.id;
@@ -300,6 +301,7 @@ export async function syncAutoSponsorsToAllEvents(
           contactEmail: sponsorUser.email,
           status: 'yes',
           notes: `Auto-created from partner tag "${sponsorUser.tag}"`,
+          addedByUnderboss: true,
         },
       });
       sponsorId = created.id;

--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -1,6 +1,6 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isSuperAdmin, isUnderboss } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
@@ -49,7 +49,18 @@ router.get('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Resp
       orderBy,
     });
 
-    res.json({ sponsors });
+    // Strip contact info from underboss-added sponsors for non-privileged users
+    const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
+    const sanitized = userIsPrivileged
+      ? sponsors
+      : sponsors.map(s => {
+          if (s.addedByUnderboss) {
+            return { ...s, contactEmail: null, contactPhone: null, contactName: null, contactTwitter: null };
+          }
+          return s;
+        });
+
+    res.json({ sponsors: sanitized });
   } catch (error) {
     next(error);
   }
@@ -237,6 +248,7 @@ router.post('/:partyId/sponsors/ensure-from-underboss', requireAuth, async (req:
           status: 'yes',
           sortOrder: sponsorUser.descriptionSortOrder,
           notes: `Auto-created from partner tag "${sponsorUser.tag}"`,
+          addedByUnderboss: true,
         },
       });
 
@@ -505,7 +517,13 @@ router.get('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthRequest
       throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
     }
 
-    res.json({ sponsor });
+    // Strip contact info from underboss-added sponsors for non-privileged users
+    const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
+    const sanitizedSponsor = (!userIsPrivileged && sponsor.addedByUnderboss)
+      ? { ...sponsor, contactEmail: null, contactPhone: null, contactName: null, contactTwitter: null }
+      : sponsor;
+
+    res.json({ sponsor: sanitizedSponsor });
   } catch (error) {
     next(error);
   }
@@ -577,6 +595,10 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
       throw new AppError(`Invalid category. Must be one of: ${validCategories.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
 
+    // Protect contact fields for underboss-added sponsors from non-privileged users
+    const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
+    const stripContactFields = existingSponsor.addedByUnderboss && !userIsPrivileged;
+
     const sponsor = await prisma.sponsor.update({
       where: { id: sponsorId },
       data: {
@@ -586,10 +608,10 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
         ...(brandInstagram !== undefined && { brandInstagram: brandInstagram?.trim() || null }),
         ...(brandDescription !== undefined && { brandDescription: brandDescription?.trim() || null }),
         ...(pointPerson !== undefined && { pointPerson: pointPerson?.trim() || null }),
-        ...(contactName !== undefined && { contactName: contactName?.trim() || null }),
-        ...(contactEmail !== undefined && { contactEmail: contactEmail?.trim()?.toLowerCase() || null }),
-        ...(contactPhone !== undefined && { contactPhone: contactPhone?.trim() || null }),
-        ...(contactTwitter !== undefined && { contactTwitter: contactTwitter?.trim() || null }),
+        ...(!stripContactFields && contactName !== undefined && { contactName: contactName?.trim() || null }),
+        ...(!stripContactFields && contactEmail !== undefined && { contactEmail: contactEmail?.trim()?.toLowerCase() || null }),
+        ...(!stripContactFields && contactPhone !== undefined && { contactPhone: contactPhone?.trim() || null }),
+        ...(!stripContactFields && contactTwitter !== undefined && { contactTwitter: contactTwitter?.trim() || null }),
         ...(telegram !== undefined && { telegram: telegram?.trim() || null }),
         ...(status !== undefined && { status }),
         ...(amount !== undefined && { amount: amount !== null && amount !== '' ? amount : null }),

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -520,12 +520,20 @@ export function PartnerForm({
       )}
 
       {/* Contact Info — CRM + Intake */}
-      {(isCrm || isIntake) && (
+      {(isCrm || isIntake) && (() => {
+        // Disable contact fields for underboss-added sponsors when backend has stripped the data
+        const contactFieldsDisabled = !!(isCrm && sponsor?.addedByUnderboss && !sponsor?.contactEmail);
+        return (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <User size={16} />
             Contact Info
           </h3>
+          {contactFieldsDisabled && (
+            <p className="text-xs text-purple-400 flex items-center gap-1">
+              <Globe size={12} /> Managed by global partner admin
+            </p>
+          )}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {isCrm && (
               <IconInput
@@ -542,6 +550,7 @@ export function PartnerForm({
               value={formData.contactName}
               onChange={e => handleChange('contactName', e.target.value)}
               placeholder="Contact Name"
+              disabled={contactFieldsDisabled}
             />
             <IconInput
               icon={Mail}
@@ -549,6 +558,7 @@ export function PartnerForm({
               value={formData.contactEmail}
               onChange={e => handleChange('contactEmail', e.target.value)}
               placeholder="Email"
+              disabled={contactFieldsDisabled}
             />
             <IconInput
               icon={Phone}
@@ -556,6 +566,7 @@ export function PartnerForm({
               value={formData.contactPhone}
               onChange={e => handleChange('contactPhone', e.target.value)}
               placeholder="Phone"
+              disabled={contactFieldsDisabled}
             />
             <IconInput
               customIcon={<XIcon size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />}
@@ -563,6 +574,7 @@ export function PartnerForm({
               value={formData.contactTwitter}
               onChange={e => handleChange('contactTwitter', e.target.value)}
               placeholder="Contact X Handle"
+              disabled={contactFieldsDisabled}
             />
             <IconInput
               customIcon={<TelegramIcon size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />}
@@ -573,7 +585,8 @@ export function PartnerForm({
             />
           </div>
         </div>
-      )}
+        );
+      })()}
 
       {/* Pipeline — CRM mode only */}
       {isCrm && (

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {
   ChevronUp, ChevronDown, Edit2, Trash2, ExternalLink,
-  Mail, Phone, User, Building2, Calendar
+  Mail, Phone, User, Building2, Calendar, Globe
 } from 'lucide-react';
 import { Sponsor, SponsorStatus, SPONSOR_CATEGORIES } from '../../types';
 import { PartnerIntakeButton } from './PartnerIntakeButton';
@@ -312,6 +312,11 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                           >
                             <Phone size={14} />
                           </a>
+                        )}
+                        {!sponsor.contactEmail && !sponsor.contactPhone && sponsor.addedByUnderboss && (
+                          <span className="text-xs text-purple-400 flex items-center gap-1">
+                            <Globe size={12} /> Global partner
+                          </span>
                         )}
                       </div>
                     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -484,6 +484,7 @@ export interface Sponsor {
   intakeToken: string | null;
   intakeSubmittedAt: string | null;
   sponsorMessage: string | null;
+  addedByUnderboss?: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Adds `addedByUnderboss` boolean column to Sponsor model with backfill migration
- Strips contact info (email, phone, name, twitter) from API responses for non-privileged users
- Shows "Global partner" badge in SponsorList for underboss-added partners
- Disables contact field editing in PartnerForm for underboss-added sponsors

## Test plan
- [ ] Verify underboss can still see contact info for underboss-added sponsors
- [ ] Verify hosts cannot see contact info for underboss-added sponsors
- [ ] Verify hosts can still see contact info for their own sponsors
- [ ] Verify editing underboss-added sponsor does NOT allow changing contact fields (as host)
- [ ] Verify backfill migration works for existing auto-created sponsors