### PR TITLE
feat: avax flyer template for tagged events

### DIFF
--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -9,7 +9,7 @@ import { PartnerForm, extractSponsorData } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
 import { uploadEventImage, updateParty, cdnUrl } from '../../lib/supabase';
 import {
-  fitText, loadImg, uses12Hour, formatFlyerTime,
+  fitText, loadImg, uses12Hour, formatFlyerTime, getTemplateUrl,
   CITY_FONT, TEXT_FONT, CITY_COLOR, TIME_COLOR, VENUE_COLOR,
   CITY_BOX, VENUE_BOX, TIME_BOX, DEFAULT_SPONSOR_BOX,
 } from './renderFlyer';
@@ -460,7 +460,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
     const ctx = canvas.getContext('2d')!;
 
     // 1) Draw template image
-    const templateImg = await loadImg('/gpp-flyer-2026-template.png');
+    const templateImg = await loadImg(getTemplateUrl(party.eventTags));
     ctx.drawImage(templateImg, 0, 0, 1080, 1080);
 
     ctx.textBaseline = 'top';
@@ -718,7 +718,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
       >
         {/* Template background */}
         <img
-          src="/gpp-flyer-2026-template.png"
+          src={getTemplateUrl(party.eventTags)}
           alt=""
           style={{ width: '100%', height: '100%', display: 'block' }}
           crossOrigin="anonymous"

--- a/frontend/src/components/flyer/autoRegenFlyer.ts
+++ b/frontend/src/components/flyer/autoRegenFlyer.ts
@@ -30,6 +30,7 @@ export interface FlyerRegenData {
   inviteCode?: string | null;
   eventType?: string | null;
   flyerConfig?: Record<string, any> | null;
+  eventTags?: string[];
 }
 
 // ---- Debounce map (partyId → timer handle) ----
@@ -228,6 +229,7 @@ async function doRegen(
     is12h,
     sponsors: sponsors.map((s) => ({ id: s.id, logoUrl: s.logoUrl! })),
     config: layoutConfig,
+    eventTags: data.eventTags,
   });
 
   // 5. Convert canvas to blob

--- a/frontend/src/components/flyer/renderFlyer.ts
+++ b/frontend/src/components/flyer/renderFlyer.ts
@@ -82,6 +82,12 @@ export function formatFlyerTime(timeStr: string, is12h: boolean): string {
     : `${hours12}:${minutes.toString().padStart(2, '0')} ${period}`;
 }
 
+/** Pick the correct GPP flyer template based on event tags. */
+export function getTemplateUrl(eventTags?: string[]): string {
+  if (eventTags?.includes('avax')) return '/gpp-flyer-avax-template.png';
+  return '/gpp-flyer-2026-template.png';
+}
+
 // ---- FlyerConfig type (persisted to DB) ----
 
 export interface FlyerConfig {
@@ -106,6 +112,7 @@ export interface RenderFlyerOptions {
   is12h: boolean;
   sponsors: { id?: string; logoUrl: string }[];
   config?: FlyerConfig;
+  eventTags?: string[];
 }
 
 /**
@@ -132,7 +139,7 @@ export async function renderFlyer(opts: RenderFlyerOptions): Promise<HTMLCanvasE
   const ctx = canvas.getContext('2d')!;
 
   // 1) Draw template image
-  const templateImg = await loadImg('/gpp-flyer-2026-template.png');
+  const templateImg = await loadImg(getTemplateUrl(opts.eventTags));
   ctx.drawImage(templateImg, 0, 0, 1080, 1080);
 
   ctx.textBaseline = 'top';

--- a/scripts/batch-generate-flyers.js
+++ b/scripts/batch-generate-flyers.js
@@ -19,6 +19,7 @@ const TEMPLATE_IMG = 'https://www.rsv.pizza/gpp-flyer-2026-og.jpg';
 const DRY_RUN = process.argv.includes('--dry-run');
 const REGENERATE = process.argv.includes('--regenerate');
 const BACKEND_URL = 'https://backend-pizza-dao.vercel.app';
+const AVAX_TEMPLATE_PATH = path.join(__dirname, '..', 'frontend', 'public', 'gpp-flyer-avax-template.png');
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
@@ -292,10 +293,13 @@ async function main() {
   const templateImage = await loadImage(templatePath);
   console.log('Template loaded.');
 
+  const avaxTemplateImage = await loadImage(AVAX_TEMPLATE_PATH);
+  console.log('Avax template loaded.');
+
   // Fetch events to process
   let query = supabase
     .from('parties')
-    .select('id, name, custom_url, invite_code, venue_name, address, date, end_time, timezone, event_image_url')
+    .select('id, name, custom_url, invite_code, venue_name, address, date, end_time, timezone, event_image_url, event_tags')
     .eq('event_type', 'gpp');
 
   if (REGENERATE) {
@@ -354,7 +358,8 @@ async function main() {
     }
 
     try {
-      const canvas = await renderFlyer(templateImage, event, sponsors);
+      const tpl = (event.event_tags || []).includes('avax') ? avaxTemplateImage : templateImage;
+      const canvas = await renderFlyer(tpl, event, sponsors);
       const imageUrl = await uploadFlyer(canvas, event.invite_code);
       await updatePartyImage(event.id, imageUrl);
       console.log('OK');

--- a/scripts/gen-template-flyers.cjs
+++ b/scripts/gen-template-flyers.cjs
@@ -18,6 +18,7 @@ const TEMPLATE_URL = 'https://www.rsv.pizza/gpp-flyer-2026-og.jpg';
 // Paths
 const FONT_DIR = path.join(__dirname, '..', 'frontend', 'public', 'fonts');
 const TEMPLATE_PATH = path.join(__dirname, '..', 'frontend', 'public', 'gpp-flyer-2026-template.png');
+const AVAX_TEMPLATE_PATH = path.join(__dirname, '..', 'frontend', 'public', 'gpp-flyer-avax-template.png');
 
 // Register fonts
 registerFont(path.join(FONT_DIR, 'Hub-191-Display.otf'), { family: 'Hub 191 Display' });
@@ -276,6 +277,9 @@ async function main() {
   const templateImg = await loadImage(TEMPLATE_PATH);
   console.log('Template loaded (1080x1080)');
 
+  const avaxTemplateImg = await loadImage(AVAX_TEMPLATE_PATH);
+  console.log('Avax template loaded');
+
   // 2) Fetch events with template image
   const events = await prisma.party.findMany({
     where: { eventType: 'gpp', eventImageUrl: TEMPLATE_URL },
@@ -290,6 +294,7 @@ async function main() {
       customUrl: true,
       inviteCode: true,
       flyerConfig: true,
+      eventTags: true,
       sponsors: {
         where: {
           logoUrl: { not: null },
@@ -339,10 +344,11 @@ async function main() {
     const sponsorLogos = event.sponsors.map(s => ({ id: s.id, logoUrl: s.logoUrl }));
     const flyerCfg = event.flyerConfig || null;
 
-    console.log(`[${i + 1}/${events.length}] ${city} — venue: ${venueName}, date: ${dateDisplay || 'TBA'}, sponsors: ${sponsorLogos.length}${flyerCfg ? ' (has config)' : ''}`);
+    console.log(`[${i + 1}/${events.length}] ${city}${(event.eventTags || []).includes('avax') ? ' [avax]' : ''} — venue: ${venueName}, date: ${dateDisplay || 'TBA'}, sponsors: ${sponsorLogos.length}${flyerCfg ? ' (has config)' : ''}`);
 
     try {
-      const canvas = await renderFlyer(templateImg, {
+      const tpl = (event.eventTags || []).includes('avax') ? avaxTemplateImg : templateImg;
+      const canvas = await renderFlyer(tpl, {
         city,
         venueName,
         streetAddress,


### PR DESCRIPTION
## Summary
- Events tagged `avax` in their `eventTags` now use a dedicated flyer template (`gpp-flyer-avax-template.png`) instead of the standard GPP template
- Added `getTemplateUrl()` helper in `renderFlyer.ts` to resolve the correct template based on event tags
- Updated FlyerGenerator (canvas render + HTML preview), autoRegenFlyer, and both batch scripts

## Files Changed
- `frontend/public/gpp-flyer-avax-template.png` — new template image
- `frontend/src/components/flyer/renderFlyer.ts` — `getTemplateUrl()` helper + `eventTags` in options
- `frontend/src/components/flyer/FlyerGenerator.tsx` — use resolved template path
- `frontend/src/components/flyer/autoRegenFlyer.ts` — pass `eventTags` through to `renderFlyer()`
- `scripts/gen-template-flyers.cjs` — fetch `eventTags`, pick template per-event
- `scripts/batch-generate-flyers.js` — fetch `event_tags`, pick template per-event

## Test plan
- [ ] Tag a test event with `"avax"` → flyer preview uses avax template
- [ ] Non-avax event still uses standard template
- [ ] Download flyer uses correct template
- [ ] `gen-template-flyers.cjs --dry-run` detects avax events

🤖 Generated with [Claude Code](https://claude.com/claude-code)