### PR TITLE
diavola-10148: cohost avatar file upload + fxtwitter X auto-fill

### DIFF
--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp } from 'lucide-react';
+import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp, Upload } from 'lucide-react';
 import { CoHost } from '../types';
 import { Checkbox } from './Checkbox';
-import { updateParty, addGuestByHost, proxyAvatarToStorage } from '../lib/supabase';
-import { getXAvatarUrl, isAutoFilledXAvatar } from '../utils/avatarUtils';
+import { updateParty, addGuestByHost, proxyAvatarToStorage, uploadCoHostAvatar } from '../lib/supabase';
+import { fetchXAvatarToSupabase, isAutoFilledXAvatar } from '../utils/avatarUtils';
 import { uuid, normalizeUrl, stripToHandle } from '../lib/utils';
 import { ALL_HOST_TABS } from '../lib/tabPermissions';
 
@@ -38,6 +38,7 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   const [newCoHostTwitter, setNewCoHostTwitter] = useState('');
   const [newCoHostInstagram, setNewCoHostInstagram] = useState('');
   const [newCoHostAvatarUrl, setNewCoHostAvatarUrl] = useState('');
+  const [newCoHostAvatarFile, setNewCoHostAvatarFile] = useState<File | null>(null);
   const [newCoHostShowOnEvent, setNewCoHostShowOnEvent] = useState(true);
   const [newCoHostCanEdit, setNewCoHostCanEdit] = useState(false);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
@@ -49,7 +50,53 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   const [editHostTwitter, setEditHostTwitter] = useState('');
   const [editHostInstagram, setEditHostInstagram] = useState('');
   const [editHostAvatarUrl, setEditHostAvatarUrl] = useState('');
+  const [editHostAvatarFile, setEditHostAvatarFile] = useState<File | null>(null);
+  const [savingHost, setSavingHost] = useState(false);
   const [expandedPermissionsId, setExpandedPermissionsId] = useState<string | null>(null);
+
+  const newAvatarInputRef = useRef<HTMLInputElement>(null);
+  const editAvatarInputRef = useRef<HTMLInputElement>(null);
+
+  // Manage object-URL preview for the locally-selected file (Add modal)
+  const newAvatarFilePreview = React.useMemo(
+    () => (newCoHostAvatarFile ? URL.createObjectURL(newCoHostAvatarFile) : null),
+    [newCoHostAvatarFile]
+  );
+  useEffect(() => {
+    return () => {
+      if (newAvatarFilePreview) URL.revokeObjectURL(newAvatarFilePreview);
+    };
+  }, [newAvatarFilePreview]);
+
+  // Manage object-URL preview for the locally-selected file (Edit modal)
+  const editAvatarFilePreview = React.useMemo(
+    () => (editHostAvatarFile ? URL.createObjectURL(editHostAvatarFile) : null),
+    [editHostAvatarFile]
+  );
+  useEffect(() => {
+    return () => {
+      if (editAvatarFilePreview) URL.revokeObjectURL(editAvatarFilePreview);
+    };
+  }, [editAvatarFilePreview]);
+
+  const handleNewAvatarFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) return;
+    if (file.size > 5 * 1024 * 1024) return;
+    setNewCoHostAvatarFile(file);
+    // Clear any URL-based avatar (file takes precedence)
+    setNewCoHostAvatarUrl('');
+  };
+
+  const handleEditAvatarFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) return;
+    if (file.size > 5 * 1024 * 1024) return;
+    setEditHostAvatarFile(file);
+    setEditHostAvatarUrl('');
+  };
 
   // Tabs available for permission assignment (exclude 'apps' which is always visible)
   const permissionTabs = ALL_HOST_TABS.filter(t => t.id !== 'apps');
@@ -110,40 +157,51 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
 
   const addCoHost = async () => {
     if (!newCoHostName.trim()) return;
+    if (savingHost) return;
+    setSavingHost(true);
 
-    // Proxy external avatar to storage
-    const avatarUrl = newCoHostAvatarUrl.trim()
-      ? await proxyAvatarToStorage(newCoHostAvatarUrl.trim())
-      : undefined;
+    try {
+      // Upload local file first; otherwise proxy any external URL through storage
+      let avatarUrl: string | undefined;
+      if (newCoHostAvatarFile) {
+        const uploaded = await uploadCoHostAvatar(newCoHostAvatarFile);
+        if (uploaded) avatarUrl = uploaded;
+      } else if (newCoHostAvatarUrl.trim()) {
+        avatarUrl = await proxyAvatarToStorage(newCoHostAvatarUrl.trim());
+      }
 
-    const newCoHost: CoHost = {
-      id: uuid(),
-      name: newCoHostName.trim(),
-      email: newCoHostEmail.trim().toLowerCase() || undefined,
-      website: newCoHostWebsite.trim() || undefined,
-      twitter: newCoHostTwitter.trim() || undefined,
-      instagram: newCoHostInstagram.trim() || undefined,
-      avatar_url: avatarUrl,
-      showOnEvent: newCoHostShowOnEvent,
-      canEdit: newCoHostCanEdit || undefined,
-    };
+      const newCoHost: CoHost = {
+        id: uuid(),
+        name: newCoHostName.trim(),
+        email: newCoHostEmail.trim().toLowerCase() || undefined,
+        website: newCoHostWebsite.trim() || undefined,
+        twitter: newCoHostTwitter.trim() || undefined,
+        instagram: newCoHostInstagram.trim() || undefined,
+        avatar_url: avatarUrl,
+        showOnEvent: newCoHostShowOnEvent,
+        canEdit: newCoHostCanEdit || undefined,
+      };
 
-    const newCoHosts = [...coHosts, newCoHost];
-    setCoHosts(newCoHosts);
+      const newCoHosts = [...coHosts, newCoHost];
+      setCoHosts(newCoHosts);
 
-    // Reset form and close modal
-    setNewCoHostName('');
-    setNewCoHostEmail('');
-    setNewCoHostWebsite('');
-    setNewCoHostTwitter('');
-    setNewCoHostInstagram('');
-    setNewCoHostAvatarUrl('');
-    setNewCoHostShowOnEvent(true);
-    setNewCoHostCanEdit(false);
-    setShowAddHostModal(false);
+      // Reset form and close modal
+      setNewCoHostName('');
+      setNewCoHostEmail('');
+      setNewCoHostWebsite('');
+      setNewCoHostTwitter('');
+      setNewCoHostInstagram('');
+      setNewCoHostAvatarUrl('');
+      setNewCoHostAvatarFile(null);
+      setNewCoHostShowOnEvent(true);
+      setNewCoHostCanEdit(false);
+      setShowAddHostModal(false);
 
-    // Auto-save
-    await saveCoHostsArray(newCoHosts);
+      // Auto-save
+      await saveCoHostsArray(newCoHosts);
+    } finally {
+      setSavingHost(false);
+    }
   };
 
   const startEditingHost = (host: CoHost) => {
@@ -154,6 +212,7 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
     setEditHostTwitter(host.twitter || '');
     setEditHostInstagram(host.instagram || '');
     setEditHostAvatarUrl(host.avatar_url || '');
+    setEditHostAvatarFile(null);
   };
 
   const cancelEditingHost = () => {
@@ -164,33 +223,44 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
     setEditHostTwitter('');
     setEditHostInstagram('');
     setEditHostAvatarUrl('');
+    setEditHostAvatarFile(null);
   };
 
   const saveHostEdit = async () => {
     if (!editHostName.trim()) return;
+    if (savingHost) return;
+    setSavingHost(true);
 
-    // Proxy external avatar to storage
-    const avatarUrl = editHostAvatarUrl.trim()
-      ? await proxyAvatarToStorage(editHostAvatarUrl.trim())
-      : undefined;
+    try {
+      // Upload local file first; otherwise proxy any external URL through storage
+      let avatarUrl: string | undefined;
+      if (editHostAvatarFile) {
+        const uploaded = await uploadCoHostAvatar(editHostAvatarFile);
+        if (uploaded) avatarUrl = uploaded;
+      } else if (editHostAvatarUrl.trim()) {
+        avatarUrl = await proxyAvatarToStorage(editHostAvatarUrl.trim());
+      }
 
-    const newCoHosts = coHosts.map(h =>
-      h.id === editingHostId
-        ? {
-          ...h,
-          name: editHostName.trim(),
-          email: editHostEmail.trim().toLowerCase() || undefined,
-          website: editHostWebsite.trim() || undefined,
-          twitter: editHostTwitter.trim() || undefined,
-          instagram: editHostInstagram.trim() || undefined,
-          avatar_url: avatarUrl,
-        }
-        : h
-    );
-    setCoHosts(newCoHosts);
-    // Auto-save
-    await saveCoHostsArray(newCoHosts);
-    cancelEditingHost();
+      const newCoHosts = coHosts.map(h =>
+        h.id === editingHostId
+          ? {
+            ...h,
+            name: editHostName.trim(),
+            email: editHostEmail.trim().toLowerCase() || undefined,
+            website: editHostWebsite.trim() || undefined,
+            twitter: editHostTwitter.trim() || undefined,
+            instagram: editHostInstagram.trim() || undefined,
+            avatar_url: avatarUrl,
+          }
+          : h
+      );
+      setCoHosts(newCoHosts);
+      // Auto-save
+      await saveCoHostsArray(newCoHosts);
+      cancelEditingHost();
+    } finally {
+      setSavingHost(false);
+    }
   };
 
   const removeCoHost = async (id: string) => {
@@ -460,37 +530,30 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                 className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
               />
 
-              <div className="grid grid-cols-2 gap-3">
-                <input
-                  type="url"
-                  value={editHostWebsite}
-                  onChange={(e) => setEditHostWebsite(e.target.value)}
-                  onBlur={() => setEditHostWebsite(normalizeUrl(editHostWebsite))}
-                  placeholder="Website"
-                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-                />
-                <input
-                  type="url"
-                  value={editHostAvatarUrl}
-                  onChange={(e) => setEditHostAvatarUrl(e.target.value)}
-                  placeholder="Avatar URL"
-                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-                />
-              </div>
+              <input
+                type="url"
+                value={editHostWebsite}
+                onChange={(e) => setEditHostWebsite(e.target.value)}
+                onBlur={() => setEditHostWebsite(normalizeUrl(editHostWebsite))}
+                placeholder="Website"
+                className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
+              />
 
               <div className="grid grid-cols-2 gap-3">
                 <input
                   type="text"
                   value={editHostTwitter}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setEditHostTwitter(val);
-                    if (!editHostAvatarUrl.trim() || isAutoFilledXAvatar(editHostAvatarUrl)) {
-                      const avatarUrl = getXAvatarUrl(val);
-                      if (avatarUrl) setEditHostAvatarUrl(avatarUrl);
-                    }
+                  onChange={(e) => setEditHostTwitter(e.target.value)}
+                  onBlur={async () => {
+                    const handle = stripToHandle(editHostTwitter);
+                    setEditHostTwitter(handle);
+                    if (!handle) return;
+                    // Only auto-fill if avatar slot is empty or holding a legacy unavatar URL
+                    if (editHostAvatarFile) return;
+                    if (editHostAvatarUrl.trim() && !isAutoFilledXAvatar(editHostAvatarUrl)) return;
+                    const fetched = await fetchXAvatarToSupabase(handle);
+                    if (fetched) setEditHostAvatarUrl(fetched);
                   }}
-                  onBlur={() => setEditHostTwitter(stripToHandle(editHostTwitter))}
                   placeholder="Twitter (no @)"
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
@@ -503,20 +566,45 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
               </div>
-            </div>
 
-            {/* Avatar Preview */}
-            {editHostAvatarUrl && (
-              <div className="flex items-center gap-2 mt-2">
-                <img
-                  src={editHostAvatarUrl}
-                  alt=""
-                  className="w-8 h-8 rounded-full object-cover"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+              {/* Avatar upload */}
+              <div>
+                <input
+                  ref={editAvatarInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleEditAvatarFileChange}
+                  className="hidden"
                 />
-                <span className="text-xs text-theme-text-muted">Avatar preview</span>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => editAvatarInputRef.current?.click()}
+                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
+                  >
+                    <Upload size={16} />
+                    Upload avatar
+                  </button>
+                  {(editAvatarFilePreview || editHostAvatarUrl) && (
+                    <>
+                      <img
+                        src={editAvatarFilePreview || editHostAvatarUrl}
+                        alt=""
+                        className="w-10 h-10 rounded-full object-cover border border-white/20"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); }}
+                        className="text-xs text-red-400 hover:text-red-300"
+                      >
+                        Clear
+                      </button>
+                    </>
+                  )}
+                </div>
               </div>
-            )}
+            </div>
 
             <div className="flex gap-3 mt-4">
               <button
@@ -529,10 +617,10 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
               <button
                 type="button"
                 onClick={saveHostEdit}
-                disabled={!editHostName.trim()}
+                disabled={!editHostName.trim() || savingHost}
                 className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm"
               >
-                Save
+                {savingHost ? 'Saving...' : 'Save'}
               </button>
             </div>
           </div>
@@ -563,37 +651,29 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                 className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
               />
 
-              <div className="grid grid-cols-2 gap-3">
-                <input
-                  type="url"
-                  value={newCoHostWebsite}
-                  onChange={(e) => setNewCoHostWebsite(e.target.value)}
-                  onBlur={() => setNewCoHostWebsite(normalizeUrl(newCoHostWebsite))}
-                  placeholder="Website"
-                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-                />
-                <input
-                  type="url"
-                  value={newCoHostAvatarUrl}
-                  onChange={(e) => setNewCoHostAvatarUrl(e.target.value)}
-                  placeholder="Avatar URL"
-                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-                />
-              </div>
+              <input
+                type="url"
+                value={newCoHostWebsite}
+                onChange={(e) => setNewCoHostWebsite(e.target.value)}
+                onBlur={() => setNewCoHostWebsite(normalizeUrl(newCoHostWebsite))}
+                placeholder="Website"
+                className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
+              />
 
               <div className="grid grid-cols-2 gap-3">
                 <input
                   type="text"
                   value={newCoHostTwitter}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setNewCoHostTwitter(val);
-                    if (!newCoHostAvatarUrl.trim() || isAutoFilledXAvatar(newCoHostAvatarUrl)) {
-                      const avatarUrl = getXAvatarUrl(val);
-                      if (avatarUrl) setNewCoHostAvatarUrl(avatarUrl);
-                    }
+                  onChange={(e) => setNewCoHostTwitter(e.target.value)}
+                  onBlur={async () => {
+                    const handle = stripToHandle(newCoHostTwitter);
+                    setNewCoHostTwitter(handle);
+                    if (!handle) return;
+                    if (newCoHostAvatarFile) return;
+                    if (newCoHostAvatarUrl.trim() && !isAutoFilledXAvatar(newCoHostAvatarUrl)) return;
+                    const fetched = await fetchXAvatarToSupabase(handle);
+                    if (fetched) setNewCoHostAvatarUrl(fetched);
                   }}
-                  onBlur={() => setNewCoHostTwitter(stripToHandle(newCoHostTwitter))}
                   placeholder="Twitter (no @)"
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
@@ -606,20 +686,45 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
               </div>
-            </div>
 
-            {/* Avatar Preview */}
-            {newCoHostAvatarUrl && (
-              <div className="flex items-center gap-2 mt-2">
-                <img
-                  src={newCoHostAvatarUrl}
-                  alt=""
-                  className="w-8 h-8 rounded-full object-cover"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+              {/* Avatar upload */}
+              <div>
+                <input
+                  ref={newAvatarInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleNewAvatarFileChange}
+                  className="hidden"
                 />
-                <span className="text-xs text-theme-text-muted">Avatar preview</span>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => newAvatarInputRef.current?.click()}
+                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
+                  >
+                    <Upload size={16} />
+                    Upload avatar
+                  </button>
+                  {(newAvatarFilePreview || newCoHostAvatarUrl) && (
+                    <>
+                      <img
+                        src={newAvatarFilePreview || newCoHostAvatarUrl}
+                        alt=""
+                        className="w-10 h-10 rounded-full object-cover border border-white/20"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => { setNewCoHostAvatarFile(null); setNewCoHostAvatarUrl(''); }}
+                        className="text-xs text-red-400 hover:text-red-300"
+                      >
+                        Clear
+                      </button>
+                    </>
+                  )}
+                </div>
               </div>
-            )}
+            </div>
 
             <div className="flex items-center gap-4 mt-3">
               <Checkbox
@@ -649,11 +754,11 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
               <button
                 type="button"
                 onClick={addCoHost}
-                disabled={!newCoHostName.trim()}
+                disabled={!newCoHostName.trim() || savingHost}
                 className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
               >
                 <UserPlus size={16} />
-                Add Host
+                {savingHost ? 'Adding...' : 'Add Host'}
               </button>
             </div>
           </div>

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -10,7 +10,7 @@ import { PartnerForm, extractSponsorData } from '../sponsors/PartnerForm';
 import type { PartnerFormData } from '../sponsors/PartnerForm';
 import { uploadEventImage, updateParty, cdnUrl, proxyAvatarToStorage } from '../../lib/supabase';
 import { uuid } from '../../lib/utils';
-import { getXAvatarUrl } from '../../utils/avatarUtils';
+import { fetchXAvatarToSupabase } from '../../utils/avatarUtils';
 import {
   fitText, loadImg, uses12Hour, formatFlyerTime, getTemplateUrl,
   CITY_FONT, TEXT_FONT, CITY_COLOR, TIME_COLOR, VENUE_COLOR,
@@ -350,9 +350,9 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
     if (data.avatarUrl) {
       avatarUrl = await proxyAvatarToStorage(data.avatarUrl);
     } else {
-      const xAvatar = data.twitter ? getXAvatarUrl(data.twitter) : null;
+      const xAvatar = data.twitter ? await fetchXAvatarToSupabase(data.twitter) : null;
       if (xAvatar) {
-        avatarUrl = await proxyAvatarToStorage(xAvatar);
+        avatarUrl = xAvatar;
       } else if (data.instagram) {
         const igAvatar = `https://unavatar.io/instagram/${data.instagram}`;
         avatarUrl = await proxyAvatarToStorage(igAvatar);

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -151,6 +151,31 @@ export async function uploadSponsorLogo(file: File): Promise<string | null> {
 }
 
 /**
+ * Upload a co-host avatar image directly to Supabase Storage and return the public URL.
+ * Used by the cohost editor's file-upload affordance.
+ */
+export async function uploadCoHostAvatar(file: File): Promise<string | null> {
+  try {
+    const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
+    const fileName = `co-host-avatars/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+    const { error } = await supabase.storage.from('event-images').upload(fileName, file, {
+      cacheControl: '3600',
+      upsert: false,
+      contentType: file.type || 'image/jpeg',
+    });
+    if (error) {
+      console.error('uploadCoHostAvatar:', error);
+      return null;
+    }
+    const { data } = supabase.storage.from('event-images').getPublicUrl(fileName);
+    return data.publicUrl;
+  } catch (error) {
+    console.error('uploadCoHostAvatar:', error);
+    return null;
+  }
+}
+
+/**
  * Proxy an external avatar image to Supabase Storage.
  * Skips if already a Supabase URL. Falls back to original URL on failure.
  */

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -8,7 +8,7 @@ import { IconInput } from '../components/IconInput';
 import { uploadProfilePicture, getUserPreferences, saveUserPreferences, UserPreferences } from '../lib/supabase';
 import { getUserSponsorships, UserSponsorshipEntry } from '../lib/api';
 import { DIETARY_OPTIONS, TOPPINGS, DRINKS, getExcludedToppingIds } from '../constants/options';
-import { getXAvatarUrl, isAutoFilledXAvatar } from '../utils/avatarUtils';
+import { fetchXAvatarToSupabase, isAutoFilledXAvatar } from '../utils/avatarUtils';
 
 export function AccountPage() {
   const { user, loading: authLoading, signOut, updateProfile } = useAuth();
@@ -459,9 +459,9 @@ export function AccountPage() {
                     type="text"
                     value={twitter}
                     onChange={(e) => setTwitter(e.target.value)}
-                    onBlur={() => {
+                    onBlur={async () => {
                       if (twitter.trim() && !profilePictureFile && (!profilePicture || isAutoFilledXAvatar(profilePicture))) {
-                        const avatarUrl = getXAvatarUrl(twitter);
+                        const avatarUrl = await fetchXAvatarToSupabase(twitter);
                         if (avatarUrl) setProfilePicture(avatarUrl);
                       }
                     }}

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -19,7 +19,7 @@ import { DonationSummary } from '../components/DonationSummary';
 import { PhotoGallery } from '../components/photos';
 import { updateParty, proxyAvatarToStorage } from '../lib/supabase';
 import { uuid } from '../lib/utils';
-import { getXAvatarUrl } from '../utils/avatarUtils';
+import { fetchXAvatarToSupabase } from '../utils/avatarUtils';
 import { CoHost } from '../types';
 import { AppsHub } from '../components/AppsHub';
 import { SponsorCRM } from '../components/sponsors';
@@ -271,9 +271,9 @@ function HostPageContent() {
               if (data.avatarUrl) {
                 avatarUrl = await proxyAvatarToStorage(data.avatarUrl);
               } else {
-                const xAvatar = data.twitter ? getXAvatarUrl(data.twitter) : null;
+                const xAvatar = data.twitter ? await fetchXAvatarToSupabase(data.twitter) : null;
                 if (xAvatar) {
-                  avatarUrl = await proxyAvatarToStorage(xAvatar);
+                  avatarUrl = xAvatar;
                 } else if (data.instagram) {
                   const igAvatar = `https://unavatar.io/instagram/${data.instagram}`;
                   avatarUrl = await proxyAvatarToStorage(igAvatar);

--- a/frontend/src/utils/avatarUtils.ts
+++ b/frontend/src/utils/avatarUtils.ts
@@ -1,16 +1,46 @@
+import { proxyAvatarToStorage } from '../lib/supabase';
+
+const HANDLE_RE = /^[a-zA-Z0-9_]{1,15}$/;
+
 /**
- * Generate an avatar URL from an X/Twitter username using unavatar.io
+ * Normalize an X/Twitter handle from a raw URL or @-handle.
+ * Returns null if the input doesn't resolve to a valid handle.
  */
-export function getXAvatarUrl(username: string): string | null {
-  const cleaned = username.replace(/^@/, '').trim();
-  if (!cleaned) return null;
-  if (!/^[a-zA-Z0-9_]{1,15}$/.test(cleaned)) return null;
-  return `https://unavatar.io/x/${cleaned}`;
+export function cleanXHandle(input: string): string | null {
+  if (!input) return null;
+  let h = input.trim();
+  if (!h) return null;
+  h = h.replace(/^https?:\/\/(www\.)?(x\.com|twitter\.com)\//i, '');
+  h = h.split(/[/?#]/)[0];
+  h = h.replace(/^@/, '').trim();
+  return HANDLE_RE.test(h) ? h : null;
 }
 
 /**
- * Check if a URL is an auto-filled unavatar.io X avatar
+ * Fetch the real X profile picture via fxtwitter, mirror it to Supabase storage,
+ * and return the public URL. Returns null if the lookup or upload fails.
  */
-export function isAutoFilledXAvatar(url: string): boolean {
-  return url.trim().startsWith('https://unavatar.io/x/');
+export async function fetchXAvatarToSupabase(handleOrUrl: string): Promise<string | null> {
+  const handle = cleanXHandle(handleOrUrl);
+  if (!handle) return null;
+  try {
+    const res = await fetch(`https://api.fxtwitter.com/${encodeURIComponent(handle)}`);
+    if (!res.ok) return null;
+    const json = await res.json();
+    if (json.code !== 200 || !json.user?.avatar_url) return null;
+    const big = String(json.user.avatar_url).replace(/_normal(\.[a-zA-Z0-9]+)$/, '_400x400$1');
+    // Mirror twimg URL into Supabase storage
+    return await proxyAvatarToStorage(big);
+  } catch {
+    return null;
+  }
 }
+
+/**
+ * Detect URLs that came from the legacy unavatar.io X auto-fill so that the X
+ * onBlur handler can safely replace them. User-uploaded files (Supabase
+ * storage URLs) and other manually-set avatars return false so we don't
+ * clobber them on blur.
+ */
+export const isAutoFilledXAvatar = (url: string): boolean =>
+  url.trim().startsWith('https://unavatar.io/x/');


### PR DESCRIPTION
## Summary
- Replace the URL text input in the HostsManager add/edit modals with a single Upload button that mirrors the PartnerForm pattern (no URL field per spec).
- Switch the X avatar auto-fill from unavatar.io to fxtwitter + Supabase storage mirror, so cohorts get the real X profile picture stored on our CDN. Auto-fill now fires on the X handle's onBlur (not onChange) to avoid hammering fxtwitter on every keystroke.
- New helper `uploadCoHostAvatar` in `frontend/src/lib/supabase.ts`. New helpers `fetchXAvatarToSupabase` + `cleanXHandle` in `frontend/src/utils/avatarUtils.ts`. `isAutoFilledXAvatar` retained so legacy unavatar URLs on existing cohosts can still be replaced on edit.

Plan: [`plans/diavola-10148-cohost-avatar-upload.md`](../blob/master/plans/diavola-10148-cohost-avatar-upload.md)

## Test plan
- [ ] On Vercel preview, open `/host/<event-slug>` and click "Add Host"
- [ ] Type an X handle, blur the field — preview should populate with the real X avatar (stored in Supabase, not unavatar.io)
- [ ] Click Upload, choose a local image — local preview shows immediately
- [ ] Save — cohost shows the uploaded image in the list
- [ ] Edit an existing cohost whose avatar is a legacy unavatar.io URL — typing a different X handle and blurring should swap the avatar
- [ ] Edit a cohost whose avatar is a user-uploaded Supabase URL — changing the X handle should NOT clobber the avatar
- [ ] Verify saved `avatar_url` values contain no `unavatar.io` strings