### PR TITLE
pie-62035: move avatar upload to top of Edit/Add Host modals

### DIFF
--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -514,6 +514,46 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
             <h2 className="text-lg font-semibold text-theme-text mb-4">Edit Host</h2>
 
             <div className="space-y-3">
+              {/* Avatar upload */}
+              <div>
+                <input
+                  ref={editAvatarInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleEditAvatarFileChange}
+                  className="hidden"
+                />
+                <div className="flex items-center gap-3">
+                  {(editAvatarFilePreview || editHostAvatarUrl) ? (
+                    <img
+                      src={editAvatarFilePreview || editHostAvatarUrl}
+                      alt=""
+                      className="w-10 h-10 rounded-full object-cover border border-white/20 shrink-0"
+                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                    />
+                  ) : (
+                    <div className="w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke shrink-0" />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => editAvatarInputRef.current?.click()}
+                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
+                  >
+                    <Upload size={16} />
+                    Upload avatar
+                  </button>
+                  {(editAvatarFilePreview || editHostAvatarUrl) && (
+                    <button
+                      type="button"
+                      onClick={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); }}
+                      className="text-xs text-red-400 hover:text-red-300"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+
               <input
                 type="text"
                 value={editHostName}
@@ -566,44 +606,6 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
               </div>
-
-              {/* Avatar upload */}
-              <div>
-                <input
-                  ref={editAvatarInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleEditAvatarFileChange}
-                  className="hidden"
-                />
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => editAvatarInputRef.current?.click()}
-                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
-                  >
-                    <Upload size={16} />
-                    Upload avatar
-                  </button>
-                  {(editAvatarFilePreview || editHostAvatarUrl) && (
-                    <>
-                      <img
-                        src={editAvatarFilePreview || editHostAvatarUrl}
-                        alt=""
-                        className="w-10 h-10 rounded-full object-cover border border-white/20"
-                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); }}
-                        className="text-xs text-red-400 hover:text-red-300"
-                      >
-                        Clear
-                      </button>
-                    </>
-                  )}
-                </div>
-              </div>
             </div>
 
             <div className="flex gap-3 mt-4">
@@ -635,6 +637,46 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
             <h2 className="text-lg font-semibold text-theme-text mb-4">Add Host</h2>
 
             <div className="space-y-3">
+              {/* Avatar upload */}
+              <div>
+                <input
+                  ref={newAvatarInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleNewAvatarFileChange}
+                  className="hidden"
+                />
+                <div className="flex items-center gap-3">
+                  {(newAvatarFilePreview || newCoHostAvatarUrl) ? (
+                    <img
+                      src={newAvatarFilePreview || newCoHostAvatarUrl}
+                      alt=""
+                      className="w-10 h-10 rounded-full object-cover border border-white/20 shrink-0"
+                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                    />
+                  ) : (
+                    <div className="w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke shrink-0" />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => newAvatarInputRef.current?.click()}
+                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
+                  >
+                    <Upload size={16} />
+                    Upload avatar
+                  </button>
+                  {(newAvatarFilePreview || newCoHostAvatarUrl) && (
+                    <button
+                      type="button"
+                      onClick={() => { setNewCoHostAvatarFile(null); setNewCoHostAvatarUrl(''); }}
+                      className="text-xs text-red-400 hover:text-red-300"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+
               <input
                 type="text"
                 value={newCoHostName}
@@ -685,44 +727,6 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                   placeholder="Instagram (no @)"
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
-              </div>
-
-              {/* Avatar upload */}
-              <div>
-                <input
-                  ref={newAvatarInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleNewAvatarFileChange}
-                  className="hidden"
-                />
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => newAvatarInputRef.current?.click()}
-                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
-                  >
-                    <Upload size={16} />
-                    Upload avatar
-                  </button>
-                  {(newAvatarFilePreview || newCoHostAvatarUrl) && (
-                    <>
-                      <img
-                        src={newAvatarFilePreview || newCoHostAvatarUrl}
-                        alt=""
-                        className="w-10 h-10 rounded-full object-cover border border-white/20"
-                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => { setNewCoHostAvatarFile(null); setNewCoHostAvatarUrl(''); }}
-                        className="text-xs text-red-400 hover:text-red-300"
-                      >
-                        Clear
-                      </button>
-                    </>
-                  )}
-                </div>
               </div>
             </div>
 

--- a/plans/pie-62035-avatar-to-top.md
+++ b/plans/pie-62035-avatar-to-top.md
@@ -1,0 +1,79 @@
+# pie-62035 — Move avatar upload to top of Edit Host & Add Host modals
+
+**Priority:** P2
+**File:** `frontend/src/components/HostsManager.tsx`
+
+## Goal
+Move the avatar upload block to the top of the Edit Host modal (and the matching Add Host modal). The avatar preview should sit on the left, the Upload button on the right, with the Clear link after the button. The block should sit above the Name field, separated from the rest of the form by the existing `space-y-3` spacing.
+
+Current order in both modals: Name → Email → Website → Twitter/Instagram → **Avatar upload** (button | avatar | clear).
+Target order: **Avatar upload** (avatar | button | clear) → Name → Email → Website → Twitter/Instagram.
+
+## Files to modify
+- `frontend/src/components/HostsManager.tsx` — only file.
+
+## Changes
+
+### Edit Host modal (around lines 510–629)
+
+Move the entire `{/* Avatar upload */}` block (currently lines ~570–606) to be the **first** child inside the `<div className="space-y-3">` container (above the Name input at line 517).
+
+Inside that block, reorder the flex row so the avatar preview comes first, then the Upload button, then the Clear link. The flex row currently renders: `[Upload button] [<img>] [Clear button]`. Change to: `[<img> placeholder when none] [Upload button] [Clear button]`.
+
+To keep the row vertically balanced when there is no avatar yet, render a neutral placeholder circle (same `w-10 h-10 rounded-full` dimensions) when `editAvatarFilePreview || editHostAvatarUrl` is falsy. Use `bg-theme-surface border border-theme-stroke` for the placeholder background.
+
+Resulting JSX shape inside the `flex items-center gap-3` row:
+
+```jsx
+{(editAvatarFilePreview || editHostAvatarUrl) ? (
+  <img
+    src={editAvatarFilePreview || editHostAvatarUrl}
+    alt=""
+    className="w-10 h-10 rounded-full object-cover border border-white/20 shrink-0"
+    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+  />
+) : (
+  <div className="w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke shrink-0" />
+)}
+<button
+  type="button"
+  onClick={() => editAvatarInputRef.current?.click()}
+  className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
+>
+  <Upload size={16} />
+  Upload avatar
+</button>
+{(editAvatarFilePreview || editHostAvatarUrl) && (
+  <button
+    type="button"
+    onClick={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); }}
+    className="text-xs text-red-400 hover:text-red-300"
+  >
+    Clear
+  </button>
+)}
+```
+
+The hidden `<input type="file" ref={editAvatarInputRef} … />` stays inside the same wrapper `<div>` as the flex row.
+
+### Add Host modal (around lines 631–~750)
+
+Apply the **identical** reorder to the Add Host modal: move the `{/* Avatar upload */}` block to be the first child inside its `space-y-3` container, and reorder the row to `[avatar placeholder or <img>] [Upload button] [Clear]`. The state names there are `newAvatarFilePreview`, `newCoHostAvatarUrl`, `newAvatarInputRef`, `setNewCoHostAvatarFile`, `setNewCoHostAvatarUrl`, `handleNewAvatarFileChange`.
+
+## Non-goals
+- Do not change any state, refs, handlers, or upload logic.
+- Do not change PartnerForm (different component, different request).
+- Do not touch styling on the inputs themselves.
+
+## Verification
+1. Open an event as host → Hosts section → click pencil on a host → Edit Host modal opens.
+   - Avatar block sits above the Name field.
+   - When the host has an avatar: image on the left, Upload button to its right, Clear link after.
+   - When no avatar: a neutral circle placeholder on the left, Upload button to its right, no Clear.
+2. Click "Add Host" → same layout, with empty placeholder.
+3. Upload a new image → preview replaces the placeholder, Clear appears.
+4. Click Clear → preview returns to placeholder, Clear disappears.
+5. Save flow still works unchanged.
+
+## Branch
+`pie-62035-avatar-to-top`


### PR DESCRIPTION
## Summary
- Move the avatar upload block to the **top** of both the **Edit Host** and **Add Host** modals in `HostsManager.tsx`, above the Name field.
- Reorder the flex row to `[avatar/placeholder] [Upload button] [Clear]` (was: `[Upload button] [avatar] [Clear]`).
- When no avatar is set, render a neutral `w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke` placeholder so the row stays visually balanced.
- Add `shrink-0` to the `<img>` so it doesn't squish on narrow widths.
- The Clear button now only renders when an avatar exists (guard moved off the image to wrap only Clear).

## Affected modals
- Edit Host modal (state: `editAvatarFilePreview`, `editHostAvatarUrl`, `editAvatarInputRef`)
- Add Host modal (state: `newAvatarFilePreview`, `newCoHostAvatarUrl`, `newAvatarInputRef`)

No state, refs, handlers, or upload/clear logic changed — JSX order + the placeholder div only.

## Preview
https://rsvpizza-git-pie-62035-avatar-to-top-pizza-dao.vercel.app

## Test plan
- [ ] Open an event as host → Hosts section → click pencil → avatar block appears above Name field.
- [ ] Host with avatar: image left, Upload button right, Clear after.
- [ ] Host with no avatar: placeholder circle left, Upload button right, no Clear.
- [ ] Click Add Host → same layout, empty placeholder.
- [ ] Upload an image → preview replaces placeholder, Clear appears.
- [ ] Click Clear → preview returns to placeholder, Clear disappears.
- [ ] Save flow still works unchanged.