### PR TITLE
artichoke-43518: Community GPP event badge on user page

### DIFF
--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -60,6 +60,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         extraGppPhotos: true,
         telegramGroup: true,
         turtleRolesEnabled: true,
+        underbossStatus: true,
         password: true, // Just to check if it exists
         userId: true,
         user: {
@@ -128,6 +129,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
           extraGppPhotos: true,
           telegramGroup: true,
           turtleRolesEnabled: true,
+          underbossStatus: true,
           password: true,
           userId: true,
           user: {
@@ -277,6 +279,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         coHosts: sanitizedCoHosts,
         selectedPizzerias: party.selectedPizzerias,
         eventType: party.eventType,
+        underbossStatus: party.underbossStatus,
         eventTags: party.eventTags,
         donationEnabled: party.donationEnabled,
         donationRecipient: party.donationRecipient,

--- a/frontend/src/components/gpp/GPPBadge.tsx
+++ b/frontend/src/components/gpp/GPPBadge.tsx
@@ -4,18 +4,21 @@ import { Globe } from 'lucide-react';
 interface GPPBadgeProps {
   variant?: 'small' | 'large';
   className?: string;
+  community?: boolean;
 }
 
-export function GPPBadge({ variant = 'small', className = '' }: GPPBadgeProps) {
+export function GPPBadge({ variant = 'small', className = '', community = false }: GPPBadgeProps) {
+  const communityClass = community ? ' gpp-badge-community' : '';
+
   if (variant === 'large') {
     return (
-      <div className={`gpp-badge bg-gradient-to-r from-[#ff6b35]/20 to-[#ff393a]/20 border border-[#ff6b35]/30 rounded-xl p-4 ${className}`}>
+      <div className={`gpp-badge${communityClass} bg-gradient-to-r from-[#ff6b35]/20 to-[#ff393a]/20 border border-[#ff6b35]/30 rounded-xl p-4 ${className}`}>
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 bg-[#ff6b35]/20 rounded-full flex items-center justify-center">
             <Globe className="w-5 h-5 text-[#ff6b35]" />
           </div>
           <div>
-            <div className="font-semibold text-theme-text">Global Pizza Party</div>
+            <div className="font-semibold text-theme-text">{community ? 'Community Global Pizza Party' : 'Global Pizza Party'}</div>
             <div className="text-sm text-theme-text-secondary">Part of the worldwide celebration</div>
           </div>
         </div>
@@ -24,9 +27,9 @@ export function GPPBadge({ variant = 'small', className = '' }: GPPBadgeProps) {
   }
 
   return (
-    <div className={`gpp-badge inline-flex items-center gap-1.5 bg-[#ff6b35]/20 text-[#ff6b35] px-2.5 py-1 rounded-full text-xs font-medium ${className}`}>
+    <div className={`gpp-badge${communityClass} inline-flex items-center gap-1.5 bg-[#ff6b35]/20 text-[#ff6b35] px-2.5 py-1 rounded-full text-xs font-medium ${className}`}>
       <Globe className="w-3 h-3" />
-      <span>Global Pizza Party</span>
+      <span>{community ? 'Community Global Pizza Party Event' : 'Global Pizza Party'}</span>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -578,6 +578,10 @@ body.gpp-theme-active .pac-item-query {
 /* Hide GPP badge on GPP-themed pages (redundant since the whole page is GPP-styled) */
 .gpp-theme .gpp-badge, body.gpp-theme-active .gpp-badge { display: none !important; }
 
+/* Exception: community-listed GPP events should still show the badge to mark them as community-organized */
+.gpp-theme .gpp-badge.gpp-badge-community,
+body.gpp-theme-active .gpp-badge.gpp-badge-community { display: inline-flex !important; }
+
 /* Round the bottom-right corner of the event image on desktop */
 .gpp-theme .card .aspect-square {
   border-bottom-right-radius: 18px;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -416,6 +416,7 @@ export interface PublicEvent {
   userId: string | null;
   selectedPizzerias?: Pizzeria[];
   eventType?: string | null;
+  underbossStatus?: string | null;
   eventTags?: string[];
   donationEnabled?: boolean;
   donationRecipient?: string | null;

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -792,7 +792,7 @@ export function EventPage() {
               <div className="p-6 md:border-b md:border-theme-stroke">
                 {event.eventType === 'gpp' && (
                   <div className="mb-3">
-                    <GPPBadge />
+                    <GPPBadge community={event.underbossStatus === 'listed'} />
                   </div>
                 )}
                 <h1 className="text-4xl md:text-5xl font-bold text-theme-text mb-0" data-testid="event-name" style={{ fontFamily: "'Rubik', sans-serif" }}>{event.name}</h1>


### PR DESCRIPTION
## Summary
Show a **"Community Global Pizza Party Event"** badge on the user-facing `EventPage` for community-listed GPP events (`eventType === 'gpp' && underbossStatus === 'listed'`). Regular GPP events keep the existing hidden-badge behavior; non-GPP events are unchanged.

## Changes
- `frontend/src/components/gpp/GPPBadge.tsx` — add optional `community?: boolean` prop. When true, small-variant text becomes "Community Global Pizza Party Event", large-variant title becomes "Community Global Pizza Party", and the root element gets an extra `gpp-badge-community` class.
- `frontend/src/index.css` — add a CSS exception under the existing `.gpp-theme .gpp-badge { display: none }` rule so `.gpp-badge.gpp-badge-community` stays visible (`display: inline-flex !important;`).
- `frontend/src/pages/EventPage.tsx` — pass `community={event.underbossStatus === 'listed'}` to `<GPPBadge />`.

No i18n keys added (matches existing badge text). Host-side `PartyHeader.tsx` "Community Event" pill is untouched.

## Test plan
- [ ] Open a community-listed GPP event on the Vercel preview → "Community Global Pizza Party Event" badge appears above the title
- [ ] Open a non-listed GPP event (pending/approved/hidden) → no badge visible (existing behavior)
- [ ] Open a non-GPP event → no badge visible (existing behavior)
- [ ] Verify mobile and desktop layouts both render correctly
- [ ] Verify host-side `PartyHeader.tsx` "Community Event" pill still works (no regression)

Preview: https://rsvpizza-git-artichoke-43518-community-badge-pizza-dao.vercel.app

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>