### PR TITLE
crust-37090: Narrow poster sponsor container 20%

### DIFF
--- a/frontend/src/components/generative/configs/posterConfig.ts
+++ b/frontend/src/components/generative/configs/posterConfig.ts
@@ -48,7 +48,7 @@ export const POSTER_CONFIG: FormatConfig = {
   sponsorBox: {
     defaultX: 35,
     defaultY: 1080,
-    width: 800,
+    width: 640,
     height: 350,
     defaultRows: 3,
   },


### PR DESCRIPTION
## Summary
Narrow the event poster's sponsor logo container by 20%: `sponsorBox.width` 800 → 640 in `posterConfig.ts`. `defaultX` stays at 35 so the box remains left-aligned with the city/time/venue text.

Logos auto-resize to fit the new width via the existing 3-row sponsor-sizing heuristic.

## Test plan
- [ ] Host dashboard → Print tab → Event Poster
- [ ] Sponsor box visually 20% narrower, left edge still aligned with text
- [ ] With 6+ sponsors, logos reflow appropriately
- [ ] Download produces the narrower layout at hi-res

Generated with Claude Code