### PR TITLE
Partner flyer: editable supported-by tagline

### DIFF
--- a/frontend/src/components/flyer/renderFlyer.ts
+++ b/frontend/src/components/flyer/renderFlyer.ts
@@ -288,10 +288,10 @@ export async function renderPartnerFlyer(
   // Draw tagline text (e.g. "supported by") in venue style
   const tagText = tagline ?? 'supported by';
   if (tagText) {
-    const tagFontSize = fitText(tagText, 'Hub 191', 46, 600);
+    const tagFontSize = fitText(tagText, 'Hub 191', 58, 600);
     ctx.fillStyle = VENUE_COLOR;
     ctx.font = `${tagFontSize}px "Hub 191"`;
-    ctx.fillText(tagText.toUpperCase(), DEFAULT_POSITIONS.city.x, 640);
+    ctx.fillText(tagText.toUpperCase(), DEFAULT_POSITIONS.city.x, 660);
   }
 
   // Draw partner logo
@@ -307,7 +307,7 @@ export async function renderPartnerFlyer(
     ctx.drawImage(logoImg, logoPos.x - w / 2, logoPos.y - h / 2, w, h);
   } else {
     // Default: large, centered in box
-    const boxX = 50, boxY = 660, boxW = 980, boxH = 380;
+    const boxX = 50, boxY = 730, boxW = 980, boxH = 310;
     const scale = Math.min(boxW / logoImg.width, boxH / logoImg.height);
     const w = logoImg.width * scale;
     const h = logoImg.height * scale;

--- a/frontend/src/components/flyer/renderFlyer.ts
+++ b/frontend/src/components/flyer/renderFlyer.ts
@@ -267,6 +267,7 @@ export async function renderPartnerFlyer(
   logoUrl: string,
   logoPos?: { x: number; y: number },
   logoSize?: number,
+  tagline?: string,
 ): Promise<HTMLCanvasElement> {
   const canvas = document.createElement('canvas');
   canvas.width = 1080;
@@ -283,6 +284,15 @@ export async function renderPartnerFlyer(
   ctx.fillStyle = CITY_COLOR;
   ctx.font = `${cityFontSize}px "Hub 191 Display"`;
   ctx.fillText(city.toUpperCase(), DEFAULT_POSITIONS.city.x, DEFAULT_POSITIONS.city.y);
+
+  // Draw tagline text (e.g. "supported by") in venue style
+  const tagText = tagline ?? 'supported by';
+  if (tagText) {
+    const tagFontSize = fitText(tagText, 'Hub 191', 46, 600);
+    ctx.fillStyle = VENUE_COLOR;
+    ctx.font = `${tagFontSize}px "Hub 191"`;
+    ctx.fillText(tagText.toUpperCase(), DEFAULT_POSITIONS.city.x, 640);
+  }
 
   // Draw partner logo
   const logoImg = await loadImg(logoUrl);

--- a/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
+++ b/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
@@ -116,7 +116,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
     } else {
       // First drag -- logo is centered in default box, compute center
       const cx = 50 + 980 / 2; // 540
-      const cy = 660 + 380 / 2; // 850
+      const cy = 730 + 310 / 2; // 885
       dragOffsetRef.current = { x: pos.x - cx, y: pos.y - cy };
       setLogoPos({ x: cx, y: cy });
     }
@@ -148,7 +148,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
     if (logoPos) {
       dragOffsetRef.current = { x: pos.x - logoPos.x, y: pos.y - logoPos.y };
     } else {
-      const cx = 540, cy = 850;
+      const cx = 540, cy = 885;
       dragOffsetRef.current = { x: pos.x - cx, y: pos.y - cy };
       setLogoPos({ x: cx, y: cy });
     }
@@ -182,7 +182,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
 
     // If logo hasn't been positioned yet, place it at center of default box
     if (!logoPos) {
-      setLogoPos({ x: 540, y: 850 });
+      setLogoPos({ x: 540, y: 885 });
     }
 
     const handleMove = (moveEvent: MouseEvent) => {
@@ -206,7 +206,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
     const sc = rect ? rect.width / 1080 : 1;
 
     if (!logoPos) {
-      setLogoPos({ x: 540, y: 850 });
+      setLogoPos({ x: 540, y: 885 });
     }
 
     const handleMove = (moveEvent: TouchEvent) => {
@@ -285,12 +285,12 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
             onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); setEditingField('tagline'); }}
             style={{
               position: 'absolute',
-              top: `${(640 / 1080) * 100}%`,
+              top: `${(660 / 1080) * 100}%`,
               left: `${(50 / 1080) * 100}%`,
               width: `${(600 / 1080) * 100}%`,
-              height: `${(60 / 1080) * 100}%`,
+              height: `${(70 / 1080) * 100}%`,
               color: '#0497C1',
-              fontSize: 46 * previewScale,
+              fontSize: 58 * previewScale,
               fontFamily: '"Hub 191", "Comic Sans MS", cursive',
               textTransform: 'uppercase',
               lineHeight: 1.2,
@@ -323,13 +323,13 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
               />
             ) : (
               <span
-                style={{ display: 'inline-flex', alignItems: 'center', gap: 4, position: 'relative', paddingRight: 24, cursor: 'pointer' }}
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 2, cursor: 'pointer' }}
                 onClick={(e) => { e.stopPropagation(); setEditingField('tagline'); }}
               >
                 {(tagline || 'supported by').toUpperCase()}
                 <Pencil
-                  size={16}
-                  style={{ cursor: 'pointer', opacity: 0.6, flexShrink: 0, position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)' }}
+                  size={12 * previewScale > 8 ? 12 * previewScale : 8}
+                  style={{ cursor: 'pointer', opacity: 0.6, flexShrink: 0, marginTop: -2 }}
                   onClick={(e) => { e.stopPropagation(); setEditingField('tagline'); }}
                 />
               </span>
@@ -366,9 +366,9 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
               style={{
                 position: 'absolute',
                 left: `${(50 / 1080) * 100}%`,
-                top: `${(660 / 1080) * 100}%`,
+                top: `${(730 / 1080) * 100}%`,
                 width: `${(980 / 1080) * 100}%`,
-                height: `${(380 / 1080) * 100}%`,
+                height: `${(310 / 1080) * 100}%`,
                 cursor: 'grab',
               }}
               onMouseDown={handleDragStart}

--- a/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
+++ b/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
@@ -328,7 +328,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
               >
                 {(tagline || 'supported by').toUpperCase()}
                 <Pencil
-                  size={12 * previewScale > 8 ? 12 * previewScale : 8}
+                  size={30 * previewScale > 14 ? 30 * previewScale : 14}
                   style={{ cursor: 'pointer', opacity: 0.6, flexShrink: 0, marginTop: -2 }}
                   onClick={(e) => { e.stopPropagation(); setEditingField('tagline'); }}
                 />

--- a/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
+++ b/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Download } from 'lucide-react';
+import { Download, Type } from 'lucide-react';
 import { Sponsor } from '../../types';
 import { renderPartnerFlyer } from '../flyer/renderFlyer';
+import { IconInput } from '../IconInput';
 
 interface PartnerFlyerGeneratorProps {
   sponsors: Sponsor[];
@@ -16,6 +17,9 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
   const [fontsReady, setFontsReady] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Tagline text shown between city name and logo
+  const [tagline, setTagline] = useState('supported by');
 
   // Logo position & size state (canvas coordinates, 1080x1080)
   const [logoPos, setLogoPos] = useState<{ x: number; y: number } | null>(null);
@@ -70,6 +74,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
           sponsor.logoUrl!,
           logoPos ?? undefined,
           logoSize,
+          tagline,
         );
         if (cancelled) return;
         canvasRef.current = canvas;
@@ -80,7 +85,7 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
     })();
 
     return () => { cancelled = true; };
-  }, [fontsReady, selectedId, cityName, sponsors, logoPos, logoSize]);
+  }, [fontsReady, selectedId, cityName, sponsors, logoPos, logoSize, tagline]);
 
   // --- Drag handlers ---
   const handleDragStart = useCallback((e: React.MouseEvent) => {
@@ -246,6 +251,15 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
           <option key={s.id} value={s.id}>{s.name}</option>
         ))}
       </select>
+
+      <div className="mb-3">
+        <IconInput
+          icon={Type}
+          value={tagline}
+          onChange={e => setTagline(e.target.value)}
+          placeholder="e.g. supported by"
+        />
+      </div>
 
       {previewUrl && (
         <div

--- a/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
+++ b/frontend/src/components/sponsors/PartnerFlyerGenerator.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Download, Type } from 'lucide-react';
+import { Download, Pencil } from 'lucide-react';
 import { Sponsor } from '../../types';
 import { renderPartnerFlyer } from '../flyer/renderFlyer';
-import { IconInput } from '../IconInput';
 
 interface PartnerFlyerGeneratorProps {
   sponsors: Sponsor[];
@@ -20,6 +19,8 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
 
   // Tagline text shown between city name and logo
   const [tagline, setTagline] = useState('supported by');
+  const [editingField, setEditingField] = useState<'tagline' | null>(null);
+  const [containerWidth, setContainerWidth] = useState(400);
 
   // Logo position & size state (canvas coordinates, 1080x1080)
   const [logoPos, setLogoPos] = useState<{ x: number; y: number } | null>(null);
@@ -44,6 +45,20 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
       setFontsReady(true);
     })();
   }, []);
+
+  // Track container width for overlay font scaling
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [previewUrl]);
+
+  const previewScale = containerWidth / 1080;
 
   // Reset position/size when partner changes
   useEffect(() => {
@@ -252,15 +267,6 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
         ))}
       </select>
 
-      <div className="mb-3">
-        <IconInput
-          icon={Type}
-          value={tagline}
-          onChange={e => setTagline(e.target.value)}
-          placeholder="e.g. supported by"
-        />
-      </div>
-
       {previewUrl && (
         <div
           ref={containerRef}
@@ -273,6 +279,62 @@ export function PartnerFlyerGenerator({ sponsors, cityName }: PartnerFlyerGenera
             className="w-full rounded-lg pointer-events-none"
             draggable={false}
           />
+
+          {/* Tagline text overlay — inline editable */}
+          <div
+            onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); setEditingField('tagline'); }}
+            style={{
+              position: 'absolute',
+              top: `${(640 / 1080) * 100}%`,
+              left: `${(50 / 1080) * 100}%`,
+              width: `${(600 / 1080) * 100}%`,
+              height: `${(60 / 1080) * 100}%`,
+              color: '#0497C1',
+              fontSize: 46 * previewScale,
+              fontFamily: '"Hub 191", "Comic Sans MS", cursive',
+              textTransform: 'uppercase',
+              lineHeight: 1.2,
+              whiteSpace: 'nowrap',
+              zIndex: 15,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            {editingField === 'tagline' ? (
+              <input
+                autoFocus
+                value={tagline}
+                onChange={e => setTagline(e.target.value)}
+                onBlur={() => setEditingField(null)}
+                onKeyDown={e => { if (e.key === 'Enter') setEditingField(null); }}
+                className="w-full"
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  color: 'inherit',
+                  fontSize: 'inherit',
+                  fontFamily: 'inherit',
+                  textTransform: 'inherit' as React.CSSProperties['textTransform'],
+                  lineHeight: 'inherit',
+                  padding: 0,
+                  margin: 0,
+                }}
+              />
+            ) : (
+              <span
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 4, position: 'relative', paddingRight: 24, cursor: 'pointer' }}
+                onClick={(e) => { e.stopPropagation(); setEditingField('tagline'); }}
+              >
+                {(tagline || 'supported by').toUpperCase()}
+                <Pencil
+                  size={16}
+                  style={{ cursor: 'pointer', opacity: 0.6, flexShrink: 0, position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)' }}
+                  onClick={(e) => { e.stopPropagation(); setEditingField('tagline'); }}
+                />
+              </span>
+            )}
+          </div>
 
           {/* Transparent drag overlay for logo area */}
           {logoOverlayStyle ? (


### PR DESCRIPTION
## Summary
- Adds editable tagline text (defaults to "supported by") rendered in blue venue-style between city name and partner logo
- New tagline parameter on renderPartnerFlyer()
- Input field in PartnerFlyerGenerator UI, persists across partner switches

## Test plan
- [ ] Open GPP host dashboard - Partners tab - Partner Flyer card
- [ ] Confirm blue SUPPORTED BY text appears between city name and logo
- [ ] Edit the text field - preview updates in real-time
- [ ] Clear the text - no tagline rendered on flyer
- [ ] Switch partners - tagline text persists
- [ ] Download - PNG includes the tagline

Generated with Claude Code