### PR TITLE
capricciosa-60499: reconcile guest status on approve/decline

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -796,9 +796,19 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
       throw new AppError('approved must be a boolean', 400, 'VALIDATION_ERROR');
     }
 
+    // Only reconcile status when row is PENDING — avoid clobbering WAITLISTED.
+    const existing = await prisma.guest.findUnique({
+      where: { id: guestId, partyId },
+      select: { status: true },
+    });
+    const updateData: { approved: boolean; status?: 'CONFIRMED' | 'DECLINED' } = { approved };
+    if (existing?.status === 'PENDING') {
+      updateData.status = approved ? 'CONFIRMED' : 'DECLINED';
+    }
+
     const guest = await prisma.guest.update({
       where: { id: guestId, partyId },
-      data: { approved },
+      data: updateData,
     });
 
     // Trigger appropriate webhook

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -125,12 +125,14 @@ export const GPPDashboardTab: React.FC = () => {
           </div>
           <div className="text-xs text-theme-text-muted">Days Until Event</div>
         </div>
-        <div className="card p-4 text-center">
-          <div className="text-2xl font-bold text-theme-text">
-            {guests.filter((g) => g.status === 'PENDING').length}
+        {party.requireApproval && (
+          <div className="card p-4 text-center">
+            <div className="text-2xl font-bold text-theme-text">
+              {guests.filter((g) => g.approved === null).length}
+            </div>
+            <div className="text-xs text-theme-text-muted">Pending Approval</div>
           </div>
-          <div className="text-xs text-theme-text-muted">Pending Approval</div>
-        </div>
+        )}
         {party.underbossStatus === 'approved' && (
           <div className="card p-4 text-center border border-green-500/30">
             <div className="flex items-center justify-center gap-1.5 text-green-400">


### PR DESCRIPTION
## Summary

Fixes a long-standing data drift in `guests`: the approve/decline endpoint only wrote the `approved` flag, leaving `status` stuck at `PENDING`. Over time **5,139 production rows** ended up with `status=PENDING` but `approved=true/false`, inflating the host dashboard "Pending Approval" count and hiding actionable guests.

Reported on Providence (`/host/cmo1txdxz0001jr04rzdjchat`): dashboard showed "3 Pending Approval" but those guests were indistinguishable from approved ones on the Guests tab.

## Changes

- **`backend/src/routes/party.routes.ts`** — When the existing row is `PENDING`, the PATCH `/approve` handler now also sets `status` to `CONFIRMED`/`DECLINED`. Guarded with a pre-fetch so `WAITLISTED` rows are never clobbered.
- **`frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx`** — "Pending Approval" card counts `approved === null` (the real source of truth) and only renders when `party.requireApproval` is on.

## Drift scope (queried 2026-05-14)

| status=PENDING AND… | rows |
|---|---|
| approved = true (already approved) | 5,119 |
| approved = null (genuinely awaiting action) | 2,769 |
| approved = false (declined) | 20 |

## Deploy & backfill

1. Merge this PR.
2. Manually deploy backend: `cd backend && vercel --prod --scope pizza-dao`.
3. Run backfill (after backend is live to avoid mid-flight regression):
   ```sql
   UPDATE guests SET status = 'CONFIRMED' WHERE status = 'PENDING' AND approved = true;
   UPDATE guests SET status = 'DECLINED'  WHERE status = 'PENDING' AND approved = false;
   ```

## Test plan

- [ ] Vercel preview loads cleanly
- [ ] Providence host dashboard "Pending Approval" matches `approved IS NULL` count (still 0 in preview prior to backfill, since both Providence pendings have `approved=true`)
- [ ] Create a fresh test RSVP on a `requireApproval=true` party → row appears as Pending with Approve/Decline buttons
- [ ] Approve it → DB row has `approved=true` AND `status='CONFIRMED'`; dashboard counter decrements
- [ ] Decline another → DB row has `approved=false` AND `status='DECLINED'`
- [ ] On a party with `requireApproval=false`, the Pending Approval card doesn't render at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)