### PR TITLE
brick-oven-36790: require TLD in RSVP email

### DIFF
--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -371,12 +371,22 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
       setError('Please enter your name');
       return;
     }
+    const emailValue = email.trim();
+    if (!emailValue) {
+      setError('Please enter your email');
+      return;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+    if (!emailRegex.test(emailValue)) {
+      setError('Please enter a valid email address (including a domain like .com)');
+      return;
+    }
     setError(null);
     // Track funnel step
     const slug = eventData.customUrl || eventData.inviteCode;
     if (slug) trackRsvpFunnel(slug, 'rsvp_step1_complete');
     setStep(2);
-  }, [name, eventData.customUrl, eventData.inviteCode]);
+  }, [name, email, eventData.customUrl, eventData.inviteCode]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
Closes brick-oven-36790.

## What changed
Added email format validation (including a TLD check) inside `handleStep1Continue` in `frontend/src/hooks/useRSVPForm.ts`, between the existing name check and the step-advance. Uses the regex `/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/` to require a non-empty local part, `@`, a domain, a dot, and at least a 2-character TLD. `email` was added to the `useCallback` dep array.

## How to test
1. Open an event RSVP form (step 1).
2. Enter a name and the email `foo@bar` then click Continue — form should stay on step 1 and show "Please enter a valid email address (including a domain like .com)".
3. Clear the email field and click Continue — should show "Please enter your email".
4. Enter `foo@bar.co` and click Continue — should advance to step 2.