### PR TITLE
fix(pepperoni-85854): event address link opens Google Maps place listing

### DIFF
--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -504,10 +504,10 @@ export function EventPage() {
   };
 
   // Interactive Google Maps JS SDK venue thumbnail (see VenueMap component)
-  const googleMapsUrl = event.latitude && event.longitude
-    ? `https://www.google.com/maps/search/?api=1&query=${event.latitude},${event.longitude}`
-    : event.address
-      ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`
+  const googleMapsUrl = event.address
+    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`
+    : event.latitude && event.longitude
+      ? `https://www.google.com/maps/search/?api=1&query=${event.latitude},${event.longitude}`
       : null;
 
   const metaTitle = event.name;


### PR DESCRIPTION
## Bug

On event pages whose venue has a real address (e.g. Cuube Group office on `/chicago`), clicking the address opened Google Maps but only dropped a generic coordinate pin instead of resolving to the actual place listing (with name, hours, photos, reviews).

## Root cause

`EventPage.tsx` built the `googleMapsUrl` with `event.latitude && event.longitude` checked **first**, falling back to `event.address` only when coordinates were missing. Since most events have coordinates (geocoded from the address at create time), the lat/lng query always won — and Google Maps' `query=lat,lng` form is interpreted as "drop a pin here" rather than "find the place at this address".

## Fix

Swap the ternary so `event.address` is preferred when present, with `event.latitude && event.longitude` as the fallback. One file changed, 4 lines added / 4 lines removed.

```ts
// before
const googleMapsUrl = event.latitude && event.longitude
  ? `https://www.google.com/maps/search/?api=1&query=${event.latitude},${event.longitude}`
  : event.address
    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`
    : null;

// after
const googleMapsUrl = event.address
  ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`
  : event.latitude && event.longitude
    ? `https://www.google.com/maps/search/?api=1&query=${event.latitude},${event.longitude}`
    : null;
```

## Test plan

- [ ] Visit `/chicago` on the Vercel preview — address link should open the Cuube Group office place listing (not a bare coordinate pin)
- [ ] Visit any event whose `address` is set — link opens the named venue page
- [ ] Visit an event with only lat/lng (no address) — link still falls back to a coordinate pin
- [ ] `npm run build` in `frontend/` succeeds