### PR TITLE
Unify RSVP flow: shared RSVPFlowContent component

### DIFF
--- a/frontend/src/components/RSVPFlowContent.tsx
+++ b/frontend/src/components/RSVPFlowContent.tsx
@@ -1,0 +1,274 @@
+import React, { useState, useRef } from 'react';
+import { Check, AlertCircle, Loader2, X, Heart, Calendar } from 'lucide-react';
+import { PublicEvent } from '../lib/api';
+import { DonationStep } from './DonationStep';
+import { RSVPFormStep1 } from './RSVPFormStep1';
+import { RSVPFormStep2 } from './RSVPFormStep2';
+import { ShareRSVP } from './ShareRSVP';
+import { AddToCalendarPopup } from './AddToCalendarPopup';
+import { MintStatus, MintResult } from '../hooks/useMintNFT';
+import { getNFTViewUrl, getChainConfig, NFTChain } from '../lib/nftContract';
+import type { useRSVPForm } from '../hooks/useRSVPForm';
+
+interface RSVPFlowContentProps {
+  event: PublicEvent;
+  form: ReturnType<typeof useRSVPForm>;
+  eventName: string;
+  closeButtonLabel: string;
+  onClose: () => void;
+  isEditing?: boolean;
+  walletFieldSlot?: React.ReactNode;
+  donationSlot?: React.ReactNode;
+  mintStatus?: MintStatus;
+  mintResult?: MintResult;
+  twitterHandles: string[];
+}
+
+export function RSVPFlowContent({
+  event,
+  form,
+  eventName,
+  closeButtonLabel,
+  onClose,
+  isEditing,
+  walletFieldSlot,
+  donationSlot,
+  mintStatus,
+  mintResult,
+  twitterHandles,
+}: RSVPFlowContentProps) {
+  // Calendar popup state (success screen)
+  const [calendarOpen, setCalendarOpen] = useState(false);
+  const calendarBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Donation state (success screen)
+  const [showDonation, setShowDonation] = useState(false);
+  const [donationComplete, setDonationComplete] = useState(false);
+
+  // ---- Success screen ----
+  if (form.submitted) {
+    const getSuccessIcon = () => {
+      if (form.alreadyRegistered && !form.wasUpdated) return 'bg-[#ff393a]/20 border-[#ff393a]/30';
+      if (form.waitlisted) return 'bg-[#ffc107]/20 border-[#ffc107]/30';
+      if (form.pendingApproval) return 'bg-[#ffc107]/20 border-[#ffc107]/30';
+      return 'bg-[#39d98a]/20 border-[#39d98a]/30';
+    };
+
+    const getSuccessTitle = () => {
+      if (form.wasUpdated) return 'RSVP Updated';
+      if (form.alreadyRegistered) return "You're already registered!";
+      if (form.waitlisted) return "You're on the Waitlist!";
+      if (form.pendingApproval) return 'RSVP Submitted!';
+      return `See you at ${eventName}!`;
+    };
+
+    const getSuccessIconComponent = () => {
+      if (form.alreadyRegistered && !form.wasUpdated) {
+        return <AlertCircle className="w-8 h-8 text-[#ff393a]" />;
+      }
+      if (form.waitlisted) {
+        return <span className="text-2xl font-bold text-[#ffc107]">#{form.waitlistPosition}</span>;
+      }
+      if (form.pendingApproval) {
+        return <Loader2 className="w-8 h-8 text-[#ffc107]" />;
+      }
+      return <Check className="w-8 h-8 text-[#39d98a]" />;
+    };
+
+    return (
+      <div className="card p-8 max-w-md w-full text-center">
+        <div className={`w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 border ${getSuccessIcon()}`}>
+          {getSuccessIconComponent()}
+        </div>
+        <h1 className="text-2xl font-bold text-theme-text mb-2">
+          {getSuccessTitle()}
+        </h1>
+        {form.alreadyRegistered && !form.wasUpdated && (
+          <p className="text-theme-text-secondary mb-4">
+            This email has already been used to RSVP to this event.
+          </p>
+        )}
+        {form.wasUpdated && (
+          <p className="text-theme-text-secondary mb-4">
+            Your preferences have been saved.
+          </p>
+        )}
+        {form.waitlisted && !form.wasUpdated && (
+          <p className="text-theme-text-secondary mb-4">
+            This event is currently at capacity, but you're #{form.waitlistPosition} on the waitlist!
+            We'll notify you if a spot opens up.
+          </p>
+        )}
+        {form.pendingApproval && !form.alreadyRegistered && !form.waitlisted && (
+          <p className="text-theme-text-secondary mb-4">
+            Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
+          </p>
+        )}
+        {/* Share Section */}
+        {(!form.alreadyRegistered || form.wasUpdated) && (
+          <ShareRSVP
+            eventName={eventName}
+            eventImageUrl={event.eventImageUrl}
+            customUrl={event.customUrl}
+            inviteCode={event.inviteCode}
+            twitterHandles={twitterHandles}
+          />
+        )}
+        {/* NFT Minting Status */}
+        {event.nftEnabled && form.ethereumAddress.trim() && event.eventImageUrl && (
+          <div className="mt-4 pt-4 border-t border-theme-stroke">
+            {mintStatus === 'minting' && (
+              <div className="flex items-center gap-2 text-theme-text-secondary justify-center">
+                <Loader2 size={16} className="animate-spin" />
+                <span>Minting your NFT...</span>
+              </div>
+            )}
+            {mintStatus === 'success' && (mintResult?.txHash || mintResult?.tokenId) && (
+              <div className="space-y-2">
+                <p className="text-[#39d98a] font-medium">
+                  {mintResult.alreadyMinted ? 'NFT Already Claimed!' : 'NFT Minted!'}
+                </p>
+                {mintResult.tokenId ? (
+                  <a
+                    href={getNFTViewUrl((event.nftChain || 'base') as NFTChain, mintResult.tokenId)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-theme-text-secondary hover:text-theme-text underline"
+                  >
+                    View on OpenSea
+                  </a>
+                ) : mintResult.txHash ? (
+                  <a
+                    href={`${getChainConfig((event.nftChain || 'base') as NFTChain).explorerUrl}/tx/${mintResult.txHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-theme-text-secondary hover:text-theme-text underline"
+                  >
+                    View Transaction
+                  </a>
+                ) : null}
+              </div>
+            )}
+            {mintStatus === 'error' && (
+              <p className="text-[#ff393a] text-sm">{mintResult?.error || 'NFT minting failed'}</p>
+            )}
+          </div>
+        )}
+        {/* Donation Section */}
+        {event.donationEnabled && !donationComplete && !showDonation && (
+          <>
+            <button
+              onClick={() => setShowDonation(true)}
+              className="w-full bg-theme-surface border border-theme-stroke rounded-xl p-4 hover:bg-theme-surface-hover transition-colors cursor-pointer mt-4 flex items-center justify-center gap-2 text-theme-text"
+            >
+              <Heart size={18} className="text-[#ff393a]" />
+              Donate
+            </button>
+            <p className="text-theme-text-secondary text-sm text-center mt-1">
+              {event.donationRecipient ? (
+                <>Buy Pizza for {event.donationRecipientUrl ? <a href={event.donationRecipientUrl} target="_blank" rel="noopener noreferrer" className="text-[#ff393a] hover:text-[#ff6b6b] underline transition-colors">{event.donationRecipient}</a> : event.donationRecipient}</>
+              ) : `Buy Pizza for ${eventName}`}
+            </p>
+          </>
+        )}
+        {showDonation && (
+          <div className="mt-4">
+            <DonationStep
+              partyId={event.id}
+              partyName={eventName}
+              guestName={form.name}
+              guestEmail={form.email}
+              onComplete={() => {
+                setDonationComplete(true);
+                setShowDonation(false);
+              }}
+              onSkip={() => setShowDonation(false)}
+            />
+          </div>
+        )}
+        {donationComplete && (
+          <div className="flex items-center justify-center gap-2 mt-4 text-[#39d98a]">
+            <Check size={16} />
+            <span className="text-sm">Thanks for your support!</span>
+          </div>
+        )}
+        {/* Calendar Button */}
+        {event.date && (
+          <div className="mt-4 relative">
+            <button
+              ref={calendarBtnRef}
+              onClick={() => setCalendarOpen(!calendarOpen)}
+              className="btn-secondary w-full flex items-center justify-center gap-2"
+            >
+              <Calendar size={16} />
+              Add to Calendar
+            </button>
+            <AddToCalendarPopup
+              isOpen={calendarOpen}
+              onClose={() => setCalendarOpen(false)}
+              event={event}
+              anchorRef={calendarBtnRef}
+            />
+          </div>
+        )}
+        <button
+          onClick={onClose}
+          className="btn-secondary mt-4"
+        >
+          {closeButtonLabel}
+        </button>
+      </div>
+    );
+  }
+
+  // ---- Step 1 - Personal Info ----
+  if (form.step === 1) {
+    return (
+      <div className="card p-8 max-w-lg w-full relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
+        >
+          <X size={24} />
+        </button>
+
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-theme-text">{isEditing ? 'Edit RSVP' : `RSVP to ${eventName}`}</h1>
+          <p className="text-sm text-theme-text-secondary">Step 1 of 2</p>
+        </div>
+
+        <RSVPFormStep1
+          form={form}
+          eventName={eventName}
+          isEditing={isEditing}
+          showWallet={!!(event.nftEnabled || event.eventType === 'gpp')}
+          showTurtleRoles={!!event.turtleRolesEnabled}
+          walletFieldSlot={walletFieldSlot}
+        />
+      </div>
+    );
+  }
+
+  // ---- Step 2 - Pizza Preferences ----
+  return (
+    <div className="card p-8 max-w-2xl w-full relative">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
+      >
+        <X size={24} />
+      </button>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-theme-text">{isEditing ? 'Edit Pizza Preferences' : 'Pizza Requests'}</h1>
+        <p className="text-sm text-theme-text-secondary">Step 2 of 2</p>
+      </div>
+
+      <RSVPFormStep2
+        form={form}
+        isEditing={isEditing}
+        donationSlot={donationSlot}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -1,19 +1,15 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { Check, AlertCircle, Loader2, X, Wallet, Heart } from 'lucide-react';
+import { Check, X, Wallet } from 'lucide-react';
 import { ExistingGuestData } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import { IconInput } from './IconInput';
 import { PublicEvent } from '../lib/api';
-import { DonationStep } from './DonationStep';
 import { useRSVPForm, publicEventToRSVPData, RSVPSubmitResult } from '../hooks/useRSVPForm';
-import { RSVPFormStep1 } from './RSVPFormStep1';
-import { RSVPFormStep2 } from './RSVPFormStep2';
-import { ShareRSVP } from './ShareRSVP';
 import { useMintNFT, MintStatus, MintResult } from '../hooks/useMintNFT';
-import { getNFTViewUrl, getChainConfig, NFTChain } from '../lib/nftContract';
 import { useAccount } from 'wagmi';
 import { ConnectKitButton } from 'connectkit';
+import { RSVPFlowContent } from './RSVPFlowContent';
 
 interface RSVPModalProps {
   isOpen: boolean;
@@ -26,14 +22,10 @@ interface RSVPModalProps {
 export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess }: RSVPModalProps) {
   const { user } = useAuth();
 
-  // NFT minting state (stays in modal — not shared)
+  // NFT minting state
   const [mintStatus, setMintStatus] = useState<MintStatus>('idle');
   const [mintResult, setMintResult] = useState<MintResult>({});
   const { mint: mintNFT } = useMintNFT();
-
-  // Donation state (stays in modal success screen)
-  const [showDonation, setShowDonation] = useState(false);
-  const [donationComplete, setDonationComplete] = useState(false);
 
   // Track closed->open transition for reset
   const wasOpenRef = useRef(false);
@@ -106,14 +98,10 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
   // Reset state when modal opens and lock body scroll
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
-      // Modal just opened: reset all form state
       form.resetForm();
       setMintStatus('idle');
       setMintResult({});
-      setShowDonation(false);
-      setDonationComplete(false);
 
-      // Lock body scroll
       document.body.classList.add('modal-open');
     } else if (!isOpen) {
       document.body.classList.remove('modal-open');
@@ -139,6 +127,20 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
   if (!isOpen) return null;
 
   const isEditing = !!existingGuest;
+
+  // ---- Build twitter handles ----
+  const twitterHandles: string[] = [];
+  if (event.hostProfile?.twitter) twitterHandles.push(event.hostProfile.twitter);
+  if (event.coHosts) {
+    for (const host of event.coHosts) {
+      if (host.twitter && host.showOnEvent !== false) twitterHandles.push(host.twitter);
+    }
+  }
+  if (event.sponsors) {
+    for (const sponsor of event.sponsors) {
+      if (sponsor.brandTwitter) twitterHandles.push(sponsor.brandTwitter);
+    }
+  }
 
   // ---- Wallet field slot with ConnectKit ----
   const walletFieldSlot = (
@@ -196,253 +198,24 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
     </div>
   );
 
-  // ---- Success screen ----
-  if (form.submitted) {
-    const getSuccessIcon = () => {
-      if (form.alreadyRegistered && !form.wasUpdated) return 'bg-[#ff393a]/20 border-[#ff393a]/30';
-      if (form.waitlisted) return 'bg-[#ffc107]/20 border-[#ffc107]/30';
-      if (form.pendingApproval) return 'bg-[#ffc107]/20 border-[#ffc107]/30';
-      return 'bg-[#39d98a]/20 border-[#39d98a]/30';
-    };
-
-    const getSuccessTitle = () => {
-      if (form.wasUpdated) return 'RSVP Updated';
-      if (form.alreadyRegistered) return "You're already registered!";
-      if (form.waitlisted) return "You're on the Waitlist!";
-      if (form.pendingApproval) return 'RSVP Submitted!';
-      return `See you at ${event.name}!`;
-    };
-
-    const getSuccessIconComponent = () => {
-      if (form.alreadyRegistered && !form.wasUpdated) {
-        return <AlertCircle className="w-8 h-8 text-[#ff393a]" />;
-      }
-      if (form.waitlisted) {
-        return <span className="text-2xl font-bold text-[#ffc107]">#{form.waitlistPosition}</span>;
-      }
-      if (form.pendingApproval) {
-        return <Loader2 className="w-8 h-8 text-[#ffc107]" />;
-      }
-      return <Check className="w-8 h-8 text-[#39d98a]" />;
-    };
-
-    return createPortal(
-      <div
-        className="fixed inset-0 z-50 flex items-center justify-center px-2 py-4 sm:p-4 bg-black/60 backdrop-blur-sm"
-        onClick={handleClose}
-      >
-        <div
-          className="card p-8 max-w-md w-full text-center"
-          data-testid="rsvp-success"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className={`w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 border ${getSuccessIcon()}`}>
-            {getSuccessIconComponent()}
-          </div>
-          <h1 className="text-2xl font-bold text-theme-text mb-2">
-            {getSuccessTitle()}
-          </h1>
-          {form.alreadyRegistered && !form.wasUpdated && (
-            <p className="text-theme-text-secondary mb-4">
-              This email has already been used to RSVP to this event.
-            </p>
-          )}
-          {form.wasUpdated && (
-            <p className="text-theme-text-secondary mb-4">
-              Your preferences have been saved.
-            </p>
-          )}
-          {form.waitlisted && !form.wasUpdated && (
-            <p className="text-theme-text-secondary mb-4">
-              This event is currently at capacity, but you're #{form.waitlistPosition} on the waitlist!
-              We'll notify you if a spot opens up.
-            </p>
-          )}
-          {form.pendingApproval && !form.alreadyRegistered && !form.waitlisted && (
-            <p className="text-theme-text-secondary mb-4">
-              Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
-            </p>
-          )}
-          {/* Share Section */}
-          {(!form.alreadyRegistered || form.wasUpdated) && (() => {
-            const twitterHandles: string[] = [];
-            if (event.hostProfile?.twitter) twitterHandles.push(event.hostProfile.twitter);
-            if (event.coHosts) {
-              for (const host of event.coHosts) {
-                if (host.twitter && host.showOnEvent !== false) twitterHandles.push(host.twitter);
-              }
-            }
-            if (event.sponsors) {
-              for (const sponsor of event.sponsors) {
-                if (sponsor.brandTwitter) twitterHandles.push(sponsor.brandTwitter);
-              }
-            }
-            return (
-              <ShareRSVP
-                eventName={event.name}
-                eventImageUrl={event.eventImageUrl}
-                customUrl={event.customUrl}
-                inviteCode={event.inviteCode}
-                twitterHandles={twitterHandles}
-              />
-            );
-          })()}
-          {/* NFT Minting Status */}
-          {event.nftEnabled && form.ethereumAddress.trim() && event.eventImageUrl && (
-            <div className="mt-4 pt-4 border-t border-theme-stroke">
-              {mintStatus === 'minting' && (
-                <div className="flex items-center gap-2 text-theme-text-secondary justify-center">
-                  <Loader2 size={16} className="animate-spin" />
-                  <span>Minting your NFT...</span>
-                </div>
-              )}
-              {mintStatus === 'success' && (mintResult.txHash || mintResult.tokenId) && (
-                <div className="space-y-2">
-                  <p className="text-[#39d98a] font-medium">
-                    {mintResult.alreadyMinted ? 'NFT Already Claimed!' : 'NFT Minted!'}
-                  </p>
-                  {mintResult.tokenId ? (
-                    <a
-                      href={getNFTViewUrl((event.nftChain || 'base') as NFTChain, mintResult.tokenId)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-theme-text-secondary hover:text-theme-text underline"
-                    >
-                      View on OpenSea
-                    </a>
-                  ) : mintResult.txHash ? (
-                    <a
-                      href={`${getChainConfig((event.nftChain || 'base') as NFTChain).explorerUrl}/tx/${mintResult.txHash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-theme-text-secondary hover:text-theme-text underline"
-                    >
-                      View Transaction
-                    </a>
-                  ) : null}
-                </div>
-              )}
-              {mintStatus === 'error' && (
-                <p className="text-[#ff393a] text-sm">{mintResult.error || 'NFT minting failed'}</p>
-              )}
-            </div>
-          )}
-          {/* Donation Section */}
-          {event.donationEnabled && !donationComplete && !showDonation && (
-            <>
-              <button
-                onClick={() => setShowDonation(true)}
-                className="w-full bg-theme-surface border border-theme-stroke rounded-xl p-4 hover:bg-theme-surface-hover transition-colors cursor-pointer mt-4 flex items-center justify-center gap-2 text-theme-text"
-              >
-                <Heart size={18} className="text-[#ff393a]" />
-                Donate
-              </button>
-              <p className="text-theme-text-secondary text-sm text-center mt-1">
-                {event.donationRecipient ? (
-                  <>Buy Pizza for {event.donationRecipientUrl ? <a href={event.donationRecipientUrl} target="_blank" rel="noopener noreferrer" className="text-[#ff393a] hover:text-[#ff6b6b] underline transition-colors">{event.donationRecipient}</a> : event.donationRecipient}</>
-                ) : `Buy Pizza for ${event.name}`}
-              </p>
-            </>
-          )}
-          {showDonation && (
-            <div className="mt-4">
-              <DonationStep
-                partyId={event.id}
-                partyName={event.name}
-                guestName={form.name}
-                guestEmail={form.email}
-                onComplete={() => {
-                  setDonationComplete(true);
-                  setShowDonation(false);
-                }}
-                onSkip={() => setShowDonation(false)}
-              />
-            </div>
-          )}
-          {donationComplete && (
-            <div className="flex items-center justify-center gap-2 mt-4 text-[#39d98a]">
-              <Check size={16} />
-              <span className="text-sm">Thanks for your support!</span>
-            </div>
-          )}
-          <button
-            onClick={handleClose}
-            className="btn-secondary mt-4"
-          >
-            Close
-          </button>
-        </div>
-      </div>,
-      document.body
-    );
-  }
-
-  // ---- Step 1 - Personal Info ----
-  if (form.step === 1) {
-    return createPortal(
-      <div
-        className="fixed inset-0 z-50 overflow-y-auto bg-black/60 backdrop-blur-sm"
-        data-testid="rsvp-modal"
-        onClick={handleClose}
-      >
-        <div className="min-h-full flex items-center justify-center px-2 py-4 sm:p-4">
-          <div
-            className="card p-8 max-w-lg w-full relative"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              onClick={handleClose}
-              className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
-            >
-              <X size={24} />
-            </button>
-
-            <div className="mb-6">
-              <h1 className="text-2xl font-bold text-theme-text">{isEditing ? 'Edit RSVP' : `RSVP to ${event.name}`}</h1>
-              <p className="text-sm text-theme-text-secondary">Step 1 of 2</p>
-            </div>
-
-            <RSVPFormStep1
-              form={form}
-              eventName={event.name}
-              isEditing={isEditing}
-              showWallet={!!(event.nftEnabled || event.eventType === 'gpp')}
-              showTurtleRoles={!!event.turtleRolesEnabled}
-              walletFieldSlot={walletFieldSlot}
-            />
-          </div>
-        </div>
-      </div>,
-      document.body
-    );
-  }
-
-  // ---- Step 2 - Pizza Preferences ----
   return createPortal(
     <div
       className="fixed inset-0 z-50 overflow-y-auto bg-black/60 backdrop-blur-sm"
       onClick={handleClose}
     >
       <div className="min-h-full flex items-center justify-center px-2 py-4 sm:p-4">
-        <div
-          className="card p-8 max-w-2xl w-full relative"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <button
-            onClick={handleClose}
-            className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
-          >
-            <X size={24} />
-          </button>
-
-          <div className="mb-6">
-            <h1 className="text-2xl font-bold text-theme-text">{isEditing ? 'Edit Pizza Preferences' : 'Pizza Requests'}</h1>
-            <p className="text-sm text-theme-text-secondary">Step 2 of 2</p>
-          </div>
-
-          <RSVPFormStep2
+        <div onClick={(e) => e.stopPropagation()} data-testid={form.submitted ? 'rsvp-success' : 'rsvp-modal'}>
+          <RSVPFlowContent
+            event={event}
             form={form}
+            eventName={event.name}
+            closeButtonLabel="Close"
+            onClose={handleClose}
             isEditing={isEditing}
+            walletFieldSlot={walletFieldSlot}
+            mintStatus={mintStatus}
+            mintResult={mintResult}
+            twitterHandles={twitterHandles}
           />
         </div>
       </div>

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -1,18 +1,57 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Check, AlertCircle, Loader2, Lock, X, ChevronRight, Heart } from 'lucide-react';
+import { AlertCircle, Loader2, Lock, ChevronRight, Heart } from 'lucide-react';
 import { getPartyByInviteCodeOrCustomUrl, verifyPartyPassword, isUserGuestAtParty, DbParty } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import { DonationForm } from '../components/DonationForm';
-import { getDonationStats } from '../lib/api';
+import { PublicEvent, getDonationStats } from '../lib/api';
 import { DonationPublicStats } from '../types';
 import { useRSVPForm, dbPartyToRSVPData } from '../hooks/useRSVPForm';
-import { RSVPFormStep1 } from '../components/RSVPFormStep1';
-import { RSVPFormStep2 } from '../components/RSVPFormStep2';
 // GPP theme applied conditionally
 import { GPPClouds } from '../components/GPPClouds';
 import { useConfetti } from '../hooks/useConfetti';
-import { ShareRSVP } from '../components/ShareRSVP';
+import { RSVPFlowContent } from '../components/RSVPFlowContent';
+
+/** Map DbParty (snake_case) to a partial PublicEvent for RSVPFlowContent */
+function dbPartyToPublicEvent(party: DbParty, inviteCode: string): PublicEvent {
+  return {
+    id: party.id,
+    name: party.name,
+    inviteCode: party.invite_code || inviteCode,
+    customUrl: party.custom_url,
+    date: party.date,
+    duration: party.duration,
+    timezone: party.timezone,
+    pizzaStyle: party.pizza_style,
+    availableBeverages: party.available_beverages || [],
+    availableToppings: party.available_toppings || [],
+    availableDietaryOptions: party.available_dietary_options || [],
+    address: party.address,
+    latitude: party.latitude,
+    longitude: party.longitude,
+    venueName: party.venue_name,
+    maxGuests: party.max_guests,
+    hideGuests: party.hide_guests,
+    eventImageUrl: party.event_image_url,
+    description: party.description,
+    rsvpClosedAt: party.rsvp_closed_at,
+    coHosts: party.co_hosts || [],
+    hasPassword: !!party.has_password,
+    hostName: party.host_name || null,
+    hostProfile: party.host_profile || null,
+    guestCount: 0,
+    userId: party.user_id,
+    selectedPizzerias: party.selected_pizzerias as any,
+    eventType: party.event_type,
+    eventTags: party.event_tags,
+    donationEnabled: party.donation_enabled,
+    donationRecipient: party.donation_recipient,
+    donationRecipientUrl: party.donation_recipient_url,
+    nftEnabled: party.nft_enabled,
+    nftChain: party.nft_chain,
+    turtleRolesEnabled: party.turtle_roles_enabled,
+  } as PublicEvent;
+}
 
 export function RSVPPage() {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -24,7 +63,7 @@ export function RSVPPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [party, setParty] = useState<DbParty | null>(null);
 
-  // Donation state (page-specific)
+  // Donation state (page-specific, for Step 2 slot)
   const [donationsEnabled, setDonationsEnabled] = useState(false);
   const [donationStats, setDonationStats] = useState<DonationPublicStats | null>(null);
   const [showDonationForm, setShowDonationForm] = useState(false);
@@ -117,6 +156,7 @@ export function RSVPPage() {
       address: null,
       availableBeverages: [],
       availableToppings: [],
+      availableDietaryOptions: [],
     },
     user,
     isOpen: !!party, // Only active when party is loaded
@@ -212,6 +252,18 @@ export function RSVPPage() {
     );
   }
 
+  // ---- Build twitter handles ----
+  const twitterHandles: string[] = [];
+  if (party?.host_profile) {
+    const hp = party.host_profile as any;
+    if (hp.twitter) twitterHandles.push(hp.twitter);
+  }
+  if (party?.co_hosts) {
+    for (const host of party.co_hosts as any[]) {
+      if (host.twitter && host.showOnEvent !== false) twitterHandles.push(host.twitter);
+    }
+  }
+
   // ---- Donation slot for Step 2 ----
   const donationSlot = donationsEnabled && donationStats ? (
     <>
@@ -263,126 +315,24 @@ export function RSVPPage() {
     </>
   ) : undefined;
 
-  // ---- Success screen ----
-  if (form.submitted) {
-    const getSuccessIcon = () => {
-      if (form.alreadyRegistered) return 'bg-[#ff393a]/20 border-[#ff393a]/30';
-      if (form.pendingApproval) return 'bg-[#ffc107]/20 border-[#ffc107]/30';
-      return 'bg-[#39d98a]/20 border-[#39d98a]/30';
-    };
+  // ---- Map party to PublicEvent for RSVPFlowContent ----
+  const publicEvent = party ? dbPartyToPublicEvent(party, inviteCode || '') : null;
 
-    const getSuccessTitle = () => {
-      if (form.alreadyRegistered) return "You're already registered!";
-      if (form.pendingApproval) return 'RSVP Submitted!';
-      return `See you at ${party?.name}!`;
-    };
+  if (!publicEvent) return null;
 
-    return (
-      <div className={`min-h-screen flex items-center justify-center p-4 ${gppClass}`} onClick={(e) => { if (isGPP) fireConfetti(e.clientX, e.clientY); }}>
-        {isGPP && <GPPClouds />}
-        <div className="card p-8 max-w-md text-center">
-          <div className={`w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 border ${getSuccessIcon()}`}>
-            {form.alreadyRegistered ? (
-              <AlertCircle className="w-8 h-8 text-[#ff393a]" />
-            ) : form.pendingApproval ? (
-              <Loader2 className="w-8 h-8 text-[#ffc107]" />
-            ) : (
-              <Check className="w-8 h-8 text-[#39d98a]" />
-            )}
-          </div>
-          <h1 className="text-2xl font-bold text-theme-text mb-2">
-            {getSuccessTitle()}
-          </h1>
-          {form.alreadyRegistered && (
-            <p className="text-theme-text-secondary mb-4">
-              This email has already been used to RSVP to this event.
-            </p>
-          )}
-          {form.pendingApproval && !form.alreadyRegistered && (
-            <p className="text-theme-text-secondary mb-4">
-              Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
-            </p>
-          )}
-          {!form.alreadyRegistered && !form.pendingApproval && (() => {
-            const twitterHandles: string[] = [];
-            if (party?.co_hosts) {
-              for (const host of party.co_hosts as any[]) {
-                if (host.twitter && host.showOnEvent !== false) twitterHandles.push(host.twitter);
-              }
-            }
-            return (
-              <ShareRSVP
-                eventName={party?.name || ''}
-                eventImageUrl={party?.event_image_url || null}
-                customUrl={party?.custom_url || null}
-                inviteCode={inviteCode || ''}
-                twitterHandles={twitterHandles}
-              />
-            );
-          })()}
-          <button
-            onClick={handleClose}
-            className="btn-secondary"
-          >
-            Back to Event
-          </button>
-        </div>
-        {ConfettiOverlay}
-      </div>
-    );
-  }
-
-  // ---- Step 1 - Personal Info ----
-  if (form.step === 1) {
-    return (
-      <div className={`min-h-screen flex items-center justify-center p-4 ${gppClass}`} onClick={(e) => { if (isGPP) fireConfetti(e.clientX, e.clientY); }}>
-        {isGPP && <GPPClouds />}
-        <div className="card p-8 max-w-lg w-full relative">
-          <button
-            onClick={handleClose}
-            className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
-          >
-            <X size={24} />
-          </button>
-
-          <div className="mb-6">
-            <h1 className="text-2xl font-bold text-theme-text">RSVP to {party?.name}</h1>
-            <p className="text-sm text-theme-text-secondary">Step 1 of 2</p>
-          </div>
-
-          <RSVPFormStep1
-            form={form}
-            eventName={party?.name || ''}
-            showWallet={!!(party?.nft_enabled || party?.event_type === 'gpp')}
-            showTurtleRoles={!!party?.turtle_roles_enabled}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  // ---- Step 2 - Pizza Preferences ----
+  // ---- Unified RSVP flow ----
   return (
-    <div className={`min-h-screen flex items-center justify-center p-4 ${gppClass}`}>
+    <div className={`min-h-screen flex items-center justify-center p-4 ${gppClass}`} onClick={(e) => { if (isGPP) fireConfetti(e.clientX, e.clientY); }}>
       {isGPP && <GPPClouds />}
-      <div className="card p-8 max-w-2xl w-full relative">
-        <button
-          onClick={handleClose}
-          className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
-        >
-          <X size={24} />
-        </button>
-
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-theme-text">Pizza Requests</h1>
-          <p className="text-sm text-theme-text-secondary">Step 2 of 2</p>
-        </div>
-
-        <RSVPFormStep2
-          form={form}
-          donationSlot={donationSlot}
-        />
-      </div>
+      <RSVPFlowContent
+        event={publicEvent}
+        form={form}
+        eventName={party?.name || ''}
+        closeButtonLabel="Back to Event"
+        onClose={handleClose}
+        donationSlot={donationSlot}
+        twitterHandles={twitterHandles}
+      />
       {ConfettiOverlay}
     </div>
   );


### PR DESCRIPTION
## Summary
- Extract `RSVPFlowContent` component that renders the full RSVP card content (step 1, step 2, success screen)
- `RSVPModal` becomes a thin portal/backdrop wrapper delegating to `RSVPFlowContent`
- `RSVPPage` replaces three separate if-blocks with a single `RSVPFlowContent` render
- RSVPPage gains: waitlist support, "RSVP Updated" state, donation on success, NFT minting display, calendar button, consistent share logic

## Test plan
- [ ] RSVP via modal → all 3 steps + success render correctly, NFT minting works, ConnectKit wallet works
- [ ] RSVP via standalone page → all 3 steps + success render correctly, GPP confetti works
- [ ] Edit existing RSVP (modal) → "Edit RSVP" / "Edit Pizza Preferences" headers, "RSVP Updated" on success
- [ ] Event with donations → donate button on success screen in both flows
- [ ] Event without date → calendar button hidden
- [ ] Password-protected event → password screen still works on RSVPPage
- [ ] Waitlisted RSVP → position shown in both flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)