### PR TITLE
bellpepper-98246: fix GPP dup check for non-Latin-script cities

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -264,31 +264,35 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
     const normalizedHostName = hostName.trim();
     const normalizedTelegram = telegram?.trim().replace(/^@/, '') || null;
 
-    // Generate custom URL from city name (strip diacritics, lowercase, no spaces/special chars)
-    const customUrl = normalizedCity
+    // Generate custom URL from city name (strip diacritics, lowercase, no spaces/special chars).
+    // NULL when the slug is empty (e.g. non-Latin scripts) so the unique constraint stays distinct.
+    const slug = normalizedCity
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
       .toLowerCase()
       .replace(/[^a-z0-9]/g, '');
+    const customUrl = slug.length > 0 ? slug : null;
 
-    // Check for existing GPP event in this city
-    const existingEvent = await prisma.party.findFirst({
-      where: {
-        customUrl,
-        eventType: 'gpp',
-      },
-      select: {
-        id: true,
-        name: true,
-        customUrl: true,
-        inviteCode: true,
-      },
-    });
+    const eventName = `Global Pizza Party ${normalizedCity}`;
+
+    const existingRows = await prisma.$queryRaw<Array<{
+      id: string;
+      name: string;
+      custom_url: string | null;
+      invite_code: string;
+    }>>`
+      SELECT id, name, custom_url, invite_code
+      FROM parties
+      WHERE event_type = 'gpp'
+        AND lower(unaccent(name)) = lower(unaccent(${eventName}))
+      LIMIT 1
+    `;
+    const existingEvent = existingRows[0];
 
     if (existingEvent) {
-      const eventUrl = existingEvent.customUrl
-        ? `https://rsv.pizza/${existingEvent.customUrl}`
-        : `https://rsv.pizza/${existingEvent.inviteCode}`;
+      const eventUrl = existingEvent.custom_url
+        ? `https://rsv.pizza/${existingEvent.custom_url}`
+        : `https://rsv.pizza/${existingEvent.invite_code}`;
 
       throw new AppError(
         `This city's Global Pizza Party has already been created! Visit the event page: ${eventUrl}`,
@@ -318,9 +322,6 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
         data: { telegram: normalizedTelegram },
       });
     }
-
-    // Generate event name with city (no dash, just space)
-    const eventName = `Global Pizza Party ${normalizedCity}`;
 
     // Calculate default date: May 22 of current or next year, 6-9 PM in event timezone
     const now = new Date();

--- a/supabase/migrations/20260515010457_bellpepper_98246_gpp_dup_check.sql
+++ b/supabase/migrations/20260515010457_bellpepper_98246_gpp_dup_check.sql
@@ -1,0 +1,8 @@
+-- Enable case + diacritic folding for GPP duplicate-city detection.
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Flip the one stranded '' custom_url (Taipei) to NULL so the column is consistent
+-- with the other 22 GPP events that already have NULL.
+UPDATE parties
+SET custom_url = NULL
+WHERE event_type = 'gpp' AND custom_url = '';


### PR DESCRIPTION
## Summary

Fixes the `POST /api/gpp/events` duplicate-city check for non-Latin-script cities (Japanese, Chinese, Korean, Cyrillic, Arabic, Hebrew, Thai, Greek, etc.). Reported by a user in Tokyo (`東京`) who hit "This city's Global Pizza Party has already been created!" linking to the Taipei (`臺北`) event.

Plan: `plans/bellpepper-98246-gpp-non-latin-city-dup-check.md`

### Root cause

`backend/src/routes/gpp.routes.ts` generated `customUrl` by stripping everything that wasn't `[a-z0-9]`. For non-Latin scripts that yields `''`, and the dedup `findFirst({ where: { customUrl: '' } })` then matched the one existing row whose `custom_url` was `''` (Taipei). Every new non-Latin city was therefore falsely told it already existed and pointed to the Taipei URL.

### Fix (three parts)

1. **Slug -> NULL fallback** when stripped slug is empty. `String? @unique` treats NULLs as distinct in Postgres, and the existing URL builder already falls back to `inviteCode` when `customUrl` is falsy — matches the 22 existing GPP rows that already have NULL.
2. **Dedup by `lower(unaccent(name))`** via `$queryRaw` instead of by slug. Prisma's `mode: 'insensitive'` only folds case, not diacritics. Bonus: also catches `São Paulo` vs `Sao Paulo`. `eventName` declaration moved up above the dedup check.
3. **Migration** (`supabase/migrations/20260515010457_bellpepper_98246_gpp_dup_check.sql`) enables the `unaccent` extension and flips the one stranded `''` Taipei row to NULL. Idempotent.

### IMPORTANT — deploy order

The new dedup SQL requires the `unaccent` extension, which is currently available but not enabled on prod. **The migration must be applied to prod BEFORE the backend deploys**, or every GPP event creation will 500.

## Test plan

After migration applied + backend deployed:

- [ ] Submit `東京` / unique email — expect 201 (not 409)
- [ ] Submit `서울` (Korean) — expect 201
- [ ] Re-submit `東京` with another email — expect 409 pointing at the Tokyo event (not Taipei)
- [ ] Submit `Tokyo` (Latin) — expect 201 (different script, no match)
- [ ] Re-submit `tokyo` — expect 409 (case-insensitive match)
- [ ] Submit `São Paulo`, then `Sao Paulo` — expect second one to 409 (diacritic fold)
- [ ] `SELECT count(*) FROM parties WHERE event_type='gpp' AND custom_url=''` -> 0

## Notes for reviewer

- Backend-only change; no frontend or Prisma schema changes.
- Vercel frontend preview will build but won't include the fix (backend only deploys from master).
- Pre-existing TypeScript error in `src/middleware/auth.test.ts` is unrelated to this PR.
