### PR TITLE
artichoke-93963: add copy email buttons in admin sections

### DIFF
--- a/frontend/src/components/CopyEmailButton.tsx
+++ b/frontend/src/components/CopyEmailButton.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyEmailButtonProps {
+  email: string;
+  size?: number;
+  className?: string;
+}
+
+export function CopyEmailButton({ email, size = 12, className = '' }: CopyEmailButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard.writeText(email);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`shrink-0 opacity-40 hover:opacity-100 transition-opacity text-theme-text-faint ${className}`}
+      title="Copy email"
+    >
+      {copied ? <Check size={size} className="text-green-400" /> : <Copy size={size} />}
+    </button>
+  );
+}

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote, ChevronLeft, ChevronRight, MessageCircle } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
+import { CopyEmailButton } from '../CopyEmailButton';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
 import { triggerFlyerRegenForEvents } from '../flyer/autoRegenFlyer';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
@@ -610,7 +611,10 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
             />
           </div>
           {event.host.email && (
-            <div className="text-xs text-theme-text-faint truncate max-w-[150px]">{event.host.email}</div>
+            <div className="flex items-center gap-1">
+              <div className="text-xs text-theme-text-faint truncate max-w-[150px]">{event.host.email}</div>
+              <CopyEmailButton email={event.host.email} />
+            </div>
           )}
           <HostTagsPills
             tags={eventTags}

--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Handshake, Plus, Edit2, Trash2, RefreshCw, Check, AlertCircle, GripVertical, Copy, Image } from 'lucide-react';
+import { Handshake, Plus, Edit2, Trash2, RefreshCw, Check, AlertCircle, GripVertical, Image } from 'lucide-react';
 import { fetchSponsorUsers, createSponsorUser, updateSponsorUser, deleteSponsorUser, reorderSponsorUsers } from '../../lib/api';
 import { proxyAvatarToStorage } from '../../lib/supabase';
 import type { SponsorUser, UnderbossEvent } from '../../types';
 import { PartnerForm } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
 import { PartnerCitiesFlyer } from './PartnerCitiesFlyer';
+import { CopyEmailButton } from '../CopyEmailButton';
 
 interface PartnerManagerProps {
   isAdmin?: boolean;
@@ -24,7 +25,6 @@ export function PartnerManager({ isAdmin, events, onSyncComplete, onFlyerRegenNe
   const [saving, setSaving] = useState(false);
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [copiedEmail, setCopiedEmail] = useState<string | null>(null);
   const [flyerPartnerId, setFlyerPartnerId] = useState<string | null>(null);
 
   const loadPartners = useCallback(async () => {
@@ -261,18 +261,7 @@ export function PartnerManager({ isAdmin, events, onSyncComplete, onFlyerRegenNe
                   </div>
                   <div className="flex items-center gap-1">
                     <div className="text-xs text-theme-text-faint truncate">{partner.email}</div>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        navigator.clipboard.writeText(partner.email);
-                        setCopiedEmail(partner.id);
-                        setTimeout(() => setCopiedEmail(null), 1500);
-                      }}
-                      className="shrink-0 opacity-40 hover:opacity-100 transition-opacity text-theme-text-faint"
-                      title="Copy email"
-                    >
-                      {copiedEmail === partner.id ? <Check size={12} className="text-green-400" /> : <Copy size={12} />}
-                    </button>
+                    <CopyEmailButton email={partner.email} />
                   </div>
                   <div className="flex items-center gap-3 mt-1">
                     {partner.autoCoHost && (

--- a/frontend/src/i18n/locales/de/event.json
+++ b/frontend/src/i18n/locales/de/event.json
@@ -44,7 +44,7 @@
     "ens": "(Ethereum Name Service) ist das dezentrale Namensprotokoll, das menschenlesbare Namen im Internet ermöglicht. Anstatt lange, komplexe Blockchain-Adressen zu kopieren und einzufügen, können Sie mit ENS diese durch einen einfachen, einprägsamen Namen ersetzen (wie pizzadao.eth), der in Wallets, Apps und im dezentralen Web funktioniert.",
     "brave": "Browser ist ein schneller, privater und sicherer Webbrowser für PC, Mac und Mobilgeräte. Jetzt herunterladen für ein schnelleres, werbefreies Surferlebnis, das Daten spart.",
     "wpc": "ist eine in den USA ansässige gemeinnützige, multinationale Gruppe von Elite-Pizza-Fachleuten. Sie engagiert sich für Bildungsarbeit, Gemeinschaftsdienst und die Förderung von Pizza!",
-    "ownTheDoge": "ist die Community, die gemeinsam das ikonische Doge-Meme besitzt, geprägt von Kabosus Besitzerin Atsuko Sato, über $DOG. Inhaber können $DOG sperren, um „Doge Pixel"-NFTs aus dem berühmten Bild zu prägen.",
+    "ownTheDoge": "ist die Community, die gemeinsam das ikonische Doge-Meme besitzt, geprägt von Kabosus Besitzerin Atsuko Sato, über $DOG. Inhaber können $DOG sperren, um „Doge Pixel“-NFTs aus dem berühmten Bild zu prägen.",
     "swcEu": "ist eine gemeinnützige Organisation, die sich für klare und vernünftige Krypto-Regulierungen einsetzt. Wenn Sie an die Kraft der Blockchain glauben und möchten, dass die EU und Ihre Regierung ein positives Geschäfts- und Politikumfeld für Krypto-Assets und Blockchain-Technologie fördern, lassen Sie Ihre Stimme hören."
   },
   "dateTbd": "Datum folgt",

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { GPPClouds } from '../components/GPPClouds';
 import { IconInput } from '../components/IconInput';
+import { CopyEmailButton } from '../components/CopyEmailButton';
 import { FunnelTab } from '../components/underboss/FunnelTab';
 import {
   Shield, ShieldCheck, UserPlus, Trash2, Loader2,
@@ -625,7 +626,12 @@ export function AdminPage() {
                 <tbody>
                   {admins.map((admin) => (
                     <tr key={admin.id} className="border-b border-theme-stroke hover:bg-theme-surface transition-colors">
-                      <td className="px-4 py-3 text-theme-text">{admin.email}</td>
+                      <td className="px-4 py-3 text-theme-text">
+                        <div className="flex items-center gap-2">
+                          <span>{admin.email}</span>
+                          <CopyEmailButton email={admin.email} />
+                        </div>
+                      </td>
                       <td className="px-4 py-3 text-theme-text-secondary">{admin.name || '-'}</td>
                       <td className="px-4 py-3">
                         <span
@@ -732,7 +738,12 @@ export function AdminPage() {
                 <tbody>
                   {graphicsAdmins.map((ga) => (
                     <tr key={ga.id} className="border-b border-theme-stroke hover:bg-theme-surface transition-colors">
-                      <td className="px-4 py-3 text-theme-text">{ga.email}</td>
+                      <td className="px-4 py-3 text-theme-text">
+                        <div className="flex items-center gap-2">
+                          <span>{ga.email}</span>
+                          <CopyEmailButton email={ga.email} />
+                        </div>
+                      </td>
                       <td className="px-4 py-3 text-theme-text-secondary">{ga.name || '-'}</td>
                       <td className="px-4 py-3 text-theme-text-muted">
                         {new Date(ga.createdAt).toLocaleDateString()}
@@ -849,7 +860,12 @@ export function AdminPage() {
                   {underbosses.map((ub) => (
                     <tr key={ub.id} className="border-b border-theme-stroke hover:bg-theme-surface transition-colors">
                       <td className="px-4 py-3 text-theme-text">{ub.name}</td>
-                      <td className="px-4 py-3 text-theme-text-secondary">{ub.email}</td>
+                      <td className="px-4 py-3 text-theme-text-secondary">
+                        <div className="flex items-center gap-2">
+                          <span>{ub.email}</span>
+                          <CopyEmailButton email={ub.email} />
+                        </div>
+                      </td>
                       <td className="px-4 py-3 text-theme-text-secondary">
                         {editingUbId === ub.id ? (
                           <div>
@@ -1016,7 +1032,12 @@ export function AdminPage() {
                 <tbody>
                   {sponsorUsers.map((sp) => (
                     <tr key={sp.id} className="border-b border-theme-stroke hover:bg-theme-surface transition-colors">
-                      <td className="px-4 py-3 text-theme-text">{sp.email}</td>
+                      <td className="px-4 py-3 text-theme-text">
+                        <div className="flex items-center gap-2">
+                          <span>{sp.email}</span>
+                          <CopyEmailButton email={sp.email} />
+                        </div>
+                      </td>
                       <td className="px-4 py-3 text-theme-text-secondary">{sp.name || '-'}</td>
                       <td className="px-4 py-3">
                         <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700 border border-purple-300">

--- a/plans/artichoke-93963-admin-copy-email-buttons.md
+++ b/plans/artichoke-93963-admin-copy-email-buttons.md
@@ -1,0 +1,142 @@
+# artichoke-93963 — Add copy email buttons to admin sections
+
+**Priority**: Medium
+**Task**: Add copy email buttons next to every email displayed in admin sections, matching the existing pattern on the partners tab of `/underboss` (PartnerManager.tsx).
+
+---
+
+## Reference pattern
+
+`frontend/src/components/underboss/PartnerManager.tsx` lines 264-275:
+
+```tsx
+<button
+  onClick={(e) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(partner.email);
+    setCopiedEmail(partner.id);
+    setTimeout(() => setCopiedEmail(null), 1500);
+  }}
+  className="shrink-0 opacity-40 hover:opacity-100 transition-opacity text-theme-text-faint"
+  title="Copy email"
+>
+  {copiedEmail === partner.id ? <Check size={12} className="text-green-400" /> : <Copy size={12} />}
+</button>
+```
+
+State at top of component:
+```tsx
+const [copiedEmail, setCopiedEmail] = useState<string | null>(null);
+```
+
+---
+
+## Approach
+
+Extract the pattern into a reusable component to avoid duplicating state in every consumer. Use it in all 5 locations and refactor `PartnerManager.tsx` to use it too.
+
+### New component
+
+**File**: `frontend/src/components/CopyEmailButton.tsx`
+
+```tsx
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyEmailButtonProps {
+  email: string;
+  size?: number;
+  className?: string;
+}
+
+export function CopyEmailButton({ email, size = 12, className = '' }: CopyEmailButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard.writeText(email);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`shrink-0 opacity-40 hover:opacity-100 transition-opacity text-theme-text-faint ${className}`}
+      title="Copy email"
+    >
+      {copied ? <Check size={size} className="text-green-400" /> : <Copy size={size} />}
+    </button>
+  );
+}
+```
+
+---
+
+## Files to modify
+
+### 1. `frontend/src/components/CopyEmailButton.tsx` — CREATE
+New reusable component as above.
+
+### 2. `frontend/src/pages/AdminPage.tsx` — 4 spots
+For each table row that renders an email in a `<td>`, wrap the email cell content in a flex container with the email text + `<CopyEmailButton email={x} />`.
+
+- **~line 639** (Admin list): `{admin.email}` → flex wrapper with `<CopyEmailButton email={admin.email} />`
+- **~line 746** (Graphics Admin list): `{ga.email}` → same
+- **~line 863** (Underboss list): `{ub.email}` → same
+- **~line 1030** (Sponsor/Partner list): `{sp.email}` → same
+
+Pattern for each `<td>`:
+```tsx
+<td className="px-4 py-3 text-theme-text">
+  <div className="flex items-center gap-2">
+    <span>{admin.email}</span>
+    <CopyEmailButton email={admin.email} />
+  </div>
+</td>
+```
+
+Add `import { CopyEmailButton } from '../components/CopyEmailButton';` at the top.
+
+### 3. `frontend/src/components/underboss/EventRow.tsx` — 1 spot
+**~line 613**: `event.host.email` is shown in a truncated div. Wrap in a flex container.
+
+```tsx
+{event.host.email && (
+  <div className="flex items-center gap-1">
+    <div className="text-xs text-theme-text-faint truncate max-w-[150px]">{event.host.email}</div>
+    <CopyEmailButton email={event.host.email} />
+  </div>
+)}
+```
+
+Add the import.
+
+### 4. `frontend/src/components/underboss/PartnerManager.tsx` — REFACTOR
+Replace the inline copy button (lines 264-275) with `<CopyEmailButton email={partner.email} />`. Remove the now-unused `copiedEmail` state and `setCopiedEmail` setter. Keep behavior identical.
+
+Add the import. Remove `Copy` and `Check` from `lucide-react` imports if they're no longer used elsewhere in the file (verify first — `Check` is also used at line 280 and 285, so it should stay).
+
+---
+
+## Verification
+
+After implementation:
+1. `cd frontend && npm run build` — must pass with no TypeScript errors
+2. Visual check on Vercel preview:
+   - `/admin` → Admins tab → click copy icon on a row → confirm icon flips to green check for 1.5s, email is in clipboard
+   - `/admin` → Graphics Admins tab → same
+   - `/admin` → Underbosses tab → same
+   - `/admin` → Partners tab → same
+   - `/underboss` → Events tab → click copy icon next to host email → same
+   - `/underboss` → Partners tab → confirm refactored button still works identically (the original existing one)
+3. Confirm clicking the copy button doesn't trigger row-level click handlers (the `e.stopPropagation()` covers this).
+
+---
+
+## Non-goals
+- Do NOT modify `ClickableEmail` component — it's used for domain-only links in other contexts.
+- Do NOT add copy buttons in non-admin places (event RSVP lists for guests, etc.) — out of scope for this task.
+- Do NOT add toast notifications — the inline check icon is the existing UX pattern.


### PR DESCRIPTION
## Summary
Adds a copy-email button next to every email shown in admin sections, matching the existing pattern on the `/underboss` partners tab.

- New `<CopyEmailButton email={x} />` shared component (`frontend/src/components/CopyEmailButton.tsx`)
- 5 locations updated:
  - `/admin` Admins tab
  - `/admin` Graphics Admins tab
  - `/admin` Underbosses tab
  - `/admin` Partners tab
  - `/underboss` Events tab → host email row
- Refactored `PartnerManager.tsx` to use the new component (removes duplicated `copiedEmail` state and the inline button)

## Test plan
- [ ] `/admin` → Admins tab → click copy icon → green check appears for 1.5s, email lands in clipboard
- [ ] Same for Graphics Admins, Underbosses, and Partners tabs
- [ ] `/underboss` Events tab → click copy next to host email → works, does not trigger row click
- [ ] `/underboss` Partners tab → existing copy button (now using the shared component) still works identically

Preview: https://rsvpizza-git-artichoke-93963-copy-email-pizza-dao.vercel.app

Generated with Claude Code.