### PR TITLE
olive-79044: Make all scorecard items interactive

### DIFF
--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -1,10 +1,17 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Trophy, Loader2 } from 'lucide-react';
 import { getScorecard, completeScorecardItem, ScorecardItem as ScorecardItemType } from '../../lib/api';
-import { ScorecardItem, ScorecardItemKey } from './ScorecardItem';
+import { ScorecardItem, ScorecardItemKey, ActionContext } from './ScorecardItem';
 
 interface GuestScorecardProps {
   inviteCode: string;
+  eventName: string;
+  eventImageUrl: string | null;
+  customUrl: string | null;
+  telegramUrl: string | null;
+  twitterHandles: string[];
+  onOpenPhotos: () => void;
+  onOpenScanner: () => void;
 }
 
 const ITEM_ORDER: ScorecardItemKey[] = [
@@ -18,7 +25,7 @@ const ITEM_ORDER: ScorecardItemKey[] = [
   'signup_pizzadao',
 ];
 
-export function GuestScorecard({ inviteCode }: GuestScorecardProps) {
+export function GuestScorecard({ inviteCode, eventName, eventImageUrl, customUrl, telegramUrl, twitterHandles, onOpenPhotos, onOpenScanner }: GuestScorecardProps) {
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
   const [totalItems, setTotalItems] = useState(8);
@@ -65,6 +72,15 @@ export function GuestScorecard({ inviteCode }: GuestScorecardProps) {
     } finally {
       setCompletingItem(null);
     }
+  };
+
+  const actionContext: ActionContext = {
+    eventName,
+    eventUrl: `https://rsv.pizza/${customUrl || inviteCode}`,
+    twitterHandles,
+    telegramUrl,
+    onOpenPhotos,
+    onOpenScanner,
   };
 
   if (loading) {
@@ -124,6 +140,7 @@ export function GuestScorecard({ inviteCode }: GuestScorecardProps) {
                 completed={item.completed}
                 loading={completingItem === key}
                 onComplete={handleComplete}
+                actionContext={actionContext}
               />
             </div>
           );

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -127,7 +127,7 @@ export function GuestScorecard({ inviteCode, eventName, eventImageUrl, customUrl
         <p className="text-xs text-white/50 mt-1.5 mb-2">
           {isComplete
             ? 'All tasks completed! You are a Pizza Chef!'
-            : `Complete tasks to earn your Pizza Chef title`}
+            : `Level up your pizza party playing card`}
         </p>
       </div>
 

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -20,11 +20,9 @@ const ITEM_ORDER: ScorecardItemKey[] = [
   'post',
   'photo',
   'vouch',
-  'pizza_selfie',
   'sign_pizza_box',
   'join_telegram',
   'follow_pizzadao',
-  'signup_pizzadao',
 ];
 
 export function GuestScorecard({ inviteCode, eventName, eventImageUrl, customUrl, telegramUrl, twitterHandles, guestId, guestName, onOpenPhotos, onOpenScanner }: GuestScorecardProps) {

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -10,6 +10,8 @@ interface GuestScorecardProps {
   customUrl: string | null;
   telegramUrl: string | null;
   twitterHandles: string[];
+  guestId: string;
+  guestName: string;
   onOpenPhotos: () => void;
   onOpenScanner: () => void;
 }
@@ -25,7 +27,7 @@ const ITEM_ORDER: ScorecardItemKey[] = [
   'signup_pizzadao',
 ];
 
-export function GuestScorecard({ inviteCode, eventName, eventImageUrl, customUrl, telegramUrl, twitterHandles, onOpenPhotos, onOpenScanner }: GuestScorecardProps) {
+export function GuestScorecard({ inviteCode, eventName, eventImageUrl, customUrl, telegramUrl, twitterHandles, guestId, guestName, onOpenPhotos, onOpenScanner }: GuestScorecardProps) {
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
   const [totalItems, setTotalItems] = useState(8);
@@ -77,6 +79,9 @@ export function GuestScorecard({ inviteCode, eventName, eventImageUrl, customUrl
   const actionContext: ActionContext = {
     eventName,
     eventUrl: `https://rsv.pizza/${customUrl || inviteCode}`,
+    inviteCode,
+    guestId,
+    guestName,
     twitterHandles,
     telegramUrl,
     onOpenPhotos,

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -19,6 +19,9 @@ export type ScorecardItemKey =
 export interface ActionContext {
   eventName: string;
   eventUrl: string;
+  inviteCode: string;
+  guestId: string;
+  guestName: string;
   twitterHandles: string[];
   telegramUrl: string | null;
   onOpenPhotos: () => void;
@@ -36,7 +39,7 @@ interface ScorecardItemProps {
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
   post: { label: 'Post about the party', emoji: '📣' },
   photo: { label: 'Upload a photo', emoji: '📸' },
-  vouch: { label: 'Check someone in', emoji: '⛶' },
+  vouch: { label: 'Proof of network', emoji: '🤝' },
   pizza_selfie: { label: 'Pizza selfie', emoji: '🍕' },
   sign_pizza_box: { label: 'Sign the party pizza box', emoji: '✍️' },
   join_telegram: { label: "Join your city's PizzaDAO Telegram", emoji: 'tg' },
@@ -74,6 +77,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
   const [inputValue, setInputValue] = useState('');
   const [showPizzaBoxModal, setShowPizzaBoxModal] = useState(false);
   const [showPizzaSelfieModal, setShowPizzaSelfieModal] = useState(false);
+  const [showNetworkModal, setShowNetworkModal] = useState(false);
   const [selfieUploaded, setSelfieUploaded] = useState(false);
   const config = ITEM_CONFIG[itemKey];
 
@@ -107,7 +111,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
         actionContext.onOpenPhotos();
         break;
       case 'vouch':
-        actionContext.onOpenScanner();
+        setShowNetworkModal(true);
         break;
       case 'pizza_selfie':
         setShowPizzaSelfieModal(true);
@@ -143,7 +147,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
     switch (itemKey) {
       case 'post': return 'Share';
       case 'photo': return 'Upload';
-      case 'vouch': return 'Scan QR';
+      case 'vouch': return 'Show QR';
       case 'pizza_selfie': return 'I took one!';
       case 'sign_pizza_box': return 'I signed it!';
       case 'join_telegram': return 'I joined!';
@@ -289,6 +293,54 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
               className="w-full py-2.5 rounded-lg bg-[#E52828] hover:bg-[#CC2020] text-white font-medium transition-colors"
             >
               I signed it!
+            </button>
+          </div>
+        </div>
+      )}
+      {/* Proof of Network Modal */}
+      {showNetworkModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          onClick={() => setShowNetworkModal(false)}
+        >
+          <div
+            className="rounded-2xl shadow-lg max-w-sm w-full mx-4 p-7 relative"
+            style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)' }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setShowNetworkModal(false)}
+              className="absolute top-3 right-3 text-black/40 hover:text-black/70"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <h3 className="text-lg font-bold text-[#1a1a1a] mb-1">Proof of Network</h3>
+            <p className="text-sm text-[#555] mb-4">
+              Show your QR so other guests can scan you, or scan someone else's code.
+            </p>
+
+            {/* QR Code */}
+            <div className="flex justify-center mb-4">
+              <div className="bg-white rounded-xl p-3">
+                <img
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(`https://rsv.pizza/checkin/${actionContext.inviteCode}/${actionContext.guestId}`)}`}
+                  alt="Your QR code"
+                  width={200}
+                  height={200}
+                  className="block"
+                />
+              </div>
+            </div>
+            <p className="text-center text-xs text-[#555]/70 mb-4">{actionContext.guestName}</p>
+
+            <button
+              onClick={() => {
+                setShowNetworkModal(false);
+                actionContext.onOpenScanner();
+              }}
+              className="w-full py-2.5 rounded-lg bg-[#E52828] hover:bg-[#CC2020] text-white font-medium transition-colors"
+            >
+              Scan Someone Else's QR
             </button>
           </div>
         </div>

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -10,11 +10,9 @@ export type ScorecardItemKey =
   | 'post'
   | 'photo'
   | 'vouch'
-  | 'pizza_selfie'
   | 'sign_pizza_box'
   | 'join_telegram'
-  | 'follow_pizzadao'
-  | 'signup_pizzadao';
+  | 'follow_pizzadao';
 
 export interface ActionContext {
   eventName: string;
@@ -39,12 +37,10 @@ interface ScorecardItemProps {
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
   post: { label: 'Post about the party', emoji: '📣' },
   photo: { label: 'Upload a photo', emoji: '📸' },
-  vouch: { label: 'Proof of network', emoji: '🤝' },
-  pizza_selfie: { label: 'Pizza selfie', emoji: '🍕' },
+  vouch: { label: 'Make a friend', emoji: '🤝' },
   sign_pizza_box: { label: 'Sign the party pizza box', emoji: '✍️' },
   join_telegram: { label: "Join your city's PizzaDAO Telegram", emoji: 'tg' },
   follow_pizzadao: { label: 'Follow @pizza_dao', emoji: 'x' },
-  signup_pizzadao: { label: 'Sign up on pizzadao.org', emoji: '🌐' },
 };
 
 const XIcon = () => (
@@ -76,9 +72,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
   const [showInput, setShowInput] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [showPizzaBoxModal, setShowPizzaBoxModal] = useState(false);
-  const [showPizzaSelfieModal, setShowPizzaSelfieModal] = useState(false);
   const [showNetworkModal, setShowNetworkModal] = useState(false);
-  const [selfieUploaded, setSelfieUploaded] = useState(false);
   const config = ITEM_CONFIG[itemKey];
 
   const isDisabled = itemKey === 'join_telegram' && !actionContext.telegramUrl;
@@ -113,9 +107,6 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
       case 'vouch':
         setShowNetworkModal(true);
         break;
-      case 'pizza_selfie':
-        setShowPizzaSelfieModal(true);
-        break;
       case 'sign_pizza_box':
         setShowPizzaBoxModal(true);
         break;
@@ -127,10 +118,6 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
         break;
       case 'follow_pizzadao':
         window.open('https://x.com/pizza_dao', '_blank');
-        onComplete(itemKey, undefined, 'self_report');
-        break;
-      case 'signup_pizzadao':
-        window.open('https://pizzadao.org', '_blank');
         onComplete(itemKey, undefined, 'self_report');
         break;
     }
@@ -148,11 +135,9 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
       case 'post': return 'Share';
       case 'photo': return 'Upload';
       case 'vouch': return 'Show QR';
-      case 'pizza_selfie': return 'I took one!';
       case 'sign_pizza_box': return 'I signed it!';
       case 'join_telegram': return 'I joined!';
       case 'follow_pizzadao': return 'I followed!';
-      case 'signup_pizzadao': return 'I signed up!';
       default: return '';
     }
   };
@@ -216,52 +201,6 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
         </div>
       )}
 
-      {/* Pizza Selfie Modal */}
-      {showPizzaSelfieModal && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
-          onClick={() => setShowPizzaSelfieModal(false)}
-        >
-          <div
-            className="rounded-2xl shadow-lg max-w-sm w-full mx-4 p-7 relative"
-            style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)' }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              onClick={() => setShowPizzaSelfieModal(false)}
-              className="absolute top-3 right-3 text-black/40 hover:text-black/70"
-            >
-              <X className="w-5 h-5" />
-            </button>
-            <h3 className="text-lg font-bold text-[#1a1a1a] mb-3">Pizza Selfie</h3>
-            <p className="text-sm text-[#555] mb-4">
-              Take a selfie with a slice of pizza and upload it to the photo gallery!
-            </p>
-            {!selfieUploaded ? (
-              <button
-                onClick={() => {
-                  actionContext.onOpenPhotos();
-                  setSelfieUploaded(true);
-                }}
-                className="w-full py-2.5 rounded-lg bg-[#E52828] hover:bg-[#CC2020] text-white font-medium transition-colors"
-              >
-                Upload Photo
-              </button>
-            ) : (
-              <button
-                onClick={() => {
-                  setShowPizzaSelfieModal(false);
-                  onComplete('pizza_selfie', undefined, 'self_report');
-                }}
-                className="w-full py-2.5 rounded-lg bg-green-500 hover:bg-green-600 text-white font-medium transition-colors"
-              >
-                I uploaded my selfie!
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-
       {/* Pizza Box Modal */}
       {showPizzaBoxModal && (
         <div
@@ -314,7 +253,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
             >
               <X className="w-5 h-5" />
             </button>
-            <h3 className="text-lg font-bold text-[#1a1a1a] mb-1">Proof of Network</h3>
+            <h3 className="text-lg font-bold text-[#1a1a1a] mb-1">Make a Friend</h3>
             <p className="text-sm text-[#555] mb-4">
               Show your QR so other guests can scan you, or scan someone else's code.
             </p>

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import {
   Loader2,
   Link2,
+  X,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 
@@ -15,11 +16,21 @@ export type ScorecardItemKey =
   | 'follow_pizzadao'
   | 'signup_pizzadao';
 
+export interface ActionContext {
+  eventName: string;
+  eventUrl: string;
+  twitterHandles: string[];
+  telegramUrl: string | null;
+  onOpenPhotos: () => void;
+  onOpenScanner: () => void;
+}
+
 interface ScorecardItemProps {
   itemKey: ScorecardItemKey;
   completed: boolean;
   loading?: boolean;
   onComplete: (itemKey: ScorecardItemKey, proofUrl?: string, proofType?: string) => void;
+  actionContext: ActionContext;
 }
 
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
@@ -29,32 +40,93 @@ const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = 
   pizza_selfie: { label: 'Pizza selfie', emoji: '🍕' },
   sign_pizza_box: { label: 'Sign the party pizza box', emoji: '✍️' },
   join_telegram: { label: "Join your city's PizzaDAO Telegram", emoji: 'tg' },
-  follow_pizzadao: { label: 'Follow @pizza_dao', emoji: '🐦' },
+  follow_pizzadao: { label: 'Follow @pizza_dao', emoji: 'x' },
   signup_pizzadao: { label: 'Sign up on pizzadao.org', emoji: '🌐' },
 };
 
-export function ScorecardItem({ itemKey, completed, loading, onComplete }: ScorecardItemProps) {
+const XIcon = () => (
+  <svg width={20} height={20} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+const TelegramIcon = () => (
+  <svg viewBox="0 0 24 24" className="w-6 h-6" fill="#0088cc">
+    <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>
+  </svg>
+);
+
+/** Build share text that fits within maxLen chars */
+function buildShareText(base: string, handles: string[], maxLen: number): string {
+  let mentions = handles.map(h => `@${h}`);
+  let text = `${base}\n\n${mentions.join(' ')}`;
+  if (text.length <= maxLen) return text;
+  // Drop handles from end but always keep @Pizza_DAO (first)
+  while (mentions.length > 1 && text.length > maxLen) {
+    mentions.pop();
+    text = `${base}\n\n${mentions.join(' ')}`;
+  }
+  return text;
+}
+
+export function ScorecardItem({ itemKey, completed, loading, onComplete, actionContext }: ScorecardItemProps) {
   const [showInput, setShowInput] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  const [showPizzaBoxModal, setShowPizzaBoxModal] = useState(false);
   const config = ITEM_CONFIG[itemKey];
 
-  // Items that need URL proof
-  const needsUrlProof = itemKey === 'post';
-  // Auto-complete items (no user action needed from this UI)
-  const isAutoItem = itemKey === 'photo' || itemKey === 'vouch' || itemKey === 'pizza_selfie';
-  // Self-report items
-  const isSelfReport = itemKey === 'sign_pizza_box' || itemKey === 'join_telegram' || itemKey === 'follow_pizzadao' || itemKey === 'signup_pizzadao';
+  const isDisabled = itemKey === 'join_telegram' && !actionContext.telegramUrl;
 
   const handleAction = () => {
-    if (completed) return;
+    if (completed || isDisabled) return;
 
-    if (needsUrlProof) {
-      // Open Twitter intent first, then show input for URL
-      const tweetText = encodeURIComponent("Having a great time at the pizza party! @pizza_dao #PizzaDAO");
-      window.open(`https://twitter.com/intent/tweet?text=${tweetText}`, '_blank');
-      setShowInput(true);
-    } else if (isSelfReport) {
-      onComplete(itemKey, undefined, 'self_report');
+    switch (itemKey) {
+      case 'post': {
+        const city = actionContext.eventName.replace(/^Global Pizza Party\s*/i, '') || actionContext.eventName;
+        const baseText = `\u{1F5FA}\uFE0F\u{1F355}\u{1F973}\nI'm at the Global Pizza Party in ${city}!`;
+        // Build deduplicated handles list, always starting with Pizza_DAO
+        const allHandles = ['Pizza_DAO', ...actionContext.twitterHandles];
+        const seen = new Set<string>();
+        const uniqueHandles: string[] = [];
+        for (const h of allHandles) {
+          const normalized = h.replace(/^@/, '').trim();
+          if (normalized && !seen.has(normalized.toLowerCase())) {
+            seen.add(normalized.toLowerCase());
+            uniqueHandles.push(normalized);
+          }
+        }
+        const shareText = buildShareText(baseText, uniqueHandles, 250);
+        const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(actionContext.eventUrl)}`;
+        window.open(intentUrl, '_blank');
+        setShowInput(true);
+        break;
+      }
+      case 'photo':
+        actionContext.onOpenPhotos();
+        break;
+      case 'vouch':
+        actionContext.onOpenScanner();
+        break;
+      case 'pizza_selfie':
+        onComplete(itemKey, undefined, 'self_report');
+        break;
+      case 'sign_pizza_box':
+        setShowPizzaBoxModal(true);
+        break;
+      case 'join_telegram':
+        if (actionContext.telegramUrl) {
+          window.open(actionContext.telegramUrl, '_blank');
+          onComplete(itemKey, undefined, 'self_report');
+        }
+        break;
+      case 'follow_pizzadao':
+        window.open('https://x.com/pizza_dao', '_blank');
+        onComplete(itemKey, undefined, 'self_report');
+        break;
+      case 'signup_pizzadao':
+        window.open('https://pizzadao.org', '_blank');
+        onComplete(itemKey, undefined, 'self_report');
+        break;
     }
   };
 
@@ -66,12 +138,24 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
   };
 
   const getActionLabel = (): string => {
-    if (itemKey === 'post') return 'Share';
-    if (itemKey === 'sign_pizza_box') return 'I signed it!';
-    if (itemKey === 'join_telegram') return 'I joined!';
-    if (itemKey === 'follow_pizzadao') return 'I followed!';
-    if (itemKey === 'signup_pizzadao') return 'I signed up!';
-    return '';
+    switch (itemKey) {
+      case 'post': return 'Share';
+      case 'photo': return 'Upload';
+      case 'vouch': return 'Scan QR';
+      case 'pizza_selfie': return 'I took one!';
+      case 'sign_pizza_box': return 'I signed it!';
+      case 'join_telegram': return 'I joined!';
+      case 'follow_pizzadao': return 'I followed!';
+      case 'signup_pizzadao': return 'I signed up!';
+      default: return '';
+    }
+  };
+
+  const renderEmoji = () => {
+    if (completed) return '✅';
+    if (config.emoji === 'tg') return <TelegramIcon />;
+    if (config.emoji === 'x') return <XIcon />;
+    return config.emoji;
   };
 
   return (
@@ -79,11 +163,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
       <div className={`flex items-center gap-3 py-2.5 px-3 rounded-lg transition-colors ${completed ? 'bg-green-500/10' : 'bg-white/5 hover:bg-white/10'}`}>
         {/* Emoji */}
         <span className="w-8 h-8 flex items-center justify-center flex-shrink-0 text-2xl leading-none">
-          {completed ? '✅' : config.emoji === 'tg' ? (
-            <svg viewBox="0 0 24 24" className="w-6 h-6" fill="#0088cc">
-              <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>
-            </svg>
-          ) : config.emoji}
+          {renderEmoji()}
         </span>
 
         {/* Label */}
@@ -96,12 +176,11 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
           <Loader2 className="w-4 h-4 animate-spin text-white/50" />
         ) : completed ? (
           <span className="text-xs text-green-400 font-medium">Done</span>
-        ) : isAutoItem ? (
-          <span className="text-xs text-white/40">Auto</span>
         ) : (
           <button
             onClick={handleAction}
-            className="text-xs font-medium px-3 py-1.5 rounded-full bg-[#ff393a] hover:bg-[#ff5a5b] text-white transition-colors"
+            disabled={isDisabled}
+            className="text-xs font-medium px-3 py-1.5 rounded-full bg-[#ff393a] hover:bg-[#ff5a5b] text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {getActionLabel()}
           </button>
@@ -126,6 +205,41 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
               className="px-3 py-1.5 rounded bg-[#ff393a] hover:bg-[#ff5a5b] text-white text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Submit
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Pizza Box Modal */}
+      {showPizzaBoxModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          onClick={() => setShowPizzaBoxModal(false)}
+        >
+          <div
+            className="bg-[#1a1a2e] border border-white/10 rounded-xl max-w-sm w-full mx-4 p-6 relative"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setShowPizzaBoxModal(false)}
+              className="absolute top-3 right-3 text-white/50 hover:text-white"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <h3 className="text-lg font-bold text-white mb-3">Sign the Pizza Box</h3>
+            <p className="text-sm text-white/70 mb-4">
+              It's a PizzaDAO tradition! Every party has a pizza box that all guests
+              sign as a memento. Find the party pizza box, grab a marker, and leave
+              your mark -- your name, a doodle, a message, anything goes!
+            </p>
+            <button
+              onClick={() => {
+                onComplete('sign_pizza_box', undefined, 'self_report');
+                setShowPizzaBoxModal(false);
+              }}
+              className="w-full py-2.5 rounded-lg bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium transition-colors"
+            >
+              I signed it!
             </button>
           </div>
         </div>

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -219,17 +219,18 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
           onClick={() => setShowPizzaSelfieModal(false)}
         >
           <div
-            className="bg-[#1a1a2e] border border-white/10 rounded-xl max-w-sm w-full mx-4 p-6 relative"
+            className="rounded-2xl shadow-lg max-w-sm w-full mx-4 p-7 relative"
+            style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)' }}
             onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={() => setShowPizzaSelfieModal(false)}
-              className="absolute top-3 right-3 text-white/50 hover:text-white"
+              className="absolute top-3 right-3 text-black/40 hover:text-black/70"
             >
               <X className="w-5 h-5" />
             </button>
-            <h3 className="text-lg font-bold text-white mb-3">Pizza Selfie</h3>
-            <p className="text-sm text-white/70 mb-4">
+            <h3 className="text-lg font-bold text-[#1a1a1a] mb-3">Pizza Selfie</h3>
+            <p className="text-sm text-[#555] mb-4">
               Take a selfie with a slice of pizza and upload it to the photo gallery!
             </p>
             {!selfieUploaded ? (
@@ -238,7 +239,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
                   actionContext.onOpenPhotos();
                   setSelfieUploaded(true);
                 }}
-                className="w-full py-2.5 rounded-lg bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium transition-colors"
+                className="w-full py-2.5 rounded-lg bg-[#E52828] hover:bg-[#CC2020] text-white font-medium transition-colors"
               >
                 Upload Photo
               </button>
@@ -264,17 +265,18 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
           onClick={() => setShowPizzaBoxModal(false)}
         >
           <div
-            className="bg-[#1a1a2e] border border-white/10 rounded-xl max-w-sm w-full mx-4 p-6 relative"
+            className="rounded-2xl shadow-lg max-w-sm w-full mx-4 p-7 relative"
+            style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)' }}
             onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={() => setShowPizzaBoxModal(false)}
-              className="absolute top-3 right-3 text-white/50 hover:text-white"
+              className="absolute top-3 right-3 text-black/40 hover:text-black/70"
             >
               <X className="w-5 h-5" />
             </button>
-            <h3 className="text-lg font-bold text-white mb-3">Sign the Pizza Box</h3>
-            <p className="text-sm text-white/70 mb-4">
+            <h3 className="text-lg font-bold text-[#1a1a1a] mb-3">Sign the Pizza Box</h3>
+            <p className="text-sm text-[#555] mb-4">
               It's a PizzaDAO tradition! Every party has a pizza box that all guests
               sign as a memento. Find the party pizza box, grab a marker, and leave
               your mark -- your name, a doodle, a message, anything goes!
@@ -284,7 +286,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
                 onComplete('sign_pizza_box', undefined, 'self_report');
                 setShowPizzaBoxModal(false);
               }}
-              className="w-full py-2.5 rounded-lg bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium transition-colors"
+              className="w-full py-2.5 rounded-lg bg-[#E52828] hover:bg-[#CC2020] text-white font-medium transition-colors"
             >
               I signed it!
             </button>

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -73,6 +73,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
   const [showInput, setShowInput] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [showPizzaBoxModal, setShowPizzaBoxModal] = useState(false);
+  const [showPizzaSelfieModal, setShowPizzaSelfieModal] = useState(false);
   const config = ITEM_CONFIG[itemKey];
 
   const isDisabled = itemKey === 'join_telegram' && !actionContext.telegramUrl;
@@ -108,7 +109,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
         actionContext.onOpenScanner();
         break;
       case 'pizza_selfie':
-        onComplete(itemKey, undefined, 'self_report');
+        setShowPizzaSelfieModal(true);
         break;
       case 'sign_pizza_box':
         setShowPizzaBoxModal(true);
@@ -189,8 +190,8 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
 
       {/* URL Input (for post item) - appears below the row */}
       {showInput && !completed && (
-        <div className="ml-11 p-3 bg-[#1a1a2e] border border-white/10 rounded-lg">
-          <p className="text-xs text-white/60 mb-2">Paste the link to your post:</p>
+        <div className="ml-11 p-3 bg-theme-surface border border-theme-stroke rounded-lg">
+          <p className="text-xs text-theme-text-muted mb-2">Paste the link to your post:</p>
           <div className="flex gap-2">
             <IconInput
               icon={Link2}
@@ -205,6 +206,40 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
               className="px-3 py-1.5 rounded bg-[#ff393a] hover:bg-[#ff5a5b] text-white text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Submit
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Pizza Selfie Modal */}
+      {showPizzaSelfieModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          onClick={() => setShowPizzaSelfieModal(false)}
+        >
+          <div
+            className="bg-[#1a1a2e] border border-white/10 rounded-xl max-w-sm w-full mx-4 p-6 relative"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setShowPizzaSelfieModal(false)}
+              className="absolute top-3 right-3 text-white/50 hover:text-white"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <h3 className="text-lg font-bold text-white mb-3">Pizza Selfie</h3>
+            <p className="text-sm text-white/70 mb-4">
+              Take a selfie with a slice of pizza and upload it to the photo gallery!
+            </p>
+            <button
+              onClick={() => {
+                setShowPizzaSelfieModal(false);
+                actionContext.onOpenPhotos();
+                onComplete('pizza_selfie', undefined, 'self_report');
+              }}
+              className="w-full py-2.5 rounded-lg bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium transition-colors"
+            >
+              Upload Photo
             </button>
           </div>
         </div>

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -74,6 +74,7 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
   const [inputValue, setInputValue] = useState('');
   const [showPizzaBoxModal, setShowPizzaBoxModal] = useState(false);
   const [showPizzaSelfieModal, setShowPizzaSelfieModal] = useState(false);
+  const [selfieUploaded, setSelfieUploaded] = useState(false);
   const config = ITEM_CONFIG[itemKey];
 
   const isDisabled = itemKey === 'join_telegram' && !actionContext.telegramUrl;
@@ -231,16 +232,27 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete, actionC
             <p className="text-sm text-white/70 mb-4">
               Take a selfie with a slice of pizza and upload it to the photo gallery!
             </p>
-            <button
-              onClick={() => {
-                setShowPizzaSelfieModal(false);
-                actionContext.onOpenPhotos();
-                onComplete('pizza_selfie', undefined, 'self_report');
-              }}
-              className="w-full py-2.5 rounded-lg bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium transition-colors"
-            >
-              Upload Photo
-            </button>
+            {!selfieUploaded ? (
+              <button
+                onClick={() => {
+                  actionContext.onOpenPhotos();
+                  setSelfieUploaded(true);
+                }}
+                className="w-full py-2.5 rounded-lg bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium transition-colors"
+              >
+                Upload Photo
+              </button>
+            ) : (
+              <button
+                onClick={() => {
+                  setShowPizzaSelfieModal(false);
+                  onComplete('pizza_selfie', undefined, 'self_report');
+                }}
+                className="w-full py-2.5 rounded-lg bg-green-500 hover:bg-green-600 text-white font-medium transition-colors"
+              >
+                I uploaded my selfie!
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1047,6 +1047,8 @@ export function EventPage() {
                       ...(event.coHosts || []).filter((c: any) => c.twitter).map((c: any) => c.twitter),
                       ...(event.sponsors || []).filter((s) => s.brandTwitter).map((s) => s.brandTwitter!),
                     ]}
+                    guestId={existingGuestData?.id || ''}
+                    guestName={existingGuestData?.name || user?.name || ''}
                     onOpenPhotos={() => setShowPhotos(true)}
                     onOpenScanner={() => setShowScanner(true)}
                   />

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -33,6 +33,7 @@ import { ParticipatingPizzerias } from '../components/ParticipatingPizzerias';
 import { LastYearPhotos } from '../components/LastYearPhotos';
 import VenueMap from '../components/VenueMap';
 import { CheckInButton } from '../components/CheckInButton';
+import { CheckInScanner } from '../components/CheckInScanner';
 import { GuestScorecard } from '../components/scorecard';
 
 export function EventPage() {
@@ -58,6 +59,7 @@ export function EventPage() {
   const [existingGuestData, setExistingGuestData] = useState<ExistingGuestData | null>(null);
   const [photoStats, setPhotoStats] = useState<PhotoStats | null>(null);
   const [showPhotos, setShowPhotos] = useState(false);
+  const [showScanner, setShowScanner] = useState(false);
   const [showPizzaChef, setShowPizzaChef] = useState(false);
   const [showPizzaDAO, setShowPizzaDAO] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -1034,7 +1036,20 @@ export function EventPage() {
 
                 {/* Guest Scorecard - shown after check-in on event day */}
                 {isEventDay && existingGuestData?.checkedInAt && (
-                  <GuestScorecard inviteCode={event.customUrl || event.inviteCode} />
+                  <GuestScorecard
+                    inviteCode={event.customUrl || event.inviteCode}
+                    eventName={event.name}
+                    eventImageUrl={event.eventImageUrl}
+                    customUrl={event.customUrl}
+                    telegramUrl={event.telegramGroup || null}
+                    twitterHandles={[
+                      ...(event.hostProfile?.twitter ? [event.hostProfile.twitter] : []),
+                      ...(event.coHosts || []).filter((c: any) => c.twitter).map((c: any) => c.twitter),
+                      ...(event.sponsors || []).filter((s) => s.brandTwitter).map((s) => s.brandTwitter!),
+                    ]}
+                    onOpenPhotos={() => setShowPhotos(true)}
+                    onOpenScanner={() => setShowScanner(true)}
+                  />
                 )}
 
                 {/* Guest Count - Mobile */}
@@ -1347,6 +1362,15 @@ export function EventPage() {
         isOpen={showPizzaDAO}
         onClose={() => setShowPizzaDAO(false)}
       />
+
+      {showScanner && (
+        <CheckInScanner
+          inviteCode={event.customUrl || event.inviteCode}
+          currentGuestId={existingGuestData?.id}
+          onVouchSuccess={() => setShowScanner(false)}
+          onClose={() => setShowScanner(false)}
+        />
+      )}
 
       {ConfettiOverlay}
     </div>


### PR DESCRIPTION
## Summary
- Make all 8 scorecard items interactive with real actions (post tweet, upload photo, QR scan, pizza selfie, sign pizza box, join Telegram, follow @pizza_dao, sign up on pizzadao.org)
- Pizza selfie uses two-step flow: open photo gallery → confirm upload
- Tweet intent includes event-specific text with city name and @handles from host/cohosts/sponsors
- Theme-aware styling for post URL input
- Telegram button disabled when event has no telegram URL

## Files changed
- `ScorecardItem.tsx` — ActionContext interface, per-item switch logic, pizza box + pizza selfie modals, X/Telegram SVGs
- `GuestScorecard.tsx` — expanded props, builds ActionContext from event data
- `EventPage.tsx` — passes event data to GuestScorecard, renders CheckInScanner for vouch item

## Test plan
- [ ] Visit preview at `/scorecardtest` as a checked-in guest
- [ ] Verify each scorecard item triggers the correct action
- [ ] Verify pizza selfie requires photo upload before marking complete
- [ ] Verify tweet text includes correct @handles
- [ ] Verify Telegram button is disabled when no URL set

🤖 Generated with [Claude Code](https://claude.com/claude-code)