### PR TITLE
jalapeno-32738: harden legacy flyer localStorage migration

### DIFF
--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -412,22 +412,81 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
     try { localStorage.setItem(storageKey, JSON.stringify(state)); } catch {}
   }, [storageKey, positions, poppedLogos, logoSizes, sponsorBoxSize, editVenueName, editStreetAddress, editCity, editTime]);
 
-  // One-time backfill: if DB has no flyerConfig but localStorage does, sync to DB
-  const backfillDone = useRef(false);
+  // One-time migration: legacy hosts customized their flyer in localStorage BEFORE
+  // calzone-91482 introduced DB persistence. The auto-regen gate in
+  // autoRegenFlyer.ts:68 skips regen for any party with no DB config but a
+  // localStorage key. Migrate the localStorage payload into DB on FlyerGenerator
+  // mount so future regens (billed sponsors, logo edits, timezone changes from
+  // napoletana-11413) preserve their customizations.
+  // jalapeno-32738
+  const migrationDone = useRef(false);
   useEffect(() => {
-    if (backfillDone.current || !party?.id || party.flyerConfig) return;
-    backfillDone.current = true;
+    if (migrationDone.current || !party?.id || !storageKey) return;
+
+    // Treat empty object {} as "no real config" — the regen gate uses a truthy
+    // check (`!party.flyerConfig`) so {} would block migration forever.
+    const dbConfig = party.flyerConfig as Record<string, any> | null | undefined;
+    const hasRealDbConfig = !!dbConfig && Object.keys(dbConfig).length > 0;
+    if (hasRealDbConfig) return;
+
+    migrationDone.current = true;
+
+    let raw: string | null = null;
     try {
-      const raw = storageKey ? localStorage.getItem(storageKey) : null;
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        // Only backfill if there's meaningful customization data
-        if (parsed && (parsed.positions || parsed.poppedLogos || parsed.logoSizes || parsed.editCity || parsed.editVenueName || parsed.editStreetAddress || parsed.editTime)) {
-          updateParty(party.id, { flyer_config: parsed }).catch(() => {});
+      raw = localStorage.getItem(storageKey);
+    } catch {
+      return; // localStorage unavailable — nothing to migrate
+    }
+    if (!raw) return; // no legacy data
+
+    let parsed: Record<string, any> | null = null;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      // Corrupt JSON — clear the key so the regen gate stops blocking this party.
+      console.warn('[jalapeno-32738] corrupt flyer localStorage, clearing:', err);
+      try { localStorage.removeItem(storageKey); } catch {}
+      return;
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      // Defensive: parsed null or a primitive — treat as corrupt.
+      try { localStorage.removeItem(storageKey); } catch {}
+      return;
+    }
+
+    // Only migrate if there's at least one customization field.
+    const hasContent =
+      parsed.positions || parsed.poppedLogos || parsed.logoSizes ||
+      parsed.sponsorBoxSize || parsed.editCity || parsed.editVenueName ||
+      parsed.editStreetAddress || parsed.editTime != null;
+    if (!hasContent) {
+      // Empty state — clear the stale key but don't waste a DB write.
+      try { localStorage.removeItem(storageKey); } catch {}
+      return;
+    }
+
+    updateParty(party.id, { flyer_config: parsed })
+      .then((ok) => {
+        if (ok) {
+          // DB write succeeded — clear localStorage so we don't drift.
+          try { localStorage.removeItem(storageKey); } catch {}
+          // Refresh party state so the regen gate now sees the DB config.
+          if (party.inviteCode) {
+            loadParty(party.inviteCode).catch(() => {});
+          }
+        } else {
+          // DB write failed — leave localStorage intact as fallback and
+          // allow a retry on next mount.
+          console.warn('[jalapeno-32738] updateParty returned false; preserving localStorage fallback');
+          migrationDone.current = false;
         }
-      }
-    } catch {}
-  }, [party?.id, party?.flyerConfig, storageKey]);
+      })
+      .catch((err) => {
+        console.warn('[jalapeno-32738] migration failed; preserving localStorage fallback:', err);
+        migrationDone.current = false;
+      });
+  }, [party?.id, party?.flyerConfig, party?.inviteCode, storageKey, loadParty]);
 
   if (!party) return null;
 


### PR DESCRIPTION
## Summary
Hardens the existing legacy-flyer-customization migration useEffect at `FlyerGenerator.tsx:415-430` (originally added in calzone-91482) so the localStorage → DB migration actually completes cleanly. Without this, hosts who customized their flyer before DB persistence shipped remain blocked by the regen gate in `autoRegenFlyer.ts:68-75` — the new triggers from napoletana-11413 silently no-op for them.

Fixes 4 gaps in the existing migration:
- **Never cleared localStorage on success** → regen gate kept firing, defeating the migration.
- **Treated `flyerConfig === {}` as already-migrated** (truthy `!party.flyerConfig` check) → empty-object hosts stayed stuck.
- **Silently swallowed `updateParty` failures** → no logging, no retry signal.
- **Didn't clean up corrupt JSON** → malformed localStorage blocked the gate forever.

## Test plan
- [ ] Set `parties.flyer_config = NULL`, seed `localStorage['flyer-<party-id>']` with valid customization JSON, open FlyerGenerator → DB writes within ~1s + localStorage cleared
- [ ] Reload — FlyerGenerator shows the saved customizations (loaded from DB)
- [ ] Trigger an auto-regen on the same party → regen runs (no longer blocked by localStorage gate) and preserves customizations
- [ ] Corrupt-JSON path: seed `'{garbage'` in localStorage on a NULL-config party → warning logged, localStorage cleared, DB stays NULL
- [ ] DB-failure path: network-throttle, open FlyerGenerator → warning logged, localStorage preserved, migrationDone resets so retry succeeds on next mount

Plan: `plans/jalapeno-32738-flyer-localstorage-migrate.md`