### PR TITLE
napoletana-11413: fix flyer auto-regen trigger coverage gaps

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -494,7 +494,14 @@ export const EventDetailsTab: React.FC = () => {
         timezone,
       }));
       if (party?.inviteCode) await loadParty(party.inviteCode);
-      if (party) triggerFlyerRegen(party, loadParty);
+      if (party) {
+        // Pass a party-shaped object with the just-saved timezone/date/duration so the
+        // regen doesn't race the React context refresh and render with stale values.
+        triggerFlyerRegen(
+          { ...party, timezone: timezone || null, date: startDateTime, duration: calculatedDuration },
+          loadParty,
+        );
+      }
     }
   };
 
@@ -1002,7 +1009,20 @@ export const EventDetailsTab: React.FC = () => {
 
       {/* Mobile Date/Time Modal */}
       {showDateTimeModal && createPortal(
-        <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70" onClick={() => setShowDateTimeModal(false)}>
+        <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70" onClick={async () => {
+          if (
+            originalValues && (
+              startDate !== originalValues.startDate ||
+              startTime !== originalValues.startTime ||
+              endDate !== originalValues.endDate ||
+              endTime !== originalValues.endTime ||
+              timezone !== originalValues.timezone
+            )
+          ) {
+            await saveDateTime();
+          }
+          setShowDateTimeModal(false);
+        }}>
           <div className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl max-w-sm w-full p-5" onClick={(e) => e.stopPropagation()}>
             <h2 className="text-lg font-semibold text-theme-text mb-4">Event Time</h2>
 

--- a/frontend/src/components/flyer/autoRegenFlyer.ts
+++ b/frontend/src/components/flyer/autoRegenFlyer.ts
@@ -33,6 +33,12 @@ export interface FlyerRegenData {
   eventTags?: string[];
 }
 
+/**
+ * Sponsor statuses that cause a sponsor to appear on the flyer.
+ * Keep this in sync with the filter inside `doRegen()` and any UI gates.
+ */
+export const FLYER_SPONSOR_STATUSES = new Set<string>(['yes', 'billed', 'paid']);
+
 // ---- Debounce map (partyId → timer handle) ----
 const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -169,7 +175,7 @@ async function doRegen(
   // 2. Fetch sponsors with logo + yes/paid status
   const sponsorResult = await getSponsors(data.id);
   const sponsors = (sponsorResult?.sponsors ?? []).filter(
-    (s) => s.logoUrl && (s.status === 'yes' || s.status === 'paid' || s.status === 'billed'),
+    (s) => s.logoUrl && FLYER_SPONSOR_STATUSES.has(s.status),
   );
 
   // 3. Derive flyer text fields, preserving user customizations from flyerConfig

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -19,7 +19,7 @@ import { SponsorList } from './SponsorList';
 import { PartnerForm, extractSponsorData } from './PartnerForm';
 import type { PartnerFormData } from './PartnerForm';
 import { usePizza } from '../../contexts/PizzaContext';
-import { triggerFlyerRegen } from '../flyer/autoRegenFlyer';
+import { triggerFlyerRegen, FLYER_SPONSOR_STATUSES } from '../flyer/autoRegenFlyer';
 import { PartnerFlyerGenerator } from './PartnerFlyerGenerator';
 
 interface SponsorCRMProps {
@@ -108,6 +108,8 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
   // Handle form submission
   const handleFormSubmit = async (formData: PartnerFormData, coHostData?: { name: string; website: string; twitter: string; instagram: string; logoUrl: string; avatarUrl?: string }) => {
     const data = extractSponsorData(formData);
+    // Capture pre-edit snapshot for flyer-regen decision (only matters when editing)
+    const previousSponsor = editingSponsor;
     setIsSubmitting(true);
     try {
       if (editingSponsor) {
@@ -152,10 +154,22 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
       const statsResult = await getSponsorStats(partyId);
       if (statsResult) setStats(statsResult);
 
-      // Auto-regenerate flyer if sponsor has yes/paid status and a logo
-      const FLYER_STATUSES = new Set(['yes', 'paid']);
-      if (party && data.status && FLYER_STATUSES.has(data.status) && data.logoUrl) {
-        triggerFlyerRegen(party, loadParty);
+      // Auto-regenerate flyer if the change affects the flyer:
+      //  - new/edited sponsor with a flyer status + logo
+      //  - existing sponsor transitioned into or out of flyer status
+      //  - existing sponsor still on flyer AND its logoUrl changed
+      if (party && data.status) {
+        const willBeOnFlyer = FLYER_SPONSOR_STATUSES.has(data.status) && !!data.logoUrl;
+        const wasOnFlyer = !!previousSponsor
+          && FLYER_SPONSOR_STATUSES.has(previousSponsor.status)
+          && !!previousSponsor.logoUrl;
+        const logoChanged = !!previousSponsor
+          && (previousSponsor.logoUrl || null) !== (data.logoUrl || null);
+
+        if (willBeOnFlyer || wasOnFlyer !== willBeOnFlyer || (wasOnFlyer && logoChanged)) {
+          if (party.inviteCode) await loadParty(party.inviteCode);
+          triggerFlyerRegen(party, loadParty);
+        }
       }
 
       // Close form
@@ -178,8 +192,8 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
       if (statsResult) setStats(statsResult);
 
       // Auto-regenerate flyer if deleted sponsor was on the flyer
-      const FLYER_STATUSES = new Set(['yes', 'paid']);
-      if (party && deletedSponsor && FLYER_STATUSES.has(deletedSponsor.status) && deletedSponsor.logoUrl) {
+      if (party && deletedSponsor && FLYER_SPONSOR_STATUSES.has(deletedSponsor.status) && deletedSponsor.logoUrl) {
+        if (party.inviteCode) await loadParty(party.inviteCode);
         triggerFlyerRegen(party, loadParty);
       }
     }
@@ -226,9 +240,9 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
       const statsResult = await getSponsorStats(partyId);
       if (statsResult) setStats(statsResult);
 
-      // Auto-regenerate flyer when a sponsor transitions to/from yes/paid
-      const FLYER_STATUSES = new Set(['yes', 'paid']);
-      if (party && (FLYER_STATUSES.has(oldStatus) || FLYER_STATUSES.has(newStatus))) {
+      // Auto-regenerate flyer when a sponsor transitions to/from a flyer status
+      if (party && (FLYER_SPONSOR_STATUSES.has(oldStatus) || FLYER_SPONSOR_STATUSES.has(newStatus))) {
+        if (party.inviteCode) await loadParty(party.inviteCode);
         triggerFlyerRegen(party, loadParty);
       }
     } catch {


### PR DESCRIPTION
## Summary
Fixes three client-side gaps in flyer auto-regeneration triggers so the GPP flyer regenerates correctly when (1) sponsors are created/saved directly in `billed` status, (2) the logo URL is edited on an already-on-flyer sponsor, and (3) only the event timezone changes (no time-field touch).

- Extract shared `FLYER_SPONSOR_STATUSES = {yes, billed, paid}` constant in `autoRegenFlyer.ts`; replace 3 inline `{yes, paid}` sets in `SponsorCRM.tsx`.
- Capture pre-edit sponsor in `handleFormSubmit`; fire regen on flyer-state transitions and on logo-URL change for still-on-flyer sponsors.
- Pass current form state (`timezone`, `startDateTime`, `calculatedDuration`) into `triggerFlyerRegen` in `EventDetailsTab.tsx` to avoid the stale-party-closure race. Auto-save on date/time modal backdrop close.

## Test plan
- [ ] Create a sponsor with status `billed` + logo -> flyer regenerates within ~5s
- [ ] Edit `logoUrl` on a `paid` sponsor (no status change) -> flyer regenerates
- [ ] Edit `notes`/`pointPerson` only on a `paid` sponsor -> NO regen fires
- [ ] Change ONLY timezone on a GPP event, click Done -> flyer shows new timezone
- [ ] Change timezone, click outside modal -> still saves and regens
- [ ] Regression: event name, location, sponsor delete, inline status dropdown all still trigger regen

Plan: `plans/napoletana-11413-flyer-regen-gaps.md`