### PR TITLE
pizzaiolo-97053: audit log for underboss_status changes

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -170,6 +170,7 @@ model Party {
   // Underboss dashboard fields
   hostStatus      String? @map("host_status")
   underbossStatus String  @default("pending") @map("underboss_status")
+  statusAudit     PartyStatusAudit[]
   hostTags        Json    @default("[]") @map("host_tags")
   underbossNotes  String? @map("underboss_notes")
 
@@ -212,6 +213,23 @@ model Party {
   scorecardItems        GuestScorecardItem[]
 
   @@map("parties")
+}
+
+model PartyStatusAudit {
+  id         String   @id @default(uuid()) @db.Uuid
+  partyId    String   @map("party_id") @db.Uuid
+  party      Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  action     String
+  oldStatus  String?  @map("old_status")
+  newStatus  String   @map("new_status")
+  actorEmail String   @map("actor_email")
+  actorKind  String   @map("actor_kind")
+  reason     String?
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([partyId])
+  @@index([createdAt(sort: Desc)])
+  @@map("party_status_audit")
 }
 
 model Guest {

--- a/backend/src/helpers/statusAudit.ts
+++ b/backend/src/helpers/statusAudit.ts
@@ -1,0 +1,39 @@
+import { Prisma } from '@prisma/client';
+
+const STATUS_TO_ACTION: Record<string, string> = {
+  approved: 'approve',
+  rejected: 'reject',
+  listed:   'list',
+  hidden:   'hide',
+  pending:  'pending',
+};
+
+export type ActorKind = 'admin' | 'underboss' | 'owner' | 'system';
+
+/**
+ * Writes a single row to party_status_audit. Must be called inside an
+ * interactive $transaction with the status update. If this throws, the
+ * surrounding transaction aborts and the status change rolls back —
+ * fail-closed by design (see pizzaiolo-97053).
+ */
+export function writeStatusAudit(
+  tx: Prisma.TransactionClient,
+  partyId: string,
+  oldStatus: string | null,
+  newStatus: string,
+  actorEmail: string,
+  actorKind: ActorKind,
+  reason?: string,
+) {
+  return tx.partyStatusAudit.create({
+    data: {
+      partyId,
+      action:     STATUS_TO_ACTION[newStatus] ?? newStatus,
+      oldStatus,
+      newStatus,
+      actorEmail: (actorEmail || 'unknown').toLowerCase(),
+      actorKind,
+      reason: reason ?? null,
+    },
+  });
+}

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -5,6 +5,7 @@ import { AppError } from '../middleware/error.js';
 import crypto from 'crypto';
 import { addPartnerToParty, removePartnerFromParty, getAutoCoHostPartners } from '../helpers/partnerSync.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
+import { writeStatusAudit, ActorKind } from '../helpers/statusAudit.js';
 
 // Extend Request to include underboss
 interface UnderbossRequest extends AuthRequest {
@@ -638,12 +639,31 @@ router.patch('/events/bulk-status', requireAuth, requireUnderbossAuth, async (re
       throw new AppError(`status must be one of: ${validStatuses.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
 
-    const result = await prisma.party.updateMany({
-      where: { id: { in: partyIds } },
-      data: { underbossStatus: status },
+    const email = req.userEmail!;
+    const isAdminUser = await isAdmin(email);
+    const actorKind: ActorKind = isAdminUser ? 'admin' : 'underboss';
+
+    const updatedCount = await prisma.$transaction(async (tx) => {
+      const before = await tx.party.findMany({
+        where: { id: { in: partyIds } },
+        select: { id: true, underbossStatus: true },
+      });
+
+      // Skip no-ops to avoid noisy audit rows.
+      const changing = before.filter(p => p.underbossStatus !== status);
+
+      await tx.party.updateMany({
+        where: { id: { in: changing.map(p => p.id) } },
+        data: { underbossStatus: status },
+      });
+
+      for (const p of changing) {
+        await writeStatusAudit(tx, p.id, p.underbossStatus, status, email, actorKind);
+      }
+      return changing.length;
     });
 
-    res.json({ updated: result.count });
+    res.json({ updated: updatedCount });
   } catch (error) {
     next(error);
   }
@@ -829,10 +849,22 @@ router.patch('/event/:partyId/status', requireAuth, async (req: AuthRequest, res
 
     if (underboss) {
       // Underboss/admin: allow all statuses
-      const party = await prisma.party.update({
-        where: { id: partyId },
-        data: { underbossStatus: status },
-        select: { id: true, underbossStatus: true },
+      const actorKind: ActorKind = isAdminUser ? 'admin' : 'underboss';
+      const party = await prisma.$transaction(async (tx) => {
+        const before = await tx.party.findUnique({
+          where: { id: partyId },
+          select: { underbossStatus: true },
+        });
+        if (!before) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+        const updated = await tx.party.update({
+          where: { id: partyId },
+          data: { underbossStatus: status },
+          select: { id: true, underbossStatus: true },
+        });
+
+        await writeStatusAudit(tx, partyId, before.underbossStatus, status, email, actorKind);
+        return updated;
       });
       return res.json({ party });
     }
@@ -863,10 +895,15 @@ router.patch('/event/:partyId/status', requireAuth, async (req: AuthRequest, res
       throw new AppError('Cannot change status from current state', 403, 'FORBIDDEN');
     }
 
-    const updated = await prisma.party.update({
-      where: { id: partyId },
-      data: { underbossStatus: status },
-      select: { id: true, underbossStatus: true },
+    const updated = await prisma.$transaction(async (tx) => {
+      const result = await tx.party.update({
+        where: { id: partyId },
+        data: { underbossStatus: status },
+        select: { id: true, underbossStatus: true },
+      });
+
+      await writeStatusAudit(tx, partyId, party.underbossStatus, status, email, 'owner');
+      return result;
     });
 
     res.json({ party: updated });

--- a/supabase/migrations/20260515_create_party_status_audit.sql
+++ b/supabase/migrations/20260515_create_party_status_audit.sql
@@ -1,0 +1,28 @@
+-- ============================================
+-- Party Status Audit Log (pizzaiolo-97053)
+-- ============================================
+-- Records every change to parties.underboss_status with the actor email.
+-- Service-role read only — never exposed to anon/authenticated.
+-- ============================================
+
+CREATE TABLE party_status_audit (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id    UUID NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  action      TEXT NOT NULL CHECK (action IN ('approve','reject','list','hide','pending')),
+  old_status  TEXT,                       -- nullable: first-ever transition has no prior value
+  new_status  TEXT NOT NULL,
+  actor_email TEXT NOT NULL,              -- 'unknown' for system / pre-audit writes
+  actor_kind  TEXT NOT NULL CHECK (actor_kind IN ('admin','underboss','owner','system')),
+  reason      TEXT,                       -- reserved for future use (e.g. fingerprint detector)
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_party_status_audit_party_id   ON party_status_audit (party_id);
+CREATE INDEX idx_party_status_audit_created_at ON party_status_audit (created_at DESC);
+
+-- Permissions: backend / service-role only.
+-- Follow Feb 2026 audit pattern: revoke broad access, do NOT grant column-level SELECT to anon/authenticated.
+REVOKE ALL ON party_status_audit FROM anon, authenticated;
+
+-- Enable RLS as belt-and-suspenders (service_role bypasses RLS by default; no policies = deny-all otherwise).
+ALTER TABLE party_status_audit ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

Adds an audit trail for every change to `parties.underboss_status` so we can answer "who approved/rejected this event?" after the fact (incident 2026-05-14: two Tanzania GPP events were auto-rejected then manually re-approved; actor was unrecoverable from logs).

**Plan:** [`plans/pizzaiolo-97053-underboss-status-audit-log.md`](./plans/pizzaiolo-97053-underboss-status-audit-log.md)

### Changes
- **New table** `party_status_audit` — service-role only (REVOKE from anon/authenticated, RLS enabled with no policies = deny-all). Captures `party_id`, `action`, `old_status`, `new_status`, `actor_email`, `actor_kind` (`admin`/`underboss`/`owner`/`system`), optional `reason`, `created_at`. `ON DELETE CASCADE` — `deletion_log` already covers the snapshot of a deleted event.
- **New Prisma model** `PartyStatusAudit` + `Party.statusAudit` relation.
- **New helper** `backend/src/helpers/statusAudit.ts` — `writeStatusAudit(tx, partyId, oldStatus, newStatus, actorEmail, actorKind)` parallels `auditContext.ts` style.
- **Instrumented all three write sites** in `backend/src/routes/underboss.routes.ts`:
  - `PATCH /events/bulk-status` — refactored from `updateMany` to interactive `$transaction`, skips no-op rows, writes one audit per changed row.
  - `PATCH /event/:partyId/status` underboss/admin branch — wrapped in `$transaction`, captures old status, writes audit. `actor_kind = admin | underboss`.
  - Same endpoint, owner branch — wrapped in `$transaction`, uses already-fetched `party.underbossStatus` as old. `actor_kind = owner`.
- **Fail-closed**: no try/catch around `writeStatusAudit`. If the audit insert errors, the transaction rolls back and the status change is rejected. Intentional — silent audit holes are worse than a temporary 500.

### Out of scope
- Backfill (skipped per plan — `actor_email = 'unknown'` would be noise; legacy transitions are unrecoverable).
- UI surface for the audit log (separate task).
- Guest approval auditing.
- Soft-cancel auditing (no `cancelled` field exists on `Party` yet; cancel = delete, covered by `deletion_log`).

---

## ⚠️ DEPLOY ORDERING — READ BEFORE MERGE ⚠️

**The DB migration MUST be applied to prod Supabase BEFORE merging this PR.**

Backend code references `prisma.partyStatusAudit`. If the table is missing in prod when the backend deploys, **every approve/reject/list/hide/bulk-status call will 500 in production.**

Order of operations:
1. Apply migration via `mcp__supabase-pizzadao__apply_migration` (project ID `znpiwdvvsqaxuskpfleo`) using `supabase/migrations/20260515_create_party_status_audit.sql`.
2. Confirm table exists + RLS enabled + REVOKE applied.
3. Merge this PR to `master`.
4. Backend auto-deploys (or manual: `cd backend && vercel --prod --scope pizza-dao`).

## Test plan

- [ ] Apply migration to prod
- [ ] Approve a test event via underboss dashboard → 1 audit row, `action='approve'`, correct `actor_kind` + `actor_email`
- [ ] Reject same event → `action='reject'`, `old_status='approved'`, `new_status='rejected'`
- [ ] As event owner, flip a rejected event to listed → `actor_kind='owner'`
- [ ] Bulk-status 3 events with mixed current statuses to `listed` → exactly N rows (no-ops skipped)
- [ ] Delete a party with audit rows → audit rows gone (cascade); `deletion_log` row exists
- [ ] Anon Supabase client `SELECT * FROM party_status_audit` → `permission denied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)