### PR TITLE
sausage-94261: approve/reject buttons on /map InfoWindows

### DIFF
--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { MarkerClusterer } from '@googlemaps/markerclusterer';
-import { GPPEventMapItem } from '../lib/api';
+import { GPPEventMapItem, updateUnderbossStatus } from '../lib/api';
 
 interface GPPEventsMapProps {
   events: GPPEventMapItem[];
@@ -14,8 +14,13 @@ export default function GPPEventsMap({
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
   const markersRef = useRef<google.maps.Marker[]>([]);
+  const markerByEventIdRef = useRef<Map<string, google.maps.Marker>>(new Map());
+  const eventByIdRef = useRef<Map<string, GPPEventMapItem>>(new Map());
   const clustererRef = useRef<MarkerClusterer | null>(null);
   const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
+  const infoWindowListenerRef = useRef<google.maps.MapsEventListener | null>(
+    null
+  );
   const [error, setError] = useState(false);
 
   // Filter out events with no valid coordinates
@@ -42,9 +47,17 @@ export default function GPPEventsMap({
     const initMap = () => {
       if (!containerRef.current) return;
 
+      // Populate event lookup ref (kept in sync with marker rebuild)
+      const eventIndex = new Map<string, GPPEventMapItem>();
+      for (const ev of validEvents) {
+        eventIndex.set(ev.id, ev);
+      }
+      eventByIdRef.current = eventIndex;
+
       // Clean up previous markers & clusterer
       markersRef.current.forEach((m) => m.setMap(null));
       markersRef.current = [];
+      markerByEventIdRef.current.clear();
       if (clustererRef.current) {
         clustererRef.current.clearMarkers();
         clustererRef.current = null;
@@ -129,6 +142,24 @@ export default function GPPEventsMap({
 
         const linkHtml = `<a href="/${event.slug}" target="_blank" rel="noopener noreferrer" style="color:#E52828;font-size:12px;text-decoration:none;font-weight:500">View Event &rarr;</a>`;
 
+        let actionsHtml = '';
+        if (event.underbossStatus === 'approved') {
+          actionsHtml = `
+            <span style="background:#dcfce7;color:#16a34a;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Approved</span>
+            <button data-action="reject" data-event-id="${event.id}" style="background:none;border:none;color:#dc2626;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark rejected</button>
+          `;
+        } else if (event.underbossStatus === 'rejected') {
+          actionsHtml = `
+            <span style="background:#fee2e2;color:#dc2626;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Rejected</span>
+            <button data-action="approve" data-event-id="${event.id}" style="background:none;border:none;color:#16a34a;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark approved</button>
+          `;
+        } else {
+          actionsHtml = `
+            <button data-action="approve" data-event-id="${event.id}" style="background:#16a34a;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Approve</button>
+            <button data-action="reject" data-event-id="${event.id}" style="background:#dc2626;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Reject</button>
+          `;
+        }
+
         return `
           <div style="max-width:260px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:4px">
             <h3 style="margin:0 0 4px;font-size:15px;font-weight:700;color:#1a1a1a">${event.name}</h3>
@@ -139,9 +170,81 @@ export default function GPPEventsMap({
               ${linkHtml}
               ${rsvpHtml}
             </div>
+            <div style="margin-top:8px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+              ${actionsHtml}
+            </div>
           </div>
         `;
       }
+
+      async function onActionClick(e: Event) {
+        const button = e.currentTarget as HTMLButtonElement;
+        const action = button.dataset.action as 'approve' | 'reject';
+        const eventId = button.dataset.eventId;
+        if (!action || !eventId) return;
+
+        const actionButtons = document.querySelectorAll<HTMLButtonElement>(
+          '[data-action][data-event-id]'
+        );
+        const originalText = button.textContent;
+        actionButtons.forEach((b) => {
+          b.disabled = true;
+        });
+        button.textContent = 'Saving…';
+
+        try {
+          await updateUnderbossStatus(
+            eventId,
+            action === 'approve' ? 'approved' : 'rejected'
+          );
+        } catch (err) {
+          alert((err as Error).message || 'Failed to update');
+          actionButtons.forEach((b) => {
+            b.disabled = false;
+          });
+          button.textContent = originalText;
+          return;
+        }
+
+        const current = eventByIdRef.current.get(eventId);
+        if (!current) return;
+        const updated: GPPEventMapItem = {
+          ...current,
+          underbossStatus: action === 'approve' ? 'approved' : 'rejected',
+        };
+
+        // Mutate ref directly — no state update, so no useEffect re-run
+        eventByIdRef.current.set(eventId, updated);
+
+        infoWindow.setContent(buildInfoContent(updated));
+
+        if (action === 'reject') {
+          const marker = markerByEventIdRef.current.get(eventId);
+          if (marker) {
+            clustererRef.current?.removeMarker(marker);
+            marker.setMap(null);
+            markerByEventIdRef.current.delete(eventId);
+            markersRef.current = markersRef.current.filter((m) => m !== marker);
+          }
+        }
+      }
+
+      function attachActionHandlers() {
+        const buttons = document.querySelectorAll<HTMLButtonElement>(
+          '[data-action][data-event-id]'
+        );
+        buttons.forEach((b) => {
+          b.addEventListener('click', onActionClick);
+        });
+      }
+
+      if (infoWindowListenerRef.current) {
+        infoWindowListenerRef.current.remove();
+      }
+      infoWindowListenerRef.current = infoWindow.addListener(
+        'domready',
+        attachActionHandlers
+      );
 
       // Build markers
       const markers: google.maps.Marker[] = [];
@@ -164,12 +267,15 @@ export default function GPPEventsMap({
           },
         });
 
+        const eventId = event.id;
         marker.addListener('click', () => {
-          infoWindow.setContent(buildInfoContent(event));
+          const latest = eventByIdRef.current.get(eventId) ?? event;
+          infoWindow.setContent(buildInfoContent(latest));
           infoWindow.open(map, marker);
         });
 
         markers.push(marker);
+        markerByEventIdRef.current.set(event.id, marker);
       }
 
       markersRef.current = markers;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3264,6 +3264,7 @@ export interface GPPEventMapItem {
   longitude: number | null;
   rsvpCount: number;
   country: string | null;
+  underbossStatus?: string | null;
 }
 
 interface GPPEventApiResponse {
@@ -3279,6 +3280,7 @@ interface GPPEventApiResponse {
   longitude: number | null;
   guestCount: number;
   country: string | null;
+  underbossStatus?: string | null;
 }
 
 interface GPPEventsApiPayload {
@@ -3304,6 +3306,7 @@ export async function fetchGppEventsForMap(): Promise<GPPEventMapItem[]> {
     longitude: e.longitude,
     rsvpCount: e.guestCount ?? 0,
     country: e.country,
+    underbossStatus: e.underbossStatus,
   }));
 }
 


### PR DESCRIPTION
## Summary
- Adds Approve / Reject buttons inside each event InfoWindow on the underboss-gated `/map` page
- Calls existing `updateUnderbossStatus` API (same endpoint the underboss EventTable uses) — no backend changes
- After a click, the card swaps to a status pill with a re-clickable inverse action (approved ↔ rejected) so an underboss can correct themselves without leaving the map
- On reject we also remove the pin from the clusterer in-session; the next reload won't show it since `/api/gpp/events` already filters `underbossStatus NOT IN ('rejected','hidden')` (`gpp.routes.ts:636`)

## Notes
- State is held in refs (not React state) so a click doesn't trigger a full marker/clusterer rebuild — an earlier iteration used state and the rebuild was undoing the marker removal on reject
- Click handlers are attached via Google Maps `domready` event since the InfoWindow content lives outside the React tree

## Test plan
- [ ] Sign in as an underboss/admin and visit `/map` on the Vercel preview
- [ ] Click a pending pin → confirm Approve + Reject buttons appear
- [ ] Click Approve → card shows green "Approved" pill + a "Mark rejected" ghost link; pin remains on map
- [ ] Click "Mark rejected" → card shows red "Rejected" pill + "Mark approved"; pin disappears from clusterer
- [ ] Refresh → that event no longer appears in the data
- [ ] Open a different pin, click Reject → only that pin is removed, others stay
- [ ] DevTools Network: each click hits `PATCH /api/underboss/event/:id/status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)