### PR TITLE
prosciutto-45878: fix invite email timezone (UTC drift)

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -955,6 +955,7 @@ router.post('/:partyId/guests/:guestId/promote', async (req: AuthRequest, res: R
           select: {
             name: true,
             date: true,
+            timezone: true,
             address: true,
             inviteCode: true,
             customUrl: true,
@@ -968,6 +969,7 @@ router.post('/:partyId/guests/:guestId/promote', async (req: AuthRequest, res: R
             guestId: guest.id,
             partyName: party.name,
             partyDate: party.date,
+            partyTimezone: party.timezone,
             partyAddress: party.address,
             inviteCode: party.inviteCode,
             customUrl: party.customUrl,

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -537,6 +537,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             guestName: name.trim(),
             partyName: party.name,
             partyDate: party.date,
+            partyTimezone: party.timezone,
             waitlistPosition: waitlistPosition!,
             inviteCode,
             customUrl: party.customUrl,
@@ -912,6 +913,7 @@ async function sendWaitlistConfirmationEmail(params: {
   guestName: string;
   partyName: string;
   partyDate: Date | null;
+  partyTimezone: string | null;
   waitlistPosition: number;
   inviteCode: string;
   customUrl: string | null;
@@ -936,6 +938,7 @@ async function sendWaitlistConfirmationEmail(params: {
         day: 'numeric',
         hour: 'numeric',
         minute: '2-digit',
+        timeZone: params.partyTimezone || undefined,
       })
     : 'Date TBD';
 
@@ -1013,6 +1016,7 @@ export async function sendPromotionEmail(params: {
   guestId: string;
   partyName: string;
   partyDate: Date | null;
+  partyTimezone: string | null;
   partyAddress: string | null;
   inviteCode: string;
   customUrl: string | null;
@@ -1043,6 +1047,7 @@ export async function sendPromotionEmail(params: {
         day: 'numeric',
         hour: 'numeric',
         minute: '2-digit',
+        timeZone: params.partyTimezone || undefined,
       })
     : 'Date TBD';
 

--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -49,6 +49,7 @@ export function buildInviteEmail(
         day: 'numeric',
         hour: 'numeric',
         minute: '2-digit',
+        timeZone: party.timezone || undefined,
       })
     : 'Date TBD';
 


### PR DESCRIPTION
## Summary
Three backend email templates (`buildInviteEmail`, `sendWaitlistConfirmationEmail`, `sendPromotionEmail`) formatted event dates with `toLocaleDateString` but never passed the `timeZone` option, so dates rendered in the Vercel server's UTC zone. For Lima (UTC-5), a 7 PM May 22 event displayed as "12:00 AM May 23" in invitation emails.

Bringing these three in line with `sendRSVPConfirmationEmail` and `sendApprovalEmail`, which already pass `params.partyTimezone || undefined` to the formatter.

## Changes
- `backend/src/routes/v1/guests.ts`: `buildInviteEmail` now passes `party.timezone` to the date formatter
- `backend/src/routes/rsvp.routes.ts`: `sendWaitlistConfirmationEmail` and `sendPromotionEmail` gain a required `partyTimezone` param; same call site at L535 updated
- `backend/src/routes/party.routes.ts`: `sendPromotionEmail` caller now selects + passes `timezone`

## Verification
- `npx tsc --noEmit` clean (the required param ensures no caller is missed)
- Manual: a Lima party (`timezone: "America/Lima"`, `date: 2026-05-23T00:00:00Z`) now renders as "Friday, May 22, 2026 at 7:00 PM" instead of "Saturday, May 23, 2026 at 12:00 AM"

## Deploy
Backend-only change. After merge, run `cd backend && vercel --prod --scope pizza-dao`.

prosciutto-45878