### PR TITLE
oregano-58698: remove 'future' from SWC notify copy

### DIFF
--- a/frontend/src/i18n/locales/de/rsvp.json
+++ b/frontend/src/i18n/locales/de/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "Welcher Ninja Turtle sind Sie am ähnlichsten?",
     "mailingList": "PizzaDAO-Mailingliste beitreten",
     "swcJoin": "Stand with Crypto beitreten",
-    "swcNotify": "Benachrichtigen Sie mich über zukünftige Stand With Crypto Events.",
+    "swcNotify": "Benachrichtigen Sie mich über Stand With Crypto Events.",
     "swcBrNotify": "Benachrichtigen Sie mich über Veranstaltungen von Juntos por Cripto.",
     "ethconfDiscount": "ETHConf-Rabatt zusenden",
     "next": "Weiter",

--- a/frontend/src/i18n/locales/en/rsvp.json
+++ b/frontend/src/i18n/locales/en/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "What ninja turtle(s) are you most like?",
     "mailingList": "Join PizzaDAO's mailing list",
     "swcJoin": "Join Stand with Crypto",
-    "swcNotify": "Notify me about future Stand With Crypto events.",
+    "swcNotify": "Notify me about Stand With Crypto events.",
     "swcBrNotify": "Notify me about Juntos por Cripto events.",
     "ethconfDiscount": "Send me an ETHConf Discount",
     "next": "Next",

--- a/frontend/src/i18n/locales/es/rsvp.json
+++ b/frontend/src/i18n/locales/es/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "¿A cuál(es) tortuga(s) ninja te pareces más?",
     "mailingList": "Unirme a la lista de correo de PizzaDAO",
     "swcJoin": "Unirme a Stand with Crypto",
-    "swcNotify": "Notificarme sobre futuros eventos de Stand With Crypto.",
+    "swcNotify": "Notificarme sobre eventos de Stand With Crypto.",
     "swcBrNotify": "Notifícame sobre eventos de Juntos por Cripto.",
     "ethconfDiscount": "Enviarme un descuento de ETHConf",
     "next": "Siguiente",

--- a/frontend/src/i18n/locales/fr/rsvp.json
+++ b/frontend/src/i18n/locales/fr/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "À quelle(s) tortue(s) ninja ressemblez-vous le plus ?",
     "mailingList": "Rejoindre la liste de diffusion PizzaDAO",
     "swcJoin": "Rejoindre Stand with Crypto",
-    "swcNotify": "Me notifier des futurs événements Stand With Crypto.",
+    "swcNotify": "Me notifier des événements Stand With Crypto.",
     "swcBrNotify": "Informez-moi des événements de Juntos por Cripto.",
     "ethconfDiscount": "M'envoyer une réduction ETHConf",
     "next": "Suivant",

--- a/frontend/src/i18n/locales/ja/rsvp.json
+++ b/frontend/src/i18n/locales/ja/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "あなたはどの忍者タートルに似ていますか？",
     "mailingList": "PizzaDAOのメーリングリストに参加",
     "swcJoin": "Stand with Cryptoに参加",
-    "swcNotify": "今後のStand With Cryptoイベントについて通知を受け取る。",
+    "swcNotify": "Stand With Cryptoイベントについて通知を受け取る。",
     "swcBrNotify": "Juntos por Cripto のイベントについて通知してください。",
     "ethconfDiscount": "ETHConf割引を送ってほしい",
     "next": "次へ",

--- a/frontend/src/i18n/locales/pt/rsvp.json
+++ b/frontend/src/i18n/locales/pt/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "Com qual tartaruga ninja você mais se identifica?",
     "mailingList": "Inscrever-se na lista de emails do PizzaDAO",
     "swcJoin": "Participar do Stand with Crypto",
-    "swcNotify": "Notifique-me sobre futuros eventos Stand With Crypto.",
+    "swcNotify": "Notifique-me sobre eventos Stand With Crypto.",
     "swcBrNotify": "Notifique-me sobre eventos da Juntos por Cripto.",
     "ethconfDiscount": "Envie-me um desconto ETHConf",
     "next": "Próximo",

--- a/frontend/src/i18n/locales/zh/rsvp.json
+++ b/frontend/src/i18n/locales/zh/rsvp.json
@@ -9,7 +9,7 @@
     "roleQuestion": "你最像哪只忍者龟？",
     "mailingList": "订阅 PizzaDAO 邮件列表",
     "swcJoin": "加入 Stand with Crypto",
-    "swcNotify": "通知我未来的 Stand With Crypto 活动。",
+    "swcNotify": "通知我 Stand With Crypto 活动。",
     "swcBrNotify": "通知我有关 Juntos por Cripto 活动的信息。",
     "ethconfDiscount": "给我发送 ETHConf 折扣",
     "next": "下一步",

--- a/plans/oregano-58698-swc-notify-future-copy.md
+++ b/plans/oregano-58698-swc-notify-future-copy.md
@@ -1,0 +1,52 @@
+# oregano-58698: Remove "future" from SWC notify checkbox copy
+
+**Priority:** P3
+**Type:** Copy / i18n
+
+## Problem
+The Stand With Crypto opt-in checkbox (used for CA/AU/EU/UK) reads "Notify me about **future** Stand With Crypto events." The word "future" is redundant (a notification is implicitly forward-looking) and was supposed to have been removed earlier.
+
+Affected key: `swcNotify` in `frontend/src/i18n/locales/{lang}/rsvp.json`.
+
+The `swcBrNotify` key (Juntos por Cripto) already lacks "future" and should NOT be touched.
+
+## Exact edits
+
+For each locale, replace only the `swcNotify` line:
+
+| Locale | Before | After |
+|---|---|---|
+| en | `Notify me about future Stand With Crypto events.` | `Notify me about Stand With Crypto events.` |
+| de | `Benachrichtigen Sie mich über zukünftige Stand With Crypto Events.` | `Benachrichtigen Sie mich über Stand With Crypto Events.` |
+| fr | `Me notifier des futurs événements Stand With Crypto.` | `Me notifier des événements Stand With Crypto.` |
+| es | `Notificarme sobre futuros eventos de Stand With Crypto.` | `Notificarme sobre eventos de Stand With Crypto.` |
+| pt | `Notifique-me sobre futuros eventos Stand With Crypto.` | `Notifique-me sobre eventos Stand With Crypto.` |
+| ja | `今後のStand With Cryptoイベントについて通知を受け取る。` | `Stand With Cryptoイベントについて通知を受け取る。` |
+| zh | `通知我未来的 Stand With Crypto 活动。` | `通知我 Stand With Crypto 活动。` |
+
+(8th locale is whichever else lives under `frontend/src/i18n/locales/`; only edit `swcNotify` in that file too if present, otherwise skip.)
+
+## Files to modify
+- `frontend/src/i18n/locales/en/rsvp.json`
+- `frontend/src/i18n/locales/de/rsvp.json`
+- `frontend/src/i18n/locales/fr/rsvp.json`
+- `frontend/src/i18n/locales/es/rsvp.json`
+- `frontend/src/i18n/locales/pt/rsvp.json`
+- `frontend/src/i18n/locales/ja/rsvp.json`
+- `frontend/src/i18n/locales/zh/rsvp.json`
+
+## Out of scope
+- Do NOT touch `swcJoin`, `swcBrNotify`, or any `swc*Modal.*` keys.
+- Do NOT touch database fields, schema, or backend.
+- Do NOT change the i18n key name.
+
+## Verification
+- `grep -ri "future" frontend/src/i18n/locales/*/rsvp.json` returns no SWC-related matches.
+- `grep -ri "futur" frontend/src/i18n/locales/*/rsvp.json` returns nothing related to SWC (fr/es/pt).
+- `grep -ri "zukünftig" frontend/src/i18n/locales/de/rsvp.json` returns nothing.
+- `grep "今後" frontend/src/i18n/locales/ja/rsvp.json` returns nothing in the swc block.
+- `grep "未来" frontend/src/i18n/locales/zh/rsvp.json` returns nothing.
+- JSON files are still valid (the agent should run `node -e "JSON.parse(require('fs').readFileSync(p))"` on each).
+
+## Branch
+`oregano-58698-swc-notify-future`


### PR DESCRIPTION
## Summary
- Drops the word "future" from the `swcNotify` i18n string in all 7 locales (en/de/fr/es/pt/ja/zh).
- "Notify me about future Stand With Crypto events." was redundant — a notification is implicitly forward-looking.
- Affects the CA/AU/EU/UK Stand With Crypto opt-in checkboxes on the RSVP form. `swcJoin` (US), `swcBrNotify` (Brazil), and all `swc*Modal` consent copy are unchanged.

See `plans/oregano-58698-swc-notify-future-copy.md` for the per-locale before/after table.

## Test plan
- [ ] Open RSVP form on a Vercel preview, scroll to the SWC checkbox, confirm the new copy renders for each locale.
- [ ] Verify the US (`swcJoin`) and Brazil (`swcBrNotify`) checkboxes still read as before.
- [ ] Confirm modal consent text is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)