### PR TITLE
fix(buffalo-73455): capture venueName on event create (homepage form)

### DIFF
--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -29,6 +29,7 @@ export function EventForm() {
   const [expectedGuests, setExpectedGuests] = useState('');
   const [partyAddress, setPartyAddress] = useState('');
   const [partyPlaceId, setPartyPlaceId] = useState<string | null>(null);
+  const [partyVenueName, setPartyVenueName] = useState<string | null>(null);
   const [partyPassword, setPartyPassword] = useState('');
   const [eventImageUrl, setEventImageUrl] = useState('');
   const [eventImageFile, setEventImageFile] = useState<File | null>(null);
@@ -117,7 +118,8 @@ export function EventForm() {
         formData.timezone || undefined,
         undefined, // hostEmail
         formData.hideGuests || false,
-        formData.partyPlaceId || undefined
+        formData.partyPlaceId || undefined,
+        formData.partyVenueName || undefined
       );
 
       setCreating(false);
@@ -193,7 +195,7 @@ export function EventForm() {
     if (!user) {
       const formData = {
         partyName, startDate, startTime, endDate, endTime, timezone,
-        expectedGuests, partyAddress, partyPlaceId, partyPassword, eventImageUrl, eventDescription,
+        expectedGuests, partyAddress, partyPlaceId, partyVenueName, partyPassword, eventImageUrl, eventDescription,
         customUrl, requireApproval, limitGuests, hideGuests
       };
       sessionStorage.setItem('pendingPartyForm', JSON.stringify(formData));
@@ -259,7 +261,8 @@ export function EventForm() {
         timezone || undefined,
         undefined, // hostEmail
         hideGuests,
-        partyPlaceId || undefined
+        partyPlaceId || undefined,
+        partyVenueName || undefined
       );
 
       setCreating(false);
@@ -295,13 +298,15 @@ export function EventForm() {
           value={partyAddress}
           onChange={(newAddress) => {
             setPartyAddress(newAddress);
-            // Manual edits without picking from dropdown invalidate the captured place_id
+            // Manual edits without picking from dropdown invalidate captured place_id + venue_name
             setPartyPlaceId(null);
+            setPartyVenueName(null);
           }}
           onTimezoneChange={setTimezone}
-          onPlaceSelected={(address, _venueName, placeId) => {
+          onPlaceSelected={(address, venueName, placeId) => {
             setPartyAddress(address);
             setPartyPlaceId(placeId);
+            setPartyVenueName(venueName);
           }}
           placeholder={t('eventForm.eventLocation')}
         />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -186,6 +186,7 @@ export async function createPartyApi(data: CreatePartyData) {
       pizzaStyle: data.pizzaStyle || 'new-york',
       address: data.address,
       placeId: data.placeId,
+      venueName: data.venueName,
       maxGuests: data.maxGuests,
       hideGuests: data.hideGuests,
       requireApproval: data.requireApproval,

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -793,7 +793,8 @@ export async function createParty(
   timezone?: string,
   hostEmail?: string,
   hideGuests?: boolean,
-  placeId?: string
+  placeId?: string,
+  venueName?: string
 ): Promise<DbParty | null> {
   // Use API if authenticated (secure path)
   if (isAuthenticated()) {
@@ -806,6 +807,7 @@ export async function createParty(
         maxGuests: expectedGuests,
         address,
         placeId,
+        venueName,
         availableBeverages,
         duration,
         password,
@@ -880,6 +882,7 @@ export async function createParty(
       custom_url: customUrl || null,
       address: address || null,
       place_id: placeId || null,
+      venue_name: venueName || null,
       co_hosts: coHosts,
     })
     .select()


### PR DESCRIPTION
## Summary
Follow-up fix to PR #307. EventForm (homepage create flow) was silently dropping venueName from the LocationAutocomplete:

- `EventForm.tsx` discarded `_venueName` from the `onPlaceSelected` callback
- `createParty` (supabase.ts) had no `venueName` parameter, so even if EventForm captured it there was no way to pass it
- `createPartyApi` body (api.ts) was missing `venueName: data.venueName` from the hand-maintained whitelist (same pattern as the mushroom-38004 silent-field-drop bug)

Backend POST handler already accepted venueName, so this is frontend-only. EventDetailsTab (edit flow on /host/<code>) was already working end-to-end — only the create flow was broken.

## Test plan
- [ ] Create a new event from `rsv.pizza/`, pick a named place (e.g. "Empire State Building") from the autocomplete dropdown
- [ ] Confirm via Supabase: `SELECT venue_name, address, place_id FROM parties WHERE invite_code = '<new>';` returns the venue name
- [ ] Confirm existing /host/<code> edit flow still saves venueName (no regression)
- [ ] Confirm manually editing the address text (without picking from dropdown) clears the captured venueName (so a stale "Empire State Building" isn't saved with a different address)

🤖 Generated with [Claude Code](https://claude.com/claude-code)