### PR TITLE
fix: admin/superadmin bypass password-protected events

### DIFF
--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
+import { isAdmin } from '../middleware/auth.js';
 import { GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 
 const PIZZADAO_AVATAR_URL = 'https://znpiwdvvsqaxuskpfleo.supabase.co/storage/v1/object/public/profile-pictures/cmkgpzby50002f8y1d8md1dzn/1768937020563.jpg';
@@ -362,6 +363,12 @@ router.post('/:slug/check-host', async (req: Request, res: Response, next: NextF
         isHost = true;
         canEdit = true;
       }
+    }
+
+    // Admin/superadmin bypass password on all events
+    if (!isHost && await isAdmin(email)) {
+      isHost = true;
+      canEdit = true;
     }
 
     res.json({ isHost, canEdit });

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -29,7 +29,7 @@ type AppCategory = 'planning' | 'promotion' | 'day-of' | 'after-party';
 
 const CATEGORY_ORDER: { key: AppCategory; label: string }[] = [
   { key: 'planning', label: 'Planning' },
-  { key: 'promotion', label: 'Promotion' },
+  { key: 'promotion', label: 'Lead-up' },
   { key: 'day-of', label: 'Day-of' },
   { key: 'after-party', label: 'After Party' },
 ];
@@ -49,6 +49,15 @@ interface AppItem {
 const apps: AppItem[] = [
   // Planning
   {
+    id: 'party-kit',
+    name: 'Party Kit',
+    description: 'Event supplies and party kit management',
+    icon: Package,
+    status: 'live',
+    category: 'planning',
+    tab: 'gpp',
+  },
+  {
     id: 'venue',
     name: 'Venue',
     description: 'Venue details and floor plans',
@@ -58,13 +67,13 @@ const apps: AppItem[] = [
     tab: 'venue',
   },
   {
-    id: 'party-kit',
-    name: 'Party Kit',
-    description: 'Event supplies and party kit management',
-    icon: Package,
+    id: 'sponsor-crm',
+    name: 'Partners',
+    description: 'Manage event partners and sponsorships',
+    icon: Handshake,
     status: 'live',
     category: 'planning',
-    tab: 'gpp',
+    tab: 'partners',
   },
   {
     id: 'pizzeria-selection',
@@ -76,15 +85,6 @@ const apps: AppItem[] = [
     tab: 'pizza',
   },
   {
-    id: 'staffing',
-    name: 'Staffing',
-    description: 'Volunteer and staff management',
-    icon: UserCog,
-    status: 'live',
-    category: 'planning',
-    tab: 'staff',
-  },
-  {
     id: 'budget',
     name: 'Budget',
     description: 'Event budget tracking and planning',
@@ -93,17 +93,17 @@ const apps: AppItem[] = [
     category: 'planning',
     tab: 'budget',
   },
-
-  // Promotion
   {
-    id: 'marketing-promo',
-    name: 'Promo',
-    description: 'Promotional materials and marketing tools',
-    icon: Megaphone,
+    id: 'staffing',
+    name: 'Staffing',
+    description: 'Volunteer and staff management',
+    icon: UserCog,
     status: 'live',
-    category: 'promotion',
-    tab: 'promo',
+    category: 'planning',
+    tab: 'staff',
   },
+
+  // Lead-up
   {
     id: 'flyer',
     name: 'Flyer',
@@ -112,6 +112,15 @@ const apps: AppItem[] = [
     status: 'live',
     category: 'promotion',
     tab: 'flyer',
+  },
+  {
+    id: 'marketing-promo',
+    name: 'Promo',
+    description: 'Promotional materials and marketing tools',
+    icon: Megaphone,
+    status: 'live',
+    category: 'promotion',
+    tab: 'promo',
   },
   {
     id: 'print-nametags',
@@ -161,15 +170,6 @@ const apps: AppItem[] = [
     status: 'live',
     category: 'after-party',
     tab: 'report',
-  },
-  {
-    id: 'sponsor-crm',
-    name: 'Partners',
-    description: 'Manage event partners and sponsorships',
-    icon: Handshake,
-    status: 'live',
-    category: 'planning',
-    tab: 'partners',
   },
   {
     id: 'payment-portal',

--- a/frontend/src/components/underboss/PartnerCitiesFlyer.tsx
+++ b/frontend/src/components/underboss/PartnerCitiesFlyer.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Download, RotateCcw } from 'lucide-react';
+import { X, Download, RotateCcw, Pencil, Loader2 } from 'lucide-react';
 import type { SponsorUser, UnderbossEvent } from '../../types';
-import { loadImg, CITY_COLOR, CITY_FONT } from '../flyer/renderFlyer';
+import { loadImg, CITY_COLOR, CITY_FONT, TEXT_FONT, VENUE_COLOR } from '../flyer/renderFlyer';
 import { getCityTier } from '../../utils/sponsorshipPricing';
 
 interface PartnerCitiesFlyerProps {
@@ -15,7 +15,13 @@ const DEFAULT_LOGO_POS = { x: 340, y: 36 };
 const DEFAULT_LOGO_SIZE = 50;
 const CITY_BOX = { x: 40, y: 550, width: 500, height: 490 };
 const MAX_VISIBLE = 10;
+const CITY_FONT_SIZE = 36;
+const CITY_LINE_SPACING = 1.25;
+const SUBHEAD_TEXT = 'SUPPORTING THE EVENTS IN';
+const SUBHEAD_FONT_SIZE = 28;
+const SUBHEAD_Y = 510; // just above city box
 
+/** Render to canvas for download only */
 async function renderCitiesFlyer(
   cities: string[],
   logoUrl: string,
@@ -27,11 +33,10 @@ async function renderCitiesFlyer(
   canvas.height = 1080;
   const ctx = canvas.getContext('2d')!;
 
-  // 1) Template
   const tpl = await loadImg('/gpp-partner-flyer-template.png');
   ctx.drawImage(tpl, 0, 0, 1080, 1080);
 
-  // 2) Partner logo
+  // Partner logo
   try {
     const img = await loadImg(logoUrl);
     const maxH = logoSize;
@@ -42,39 +47,37 @@ async function renderCitiesFlyer(
     ctx.drawImage(img, logoPos.x, logoPos.y - h / 2, w, h);
   } catch { /* skip */ }
 
-  // 3) City names
+  // "Supporting the Events in" subheading
   ctx.textBaseline = 'top';
+  ctx.fillStyle = VENUE_COLOR;
+  ctx.font = `${SUBHEAD_FONT_SIZE}px ${TEXT_FONT}`;
+  ctx.fillText(SUBHEAD_TEXT, CITY_BOX.x, SUBHEAD_Y);
+
+  // City names
   const hasOverflow = cities.length > MAX_VISIBLE;
   const display = hasOverflow ? cities.slice(0, MAX_VISIBLE) : cities;
   const suffix = hasOverflow ? `+ ${cities.length - MAX_VISIBLE} MORE` : null;
-  const lines = display.length + (suffix ? 1 : 0);
-
-  // Auto-size font
-  let fontSize = 48;
-  const spacing = 1.2;
-  const mc = document.createElement('canvas').getContext('2d')!;
-  while (fontSize > 12) {
-    mc.font = `${fontSize}px ${CITY_FONT}`;
-    if (lines * fontSize * spacing > CITY_BOX.height) { fontSize--; continue; }
-    let fits = true;
-    for (const c of display) {
-      if (mc.measureText(c.toUpperCase()).width > CITY_BOX.width) { fits = false; break; }
-    }
-    if (suffix && fits && mc.measureText(suffix).width > CITY_BOX.width) fits = false;
-    if (fits) break;
-    fontSize--;
-  }
 
   ctx.fillStyle = CITY_COLOR;
-  ctx.font = `${fontSize}px ${CITY_FONT}`;
+  ctx.font = `${CITY_FONT_SIZE}px ${CITY_FONT}`;
   let y = CITY_BOX.y;
   for (const c of display) {
     ctx.fillText(c.toUpperCase(), CITY_BOX.x, y);
-    y += fontSize * spacing;
+    y += CITY_FONT_SIZE * CITY_LINE_SPACING;
   }
   if (suffix) ctx.fillText(suffix, CITY_BOX.x, y);
 
   return canvas;
+}
+
+/** Sort cities by tier (1 first) then alphabetical */
+function sortCitiesByTier(cities: string[]): string[] {
+  return [...cities].sort((a, b) => {
+    const tierA = getCityTier(a);
+    const tierB = getCityTier(b);
+    if (tierA !== tierB) return tierA - tierB;
+    return a.localeCompare(b);
+  });
 }
 
 export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFlyerProps) {
@@ -83,28 +86,31 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
   const [containerWidth, setContainerWidth] = useState(500);
   const [fontsLoaded, setFontsLoaded] = useState(false);
   const [downloading, setDownloading] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
   const previewRef = useRef<HTMLDivElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
   const draggingRef = useRef(false);
   const offsetRef = useRef({ x: 0, y: 0 });
 
-  const cities = useMemo(() => {
+  // Derive initial cities from events
+  const defaultCities = useMemo(() => {
     const raw = events
       .filter(e => e.eventTags?.includes(partner.tag))
       .map(e => e.name.replace(/^Global Pizza Party\s*/i, '').trim())
       .filter(Boolean);
-    const unique = [...new Set(raw)];
-    // Sort by tier (1 first) then alphabetical within each tier
-    return unique.sort((a, b) => {
-      const tierA = getCityTier(a);
-      const tierB = getCityTier(b);
-      if (tierA !== tierB) return tierA - tierB;
-      return a.localeCompare(b);
-    });
+    return sortCitiesByTier([...new Set(raw)]);
   }, [events, partner.tag]);
 
+  const [editCities, setEditCities] = useState<string[]>(defaultCities);
+  useEffect(() => { setEditCities(defaultCities); }, [defaultCities]);
+
   const scale = containerWidth / 1080;
+
+  // Visible cities + overflow
+  const hasOverflow = editCities.length > MAX_VISIBLE;
+  const displayCities = hasOverflow ? editCities.slice(0, MAX_VISIBLE) : editCities;
+  const overflowCount = hasOverflow ? editCities.length - MAX_VISIBLE : 0;
 
   // Fonts
   useEffect(() => {
@@ -115,7 +121,7 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
       .catch(() => setFontsLoaded(true));
   }, []);
 
-  // Container width
+  // Container width tracking
   useEffect(() => {
     if (!previewRef.current) return;
     const obs = new ResizeObserver(entries => {
@@ -125,35 +131,18 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
     return () => obs.disconnect();
   }, []);
 
-  // Render preview
-  const renderPreview = useCallback(async () => {
-    if (!canvasRef.current || !fontsLoaded || !partner.coHostLogoUrl) return;
-    try {
-      const result = await renderCitiesFlyer(cities, partner.coHostLogoUrl, logoPos, logoSize);
-      const ctx = canvasRef.current.getContext('2d');
-      if (ctx) {
-        canvasRef.current.width = 1080;
-        canvasRef.current.height = 1080;
-        ctx.drawImage(result, 0, 0);
-      }
-    } catch (err) {
-      console.error('Partner flyer preview failed:', err);
-    }
-  }, [cities, partner.coHostLogoUrl, logoPos, logoSize, fontsLoaded]);
-
-  useEffect(() => { renderPreview(); }, [renderPreview]);
-
-  // Coordinate conversion
+  // Coordinate conversion (screen → 1080px canvas space)
   const toCanvas = useCallback((cx: number, cy: number) => {
-    if (!previewRef.current) return null;
-    const r = previewRef.current.getBoundingClientRect();
+    if (!canvasRef.current) return null;
+    const r = canvasRef.current.getBoundingClientRect();
     const s = r.width / 1080;
     return { x: (cx - r.left) / s, y: (cy - r.top) / s };
   }, []);
 
   // Logo drag - mouse
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
+  const onLogoMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     const p = toCanvas(e.clientX, e.clientY);
     if (!p) return;
     draggingRef.current = true;
@@ -168,14 +157,19 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
         y: Math.max(0, Math.min(1080, q.y - offsetRef.current.y)),
       });
     };
-    const up = () => { draggingRef.current = false; document.removeEventListener('mousemove', move); document.removeEventListener('mouseup', up); };
+    const up = () => {
+      draggingRef.current = false;
+      document.removeEventListener('mousemove', move);
+      document.removeEventListener('mouseup', up);
+    };
     document.addEventListener('mousemove', move);
     document.addEventListener('mouseup', up);
   }, [toCanvas, logoPos]);
 
   // Logo drag - touch
-  const onTouchStart = useCallback((e: React.TouchEvent) => {
+  const onLogoTouchStart = useCallback((e: React.TouchEvent) => {
     if (e.touches.length !== 1) return;
+    e.stopPropagation();
     const t = e.touches[0];
     const p = toCanvas(t.clientX, t.clientY);
     if (!p) return;
@@ -192,28 +186,66 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
         y: Math.max(0, Math.min(1080, q.y - offsetRef.current.y)),
       });
     };
-    const end = () => { draggingRef.current = false; document.removeEventListener('touchmove', move); document.removeEventListener('touchend', end); };
+    const end = () => {
+      draggingRef.current = false;
+      document.removeEventListener('touchmove', move);
+      document.removeEventListener('touchend', end);
+    };
     document.addEventListener('touchmove', move, { passive: false });
     document.addEventListener('touchend', end);
   }, [toCanvas, logoPos]);
 
-  // Logo dimensions for overlay
-  const [logoDims, setLogoDims] = useState<{ w: number; h: number } | null>(null);
-  useEffect(() => {
-    if (!partner.coHostLogoUrl) return;
-    loadImg(partner.coHostLogoUrl)
-      .then(img => {
-        const s = Math.min(logoSize * 3 / img.width, logoSize / img.height);
-        setLogoDims({ w: img.width * s, h: img.height * s });
-      })
-      .catch(() => setLogoDims(null));
-  }, [partner.coHostLogoUrl, logoSize]);
+  // Logo resize drag
+  const onResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startY = e.clientY;
+    const startSize = logoSize;
+    const rect = canvasRef.current?.getBoundingClientRect();
+    const sc = rect ? rect.width / 1080 : 1;
+
+    const move = (ev: MouseEvent) => {
+      const delta = (ev.clientY - startY) / sc;
+      setLogoSize(Math.max(20, Math.min(120, Math.round(startSize + delta))));
+    };
+    const up = () => {
+      document.removeEventListener('mousemove', move);
+      document.removeEventListener('mouseup', up);
+    };
+    document.addEventListener('mousemove', move);
+    document.addEventListener('mouseup', up);
+  }, [logoSize]);
+
+  const onResizeTouchStart = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation();
+    const startY = e.touches[0].clientY;
+    const startSize = logoSize;
+    const rect = canvasRef.current?.getBoundingClientRect();
+    const sc = rect ? rect.width / 1080 : 1;
+
+    const move = (ev: TouchEvent) => {
+      ev.preventDefault();
+      const delta = (ev.touches[0].clientY - startY) / sc;
+      setLogoSize(Math.max(20, Math.min(120, Math.round(startSize + delta))));
+    };
+    const up = () => {
+      document.removeEventListener('touchmove', move);
+      document.removeEventListener('touchend', up);
+    };
+    document.addEventListener('touchmove', move, { passive: false });
+    document.addEventListener('touchend', up);
+  }, [logoSize]);
+
+  // City editing
+  const handleCityRename = (index: number, value: string) => {
+    setEditCities(prev => prev.map((c, i) => i === index ? value : c));
+  };
 
   const handleDownload = async () => {
     if (!partner.coHostLogoUrl) return;
     setDownloading(true);
     try {
-      const canvas = await renderCitiesFlyer(cities, partner.coHostLogoUrl, logoPos, logoSize);
+      const canvas = await renderCitiesFlyer(editCities, partner.coHostLogoUrl, logoPos, logoSize);
       const a = document.createElement('a');
       a.download = `gpp-partner-${partner.tag}.png`;
       a.href = canvas.toDataURL('image/png');
@@ -225,11 +257,185 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
     }
   };
 
-  const handleReset = () => { setLogoPos(DEFAULT_LOGO_POS); setLogoSize(DEFAULT_LOGO_SIZE); };
+  const handleReset = () => {
+    setLogoPos(DEFAULT_LOGO_POS);
+    setLogoSize(DEFAULT_LOGO_SIZE);
+    setEditCities(defaultCities);
+    setEditingIndex(null);
+  };
+
   const name = partner.coHostName || partner.name || partner.tag;
 
+  /** The 1080px HTML preview content (same pattern as FlyerGenerator) */
+  const renderFlyerContent = () => (
+    <div
+      style={{
+        width: 1080,
+        height: 1080,
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Template background */}
+      <img
+        src="/gpp-partner-flyer-template.png"
+        alt=""
+        style={{ width: '100%', height: '100%', display: 'block' }}
+        crossOrigin="anonymous"
+      />
+
+      {/* Partner logo — draggable */}
+      {partner.coHostLogoUrl && (
+        <div
+          onMouseDown={onLogoMouseDown}
+          onTouchStart={onLogoTouchStart}
+          style={{
+            position: 'absolute',
+            top: logoPos.y - logoSize / 2,
+            left: logoPos.x,
+            cursor: draggingRef.current ? 'grabbing' : 'grab',
+            userSelect: 'none',
+            WebkitUserSelect: 'none',
+            zIndex: 10,
+          }}
+        >
+          <img
+            src={partner.coHostLogoUrl}
+            alt={name}
+            crossOrigin="anonymous"
+            style={{
+              height: logoSize,
+              maxWidth: logoSize * 3,
+              objectFit: 'contain',
+            }}
+            draggable={false}
+          />
+          {/* Resize handle */}
+          <div
+            onMouseDown={onResizeStart}
+            onTouchStart={onResizeTouchStart}
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              right: 0,
+              width: 14,
+              height: 14,
+              cursor: 'nwse-resize',
+              zIndex: 35,
+              background: 'linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.5) 50%)',
+              borderRadius: '0 0 4px 0',
+            }}
+          />
+        </div>
+      )}
+
+      {/* "Supporting the Events in" subheading */}
+      <div
+        style={{
+          position: 'absolute',
+          top: SUBHEAD_Y,
+          left: CITY_BOX.x,
+          fontSize: SUBHEAD_FONT_SIZE,
+          fontFamily: TEXT_FONT,
+          color: VENUE_COLOR,
+          textTransform: 'uppercase',
+          lineHeight: 1,
+          whiteSpace: 'nowrap',
+          userSelect: 'none',
+          WebkitUserSelect: 'none',
+        }}
+      >
+        {SUBHEAD_TEXT}
+      </div>
+
+      {/* City names — inline editable */}
+      {displayCities.map((city, i) => {
+        const isEditing = editingIndex === i;
+        const y = CITY_BOX.y + i * (CITY_FONT_SIZE * CITY_LINE_SPACING);
+        return (
+          <div
+            key={i}
+            onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); setEditingIndex(i); }}
+            style={{
+              position: 'absolute',
+              top: y,
+              left: CITY_BOX.x,
+              width: CITY_BOX.width,
+              height: CITY_FONT_SIZE * CITY_LINE_SPACING,
+              fontSize: CITY_FONT_SIZE,
+              fontFamily: CITY_FONT,
+              color: CITY_COLOR,
+              textTransform: 'uppercase',
+              lineHeight: 1,
+              whiteSpace: 'nowrap',
+              cursor: isEditing ? 'text' : 'default',
+              userSelect: isEditing ? 'auto' : 'none',
+              WebkitUserSelect: isEditing ? 'auto' : 'none',
+            }}
+          >
+            {isEditing ? (
+              <input
+                autoFocus
+                value={city}
+                onChange={e => handleCityRename(i, e.target.value)}
+                onBlur={() => setEditingIndex(null)}
+                onKeyDown={e => { if (e.key === 'Enter') setEditingIndex(null); if (e.key === 'Escape') setEditingIndex(null); }}
+                onClick={e => e.stopPropagation()}
+                onMouseDown={e => e.stopPropagation()}
+                style={{
+                  width: '100%',
+                  background: 'rgba(0,0,0,0.5)',
+                  border: '1px solid rgba(255,255,255,0.3)',
+                  borderRadius: 4,
+                  outline: 'none',
+                  color: 'inherit',
+                  fontSize: 'inherit',
+                  fontFamily: 'inherit',
+                  textTransform: 'inherit' as any,
+                  lineHeight: 'inherit',
+                  padding: '0 4px',
+                  margin: 0,
+                }}
+              />
+            ) : (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, position: 'relative', paddingRight: 50 }}>
+                {city.toUpperCase()}
+                <Pencil
+                  size={28}
+                  style={{ cursor: 'pointer', opacity: 0.6, flexShrink: 0, position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)' }}
+                  onClick={(e) => { e.stopPropagation(); setEditingIndex(i); }}
+                />
+              </span>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Overflow "+ X MORE" */}
+      {hasOverflow && (
+        <div
+          style={{
+            position: 'absolute',
+            top: CITY_BOX.y + MAX_VISIBLE * (CITY_FONT_SIZE * CITY_LINE_SPACING),
+            left: CITY_BOX.x,
+            fontSize: CITY_FONT_SIZE,
+            fontFamily: CITY_FONT,
+            color: CITY_COLOR,
+            textTransform: 'uppercase',
+            lineHeight: 1,
+            whiteSpace: 'nowrap',
+            userSelect: 'none',
+            WebkitUserSelect: 'none',
+          }}
+        >
+          + {overflowCount} MORE
+        </div>
+      )}
+    </div>
+  );
+
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black" onClick={onClose}>
       <div className="bg-theme-card border border-theme-stroke rounded-2xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-theme-stroke">
@@ -238,47 +444,67 @@ export function PartnerCitiesFlyer({ partner, events, onClose }: PartnerCitiesFl
         </div>
 
         <div className="p-4">
-          {cities.length === 0 ? (
-            <p className="text-sm text-theme-text-faint text-center py-8">No events tagged with "{partner.tag}".</p>
+          {defaultCities.length === 0 ? (
+            <p className="text-sm text-theme-text-faint text-center py-8">No events tagged with &ldquo;{partner.tag}&rdquo;.</p>
           ) : (
-            <>
-              <div ref={previewRef} className="relative w-full select-none" style={{ aspectRatio: '1 / 1' }}>
-                <canvas ref={canvasRef} width={1080} height={1080} className="w-full h-full rounded-lg" />
-                {logoDims && (
+            <div className="space-y-4">
+              {/* Hint */}
+              <p className="text-center text-xs text-white/40">
+                Double-click city names to edit. Drag logo to reposition. Drag corner to resize.
+              </p>
+
+              {/* Scaled preview — same pattern as FlyerGenerator */}
+              <div className="relative mx-auto" style={{ maxWidth: 500 }}>
+                <div
+                  ref={previewRef}
+                  style={{
+                    width: '100%',
+                    paddingBottom: '100%',
+                    position: 'relative',
+                    borderRadius: 16,
+                    overflow: 'hidden',
+                    boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
+                  }}
+                >
                   <div
-                    onMouseDown={onMouseDown}
-                    onTouchStart={onTouchStart}
-                    className="absolute cursor-move"
+                    ref={canvasRef}
                     style={{
-                      left: logoPos.x * scale,
-                      top: (logoPos.y - logoDims.h / 2) * scale,
-                      width: logoDims.w * scale,
-                      height: logoDims.h * scale,
-                      border: '1px dashed rgba(255,255,255,0.4)',
-                      borderRadius: 4,
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: 1080,
+                      height: 1080,
+                      transform: `scale(${scale})`,
+                      transformOrigin: 'top left',
                     }}
-                    title="Drag to reposition logo"
-                  />
-                )}
+                  >
+                    {fontsLoaded && renderFlyerContent()}
+                  </div>
+                </div>
               </div>
 
-              <div className="mt-4 space-y-3">
-                <div className="flex items-center gap-3">
-                  <label className="text-xs text-theme-text-faint whitespace-nowrap w-16">Logo size</label>
-                  <input type="range" min={20} max={120} value={logoSize} onChange={e => setLogoSize(Number(e.target.value))} className="flex-1 accent-red-500" />
-                  <span className="text-xs text-theme-text-faint w-8 text-right">{logoSize}</span>
-                </div>
-                <p className="text-xs text-theme-text-faint">{cities.length} cit{cities.length === 1 ? 'y' : 'ies'} tagged with "{partner.tag}"</p>
-                <div className="flex items-center gap-2">
-                  <button onClick={handleDownload} disabled={downloading} className="flex-1 flex items-center justify-center gap-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white py-2 rounded-lg text-sm font-medium transition-colors">
-                    <Download size={14} />{downloading ? 'Generating...' : 'Download PNG'}
-                  </button>
-                  <button onClick={handleReset} className="p-2 text-theme-text-faint hover:text-theme-text-secondary transition-colors border border-theme-stroke rounded-lg" title="Reset to defaults">
-                    <RotateCcw size={14} />
-                  </button>
-                </div>
+              {/* Action buttons */}
+              <div className="flex justify-center gap-3">
+                <button
+                  onClick={handleDownload}
+                  disabled={downloading}
+                  className="btn-primary flex items-center gap-2 px-6 py-3"
+                >
+                  {downloading ? (
+                    <><Loader2 className="w-5 h-5 animate-spin" /> Generating...</>
+                  ) : (
+                    <><Download className="w-5 h-5" /> Download</>
+                  )}
+                </button>
+                <button
+                  onClick={handleReset}
+                  className="flex items-center gap-2 px-4 py-3 rounded-lg bg-white/10 hover:bg-white/20 text-white/70 hover:text-white transition-colors text-sm"
+                  title="Reset to defaults"
+                >
+                  <RotateCcw className="w-4 h-4" /> Reset
+                </button>
               </div>
-            </>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Admins and superadmins were blocked by password-protected event pages (e.g. /kandy, /galle) because the `check-host` endpoint only checked co-hosts and GPP global editors
- Added `isAdmin()` check to the `check-host` endpoint so admin/superadmin users automatically bypass the password gate on **all** events

## Test plan
- [ ] Log in as hello@rarepizzas.com (admin) and visit rsv.pizza/kandy — should see event without password prompt
- [ ] Log in as hello@rarepizzas.com and visit rsv.pizza/galle — should see event without password prompt
- [ ] Log in as a non-admin, non-host user and visit a password-protected event — should still see password prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)