### PR TITLE
margherita-64191: fix partner sort dropdown arrow overlap

### DIFF
--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -710,7 +710,7 @@ export function PartnerDashboardPage() {
               <select
                 value={sortBy}
                 onChange={(e) => setSortBy(e.target.value)}
-                className="bg-theme-input border border-theme-stroke rounded-lg px-3 py-1.5 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+                className="bg-theme-input border border-theme-stroke rounded-lg pl-3 pr-8 py-1.5 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
               >
                 <option value="date-desc">Newest first</option>
                 <option value="date-asc">Oldest first</option>
@@ -724,7 +724,7 @@ export function PartnerDashboardPage() {
                 <select
                   value={regionFilter}
                   onChange={(e) => setRegionFilter(e.target.value)}
-                  className="bg-theme-input border border-theme-stroke rounded-lg px-3 py-1.5 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+                  className="bg-theme-input border border-theme-stroke rounded-lg pl-3 pr-8 py-1.5 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
                 >
                   <option value="all">Region: All</option>
                   {GPP_REGIONS.map((r) => (


### PR DESCRIPTION
## Issue
On the `/partner` dashboard page, the native dropdown chevron on the **Sort** and **Region** `<select>` elements was overlapping the option text (e.g. "Newest first"). The selects only had `px-3` (0.75rem horizontal padding), which doesn't leave room for the browser-rendered arrow on the right side.

## Fix
Changed `px-3` -> `pl-3 pr-8` on both `<select>` elements in `PartnerDashboardPage.tsx` (lines 713 and 727). Now the chevron sits inside the 2rem right padding without colliding with the option label.

Applies to:
- Sort dropdown (Newest first / Oldest first / Most RSVPs / Most clicks / Name A-Z)
- Region filter dropdown (only visible when events span multiple regions)

Pure CSS class change — no logic touched.

## Preview
https://rsvpizza-git-margherita-64191-partner-sort-arrow-pizza-dao.vercel.app/partner