### PR TITLE
blackolive-76568: Google Maps geocoder fallback for CJK venue addresses

### DIFF
--- a/frontend/src/components/VenueMap.tsx
+++ b/frontend/src/components/VenueMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { MapPin } from 'lucide-react';
-import { geocodeAddress } from '../lib/ordering';
+import { geocodeAddress, geocodeAddressGoogle } from '../lib/ordering';
 
 interface VenueMapProps {
   address: string;
@@ -11,12 +11,70 @@ interface VenueMapProps {
   zoom?: number;
 }
 
+// Module-scope singleton: ensures we only inject the Maps JS SDK once per
+// page even when multiple <VenueMap> instances mount (EventPage renders 3:
+// the mobile square thumbnail, the desktop side-by-side, and the mobile
+// location section). Without this, each instance races to insert its own
+// <script> and the SDK warns "You have included the Google Maps JavaScript
+// API multiple times".
+let mapsLoaderPromise: Promise<void> | null = null;
+
+function loadGoogleMaps(apiKey: string): Promise<void> {
+  if (typeof window !== 'undefined' && window.google?.maps) {
+    return Promise.resolve();
+  }
+  if (mapsLoaderPromise) return mapsLoaderPromise;
+
+  mapsLoaderPromise = new Promise<void>((resolve, reject) => {
+    // Some other component on the page may have already inserted the script.
+    // Wait for it to finish loading instead of duplicating it.
+    const existingScript = document.querySelector(
+      'script[src*="maps.googleapis.com/maps/api/js"]'
+    );
+
+    if (existingScript) {
+      const waitForMaps = () => {
+        if (window.google?.maps) {
+          resolve();
+        } else {
+          setTimeout(waitForMaps, 100);
+        }
+      };
+      waitForMaps();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=Function.prototype`;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      // Reset so a future mount can retry (e.g. transient network failure
+      // during initial page load).
+      mapsLoaderPromise = null;
+      reject(new Error('Failed to load Google Maps JS SDK'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return mapsLoaderPromise;
+}
+
 /**
  * Dynamic Google Maps JS SDK venue thumbnail with a single red pin at the
  * geocoded venue address. Uses the same dynamic-loader + script-tag-collision
  * pattern as ParticipatingPizzeriasMap.tsx / GPPMap.tsx. Fills its parent
  * container via `className` so callers control sizing (aspect-square, w-[40%]
  * absolute, w-full h-48, etc.).
+ *
+ * Geocoding pipeline (in priority order):
+ *   1. Stored `latitude`/`longitude` props — no network call.
+ *   2. `geocodeAddress` (Nominatim, OSM) — handles English/European addresses
+ *      with no Google quota cost.
+ *   3. `geocodeAddressGoogle` (Maps JS SDK Geocoder) — fallback for the long
+ *      tail (CJK script, unusual transliterations) where Nominatim returns
+ *      zero results.
  */
 export default function VenueMap({
   address,
@@ -32,9 +90,7 @@ export default function VenueMap({
   const [location, setLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [error, setError] = useState(false);
 
-  // Use stored lat/lng if available; otherwise geocode the venue address.
-  // We use the existing `geocodeAddress` helper as the fallback so behavior
-  // matches the distance badges in ParticipatingPizzerias.
+  // Resolve coordinates: stored props → Nominatim → Google SDK Geocoder.
   useEffect(() => {
     let cancelled = false;
     if (!address) {
@@ -42,19 +98,39 @@ export default function VenueMap({
       return;
     }
 
-    // If stored coordinates are provided, use them directly (no network call)
+    // Path 1: stored coordinates — no network call.
     if (latitude != null && longitude != null) {
       setLocation({ lat: latitude, lng: longitude });
       return;
     }
 
-    // Fallback: client-side geocoding via Nominatim
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
     (async () => {
       try {
-        const result = await geocodeAddress(address);
+        // Path 2: Nominatim (free, no Google quota cost). Handles the
+        // common case of English/European addresses.
+        const nominatimResult = await geocodeAddress(address);
         if (cancelled) return;
-        if (result) {
-          setLocation(result);
+        if (nominatimResult) {
+          setLocation(nominatimResult);
+          return;
+        }
+
+        // Path 3: Google SDK Geocoder fallback. Handles CJK-script
+        // addresses (e.g. Shenzhen) and other long-tail cases where
+        // Nominatim returns zero results. Skip if no API key, since
+        // we couldn't render the map anyway.
+        if (!apiKey) {
+          setError(true);
+          return;
+        }
+        await loadGoogleMaps(apiKey);
+        if (cancelled) return;
+        const googleResult = await geocodeAddressGoogle(address);
+        if (cancelled) return;
+        if (googleResult) {
+          setLocation(googleResult);
         } else {
           setError(true);
         }
@@ -78,8 +154,10 @@ export default function VenueMap({
     }
     if (!location) return;
 
+    let cancelled = false;
+
     const initMap = () => {
-      if (!containerRef.current) return;
+      if (cancelled || !containerRef.current) return;
 
       if (!mapRef.current) {
         mapRef.current = new google.maps.Map(containerRef.current, {
@@ -113,34 +191,15 @@ export default function VenueMap({
       });
     };
 
-    if (window.google?.maps) {
-      initMap();
-      return;
-    }
+    loadGoogleMaps(apiKey)
+      .then(() => initMap())
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
 
-    const existingScript = document.querySelector(
-      'script[src*="maps.googleapis.com/maps/api/js"]'
-    );
-
-    if (existingScript) {
-      const waitForMaps = () => {
-        if (window.google?.maps) {
-          initMap();
-        } else {
-          setTimeout(waitForMaps, 100);
-        }
-      };
-      waitForMaps();
-      return;
-    }
-
-    const script = document.createElement('script');
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=Function.prototype`;
-    script.async = true;
-    script.defer = true;
-    script.onload = () => initMap();
-    script.onerror = () => setError(true);
-    document.head.appendChild(script);
+    return () => {
+      cancelled = true;
+    };
   }, [location, venueName, address, zoom]);
 
   // No address → render a subtle placeholder so the parent layout still has

--- a/frontend/src/lib/ordering.ts
+++ b/frontend/src/lib/ordering.ts
@@ -84,6 +84,44 @@ export async function geocodeAddress(address: string): Promise<{ lat: number; ln
   return null;
 }
 
+// Geocode an address using the already-loaded Google Maps JS SDK Geocoder.
+// The caller is responsible for awaiting `loadGoogleMaps()` before invoking
+// this — we only do a defensive guard and return null if the SDK is missing.
+//
+// Used as a second-stage fallback in `VenueMap.tsx` when Nominatim returns
+// no result (e.g. for Chinese-script addresses like Shenzhen's). Reuses the
+// same browser-referrer-restricted Maps JS key already loaded for the map
+// render itself, so no extra key configuration is needed. Geocoding API
+// quota is billed separately from Maps JS map loads, so callers should only
+// invoke this on the long-tail miss path, never as a first try.
+export async function geocodeAddressGoogle(
+  address: string
+): Promise<{ lat: number; lng: number } | null> {
+  if (typeof window === 'undefined' || !window.google?.maps?.Geocoder) {
+    return null;
+  }
+
+  try {
+    const geocoder = new window.google.maps.Geocoder();
+    return await new Promise<{ lat: number; lng: number } | null>((resolve) => {
+      geocoder.geocode({ address }, (results, status) => {
+        if (status !== 'OK' || !results || results.length === 0) {
+          resolve(null);
+          return;
+        }
+        const loc = results[0].geometry?.location;
+        if (!loc) {
+          resolve(null);
+          return;
+        }
+        resolve({ lat: loc.lat(), lng: loc.lng() });
+      });
+    });
+  } catch {
+    return null;
+  }
+}
+
 // Create a Square order
 export async function createSquareOrder(
   locationId: string,


### PR DESCRIPTION
## Problem

`rsv.pizza/shenzhen` shows the gradient "no map" placeholder (a `MapPin` icon over a red/orange gradient) instead of an actual venue map with a pin.

The Shenzhen party has `latitude: null` / `longitude: null` and a Chinese-script address (`南山区前海嘉里中心T2栋102号铺`). Same bug occurs for any future event whose address is in CJK script (Chinese/Japanese/Korean) and lacks stored lat/lng. Since GPP is global, this is not a one-off.

## Root cause

`VenueMap.tsx` falls back to `geocodeAddress(address)` (Nominatim) when stored lat/lng are missing. Nominatim returns zero results for the URL-encoded Chinese-script address, so the component calls `setError(true)` and renders the placeholder.

The Google Maps Geocoder *does* return a valid result for the same address. The Maps JS SDK is already loaded later in the same component for the map render itself — we just need to load it earlier and run the Geocoder as a fallback.

## Approach (Option A — Google Maps JS SDK Geocoder)

Geocoding pipeline (in priority order):

1. Stored `latitude`/`longitude` props → use directly. No network call. Unchanged.
2. `geocodeAddress` (Nominatim, OSM) → handles English/European addresses with no Google quota cost.
3. **New:** `geocodeAddressGoogle` (Maps JS SDK Geocoder) → fallback for the long tail (CJK script, unusual transliterations).

Order matters: Nominatim first preserves the zero-Google-cost path for the common case and only burns quota on the long-tail miss path.

### Files changed

- `frontend/src/lib/ordering.ts` — added `geocodeAddressGoogle(address)` helper. Promise-wraps the callback-style SDK Geocoder. Defensive guard returns `null` if the SDK isn't loaded yet (the caller is responsible for awaiting `loadGoogleMaps()` first).
- `frontend/src/components/VenueMap.tsx` — extracted a module-scope `loadGoogleMaps(apiKey)` singleton so multiple `<VenueMap>` mounts on the same page share one SDK load (EventPage renders 3 instances). Refactored the geocoding `useEffect` to chain Nominatim → `loadGoogleMaps` → Google geocode → `setError`. Replaced the inline duplicate loader in the map-render `useEffect` with the same singleton.

All existing behavior preserved: marker icon (`/molto-benny.png` 54×54 anchored at 27,54), `disableDefaultUI`, `gestureHandling: 'greedy'`, `zoomControl`, `mapTypeId: 'roadmap'`, `data-testid="venue-map"`, and both placeholder branches (no-address and error).

Why Option A over the Geocoding REST API: the existing key is browser-referrer-restricted; the SDK Geocoder uses the same `maps/api/js` endpoint that already works in production. No new key configuration, no separate quota line item.

## Vercel preview

https://rsvpizza-git-blackolive-76568-google-geocode-pizza-dao.vercel.app
(slug is 54 chars, under the 63-char DNS limit)

## Test plan

- [ ] Visit `<preview>/shenzhen` — expect interactive Google Map with the molto-benny pin centered on the Shenzhen venue. No gradient placeholder.
  - [ ] Browser DevTools → Network: one call to `nominatim.openstreetmap.org/search` returns `[]`, then SDK Geocoder call succeeds.
- [ ] Visit a known event with stored lat/lng (any US event) on the same preview — expect map renders, zero Nominatim calls, zero geocoder calls (path 1 short-circuits).
- [ ] Visit a known event with English-script address but null lat/lng — expect map renders, one Nominatim call returns a result, no Google geocoder call (path 2 short-circuits).
- [ ] Visit any EventPage on desktop and mobile widths to exercise all three `<VenueMap>` mount sites — confirm no console errors and no "You have included the Google Maps JavaScript API multiple times" warning (the singleton loader prevents duplicate `<script>` tags).

## Out of scope (follow-ups from the plan)

- Backfilling stored `latitude`/`longitude` for events with CJK addresses (one-off backend task: server-side geocode + UPDATE).
- Switching the pizzeria-search / RSVP flows (`useRSVPForm.ts`, `PizzeriaSelection.tsx`, `PizzeriaSearch.tsx`, `PizzaOrderSummary.tsx`) to also use the Google geocoder fallback — they stay on Nominatim-only for now.
- Caching geocoder results in localStorage to save quota across reloads.

## Deviations from plan

None. Implementation matches `plans/blackolive-76568-google-geocode-fallback.md`. (Note: the implementation was done on a branch checked out in the main repo rather than in a `git worktree`, because the harness's Bash sandbox blocked `git` operations targeting any worktree path — the file edits and resulting commit are identical to what a worktree workflow would have produced.)