### PR TITLE
pesto-58917: venue checklist auto-completes on event address

### DIFF
--- a/backend/src/routes/checklist.routes.ts
+++ b/backend/src/routes/checklist.routes.ts
@@ -39,14 +39,10 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
       select: { id: true },
     });
 
-    // 2. venue_added: party.venue_name is set OR venues table has an entry with isSelected
+    // 2. venue_added: party.address is set (picking a venue or filling the location autocomplete both write address)
     const party = await prisma.party.findUnique({
       where: { id: partyId },
-      select: { venueName: true, coHosts: true, userId: true, region: true, user: { select: { email: true, name: true } } },
-    });
-    const selectedVenue = await prisma.venue.findFirst({
-      where: { partyId, isSelected: true },
-      select: { id: true },
+      select: { address: true, venueName: true, coHosts: true, userId: true, region: true, user: { select: { email: true, name: true } } },
     });
 
     // 3. budget_submitted: budget_items has items for this party
@@ -98,7 +94,7 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
     const autoCompleteStates = {
       event_created: true,
       party_kit_submitted: !!partyKit,
-      venue_added: !!(party?.venueName) || !!selectedVenue,
+      venue_added: !!party?.address,
       budget_submitted: budgetItemCount > 0,
       team_built: teamBuilt,
     };


### PR DESCRIPTION
## Summary
- `venue_added` auto-complete now triggers on `party.address` instead of `venueName || selectedVenue`
- Selecting a venue and filling the create-form location autocomplete both write `address`, so the simpler check covers all real flows
- Removes redundant `venues` table lookup

## Test plan
- [ ] Create a new event with just a location autocomplete → checklist tab → "Find a Venue" row shows complete
- [ ] Pick a venue from venue tab → "Find a Venue" stays complete
- [ ] Existing event with no address → row stays incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)