### PR TITLE
dough-19767: clickable circles on GPP dashboard checklist

### DIFF
--- a/backend/src/routes/checklist.routes.ts
+++ b/backend/src/routes/checklist.routes.ts
@@ -39,14 +39,10 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
       select: { id: true },
     });
 
-    // 2. venue_added: party.venue_name is set OR venues table has an entry with isSelected
+    // 2. venue_added: party.address is set (picking a venue or filling the location autocomplete both write address)
     const party = await prisma.party.findUnique({
       where: { id: partyId },
-      select: { venueName: true, coHosts: true, userId: true, region: true, user: { select: { email: true, name: true } } },
-    });
-    const selectedVenue = await prisma.venue.findFirst({
-      where: { partyId, isSelected: true },
-      select: { id: true },
+      select: { address: true, venueName: true, coHosts: true, userId: true, region: true, user: { select: { email: true, name: true } } },
     });
 
     // 3. budget_submitted: budget_items has items for this party
@@ -98,7 +94,7 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
     const autoCompleteStates = {
       event_created: true,
       party_kit_submitted: !!partyKit,
-      venue_added: !!(party?.venueName) || !!selectedVenue,
+      venue_added: !!party?.address,
       budget_submitted: budgetItemCount > 0,
       team_built: teamBuilt,
     };

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X, type LucideIcon } from 'lucide-react';
+import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X, Lock, type LucideIcon } from 'lucide-react';
 import { usePizza } from '../../contexts/PizzaContext';
-import { getChecklist, seedChecklist, updateUnderbossStatus } from '../../lib/api';
+import { getChecklist, seedChecklist, updateUnderbossStatus, toggleChecklistItem } from '../../lib/api';
 import { AutoCompleteStates, ChecklistItem } from '../../types';
 import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
@@ -18,6 +18,7 @@ export const GPPDashboardTab: React.FC = () => {
   const [coHostCount, setCoHostCount] = useState(party?.coHosts?.length ?? 0);
   const [showCompleted, setShowCompleted] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!party?.id) return;
@@ -63,6 +64,21 @@ export const GPPDashboardTab: React.FC = () => {
     }
   };
 
+  const handleToggleItem = async (itemId: string) => {
+    if (!party?.id || togglingId) return;
+    setTogglingId(itemId);
+    try {
+      const result = await toggleChecklistItem(party.id, itemId);
+      if (result?.item) {
+        setDbItems(prev => prev.map(it => it.id === itemId
+          ? { ...it, completed: result.item.completed, completedAt: result.item.completedAt }
+          : it));
+      }
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
   const checklist = useMemo(() => {
     if (!party || dbItems.length === 0) return [];
     return dbItems.map((item) => {
@@ -70,6 +86,9 @@ export const GPPDashboardTab: React.FC = () => {
         ? (autoStates?.[item.autoRule as keyof AutoCompleteStates] ?? false)
         : item.completed;
       return {
+        id: item.id,
+        isAuto: item.isAuto,
+        autoRule: item.autoRule,
         label: item.name,
         done,
         tab: item.linkTab,
@@ -248,19 +267,49 @@ export const GPPDashboardTab: React.FC = () => {
             {checklist.filter(item => showCompleted || !item.done).map((item) => {
               const Icon = item.icon;
               const clickable = item.tab || item.onClick;
-              const Wrapper = clickable ? 'button' : 'div';
+              const handleRowAction = item.onClick || (item.tab ? () => goToTab(item.tab!) : undefined);
+              const baseCircle = item.done ? (
+                <CheckCircle size={18} className="text-green-500 shrink-0" />
+              ) : (
+                <Circle size={18} className="text-theme-text-faint shrink-0" />
+              );
               return (
                 <React.Fragment key={item.label}>
-                  <Wrapper
-                    onClick={clickable ? (item.onClick || (() => goToTab(item.tab!))) : undefined}
+                  <div
+                    onClick={clickable && handleRowAction ? handleRowAction : undefined}
+                    onKeyDown={clickable && handleRowAction ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowAction();
+                      }
+                    } : undefined}
+                    role={clickable ? 'button' : undefined}
+                    tabIndex={clickable ? 0 : undefined}
                     className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-left group ${
                       clickable ? 'hover:bg-theme-surface cursor-pointer' : ''
                     }`}
                   >
-                    {item.done ? (
-                      <CheckCircle size={18} className="text-green-500 shrink-0" />
+                    {item.isAuto ? (
+                      <span
+                        title="Auto-completes based on event setup"
+                        className="relative inline-flex shrink-0"
+                      >
+                        {baseCircle}
+                        <Lock
+                          size={9}
+                          className="absolute -bottom-0.5 -right-0.5 text-theme-text-muted bg-theme-surface rounded-full p-px"
+                        />
+                      </span>
                     ) : (
-                      <Circle size={18} className="text-theme-text-faint shrink-0" />
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); handleToggleItem(item.id); }}
+                        disabled={togglingId === item.id}
+                        aria-label={`Mark ${item.label} ${item.done ? 'incomplete' : 'complete'}`}
+                        className="shrink-0 hover:opacity-70 transition-opacity disabled:opacity-50"
+                      >
+                        {baseCircle}
+                      </button>
                     )}
                     <Icon size={16} className={item.done ? 'text-theme-text-muted shrink-0' : 'text-theme-text-secondary shrink-0'} />
                     <span
@@ -286,7 +335,7 @@ export const GPPDashboardTab: React.FC = () => {
                         {item.label === 'Build a Team' && hostsExpanded ? '\u25B2' : 'Go \u2192'}
                       </span>
                     )}
-                  </Wrapper>
+                  </div>
                   {item.label === 'Build a Team' && hostsExpanded && (
                     <div className="ml-9 mr-3 mb-2 mt-1 p-4 bg-theme-surface rounded-xl border border-theme-stroke animate-fade-in">
                       <HostsManager

--- a/plans/dough-19767-gpp-dashboard-checklist-toggle.md
+++ b/plans/dough-19767-gpp-dashboard-checklist-toggle.md
@@ -1,0 +1,178 @@
+# dough-19767 — GPP dashboard checklist: clickable circles for manual items + visual "auto" cue
+
+**Priority**: P1
+
+## Problem
+
+On the GPP host dashboard ("Event Setup" card in `GPPDashboardTab`), the checklist circle is purely decorative. Manual items like "Find Partners" and "Prepare for the Party" can never be marked done from this view — the only way to toggle them is to navigate to the separate `/checklist` tab, which most hosts never visit.
+
+DB confirms the symptom: across 537 GPP events with seeded defaults, **zero** `checklist_items` rows have `completed_at` set. Nobody has ever successfully toggled a manual item, because the dashboard never sends a toggle.
+
+Current rendering in `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx:248-302`:
+- The whole row is a `<button>` if the item has a `linkTab` or custom `onClick`, otherwise a `<div>`.
+- Click on a row with `linkTab` → navigates away (e.g. "Find Partners" → `/partners`).
+- Click on a row with neither (like "Prepare for the Party") → nothing.
+- The leading `CheckCircle` / `Circle` icon has no click handler of its own.
+
+Auto-completed items (like "Find a Venue", "Set Up Budget") also look identical to manual items, so the user can't tell which ones the system will check off automatically vs which ones need manual action.
+
+## Goal
+
+1. The leading circle becomes an interactive control for **manual** items — clicking it toggles completion via `toggleChecklistItem` and refreshes the row state.
+2. **Auto** items show their circle in a way that visually signals "auto" (so the user understands why it's not clickable). Use a `Lock` icon (or similar visual diff — see notes below) — do not call toggle on these.
+3. Row-level navigation (`Go →` for items with `linkTab`) keeps working — only the circle is the new toggle hit-target, not the whole row.
+
+## Files to modify
+
+- `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx` (only file)
+
+## Implementation
+
+### 1. Import `toggleChecklistItem` and a "lock" icon
+
+```ts
+import { ..., Lock } from 'lucide-react';
+import { getChecklist, seedChecklist, updateUnderbossStatus, toggleChecklistItem } from '../../lib/api';
+```
+
+### 2. Carry `isAuto` and `id` through the `checklist` memo
+
+In the `checklist = useMemo(...)` block (line ~66), include `isAuto`, `autoRule`, and `id` in each mapped item so the renderer can decide whether the circle is interactive and which item to toggle:
+
+```ts
+return {
+  id: item.id,
+  isAuto: item.isAuto,
+  autoRule: item.autoRule,
+  label: item.name,
+  done,
+  tab: item.linkTab,
+  onClick: ...,
+  icon: ICON_MAP[item.name] ?? ClipboardCheck,
+  dueDate: item.dueDate ? item.dueDate.split('T')[0] : null,
+};
+```
+
+### 3. Add a toggle handler
+
+After `goToTab`, add:
+
+```ts
+const [togglingId, setTogglingId] = useState<string | null>(null);
+
+const handleToggleItem = async (itemId: string) => {
+  if (!party?.id || togglingId) return;
+  setTogglingId(itemId);
+  try {
+    const result = await toggleChecklistItem(party.id, itemId);
+    if (result?.item) {
+      // Optimistic-ish: update the single row in dbItems so the UI reflects the new state
+      setDbItems(prev => prev.map(it => it.id === itemId ? { ...it, completed: result.item.completed, completedAt: result.item.completedAt } : it));
+    }
+  } finally {
+    setTogglingId(null);
+  }
+};
+```
+
+(Local-only update — no refetch needed; auto-states haven't changed.)
+
+### 4. Replace the leading icon block in the render
+
+Currently (line ~260):
+
+```tsx
+{item.done ? (
+  <CheckCircle size={18} className="text-green-500 shrink-0" />
+) : (
+  <Circle size={18} className="text-theme-text-faint shrink-0" />
+)}
+```
+
+Replace with a small helper component (or inline) that:
+
+- **If `item.isAuto`**: render the existing `CheckCircle`/`Circle` BUT wrap it with a tooltip or overlay that makes it clear it's automatic. Recommended: use a `Lock` overlay (small lock icon top-right corner) OR render the unchecked state with a `Lock` icon instead of an empty `Circle`. Add `title="Auto-completes when {autoRule explanation}"` for hover hint. Do NOT make it clickable — render as a plain `<span>` so row navigation isn't blocked.
+
+- **If NOT `item.isAuto`**: render the icon inside a `<button type="button">` that:
+  - calls `e.stopPropagation()` so the row's parent `<button>`/navigation doesn't fire
+  - calls `handleToggleItem(item.id)`
+  - has hover styling (`hover:opacity-80` or similar)
+  - disabled while `togglingId === item.id`
+  - `aria-label="Mark {label} {done ? 'incomplete' : 'complete'}"`
+
+```tsx
+const ToggleCircle = ({ item }: { item: ChecklistRow }) => {
+  const baseIcon = item.done
+    ? <CheckCircle size={18} className="text-green-500 shrink-0" />
+    : <Circle size={18} className="text-theme-text-faint shrink-0" />;
+
+  if (item.isAuto) {
+    return (
+      <span
+        title="Auto-completes based on event setup"
+        className="relative inline-flex shrink-0"
+      >
+        {baseIcon}
+        <Lock
+          size={9}
+          className="absolute -bottom-0.5 -right-0.5 text-theme-text-muted bg-theme-surface rounded-full p-px"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); handleToggleItem(item.id); }}
+      disabled={togglingId === item.id}
+      aria-label={`Mark ${item.label} ${item.done ? 'incomplete' : 'complete'}`}
+      className="shrink-0 hover:opacity-70 transition-opacity disabled:opacity-50"
+    >
+      {baseIcon}
+    </button>
+  );
+};
+```
+
+(Define inside the component so it can close over `handleToggleItem` and `togglingId`.)
+
+### 5. Crucial: row wrapper must allow nested buttons
+
+The outer `<Wrapper>` is a `<button>` when `clickable` is truthy. Nesting a `<button>` inside a `<button>` is invalid HTML and React will warn. **Change the outer wrapper to always be a `<div>`** with `role="button"` when clickable, OR move the click handler off the wrapper and onto a dedicated trailing `Go →` span/button. Recommended: change outer wrapper to always `<div>`, and put the `onClick={clickable ? ... : undefined}` on the div with appropriate `role`/`tabIndex`/keyboard handler.
+
+```tsx
+<div
+  onClick={clickable ? (item.onClick || (() => goToTab(item.tab!))) : undefined}
+  onKeyDown={clickable ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); (item.onClick || (() => goToTab(item.tab!)))(); } } : undefined}
+  role={clickable ? 'button' : undefined}
+  tabIndex={clickable ? 0 : undefined}
+  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-left group ${
+    clickable ? 'hover:bg-theme-surface cursor-pointer' : ''
+  }`}
+>
+  <ToggleCircle item={item} />
+  ...
+</div>
+```
+
+This is the only structural change — needed so the inner toggle button is legal.
+
+## Verification
+
+After deploy to Vercel preview:
+
+1. As a GPP host, open `/host/{inviteCode}` → "Event Setup" card.
+2. Click the circle next to "Prepare for the Party" → it fills green, item moves to "completed" (visible only if "Show completed" is on).
+3. Click again → reverts to empty.
+4. Click the circle next to "Find Partners" → it toggles WITHOUT navigating away to /partners.
+5. Click the label/row body of "Find Partners" → still navigates to /partners.
+6. Auto items (Find a Venue, Set Up Budget, etc.) show a small Lock indicator over their circle and clicking the circle does nothing (no navigation, no error). Hover tooltip says it auto-completes.
+7. Refresh the page → manual toggles persisted (verify via DB: `SELECT name, completed, completed_at FROM checklist_items WHERE party_id = '...' AND name IN ('Find Partners', 'Prepare for the Party')`).
+8. `/checklist` standalone tab shows the same completion state (sanity check that both surfaces share the same source of truth).
+
+## Out of scope
+
+- Changing the standalone `/checklist` tab's UI.
+- Changing the seed/reseed flow or `checklist_defaults` rows.
+- Adding any new auto-rules (e.g., "post_to_socials" detection).


### PR DESCRIPTION
## Summary

On the GPP host dashboard ("Event Setup" card in `GPPDashboardTab`), the leading circle next to each checklist item was previously decorative. As a result, manual items like "Find Partners" and "Prepare for the Party" could never be marked done from this surface — DB confirms **zero** `checklist_items.completed_at` rows across all 537 seeded GPP events.

### Changes (single file: `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx`)

- Import `toggleChecklistItem` from `lib/api` and the `Lock` icon from `lucide-react`.
- Carry `id`, `isAuto`, `autoRule` through the `checklist` memo so the renderer can decide circle behavior.
- Add `togglingId` state and a `handleToggleItem(itemId)` async helper that calls the existing API and patches the affected row in `dbItems` (no full refetch — auto-states haven't changed).
- Replace the leading circle block with a per-item conditional:
  - **Manual items** → wrapped in a `<button type="button">` that calls `e.stopPropagation()` + `handleToggleItem(item.id)`, disabled while toggling, with an `aria-label`.
  - **Auto items** → wrapped in a `<span>` with a small `Lock` overlay (bottom-right) and a `title` tooltip.
- Change the outer row wrapper from `<button>`/`<div>` to always `<div role="button" tabIndex={0}>` with a keyboard handler. This is required because the new inner toggle is a `<button>` and nested buttons are invalid HTML.

Row-level `Go ->` navigation for items with `linkTab` / custom `onClick` continues to work via the wrapper div's `onClick`.

## Test plan

- [ ] As a GPP host, open `/host/{inviteCode}` → "Event Setup" card.
- [ ] Click the circle next to "Prepare for the Party" → fills green, item disappears (unless "Show completed" is on).
- [ ] Click again → reverts to empty.
- [ ] Click the circle next to "Find Partners" → toggles **without** navigating to `/partners`.
- [ ] Click the label/row body of "Find Partners" → still navigates to `/partners`.
- [ ] Auto items (Find a Venue, Set Up Budget, etc.) show a small Lock indicator over their circle; clicking the circle does nothing.
- [ ] Refresh the page → manual toggles persist (verify via DB).
- [ ] `/checklist` standalone tab shows the same completion state.
- [ ] No React warnings about nested `<button>` in console.

## Verification done

- `npx tsc --noEmit` passes in `frontend/`.

## Out of scope

- Standalone `/checklist` tab UI.
- Seed/reseed flow or `checklist_defaults` rows.
- New auto-rules.