### PR TITLE
pineapple-75000: surface host telegram in /underboss

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -223,6 +223,7 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
       name: party.user?.name || null,
       email: party.user?.email || null,
     },
+    hostTelegram: party.user?.telegram || null,
     coHosts: party.coHosts || [],
     progress: computeProgress(party, underbossEmails),
     guestCount,
@@ -405,7 +406,7 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
     const events = await prisma.party.findMany({
       where: whereClause,
       include: {
-        user: { select: { name: true, email: true } },
+        user: { select: { name: true, email: true, telegram: true } },
         guests: {
           select: { id: true, approved: true, checkedInAt: true, status: true },
         },
@@ -472,7 +473,7 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
       prisma.party.findMany({
         where: { region, eventType: 'gpp' },
         include: {
-          user: { select: { name: true, email: true } },
+          user: { select: { name: true, email: true, telegram: true } },
           guests: {
             select: { id: true, approved: true, checkedInAt: true, status: true },
           },
@@ -537,7 +538,7 @@ router.get('/:region/events/:partyId', requireAuth, requireUnderbossAuth, async 
     const party = await prisma.party.findFirst({
       where: { id: partyId, region, eventType: 'gpp' },
       include: {
-        user: { select: { name: true, email: true } },
+        user: { select: { name: true, email: true, telegram: true } },
         guests: {
           select: { id: true, name: true, email: true, approved: true, checkedInAt: true, submittedAt: true },
           orderBy: { submittedAt: 'desc' },

--- a/frontend/src/components/underboss/CitiesTable.tsx
+++ b/frontend/src/components/underboss/CitiesTable.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { Search, MapPin, Check, X, Clock, ExternalLink, ArrowUpDown, ChevronDown, Camera, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Search, MapPin, Check, X, Clock, ExternalLink, ArrowUpDown, ChevronDown, Camera, ChevronLeft, ChevronRight, Send } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { fetchSheetCities, SheetCity } from '../../lib/cities';
 import { fetchCityStatuses, updateCityStatus, CityStatusMap, getPartyPhotos } from '../../lib/api';
@@ -32,6 +32,7 @@ interface MergedCity {
   matchedEventUrl: string | null; // link to the matching event if auto-detected
   photoCount: number;
   matchedEventIds: string[];
+  hostTelegram: string | null;
 }
 
 type SortField = 'city' | 'country' | 'underboss' | 'status';
@@ -189,6 +190,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
         matchedEventUrl: matchedEvent ? `/${matchedEvent}` : null,
         photoCount: matchedEvents.reduce((sum, e) => sum + (e.photoCount || 0), 0) + (gppCounts[gppKey] || 0),
         matchedEventIds: matchedEvents.map(e => e.id),
+        hostTelegram: matchedEvents[0]?.hostTelegram || null,
       };
     });
   }, [sheetCities, cityStatuses, findMatchingEvents, gppCounts]);
@@ -812,6 +814,17 @@ function CityRow({
                 title="Telegram group"
               >
                 <ExternalLink size={10} />
+              </a>
+            )}
+            {city.hostTelegram && (
+              <a
+                href={`https://t.me/${city.hostTelegram.replace(/^@/, '')}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-purple-400 hover:text-purple-300 transition-colors"
+                title="DM host on Telegram"
+              >
+                <Send size={10} />
               </a>
             )}
           </div>

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote, ChevronLeft, ChevronRight, MessageCircle } from 'lucide-react';
+import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote, ChevronLeft, ChevronRight, MessageCircle, Send } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
 import { CopyEmailButton } from '../CopyEmailButton';
@@ -541,6 +541,17 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                     title="Telegram group"
                   >
                     <MessageCircle size={12} />
+                  </a>
+                )}
+                {event.hostTelegram && (
+                  <a
+                    href={`https://t.me/${event.hostTelegram.replace(/^@/, '')}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-purple-400 hover:text-purple-300 transition-colors shrink-0"
+                    title="DM host on Telegram"
+                  >
+                    <Send size={12} />
                   </a>
                 )}
               </div>

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -4,6 +4,7 @@ import { X, Search, Check, AlertCircle, Loader2, Send, ChevronDown, MessageSquar
 import { IconInput } from '../IconInput';
 import { fetchTelegramGroups, TelegramGroup } from '../../lib/telegram';
 import { sendTelegramBroadcast, sendTelegramTest, BroadcastResult } from '../../lib/api';
+import type { UnderbossEvent } from '../../types';
 
 /** Normalize a city name for fuzzy matching (strip accents, suffixes, etc.) */
 function normalizeCity(name: string): string {
@@ -94,11 +95,12 @@ function citiesMatch(eventCity: string, sheetCity: string): boolean {
 interface TelegramBroadcastProps {
   onClose: () => void;
   preSelectedCities?: string[];
+  events?: UnderbossEvent[];
 }
 
 type ViewState = 'compose' | 'sending' | 'results';
 
-export function TelegramBroadcast({ onClose, preSelectedCities }: TelegramBroadcastProps) {
+export function TelegramBroadcast({ onClose, preSelectedCities, events }: TelegramBroadcastProps) {
   // Data loading
   const [groups, setGroups] = useState<TelegramGroup[]>([]);
   const [loadingGroups, setLoadingGroups] = useState(true);
@@ -153,6 +155,25 @@ export function TelegramBroadcast({ onClose, preSelectedCities }: TelegramBroadc
     const regionSet = new Set(groups.map(g => g.region).filter(Boolean));
     return Array.from(regionSet).sort();
   }, [groups]);
+
+  // Build a lookup of group.city -> host telegram handle by fuzzy-matching event city names.
+  const hostTelegramByGroupId = useMemo(() => {
+    const map: Record<string, string> = {};
+    if (!events || events.length === 0) return map;
+    // Extract event city from "Global Pizza Party <city>" naming convention
+    const eventCities: { city: string; handle: string }[] = [];
+    for (const ev of events) {
+      if (!ev.hostTelegram) continue;
+      const match = ev.name.match(/Global Pizza Party\s+(.+)/i);
+      const city = match ? match[1].trim() : ev.name;
+      eventCities.push({ city, handle: ev.hostTelegram });
+    }
+    for (const g of groups) {
+      const found = eventCities.find(ec => citiesMatch(ec.city, g.city));
+      if (found) map[g.groupId] = found.handle;
+    }
+    return map;
+  }, [events, groups]);
 
   // Filtered groups
   const filteredGroups = useMemo(() => {
@@ -454,10 +475,11 @@ export function TelegramBroadcast({ onClose, preSelectedCities }: TelegramBroadc
                               {allFilteredSelected && <Check size={10} className="text-white" />}
                             </button>
                           </div>
-                          <div className="flex-1 grid grid-cols-3 gap-2">
+                          <div className="flex-1 grid grid-cols-4 gap-2">
                             <span>City</span>
                             <span>Country</span>
                             <span>Underboss</span>
+                            <span>Host TG</span>
                           </div>
                           <div className="w-14 text-right">Test</div>
                         </div>
@@ -482,10 +504,26 @@ export function TelegramBroadcast({ onClose, preSelectedCities }: TelegramBroadc
                                 {selectedIds.has(group.groupId) && <Check size={10} className="text-white" />}
                               </div>
                             </div>
-                            <div className="flex-1 grid grid-cols-3 gap-2 text-sm">
+                            <div className="flex-1 grid grid-cols-4 gap-2 text-sm">
                               <span className="text-theme-text truncate">{group.city}</span>
                               <span className="text-theme-text-secondary truncate">{group.country}</span>
                               <span className="text-theme-text-faint truncate">{group.underboss}</span>
+                              <span className="text-theme-text-faint truncate">
+                                {hostTelegramByGroupId[group.groupId] ? (
+                                  <a
+                                    href={`https://t.me/${hostTelegramByGroupId[group.groupId].replace(/^@/, '')}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-purple-400 hover:text-purple-300 transition-colors"
+                                    title="DM host on Telegram"
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    @{hostTelegramByGroupId[group.groupId].replace(/^@/, '')}
+                                  </a>
+                                ) : (
+                                  '—'
+                                )}
+                              </span>
                             </div>
                             <div className="w-14 text-right">
                               <button

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -456,7 +456,7 @@ export function UnderbossDashboard() {
       <Footer />
 
       {/* Telegram Broadcast Modal */}
-      {showBroadcast && <TelegramBroadcast onClose={() => { setShowBroadcast(false); setBroadcastCities([]); }} preSelectedCities={broadcastCities} />}
+      {showBroadcast && <TelegramBroadcast onClose={() => { setShowBroadcast(false); setBroadcastCities([]); }} preSelectedCities={broadcastCities} events={filteredData?.events ?? []} />}
 
       {/* Add Underboss Modal */}
       {showAddUnderboss && createPortal(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1019,6 +1019,7 @@ export interface UnderbossEvent {
   duration: number | null;
   country?: string | null;
   host: { name: string | null; email: string | null };
+  hostTelegram?: string | null;
   coHosts: any[];
   progress: UnderbossEventProgress;
   guestCount: number;


### PR DESCRIPTION
## Summary
- Threads `users.telegram` through the existing `/underboss` Prisma read path and exposes it as `UnderbossEvent.hostTelegram`.
- Adds a small purple `Send` (paper-plane) icon next to the existing Telegram-group icon in **EventRow** and in the city-name cell of **CitiesTable**. Clicking opens `https://t.me/<handle>` in a new tab.
- Adds a read-only **Host TG** column to the **TelegramBroadcast** modal that fuzzy-matches groups to events via the existing `citiesMatch` helper. Shows `@<handle>` (clickable) when matched, `—` otherwise. No selection state, no send path — just a way for admins to DM hosts manually via Telegram Web/Desktop while the broadcast modal is open.

## Backend constraint (important)
The backend only deploys from `master`, and preview branches share the production backend. **The new `hostTelegram` field will NOT be returned by the API until this PR is merged** — the Vercel frontend preview will look unchanged until then. Plan accordingly when reviewing.

## Test plan
- [ ] After merge: log in to `/underboss`, open the Events tab, pick a GPP city with a known host — the purple paper-plane icon appears next to the existing blue MessageCircle. Hovering brightens it; tooltip reads "DM host on Telegram".
- [ ] Click the icon — opens `https://t.me/<handle>` in a new tab.
- [ ] Cities tab: same icon appears next to the existing group-chat `ExternalLink` in the city-name cell.
- [ ] Missing-handle case (sheet city with no matched event): no icon renders, no crash, no `https://t.me/null`.
- [ ] Open the Telegram broadcast modal — the group list now shows a "Host TG" column. Matched cities show `@<handle>` as a clickable Telegram link; unmatched cities show `—`.

## Follow-up
Batch DM-sending from the broadcast modal is intentionally a separate task (`pineapple-75001`). Telegram bots can only DM users by numeric `chat_id`, which requires hosts to have `/start`'d the bot first (a flow we don't have yet). Documented in the plan's "Open question" section.

[plan](../tree/pineapple-75000-host-tg/plans/pineapple-75000-host-telegram-in-underboss.md)