### PR TITLE
feat: public-facing /map (drops gate, curated filter)

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -647,7 +647,12 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
   try {
     const { limit = '500', offset = '0', city, country, region } = req.query;
 
-    const where: any = { eventType: 'gpp', underbossStatus: { notIn: ['rejected', 'hidden'] } };
+    const where: any = { eventType: 'gpp' };
+    if (req.query.curated === '1') {
+      where.underbossStatus = { in: ['approved', 'listed'] };
+    } else {
+      where.underbossStatus = { notIn: ['rejected', 'hidden'] };
+    }
     if (city) {
       where.name = { contains: city as string, mode: 'insensitive' };
     }

--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -5,11 +5,13 @@ import { GPPEventMapItem, updateUnderbossStatus } from '../lib/api';
 interface GPPEventsMapProps {
   events: GPPEventMapItem[];
   height?: string;
+  canModerate?: boolean;
 }
 
 export default function GPPEventsMap({
   events,
   height = '100%',
+  canModerate = false,
 }: GPPEventsMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
@@ -140,25 +142,32 @@ export default function GPPEventsMap({
 
         const rsvpHtml = `<span style="background:#fef2f2;color:#E52828;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:500">${event.rsvpCount.toLocaleString()} RSVPs</span>`;
 
-        const linkHtml = `<a href="/${event.slug}" target="_blank" rel="noopener noreferrer" style="color:#E52828;font-size:12px;text-decoration:none;font-weight:500">View Event &rarr;</a>`;
+        const linkLabel = canModerate ? 'View Event &rarr;' : 'RSVP &rarr;';
+        const linkHtml = `<a href="/${event.slug}" target="_blank" rel="noopener noreferrer" style="color:#E52828;font-size:12px;text-decoration:none;font-weight:500">${linkLabel}</a>`;
 
         let actionsHtml = '';
-        if (event.underbossStatus === 'approved') {
-          actionsHtml = `
-            <span style="background:#dcfce7;color:#16a34a;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Approved</span>
-            <button data-action="reject" data-event-id="${event.id}" style="background:none;border:none;color:#dc2626;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark rejected</button>
-          `;
-        } else if (event.underbossStatus === 'rejected') {
-          actionsHtml = `
-            <span style="background:#fee2e2;color:#dc2626;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Rejected</span>
-            <button data-action="approve" data-event-id="${event.id}" style="background:none;border:none;color:#16a34a;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark approved</button>
-          `;
-        } else {
-          actionsHtml = `
-            <button data-action="approve" data-event-id="${event.id}" style="background:#16a34a;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Approve</button>
-            <button data-action="reject" data-event-id="${event.id}" style="background:#dc2626;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Reject</button>
-          `;
+        if (canModerate) {
+          if (event.underbossStatus === 'approved') {
+            actionsHtml = `
+              <span style="background:#dcfce7;color:#16a34a;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Approved</span>
+              <button data-action="reject" data-event-id="${event.id}" style="background:none;border:none;color:#dc2626;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark rejected</button>
+            `;
+          } else if (event.underbossStatus === 'rejected') {
+            actionsHtml = `
+              <span style="background:#fee2e2;color:#dc2626;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Rejected</span>
+              <button data-action="approve" data-event-id="${event.id}" style="background:none;border:none;color:#16a34a;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark approved</button>
+            `;
+          } else {
+            actionsHtml = `
+              <button data-action="approve" data-event-id="${event.id}" style="background:#16a34a;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Approve</button>
+              <button data-action="reject" data-event-id="${event.id}" style="background:#dc2626;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Reject</button>
+            `;
+          }
         }
+
+        const actionsRowHtml = canModerate
+          ? `<div style="margin-top:8px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">${actionsHtml}</div>`
+          : '';
 
         return `
           <div style="max-width:260px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:4px">
@@ -170,9 +179,7 @@ export default function GPPEventsMap({
               ${linkHtml}
               ${rsvpHtml}
             </div>
-            <div style="margin-top:8px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-              ${actionsHtml}
-            </div>
+            ${actionsRowHtml}
           </div>
         `;
       }
@@ -230,6 +237,7 @@ export default function GPPEventsMap({
       }
 
       function attachActionHandlers() {
+        if (!canModerate) return;
         const buttons = document.querySelectorAll<HTMLButtonElement>(
           '[data-action][data-event-id]'
         );
@@ -240,11 +248,14 @@ export default function GPPEventsMap({
 
       if (infoWindowListenerRef.current) {
         infoWindowListenerRef.current.remove();
+        infoWindowListenerRef.current = null;
       }
-      infoWindowListenerRef.current = infoWindow.addListener(
-        'domready',
-        attachActionHandlers
-      );
+      if (canModerate) {
+        infoWindowListenerRef.current = infoWindow.addListener(
+          'domready',
+          attachActionHandlers
+        );
+      }
 
       // Build markers
       const markers: google.maps.Marker[] = [];
@@ -352,7 +363,7 @@ export default function GPPEventsMap({
     script.onload = () => initMap();
     script.onerror = () => setError(true);
     document.head.appendChild(script);
-  }, [validEvents]);
+  }, [validEvents, canModerate]);
 
   if (error) {
     return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3291,11 +3291,15 @@ interface GPPEventsApiPayload {
   offset: number;
 }
 
-export async function fetchGppEventsForMap(force?: boolean): Promise<GPPEventMapItem[]> {
-  const data = await apiRequest<GPPEventsApiPayload>(`/api/gpp/events?limit=500${force ? `&_t=${Date.now()}` : ''}`, {
+export async function fetchGppEventsForMap(force?: boolean, curated?: boolean): Promise<GPPEventMapItem[]> {
+  const params: string[] = ['limit=500'];
+  if (curated) params.push('curated=1');
+  if (force) params.push(`_t=${Date.now()}`);
+  const url = `/api/gpp/events?${params.join('&')}`;
+  const data = await apiRequest<GPPEventsApiPayload>(url, {
     requireAuth: false,
   });
-  return (data.events || []).map((e) => ({
+  let events = (data.events || []).map((e) => ({
     id: e.id,
     name: e.name,
     city: e.city,
@@ -3309,6 +3313,10 @@ export async function fetchGppEventsForMap(force?: boolean): Promise<GPPEventMap
     country: e.country,
     underbossStatus: e.underbossStatus,
   }));
+  if (curated) {
+    events = events.filter((e) => e.underbossStatus === 'approved' || e.underbossStatus === 'listed');
+  }
+  return events;
 }
 
 // RSVP Funnel Stats (Underboss dashboard)

--- a/frontend/src/pages/EventsMapPage.tsx
+++ b/frontend/src/pages/EventsMapPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, lazy, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { ArrowLeft, Loader2, Shield, RefreshCw } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Loader2, RefreshCw } from 'lucide-react';
 import { fetchGppEventsForMap, fetchUnderbossMe, GPPEventMapItem } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { LoginModal } from '../components/LoginModal';
@@ -14,15 +14,13 @@ export function EventsMapPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showLoginModal, setShowLoginModal] = useState(false);
-  const [accessChecked, setAccessChecked] = useState(false);
-  const [authorized, setAuthorized] = useState(false);
-  const [accessError, setAccessError] = useState<string | null>(null);
+  const [canModerate, setCanModerate] = useState<boolean | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const loadEvents = () => {
+  const loadEvents = (moderator: boolean) => {
     setLoading(true);
     setError(null);
-    fetchGppEventsForMap()
+    fetchGppEventsForMap(false, !moderator)
       .then((data) => {
         setEvents(data);
         setLoading(false);
@@ -38,7 +36,7 @@ export function EventsMapPage() {
     if (isRefreshing) return;
     setIsRefreshing(true);
     try {
-      const data = await fetchGppEventsForMap(true);
+      const data = await fetchGppEventsForMap(true, !canModerate);
       setEvents(data);
     } catch (err) {
       console.error('Failed to refresh events:', err);
@@ -51,27 +49,25 @@ export function EventsMapPage() {
     if (authLoading) return;
 
     if (!user) {
-      setAccessChecked(true);
+      setCanModerate(false);
+      loadEvents(false);
       return;
     }
 
-    async function checkAccess() {
+    async function resolveModeratorStatus() {
       try {
         const me = await fetchUnderbossMe();
-        if (me.isAdmin || me.isUnderboss) {
-          setAuthorized(true);
-          loadEvents();
-        } else {
-          setAccessError('You are not authorized to view this page.');
-        }
-      } catch (err: any) {
-        setAccessError(err.message || 'Failed to check access');
-      } finally {
-        setAccessChecked(true);
+        const isMod = !!(me.isAdmin || me.isUnderboss);
+        setCanModerate(isMod);
+        loadEvents(isMod);
+      } catch (err) {
+        console.error('Failed to check moderator status:', err);
+        setCanModerate(false);
+        loadEvents(false);
       }
     }
 
-    checkAccess();
+    resolveModeratorStatus();
   }, [user, authLoading]);
 
   // Count unique cities
@@ -83,8 +79,19 @@ export function EventsMapPage() {
         <title>Global Pizza Party 2026 Map | RSV.Pizza</title>
         <meta
           name="description"
-          content="See every Global Pizza Party 2026 event on the world map. Free pizza events on May 22, 2026, hosted worldwide."
+          content="See every Global Pizza Party 2026 event on the world map — find a free pizza event near you on May 22, 2026."
         />
+        <link rel="canonical" href="https://rsv.pizza/map" />
+        <meta property="og:title" content="Global Pizza Party 2026 Map | RSV.Pizza" />
+        <meta
+          property="og:description"
+          content="See every Global Pizza Party 2026 event on the world map — find a free pizza event near you on May 22, 2026."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://rsv.pizza/map" />
+        <meta property="og:image" content="https://rsv.pizza/gpp-flyer-2026-og.jpg" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="https://rsv.pizza/gpp-flyer-2026-og.jpg" />
       </Helmet>
 
       <div
@@ -105,107 +112,83 @@ export function EventsMapPage() {
           <h1 className="text-lg font-bold text-white tracking-tight">
             GPP 2026 Map
           </h1>
+          <Link
+            to="/gpp"
+            className="ml-auto flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-semibold text-white transition-all hover:-translate-y-0.5"
+            style={{ background: '#E52828' }}
+          >
+            Host one
+            <ArrowRight size={14} />
+          </Link>
         </header>
 
         {/* Map area */}
         <div className="flex-1 relative">
-          {(!accessChecked || authLoading) ? (
+          {(authLoading || canModerate === null || loading) && !error && (
             <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
               <div className="flex flex-col items-center gap-3">
                 <Loader2 size={36} className="animate-spin text-[#E52828]" />
+                <span className="text-sm font-medium text-gray-700">
+                  Loading events...
+                </span>
               </div>
             </div>
-          ) : !user ? (
+          )}
+
+          {error && (
             <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
-              <div className="bg-white rounded-2xl p-8 shadow-lg flex flex-col items-center gap-3">
-                <Shield size={32} className="text-[#E52828]" />
-                <h2 className="text-lg font-bold text-gray-800">Underboss access required</h2>
-                <p className="text-sm text-gray-600 text-center max-w-xs">
-                  Sign in with your underboss email to view the events map.
-                </p>
+              <div className="flex flex-col items-center gap-3 bg-white rounded-2xl p-8 shadow-lg">
+                <p className="text-red-600 font-medium">{error}</p>
                 <button
-                  onClick={() => setShowLoginModal(true)}
+                  onClick={() => loadEvents(!!canModerate)}
                   className="px-5 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5"
                   style={{ background: '#E52828' }}
                 >
-                  Sign in
+                  Retry
                 </button>
               </div>
             </div>
-          ) : accessError ? (
-            <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
-              <div className="bg-white rounded-2xl p-8 shadow-lg flex flex-col items-center gap-3">
-                <p className="text-red-600 font-medium">{accessError}</p>
+          )}
+
+          {/* Floating stats badge */}
+          {!loading && !error && events.length > 0 && (
+            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10">
+              <div className="bg-white/90 backdrop-blur-sm rounded-full pl-5 pr-2 py-1.5 shadow-lg border border-white/50 flex items-center gap-2">
+                <span className="text-sm font-semibold text-gray-800">
+                  {events.length.toLocaleString()} events across{' '}
+                  {cityCount} {cityCount === 1 ? 'city' : 'cities'}
+                </span>
+                <button
+                  onClick={refreshEvents}
+                  disabled={isRefreshing}
+                  className="p-1.5 rounded-full text-gray-600 hover:text-[#E52828] hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Refresh events"
+                  aria-label="Refresh events"
+                >
+                  <RefreshCw size={14} className={isRefreshing ? 'animate-spin' : ''} />
+                </button>
               </div>
             </div>
-          ) : authorized ? (
-            <>
-              {loading && (
-                <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
-                  <div className="flex flex-col items-center gap-3">
-                    <Loader2 size={36} className="animate-spin text-[#E52828]" />
-                    <span className="text-sm font-medium text-gray-700">
-                      Loading events...
-                    </span>
-                  </div>
-                </div>
-              )}
+          )}
 
-              {error && (
-                <div className="absolute inset-0 flex items-center justify-center z-10 bg-white/30">
-                  <div className="flex flex-col items-center gap-3 bg-white rounded-2xl p-8 shadow-lg">
-                    <p className="text-red-600 font-medium">{error}</p>
-                    <button
-                      onClick={loadEvents}
-                      className="px-5 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5"
-                      style={{ background: '#E52828' }}
-                    >
-                      Retry
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {/* Floating stats badge */}
-              {!loading && !error && events.length > 0 && (
-                <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10">
-                  <div className="bg-white/90 backdrop-blur-sm rounded-full pl-5 pr-2 py-1.5 shadow-lg border border-white/50 flex items-center gap-2">
-                    <span className="text-sm font-semibold text-gray-800">
-                      {events.length.toLocaleString()} events across{' '}
-                      {cityCount} {cityCount === 1 ? 'city' : 'cities'}
-                    </span>
-                    <button
-                      onClick={refreshEvents}
-                      disabled={isRefreshing}
-                      className="p-1.5 rounded-full text-gray-600 hover:text-[#E52828] hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      title="Refresh events"
-                      aria-label="Refresh events"
-                    >
-                      <RefreshCw size={14} className={isRefreshing ? 'animate-spin' : ''} />
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              <Suspense
-                fallback={
-                  <div
-                    className="flex items-center justify-center"
-                    style={{ height: 'calc(100vh - 64px)' }}
-                  >
-                    <Loader2 size={36} className="animate-spin text-[#E52828]" />
-                  </div>
-                }
+          <Suspense
+            fallback={
+              <div
+                className="flex items-center justify-center"
+                style={{ height: 'calc(100vh - 64px)' }}
               >
-                {!loading && !error && (
-                  <GPPEventsMap
-                    events={events}
-                    height="calc(100vh - 64px)"
-                  />
-                )}
-              </Suspense>
-            </>
-          ) : null}
+                <Loader2 size={36} className="animate-spin text-[#E52828]" />
+              </div>
+            }
+          >
+            {!loading && !error && canModerate !== null && (
+              <GPPEventsMap
+                events={events}
+                height="calc(100vh - 64px)"
+                canModerate={canModerate}
+              />
+            )}
+          </Suspense>
         </div>
       </div>
 

--- a/frontend/src/pages/GPPLandingPage.tsx
+++ b/frontend/src/pages/GPPLandingPage.tsx
@@ -636,6 +636,14 @@ export function GPPLandingPage() {
               View All Pizzerias
               <MapPin size={16} />
             </Link>
+            <Link
+              to="/map"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-medium transition-all hover:-translate-y-0.5 border-2"
+              style={{ borderColor: C.red, color: C.red }}
+            >
+              View global map
+              <ArrowRight size={16} />
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- `/map` is now publicly viewable. Moderation UI (Approve/Reject) shown only for signed-in underbosses/admins.
- Backend: new `?curated=1` param on `GET /api/gpp/events` filters to `underbossStatus IN ('approved','listed')`. Default behavior unchanged.
- Public InfoWindow: "View Event →" renamed to "RSVP →"; moderation row hidden.
- New "Host one →" CTA in the `/map` header → `/gpp`.
- New "View global map →" link on `GPPLandingPage` next to "View All Pizzerias".
- Updated `<Helmet>` with SEO description, canonical, full og:/twitter: tags (reuses existing `gpp-flyer-2026-og.jpg`).
- Belt-and-suspenders client-side filter so the Vercel preview shows the right behavior **before** the backend is deployed to prod.

## Flag
`GPPLandingPage`'s embedded map (`GPPMap.tsx`) loads from a hardcoded Google Maps KML URL, NOT `/api/gpp/events`, so the curated filter does NOT flow there. Replacing GPPMap with a live, curated, API-backed widget is a separate effort.

## Deploy steps after merge
Per project convention, the backend doesn't auto-deploy. After merging:
\`\`\`
cd backend && vercel --prod --scope pizza-dao
\`\`\`
Until then, the production frontend will still receive pending events from the API; the client-side filter handles this gracefully.

## Test plan
- [ ] Logged-out at \`/map\` (preview) → map loads with curated events; "RSVP →" in cards; no moderation buttons; "Host one →" in header
- [ ] Signed in as non-underboss → same as logged-out
- [ ] Signed in as underboss → sees Approve/Reject; sees pending events
- [ ] DevTools Network: public call has \`&curated=1\`; underboss call doesn't
- [ ] \`GPPLandingPage\` shows "View global map →" link → navigates to \`/map\`
- [ ] OG card preview renders correctly (Twitter card validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)