### PR TITLE
fix(prosciutto-85133): surface backend RSVP errors instead of swallowing

### DIFF
--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1247,10 +1247,10 @@ export async function addGuestToParty(
   swcUkOptIn?: boolean,
   swcBrOptIn?: boolean,
   ethconfOptIn?: boolean
-): Promise<{ guest: DbGuest; alreadyRegistered: boolean; requireApproval: boolean; updated: boolean; waitlisted: boolean; waitlistPosition: number | null } | null> {
+): Promise<{ guest: DbGuest; alreadyRegistered: boolean; requireApproval: boolean; updated: boolean; waitlisted: boolean; waitlistPosition: number | null }> {
   if (!inviteCode) {
     console.error('Invite code is required to add guest');
-    return null;
+    throw new Error('Invite code is required to submit RSVP');
   }
 
   try {
@@ -1331,7 +1331,7 @@ export async function addGuestToParty(
     };
   } catch (error) {
     console.error('Error adding guest:', error);
-    return null;
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Bug

Users on `rsv.pizza/chicago` (and any RSVP form) see the generic "Failed to submit. Please try again." message instead of the actual backend error. This blocks debugging the real failure for affected users.

## Root cause

The `brick-oven-63995` fix (`9400c4eb`) added `throw new Error(message)` inside the `!response.ok` branch of `addGuestToParty`, intending to bubble the backend error up to the RSVP form. But the function's own outer `catch (error)` block was still in place and immediately swallowed the throw, returning `null`. So the caller in `useRSVPForm` only ever saw `null` and fell back to the generic message.

## Fix

In `frontend/src/lib/supabase.ts` `addGuestToParty`:

1. Outer `catch` now `throw error` instead of `return null`, so the error reaches `useRSVPForm`'s existing `try/catch (err) { setError(err.message) }`.
2. Dropped `| null` from the return type — the function now either returns the success object or throws.
3. The early `return null` for missing `inviteCode` becomes `throw new Error('Invite code is required to submit RSVP')` for a consistent contract.

`useRSVPForm.ts` is not modified — its existing `catch (err) { setError(err instanceof Error ? err.message : 'Failed to submit. Please try again.') }` already does the right thing. The `if (result) { ... } else { setError('Failed to submit...') }` `else` branch is now unreachable on the failure path but harmless; left alone to keep the diff minimal.

## Test plan

- [ ] `cd frontend && npx tsc --noEmit` passes (verified locally).
- [ ] On the Vercel preview, go to `/chicago`, fill in step 1 with input that the backend rejects (e.g. malformed email), submit — should see the backend's actual error message in the red box, not "Failed to submit. Please try again."
- [ ] Submit a valid RSVP — should still succeed normally.
- [ ] Once this lands, real Chicago user reports should now show the underlying error so we can diagnose the actual `/chicago` failure.

## Preview

https://rsvpizza-git-prosciutto-85133-rsvp-error-surface-pizza-dao.vercel.app

Plan: `plans/prosciutto-85133-rsvp-error-swallow.md`