### PR TITLE
brick-oven-63995: RSVP Step 2 i18n + surface backend errors

### DIFF
--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -446,7 +446,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
         setError('Failed to submit. Please try again.');
       }
     } catch (err) {
-      setError('Failed to submit. The party may no longer exist.');
+      setError(err instanceof Error ? err.message : 'Failed to submit. Please try again.');
     }
 
     setSubmitting(false);

--- a/frontend/src/i18n/locales/de/rsvp.json
+++ b/frontend/src/i18n/locales/de/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "Vor-Ort-Unterstützung"
   },
   "dietary": {
+    "Meat": "Fleisch",
     "Vegetarian": "Vegetarisch",
     "Vegan": "Vegan",
+    "Plain": "Klassisch",
     "Gluten-Free": "Glutenfrei",
     "Dairy-Free": "Laktosefrei"
   }

--- a/frontend/src/i18n/locales/en/rsvp.json
+++ b/frontend/src/i18n/locales/en/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "Ground Support"
   },
   "dietary": {
+    "Meat": "Meat",
     "Vegetarian": "Vegetarian",
     "Vegan": "Vegan",
+    "Plain": "Plain",
     "Gluten-Free": "Gluten-Free",
     "Dairy-Free": "Dairy-Free"
   }

--- a/frontend/src/i18n/locales/es/rsvp.json
+++ b/frontend/src/i18n/locales/es/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "Apoyo en Campo"
   },
   "dietary": {
+    "Meat": "Carne",
     "Vegetarian": "Vegetariano",
     "Vegan": "Vegano",
+    "Plain": "Simple",
     "Gluten-Free": "Sin Gluten",
     "Dairy-Free": "Sin Lácteos"
   }

--- a/frontend/src/i18n/locales/fr/rsvp.json
+++ b/frontend/src/i18n/locales/fr/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "Soutien terrain"
   },
   "dietary": {
+    "Meat": "Viande",
     "Vegetarian": "Végétarien",
     "Vegan": "Végétalien",
+    "Plain": "Nature",
     "Gluten-Free": "Sans gluten",
     "Dairy-Free": "Sans produits laitiers"
   }

--- a/frontend/src/i18n/locales/ja/rsvp.json
+++ b/frontend/src/i18n/locales/ja/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "グラウンドサポート"
   },
   "dietary": {
+    "Meat": "肉",
     "Vegetarian": "ベジタリアン",
     "Vegan": "ヴィーガン",
+    "Plain": "プレーン",
     "Gluten-Free": "グルテンフリー",
     "Dairy-Free": "乳製品フリー"
   }

--- a/frontend/src/i18n/locales/pt/rsvp.json
+++ b/frontend/src/i18n/locales/pt/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "Apoio Local"
   },
   "dietary": {
+    "Meat": "Carne",
     "Vegetarian": "Vegetariano",
     "Vegan": "Vegano",
+    "Plain": "Simples",
     "Gluten-Free": "Sem Glúten",
     "Dairy-Free": "Sem Laticínios"
   }

--- a/frontend/src/i18n/locales/zh/rsvp.json
+++ b/frontend/src/i18n/locales/zh/rsvp.json
@@ -125,8 +125,10 @@
     "Ground Support": "后勤支持"
   },
   "dietary": {
+    "Meat": "肉类",
     "Vegetarian": "素食",
     "Vegan": "纯素",
+    "Plain": "原味",
     "Gluten-Free": "无麸质",
     "Dairy-Free": "无乳制品"
   }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1281,9 +1281,13 @@ export async function addGuestToParty(
     });
 
     if (!response.ok) {
-      const errorData = await response.json();
+      let errorData: any = null;
+      try {
+        errorData = await response.json();
+      } catch {}
       console.error('Error adding guest:', errorData);
-      return null;
+      const message = errorData?.error?.message || errorData?.message || `HTTP ${response.status}`;
+      throw new Error(message);
     }
 
     const data = await response.json();


### PR DESCRIPTION
## Summary

Two fixes addressing the `/warri` RSVP Step 2 report:

1. **Missing dietary i18n keys** — `Meat` and `Plain` were rendering as raw translation keys (`dietary.Meat`, `dietary.Plain`). Added entries to all 7 locales (`en`, `es`, `fr`, `de`, `pt`, `ja`, `zh`) in the same order as `DIETARY_OPTIONS` (Meat, Vegetarian, Vegan, Plain, Gluten-Free, Dairy-Free).
2. **Surface backend errors** — `addGuestToParty` now `throw`s with the backend's `error.message` on non-2xx; `useRSVPForm` shows that real message instead of the generic "Failed to submit. Please try again." Network-failure path (catch + return null) keeps the generic message.

Diagnosis: direct curl to `POST /api/rsvp/warri/guest` returns 201 even when Privy hits `max_accounts_reached` (caught and non-fatal in backend), so the user's submit failure was intermittent (likely network). Now future failures self-report instead of being swallowed.

## Test plan

- [ ] Visit `/warri` RSVP Step 2 on the preview deploy — confirm Meat and Plain buttons show localized labels.
- [ ] Switch language to es/fr/de/pt/ja/zh — confirm labels render in language.
- [ ] Simulate a backend 5xx (or block the network) — confirm the error toast now shows the backend message instead of "Failed to submit. Please try again."