### PR TITLE
romana-72488: restore manual host check-in + surface check-in errors

### DIFF
--- a/backend/src/routes/checkin.routes.ts
+++ b/backend/src/routes/checkin.routes.ts
@@ -248,6 +248,69 @@ router.post('/:inviteCode/vouch', requireAuth, async (req: AuthRequest, res: Res
   }
 });
 
+// POST /api/checkin/:inviteCode/:guestId — Manual host/co-host check-in
+router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { inviteCode, guestId } = req.params;
+
+    const party = await findPartyByCode(inviteCode);
+    if (!party) {
+      throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+    }
+
+    const canCheckIn = await canUserCheckIn(party.id, req.userId, req.userEmail);
+    if (!canCheckIn) {
+      throw new AppError('You are not authorized to check in guests for this event', 403, 'UNAUTHORIZED');
+    }
+
+    const guest = await prisma.guest.findFirst({
+      where: { id: guestId, partyId: party.id },
+    });
+
+    if (!guest) {
+      throw new AppError('Guest not found', 404, 'GUEST_NOT_FOUND');
+    }
+
+    if (guest.checkedInAt) {
+      return res.status(200).json({
+        success: true,
+        alreadyCheckedIn: true,
+        guest: {
+          id: guest.id,
+          name: guest.name,
+          email: guest.email,
+          checkedInAt: guest.checkedInAt,
+          checkedInBy: guest.checkedInBy,
+        },
+        message: `${guest.name} was already checked in`,
+      });
+    }
+
+    const updatedGuest = await prisma.guest.update({
+      where: { id: guestId },
+      data: {
+        checkedInAt: new Date(),
+        checkedInBy: req.userId, // CUID string; `checkedInBy` column is text, not uuid
+      },
+    });
+
+    res.status(200).json({
+      success: true,
+      alreadyCheckedIn: false,
+      guest: {
+        id: updatedGuest.id,
+        name: updatedGuest.name,
+        email: updatedGuest.email,
+        checkedInAt: updatedGuest.checkedInAt,
+        checkedInBy: updatedGuest.checkedInBy,
+      },
+      message: `${updatedGuest.name} has been checked in!`,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // GET /api/checkin/:inviteCode/:guestId — Get guest check-in status (requires auth, host/co-host only)
 router.get('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {

--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -20,6 +20,13 @@ export const GuestList: React.FC = () => {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkActionInProgress, setBulkActionInProgress] = useState(false);
 
+  // Transient toast for check-in success/error
+  const [toast, setToast] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const showToast = (type: 'success' | 'error', text: string) => {
+    setToast({ type, text });
+    setTimeout(() => setToast(null), 3500);
+  };
+
   const toggleSelect = useCallback((id: string) => {
     setSelectedIds(prev => {
       const next = new Set(prev);
@@ -183,11 +190,16 @@ export const GuestList: React.FC = () => {
 
     setCheckingInId(guestId);
     try {
-      await checkInGuest(party.inviteCode, guestId);
+      const result = await checkInGuest(party.inviteCode, guestId);
       // Reload party data to get updated check-in status
       await loadParty(party.inviteCode);
+      if (!result.alreadyCheckedIn) {
+        showToast('success', result.message || 'Guest checked in');
+      }
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to check in guest';
       console.error('Failed to check in guest:', error);
+      showToast('error', message);
     } finally {
       setCheckingInId(null);
     }
@@ -214,15 +226,27 @@ export const GuestList: React.FC = () => {
   const handleBulkCheckIn = async () => {
     if (!party?.inviteCode) return;
     setBulkActionInProgress(true);
+    let successCount = 0;
+    const failures: string[] = [];
     try {
       const ids = [...selectedIds];
       const eligible = guests.filter(g => g.id && ids.includes(g.id) && (g.status === 'CONFIRMED' || g.status === 'INVITED') && !g.checkedInAt);
       for (const g of eligible) {
-        if (g.id) await checkInGuest(party.inviteCode, g.id);
+        if (!g.id) continue;
+        try {
+          await checkInGuest(party.inviteCode, g.id);
+          successCount++;
+        } catch (e) {
+          failures.push(g.name);
+          console.error(`Bulk check-in failed for ${g.name}:`, e);
+        }
       }
       await loadParty(party.inviteCode);
-    } catch (e) {
-      console.error('Bulk check-in failed:', e);
+      if (failures.length === 0 && successCount > 0) {
+        showToast('success', `Checked in ${successCount} guest${successCount === 1 ? '' : 's'}`);
+      } else if (failures.length > 0) {
+        showToast('error', `Failed to check in ${failures.length} guest${failures.length === 1 ? '' : 's'}: ${failures.slice(0, 3).join(', ')}${failures.length > 3 ? '…' : ''}`);
+      }
     } finally {
       clearSelection();
       setBulkActionInProgress(false);
@@ -278,7 +302,20 @@ export const GuestList: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <>
+      {toast && (
+        <div
+          className={`fixed top-4 left-1/2 -translate-x-1/2 z-50 text-sm font-medium px-4 py-2 rounded-xl shadow-lg animate-fade-in ${
+            toast.type === 'success'
+              ? 'bg-[#39d98a]/90 text-black'
+              : 'bg-red-500/90 text-white'
+          }`}
+          role="status"
+        >
+          {toast.text}
+        </div>
+      )}
+      <div className="space-y-6">
       {/* Confirmed Guests Section */}
       <div className="card p-6">
         <div className="flex justify-between items-center mb-4">
@@ -508,6 +545,7 @@ export const GuestList: React.FC = () => {
           </button>
         </div>
       )}
-    </div>
+      </div>
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- Re-adds `POST /api/checkin/:inviteCode/:guestId` (manual host check-in) — removed in commit 7425a7ab when check-in was refactored to QR/vouch. The frontend's Check In button (single + bulk) has been silently 404ing ever since.
- Adds a transient toast in `GuestList.tsx` so future check-in failures are visible instead of being swallowed by `console.error`.

## Why this broke
Frontend `checkInGuest()` posts to `/api/checkin/:inviteCode/:guestId`. The route exists for GET (status) but the POST was removed in the QR refactor and never re-added. Hosts clicked "Check In" -> 404 -> silent fail.

## Deploy note
Backend changes only deploy from `master`. After merge, run `cd backend && vercel --prod --scope pizza-dao`. Preview frontends against prod backend will still 404 until the backend ships — but the new error toast will surface the failure clearly (proves the toast plumbing works).

## Test plan
- [ ] Click "Check In" on a CONFIRMED guest -> row flips to "Checked in", green success toast
- [ ] Bulk-select multiple guests, click "Check in" -> all flip, single summary toast
- [ ] Non-host tries the endpoint -> 403, red error toast
- [ ] QR / peer-vouch flows still work (untouched)

Plan: `plans/romana-72488-restore-manual-checkin.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)