### PR TITLE
fix: include 'billed' status in sponsor flyer dropdown

### DIFF
--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -276,7 +276,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
     if (!party?.id) return;
     getSponsors(party.id).then(result => {
       if (result?.sponsors) {
-        setSponsors(result.sponsors.filter(s => s.logoUrl && (s.status === 'yes' || s.status === 'paid')));
+        setSponsors(result.sponsors.filter(s => s.logoUrl && (s.status === 'yes' || s.status === 'paid' || s.status === 'billed')));
       }
     });
   }, [party?.id]);
@@ -333,7 +333,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
       await updateSponsor(party.id, editingSponsor.id, data);
       const result = await getSponsors(party.id);
       if (result?.sponsors) {
-        setSponsors(result.sponsors.filter(s => s.logoUrl && (s.status === 'yes' || s.status === 'paid')));
+        setSponsors(result.sponsors.filter(s => s.logoUrl && (s.status === 'yes' || s.status === 'paid' || s.status === 'billed')));
       }
       setEditingSponsor(null);
     } finally {

--- a/frontend/src/components/flyer/autoRegenFlyer.ts
+++ b/frontend/src/components/flyer/autoRegenFlyer.ts
@@ -169,7 +169,7 @@ async function doRegen(
   // 2. Fetch sponsors with logo + yes/paid status
   const sponsorResult = await getSponsors(data.id);
   const sponsors = (sponsorResult?.sponsors ?? []).filter(
-    (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid'),
+    (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid' || s.status === 'billed'),
   );
 
   // 3. Derive flyer text fields from party data

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -413,7 +413,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
       {/* Partner Flyer Generator (GPP only) */}
       {party?.eventType === 'gpp' && (() => {
         const flyerSponsors = sponsors.filter(
-          s => (s.status === 'yes' || s.status === 'paid') && s.logoUrl
+          s => (s.status === 'yes' || s.status === 'paid' || s.status === 'billed') && s.logoUrl
         );
         const cityName = party.name?.replace(/^Global Pizza Party\s*/i, '').trim() || '';
         return flyerSponsors.length > 0 ? (

--- a/frontend/src/pages/GraphicsDashboard.tsx
+++ b/frontend/src/pages/GraphicsDashboard.tsx
@@ -286,7 +286,7 @@ export function GraphicsDashboard() {
 
         const sponsorResult = await getSponsors(event.id);
         const sponsors = (sponsorResult?.sponsors ?? []).filter(
-          (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid'),
+          (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid' || s.status === 'billed'),
         );
 
         const canvas = await renderFlyer({
@@ -383,7 +383,7 @@ export function GraphicsDashboard() {
 
       const sponsorResult = await getSponsors(event.id);
       const sponsors = (sponsorResult?.sponsors ?? []).filter(
-        (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid'),
+        (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid' || s.status === 'billed'),
       );
 
       const canvas = await renderFlyer({


### PR DESCRIPTION
## Summary
- Sponsors with status `billed` (like Goldsky and CCpayment) were excluded from flyer generation dropdowns
- Updated filter in 4 files (6 occurrences) to treat `billed` the same as `yes` and `paid`

## Test plan
- [ ] Open Vancouver event Graphics Dashboard
- [ ] Verify Goldsky and CCpayment now appear in the partner flyer dropdown
- [ ] Generate a partner flyer for one of the previously-missing sponsors

🤖 Generated with [Claude Code](https://claude.com/claude-code)