### PR TITLE
slice-63708: shrink promo flyer + partner X-tag helper

### DIFF
--- a/frontend/src/components/promo/SocialComposer.tsx
+++ b/frontend/src/components/promo/SocialComposer.tsx
@@ -70,6 +70,7 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
   const [threadPosts, setThreadPosts] = useState<string[]>(['', '']);
   const [copied, setCopied] = useState(false);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+  const [copiedHandle, setCopiedHandle] = useState<string | null>(null);
   const [shared, setShared] = useState<Record<SocialPlatform, boolean>>({
     twitter: false,
     instagram: false,
@@ -149,6 +150,25 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
     }
   };
 
+  const partnerXHandles = (party.coHosts ?? [])
+    .filter(c => c.isPartner && c.twitter && c.twitter.trim())
+    .map(c => ({
+      id: c.id,
+      name: c.name,
+      avatarUrl: c.avatar_url ?? null,
+      handle: c.twitter!.replace(/^@/, '').trim(),
+    }));
+
+  const handleCopyHandle = async (id: string, handle: string) => {
+    try {
+      await navigator.clipboard.writeText(handle);
+      setCopiedHandle(id);
+      setTimeout(() => setCopiedHandle(null), 1500);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
   const updateThreadPost = (idx: number, value: string) => {
     setThreadPosts(prev => {
       const next = [...prev];
@@ -188,25 +208,69 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
 
       {/* Event Image Preview */}
       {party.eventImageUrl && (
-        <div className="rounded-lg overflow-hidden border border-theme-stroke bg-theme-surface">
-          <div className="relative">
+        <div className="w-48 rounded-lg overflow-hidden border border-theme-stroke bg-theme-surface">
+          <div className="relative w-48 h-48">
             <img
               src={party.eventImageUrl}
               alt={party.name}
-              className="w-full h-40 object-cover"
+              className="w-full h-full object-cover"
             />
             <button
               type="button"
               onClick={handleDownloadImage}
-              className="absolute bottom-2 right-2 flex items-center gap-1.5 bg-black/70 hover:bg-black/90 text-theme-text text-xs font-medium px-3 py-1.5 rounded-lg transition-colors backdrop-blur-sm"
+              className="absolute bottom-2 right-2 flex items-center gap-1 bg-black/70 hover:bg-black/90 text-theme-text text-xs font-medium px-2 py-1 rounded-lg transition-colors backdrop-blur-sm"
             >
-              <Download size={14} />
+              <Download size={12} />
               {t('promo.downloadImage')}
             </button>
           </div>
           <div className="px-3 py-2 flex items-center gap-2 text-theme-text-muted text-xs">
             <Image size={12} />
             {t('promo.attachImage')}
+          </div>
+        </div>
+      )}
+
+      {/* Partner X-tag helper - only on Twitter/X tab */}
+      {isTwitter && partnerXHandles.length > 0 && (
+        <div className="rounded-lg border border-theme-stroke bg-theme-surface p-3">
+          <div className="text-xs text-theme-text-muted font-medium mb-1">
+            {t('promo.tagYourPartners')}
+          </div>
+          <div className="text-xs text-theme-text-muted/70 mb-2">
+            {t('promo.tagYourPartnersHint')}
+          </div>
+          <div className="space-y-1.5">
+            {partnerXHandles.map(p => (
+              <div key={p.id} className="flex items-center gap-2">
+                {p.avatarUrl ? (
+                  <img
+                    src={p.avatarUrl}
+                    alt={p.name}
+                    className="w-6 h-6 rounded-full object-cover flex-shrink-0"
+                  />
+                ) : (
+                  <div className="w-6 h-6 rounded-full bg-theme-surface-hover text-theme-text-muted text-xs flex items-center justify-center flex-shrink-0">
+                    {p.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm text-theme-text truncate">{p.name}</div>
+                  <div className="text-xs text-theme-text-muted truncate">@{p.handle}</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleCopyHandle(p.id, p.handle)}
+                  className="text-xs text-theme-text-muted hover:text-theme-text-secondary transition-colors flex items-center gap-1 px-2 py-1 rounded"
+                >
+                  {copiedHandle === p.id ? (
+                    <><Check size={12} className="text-green-400" /> {t('promo.copied')}</>
+                  ) : (
+                    <><Copy size={12} /> {t('promo.copy')}</>
+                  )}
+                </button>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -683,7 +683,9 @@
     "sent": "{{count}} sent",
     "skipped": "{{count}} skipped",
     "failed": "{{count}} failed",
-    "inviteMore": "Invite more"
+    "inviteMore": "Invite more",
+    "tagYourPartners": "Tag your partners in the image",
+    "tagYourPartnersHint": "Copy each handle, then paste it into X's tag-people field after you attach the image."
   },
   "raffle": {
     "editPrize": "Edit Prize",


### PR DESCRIPTION
## Summary
Two polish changes to the promo widget's Social Media tab (`SocialComposer.tsx`):

1. **Flyer preview is now a 192px square** (mirrors `PartyHeader.tsx` `w-48 h-48`) instead of stretching full-width with `h-40`.
2. **New "Tag your partners in the image" helper** on the X/Twitter tab — lists co-hosts with `isPartner === true` and a `twitter` handle, with per-row Copy buttons that put just the bare screen name (no leading `@`) onto the clipboard so it can be pasted into X's tag-people field.

The block only renders on the Twitter tab and only when at least one matching partner exists. Other platforms (Instagram, Facebook, LinkedIn) are unaffected.

Two new `host.json` strings: `promo.tagYourPartners`, `promo.tagYourPartnersHint`. Reuses existing `promo.copy` and `promo.copied`.

## Test plan
- [ ] Load Social Media tab on an event with `eventImageUrl` set — flyer is a 192px square, download button still works
- [ ] Switch to the X tab on an event with at least one partner co-host who has a `twitter` handle — partner-tag block appears below the flyer
- [ ] Click the Copy button on a partner row — clipboard contains the bare screen name (no `@`), button toggles to "Copied!" for ~1.5s
- [ ] Switch to Instagram / Facebook / LinkedIn — partner-tag block is hidden
- [ ] Load an event with no partner co-hosts — partner-tag block does not appear on any tab

## Preview
https://rsvpizza-git-slice-63708-promo-flyer-partners-pizza-dao.vercel.app