### PR TITLE
feat: graphics dashboard flyer edit & regenerate

### DIFF
--- a/backend/src/helpers/partyAccess.ts
+++ b/backend/src/helpers/partyAccess.ts
@@ -1,5 +1,5 @@
 import { prisma } from '../config/database.js';
-import { isSuperAdmin } from '../middleware/auth.js';
+import { isSuperAdmin, isAdmin, isUnderboss } from '../middleware/auth.js';
 
 /**
  * Emails that automatically get editor access to ALL GPP events.
@@ -75,6 +75,16 @@ export async function canUserEditParty(
     }
   }
 
+  // For GPP events, admins, underbosses, and graphics admins can edit
+  if (userEmail && (party as any).eventType === 'gpp') {
+    if (await isAdmin(userEmail)) return true;
+    if (await isUnderboss(userEmail)) return true;
+    const gfxAdmin = await prisma.graphicsAdmin.findUnique({
+      where: { email: userEmail.toLowerCase() },
+    });
+    if (gfxAdmin) return true;
+  }
+
   // Check if user is a co-host with edit permissions
   if (userEmail) {
     const coHosts = party.coHosts as Array<{ email?: string; canEdit?: boolean }> | null;
@@ -134,6 +144,16 @@ export async function canUserAccessTab(
     if (GPP_GLOBAL_EDITORS.some(e => e.toLowerCase() === userEmail.toLowerCase())) {
       return true;
     }
+  }
+
+  // For GPP events, admins, underbosses, and graphics admins can access all tabs
+  if (userEmail && party.eventType === 'gpp') {
+    if (await isAdmin(userEmail)) return true;
+    if (await isUnderboss(userEmail)) return true;
+    const gfxAdmin = await prisma.graphicsAdmin.findUnique({
+      where: { email: userEmail.toLowerCase() },
+    });
+    if (gfxAdmin) return true;
   }
 
   // Check co-host tab permissions

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -193,6 +193,7 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
   return {
     id: party.id,
     name: party.name,
+    inviteCode: party.inviteCode,
     customUrl: party.customUrl,
     date: party.date,
     address: party.address,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ function SponsorIntakeRedirect() {
 }
 
 const GraphicsDashboard = React.lazy(() => import('./pages/GraphicsDashboard').then(m => ({ default: m.GraphicsDashboard })));
+const GraphicsFlyerEdit = React.lazy(() => import('./pages/GraphicsFlyerEdit').then(m => ({ default: m.GraphicsFlyerEdit })));
 
 function App() {
   return (
@@ -66,6 +67,7 @@ function App() {
             <Route path="/partner-intake/:token" element={<PartnerIntakePage />} />
             <Route path="/sponsor-intake/:token" element={<SponsorIntakeRedirect />} />
             <Route path="/graphics" element={<Suspense fallback={null}><GraphicsDashboard /></Suspense>} />
+            <Route path="/graphics/:slug/edit" element={<Suspense fallback={null}><GraphicsFlyerEdit /></Suspense>} />
             <Route path="/post" element={<PostComposerPage />} />
             <Route path="/onesheet/:slug" element={<OneSheetPage />} />
             <Route path="/raleigh" element={<Navigate to="/durham" replace />} />

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -1605,6 +1605,7 @@ export function FlyerGenerator() {
           onSubmit={handleEditSponsor}
           onClose={() => setEditingSponsor(null)}
           isLoading={isSubmitting}
+          logoOnly
         />
       )}
     </div>

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -196,6 +196,7 @@ interface PartnerFormProps {
   onSubmit: (data: PartnerFormData) => Promise<void>;
   onClose?: () => void;
   isLoading?: boolean;
+  logoOnly?: boolean;
   // CRM mode
   sponsor?: Sponsor | null;
   partyId?: string;
@@ -219,6 +220,7 @@ export function PartnerForm({
   onSubmit,
   onClose,
   isLoading,
+  logoOnly,
   sponsor,
   partyId,
   onSponsorUpdate,
@@ -375,7 +377,7 @@ export function PartnerForm({
       )}
 
       {/* Account — Partner mode only */}
-      {isPartner && (
+      {!logoOnly && isPartner && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <Mail size={16} />
@@ -410,7 +412,7 @@ export function PartnerForm({
       )}
 
       {/* Partner / Company Info — All modes */}
-      <div className="space-y-3">
+      {!logoOnly && <div className="space-y-3">
         <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
           <Building2 size={16} />
           {isIntake ? 'Company Info' : 'Partner Info'}
@@ -459,10 +461,10 @@ export function PartnerForm({
             placeholder="1-2 sentence brand description (shown on event page)"
           />
         )}
-      </div>
+      </div>}
 
       {/* Also add as co-host — CRM mode, new partners only */}
-      {isCrm && !isEditing && onAddAsCoHost && (
+      {!logoOnly && isCrm && !isEditing && onAddAsCoHost && (
         <Checkbox
           checked={addAsCoHost}
           onChange={() => setAddAsCoHost(!addAsCoHost)}
@@ -472,7 +474,7 @@ export function PartnerForm({
       )}
 
       {/* Co-Host Profile (avatar) — Partner + CRM (when adding as co-host) */}
-      {(isPartner || (isCrm && addAsCoHost)) && (
+      {!logoOnly && (isPartner || (isCrm && addAsCoHost)) && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <User size={16} />
@@ -500,7 +502,7 @@ export function PartnerForm({
       )}
 
       {/* Category — Partner mode */}
-      {isPartner && (
+      {!logoOnly && isPartner && (
         <div className="relative">
           <Building2 size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />
           <select
@@ -520,7 +522,7 @@ export function PartnerForm({
       )}
 
       {/* Contact Info — CRM + Intake */}
-      {(isCrm || isIntake) && (() => {
+      {!logoOnly && (isCrm || isIntake) && (() => {
         // Disable contact fields for underboss-added sponsors when backend has stripped the data
         const contactFieldsDisabled = !!(isCrm && sponsor?.addedByUnderboss && !sponsor?.contactEmail);
         return (
@@ -589,7 +591,7 @@ export function PartnerForm({
       })()}
 
       {/* Pipeline — CRM mode only */}
-      {isCrm && (
+      {!logoOnly && isCrm && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <Calendar size={16} />
@@ -640,7 +642,7 @@ export function PartnerForm({
       )}
 
       {/* Fundraising — CRM mode only */}
-      {isCrm && (
+      {!logoOnly && isCrm && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <DollarSign size={16} />
@@ -684,7 +686,7 @@ export function PartnerForm({
       )}
 
       {/* Sponsorship Details — Intake mode only (CRM has it under Fundraising) */}
-      {isIntake && (
+      {!logoOnly && isIntake && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <FileText size={16} />
@@ -719,7 +721,7 @@ export function PartnerForm({
       )}
 
       {/* Sponsor Message (from intake form — CRM read-only) */}
-      {isCrm && sponsor?.sponsorMessage && (
+      {!logoOnly && isCrm && sponsor?.sponsorMessage && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <FileText size={16} />
@@ -783,7 +785,7 @@ export function PartnerForm({
       </div>
 
       {/* Message to Host — Intake mode only (writable) */}
-      {isIntake && (
+      {!logoOnly && isIntake && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <MessageSquare size={16} />
@@ -801,7 +803,7 @@ export function PartnerForm({
       )}
 
       {/* Automation — Partner mode only */}
-      {isPartner && (
+      {!logoOnly && isPartner && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <Settings size={16} />
@@ -825,7 +827,7 @@ export function PartnerForm({
       )}
 
       {/* Partner Intake Form — CRM mode, editing only */}
-      {isCrm && sponsor && partyId && onSponsorUpdate && (
+      {!logoOnly && isCrm && sponsor && partyId && onSponsorUpdate && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <FileText size={16} />
@@ -849,7 +851,7 @@ export function PartnerForm({
       )}
 
       {/* Notes — CRM + Partner modes (not intake) */}
-      {(isCrm || isPartner) && (
+      {!logoOnly && (isCrm || isPartner) && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <FileText size={16} />
@@ -867,7 +869,7 @@ export function PartnerForm({
       )}
 
       {/* Sync message — Partner mode only */}
-      {isPartner && syncMessage && (
+      {!logoOnly && isPartner && syncMessage && (
         <p className="text-sm text-green-400 flex items-center gap-1">
           <Check size={14} /> {syncMessage}
         </p>

--- a/frontend/src/pages/GraphicsDashboard.tsx
+++ b/frontend/src/pages/GraphicsDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { useNavigate } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
@@ -8,7 +9,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { fetchUnderbossMe, fetchUnderbossDashboard } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
 import {
-  Loader2, Shield, Image, ExternalLink, Search, AlertTriangle,
+  Loader2, Shield, Image, Pencil, Search, AlertTriangle, RefreshCw,
 } from 'lucide-react';
 import type { UnderbossEvent } from '../types';
 import { GPP_REGIONS } from '../types';
@@ -18,6 +19,7 @@ import { uploadEventImage, updateParty } from '../lib/supabase';
 
 export function GraphicsDashboard() {
   const { user, loading: authLoading } = useAuth();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [meData, setMeData] = useState<UnderbossMeResponse | null>(null);
@@ -30,6 +32,9 @@ export function GraphicsDashboard() {
   // Mass generation state
   const [massGenerating, setMassGenerating] = useState(false);
   const [massProgress, setMassProgress] = useState({ current: 0, total: 0 });
+
+  // Single event regeneration state
+  const [regeneratingId, setRegeneratingId] = useState<string | null>(null);
 
   const loadDashboard = useCallback(async () => {
     try {
@@ -188,6 +193,95 @@ export function GraphicsDashboard() {
     setMassGenerating(false);
   };
 
+  const handleRegenerate = async (event: UnderbossEvent) => {
+    setRegeneratingId(event.id);
+
+    try {
+      // Load fonts
+      try {
+        const display = new FontFace('Hub 191 Display', 'url(/fonts/Hub-191-Display.otf)');
+        const regular = new FontFace('Hub 191', 'url(/fonts/Hub-191-Regular.otf)');
+        const [disp, reg] = await Promise.all([display.load(), regular.load()]);
+        document.fonts.add(disp);
+        document.fonts.add(reg);
+      } catch {
+        // Continue with fallback fonts
+      }
+
+      const city = event.name.replace(/^Global Pizza Party\s*/i, '').trim() || event.name;
+      const venueName = event.venueName || 'LOCATION TBA';
+      const streetAddress = event.address ? event.address.split(',')[0].trim() : '';
+
+      let dateDisplay = '';
+      let timeDisplay = '';
+      let is12h = false;
+      if (event.date) {
+        const tz = event.timezone || 'UTC';
+        is12h = uses12Hour(tz);
+        const start = getDateTimeInTimezone(event.date, tz);
+        const startFormatted = formatFlyerTime(start.timeStr, is12h);
+        timeDisplay = startFormatted;
+        if (event.duration) {
+          const endDate = new Date(new Date(event.date).getTime() + event.duration * 3600000);
+          const end = getDateTimeInTimezone(endDate, tz);
+          const endFormatted = formatFlyerTime(end.timeStr, is12h);
+          timeDisplay = `${startFormatted} - ${endFormatted}`;
+        }
+        const eventDate = new Date(event.date);
+        const monthFormatter = new Intl.DateTimeFormat('en-US', { timeZone: tz, month: 'short' });
+        const dayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: tz, day: 'numeric' });
+        const monthStr = monthFormatter.format(eventDate).toUpperCase();
+        const dayStr = dayFormatter.format(eventDate);
+        dateDisplay = `${monthStr} ${dayStr}`;
+      }
+
+      const rawCfg = event.flyerConfig as FlyerConfig | null | undefined;
+      const layoutConfig: FlyerConfig | undefined = rawCfg
+        ? {
+            positions: rawCfg.positions,
+            poppedLogos: rawCfg.poppedLogos,
+            logoSizes: rawCfg.logoSizes,
+            sponsorBoxSize: rawCfg.sponsorBoxSize,
+          }
+        : undefined;
+
+      const canvas = await renderFlyer({
+        city,
+        venueName,
+        streetAddress,
+        dateDisplay,
+        timeDisplay,
+        is12h,
+        sponsors: [],
+        config: layoutConfig,
+      });
+
+      const blob = await new Promise<Blob | null>(resolve =>
+        canvas.toBlob(b => resolve(b), 'image/png')
+      );
+      if (!blob) { setRegeneratingId(null); return; }
+
+      const file = new File([blob], `gpp-flyer-${event.customUrl || event.id}.png`, { type: 'image/png' });
+      const uploadedUrl = await uploadEventImage(file);
+      if (!uploadedUrl) { setRegeneratingId(null); return; }
+
+      await updateParty(event.id, {
+        event_image_url: uploadedUrl,
+        flyer_generated_at: new Date().toISOString(),
+      });
+
+      setEvents(prev => prev.map(e =>
+        e.id === event.id
+          ? { ...e, eventImageUrl: uploadedUrl, flyerGeneratedAt: new Date().toISOString(), flyerStale: false }
+          : e
+      ));
+    } catch (err) {
+      console.error(`Failed to regenerate flyer for ${event.name}:`, err);
+    } finally {
+      setRegeneratingId(null);
+    }
+  };
+
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-[#0a0a0a]">
@@ -322,7 +416,8 @@ export function GraphicsDashboard() {
             {filtered.map(event => (
               <div
                 key={event.id}
-                className="group bg-white/[0.03] border border-white/[0.06] rounded-xl overflow-hidden hover:border-white/15 transition-colors"
+                className="group bg-white/[0.03] border border-white/[0.06] rounded-xl overflow-hidden hover:border-white/15 transition-colors cursor-pointer"
+                onClick={() => navigate(`/graphics/${event.customUrl || event.inviteCode}/edit`)}
               >
                 {/* Flyer image */}
                 <div className="aspect-square relative overflow-hidden bg-black/40">
@@ -344,17 +439,20 @@ export function GraphicsDashboard() {
                       New partners
                     </div>
                   )}
+                  {/* Regenerate button */}
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleRegenerate(event); }}
+                    disabled={regeneratingId === event.id}
+                    className="absolute top-2 left-2 p-1.5 bg-black/60 rounded-full text-white/70 hover:text-white hover:bg-black/80 transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-100"
+                    title="Regenerate flyer"
+                  >
+                    <RefreshCw size={14} className={regeneratingId === event.id ? 'animate-spin' : ''} />
+                  </button>
                   {/* Hover overlay */}
-                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center opacity-0 group-hover:opacity-100">
-                    <a
-                      href={`/${event.customUrl || event.id}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="p-2 bg-white/20 rounded-full hover:bg-white/30 transition-colors"
-                      title="View event"
-                    >
-                      <ExternalLink size={16} className="text-white" />
-                    </a>
+                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center opacity-0 group-hover:opacity-100 pointer-events-none">
+                    <div className="p-2 bg-white/20 rounded-full">
+                      <Pencil size={16} className="text-white" />
+                    </div>
                   </div>
                 </div>
 

--- a/frontend/src/pages/GraphicsFlyerEdit.tsx
+++ b/frontend/src/pages/GraphicsFlyerEdit.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import { PizzaProvider, usePizza } from '../contexts/PizzaContext';
+import { FlyerTab } from '../components/flyer/FlyerTab';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+function FlyerEditInner() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const { party, partyLoading, loadParty } = usePizza();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    loadParty(slug).then(success => {
+      if (!success) setError('Event not found');
+    });
+  }, [slug, loadParty]);
+
+  if (partyLoading) {
+    return (
+      <div className="flex items-center justify-center py-32">
+        <Loader2 size={32} className="animate-spin text-white/40" />
+      </div>
+    );
+  }
+
+  if (error || !party) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32">
+        <p className="text-white/50">{error || 'Event not found'}</p>
+        <button
+          onClick={() => navigate('/graphics')}
+          className="mt-4 px-4 py-2 bg-white/10 text-white rounded-lg text-sm hover:bg-white/20 transition-colors"
+        >
+          Back to Graphics
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <button
+          onClick={() => navigate('/graphics')}
+          className="flex items-center gap-2 text-white/50 hover:text-white transition-colors text-sm"
+        >
+          <ArrowLeft size={16} />
+          Back to Graphics Dashboard
+        </button>
+      </div>
+      <FlyerTab />
+    </div>
+  );
+}
+
+export function GraphicsFlyerEdit() {
+  return (
+    <div className="min-h-screen bg-[#0a0a0a]">
+      <Helmet>
+        <title>Edit Flyer | RSV.Pizza</title>
+      </Helmet>
+      <Header />
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+        <PizzaProvider>
+          <FlyerEditInner />
+        </PizzaProvider>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1007,6 +1007,7 @@ export interface UnderbossEventProgress {
 export interface UnderbossEvent {
   id: string;
   name: string;
+  inviteCode: string;
   customUrl: string | null;
   date: string | null;
   address: string | null;


### PR DESCRIPTION
## Summary
- Add per-event flyer regeneration button (RefreshCw icon) on each card in the Graphics Dashboard
- Click any flyer card to navigate to a new `/graphics/:slug/edit` page with the full FlyerGenerator for that event
- Extend `canUserEditParty` and `canUserAccessTab` to grant admins, underbosses, and graphics admins edit access to GPP events
- Add `inviteCode` to the underboss dashboard API response so flyer edit routing works even without a customUrl
- Add `logoOnly` prop to `PartnerForm` — when set, the form only shows the logo upload field (used in FlyerGenerator for quick logo changes)

## Test plan
- [ ] Navigate to `/graphics` as a graphics admin and verify cards show a regenerate button on hover (top-left corner)
- [ ] Click the regenerate button on a card; verify spinner appears and flyer updates after generation
- [ ] Click a flyer card; verify navigation to `/graphics/:slug/edit` with the full flyer editor loaded
- [ ] In the flyer editor, edit a sponsor logo (verify only the logo section is shown in the edit modal)
- [ ] Verify back arrow navigates back to `/graphics`
- [ ] Confirm that admins, underbosses, and graphics admins can save changes on GPP events they don't own

🤖 Generated with [Claude Code](https://claude.com/claude-code)