### PR TITLE
feat: GPP pizzerias world map

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { randomBytes } from 'crypto';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
 import { getAutoCoHostPartners, addPartnerToParty } from '../helpers/partnerSync.js';
@@ -600,6 +601,51 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
     });
   } catch (error) {
     next(error);
+  }
+});
+
+// GET /api/gpp/pizzerias - All GPP pizzerias (flattened across events)
+router.get('/pizzerias', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const where: any = {
+      eventType: 'gpp',
+      selectedPizzerias: { not: Prisma.DbNull },
+      underbossStatus: { notIn: ['rejected', 'hidden'] },
+    };
+
+    const parties = await prisma.party.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        customUrl: true,
+        inviteCode: true,
+        address: true,
+        selectedPizzerias: true,
+      },
+    });
+
+    // Flatten: for each event, for each pizzeria, emit { ...pizzeria, eventCity, eventSlug }
+    const pizzerias: any[] = [];
+    for (const party of parties) {
+      const raw = party.selectedPizzerias;
+      if (!Array.isArray(raw)) continue;
+      // Extract city from party name (GPP events are named like "Global Pizza Party CityName")
+      const eventCity = party.name?.replace(/^Global Pizza Party\s*/i, '').trim() || 'Unknown';
+      const eventSlug = party.customUrl || party.inviteCode;
+
+      for (const p of raw as any[]) {
+        // Strip heavy fields
+        const { photos, orderingOptions, ...light } = p;
+        pizzerias.push({ ...light, eventCity, eventSlug });
+      }
+    }
+
+    res.set('Cache-Control', 'public, max-age=600');
+    res.json(pizzerias);
+  } catch (err) {
+    console.error('Error fetching GPP pizzerias:', err);
+    res.status(500).json({ error: 'Failed to fetch pizzerias' });
   }
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@googlemaps/markerclusterer": "^2.6.2",
     "@napi-rs/canvas": "^0.1.88",
     "@stripe/react-stripe-js": "^5.4.1",
     "@stripe/stripe-js": "^8.6.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
 import { PostComposerPage } from './pages/PostComposerPage';
 import { OneSheetPage } from './pages/OneSheetPage';
+import { GPPPizzeriasPage } from './pages/GPPPizzeriasPage';
 
 // Legacy redirect: /sponsor-intake/:token → /partner-intake/:token
 // <Navigate> doesn't forward path params, so we wrap useParams().
@@ -46,6 +47,7 @@ function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/new" element={<NewEventPage />} />
             <Route path="/gpp" element={<GPPLandingPage />} />
+            <Route path="/gpp/pizzerias" element={<GPPPizzeriasPage />} />
             <Route path="/account" element={<AccountPage />} />
             <Route path="/auth/verify" element={<AuthVerifyPage />} />
             <Route path="/parties" element={<PartiesListPage />} />

--- a/frontend/src/components/GPPPizzeriasMap.tsx
+++ b/frontend/src/components/GPPPizzeriasMap.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { MarkerClusterer } from '@googlemaps/markerclusterer';
+import { GPPPizzeriaMapItem } from '../lib/api';
+
+interface GPPPizzeriasMapProps {
+  pizzerias: GPPPizzeriaMapItem[];
+  height?: string;
+}
+
+export default function GPPPizzeriasMap({
+  pizzerias,
+  height = '100%',
+}: GPPPizzeriasMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const markersRef = useRef<google.maps.Marker[]>([]);
+  const clustererRef = useRef<MarkerClusterer | null>(null);
+  const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
+  const [error, setError] = useState(false);
+
+  // Filter out pizzerias with no valid coordinates
+  const validPizzerias = useMemo(
+    () =>
+      pizzerias.filter(
+        (p) =>
+          p.location &&
+          !(p.location.lat === 0 && p.location.lng === 0)
+      ),
+    [pizzerias]
+  );
+
+  useEffect(() => {
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    if (!apiKey) {
+      setError(true);
+      return;
+    }
+
+    if (validPizzerias.length === 0) return;
+
+    const initMap = () => {
+      if (!containerRef.current) return;
+
+      // Clean up previous markers & clusterer
+      markersRef.current.forEach((m) => m.setMap(null));
+      markersRef.current = [];
+      if (clustererRef.current) {
+        clustererRef.current.clearMarkers();
+        clustererRef.current = null;
+      }
+
+      if (!mapRef.current) {
+        mapRef.current = new google.maps.Map(containerRef.current, {
+          center: { lat: 20, lng: 0 },
+          zoom: 3,
+          minZoom: 2,
+          maxZoom: 18,
+          mapTypeId: 'roadmap',
+          disableDefaultUI: true,
+          zoomControl: true,
+          gestureHandling: 'greedy',
+          restriction: {
+            latLngBounds: { north: 85, south: -85, west: -180, east: 180 },
+            strictBounds: true,
+          },
+          styles: [
+            { featureType: 'water', stylers: [{ color: '#b6e4f7' }] },
+            { featureType: 'landscape', stylers: [{ color: '#e8f5e9' }] },
+            { featureType: 'road', stylers: [{ visibility: 'off' }] },
+            { featureType: 'transit', stylers: [{ visibility: 'off' }] },
+            { featureType: 'poi', stylers: [{ visibility: 'off' }] },
+            {
+              featureType: 'administrative.country',
+              elementType: 'geometry.stroke',
+              stylers: [{ color: '#999' }],
+            },
+            {
+              featureType: 'administrative.province',
+              stylers: [{ visibility: 'off' }],
+            },
+          ],
+        });
+      }
+
+      const map = mapRef.current;
+
+      // Shared InfoWindow
+      if (!infoWindowRef.current) {
+        infoWindowRef.current = new google.maps.InfoWindow();
+      }
+      const infoWindow = infoWindowRef.current;
+
+      // Build markers
+      const markers: google.maps.Marker[] = [];
+
+      for (const pizzeria of validPizzerias) {
+        const position = {
+          lat: pizzeria.location.lat,
+          lng: pizzeria.location.lng,
+        };
+
+        const marker = new google.maps.Marker({
+          position,
+          title: pizzeria.name,
+          label: {
+            text: '\u{1F355}',
+            fontSize: '22px',
+          },
+          icon: {
+            path: google.maps.SymbolPath.CIRCLE,
+            scale: 0,
+          },
+        });
+
+        marker.addListener('click', () => {
+          // Build star rating display
+          let ratingHtml = '';
+          if (pizzeria.rating) {
+            const fullStars = Math.floor(pizzeria.rating);
+            const halfStar = pizzeria.rating - fullStars >= 0.5;
+            let stars = '';
+            for (let i = 0; i < fullStars; i++) stars += '\u2605';
+            if (halfStar) stars += '\u00BD';
+            const reviewText = pizzeria.reviewCount
+              ? ` (${pizzeria.reviewCount})`
+              : '';
+            ratingHtml = `<div style="color:#f59e0b;font-size:14px;margin:2px 0">${stars} <span style="color:#666;font-size:12px">${pizzeria.rating}${reviewText}</span></div>`;
+          }
+
+          // Truncate description
+          let descHtml = '';
+          if (pizzeria.description) {
+            const truncated =
+              pizzeria.description.length > 120
+                ? pizzeria.description.slice(0, 120) + '...'
+                : pizzeria.description;
+            descHtml = `<p style="color:#555;font-size:12px;margin:4px 0;line-height:1.4">${truncated}</p>`;
+          }
+
+          // Website link
+          let linkHtml = '';
+          if (pizzeria.url) {
+            linkHtml = `<a href="${pizzeria.url}" target="_blank" rel="noopener noreferrer" style="color:#E52828;font-size:12px;text-decoration:none;font-weight:500">Visit Website &rarr;</a>`;
+          }
+
+          const content = `
+            <div style="max-width:260px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:4px">
+              <h3 style="margin:0 0 4px;font-size:15px;font-weight:700;color:#1a1a1a">${pizzeria.name}</h3>
+              ${ratingHtml}
+              <p style="color:#888;font-size:12px;margin:2px 0">${pizzeria.address || ''}</p>
+              ${descHtml}
+              <div style="margin-top:6px;display:flex;align-items:center;gap:8px">
+                ${linkHtml}
+                <span style="background:#fef2f2;color:#E52828;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:500">${pizzeria.eventCity}</span>
+              </div>
+            </div>
+          `;
+
+          infoWindow.setContent(content);
+          infoWindow.open(map, marker);
+        });
+
+        markers.push(marker);
+      }
+
+      markersRef.current = markers;
+
+      // Create clusterer
+      clustererRef.current = new MarkerClusterer({ map, markers });
+    };
+
+    // Load Google Maps script if not already loaded
+    if (window.google?.maps) {
+      initMap();
+      return;
+    }
+
+    const existingScript = document.querySelector(
+      'script[src*="maps.googleapis.com/maps/api/js"]'
+    );
+
+    if (existingScript) {
+      const waitForMaps = () => {
+        if (window.google?.maps) {
+          initMap();
+        } else {
+          setTimeout(waitForMaps, 100);
+        }
+      };
+      waitForMaps();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=Function.prototype`;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => initMap();
+    script.onerror = () => setError(true);
+    document.head.appendChild(script);
+  }, [validPizzerias]);
+
+  if (error) {
+    return (
+      <div
+        style={{ height }}
+        className="flex items-center justify-center bg-gray-100 rounded-2xl"
+      >
+        <p className="text-gray-500">
+          Unable to load map. Please try again later.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="gpp-pizzerias-map"
+      style={{ height, width: '100%' }}
+    />
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3156,3 +3156,21 @@ export async function removeGraphicsAdmin(id: string): Promise<void> {
   await apiRequest(`/api/graphics-admin/${id}`, { method: 'DELETE' });
 }
 
+// GPP Pizzerias Map
+export interface GPPPizzeriaMapItem {
+  id: string;
+  name: string;
+  address: string;
+  url?: string;
+  rating?: number;
+  reviewCount?: number;
+  description?: string;
+  location: { lat: number; lng: number };
+  eventCity: string;
+  eventSlug: string;
+}
+
+export async function fetchGppPizzerias(): Promise<GPPPizzeriaMapItem[]> {
+  return apiRequest<GPPPizzeriaMapItem[]>('/api/gpp/pizzerias', { requireAuth: false });
+}
+

--- a/frontend/src/pages/GPPLandingPage.tsx
+++ b/frontend/src/pages/GPPLandingPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, lazy, Suspense } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { CheckCircle, Loader2, ArrowRight, ExternalLink } from 'lucide-react';
+import { CheckCircle, Loader2, ArrowRight, ExternalLink, MapPin } from 'lucide-react';
 import { CornerLinks } from '../components/CornerLinks';
 import { GPPClouds } from '../components/GPPClouds';
 import { LocationAutocomplete, CityData } from '../components/LocationAutocomplete';
@@ -539,7 +539,7 @@ export function GPPLandingPage() {
             </Suspense>
           </div>
 
-          <div className="text-center mt-6">
+          <div className="text-center mt-6 flex flex-wrap items-center justify-center gap-3">
             <a
               href="https://www.google.com/maps/d/u/0/viewer?mid=1ixyD2QbCZcz9IdK2gFKCNCz92hDDzEA"
               target="_blank"
@@ -550,6 +550,14 @@ export function GPPLandingPage() {
               Open Full Map
               <ExternalLink size={16} />
             </a>
+            <Link
+              to="/gpp/pizzerias"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-medium transition-all hover:-translate-y-0.5 border-2"
+              style={{ borderColor: C.red, color: C.red }}
+            >
+              View All Pizzerias
+              <MapPin size={16} />
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/GPPPizzeriasPage.tsx
+++ b/frontend/src/pages/GPPPizzeriasPage.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, lazy, Suspense } from 'react';
+import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import { fetchGppPizzerias, GPPPizzeriaMapItem } from '../lib/api';
+
+const GPPPizzeriasMap = lazy(() => import('../components/GPPPizzeriasMap'));
+
+export function GPPPizzeriasPage() {
+  const [pizzerias, setPizzerias] = useState<GPPPizzeriaMapItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPizzerias = () => {
+    setLoading(true);
+    setError(null);
+    fetchGppPizzerias()
+      .then((data) => {
+        setPizzerias(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch pizzerias:', err);
+        setError(err.message || 'Failed to load pizzerias');
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    loadPizzerias();
+  }, []);
+
+  // Count unique cities
+  const cityCount = new Set(pizzerias.map((p) => p.eventCity)).size;
+
+  return (
+    <>
+      <Helmet>
+        <title>GPP Pizzerias Map | RSV.Pizza</title>
+        <meta
+          name="description"
+          content="Explore all pizzerias participating in the Global Pizza Party worldwide."
+        />
+      </Helmet>
+
+      <div
+        className="min-h-screen flex flex-col"
+        style={{
+          background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)',
+        }}
+      >
+        {/* Header */}
+        <header className="flex items-center gap-4 px-4 py-3 sm:px-6" style={{ height: 64 }}>
+          <Link
+            to="/gpp"
+            className="flex items-center gap-1.5 text-sm font-medium text-white/80 hover:text-white transition-colors"
+          >
+            <ArrowLeft size={16} />
+            Back to GPP
+          </Link>
+          <h1 className="text-lg font-bold text-white tracking-tight">
+            GPP Pizzerias
+          </h1>
+        </header>
+
+        {/* Map area */}
+        <div className="flex-1 relative">
+          {loading && (
+            <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
+              <div className="flex flex-col items-center gap-3">
+                <Loader2 size={36} className="animate-spin text-[#E52828]" />
+                <span className="text-sm font-medium text-gray-700">
+                  Loading pizzerias...
+                </span>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
+              <div className="flex flex-col items-center gap-3 bg-white rounded-2xl p-8 shadow-lg">
+                <p className="text-red-600 font-medium">{error}</p>
+                <button
+                  onClick={loadPizzerias}
+                  className="px-5 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5"
+                  style={{ background: '#E52828' }}
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Floating stats badge */}
+          {!loading && !error && pizzerias.length > 0 && (
+            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10">
+              <div className="bg-white/90 backdrop-blur-sm rounded-full px-5 py-2 shadow-lg border border-white/50">
+                <span className="text-sm font-semibold text-gray-800">
+                  {pizzerias.length.toLocaleString()} pizzerias across{' '}
+                  {cityCount} {cityCount === 1 ? 'city' : 'cities'}
+                </span>
+              </div>
+            </div>
+          )}
+
+          <Suspense
+            fallback={
+              <div
+                className="flex items-center justify-center"
+                style={{ height: 'calc(100vh - 64px)' }}
+              >
+                <Loader2 size={36} className="animate-spin text-[#E52828]" />
+              </div>
+            }
+          >
+            {!loading && !error && (
+              <GPPPizzeriasMap
+                pizzerias={pizzerias}
+                height="calc(100vh - 64px)"
+              />
+            )}
+          </Suspense>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "name": "@rsvpizza/frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@googlemaps/markerclusterer": "^2.6.2",
         "@napi-rs/canvas": "^0.1.88",
         "@stripe/react-stripe-js": "^5.4.1",
         "@stripe/stripe-js": "^8.6.1",
@@ -1800,6 +1801,17 @@
       },
       "peerDependencies": {
         "viem": ">=2.0.0"
+      }
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.6.2.tgz",
+      "integrity": "sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/supercluster": "^7.1.3",
+        "fast-equals": "^5.2.2",
+        "supercluster": "^8.0.1"
       }
     },
     "node_modules/@hpke/chacha20poly1305": {
@@ -7187,6 +7199,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -7348,6 +7366,15 @@
         "@types/methods": "^1.1.4",
         "@types/node": "*",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/supertest": {
@@ -12608,6 +12635,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -14212,6 +14248,12 @@
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keccak": {
       "version": "3.0.4",
@@ -18733,6 +18775,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
     },
     "node_modules/superstruct": {
       "version": "1.0.4",


### PR DESCRIPTION
## Summary
- Add `GET /api/gpp/pizzerias` backend endpoint that flattens all selected pizzerias across GPP events into a single API response
- Create interactive world map page at `/gpp/pizzerias` with clustered pizza emoji markers, InfoWindows with pizzeria details (name, rating, address, description, website link, city badge), and a floating stats badge
- Add "View All Pizzerias" button on GPP landing page linking to the new map

## Test plan
- [ ] Visit `/gpp/pizzerias` and verify the map loads with pizza markers
- [ ] Click markers to see InfoWindow with pizzeria details
- [ ] Verify marker clustering works when zoomed out
- [ ] Verify the floating stats badge shows correct counts
- [ ] Click "View All Pizzerias" on `/gpp` landing page and verify navigation
- [ ] Verify loading and error states work correctly
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)