### PR TITLE
jalapeno-59763: Fix missing RSVP page links in /underboss events list

### DIFF
--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -384,7 +384,7 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
 
   const hasNotes = !!(event.underbossNotes || notesValue.trim());
 
-  const eventUrl = event.customUrl ? `https://rsv.pizza/${event.customUrl}` : null;
+  const eventUrl = `https://rsv.pizza/${event.customUrl || event.inviteCode}`;
   const relTime = formatRelativeTime(event.date);
   const fullDate = formatFullDate(event.date);
 
@@ -419,11 +419,9 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
               <span className="w-2 h-2 rounded-full bg-blue-400 shrink-0" title="Community Listed" />
             )}
             <span className="text-sm font-medium text-theme-text truncate">{event.name.replace(/^Global Pizza Party\s*/i, '')}</span>
-            {eventUrl && (
-              <a href={eventUrl} target="_blank" rel="noopener noreferrer" className="text-theme-text-faint hover:text-theme-text-secondary transition-colors shrink-0">
-                <ExternalLink size={12} />
-              </a>
-            )}
+            <a href={eventUrl} target="_blank" rel="noopener noreferrer" className="text-theme-text-faint hover:text-theme-text-secondary transition-colors shrink-0">
+              <ExternalLink size={12} />
+            </a>
             <button
               onClick={() => setNotesOpen(!notesOpen)}
               className={`transition-colors shrink-0 ${

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -463,9 +463,7 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
     saveNotes(notesValue);
   }, [notesValue, saveNotes]);
 
-  const eventUrl = event.customUrl
-    ? `https://rsv.pizza/${event.customUrl}`
-    : null;
+  const eventUrl = `https://rsv.pizza/${event.customUrl || event.inviteCode}`;
 
   const relTime = formatRelativeTime(event.date);
   const fullDate = formatFullDate(event.date);
@@ -514,16 +512,14 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                   <span className="w-2 h-2 rounded-full bg-blue-400 shrink-0" title="Community Listed" />
                 )}
                 <span className="text-sm font-medium text-theme-text truncate">{event.name.replace(/^Global Pizza Party\s*/i, '')}</span>
-                {eventUrl && (
-                  <a
-                    href={eventUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-theme-text-faint hover:text-theme-text-secondary transition-colors shrink-0"
-                  >
-                    <ExternalLink size={12} />
-                  </a>
-                )}
+                <a
+                  href={eventUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-theme-text-faint hover:text-theme-text-secondary transition-colors shrink-0"
+                >
+                  <ExternalLink size={12} />
+                </a>
                 <button
                   onClick={() => setNotesOpen(!notesOpen)}
                   className={`transition-colors shrink-0 ${


### PR DESCRIPTION
## Summary
- `EventRow.tsx` and `EventCard.tsx` only rendered the external-link icon when `event.customUrl` was set, so events without a custom URL had no link to their RSVP page.
- Falls back to `event.inviteCode` (always present), matching the pattern used in `ShareRSVP.tsx:45`.

Plan: `plans/jalapeno-59763-underboss-rsvp-links.md`

## Test plan
- [ ] Open /underboss on the Vercel preview
- [ ] Every event row shows the external-link icon next to the city name
- [ ] Clicking the icon on an event without a custom URL opens its RSVP page via inviteCode
- [ ] Clicking the icon on an event with a custom URL still opens that custom URL