### PR TITLE
truffle-87503: stop /shipping search from reloading on every keystroke

### DIFF
--- a/frontend/src/pages/ShippingDashboard.tsx
+++ b/frontend/src/pages/ShippingDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
 import { Loader2, Shield, AlertCircle, Truck, ChevronDown, LogIn, Check, Printer } from 'lucide-react';
@@ -35,14 +35,23 @@ export function ShippingDashboard() {
   const [meData, setMeData] = useState<ShippingMeResponse | null>(null);
   const [kits, setKits] = useState<ShippingKit[]>([]);
   const [stats, setStats] = useState<ShippingKitStats | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const hasLoadedOnceRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   const [showLoginModal, setShowLoginModal] = useState(false);
 
   // Filters
   const [statusFilter, setStatusFilter] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [countryFilter, setCountryFilter] = useState('');
+
+  // Debounce searchTerm → debouncedSearchTerm so the input stays responsive
+  // and the network filter only fires after the user pauses typing.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearchTerm(searchTerm), 300);
+    return () => clearTimeout(t);
+  }, [searchTerm]);
   const [sortField, setSortField] = useState('requestedAt');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
@@ -86,7 +95,7 @@ export function ShippingDashboard() {
       const filters: ShippingKitFilters = {};
       if (statusFilter) filters.status = statusFilter;
       if (countryFilter) filters.country = countryFilter;
-      if (searchTerm) filters.search = searchTerm;
+      if (debouncedSearchTerm) filters.search = debouncedSearchTerm;
       if (selectedRegion) filters.region = selectedRegion;
 
       const [kitsResult, statsResult] = await Promise.all([
@@ -99,13 +108,13 @@ export function ShippingDashboard() {
     } catch (err: any) {
       console.error('Failed to load shipping data:', err);
     }
-  }, [statusFilter, countryFilter, searchTerm, selectedRegion]);
+  }, [statusFilter, countryFilter, debouncedSearchTerm, selectedRegion]);
 
   // Initial access check
   useEffect(() => {
     if (authLoading) return;
     if (!user) {
-      setLoading(false);
+      setInitialLoading(false);
       return;
     }
 
@@ -115,7 +124,7 @@ export function ShippingDashboard() {
         setMeData(me);
 
         if (!me.role) {
-          setLoading(false);
+          setInitialLoading(false);
           setError('You are not authorized to access the shipping dashboard.');
           return;
         }
@@ -125,7 +134,7 @@ export function ShippingDashboard() {
           setSelectedRegion(me.regions[0]);
         }
       } catch (err: any) {
-        setLoading(false);
+        setInitialLoading(false);
         setError(err.message || 'Failed to check access');
       }
     }
@@ -133,12 +142,18 @@ export function ShippingDashboard() {
     checkAccess();
   }, [user, authLoading]);
 
-  // Load data when access is confirmed
+  // Load data when access is confirmed.
+  // Only flip the full-page spinner off once; subsequent refetches keep the
+  // table mounted so the search input doesn't lose focus on every keystroke.
   useEffect(() => {
     if (!meData || !meData.role) return;
 
-    setLoading(true);
-    loadData().finally(() => setLoading(false));
+    loadData().finally(() => {
+      if (!hasLoadedOnceRef.current) {
+        hasLoadedOnceRef.current = true;
+        setInitialLoading(false);
+      }
+    });
   }, [meData, loadData]);
 
   // Unique countries from kit data
@@ -242,7 +257,7 @@ export function ShippingDashboard() {
       const filters: ShippingKitFilters = {};
       if (statusFilter) filters.status = statusFilter;
       if (countryFilter) filters.country = countryFilter;
-      if (searchTerm) filters.search = searchTerm;
+      if (debouncedSearchTerm) filters.search = debouncedSearchTerm;
       if (selectedRegion) filters.region = selectedRegion;
 
       const blob = await exportShippingKitsCsv(filters);
@@ -297,7 +312,7 @@ export function ShippingDashboard() {
   }
 
   // Loading
-  if (loading || authLoading) {
+  if (initialLoading || authLoading) {
     return (
       <div className={`min-h-screen ${themeClass}`} style={backgroundStyle}>
         <Header />


### PR DESCRIPTION
## Summary

Fixes the shipping dashboard search field unmounting the page on every keystroke.

Plan: [`plans/truffle-87503-shipping-search-reload.md`](../blob/master/plans/truffle-87503-shipping-search-reload.md)

### Root cause

`loadData` is a `useCallback` keyed on `searchTerm`. A `useEffect` calls `setLoading(true)` whenever `loadData`'s identity changes, and the render early-returns a full-page spinner while `loading` is `true`. Net effect: each keystroke unmounts the input.

### Changes (one file: `frontend/src/pages/ShippingDashboard.tsx`)

- Added a 300 ms debounced `debouncedSearchTerm` used by `loadData` and `handleExport`'s filter object. The input's `value`/`onChange` still tracks `searchTerm` so typing stays instant.
- Renamed `loading` to `initialLoading` and gated it on a `hasLoadedOnceRef` so the full-page spinner only appears on the first load. Subsequent refetches (filters, status/tier mutations, CSV import) leave the table mounted and update rows in place.

## Test plan

- [ ] `/shipping` loads with a spinner once, then the dashboard appears.
- [ ] Typing "lond" quickly in the search box keeps focus, no spinner flash; network request fires ~300 ms after the last keystroke.
- [ ] Changing the status / country / region filter re-renders the table without a full-page spinner.
- [ ] Full F5 reload shows the full-page spinner once until the first kit list arrives.
- [ ] Editing a kit's status / tier from the row dropdown does not flash the full-page spinner; row updates optimistically and stats refresh silently.
- [ ] Importing a CSV closes the modal and refreshes the kit list in place — no full-page spinner.