### PR TITLE
feat: RSVP funnel tracking

### DIFF
--- a/backend/prisma/migrations/20260510100000_add_rsvp_funnel_tracking/migration.sql
+++ b/backend/prisma/migrations/20260510100000_add_rsvp_funnel_tracking/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "rsvp_funnel_events" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "party_id" UUID NOT NULL,
+    "step" TEXT NOT NULL,
+    "visitor_hash" TEXT NOT NULL,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "rsvp_funnel_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rsvp_funnel_events_party_id_visitor_hash_step_key" ON "rsvp_funnel_events"("party_id", "visitor_hash", "step");
+
+-- AddForeignKey
+ALTER TABLE "rsvp_funnel_events" ADD CONSTRAINT "rsvp_funnel_events_party_id_fkey" FOREIGN KEY ("party_id") REFERENCES "parties"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -199,6 +199,7 @@ model Party {
   aiPhoneCalls     AIPhoneCall[]
   pageViews             PageView[]
   linkClicks            LinkClick[]
+  rsvpFunnelEvents      RsvpFunnelEvent[]
   sponsorChecklistItems SponsorChecklistItem[]
   partnerEventNotes     PartnerEventNote[]
   quizQuestions         QuizQuestion[]
@@ -1064,6 +1065,25 @@ model LinkClick {
   @@index([partyId, clickedAt])
   @@index([partyId, visitorHash])
   @@map("link_clicks")
+}
+
+// ============================================
+// RSVP Funnel Tracking
+// ============================================
+
+model RsvpFunnelEvent {
+  id          String   @id @default(uuid()) @db.Uuid
+  partyId     String   @map("party_id") @db.Uuid
+  step        String   // 'rsvp_opened' | 'rsvp_step1_complete'
+  visitorHash String   @map("visitor_hash")
+  ipAddress   String?  @map("ip_address")
+  userAgent   String?  @map("user_agent")
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  party Party @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  @@unique([partyId, visitorHash, step])
+  @@map("rsvp_funnel_events")
 }
 
 // ============================================

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,6 +27,7 @@ import checklistRoutes from './routes/checklist.routes.js';
 import reportRoutes from './routes/report.routes.js';
 import pageviewRoutes from './routes/pageview.routes.js';
 import linkclickRoutes from './routes/linkclick.routes.js';
+import funnelRoutes from './routes/funnel.routes.js';
 import v1Routes from './routes/v1/index.js';
 import { setupSwagger } from './swagger.js';
 import aiPhoneRoutes from './routes/ai-phone.routes.js';
@@ -130,6 +131,7 @@ app.use('/api/preferences', preferencesRoutes); // Public preferences (used duri
 app.use('/api/user', userRoutes);
 app.use('/api/events', pageviewRoutes); // Page view tracking (public, before eventRoutes)
 app.use('/api/events', linkclickRoutes); // Link click tracking (public, before eventRoutes)
+app.use('/api/events', funnelRoutes); // RSVP funnel tracking (public)
 app.use('/api/events', quizPublicRouter); // Public quiz endpoints (before eventRoutes)
 app.use('/api/events', onesheetRoutes); // One Sheet interest form (public, before eventRoutes)
 app.use('/api/events', eventRoutes);

--- a/backend/src/routes/funnel.routes.ts
+++ b/backend/src/routes/funnel.routes.ts
@@ -1,0 +1,90 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import crypto from 'crypto';
+
+const router = Router();
+
+// POST /api/events/:slug/funnel — Fire-and-forget RSVP funnel tracking (public, no auth)
+router.post('/:slug/funnel', async (req: Request, res: Response, _next: NextFunction) => {
+  // Always return 204 — never fail the request
+  try {
+    const { slug } = req.params;
+    const { step } = req.body || {};
+
+    // Validate step
+    const validSteps = ['rsvp_opened', 'rsvp_step1_complete'];
+    if (!step || !validSteps.includes(step)) {
+      res.status(204).end();
+      return;
+    }
+
+    // Find party by inviteCode or customUrl
+    let party = await prisma.party.findUnique({
+      where: { inviteCode: slug },
+      select: { id: true },
+    });
+    if (!party) {
+      party = await prisma.party.findUnique({
+        where: { customUrl: slug },
+        select: { id: true },
+      });
+    }
+    // Alias fallback: silently resolve old slugs
+    if (!party) {
+      const alias = await prisma.slugAlias.findUnique({
+        where: { oldSlug: slug },
+        select: { partyId: true },
+      });
+      if (alias) {
+        party = await prisma.party.findUnique({
+          where: { id: alias.partyId },
+          select: { id: true },
+        });
+      }
+    }
+
+    if (!party) {
+      res.status(204).end();
+      return;
+    }
+
+    // Extract IP and User-Agent from headers
+    const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim()
+      || req.socket.remoteAddress
+      || 'unknown';
+    const ua = (req.headers['user-agent'] as string) || 'unknown';
+
+    // Compute privacy-friendly visitor hash: SHA-256(IP + User-Agent)
+    const visitorHash = crypto
+      .createHash('sha256')
+      .update(`${ip}|${ua}`)
+      .digest('hex');
+
+    // Upsert — deduplicates automatically via unique constraint
+    await prisma.rsvpFunnelEvent.upsert({
+      where: {
+        partyId_visitorHash_step: {
+          partyId: party.id,
+          visitorHash,
+          step,
+        },
+      },
+      update: {}, // No-op on duplicate
+      create: {
+        partyId: party.id,
+        step,
+        visitorHash,
+        ipAddress: ip,
+        userAgent: ua.substring(0, 500),
+      },
+    });
+
+    res.status(204).end();
+  } catch (error) {
+    // Never fail — swallow all errors and return 204
+    console.error('RSVP funnel tracking error (non-fatal):', error);
+    res.status(204).end();
+  }
+});
+
+export default router;

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -1361,4 +1361,82 @@ router.patch('/admin/assign-region/:partyId', requireAuth, async (req: AuthReque
   }
 });
 
+// GET /api/underboss/funnel-stats — RSVP funnel stats per event
+router.get('/funnel-stats', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const underboss = req.underboss!;
+    const regionsParam = req.query.regions as string | undefined;
+    const regions = regionsParam ? regionsParam.split(',') : underboss.regions;
+
+    // Build region filter
+    const isAdminUser = underboss.regions.includes('__admin__');
+    const regionFilter = isAdminUser && (!regionsParam || regions.includes('__admin__'))
+      ? {}
+      : { region: { in: regions } };
+
+    // Get events with funnel data
+    const events = await prisma.party.findMany({
+      where: regionFilter,
+      select: {
+        id: true,
+        name: true,
+        city: true,
+        _count: {
+          select: {
+            pageViews: true,
+            guests: true,
+          },
+        },
+        guests: {
+          where: { status: { not: 'INVITED' } },
+          select: { id: true },
+        },
+        rsvpFunnelEvents: {
+          select: { step: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    let totalViews = 0;
+    let totalOpened = 0;
+    let totalStep1 = 0;
+    let totalSubmitted = 0;
+
+    const eventStats = events.map((e) => {
+      const views = e._count.pageViews;
+      const opened = e.rsvpFunnelEvents.filter((f) => f.step === 'rsvp_opened').length;
+      const step1Complete = e.rsvpFunnelEvents.filter((f) => f.step === 'rsvp_step1_complete').length;
+      const submitted = e.guests.length;
+
+      totalViews += views;
+      totalOpened += opened;
+      totalStep1 += step1Complete;
+      totalSubmitted += submitted;
+
+      return {
+        eventId: e.id,
+        eventName: e.name,
+        city: e.city || '',
+        views,
+        opened,
+        step1Complete,
+        submitted,
+      };
+    });
+
+    res.json({
+      events: eventStats,
+      totals: {
+        views: totalViews,
+        opened: totalOpened,
+        step1Complete: totalStep1,
+        submitted: totalSubmitted,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -4,7 +4,7 @@ import { Check, X, Wallet } from 'lucide-react';
 import { ExistingGuestData } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import { IconInput } from './IconInput';
-import { PublicEvent } from '../lib/api';
+import { PublicEvent, trackRsvpFunnel } from '../lib/api';
 import { useRSVPForm, publicEventToRSVPData, RSVPSubmitResult } from '../hooks/useRSVPForm';
 import { useMintNFT, MintStatus, MintResult } from '../hooks/useMintNFT';
 import { useAccount } from 'wagmi';
@@ -111,6 +111,14 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
       document.body.classList.remove('modal-open');
     };
   }, [isOpen, existingGuest]);
+
+  // Track RSVP funnel: opened
+  useEffect(() => {
+    if (isOpen) {
+      const slug = event.customUrl || event.inviteCode;
+      if (slug) trackRsvpFunnel(slug, 'rsvp_opened');
+    }
+  }, [isOpen, event.customUrl, event.inviteCode]);
 
   // Auto-fill wallet address when user connects via ConnectKit
   useEffect(() => {

--- a/frontend/src/components/underboss/FunnelTab.tsx
+++ b/frontend/src/components/underboss/FunnelTab.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { fetchFunnelStats } from '../../lib/api';
+import type { FunnelStats, FunnelEventStats } from '../../lib/api';
+
+interface FunnelTabProps {
+  regions: string[];
+}
+
+function FunnelBar({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+  return (
+    <div className="flex items-center gap-3 mb-2">
+      <span className="text-sm text-white/70 w-24 text-right">{label}</span>
+      <div className="flex-1 bg-white/10 rounded-full h-6 relative overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+        <span className="absolute inset-0 flex items-center justify-center text-xs font-medium text-white">
+          {value.toLocaleString()} ({pct}%)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function FunnelTab({ regions }: FunnelTabProps) {
+  const [data, setData] = useState<FunnelStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchFunnelStats(regions).then((result) => {
+      setData(result);
+      setLoading(false);
+    });
+  }, [regions]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-white/60" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-white/60 text-center py-8">Failed to load funnel data.</p>;
+  }
+
+  const { totals, events } = data;
+  const maxVal = Math.max(totals.views, 1);
+
+  return (
+    <div className="space-y-6">
+      {/* Aggregate funnel */}
+      <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Overall RSVP Funnel</h3>
+        <FunnelBar label="Views" value={totals.views} max={maxVal} color="bg-blue-500" />
+        <FunnelBar label="Opened" value={totals.opened} max={maxVal} color="bg-cyan-500" />
+        <FunnelBar label="Step 1" value={totals.step1Complete} max={maxVal} color="bg-amber-500" />
+        <FunnelBar label="Submitted" value={totals.submitted} max={maxVal} color="bg-green-500" />
+        <div className="mt-3 text-xs text-white/50 flex gap-4">
+          <span>Open rate: {totals.views > 0 ? Math.round((totals.opened / totals.views) * 100) : 0}%</span>
+          <span>Completion: {totals.opened > 0 ? Math.round((totals.submitted / totals.opened) * 100) : 0}%</span>
+        </div>
+      </div>
+
+      {/* Per-event table */}
+      <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6 overflow-x-auto">
+        <h3 className="text-lg font-semibold text-white mb-4">Per-Event Breakdown</h3>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-white/60 border-b border-white/10">
+              <th className="text-left py-2 px-2">Event</th>
+              <th className="text-left py-2 px-2">City</th>
+              <th className="text-right py-2 px-2">Views</th>
+              <th className="text-right py-2 px-2">Opened</th>
+              <th className="text-right py-2 px-2">Step 1</th>
+              <th className="text-right py-2 px-2">Submitted</th>
+              <th className="text-right py-2 px-2">Conv %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((ev: FunnelEventStats) => (
+              <tr key={ev.eventId} className="border-b border-white/5 hover:bg-white/5">
+                <td className="py-2 px-2 text-white/90 max-w-[200px] truncate">{ev.eventName}</td>
+                <td className="py-2 px-2 text-white/70">{ev.city}</td>
+                <td className="py-2 px-2 text-right text-white/80">{ev.views}</td>
+                <td className="py-2 px-2 text-right text-white/80">{ev.opened}</td>
+                <td className="py-2 px-2 text-right text-white/80">{ev.step1Complete}</td>
+                <td className="py-2 px-2 text-right text-white/80">{ev.submitted}</td>
+                <td className="py-2 px-2 text-right text-white/80">
+                  {ev.views > 0 ? Math.round((ev.submitted / ev.views) * 100) : 0}%
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {events.length === 0 && (
+          <p className="text-center text-white/50 py-4">No funnel data yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -5,3 +5,4 @@ export { ProgressIndicator } from './ProgressIndicator';
 export { TelegramBroadcast } from './TelegramBroadcast';
 export { CitiesTable } from './CitiesTable';
 export { PartnerManager } from './PartnerManager';
+export { FunnelTab } from './FunnelTab';

--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -3,7 +3,7 @@ import { addGuestToParty, getUserPreferences, saveUserPreferences, ExistingGuest
 import { getExcludedToppingIds } from '../constants/options';
 import { searchPizzerias, geocodeAddress } from '../lib/ordering';
 import { Pizzeria } from '../types';
-import { PublicEvent } from '../lib/api';
+import { PublicEvent, trackRsvpFunnel } from '../lib/api';
 import { DbParty } from '../lib/supabase';
 import { uuid } from '../lib/utils';
 
@@ -369,8 +369,11 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
       return;
     }
     setError(null);
+    // Track funnel step
+    const slug = eventData.customUrl || eventData.inviteCode;
+    if (slug) trackRsvpFunnel(slug, 'rsvp_step1_complete');
     setStep(2);
-  }, [name]);
+  }, [name, eventData.customUrl, eventData.inviteCode]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1618,6 +1618,17 @@ export function trackLinkClick(slug: string, url: string, linkType: string, link
   }).catch(() => {});
 }
 
+// Track RSVP funnel step (public, fire-and-forget)
+export function trackRsvpFunnel(slug: string, step: 'rsvp_opened' | 'rsvp_step1_complete'): void {
+  const apiUrl = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
+  fetch(`${apiUrl}/api/events/${slug}/funnel`, {
+    method: 'POST',
+    keepalive: true,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ step }),
+  }).catch(() => {});
+}
+
 // Get link click stats (host only)
 export async function getLinkClickStats(partyId: string): Promise<LinkClickStats | null> {
   try {
@@ -3174,5 +3185,41 @@ export interface GPPPizzeriaMapItem {
 
 export async function fetchGppPizzerias(): Promise<GPPPizzeriaMapItem[]> {
   return apiRequest<GPPPizzeriaMapItem[]>('/api/gpp/pizzerias', { requireAuth: false });
+}
+
+// RSVP Funnel Stats (Underboss dashboard)
+
+export interface FunnelEventStats {
+  eventId: string;
+  eventName: string;
+  city: string;
+  views: number;
+  opened: number;
+  step1Complete: number;
+  submitted: number;
+}
+
+export interface FunnelStats {
+  events: FunnelEventStats[];
+  totals: {
+    views: number;
+    opened: number;
+    step1Complete: number;
+    submitted: number;
+  };
+}
+
+// Fetch RSVP funnel stats for underboss dashboard
+export async function fetchFunnelStats(regions?: string[]): Promise<FunnelStats | null> {
+  try {
+    const params = regions && regions.length > 0 ? `?regions=${regions.join(',')}` : '';
+    return await apiRequest<FunnelStats>(`/api/underboss/funnel-stats${params}`, {
+      method: 'GET',
+      requireAuth: true,
+    });
+  } catch (error) {
+    console.error('Error fetching funnel stats:', error);
+    return null;
+  }
 }
 

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -4,7 +4,7 @@ import { AlertCircle, Loader2, Lock, ChevronRight, Heart } from 'lucide-react';
 import { getPartyByInviteCodeOrCustomUrl, verifyPartyPassword, isUserGuestAtParty, DbParty } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import { DonationForm } from '../components/DonationForm';
-import { PublicEvent, getDonationStats } from '../lib/api';
+import { PublicEvent, getDonationStats, trackRsvpFunnel } from '../lib/api';
 import { DonationPublicStats } from '../types';
 import { useRSVPForm, dbPartyToRSVPData } from '../hooks/useRSVPForm';
 // GPP theme applied conditionally
@@ -142,6 +142,13 @@ export function RSVPPage() {
     }
     loadParty();
   }, [inviteCode, user?.email]);
+
+  // Track RSVP funnel: opened
+  useEffect(() => {
+    if (party && inviteCode) {
+      trackRsvpFunnel(inviteCode, 'rsvp_opened');
+    }
+  }, [party, inviteCode]);
 
   // Create the eventData only when party is loaded
   const eventData = party ? dbPartyToRSVPData(party) : null;

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -5,7 +5,7 @@ import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, C
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager } from '../components/underboss';
+import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, FunnelTab } from '../components/underboss';
 import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
@@ -67,7 +67,7 @@ export function UnderbossDashboard() {
   const [availableRegions, setAvailableRegions] = useState<string[]>([]);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners'>('events');
+  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'funnel'>('events');
 
   // Telegram broadcast modal state
   const [showBroadcast, setShowBroadcast] = useState(false);
@@ -432,6 +432,19 @@ export function UnderbossDashboard() {
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}
             </button>
+            <button
+              onClick={() => setActiveTab('funnel')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'funnel'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              Funnel
+              {activeTab === 'funnel' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
           </div>
 
           {activeTab === 'events' && (
@@ -444,6 +457,10 @@ export function UnderbossDashboard() {
 
           {activeTab === 'partners' && (
             <PartnerManager isAdmin={isAdmin} onSyncComplete={loadDashboard} onFlyerRegenNeeded={handleFlyerRegenForTag} />
+          )}
+
+          {activeTab === 'funnel' && (
+            <FunnelTab regions={selectedRegions} />
           )}
         </section>
         </div>


### PR DESCRIPTION
## Summary
- Adds `RsvpFunnelEvent` model tracking `rsvp_opened` and `rsvp_step1_complete` steps
- New `POST /api/events/:slug/funnel` endpoint (public, fire-and-forget, auto-dedup)
- Frontend tracks events in RSVPModal, RSVPPage, and useRSVPForm hook
- New Funnel tab on Underboss dashboard with aggregate funnel visualization and per-event table

## Test plan
- [ ] Open an event page → verify no funnel row yet
- [ ] Click RSVP → verify `rsvp_opened` row appears in DB
- [ ] Fill Step 1, click Next → verify `rsvp_step1_complete` row
- [ ] Repeat → verify no duplicates (dedup working)
- [ ] Underboss dashboard → Funnel tab shows counts
- [ ] RSVP flow unaffected (no delay, no errors if tracking fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)