### PR TITLE
fix: refresh party context after time save

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -490,6 +490,7 @@ export const EventDetailsTab: React.FC = () => {
         endTime,
         timezone,
       }));
+      if (party?.inviteCode) await loadParty(party.inviteCode);
       if (party) triggerFlyerRegen(party, loadParty);
     }
   };


### PR DESCRIPTION
## Summary
- After saving date/time in event settings, calls `loadParty()` to refresh the party context
- This ensures components like PartyHeader that read `party.date` from PizzaContext immediately reflect the updated time without requiring a page reload

## Test plan
- [ ] Go to host dashboard → Event Details
- [ ] Change the event time and click Done/Save
- [ ] Verify the time updates in the header and anywhere else it's displayed — without reloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)