### PR TITLE
salami-47402: hide drinks UI on GPP events

### DIFF
--- a/frontend/src/components/AddGuestForm.tsx
+++ b/frontend/src/components/AddGuestForm.tsx
@@ -11,6 +11,7 @@ interface AddGuestFormProps {
 
 export const AddGuestForm: React.FC<AddGuestFormProps> = ({ onClose }) => {
   const { availableToppings, availableBeverages, addGuest, dietaryOptions, party } = usePizza();
+  const isGppEvent = party?.eventType === 'gpp';
   const [name, setName] = useState('');
   const [dietaryRestrictions, setDietaryRestrictions] = useState<string[]>([]);
   const [toppings, setToppings] = useState<string[]>([]);
@@ -209,7 +210,7 @@ export const AddGuestForm: React.FC<AddGuestFormProps> = ({ onClose }) => {
           </div>
 
           {/* Beverage Preferences - Only show if party has beverages configured */}
-          {party?.availableBeverages && party.availableBeverages.length > 0 && (
+          {!isGppEvent && party?.availableBeverages && party.availableBeverages.length > 0 && (
             <div>
               <h3 className="text-sm font-medium text-theme-text-secondary mb-3">
                 Beverage Preferences

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -220,15 +220,23 @@ function AppCard({
   navigate,
   isPinned,
   onTogglePin,
+  isGppEvent,
 }: {
   app: AppItem;
   inviteCode: string;
   navigate: ReturnType<typeof useNavigate>;
   isPinned: boolean;
   onTogglePin?: (appId: string, pin: boolean) => void;
+  isGppEvent: boolean;
 }) {
   const isClickable = app.status !== 'coming-soon';
   const canPin = isPinnable(app.id) && app.status === 'live';
+
+  // GPP events hide drinks UI — relabel the pizza tile so the tile copy doesn't reference drinks.
+  const displayName = isGppEvent && app.id === 'pizzeria-selection' ? 'Pizza' : app.name;
+  const displayDescription = isGppEvent && app.id === 'pizzeria-selection'
+    ? 'Find and select nearby pizzerias'
+    : app.description;
 
   const iconBg = {
     live: 'bg-[#39d98a]/15',
@@ -298,7 +306,7 @@ function AppCard({
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <span className="text-sm font-medium text-theme-text truncate">{app.name}</span>
+            <span className="text-sm font-medium text-theme-text truncate">{displayName}</span>
             {isPinned && (
               <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-[#ff393a]/15 text-[#ff393a]">
                 Pinned
@@ -308,7 +316,7 @@ function AppCard({
               <ExternalLink size={12} className="text-[#5c7cfa] flex-shrink-0" />
             )}
           </div>
-          <p className="text-xs text-theme-text-muted leading-relaxed">{app.description}</p>
+          <p className="text-xs text-theme-text-muted leading-relaxed">{displayDescription}</p>
           <div className="mt-2">
             <StatusBadge status={app.status} />
           </div>
@@ -325,6 +333,7 @@ function AppSection({
   navigate,
   pinnedApps,
   onTogglePin,
+  isGppEvent,
 }: {
   title: string;
   apps: AppItem[];
@@ -332,6 +341,7 @@ function AppSection({
   navigate: ReturnType<typeof useNavigate>;
   pinnedApps: string[];
   onTogglePin: (appId: string, pin: boolean) => void;
+  isGppEvent: boolean;
 }) {
   return (
     <div>
@@ -347,6 +357,7 @@ function AppSection({
             navigate={navigate}
             isPinned={pinnedApps.includes(app.id)}
             onTogglePin={onTogglePin}
+            isGppEvent={isGppEvent}
           />
         ))}
       </div>
@@ -364,8 +375,9 @@ export function AppsHub({
   partyId: string;
 }) {
   const navigate = useNavigate();
-  const { loadParty } = usePizza();
+  const { loadParty, party } = usePizza();
   const [pinnedApps, setPinnedApps] = useState<string[]>(initialPinnedApps);
+  const isGppEvent = party?.eventType === 'gpp';
 
   const handleTogglePin = async (appId: string, pin: boolean) => {
     // Optimistic update
@@ -406,6 +418,7 @@ export function AppsHub({
             navigate={navigate}
             pinnedApps={pinnedApps}
             onTogglePin={handleTogglePin}
+            isGppEvent={isGppEvent}
           />
         );
       })}

--- a/frontend/src/components/BeverageOrderSummary.tsx
+++ b/frontend/src/components/BeverageOrderSummary.tsx
@@ -6,6 +6,9 @@ export const BeverageOrderSummary: React.FC = () => {
   const { beverageRecommendations, party, guests } = usePizza();
   const [isCopied, setIsCopied] = useState(false);
 
+  const isGppEvent = party?.eventType === 'gpp';
+  if (isGppEvent) return null;
+
   const totalBeverages = beverageRecommendations.reduce((acc, rec) => acc + rec.quantity, 0);
   const respondedGuests = guests.length;
   const expectedGuests = party?.maxGuests || respondedGuests;

--- a/frontend/src/components/BeverageSettings.tsx
+++ b/frontend/src/components/BeverageSettings.tsx
@@ -19,6 +19,9 @@ export const BeverageSettings: React.FC = () => {
   });
   const [customInput, setCustomInput] = useState('');
 
+  const isGppEvent = party?.eventType === 'gpp';
+  if (isGppEvent) return null;
+
   const toggleBeverage = (beverageId: string) => {
     const newSelection = selectedBeverages.includes(beverageId)
       ? selectedBeverages.filter(id => id !== beverageId)

--- a/frontend/src/components/GuestCard.tsx
+++ b/frontend/src/components/GuestCard.tsx
@@ -9,7 +9,8 @@ interface GuestCardProps {
 }
 
 export const GuestCard: React.FC<GuestCardProps> = ({ guest }) => {
-  const { removeGuest, availableToppings, availableBeverages } = usePizza();
+  const { removeGuest, availableToppings, availableBeverages, party } = usePizza();
+  const isGppEvent = party?.eventType === 'gpp';
 
   const toppingNameById = (id: string) => {
     return availableToppings.find(t => t.id === id)?.name || id;
@@ -50,7 +51,7 @@ export const GuestCard: React.FC<GuestCardProps> = ({ guest }) => {
             })}
           </div>
           {/* Beverage Preferences */}
-          {((guest.likedBeverages && guest.likedBeverages.length > 0) ||
+          {!isGppEvent && ((guest.likedBeverages && guest.likedBeverages.length > 0) ||
             (guest.dislikedBeverages && guest.dislikedBeverages.length > 0)) && (
             <div className="flex flex-wrap gap-1 mt-1.5">
               {guest.likedBeverages?.map(beverageId => {

--- a/frontend/src/components/GuestPreferencesList.tsx
+++ b/frontend/src/components/GuestPreferencesList.tsx
@@ -12,6 +12,7 @@ interface GuestPreferencesListProps {
 
 export const GuestPreferencesList: React.FC<GuestPreferencesListProps> = ({ embedded = false }) => {
   const { guests, removeGuest, approveGuest, declineGuest, party, availableToppings, availableBeverages } = usePizza();
+  const isGppEvent = party?.eventType === 'gpp';
   const [showAddForm, setShowAddForm] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
@@ -23,16 +24,17 @@ export const GuestPreferencesList: React.FC<GuestPreferencesListProps> = ({ embe
     return availableBeverages.find(b => b.id === id)?.name || id;
   };
 
-  // Filter to only guests who submitted requests (have any preferences)
+  // Filter to only guests who submitted requests (have any preferences).
+  // On GPP events, drop beverage signals so a guest who only liked drinks doesn't show as a ghost row.
   const guestsWithRequests = useMemo(() => {
     return guests.filter(guest =>
       (guest.dietaryRestrictions && guest.dietaryRestrictions.length > 0) ||
       (guest.toppings && guest.toppings.length > 0) ||
       (guest.dislikedToppings && guest.dislikedToppings.length > 0) ||
-      (guest.likedBeverages && guest.likedBeverages.length > 0) ||
-      (guest.dislikedBeverages && guest.dislikedBeverages.length > 0)
+      (!isGppEvent && guest.likedBeverages && guest.likedBeverages.length > 0) ||
+      (!isGppEvent && guest.dislikedBeverages && guest.dislikedBeverages.length > 0)
     );
-  }, [guests]);
+  }, [guests, isGppEvent]);
 
   const visibleGuests = expanded
     ? guestsWithRequests
@@ -107,6 +109,7 @@ export const GuestPreferencesList: React.FC<GuestPreferencesListProps> = ({ embe
             onRemove={removeGuest}
             toppingNameById={toppingNameById}
             beverageNameById={beverageNameById}
+            hideBeverages={isGppEvent}
           />
         ))}
       </div>

--- a/frontend/src/components/PizzaOrderSummary.tsx
+++ b/frontend/src/components/PizzaOrderSummary.tsx
@@ -23,6 +23,7 @@ import {
 export const PizzaOrderSummary: React.FC = () => {
   const { t } = useTranslation('host');
   const { recommendations, beverageRecommendations, waveRecommendations, party, guests, orderExpectedGuests, setOrderExpectedGuests, generateRecommendations, updatePizzaQuantity, removePizza } = usePizza();
+  const isGppEvent = party?.eventType === 'gpp';
   const [isCopied, setIsCopied] = useState(false);
   const [showCallScript, setShowCallScript] = useState(false);
   const [showPizzeriaSearch, setShowPizzeriaSearch] = useState(false);
@@ -310,7 +311,7 @@ Can you accommodate these delivery times? Please confirm total and timing.`;
     }).join('\n\n');
 
     // Add beverages as separate section (not per wave)
-    const beverageText = beverageRecommendations.length > 0
+    const beverageText = !isGppEvent && beverageRecommendations.length > 0
       ? '\n\n=== BEVERAGES (Order Once) ===\n' + beverageRecommendations.map(b => `${b.quantity}x ${b.beverage.name}`).join('\n')
       : '';
 
@@ -605,7 +606,7 @@ Can you accommodate these delivery times? Please confirm total and timing.`;
                     ))}
                   </>
                 )}
-                {beverageRecommendations.length > 0 && (
+                {!isGppEvent && beverageRecommendations.length > 0 && (
                   <>
                     <p className="text-theme-text pt-1 border-t border-theme-stroke mt-2">
                       <span className="text-theme-text-secondary">{t('pizza.totalDrinks')}</span>{' '}
@@ -665,7 +666,7 @@ Can you accommodate these delivery times? Please confirm total and timing.`;
                 ))}
 
                 {/* Beverage Order Section - Separate from waves */}
-                {beverageRecommendations.length > 0 && (
+                {!isGppEvent && beverageRecommendations.length > 0 && (
                   <div className="p-4 bg-blue-500/10 border border-blue-500/30 rounded-xl">
                     <h3 className="font-medium text-blue-400 mb-3 flex items-center gap-2">
                       <Beer size={16} />
@@ -708,7 +709,7 @@ Can you accommodate these delivery times? Please confirm total and timing.`;
                 </div>
 
                 {/* Beverage Order Section */}
-                {beverageRecommendations.length > 0 && (
+                {!isGppEvent && beverageRecommendations.length > 0 && (
                   <div className="mb-4 p-4 bg-blue-500/10 border border-blue-500/30 rounded-xl">
                     <h3 className="font-medium text-blue-400 mb-3 flex items-center gap-2">
                       <Beer size={16} />

--- a/frontend/src/components/RSVPFormStep2.tsx
+++ b/frontend/src/components/RSVPFormStep2.tsx
@@ -58,7 +58,7 @@ export function RSVPFormStep2({
       </div>
 
       {/* Drinks */}
-      {form.availableBeverages.length > 0 && (
+      {!form.isGppEvent && form.availableBeverages.length > 0 && (
         <div>
           <label className="block text-sm font-medium text-theme-text mb-3">
             {t('step2.drinkPreferences')}

--- a/frontend/src/components/TableRow.tsx
+++ b/frontend/src/components/TableRow.tsx
@@ -38,6 +38,8 @@ interface TableRowProps {
   // For requests variant - lookup functions
   toppingNameById?: (id: string) => string;
   beverageNameById?: (id: string) => string;
+  // Hide beverage chips in the requests variant (used for GPP events)
+  hideBeverages?: boolean;
   // Edit functionality
   editable?: boolean;
   onQuantityChange?: (id: string, newQuantity: number) => void;
@@ -66,6 +68,7 @@ export const TableRow: React.FC<TableRowProps> = ({
   onPromote,
   toppingNameById = (id) => id,
   beverageNameById = (id) => id,
+  hideBeverages = false,
   editable = false,
   onQuantityChange,
   onRemovePizza,
@@ -364,7 +367,7 @@ export const TableRow: React.FC<TableRowProps> = ({
                 </span>
               );
             })}
-            {guest.likedBeverages?.map(beverageId => {
+            {!hideBeverages && guest.likedBeverages?.map(beverageId => {
               const name = beverageNameById(beverageId);
               return (
                 <span key={beverageId} className="px-1.5 py-0.5 bg-blue-500/20 text-blue-300 text-[10px] rounded">
@@ -372,7 +375,7 @@ export const TableRow: React.FC<TableRowProps> = ({
                 </span>
               );
             })}
-            {guest.dislikedBeverages?.map(beverageId => {
+            {!hideBeverages && guest.dislikedBeverages?.map(beverageId => {
               const name = beverageNameById(beverageId);
               return (
                 <span key={beverageId} className="px-1.5 py-0.5 bg-blue-500/20 text-blue-300 text-[10px] rounded line-through">

--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -165,6 +165,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
   const isSwcUkEvent = (eventData.eventTags || []).includes('swcuk');
   const isSwcBrEvent = (eventData.eventTags || []).includes('swcbr');
   const isEthconfEvent = (eventData.eventTags || []).includes('ethconf');
+  const isGppEvent = eventData.eventType === 'gpp';
   const excludedToppings = getExcludedToppingIds(dietaryRestrictions);
 
   // ---- Validate wallet address ----
@@ -579,6 +580,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     isSwcUkEvent,
     isSwcBrEvent,
     isEthconfEvent,
+    isGppEvent,
     isEditing,
     excludedToppings,
     availableBeverages: eventData.availableBeverages,

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -4,6 +4,7 @@
     "settings": "Einstellungen",
     "guests": "Gäste",
     "pizzaAndDrinks": "Pizza & Getränke",
+    "pizza": "Pizza",
     "photos": "Fotos",
     "apps": "Apps"
   },

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -4,6 +4,7 @@
     "settings": "Settings",
     "guests": "Guests",
     "pizzaAndDrinks": "Pizza & Drinks",
+    "pizza": "Pizza",
     "photos": "Photos",
     "apps": "Apps"
   },

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -4,6 +4,7 @@
     "settings": "Ajustes",
     "guests": "Invitados",
     "pizzaAndDrinks": "Pizza y Bebidas",
+    "pizza": "Pizza",
     "photos": "Fotos",
     "apps": "Apps"
   },

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -4,6 +4,7 @@
     "settings": "Paramètres",
     "guests": "Invités",
     "pizzaAndDrinks": "Pizza et boissons",
+    "pizza": "Pizza",
     "photos": "Photos",
     "apps": "Applications"
   },

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -4,6 +4,7 @@
     "settings": "設定",
     "guests": "ゲスト",
     "pizzaAndDrinks": "ピザ＆ドリンク",
+    "pizza": "ピザ",
     "photos": "写真",
     "apps": "アプリ"
   },

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -4,6 +4,7 @@
     "settings": "Configurações",
     "guests": "Convidados",
     "pizzaAndDrinks": "Pizza e Bebidas",
+    "pizza": "Pizza",
     "photos": "Fotos",
     "apps": "Apps"
   },

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -4,6 +4,7 @@
     "settings": "设置",
     "guests": "宾客",
     "pizzaAndDrinks": "披萨和饮品",
+    "pizza": "披萨",
     "photos": "照片",
     "apps": "应用"
   },

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -161,7 +161,7 @@ function HostPageContent() {
       ...(isGPP ? [{ id: 'dashboard' as TabType, label: t('tabs.dashboard'), icon: Home }] : []),
       { id: 'details' as TabType, label: t('tabs.settings'), icon: Settings },
       { id: 'guests' as TabType, label: t('tabs.guests'), icon: Users },
-      { id: 'pizza' as TabType, label: t('tabs.pizzaAndDrinks'), icon: Pizza },
+      { id: 'pizza' as TabType, label: isGPP ? t('tabs.pizza') : t('tabs.pizzaAndDrinks'), icon: Pizza },
       { id: 'photos' as TabType, label: t('tabs.photos'), icon: Camera },
     ];
 

--- a/plans/salami-47402-hide-gpp-drinks.md
+++ b/plans/salami-47402-hide-gpp-drinks.md
@@ -1,0 +1,260 @@
+# salami-47402 — Hide drinks/beverage UI on GPP events (preserve data)
+
+**Priority**: P2 (product hygiene; GPP-only display fix)
+
+## Problem
+
+GPP (Global Pizza Party) events should not show drinks/beverage UI to hosts or guests, but every party in the system uses the same `Party.availableBeverages` schema and the same React components. Today, every GPP event surfaces:
+
+- Host: a `BeverageSettings` card on the "Pizza & Drinks" tab
+- Host: a `BeverageOrderSummary` and beverage sections inside `PizzaOrderSummary`
+- Host: a "Beverage Preferences" subsection in `AddGuestForm`
+- Host: beverage chips on guest rows (`TableRow` requests variant, `GuestCard`)
+- Guest: a "Drink Preferences" subsection in RSVP Step 2 (`RSVPFormStep2`)
+
+Per Snax: hide all of this for `Party.eventType === 'gpp'`. **No data mutations** — `Party.availableBeverages`, `RSVP.likedBeverages`, `RSVP.dislikedBeverages`, `User.defaultLikedBeverages` all stay untouched. Pure frontend conditional rendering. Non-GPP events must behave exactly as today.
+
+## Gating approach
+
+**Compute a derived boolean `isGppEvent` at each call site that already consumes the party.**
+
+Justification (vs. a `shouldShowBeverages(party)` util):
+1. The check is a trivial one-line equality. Adding a util adds a new module, a new test, and import noise for no behavior gain.
+2. Existing precedent throughout the codebase — `HostPage.tsx:92` (`const isGPP = party?.eventType === 'gpp'`), `EventPage.tsx:534`, `RSVPPage.tsx:75`, `PartyHeader.tsx:213`, `FlyerTab.tsx:13`, `PreviousYearPhotos.tsx:312`. We match the established idiom.
+3. The two RSVP-side files (`RSVPFormStep2`, `useRSVPForm`) read the party through the `RSVPEventData` shape, which already carries `eventType` (set by both `dbPartyToRSVPData` and `publicEventToRSVPData` in `useRSVPForm.ts`). Computing locally is one line.
+4. Host-side components consume `party` from `usePizza()` and can read `party?.eventType` directly. `BeverageSettings` and `BeverageOrderSummary` already destructure `party` from the context.
+
+**Single-line pattern at every gate:** `const isGppEvent = party?.eventType === 'gpp';` (or, in `useRSVPForm`, `eventData.eventType === 'gpp'`).
+
+## Files to modify
+
+Frontend only. Eight component files, one hook, one page label change, one AppsHub label override, and seven locale files for a new `tabs.pizza` key. **Zero changes** to backend, Prisma schema, Supabase, types, or `constants/options.ts`.
+
+| # | File | What changes |
+|---|---|---|
+| 1 | `frontend/src/components/BeverageSettings.tsx` | Return `null` when `isGppEvent` (after all hooks) |
+| 2 | `frontend/src/components/BeverageOrderSummary.tsx` | Return `null` when `isGppEvent` (after all hooks) |
+| 3 | `frontend/src/hooks/useRSVPForm.ts` | Expose `isGppEvent` flag in returned object |
+| 4 | `frontend/src/components/RSVPFormStep2.tsx` | Hide drinks subsection (line 61) when `form.isGppEvent` |
+| 5 | `frontend/src/components/PizzaOrderSummary.tsx` | Hide three beverage sections + omit beverages from copy-order text when `isGppEvent` |
+| 6 | `frontend/src/components/AddGuestForm.tsx` | Hide "Beverage Preferences" subsection (lines ~211–264) when `isGppEvent` |
+| 7 | `frontend/src/components/TableRow.tsx` | New optional prop `hideBeverages?: boolean`; skip beverage chip blocks (lines ~367–382) in requests variant when true |
+| 8 | `frontend/src/components/GuestPreferencesList.tsx` | Compute `isGppEvent`; pass `hideBeverages={isGppEvent}` to `TableRow`; drop beverage signals from `guestsWithRequests` filter (lines 27–35) when GPP |
+| 9 | `frontend/src/components/GuestCard.tsx` | Pull `party` from `usePizza()`; hide beverage chips block (lines ~52–73) when `isGppEvent` |
+| 10 | `frontend/src/pages/HostPage.tsx` | Line 164: conditional tab label — `isGPP ? t('tabs.pizza') : t('tabs.pizzaAndDrinks')` (`isGPP` already in scope at line 92) |
+| 11 | `frontend/src/components/AppsHub.tsx` | For the `pizzeria-selection` tile (lines 78–86), override `name` to `'Pizza'` and `description` to `'Find and select nearby pizzerias'` when `isGppEvent` (compute from `usePizza().party`) |
+| 12 | `frontend/src/i18n/locales/{de,en,es,fr,ja,pt,zh}/host.json` | Add `tabs.pizza` key alongside `tabs.pizzaAndDrinks`. Values: de/en/es/fr/pt = `"Pizza"`, ja = `"ピザ"`, zh = `"披萨"` |
+
+**Not touched** (verified): `frontend/src/lib/tabPermissions.ts:57` keeps its static "Pizza & Drinks" label — only consumed by `HostsManager.tsx`, an admin/permission-picker UI with no current-event context. Leaving it static avoids a broader refactor for no user-visible benefit on the GPP host experience.
+
+## Step-by-step changes
+
+### 1. `frontend/src/components/BeverageSettings.tsx`
+
+After the `useState` calls (line 20, after `customInput`), add:
+```ts
+const isGppEvent = party?.eventType === 'gpp';
+if (isGppEvent) return null;
+```
+Placed after all hooks so Rules of Hooks holds.
+
+### 2. `frontend/src/components/BeverageOrderSummary.tsx`
+
+After the `useState` call (Rules of Hooks), add:
+```ts
+const isGppEvent = party?.eventType === 'gpp';
+if (isGppEvent) return null;
+```
+
+### 3. `frontend/src/hooks/useRSVPForm.ts`
+
+- Compute `const isGppEvent = eventData.eventType === 'gpp';` near the other computed values (next to `isEthconfEvent`, ~line 167).
+- Add `isGppEvent` to the returned object (near the other `isSwc*Event` keys around line 575–582).
+
+This avoids leaking the conditional into JSX and matches the existing pattern of derived flags exposed from the form hook.
+
+### 4. `frontend/src/components/RSVPFormStep2.tsx`
+
+Change the drinks block guard at line 61:
+```tsx
+{form.availableBeverages.length > 0 && (
+```
+to:
+```tsx
+{!form.isGppEvent && form.availableBeverages.length > 0 && (
+```
+Closing brace at line 151 remains. No step-numbering impact — Step 2 is one "page" with multiple optional subsections.
+
+### 5. `frontend/src/components/PizzaOrderSummary.tsx`
+
+After the `usePizza()` destructure (line 25), compute:
+```ts
+const isGppEvent = party?.eventType === 'gpp';
+```
+Wrap three beverage blocks with `!isGppEvent &&`:
+- Line 608 (summary "Total drinks:" block)
+- Line 668 (multi-wave Beverage Order section)
+- Line 711 (single-wave Beverage Order section)
+
+In the `handleCopyOrder`/`handleCopyAllWaves` text-building logic at line 312–319, also gate the `beverageText`:
+```ts
+const beverageText = !isGppEvent && beverageRecommendations.length > 0
+  ? '\n\n=== BEVERAGES (Order Once) ===\n' + ...
+  : '';
+```
+Apply the same gate to any per-wave copy helper (`handleCopyWave`) if it includes beverages — verify during implementation by grepping `beverage` in this file. Hiding UI but copying beverages would leak.
+
+### 6. `frontend/src/components/AddGuestForm.tsx`
+
+The `usePizza()` destructure (line 13) already pulls `party`. Add after it:
+```ts
+const isGppEvent = party?.eventType === 'gpp';
+```
+Change Beverage Preferences block guard at line 212:
+```tsx
+{!isGppEvent && party?.availableBeverages && party.availableBeverages.length > 0 && (
+```
+Closing brace at line 264 remains.
+
+The `likedBeverages`/`dislikedBeverages` state stays in the form (defaults `[]`), and `addGuest({ ... likedBeverages, dislikedBeverages })` still passes empty arrays — preserves the data shape contract.
+
+### 7. `frontend/src/components/TableRow.tsx`
+
+Add a new optional prop `hideBeverages?: boolean` to `TableRowProps` (after `beverageNameById` at line 41):
+```ts
+hideBeverages?: boolean;
+```
+Destructure in the function signature (after line 68):
+```ts
+hideBeverages = false,
+```
+Wrap the two beverage map blocks in the requests variant (lines 367–382):
+```tsx
+{!hideBeverages && guest.likedBeverages?.map(...)}
+{!hideBeverages && guest.dislikedBeverages?.map(...)}
+```
+The `variant="beverage"` branch (lines 224–246) is only used by `PizzaOrderSummary`, which already gates the whole section in change #5 — no extra gate needed.
+
+### 8. `frontend/src/components/GuestPreferencesList.tsx`
+
+After the `usePizza()` destructure (line 14), compute:
+```ts
+const isGppEvent = party?.eventType === 'gpp';
+```
+Two changes:
+- In the `guestsWithRequests` `useMemo` (lines 27–35), drop beverage signals from the filter when `isGppEvent` so a guest who only liked drinks doesn't show up as a ghost row in the GPP "Guest Requests" panel:
+```ts
+return guests.filter(guest =>
+  (guest.dietaryRestrictions && guest.dietaryRestrictions.length > 0) ||
+  (guest.toppings && guest.toppings.length > 0) ||
+  (guest.dislikedToppings && guest.dislikedToppings.length > 0) ||
+  (!isGppEvent && guest.likedBeverages && guest.likedBeverages.length > 0) ||
+  (!isGppEvent && guest.dislikedBeverages && guest.dislikedBeverages.length > 0)
+);
+```
+- Pass the prop on the `TableRow` at lines 100–110: add `hideBeverages={isGppEvent}`.
+
+### 9. `frontend/src/components/GuestCard.tsx`
+
+Extend the `usePizza()` destructure at line 12 to also pull `party`:
+```ts
+const { removeGuest, availableToppings, availableBeverages, party } = usePizza();
+const isGppEvent = party?.eventType === 'gpp';
+```
+Wrap the existing beverage chips block (lines 53–73):
+```tsx
+{!isGppEvent && ((guest.likedBeverages && guest.likedBeverages.length > 0) || ...) && (
+  ...
+)}
+```
+
+## Special considerations (resolved)
+
+- **RSVP wizard step numbering**: Confirmed safe. Step 2 contains independent optional subsections (dietary, drinks, pizzerias, donation). The drinks block already self-hides when host configured zero beverages. `Step 2 of 2` label in `RSVPModal.tsx:265` is hard-coded.
+
+- **AccountPage** (`/account`): **No change**. Page renders global `DRINKS` from `constants/options.ts` against a user's profile-level `User.defaultLikedBeverages`. User setting, not event-tied. A user may host both GPP and non-GPP events.
+
+- **Staff form** (`StaffForm.tsx:27` "Bar / Drinks"): **No change**. Staffing *role name* (a person who tends bar), not the ordering feature.
+
+- **Budget category** (`BudgetCategorySection.tsx:18` `drinks: Wine`): **No change**. Budget category icon mapping. Drinks remain a real budget line item.
+
+- **Partner form** (`PartnerForm.tsx:107` `'drinks'` partner type): **No change**. Drinks sponsor type stays.
+
+- **AppsHub** "Pizza & Drinks" tile: **No change to the tile by default**. It routes to `/pizza` which still exists for pizza ordering. Drinks-specific cards inside that tab are hidden by changes #1 and #5. Optionally relabel — see open questions.
+
+- **tabPermissions.ts**: **No change required**. `pizza` tab stays. Optionally relabel — see open questions.
+
+- **i18n locales**: No string deletions. Strings stay in `host.json`, `rsvp.json`, `account.json` for de/en/es/fr/ja/pt/zh — they just aren't rendered for GPP. Cleaner if we ever revert.
+
+- **Real-time recommendations** (`PizzaContext.generateBeverageRecommendations`): No change. Algorithm still runs and populates `beverageRecommendations` in state. Host UI just doesn't render it for GPP. Guarantees data preservation and avoids regressing non-GPP behavior.
+
+- **Tests**: Existing unit tests for `beverageAlgorithm.test.ts` and `field-sync.test.ts` exercise the algorithm and data shapes, not UI — should pass unchanged. `RSVPModal.test.tsx` mock provides `availableBeverages: []` already (line 41) — equivalent to a GPP event with no beverages. No new tests added (conditional rendering against an established pattern).
+
+## Verification (Vercel preview)
+
+On `https://rsvpizza-git-salami-47402-hide-gpp-drinks-pizza-dao.vercel.app`:
+
+1. **GPP host view**: `/host/{gpp-invite-code}/pizza` → BeverageSettings card absent, no Beverage Order section in PizzaOrderSummary, no "Total drinks" line. **Tab label reads "Pizza"** (not "Pizza & Drinks").
+2. **GPP host — Apps hub**: pizzeria-selection tile reads **"Pizza"** with description "Find and select nearby pizzerias".
+3. **GPP host — Add Guest**: open Add Request modal → no "Beverage Preferences" subsection.
+4. **GPP host — Guest Requests**: a GPP guest whose RSVP includes liked beverages → row shows toppings/dietary chips but no blue beverage chips.
+5. **GPP guest RSVP**: `/rsvp/{gpp-invite-code}` → Step 2 shows dietary + pizzeria sections but no "Drink Preferences" block.
+6. **Non-GPP host view**: BeverageSettings **still present**; Beverage Order section **still present**; **tab label still "Pizza & Drinks"**; **AppsHub tile still "Pizza & Drinks"** (regression checks).
+7. **Non-GPP guest RSVP**: Drink Preferences section **still present** in Step 2 (regression check).
+8. **DB preservation** (Supabase SQL editor):
+   ```sql
+   select id, name, event_type, available_beverages from party where event_type = 'gpp' and array_length(available_beverages, 1) > 0 limit 3;
+   select id, party_id, liked_beverages, disliked_beverages from rsvp where array_length(liked_beverages, 1) > 0 limit 3;
+   ```
+   Expect both queries to return rows — arrays untouched.
+9. **Account page**: `/account` while signed in → Drink Preferences subsection **still present**.
+10. **Copy-order text**: non-GPP with beverages → "Copy Order" clipboard contains BEVERAGES section. GPP → clipboard text does not.
+
+## Implementation additions
+
+### 10. `frontend/src/pages/HostPage.tsx`
+
+Line 164:
+```tsx
+{ id: 'pizza' as TabType, label: t('tabs.pizzaAndDrinks'), icon: Pizza },
+```
+→
+```tsx
+{ id: 'pizza' as TabType, label: isGPP ? t('tabs.pizza') : t('tabs.pizzaAndDrinks'), icon: Pizza },
+```
+`isGPP` is already computed at line 92.
+
+### 11. `frontend/src/components/AppsHub.tsx`
+
+The `apps` array is module-level static. Simplest: keep it static, override at render time. Inside the component, after `usePizza()`:
+```ts
+const isGppEvent = party?.eventType === 'gpp';
+```
+When mapping `apps` to render tiles, override for the `pizzeria-selection` id:
+```tsx
+const displayName = isGppEvent && app.id === 'pizzeria-selection' ? 'Pizza' : app.name;
+const displayDescription = isGppEvent && app.id === 'pizzeria-selection'
+  ? 'Find and select nearby pizzerias'
+  : app.description;
+```
+Render `displayName`/`displayDescription` instead of `app.name`/`app.description`. (AppsHub strings are hard-coded English today — matches existing convention; no i18n key needed.)
+
+### 12. i18n locales — add `tabs.pizza`
+
+For each of `frontend/src/i18n/locales/{de,en,es,fr,ja,pt,zh}/host.json`, add a sibling key to `tabs.pizzaAndDrinks`:
+
+| Locale | Value |
+|---|---|
+| de | `"pizza": "Pizza"` |
+| en | `"pizza": "Pizza"` |
+| es | `"pizza": "Pizza"` |
+| fr | `"pizza": "Pizza"` |
+| ja | `"pizza": "ピザ"` |
+| pt | `"pizza": "Pizza"` |
+| zh | `"pizza": "披萨"` |
+
+## Resolved questions (Snax)
+
+- Relabel "Pizza & Drinks" → "Pizza" tab on GPP: **yes**
+- Relabel AppsHub tile copy on GPP: **yes**
+- Verification invite codes: Snax will pick GPP/non-GPP events directly when reviewing the preview.


### PR DESCRIPTION
## Summary

For `Party.eventType === 'gpp'`, hide every drinks/beverage UI surface across host and guest flows, and relabel **Pizza & Drinks** → **Pizza** on the host tab and AppsHub tile. Non-GPP events are unchanged.

**No data mutations.** `Party.availableBeverages`, `RSVP.likedBeverages`, `RSVP.dislikedBeverages`, and `User.defaultLikedBeverages` are all preserved. The beverage recommendation algorithm continues running; the result simply isn't rendered for GPP.

Plan: [`plans/salami-47402-hide-gpp-drinks.md`](./plans/salami-47402-hide-gpp-drinks.md)

## Files changed (18)

**Hidden on GPP:**
- `BeverageSettings.tsx` — early `return null`
- `BeverageOrderSummary.tsx` — early `return null`
- `RSVPFormStep2.tsx` — drinks subsection gated
- `PizzaOrderSummary.tsx` — 3 beverage sections + copy-order beverage text gated
- `AddGuestForm.tsx` — Beverage Preferences subsection gated
- `TableRow.tsx` — new `hideBeverages?` prop, gates beverage chips in requests variant
- `GuestPreferencesList.tsx` — passes `hideBeverages`, drops beverage signals from `guestsWithRequests`
- `GuestCard.tsx` — beverage chips block gated

**Relabel on GPP:**
- `HostPage.tsx:164` — tab label conditional on `isGPP`
- `AppsHub.tsx` — pizzeria-selection tile shows "Pizza" / "Find and select nearby pizzerias"
- `i18n/locales/{de,en,es,fr,ja,pt,zh}/host.json` — new `tabs.pizza` key

**Wiring:**
- `useRSVPForm.ts` — exposes `isGppEvent` flag

## Deliberately untouched

- `tabPermissions.ts` (admin-only UI, no event context)
- `AccountPage` (user-level preferences, not event-tied)
- `StaffForm` "Bar / Drinks" (staffing role, not the feature)
- `BudgetCategorySection`, `PartnerForm` (budget line / sponsor type — drinks remain real concepts)
- `beverageAlgorithm.ts`, `PizzaContext.generateBeverageRecommendations` (algorithm runs, output unrendered for GPP)
- All `beverages.*` / `drinks.*` i18n strings (kept for clean revert)
- Backend, Prisma schema, types

## Test plan

- [ ] **GPP host /pizza tab**: BeverageSettings absent, no Beverage Order in PizzaOrderSummary, no "Total drinks" line, tab labeled "Pizza"
- [ ] **GPP host AppsHub**: pizzeria-selection tile reads "Pizza" with "Find and select nearby pizzerias"
- [ ] **GPP host Add Guest modal**: no Beverage Preferences subsection
- [ ] **GPP host Guest Requests**: a GPP guest with liked beverages shows toppings/dietary chips, no beverage chips
- [ ] **GPP guest RSVP Step 2**: no Drink Preferences block (dietary + pizzeria still present)
- [ ] **Non-GPP host**: BeverageSettings present, Beverage Order present, tab still "Pizza & Drinks", AppsHub tile still "Pizza & Drinks"
- [ ] **Non-GPP guest RSVP**: Drink Preferences present in Step 2
- [ ] **`/account`**: Drink Preferences subsection still present
- [ ] **Copy Order**: non-GPP clipboard contains BEVERAGES section; GPP clipboard does not
- [ ] **DB unchanged**: `select * from party where event_type='gpp' and array_length(available_beverages,1)>0 limit 3;` still returns rows

## Verification (local)

- `npx tsc --noEmit` → zero errors
- `npx vitest run src/utils/beverageAlgorithm.test.ts` → 10/10 pass
- Other pre-existing test failures (`field-sync`, `RSVPModal`) exist on master and are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)