### PR TITLE
feat: underboss filters on /map

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -650,6 +650,8 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
     const where: any = { eventType: 'gpp' };
     if (req.query.curated === '1') {
       where.underbossStatus = { in: ['approved', 'listed'] };
+    } else if (req.query.includeAll === '1') {
+      // moderator view — no underbossStatus filter; returns rejected/hidden too
     } else {
       where.underbossStatus = { notIn: ['rejected', 'hidden'] };
     }

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -665,7 +665,7 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
       where.region = region as string;
     }
 
-    const parsedLimit = Math.min(parseInt(limit as string, 10) || 500, 500);
+    const parsedLimit = Math.min(parseInt(limit as string, 10) || 500, 2000);
     const parsedOffset = parseInt(offset as string, 10) || 0;
 
     const [events, total] = await Promise.all([

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3266,6 +3266,7 @@ export interface GPPEventMapItem {
   rsvpCount: number;
   country: string | null;
   underbossStatus?: string | null;
+  eventTags?: string[];
 }
 
 interface GPPEventApiResponse {
@@ -3282,6 +3283,7 @@ interface GPPEventApiResponse {
   guestCount: number;
   country: string | null;
   underbossStatus?: string | null;
+  eventTags?: string[];
 }
 
 interface GPPEventsApiPayload {
@@ -3291,9 +3293,10 @@ interface GPPEventsApiPayload {
   offset: number;
 }
 
-export async function fetchGppEventsForMap(force?: boolean, curated?: boolean): Promise<GPPEventMapItem[]> {
+export async function fetchGppEventsForMap(force?: boolean, curated?: boolean, includeAll?: boolean): Promise<GPPEventMapItem[]> {
   const params: string[] = ['limit=500'];
   if (curated) params.push('curated=1');
+  if (includeAll) params.push('includeAll=1');
   if (force) params.push(`_t=${Date.now()}`);
   const url = `/api/gpp/events?${params.join('&')}`;
   const data = await apiRequest<GPPEventsApiPayload>(url, {
@@ -3312,6 +3315,7 @@ export async function fetchGppEventsForMap(force?: boolean, curated?: boolean): 
     rsvpCount: e.guestCount ?? 0,
     country: e.country,
     underbossStatus: e.underbossStatus,
+    eventTags: e.eventTags ?? [],
   }));
   if (curated) {
     events = events.filter((e) => e.underbossStatus === 'approved' || e.underbossStatus === 'listed');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3294,7 +3294,7 @@ interface GPPEventsApiPayload {
 }
 
 export async function fetchGppEventsForMap(force?: boolean, curated?: boolean, includeAll?: boolean): Promise<GPPEventMapItem[]> {
-  const params: string[] = ['limit=500'];
+  const params: string[] = ['limit=2000'];
   if (curated) params.push('curated=1');
   if (includeAll) params.push('includeAll=1');
   if (force) params.push(`_t=${Date.now()}`);

--- a/frontend/src/pages/EventsMapPage.tsx
+++ b/frontend/src/pages/EventsMapPage.tsx
@@ -1,12 +1,15 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { ArrowLeft, ArrowRight, Loader2, RefreshCw } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Loader2, RefreshCw, SlidersHorizontal, ThumbsUp, ThumbsDown } from 'lucide-react';
 import { fetchGppEventsForMap, fetchUnderbossMe, GPPEventMapItem } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { LoginModal } from '../components/LoginModal';
 
 const GPPEventsMap = lazy(() => import('../components/GPPEventsMap'));
+
+const STATUS_FILTER_KEYS = ['approved', 'pending', 'listed', 'rejected'] as const;
+type StatusFilterKey = (typeof STATUS_FILTER_KEYS)[number];
 
 export function EventsMapPage() {
   const { user, loading: authLoading } = useAuth();
@@ -17,10 +20,19 @@ export function EventsMapPage() {
   const [canModerate, setCanModerate] = useState<boolean | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
+  // Filter state (only renders for moderators, but declared unconditionally for hook rules)
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [statusIncludes, setStatusIncludes] = useState<string[]>([]);
+  const [statusExcludes, setStatusExcludes] = useState<string[]>([]);
+  const [searchQ, setSearchQ] = useState('');
+  const [debouncedSearchQ, setDebouncedSearchQ] = useState('');
+  const [tagFilter, setTagFilter] = useState('all');
+  const [countryFilter, setCountryFilter] = useState('all');
+
   const loadEvents = (moderator: boolean) => {
     setLoading(true);
     setError(null);
-    fetchGppEventsForMap(false, !moderator)
+    fetchGppEventsForMap(false, !moderator, moderator)
       .then((data) => {
         setEvents(data);
         setLoading(false);
@@ -36,7 +48,7 @@ export function EventsMapPage() {
     if (isRefreshing) return;
     setIsRefreshing(true);
     try {
-      const data = await fetchGppEventsForMap(true, !canModerate);
+      const data = await fetchGppEventsForMap(true, !canModerate, !!canModerate);
       setEvents(data);
     } catch (err) {
       console.error('Failed to refresh events:', err);
@@ -70,8 +82,104 @@ export function EventsMapPage() {
     resolveModeratorStatus();
   }, [user, authLoading]);
 
-  // Count unique cities
-  const cityCount = new Set(events.map((e) => e.city)).size;
+  // Debounce search input (200ms) — mirrors EventTable behavior.
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedSearchQ(searchQ), 200);
+    return () => clearTimeout(handle);
+  }, [searchQ]);
+
+  function getStatusFilterState(key: string): 'neutral' | 'include' | 'exclude' {
+    if (statusIncludes.includes(key)) return 'include';
+    if (statusExcludes.includes(key)) return 'exclude';
+    return 'neutral';
+  }
+
+  function setStatusFilterState(key: string, newState: 'neutral' | 'include' | 'exclude') {
+    setStatusIncludes((prev) => prev.filter((k) => k !== key));
+    setStatusExcludes((prev) => prev.filter((k) => k !== key));
+    if (newState === 'include') {
+      setStatusIncludes((prev) => [...prev, key]);
+    } else if (newState === 'exclude') {
+      setStatusExcludes((prev) => [...prev, key]);
+    }
+  }
+
+  const availableTags = useMemo(
+    () => Array.from(new Set(events.flatMap((e) => e.eventTags ?? []))).sort(),
+    [events]
+  );
+  const availableCountries = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          events
+            .map((e) => e.country)
+            .filter((c): c is string => !!c)
+        )
+      ).sort(),
+    [events]
+  );
+
+  // Match an event against a status key. "pending" treats null/undefined as pending too.
+  function eventMatchesStatus(e: GPPEventMapItem, key: string): boolean {
+    if (key === 'pending') {
+      return e.underbossStatus === 'pending' || e.underbossStatus == null;
+    }
+    return e.underbossStatus === key;
+  }
+
+  const filteredEvents = useMemo(() => {
+    let result = events;
+
+    if (statusIncludes.length > 0) {
+      result = result.filter((e) => statusIncludes.every((k) => eventMatchesStatus(e, k)));
+    }
+    if (statusExcludes.length > 0) {
+      result = result.filter((e) => statusExcludes.every((k) => !eventMatchesStatus(e, k)));
+    }
+
+    const q = debouncedSearchQ.trim().toLowerCase();
+    if (q) {
+      result = result.filter(
+        (e) =>
+          e.name?.toLowerCase().includes(q) ||
+          e.city?.toLowerCase().includes(q) ||
+          e.venueName?.toLowerCase().includes(q) ||
+          e.address?.toLowerCase().includes(q) ||
+          e.country?.toLowerCase().includes(q)
+      );
+    }
+
+    if (tagFilter !== 'all') {
+      result = result.filter((e) => e.eventTags?.includes(tagFilter));
+    }
+
+    if (countryFilter !== 'all') {
+      result = result.filter((e) => e.country === countryFilter);
+    }
+
+    return result;
+  }, [events, statusIncludes, statusExcludes, debouncedSearchQ, tagFilter, countryFilter]);
+
+  const activeFilterCount =
+    statusIncludes.length +
+    statusExcludes.length +
+    (debouncedSearchQ.trim() === '' ? 0 : 1) +
+    (tagFilter !== 'all' ? 1 : 0) +
+    (countryFilter !== 'all' ? 1 : 0);
+
+  function clearFilters() {
+    setStatusIncludes([]);
+    setStatusExcludes([]);
+    setSearchQ('');
+    setDebouncedSearchQ('');
+    setTagFilter('all');
+    setCountryFilter('all');
+  }
+
+  // Count unique cities (use full events count for the non-moderator pill,
+  // filteredEvents for the moderator "X of Y" pill).
+  const cityCount = useMemo(() => new Set(events.map((e) => e.city)).size, [events]);
 
   return (
     <>
@@ -155,9 +263,32 @@ export function EventsMapPage() {
             <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10">
               <div className="bg-white/90 backdrop-blur-sm rounded-full pl-5 pr-2 py-1.5 shadow-lg border border-white/50 flex items-center gap-2">
                 <span className="text-sm font-semibold text-gray-800">
-                  {events.length.toLocaleString()} events across{' '}
-                  {cityCount} {cityCount === 1 ? 'city' : 'cities'}
+                  {canModerate && activeFilterCount > 0 ? (
+                    <>
+                      {filteredEvents.length.toLocaleString()} of{' '}
+                      {events.length.toLocaleString()} matching
+                    </>
+                  ) : (
+                    <>
+                      {events.length.toLocaleString()} events across{' '}
+                      {cityCount} {cityCount === 1 ? 'city' : 'cities'}
+                    </>
+                  )}
                 </span>
+                {canModerate && (
+                  <button
+                    onClick={() => setFiltersOpen((v) => !v)}
+                    className={`flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold transition-colors ${
+                      activeFilterCount > 0
+                        ? 'bg-[#E52828]/10 text-[#E52828] hover:bg-[#E52828]/15'
+                        : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                    aria-label="Toggle filters"
+                  >
+                    <SlidersHorizontal size={12} />
+                    Filters ({activeFilterCount})
+                  </button>
+                )}
                 <button
                   onClick={refreshEvents}
                   disabled={isRefreshing}
@@ -167,6 +298,122 @@ export function EventsMapPage() {
                 >
                   <RefreshCw size={14} className={isRefreshing ? 'animate-spin' : ''} />
                 </button>
+              </div>
+            </div>
+          )}
+
+          {/* Filter panel — moderator only */}
+          {canModerate && filtersOpen && !loading && !error && (
+            <div className="absolute top-16 left-1/2 -translate-x-1/2 z-10 w-[calc(100vw-2rem)] max-w-[640px]">
+              <div className="bg-white/95 backdrop-blur-sm rounded-2xl shadow-xl border border-white/50 p-4 space-y-3">
+                {/* Status row */}
+                <div className="space-y-1.5">
+                  <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+                    Status
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {STATUS_FILTER_KEYS.map((key) => {
+                      const state = getStatusFilterState(key);
+                      return (
+                        <div
+                          key={key}
+                          className={`flex items-center gap-1.5 px-2 py-1 rounded-lg border transition-all ${
+                            state === 'include'
+                              ? 'bg-[#39d98a]/20 border-[#39d98a]/40'
+                              : state === 'exclude'
+                                ? 'bg-[#ff393a]/20 border-[#ff393a]/40'
+                                : 'bg-gray-50 border-gray-200'
+                          }`}
+                        >
+                          <button
+                            onClick={() =>
+                              setStatusFilterState(key, state === 'include' ? 'neutral' : 'include')
+                            }
+                            className="flex items-center gap-1.5 flex-1 py-0.5 hover:opacity-70 transition-opacity"
+                            title={`Must be ${key}`}
+                          >
+                            <ThumbsUp
+                              size={12}
+                              className={`transition-all ${
+                                state === 'include' ? 'text-[#39d98a]' : 'text-gray-400'
+                              }`}
+                            />
+                            <span className="text-gray-800 text-xs capitalize">{key}</span>
+                          </button>
+                          <button
+                            onClick={() =>
+                              setStatusFilterState(key, state === 'exclude' ? 'neutral' : 'exclude')
+                            }
+                            className="p-0.5 hover:opacity-70 transition-opacity"
+                            title={`Must NOT be ${key}`}
+                          >
+                            <ThumbsDown
+                              size={12}
+                              className={`transition-all ${
+                                state === 'exclude' ? 'text-[#ff393a]' : 'text-gray-400'
+                              }`}
+                            />
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Search row */}
+                <div>
+                  <input
+                    type="text"
+                    value={searchQ}
+                    onChange={(e) => setSearchQ(e.target.value)}
+                    placeholder="Search by city, host, venue…"
+                    className="w-full bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 text-sm placeholder:text-gray-400 focus:outline-none focus:border-gray-300"
+                  />
+                </div>
+
+                {/* Tag row */}
+                <div>
+                  <select
+                    value={tagFilter}
+                    onChange={(e) => setTagFilter(e.target.value)}
+                    className="w-full bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:border-gray-300"
+                  >
+                    <option value="all">All tags</option>
+                    {availableTags.map((tag) => (
+                      <option key={tag} value={tag}>
+                        {tag}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Country row */}
+                <div>
+                  <select
+                    value={countryFilter}
+                    onChange={(e) => setCountryFilter(e.target.value)}
+                    className="w-full bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:border-gray-300"
+                  >
+                    <option value="all">All countries</option>
+                    {availableCountries.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Footer — Clear filters link */}
+                {activeFilterCount > 0 && (
+                  <div className="flex justify-end">
+                    <button
+                      onClick={clearFilters}
+                      className="text-xs text-[#E52828] hover:underline"
+                    >
+                      Clear filters
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -183,7 +430,7 @@ export function EventsMapPage() {
           >
             {!loading && !error && canModerate !== null && (
               <GPPEventsMap
-                events={events}
+                events={canModerate ? filteredEvents : events}
                 height="calc(100vh - 64px)"
                 canModerate={canModerate}
               />


### PR DESCRIPTION
## Summary
Adds a filter panel to \`/map\` for signed-in underbosses/admins. Public viewers see no change.

**Stacks on top of #325 (public-map).** Once #325 merges, I'll re-target this PR's base to \`master\`.

### Filters
- **Status pills** — three-state (include / exclude / neutral) for \`approved\`, \`pending\`, \`listed\`, \`rejected\`. Mirrors the underboss EventTable's filter pattern.
- **Search box** — name, city, venue, address, country. Debounced 200ms.
- **Tag dropdown** — single-tag filter, populated from the union of \`eventTags\` across loaded events.
- **Country dropdown** — single-country filter, populated similarly.

### UX
- New "Filters (N)" affordance inside the existing stats pill, between the count text and the refresh icon.
- Clicking it expands a panel below the pill.
- When any filter is active, the stats text switches from "454 events across 451 cities" to "23 of 454 matching".
- "Clear filters" link in the panel footer when filters are active.

### Backend
- New \`?includeAll=1\` query param on \`GET /api/gpp/events\`. Returns events of ALL \`underbossStatus\` values, including \`rejected\` and \`hidden\`. The underboss frontend call now passes this so the \`rejected\` filter pill works day one. Curated public view is unchanged. Default behavior (\`NOT IN ('rejected','hidden')\`) preserved for everything else.
- Not auth-gated — same threat model as the existing endpoint.

### Deploy
Backend needs a manual prod deploy after merge (per project convention):
\`\`\`
cd backend && vercel --prod --scope pizza-dao
\`\`\`
Until then, the production frontend's underboss view will still receive the pre-tweak result set (no rejected/hidden events) — filters still work, the \`rejected\` pill just shows nothing.

## Test plan
- [ ] Logged-out at \`/map\` (preview) → no filter UI visible
- [ ] Signed in as underboss → "Filters (0)" button visible in stats pill
- [ ] Click it → panel slides down with 4 sections
- [ ] Toggle "approved" pill to include → only approved events show; count becomes "X of Y matching"
- [ ] Toggle "rejected" pill to include → rejected events appear on the map (this verifies the backend change)
- [ ] Type "Brazil" in search → list narrows; debounce visibly delays update ~200ms
- [ ] Pick a tag → only tagged events show
- [ ] Pick a country → only that country's events show
- [ ] Combine: tag + status include → AND logic across filters
- [ ] Click "Clear filters" → all reset to defaults; stats text returns to "X events across Y cities"
- [ ] DevTools Network: underboss call has \`&includeAll=1\`; public call doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)