### PR TITLE
stromboli-48177: GPP partners aggregator page + API

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,6 +55,8 @@ const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
   : [
       'https://rsv.pizza',
       'https://www.rsv.pizza',
+      'https://globalpizza.party',
+      'https://www.globalpizza.party',
       'http://localhost:5173',  // Vite dev server
       'http://localhost:5176',  // Vite dev server (alt port)
       'http://localhost:3000',
@@ -292,6 +294,40 @@ app.get('/api', (req, res) => {
 
 <h3>Example</h3>
 <pre><code>curl https://api.rsv.pizza/api/events/london</code></pre>
+
+<h2>Partners</h2>
+
+<div class="endpoint">
+  <span class="method">GET</span>
+  <span class="path">/api/gpp/partners</span>
+  <span class="badge">public</span>
+  <p class="desc">Aggregated partner logos across all approved Global Pizza Party events. Deduplicated by normalized logo URL with a fallback on normalized name. Cached for 10 minutes.</p>
+</div>
+
+<h3>Example Request</h3>
+<pre><code>curl https://api.rsv.pizza/api/gpp/partners</code></pre>
+
+<h3>Response</h3>
+<pre><code>{
+  "partners": [
+    {
+      "name": "PizzaDAO",
+      "logoUrl": "https://...",
+      "website": "https://pizzadao.org",
+      "brandDescription": "PizzaDAO is a community of pizza enthusiasts...",
+      "brandTwitter": "PizzaDAO",
+      "brandInstagram": "rare.pizzas",
+      "category": "community",
+      "eventCount": 423,
+      "events": [
+        { "slug": "london", "city": "London" },
+        { "slug": "saopaulo", "city": "São Paulo" }
+      ]
+    }
+  ],
+  "total": 47,
+  "generatedAt": "2026-05-15T12:34:56.789Z"
+}</code></pre>
 
 <h2>Health Check</h2>
 

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -779,4 +779,170 @@ router.patch('/pizzerias/:partyId/photo', async (req: Request, res: Response, ne
   }
 });
 
+// GET /api/gpp/partners - Aggregated partners across all approved GPP events
+// Cross-event logo aggregation for the marketing site (globalpizza.party) and
+// the public partners page at rsv.pizza/partners. Sponsor rows are deduped
+// in-memory by normalized logoUrl (primary) then normalized name (fallback).
+router.get('/partners', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const sponsors = await prisma.sponsor.findMany({
+      where: {
+        party: {
+          eventType: 'gpp',
+          underbossStatus: 'approved', // strict — curated logo wall
+        },
+        status: { in: ['yes', 'billed', 'paid'] },
+        logoUrl: { not: null },
+      },
+      select: {
+        name: true,
+        logoUrl: true,
+        website: true,
+        brandDescription: true,
+        brandTwitter: true,
+        brandInstagram: true,
+        category: true,
+        sortOrder: true,
+        createdAt: true,
+        party: {
+          select: {
+            customUrl: true,
+            inviteCode: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    // Normalize logoUrl: trim, lowercase, strip protocol, strip trailing slash.
+    const normalizeUrl = (raw: string): string => {
+      return raw
+        .trim()
+        .toLowerCase()
+        .replace(/^https?:\/\//, '')
+        .replace(/\/+$/, '');
+    };
+
+    // Normalize name: strip diacritics, lowercase, alphanum only (same as city slug code above).
+    const normalizeName = (raw: string): string => {
+      return raw
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+    };
+
+    interface Aggregate {
+      name: string;
+      logoUrl: string;
+      website: string | null;
+      brandDescription: string | null;
+      brandTwitter: string | null;
+      brandInstagram: string | null;
+      category: string | null;
+      eventCount: number;
+      events: { slug: string; city: string }[];
+      // tie-break tracking
+      bestSortOrder: number;
+      bestCreatedAt: Date;
+    }
+
+    const byLogoKey = new Map<string, Aggregate>();
+    const byNameKey = new Map<string, Aggregate>();
+
+    for (const s of sponsors) {
+      if (!s.logoUrl) continue;
+
+      const logoKey = normalizeUrl(s.logoUrl);
+      const nameKey = normalizeName(s.name);
+
+      // Derive city by stripping "Global Pizza Party " prefix; fallback to full party name.
+      const partyName = s.party?.name || '';
+      const city =
+        partyName.replace(/^Global Pizza Party\s*/i, '').trim() || partyName || 'Unknown';
+      const slug = s.party?.customUrl || s.party?.inviteCode || '';
+
+      // Find existing aggregate via logoKey first, then nameKey fallback.
+      let agg = byLogoKey.get(logoKey);
+      if (!agg && nameKey) {
+        agg = byNameKey.get(nameKey);
+      }
+
+      if (agg) {
+        agg.eventCount += 1;
+        // Cap events array at 500 to defend against pathological payload size.
+        if (agg.events.length < 500 && slug) {
+          agg.events.push({ slug, city });
+        }
+        // Tie-break: prefer the representative row with lowest sortOrder; if tied,
+        // prefer the more recent createdAt.
+        const isBetter =
+          s.sortOrder < agg.bestSortOrder ||
+          (s.sortOrder === agg.bestSortOrder && s.createdAt > agg.bestCreatedAt);
+        if (isBetter) {
+          agg.name = s.name;
+          agg.logoUrl = s.logoUrl;
+          agg.website = s.website;
+          agg.brandDescription = s.brandDescription;
+          agg.brandTwitter = s.brandTwitter;
+          agg.brandInstagram = s.brandInstagram;
+          agg.category = s.category;
+          agg.bestSortOrder = s.sortOrder;
+          agg.bestCreatedAt = s.createdAt;
+        }
+        // Ensure both maps point at the same aggregate even after a fallback merge.
+        byLogoKey.set(logoKey, agg);
+        if (nameKey) byNameKey.set(nameKey, agg);
+      } else {
+        const fresh: Aggregate = {
+          name: s.name,
+          logoUrl: s.logoUrl,
+          website: s.website,
+          brandDescription: s.brandDescription,
+          brandTwitter: s.brandTwitter,
+          brandInstagram: s.brandInstagram,
+          category: s.category,
+          eventCount: 1,
+          events: slug ? [{ slug, city }] : [],
+          bestSortOrder: s.sortOrder,
+          bestCreatedAt: s.createdAt,
+        };
+        byLogoKey.set(logoKey, fresh);
+        if (nameKey) byNameKey.set(nameKey, fresh);
+      }
+    }
+
+    // Collect unique aggregates (some may be present in both maps).
+    const uniqueAggregates = Array.from(new Set(byLogoKey.values()));
+
+    // Sort by popularity (eventCount DESC), then name ASC.
+    uniqueAggregates.sort((a, b) => {
+      if (b.eventCount !== a.eventCount) return b.eventCount - a.eventCount;
+      return a.name.localeCompare(b.name);
+    });
+
+    // Strip tie-break tracking fields from the response.
+    const partners = uniqueAggregates.map((a) => ({
+      name: a.name,
+      logoUrl: a.logoUrl,
+      website: a.website,
+      brandDescription: a.brandDescription,
+      brandTwitter: a.brandTwitter,
+      brandInstagram: a.brandInstagram,
+      category: a.category,
+      eventCount: a.eventCount,
+      events: a.events,
+    }));
+
+    res.set('Cache-Control', 'public, max-age=600');
+    res.json({
+      partners,
+      total: partners.length,
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { PostComposerPage } from './pages/PostComposerPage';
 import { OneSheetPage } from './pages/OneSheetPage';
 import { GPPPizzeriasPage } from './pages/GPPPizzeriasPage';
 import { EventsMapPage } from './pages/EventsMapPage';
+import { PartnersPage } from './pages/PartnersPage';
 
 // Legacy redirect: /sponsor-intake/:token → /partner-intake/:token
 // <Navigate> doesn't forward path params, so we wrap useParams().
@@ -51,6 +52,8 @@ function App() {
             <Route path="/gpp/pizzerias" element={<GPPPizzeriasPage />} />
             {/* /map must come before /:slug */}
             <Route path="/map" element={<EventsMapPage />} />
+            {/* /partners must come before /:slug */}
+            <Route path="/partners" element={<PartnersPage />} />
             <Route path="/account" element={<AccountPage />} />
             <Route path="/auth/verify" element={<AuthVerifyPage />} />
             <Route path="/report/:slug" element={<PublicReportPage />} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3311,6 +3311,29 @@ export async function fetchGppEventsForMap(force?: boolean): Promise<GPPEventMap
   }));
 }
 
+// GPP Partners (aggregated across approved GPP events)
+export interface GPPPartner {
+  name: string;
+  logoUrl: string;
+  website: string | null;
+  brandDescription: string | null;
+  brandTwitter: string | null;
+  brandInstagram: string | null;
+  category: string | null;
+  eventCount: number;
+  events: { slug: string; city: string }[];
+}
+
+export interface GPPPartnersResponse {
+  partners: GPPPartner[];
+  total: number;
+  generatedAt: string;
+}
+
+export async function fetchGppPartners(): Promise<GPPPartnersResponse> {
+  return apiRequest<GPPPartnersResponse>('/api/gpp/partners', { requireAuth: false });
+}
+
 // RSVP Funnel Stats (Underboss dashboard)
 
 export interface FunnelEventStats {

--- a/frontend/src/pages/PartnersPage.tsx
+++ b/frontend/src/pages/PartnersPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Loader2 } from 'lucide-react';
+import { Layout } from '../components/Layout';
+import { fetchGppPartners, GPPPartner } from '../lib/api';
+
+export function PartnersPage() {
+  const [partners, setPartners] = useState<GPPPartner[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPartners = () => {
+    setLoading(true);
+    setError(null);
+    fetchGppPartners()
+      .then((data) => {
+        setPartners(data.partners || []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch partners:', err);
+        setError(err.message || 'Failed to load partners');
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    loadPartners();
+  }, []);
+
+  const totalEvents = partners.reduce((sum, p) => sum + p.eventCount, 0);
+
+  return (
+    <>
+      <Helmet>
+        <title>GPP Partners | RSV.Pizza</title>
+        <meta
+          name="description"
+          content="Brands powering the Global Pizza Party 2026"
+        />
+      </Helmet>
+
+      <Layout>
+        {loading && (
+          <div className="flex items-center justify-center py-24">
+            <div className="flex flex-col items-center gap-3">
+              <Loader2 size={36} className="animate-spin text-[#E52828]" />
+              <span className="text-sm font-medium text-theme-text-faint">
+                Loading partners...
+              </span>
+            </div>
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="flex items-center justify-center py-24 px-6">
+            <div className="flex flex-col items-center gap-3 bg-theme-surface rounded-2xl p-8 border border-theme-stroke">
+              <p className="text-red-500 font-medium">{error}</p>
+              <button
+                onClick={loadPartners}
+                className="px-5 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5"
+                style={{ background: '#E52828' }}
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && partners.length === 0 && (
+          <div className="flex items-center justify-center py-24 px-6">
+            <p className="text-sm text-theme-text-faint">
+              No partners yet — check back soon
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && partners.length > 0 && (
+          <div className="max-w-6xl mx-auto px-6 py-8">
+            <div className="flex justify-center mb-6">
+              <div className="bg-theme-surface border border-theme-stroke rounded-full px-5 py-2">
+                <span className="text-sm font-semibold">
+                  {partners.length.toLocaleString()} partners across{' '}
+                  {totalEvents.toLocaleString()} events
+                </span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+              {partners.map((partner) => {
+                const tile = (
+                  <div className="bg-theme-surface aspect-square flex items-center justify-center p-4 rounded-2xl border border-theme-stroke">
+                    <img
+                      src={partner.logoUrl}
+                      alt={partner.name}
+                      className="max-w-full max-h-full object-contain"
+                      loading="lazy"
+                    />
+                  </div>
+                );
+
+                return (
+                  <div key={`${partner.name}-${partner.logoUrl}`} className="flex flex-col">
+                    {partner.website ? (
+                      <a
+                        href={partner.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block"
+                      >
+                        {tile}
+                      </a>
+                    ) : (
+                      tile
+                    )}
+                    <div className="text-xs text-theme-text-faint mt-2 text-center">
+                      {partner.name}
+                    </div>
+                    <div className="text-[10px] text-theme-text-faint mt-1 text-center opacity-70">
+                      in {partner.eventCount.toLocaleString()}{' '}
+                      {partner.eventCount === 1 ? 'event' : 'events'}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </Layout>
+    </>
+  );
+}

--- a/plans/stromboli-48177-gpp-partners-aggregator.md
+++ b/plans/stromboli-48177-gpp-partners-aggregator.md
@@ -1,0 +1,286 @@
+# TBD-gpp-partners-aggregator: Cross-GPP partner-logo aggregation page + public API
+
+**Priority**: P2
+**Type**: Feature
+**Branch**: `TBD-gpp-partners-aggregator` (rename when claimed)
+**Preview URL**: `https://rsvpizza-git-TBD-gpp-partners-aggregator-pizza-dao.vercel.app/partners`
+
+## Summary
+
+Aggregate every partner across approved GPP 2026 events, deduplicate by logo + normalized name, and expose:
+
+1. **Public JSON API** at `GET /api/gpp/partners` — consumed by globalpizza.party for a logo scroller component.
+2. **Public page** at `rsv.pizza/partners` — responsive logo grid using existing `Layout`.
+
+Backend must merge to `master` before any frontend preview works (only master deploys backend). Pattern is a direct sibling of the existing `GET /api/gpp/pizzerias` aggregator (`backend/src/routes/gpp.routes.ts:673-716`) and the `GPPPizzeriasPage`/`EventsMapPage` frontend templates.
+
+## Data model — confirmed from code
+
+### Where partners live
+
+Partners are stored as `Sponsor` rows keyed per party (`backend/prisma/schema.prisma:866-925`, table `sponsors`).
+The canonical fields for this feature:
+
+- `id` (uuid)
+- `partyId` (uuid, FK → parties)
+- `name` (string, required)
+- `logoUrl` (string, nullable) — the value we display
+- `website` (string, nullable) — where the logo links
+- `brandDescription` (string, nullable)
+- `brandTwitter`, `brandInstagram` (string, nullable)
+- `category` (string, nullable; e.g. "hardware_wallet")
+- `status` (string; pipeline: todo, asked, yes, billed, paid, stuck, alum, skip)
+- `sortOrder` (int, default 0; per-event display order on flyer logo row)
+- `addedByUnderboss` (bool) — whether this row was bulk-added by an underboss
+
+There is **no separate `partners` JSON column on `parties`** and **no join table**. The "partner manager" in /underboss creates a `SponsorUser` (table `sponsor_users`) which then auto-syncs into individual `Sponsor` rows on each tagged party via `backend/src/helpers/partnerSync.ts`. That helper copies `SponsorUser.coHostLogoUrl` → `Sponsor.logoUrl`. **For aggregation, query `Sponsor` directly** — it's already the materialized per-event view.
+
+### GPP scope on `parties`
+
+GPP membership is identified by `Party.eventType === 'gpp'` (string column, line 97 of schema). Year scoping is implicit — there is currently only one active GPP cohort (2026); old events are not re-tagged. If you need explicit year scope later, add a filter on `Party.date` >= Jan 1 2026.
+
+### Approved GPP scoping
+
+Per requirements, approved = `Party.underbossStatus === 'approved'`. Note that the existing `/api/gpp/events` and `/api/gpp/pizzerias` use the looser filter `underbossStatus: { notIn: ['rejected', 'hidden'] }` (which includes `pending`, `approved`, `listed`). **This plan deliberately tightens to `'approved'` only** for the partners aggregator because the marketing site logo wall should only show partners associated with vetted events. Flagged as Open Question 1 below in case product disagrees.
+
+### Sponsor status filter (which sponsors count as "real partners")
+
+Reuse the public-display filter already used by `/api/events/:slug` for the OneSheet sponsor row (`backend/src/routes/event.routes.ts:172-191`):
+
+```
+status IN ('yes', 'billed', 'paid') AND logoUrl IS NOT NULL
+```
+
+This excludes pipeline-only entries (todo/asked/stuck) and partner placeholders that never sent a logo. **This is a load-bearing filter — do not loosen it without product sign-off.**
+
+### RLS / column-grant concerns
+
+The Feb 2026 SELECT-grant audit revoked table-level SELECT on `parties` for the public role but kept all backend-app access via the service role (the express backend connects via `DATABASE_URL` with full RBAC). This endpoint runs server-side through Prisma; no RLS implications. The endpoint must **not** echo any of the privacy-sensitive columns from `parties` (only `id`, `name`, `customUrl`, `inviteCode` are emitted, all of which are already public).
+
+`party_status_audit` (mentioned in the task brief, allegedly added 2026-05-15 via `pizzaiolo-97053`) does **not yet exist** in the schema/migrations on this branch. The aggregator does not need it — current `underbossStatus` is sufficient. Flagged as Open Question 2.
+
+## Dedupe key
+
+Use a two-stage normalization, applied **server-side in the aggregator** (not in SQL — keep the SQL simple and the dedupe in TypeScript so the rules are visible and testable):
+
+1. **Primary key**: normalized `logoUrl`.
+   - Trim, lowercase, strip the leading `https://` / `http://`, strip trailing `/`.
+   - Why: when a partner is bulk-added by the same SponsorUser via `partnerSync.ts`, every event gets the *same* `logoUrl` string copied. Logo URL equality is the cleanest near-perfect dedupe in practice.
+
+2. **Secondary key (fallback)**: normalized `name`.
+   - `.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/[^a-z0-9]/g,'')` — the same normalization used for city slugs in `gpp.routes.ts:269-273`.
+   - Why: handles the case where two events list the same partner with different logo CDN URLs (e.g. one uploaded to Supabase, one pointing at the partner's own CDN). Same name → same partner.
+
+**Algorithm**: Walk every sponsor row. Compute `logoKey = normalizeUrl(logoUrl)`. If we've already seen that `logoKey`, merge into the existing aggregate (increment `eventCount`, append to `events`, **prefer the first-seen** `website`/`name`/etc.). If `logoKey` is new but `nameKey` matches an existing aggregate, merge into that one too (treat as a name-collision/different-logo case). Otherwise create a new aggregate.
+
+**Tie-break on representative metadata**: when multiple sponsor rows map to the same aggregate but disagree on `name` / `website` / `category`, prefer the value from the row with the lowest `sortOrder` (i.e. most prominently placed on its event's flyer). If still tied, prefer the most-recent `createdAt`. Document this in a comment in the route.
+
+## Backend design
+
+### New endpoint: `GET /api/gpp/partners`
+
+Path: `/api/gpp/partners` — sits alongside `/api/gpp/events` and `/api/gpp/pizzerias`. Mounted via the existing `app.use('/api/gpp', gppRoutes)` line in `backend/src/index.ts:140`. No `index.ts` change needed.
+
+File: `backend/src/routes/gpp.routes.ts` — append a new handler after the `/pizzerias` block (after line 716, before `export default router`).
+
+**No auth required.** No new middleware. Inherits the same global rate limit (500 req / 15 min / IP) applied at `backend/src/index.ts:93`.
+
+### Query strategy
+
+```ts
+// pseudocode — implementation must use Prisma, not raw SQL, to match the rest of the file
+const sponsors = await prisma.sponsor.findMany({
+  where: {
+    party: {
+      eventType: 'gpp',
+      underbossStatus: 'approved',  // strict — see Open Q1
+    },
+    status: { in: ['yes', 'billed', 'paid'] },
+    logoUrl: { not: null },
+  },
+  select: {
+    name: true,
+    logoUrl: true,
+    website: true,
+    brandDescription: true,
+    brandTwitter: true,
+    brandInstagram: true,
+    category: true,
+    sortOrder: true,
+    createdAt: true,
+    party: {
+      select: {
+        customUrl: true,
+        inviteCode: true,
+        name: true,  // to derive city via "Global Pizza Party {City}" strip
+      },
+    },
+  },
+});
+```
+
+Then run the dedupe described above in-memory and emit the response. Expected scale: ~30-50 partners across ~500 events = ~5,000 sponsor rows max. Comfortable for in-memory aggregation; no need for SQL `GROUP BY`.
+
+### Response shape
+
+```json
+{
+  "partners": [
+    {
+      "name": "PizzaDAO",
+      "logoUrl": "https://...",
+      "website": "https://pizzadao.org",
+      "brandDescription": "PizzaDAO ...",
+      "brandTwitter": "PizzaDAO",
+      "brandInstagram": "rare.pizzas",
+      "category": "community",
+      "eventCount": 423,
+      "events": [
+        { "slug": "london", "city": "London" },
+        { "slug": "saopaulo", "city": "São Paulo" }
+      ]
+    }
+  ],
+  "total": 47,
+  "generatedAt": "2026-05-15T12:34:56.789Z"
+}
+```
+
+**Sort order**: `partners` array sorted by `eventCount DESC, name ASC`. The marketing site can re-sort or shuffle; defaulting to popularity gives a good logo scroller out of the box.
+
+**Field decisions, with justification**:
+
+- `eventCount` (yes, include) — lets consumers sort by popularity / sponsor-tier proxy.
+- `events: [{slug, city}]` (yes, include) — enables "this partner is in 423 cities including London, São Paulo, ..." copy on the marketing site and on rsv.pizza/partners hover. Keep it minimal — slug + city only, no dates/lat/lng. This keeps the payload small (~50 partners × ~500 events × ~40 bytes ≈ 1 MB worst case; cap individual `events` arrays at 500 to be safe).
+- `brandDescription`, `brandTwitter`, `brandInstagram`, `category` (yes, include) — already used by the per-event OneSheet endpoint; marketing site might want hover-cards.
+- **Excluded**: `contactEmail`, `contactName`, `contactPhone`, `amount`, `notes`, `status`, `intakeToken` — these are CRM-internal and not surfaced on any current public endpoint. Do not echo them.
+
+### Caching
+
+Add `res.set('Cache-Control', 'public, max-age=600')` — matches the 10-minute cache on `/api/gpp/pizzerias` (line 710). Logos change less often than event metadata, so 10 minutes is plenty. Vercel's edge will honor this automatically.
+
+No in-memory cache layer needed (the route runs on a serverless function with no persistent process to hold one); rely on edge cache.
+
+### Errors
+
+Wrap in the standard `try { ... } catch (err) { next(err); }` pattern used by every other handler in this file. On unexpected error return `500 { error: 'Failed to fetch partners' }`.
+
+## Frontend page
+
+### Route
+
+`/partners` — confirmed available (checked `frontend/src/App.tsx`, no existing route). Add **before** the catch-all `<Route path="/:slug" element={<EventPage />} />` on line 80, e.g. right after the `/map` route on line 53.
+
+```tsx
+<Route path="/partners" element={<PartnersPage />} />
+```
+
+### Files to create
+
+1. **`frontend/src/pages/PartnersPage.tsx`**
+
+   - Structure modeled on `frontend/src/pages/GPPPizzeriasPage.tsx`: same `Helmet` block (title: "GPP Partners | RSV.Pizza", description: "Brands powering the Global Pizza Party 2026"), same loading/error/retry pattern, same stats badge ("47 partners across 423 cities").
+   - Wrap in the standard `<Layout>` from `frontend/src/components/Layout.tsx` (per CLAUDE.md — no new design language). This gives free Header, Footer, GPPClouds, CornerLinks.
+   - Body: a responsive CSS grid of logo tiles.
+     - `grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 p-6 max-w-6xl mx-auto`.
+     - Each tile: white/transparent background card (`bg-theme-surface`), `aspect-square`, `flex items-center justify-center`, `p-4`, `rounded-2xl`, `border border-theme-stroke`.
+     - Logo: `<img src={partner.logoUrl} alt={partner.name} className="max-w-full max-h-full object-contain" loading="lazy" />`.
+     - Wrap each tile in `<a href={partner.website} target="_blank" rel="noopener noreferrer">` **if `partner.website` is non-null**. Otherwise render as a non-interactive `<div>`. (Decision: link out to partner site — most direct value; linking to a filtered events list is interesting but adds scope for a feature that doesn't yet exist.)
+     - Below each logo: `partner.name` in `text-xs text-theme-text-faint`, and a small "in N events" badge.
+
+   - States:
+     - **Loading**: centered spinner using `Loader2` from `lucide-react`, identical to `GPPPizzeriasPage.tsx:68-77`.
+     - **Error**: red error text with Retry button, identical pattern.
+     - **Empty** (`partners.length === 0`): centered "No partners yet — check back soon" message. Probably never hit in practice but graceful.
+
+2. **`frontend/src/lib/api.ts`** — add at the end of the GPP section (after `fetchGppEventsForMap`, around line 3320):
+
+   ```ts
+   export interface GPPPartner {
+     name: string;
+     logoUrl: string;
+     website: string | null;
+     brandDescription: string | null;
+     brandTwitter: string | null;
+     brandInstagram: string | null;
+     category: string | null;
+     eventCount: number;
+     events: { slug: string; city: string }[];
+   }
+
+   export interface GPPPartnersResponse {
+     partners: GPPPartner[];
+     total: number;
+     generatedAt: string;
+   }
+
+   export async function fetchGppPartners(): Promise<GPPPartnersResponse> {
+     return apiRequest<GPPPartnersResponse>('/api/gpp/partners', { requireAuth: false });
+   }
+   ```
+
+3. **`frontend/src/App.tsx`** — add the import and route as described above.
+
+### Files NOT to touch
+
+- `backend/prisma/schema.prisma` — no migration needed; all fields exist.
+- `backend/src/index.ts` — `gppRoutes` already mounted at `/api/gpp`.
+- `frontend/src/components/Layout.tsx` — reuse as-is.
+- Any sponsor/partner CRM code — read-only access only.
+
+## CORS / globalpizza.party consumption
+
+### CORS confirmation
+
+Default `ALLOWED_ORIGINS` array in `backend/src/index.ts:55-61` does **NOT** include `https://globalpizza.party` or `https://www.globalpizza.party`. The user's memory says it's already in the env-var-driven list (`process.env.ALLOWED_ORIGINS`) in production. **Verify in Vercel env vars before merging.** If missing, either:
+
+- Add to the env var in Vercel (preferred — no code change), or
+- Add `'https://globalpizza.party', 'https://www.globalpizza.party'` to the default array in `index.ts:55-61` as a belt-and-braces fallback (low risk; only affects local dev without the env var set).
+
+The endpoint serves CORS via the existing global `cors()` middleware on line 64, so as long as the origin is in the allowlist, browser `fetch` from globalpizza.party will work with `credentials: false` (no cookie/auth needed — `requireAuth: false`).
+
+### Consumer snippet (for the marketing-site dev)
+
+```js
+// On globalpizza.party
+const res = await fetch('https://api.rsv.pizza/api/gpp/partners');
+const { partners } = await res.json();
+
+// Render a horizontal scroller, biggest sponsors first
+const html = partners
+  .map(p => `
+    <a href="${p.website || '#'}" class="logo-scroller__item"
+       target="_blank" rel="noopener" title="${p.name} — in ${p.eventCount} cities">
+      <img src="${p.logoUrl}" alt="${p.name}" loading="lazy" />
+    </a>
+  `)
+  .join('');
+document.getElementById('partner-scroller').innerHTML = html;
+```
+
+That's all the marketing site needs. The 10-minute edge cache means even high traffic on globalpizza.party won't hammer the backend.
+
+## Implementation sequence
+
+1. Backend: add `GET /api/gpp/partners` to `backend/src/routes/gpp.routes.ts`. Commit. Merge to `master` (required — backend only deploys from master). Verify on `https://api.rsv.pizza/api/gpp/partners`.
+2. Update the inline API docs HTML in `backend/src/index.ts:160-313` — add a new `<h2>Partners</h2>` block describing the endpoint, query params (none), and example response. Keep style consistent with the existing event/pizzeria docs.
+3. Frontend: add `fetchGppPartners` to `lib/api.ts`, create `PartnersPage.tsx`, register route in `App.tsx`. Open PR; preview at `https://rsvpizza-git-{branch}-pizza-dao.vercel.app/partners` (note: will hit production backend, so step 1 must be merged first).
+4. Verify CORS from globalpizza.party — coordinate with marketing-site dev to test.
+
+## Resolved with Snax (2026-05-15)
+
+1. **Filter = strict `'approved'`** — not the looser `notIn:['rejected','hidden']` used by other GPP endpoints. This is a curated logo wall; pending/community-listed events don't qualify.
+2. **Logo tiles link to `partner.website`** in a new tab (`target="_blank" rel="noopener noreferrer"`). If `website` is null, render the tile as a non-interactive `<div>`.
+3. **`globalpizza.party` CORS**: add `'https://globalpizza.party'` AND `'https://www.globalpizza.party'` to the hardcoded fallback array in `backend/src/index.ts:55-61` (belt-and-braces, in addition to whatever's in the Vercel env var).
+
+## Out of scope / open questions
+
+1. **`party_status_audit` table.** Task brief references it as added 2026-05-15 via `pizzaiolo-97053`. Not in current schema/migrations on this branch. Plan does not rely on it. If product wants to filter by "approved AT a specific point in time" (e.g. "approved as of May 1") we'd need this — out of scope for v1.
+
+2. **GPP year scoping.** This plan implicitly scopes to "current GPP cohort" via `eventType === 'gpp'`. If old GPP events from prior years exist in DB and shouldn't surface, add a `date >= 2026-01-01` filter. Need product to confirm DB state.
+
+3. **Sponsor-as-partner vs SponsorUser-as-partner.** This plan queries `sponsors` (the per-event materialization) because `partnerSync.ts` already copies `SponsorUser.coHostLogoUrl` into every `Sponsor.logoUrl`. Alternative would be to query `SponsorUser` directly (smaller, pre-deduplicated, no name-collision worries) and derive `eventCount` by counting parties with the matching tag. **Trade-off**: `SponsorUser`-based approach misses one-off manually-added sponsors (e.g. a local sponsor for just one event); `Sponsor`-based approach captures everything but needs dedupe. Plan picks `Sponsor` for completeness. Reconsider if dedupe edge cases become noisy.
+
+4. **Logo URL normalization edge cases.** If the same partner has both an `https://supabase.../partners/coinbase.png` and an `https://coinbase.com/static/logo.png` floating around different events, normalization on URL alone won't dedupe them. The name-fallback handles this *if* names match exactly post-normalization. If we see real duplicates in production after launch, add a manual override map (`SPONSOR_NAME_ALIASES`) in the route.
+
+5. **i18n.** Page strings ("partners", "in N events", "No partners yet") should ideally use `useTranslation('partner')` like `PartnerManager.tsx` does. Decide whether to add new i18n keys or hard-code English for v1. Hard-coding is fine if the marketing site is English-only.


### PR DESCRIPTION
## Summary

- New `GET /api/gpp/partners` public endpoint aggregates Sponsor rows across all approved (`underbossStatus === 'approved'`) GPP events, in-memory deduped by normalized `logoUrl` (primary key) then normalized name (fallback). Response sorted by `eventCount DESC, name ASC`; 10-minute edge cache.
- New `/partners` public page renders a responsive logo grid using the existing `Layout` component (no new design language). Each tile links to `partner.website` when present.
- CORS fallback array in `backend/src/index.ts` now includes `https://globalpizza.party` and `https://www.globalpizza.party` so the marketing-site consumer works even without the env var set.

Plan: `plans/stromboli-48177-gpp-partners-aggregator.md`

## Endpoint

`GET /api/gpp/partners` — alongside `/api/gpp/events` and `/api/gpp/pizzerias`. No auth required, no query params, 10-minute `Cache-Control: public, max-age=600`. CRM-sensitive fields (`contactEmail`, `contactName`, `contactPhone`, `amount`, `notes`, `status`, `intakeToken`) are deliberately not echoed.

## Page

`/partners` — registered before the catch-all `/:slug` route in `App.tsx`.

## Backend deploy note

Per project convention, backend only deploys from `master`. The frontend preview deploy will hit the **production backend**, which won't have `/api/gpp/partners` until this merges. Until then the preview page will show its error state. That's expected — verifying the frontend build is what we're checking with the preview.

## Test plan

- [ ] `cd backend && npx tsc --noEmit` passes with no new errors (verified locally — only pre-existing `auth.test.ts` error remains).
- [ ] `cd frontend && npx tsc --noEmit` passes cleanly (verified locally).
- [ ] After merge to master and backend redeploy: `curl https://api.rsv.pizza/api/gpp/partners | jq '.total'` returns a sensible count.
- [ ] After merge: `https://rsv.pizza/partners` shows the logo grid, popularity-sorted.
- [ ] CORS: marketing site (`globalpizza.party`) can `fetch('/api/gpp/partners')` from the browser without errors.
- [ ] Dedupe sanity-check: pick a partner known to be in many events (e.g. PizzaDAO) and confirm exactly one tile is rendered with the expected `eventCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)