### PR TITLE
olive-79044: Bare emojis, Telegram icon, check-in symbol

### DIFF
--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -25,10 +25,10 @@ interface ScorecardItemProps {
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
   post: { label: 'Post about the party', emoji: '📣' },
   photo: { label: 'Upload a photo', emoji: '📸' },
-  vouch: { label: 'Check someone in', emoji: '🤝' },
+  vouch: { label: 'Check someone in', emoji: '⛶' },
   pizza_selfie: { label: 'Pizza selfie', emoji: '🍕' },
   sign_pizza_box: { label: 'Sign the party pizza box', emoji: '✍️' },
-  join_telegram: { label: "Join your city's PizzaDAO Telegram", emoji: '💬' },
+  join_telegram: { label: "Join your city's PizzaDAO Telegram", emoji: 'tg' },
   follow_pizzadao: { label: 'Follow @pizza_dao', emoji: '🐦' },
   signup_pizzadao: { label: 'Sign up on pizzadao.org', emoji: '🌐' },
 };
@@ -78,12 +78,13 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
     <div className="space-y-2">
       <div className={`flex items-center gap-3 py-2.5 px-3 rounded-lg transition-colors ${completed ? 'bg-green-500/10' : 'bg-white/5 hover:bg-white/10'}`}>
         {/* Emoji */}
-        <div
-          className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${completed ? 'bg-green-500/20 border-green-400' : 'bg-white/10 border-white/20'}`}
-          style={{ borderWidth: '1.5px' }}
-        >
-          <span className="text-base leading-none">{completed ? '✅' : config.emoji}</span>
-        </div>
+        <span className="w-8 h-8 flex items-center justify-center flex-shrink-0 text-2xl leading-none">
+          {completed ? '✅' : config.emoji === 'tg' ? (
+            <svg viewBox="0 0 24 24" className="w-6 h-6" fill="#0088cc">
+              <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>
+            </svg>
+          ) : config.emoji}
+        </span>
 
         {/* Label */}
         <span className={`flex-1 text-sm ${completed ? 'text-green-300 line-through opacity-70' : 'text-white'}`}>


### PR DESCRIPTION
Remove circles around emojis, use Telegram brand icon, use ⛶ for check-in.