### PR TITLE
pineapple-92163: host checklist - Select Pizzeria auto-complete + Pizza tab link; Find Partners -> Partners tab link

### DIFF
--- a/backend/src/routes/checklist.routes.ts
+++ b/backend/src/routes/checklist.routes.ts
@@ -42,7 +42,7 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
     // 2. venue_added: party.address is set (picking a venue or filling the location autocomplete both write address)
     const party = await prisma.party.findUnique({
       where: { id: partyId },
-      select: { address: true, venueName: true, coHosts: true, userId: true, region: true, user: { select: { email: true, name: true } } },
+      select: { address: true, venueName: true, coHosts: true, userId: true, region: true, selectedPizzerias: true, user: { select: { email: true, name: true } } },
     });
 
     // 3. budget_submitted: budget_items has items for this party
@@ -91,12 +91,15 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
 
     const teamBuilt = realCoHosts.length > 0;
 
+    const pizzeriasSelected = Array.isArray(party?.selectedPizzerias) && (party!.selectedPizzerias as unknown[]).length > 0;
+
     const autoCompleteStates = {
       event_created: true,
       party_kit_submitted: !!partyKit,
       venue_added: !!party?.address,
       budget_submitted: budgetItemCount > 0,
       team_built: teamBuilt,
+      pizzerias_selected: pizzeriasSelected,
     };
 
     // Check if defaults have been seeded — compare against checklist_defaults count

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -967,6 +967,7 @@ export interface AutoCompleteStates {
   venue_added: boolean;
   budget_submitted: boolean;
   team_built?: boolean;
+  pizzerias_selected?: boolean;
 }
 
 export interface ChecklistData {

--- a/supabase/migrations/20260515_fix_checklist_pizzeria_partners.sql
+++ b/supabase/migrations/20260515_fix_checklist_pizzeria_partners.sql
@@ -1,0 +1,22 @@
+-- Select Pizzeria: route to Pizza tab + auto-complete when pizzerias are selected
+UPDATE checklist_defaults
+   SET link_tab = 'pizza',
+       is_auto = true,
+       auto_rule = 'pizzerias_selected',
+       updated_at = now()
+ WHERE name = 'Select Pizzeria';
+
+UPDATE checklist_items
+   SET link_tab = 'pizza',
+       is_auto = true,
+       auto_rule = 'pizzerias_selected'
+ WHERE name = 'Select Pizzeria' AND is_default = true;
+
+-- Find Partners: fix invalid link_tab ('sponsors' is not a HostPage tab)
+UPDATE checklist_defaults
+   SET link_tab = 'partners', updated_at = now()
+ WHERE name = 'Find Partners';
+
+UPDATE checklist_items
+   SET link_tab = 'partners'
+ WHERE name = 'Find Partners' AND is_default = true;


### PR DESCRIPTION
## Summary

Three small changes to make the host checklist's pizzeria/partner items behave correctly:

1. **Backend (`backend/src/routes/checklist.routes.ts`)** - `GET /:partyId/checklist` now selects `selectedPizzerias` from the party and exposes a new `pizzerias_selected` boolean in `autoCompleteStates` (true when the JSON array is non-empty).

2. **Frontend types (`frontend/src/types.ts`)** - Add optional `pizzerias_selected?: boolean` to `AutoCompleteStates` so the typed payload matches the backend.

3. **Migration (`supabase/migrations/20260515_fix_checklist_pizzeria_partners.sql`)**:
   - "Select Pizzeria": route to Pizza tab + auto-complete via `pizzerias_selected` rule (updates both `checklist_defaults` template and existing default-seeded `checklist_items`).
   - "Find Partners": fix invalid `link_tab = 'sponsors'` -> `'partners'`.

No UI changes - the existing data-driven checklist renderer already handles auto-completion and tab linking; flipping the flags is enough.

## Deploy notes

Preview frontend talks to **prod backend + DB**, so for this to be fully functional on the preview URL:
- Apply the migration to prod DB via `mcp__supabase-pizzadao__apply_migration`.
- Redeploy backend to prod (`cd backend && vercel --prod --scope pizza-dao`) so the new `pizzerias_selected` field appears in the `/checklist` response.

## Preview

https://rsvpizza-git-pineapple-92163-pizzeria-partners-pizza-dao.vercel.app

## Test plan

- [ ] Apply migration to prod DB.
- [ ] Redeploy backend to prod.
- [ ] On a host page, "Select Pizzeria" checklist item links to the Pizza tab and auto-checks when one or more pizzerias are selected.
- [ ] "Find Partners" checklist item links to the Partners tab (not broken to a non-existent "sponsors" tab).
- [ ] Backend `build` still passes (the pre-existing `auth.test.ts` TS error is unrelated and present on master too).
- [ ] Frontend `npm run build` passes (verified locally).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code