### PR TITLE
salami-58392: admin link_tab editor for checklist defaults

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -189,6 +189,21 @@ router.patch('/gpp-nft', requireAuth, async (req: AuthRequest, res: Response, ne
 // Checklist Defaults — using dedicated table
 // ============================================
 
+// Allow-list for `link_tab` values. Mirrors the host-page TabType enumeration
+// (excluding `dashboard`, `checklist`, `apps`, and null/empty which is "no link").
+const ALLOWED_LINK_TABS = [
+  'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music',
+  'report', 'staff', 'displays', 'raffle', 'budget', 'gpp', 'promo',
+  'flyer', 'print',
+];
+
+function isValidLinkTab(v: unknown): v is string | null {
+  if (v === null || v === undefined) return true;
+  if (typeof v !== 'string') return false;
+  if (v === '') return true; // coerced to null upstream
+  return ALLOWED_LINK_TABS.includes(v);
+}
+
 // Raw-SQL admin check helpers (bypass Prisma UUID deserialization bug)
 async function rawIsAdmin(email?: string): Promise<boolean> {
   if (!email) return false;
@@ -264,23 +279,46 @@ router.patch('/checklist-defaults', requireAuth, async (req: AuthRequest, res: R
     let totalUpdated = 0;
     for (const item of items) {
       if (!item.name) continue;
+
+      const hasDueDate = Object.prototype.hasOwnProperty.call(item, 'dueDate');
+      const hasLinkTab = Object.prototype.hasOwnProperty.call(item, 'linkTab');
+
       const parsedDate = item.dueDate ? new Date(item.dueDate + 'T00:00:00.000Z') : null;
 
+      // Validate + coerce linkTab when provided
+      let linkTabValue: string | null | undefined;
+      if (hasLinkTab) {
+        if (!isValidLinkTab(item.linkTab)) {
+          throw new AppError('Invalid linkTab value', 400, 'VALIDATION_ERROR');
+        }
+        linkTabValue = item.linkTab === '' ? null : (item.linkTab ?? null);
+      }
+
+      if (!hasDueDate && !hasLinkTab) continue;
+
       // 1. Update the checklist_defaults row
+      const defaultData: Record<string, unknown> = {};
+      if (hasDueDate) defaultData.dueDate = parsedDate;
+      if (hasLinkTab) defaultData.linkTab = linkTabValue;
+
       await prisma.checklistDefault.updateMany({
         where: { name: item.name },
-        data: { dueDate: parsedDate },
+        data: defaultData,
       });
 
       // 2. Propagate to all GPP events' checklist_items
       if (gppPartyIds.length > 0) {
+        const itemData: Record<string, unknown> = {};
+        if (hasDueDate) itemData.dueDate = parsedDate;
+        if (hasLinkTab) itemData.linkTab = linkTabValue;
+
         const result = await prisma.checklistItem.updateMany({
           where: {
             partyId: { in: gppPartyIds },
             isDefault: true,
             name: item.name,
           },
-          data: { dueDate: parsedDate },
+          data: itemData,
         });
         totalUpdated += result.count;
       }
@@ -289,6 +327,11 @@ router.patch('/checklist-defaults', requireAuth, async (req: AuthRequest, res: R
     res.json({ success: true, totalUpdated });
   } catch (error: any) {
     console.error('[checklist-defaults PATCH]', error);
+    if (error instanceof AppError) {
+      return res.status(error.statusCode).json({
+        error: { message: error.message, code: error.code },
+      });
+    }
     res.status(500).json({
       error: {
         message: String(error?.message || error),
@@ -341,14 +384,19 @@ router.post('/checklist-defaults', requireAuth, async (req: AuthRequest, res: Re
       throw new AppError('Only super admins can add checklist items', 403, 'FORBIDDEN');
     }
 
-    const { name, dueDate } = req.body;
+    const { name, dueDate, linkTab } = req.body;
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
       throw new AppError('Name is required', 400, 'VALIDATION_ERROR');
     }
 
+    if (!isValidLinkTab(linkTab)) {
+      throw new AppError('Invalid linkTab value', 400, 'VALIDATION_ERROR');
+    }
+
     const trimmedName = name.trim();
     const parsedDate = dueDate ? new Date(dueDate + 'T00:00:00.000Z') : null;
+    const linkTabValue: string | null = linkTab === '' || linkTab == null ? null : linkTab;
 
     // Get next sort_order
     const existing = await prisma.checklistDefault.findMany({
@@ -365,6 +413,7 @@ router.post('/checklist-defaults', requireAuth, async (req: AuthRequest, res: Re
         dueDate: parsedDate,
         isAuto: false,
         sortOrder: nextSort,
+        linkTab: linkTabValue,
       },
     });
 
@@ -383,6 +432,7 @@ router.post('/checklist-defaults', requireAuth, async (req: AuthRequest, res: Re
           isAuto: false,
           isDefault: true,
           sortOrder: nextSort,
+          linkTab: linkTabValue,
         })),
       });
     }

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "Checklisten-Termine speichern",
     "newItemPlaceholder": "Neuer Checklisten-Eintrag...",
     "adding": "Wird hinzugefügt...",
-    "addItem": "Eintrag hinzufügen"
+    "addItem": "Eintrag hinzufügen",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "GPP-Standardbeschreibung",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "Save Checklist Dates",
     "newItemPlaceholder": "New checklist item...",
     "adding": "Adding...",
-    "addItem": "Add Item"
+    "addItem": "Add Item",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "GPP Default Description",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "Guardar Fechas del Checklist",
     "newItemPlaceholder": "Nuevo elemento del checklist...",
     "adding": "Agregando...",
-    "addItem": "Agregar Elemento"
+    "addItem": "Agregar Elemento",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "Descripción Predeterminada de GPP",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "Enregistrer les dates de la liste",
     "newItemPlaceholder": "Nouvel élément de liste...",
     "adding": "Ajout...",
-    "addItem": "Ajouter un élément"
+    "addItem": "Ajouter un élément",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "Description GPP par défaut",

--- a/frontend/src/i18n/locales/ja/admin.json
+++ b/frontend/src/i18n/locales/ja/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "チェックリストの日付を保存",
     "newItemPlaceholder": "新しいチェックリスト項目...",
     "adding": "追加中...",
-    "addItem": "項目を追加"
+    "addItem": "項目を追加",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "GPPデフォルト説明文",

--- a/frontend/src/i18n/locales/pt/admin.json
+++ b/frontend/src/i18n/locales/pt/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "Salvar Datas do Checklist",
     "newItemPlaceholder": "Novo item do checklist...",
     "adding": "Adicionando...",
-    "addItem": "Adicionar Item"
+    "addItem": "Adicionar Item",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "Descrição Padrão do GPP",

--- a/frontend/src/i18n/locales/zh/admin.json
+++ b/frontend/src/i18n/locales/zh/admin.json
@@ -83,7 +83,8 @@
     "saveChecklistDates": "保存清单日期",
     "newItemPlaceholder": "新清单项目...",
     "adding": "添加中...",
-    "addItem": "添加项目"
+    "addItem": "添加项目",
+    "linkTabPlaceholder": "Link to tab"
   },
   "gppDescription": {
     "title": "GPP 默认描述",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2480,14 +2480,14 @@ export async function fetchChecklistDefaults(): Promise<{ items: ChecklistDefaul
   return apiRequest<{ items: ChecklistDefault[] }>('/api/admin/checklist-defaults');
 }
 
-export async function updateChecklistDefaults(items: Array<{ name: string; dueDate?: string | null; sortOrder?: number; newName?: string }>): Promise<{ totalUpdated: number }> {
+export async function updateChecklistDefaults(items: Array<{ name: string; dueDate?: string | null; sortOrder?: number; newName?: string; linkTab?: string | null }>): Promise<{ totalUpdated: number }> {
   return apiRequest<{ totalUpdated: number }>('/api/admin/checklist-defaults', {
     method: 'PATCH',
     body: { items },
   });
 }
 
-export async function addChecklistDefault(data: { name: string; dueDate?: string | null }): Promise<{ createdCount: number }> {
+export async function addChecklistDefault(data: { name: string; dueDate?: string | null; linkTab?: string | null }): Promise<{ createdCount: number }> {
   return apiRequest<{ createdCount: number }>('/api/admin/checklist-defaults', {
     method: 'POST',
     body: data,

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -29,6 +29,14 @@ import { fetchSheetCities } from '../lib/cities';
 const themeClass = 'gpp-theme';
 const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)' } as React.CSSProperties;
 
+// Allowed host-page tab targets for checklist `link_tab`.
+// Keep in sync with backend ALLOWED_LINK_TABS and HostPage TabType.
+const LINK_TAB_OPTIONS: readonly string[] = [
+  'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music',
+  'report', 'staff', 'displays', 'raffle', 'budget', 'gpp', 'promo',
+  'flyer', 'print',
+];
+
 function sortByDueDate(items: ChecklistDefault[]): ChecklistDefault[] {
   return [...items].sort((a, b) => {
     if (!a.dueDate && !b.dueDate) return 0;
@@ -83,10 +91,12 @@ export function AdminPage() {
   // Checklist defaults state
   const [checklistItems, setChecklistItems] = useState<ChecklistDefault[]>([]);
   const [checklistEdits, setChecklistEdits] = useState<Record<string, string>>({});
+  const [checklistLinkTabEdits, setChecklistLinkTabEdits] = useState<Record<string, string | null>>({});
   const [savingChecklist, setSavingChecklist] = useState(false);
   const [checklistMessage, setChecklistMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [newItemName, setNewItemName] = useState('');
   const [newItemDate, setNewItemDate] = useState('');
+  const [newItemLinkTab, setNewItemLinkTab] = useState('');
   const [addingItem, setAddingItem] = useState(false);
 
   // Sponsor users state
@@ -314,11 +324,23 @@ export function AdminPage() {
     setChecklistMessage(null);
     try {
       const updates = checklistItems
-        .filter(item => checklistEdits[item.name] !== undefined)
-        .map(item => ({
-          name: item.name,
-          dueDate: checklistEdits[item.name] || null,
-        }));
+        .filter(item =>
+          checklistEdits[item.name] !== undefined ||
+          checklistLinkTabEdits[item.name] !== undefined
+        )
+        .map(item => {
+          const update: { name: string; dueDate?: string | null; linkTab?: string | null } = {
+            name: item.name,
+          };
+          if (checklistEdits[item.name] !== undefined) {
+            update.dueDate = checklistEdits[item.name] || null;
+          }
+          if (checklistLinkTabEdits[item.name] !== undefined) {
+            const raw = checklistLinkTabEdits[item.name];
+            update.linkTab = raw === '' || raw == null ? null : raw;
+          }
+          return update;
+        });
       if (updates.length === 0) {
         setChecklistMessage({ type: 'error', text: 'No changes to save' });
         setSavingChecklist(false);
@@ -327,6 +349,7 @@ export function AdminPage() {
       const result = await updateChecklistDefaults(updates);
       setChecklistMessage({ type: 'success', text: `Updated ${result.totalUpdated} checklist items across all GPP events` });
       setChecklistEdits({});
+      setChecklistLinkTabEdits({});
       // Refresh
       const clDefaults = await fetchChecklistDefaults();
       setChecklistItems(sortByDueDate(clDefaults.items));
@@ -343,10 +366,15 @@ export function AdminPage() {
     setAddingItem(true);
     setChecklistMessage(null);
     try {
-      const result = await addChecklistDefault({ name: newItemName.trim(), dueDate: newItemDate || null });
+      const result = await addChecklistDefault({
+        name: newItemName.trim(),
+        dueDate: newItemDate || null,
+        linkTab: newItemLinkTab || null,
+      });
       setChecklistMessage({ type: 'success', text: `Added "${newItemName.trim()}" to ${result.createdCount} GPP events` });
       setNewItemName('');
       setNewItemDate('');
+      setNewItemLinkTab('');
       const clDefaults = await fetchChecklistDefaults();
       setChecklistItems(sortByDueDate(clDefaults.items));
     } catch (err: any) {
@@ -1116,6 +1144,18 @@ export function AdminPage() {
                         onChange={(e) => setChecklistEdits(prev => ({ ...prev, [item.name]: e.target.value }))}
                         className="text-sm bg-white/50 border border-theme-stroke rounded-lg px-2 py-1 text-theme-text w-36"
                       />
+                      <select
+                        aria-label={t('checklist.linkTabPlaceholder')}
+                        title={t('checklist.linkTabPlaceholder')}
+                        value={checklistLinkTabEdits[item.name] ?? item.linkTab ?? ''}
+                        onChange={(e) => setChecklistLinkTabEdits(prev => ({ ...prev, [item.name]: e.target.value }))}
+                        className="text-sm bg-white/50 border border-theme-stroke rounded-lg px-2 py-1 text-theme-text w-28"
+                      >
+                        <option value="">—</option>
+                        {LINK_TAB_OPTIONS.map((tab) => (
+                          <option key={tab} value={tab}>{tab}</option>
+                        ))}
+                      </select>
                     </div>
                     <button
                       onClick={() => handleDeleteChecklistItem(item.name)}
@@ -1131,7 +1171,7 @@ export function AdminPage() {
                 )}
               </div>
 
-              {checklistItems.length > 0 && Object.keys(checklistEdits).length > 0 && (
+              {checklistItems.length > 0 && (Object.keys(checklistEdits).length > 0 || Object.keys(checklistLinkTabEdits).length > 0) && (
                 <button
                   onClick={handleSaveChecklist}
                   disabled={savingChecklist}
@@ -1157,6 +1197,18 @@ export function AdminPage() {
                   onChange={(e) => setNewItemDate(e.target.value)}
                   className="text-sm bg-white/50 border border-theme-stroke rounded-lg px-2 py-2 text-theme-text w-36"
                 />
+                <select
+                  aria-label={t('checklist.linkTabPlaceholder')}
+                  title={t('checklist.linkTabPlaceholder')}
+                  value={newItemLinkTab}
+                  onChange={(e) => setNewItemLinkTab(e.target.value)}
+                  className="text-sm bg-white/50 border border-theme-stroke rounded-lg px-2 py-2 text-theme-text w-28"
+                >
+                  <option value="">—</option>
+                  {LINK_TAB_OPTIONS.map((tab) => (
+                    <option key={tab} value={tab}>{tab}</option>
+                  ))}
+                </select>
                 <button
                   type="submit"
                   disabled={addingItem || !newItemName.trim()}


### PR DESCRIPTION
## Summary
- Super admins can now set `link_tab` per checklist item from `/admin`
- PATCH/POST `/api/admin/checklist-defaults` accept `linkTab` (validated allow-list)
- PATCH propagates the new `linkTab` to existing GPP events' `checklist_items`

## Test plan
- [ ] Vercel preview: as super admin, change a row's tab on `/admin` → save → open a GPP event's checklist → row links to new tab
- [ ] Add a new item with a tab selected → propagates to existing GPP events
- [ ] Clear a row's tab to "—" → chevron + link gone on host checklist
- [ ] curl PATCH with `linkTab='garbage'` → 400

## Notes
- No migration needed (`link_tab` column already exists).
- Backend deploys from master; preview frontend talks to production backend. Hold merge of frontend until backend is on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)