### PR TITLE
feat(olive-92973): admin-only newsletter signup counts on /partner

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -544,7 +544,20 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       include: {
         user: { select: { name: true, email: true, profilePictureUrl: true, website: true, twitter: true, instagram: true } },
         guests: {
-          select: { id: true, approved: true, checkedInAt: true, status: true },
+          select: {
+            id: true,
+            approved: true,
+            checkedInAt: true,
+            status: true,
+            // Newsletter opt-in fields (admin-only response)
+            mailingListOptIn: true,
+            swcOptIn: true,
+            swcCaOptIn: true,
+            swcAuOptIn: true,
+            swcEuOptIn: true,
+            swcUkOptIn: true,
+            swcBrOptIn: true,
+          },
         },
         budgetItems: {
           select: { id: true, cost: true, status: true },
@@ -687,8 +700,22 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
     const uniqueViewMap = new Map(uniqueViewStats.map(r => [r.party_id, Number(r.unique_count)]));
 
     const formattedEvents = events.map(event => {
-      const guestCount = event.guests.filter(g => g.status !== 'INVITED').length;
-      const approvedCount = event.guests.filter(g => g.approved !== false && g.status !== 'INVITED').length;
+      const submittedGuests = event.guests.filter(g => g.status !== 'INVITED');
+      const guestCount = submittedGuests.length;
+      const approvedCount = submittedGuests.filter(g => g.approved !== false).length;
+
+      // Admin-only: newsletter opt-in counts per event.
+      // Field is intentionally `undefined` for non-admins so JSON.stringify drops it
+      // (defense in depth — partners literally don't receive this data).
+      const newsletterSignups = req.isAdminViewing ? {
+        pizzadao: submittedGuests.filter(g => g.mailingListOptIn).length,
+        swc: submittedGuests.filter(g => g.swcOptIn).length,
+        swcCa: submittedGuests.filter(g => g.swcCaOptIn).length,
+        swcAu: submittedGuests.filter(g => g.swcAuOptIn).length,
+        swcEu: submittedGuests.filter(g => g.swcEuOptIn).length,
+        swcUk: submittedGuests.filter(g => g.swcUkOptIn).length,
+        swcBr: submittedGuests.filter(g => g.swcBrOptIn).length,
+      } : undefined;
 
       // Budget summary
       let budget = null;
@@ -794,6 +821,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         sponsorCount,
         partnerNotes: event.partnerEventNotes.length > 0 ? event.partnerEventNotes[0].notes : null,
         photoCount: event._count.photos,
+        newsletterSignups,
         checklist: event.sponsorChecklistItems.map(item => ({
           id: item.id,
           name: item.name,

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "({{count}} eindeutig)",
     "privateNotes": "Private Notizen für dieses Event...",
     "notes": "Notizen",
-    "done": "Fertig"
+    "done": "Fertig",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "Keine Events entsprechen Ihren Filtern.",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "{{count}} von {{total}} Events werden angezeigt",
     "showingCount": "{{count}} Events werden angezeigt",
     "taggedSuffix": " markiert \"{{tag}}\"",
-    "photosCountOf": "{{current}} von {{total}}"
+    "photosCountOf": "{{current}} von {{total}}",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "Städte werden geladen...",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "({{count}} unique)",
     "privateNotes": "Private notes for this event...",
     "notes": "Notes",
-    "done": "Done"
+    "done": "Done",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "No events match your filters.",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "Showing {{count}} of {{total}} events",
     "showingCount": "Showing {{count}} events",
     "taggedSuffix": " tagged \"{{tag}}\"",
-    "photosCountOf": "{{current}} of {{total}}"
+    "photosCountOf": "{{current}} of {{total}}",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "Loading cities...",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "({{count}} únicos)",
     "privateNotes": "Notas privadas para este evento...",
     "notes": "Notas",
-    "done": "Listo"
+    "done": "Listo",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "Ningún evento coincide con tus filtros.",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "Mostrando {{count}} de {{total}} eventos",
     "showingCount": "Mostrando {{count}} eventos",
     "taggedSuffix": " etiquetado \"{{tag}}\"",
-    "photosCountOf": "{{current}} de {{total}}"
+    "photosCountOf": "{{current}} de {{total}}",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "Cargando ciudades...",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "({{count}} uniques)",
     "privateNotes": "Notes privées pour cet événement...",
     "notes": "Notes",
-    "done": "Terminé"
+    "done": "Terminé",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "Aucun événement ne correspond à vos filtres.",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "Affichage de {{count}} sur {{total}} événements",
     "showingCount": "Affichage de {{count}} événements",
     "taggedSuffix": " étiqueté \"{{tag}}\"",
-    "photosCountOf": "{{current}} sur {{total}}"
+    "photosCountOf": "{{current}} sur {{total}}",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "Chargement des villes...",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "（{{count}}ユニーク）",
     "privateNotes": "このイベントの非公開メモ...",
     "notes": "メモ",
-    "done": "完了"
+    "done": "完了",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "フィルターに一致するイベントはありません。",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "{{total}}件中{{count}}件のイベントを表示",
     "showingCount": "{{count}}件のイベントを表示",
     "taggedSuffix": "（タグ「{{tag}}」）",
-    "photosCountOf": "{{total}}件中{{current}}件"
+    "photosCountOf": "{{total}}件中{{current}}件",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "都市を読み込み中...",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "({{count}} únicos)",
     "privateNotes": "Notas privadas para este evento...",
     "notes": "Notas",
-    "done": "Pronto"
+    "done": "Pronto",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "Nenhum evento corresponde aos seus filtros.",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "Mostrando {{count}} de {{total}} eventos",
     "showingCount": "Mostrando {{count}} eventos",
     "taggedSuffix": " marcado \"{{tag}}\"",
-    "photosCountOf": "{{current}} de {{total}}"
+    "photosCountOf": "{{current}} de {{total}}",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "Carregando cidades...",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -49,7 +49,9 @@
     "uniqueClicks": "（{{count}} 独立）",
     "privateNotes": "此活动的私人备注...",
     "notes": "备注",
-    "done": "完成"
+    "done": "完成",
+    "newsletterPizzadao": "PizzaDAO",
+    "newsletterSwc": "SWC"
   },
   "empty": {
     "noEventsFiltered": "没有匹配您筛选条件的活动。",
@@ -221,7 +223,17 @@
     "showingCountOfTotal": "显示 {{total}} 个活动中的 {{count}} 个",
     "showingCount": "显示 {{count}} 个活动",
     "taggedSuffix": "（标记为 \"{{tag}}\"）",
-    "photosCountOf": "{{total}} 中的 {{current}}"
+    "photosCountOf": "{{total}} 中的 {{current}}",
+    "newsletterPizzadao": "PizzaDAO Newsletter",
+    "newsletterSwc": "SWC Newsletter",
+    "newsletterSwcRegion": {
+      "global": "Global",
+      "canada": "Canada",
+      "australia": "Australia",
+      "europe": "Europe",
+      "uk": "UK",
+      "brazil": "Brazil"
+    }
   },
   "cities": {
     "loading": "正在加载城市...",

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -14,6 +14,7 @@ import {
   Wallet, TrendingUp, StickyNote, MessageCircle, MousePointerClick, Eye,
   Instagram, Youtube, Linkedin, Globe, Facebook,
   Camera, ChevronLeft, ChevronRight, X, Link2, Download,
+  Mail, Send,
 } from 'lucide-react';
 import { cdnUrl } from '../lib/supabase';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../lib/gppPhotos';
@@ -592,9 +593,33 @@ export function PartnerDashboardPage() {
           const withBudget = allEvents.filter(e => e.progress?.hasBudget).length;
           const venueRate = allEvents.length > 0 ? Math.round((withVenue / allEvents.length) * 100) : 0;
           const budgetRate = allEvents.length > 0 ? Math.round((withBudget / allEvents.length) * 100) : 0;
+
+          // Admin-only newsletter signup aggregation
+          const isAdmin = dashboardData?.isAdmin === true;
+          const newsletterTotals = isAdmin ? allEvents.reduce((acc, e) => {
+            const n = e.newsletterSignups;
+            if (n) {
+              acc.pizzadao += n.pizzadao;
+              acc.swc += n.swc;
+              acc.swcCa += n.swcCa;
+              acc.swcAu += n.swcAu;
+              acc.swcEu += n.swcEu;
+              acc.swcUk += n.swcUk;
+              acc.swcBr += n.swcBr;
+            }
+            return acc;
+          }, { pizzadao: 0, swc: 0, swcCa: 0, swcAu: 0, swcEu: 0, swcUk: 0, swcBr: 0 }) : null;
+          const swcTotal = newsletterTotals
+            ? newsletterTotals.swc + newsletterTotals.swcCa + newsletterTotals.swcAu + newsletterTotals.swcEu + newsletterTotals.swcUk + newsletterTotals.swcBr
+            : 0;
+
+          // Grid columns: expand when admin tiles are present
+          const gridColsClass = isSwc
+            ? (isAdmin ? 'md:grid-cols-3 lg:grid-cols-5' : 'md:grid-cols-3 lg:grid-cols-5')
+            : (isAdmin ? 'md:grid-cols-3 lg:grid-cols-6' : 'lg:grid-cols-4');
           return (
             <div className="mb-6 space-y-3">
-              <div className={`grid grid-cols-2 gap-3 ${isSwc ? 'md:grid-cols-3 lg:grid-cols-5' : 'lg:grid-cols-4'}`}>
+              <div className={`grid grid-cols-2 gap-3 ${gridColsClass}`}>
                 <div className="bg-theme-card border border-theme-stroke rounded-xl p-4">
                   <div className="flex items-center gap-2 mb-2">
                     <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-white/10 text-theme-text-muted"><BarChart3 size={16} /></div>
@@ -654,6 +679,43 @@ export function PartnerDashboardPage() {
                     </div>
                   )}
                 </div>
+                {isAdmin && newsletterTotals && (
+                  <>
+                    <div className="bg-theme-card border border-theme-stroke rounded-xl p-4">
+                      <div className="flex items-center gap-2 mb-2">
+                        <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-white/10 text-theme-text-muted"><Mail size={16} /></div>
+                        <span className="text-xs text-theme-text-muted uppercase tracking-wider">{t('dashboard.newsletterPizzadao')}</span>
+                      </div>
+                      <div className="text-2xl font-bold text-theme-text">{newsletterTotals.pizzadao.toLocaleString()}</div>
+                    </div>
+                    <div className="bg-theme-card border border-theme-stroke rounded-xl p-4">
+                      <div className="flex items-center gap-2 mb-2">
+                        <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-white/10 text-theme-text-muted"><Send size={16} /></div>
+                        <span className="text-xs text-theme-text-muted uppercase tracking-wider">{t('dashboard.newsletterSwc')}</span>
+                      </div>
+                      <div className="text-2xl font-bold text-theme-text">{swcTotal.toLocaleString()}</div>
+                      {swcTotal > 0 && (
+                        <div className="flex flex-wrap gap-x-3 gap-y-1 mt-3 pt-3 border-t border-theme-stroke/50 text-xs">
+                          {([
+                            ['swc', t('dashboard.newsletterSwcRegion.global'), newsletterTotals.swc],
+                            ['swcCa', t('dashboard.newsletterSwcRegion.canada'), newsletterTotals.swcCa],
+                            ['swcAu', t('dashboard.newsletterSwcRegion.australia'), newsletterTotals.swcAu],
+                            ['swcEu', t('dashboard.newsletterSwcRegion.europe'), newsletterTotals.swcEu],
+                            ['swcUk', t('dashboard.newsletterSwcRegion.uk'), newsletterTotals.swcUk],
+                            ['swcBr', t('dashboard.newsletterSwcRegion.brazil'), newsletterTotals.swcBr],
+                          ] as [string, string, number][])
+                            .filter(([, , count]) => count > 0)
+                            .map(([key, label, count]) => (
+                              <span key={key} className="inline-flex items-center gap-1">
+                                <span className="text-theme-text-muted">{label}</span>
+                                <span className="font-semibold text-theme-text">{count}</span>
+                              </span>
+                            ))}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
                 {isSwc && (
                   <>
                     <div className="bg-theme-card border border-theme-stroke rounded-xl p-4">
@@ -785,6 +847,7 @@ export function PartnerDashboardPage() {
                 event={event}
                 onToggleChecklist={(itemId) => handleToggleChecklist(event.id, itemId)}
                 cityChats={cityChats}
+                isAdmin={dashboardData?.isAdmin === true}
               />
             ))}
           </div>
@@ -805,9 +868,10 @@ interface EventCardProps {
   event: SponsorDashboardEvent;
   onToggleChecklist: (itemId: string) => void;
   cityChats: Map<string, string>;
+  isAdmin?: boolean;
 }
 
-function EventCard({ event, onToggleChecklist, cityChats }: EventCardProps) {
+function EventCard({ event, onToggleChecklist, cityChats, isAdmin = false }: EventCardProps) {
   const { t } = useTranslation('partner');
   // Filter co-hosts to show only visible ones
   const visibleCoHosts = event.coHosts.filter((h: CoHost) => h.showOnEvent !== false);
@@ -1100,6 +1164,27 @@ function EventCard({ event, onToggleChecklist, cityChats }: EventCardProps) {
                 )}
               </div>
             )}
+            {isAdmin && event.newsletterSignups && (() => {
+              const n = event.newsletterSignups;
+              const swcSum = n.swc + n.swcCa + n.swcAu + n.swcEu + n.swcUk + n.swcBr;
+              if (n.pizzadao === 0 && swcSum === 0) return null;
+              return (
+                <div className="flex items-center gap-3 text-xs text-theme-text-muted">
+                  {n.pizzadao > 0 && (
+                    <span className="flex items-center gap-1.5">
+                      <Mail size={12} />
+                      <span>{t('eventCard.newsletterPizzadao')}: <span className="font-semibold text-theme-text">{n.pizzadao}</span></span>
+                    </span>
+                  )}
+                  {swcSum > 0 && (
+                    <span className="flex items-center gap-1.5">
+                      <Send size={12} />
+                      <span>{t('eventCard.newsletterSwc')}: <span className="font-semibold text-theme-text">{swcSum}</span></span>
+                    </span>
+                  )}
+                </div>
+              );
+            })()}
           </div>
         </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1265,6 +1265,16 @@ export interface SponsorDashboardEvent {
   partnerNotes: string | null;
   photoCount: number;
   checklist: SponsorChecklistItem[];
+  // Admin-only: newsletter signup counts per event. Field is absent for non-admins.
+  newsletterSignups?: {
+    pizzadao: number;
+    swc: number;
+    swcCa: number;
+    swcAu: number;
+    swcEu: number;
+    swcUk: number;
+    swcBr: number;
+  };
 }
 
 export interface SponsorMeResponse {

--- a/plans/olive-92973-admin-newsletter-counts.md
+++ b/plans/olive-92973-admin-newsletter-counts.md
@@ -1,0 +1,219 @@
+# olive-92973 — Admin-only newsletter signup counts on /partner
+
+## Goal
+
+On the `/partner` (PartnerDashboardPage) page, show newsletter signup counts so PizzaDAO admins can see at-a-glance how many guests opted in to:
+
+- **PizzaDAO mailing list** (`guests.mailing_list_opt_in`)
+- **SWC newsletter** — sum across all six regional variants (`swc_opt_in`, `swc_ca_opt_in`, `swc_au_opt_in`, `swc_eu_opt_in`, `swc_uk_opt_in`, `swc_br_opt_in`)
+
+**Visibility is admin-only.** Partners must NOT see these numbers, neither in the aggregate stats grid nor on individual EventCards. The frontend conditional + backend conditional both gate on the admin flag (defense in depth).
+
+## Where it should appear
+
+Two places:
+
+1. **Aggregate stats grid** at the top of `/partner` (alongside Events / Total RSVPs / Impressions / Partner Link Clicks)
+   - One new tile: **"PizzaDAO Newsletter"** — total `mailingListOptIn` count across all filtered events
+   - One new tile: **"SWC Newsletter"** — total across all 6 SWC variants, with per-region breakdown sub-list (matches the existing partner-clicks tile's nested-breakdown pattern)
+
+2. **Each EventCard** — a small admin-only row showing per-event PizzaDAO + SWC signup counts. Add it inline near the existing per-event stats row (the one with Eye/views, MousePointerClick/clicks). Keep it tight — single line like `📧 PizzaDAO: 12 · SWC: 5` style.
+
+## Implementation
+
+### Backend — `backend/src/routes/sponsor-user.routes.ts`
+
+**File**: `backend/src/routes/sponsor-user.routes.ts` (the `/api/sponsor/events` handler, around line 519)
+
+1. In the `guests` Prisma select (around line 547), add the opt-in boolean columns:
+
+   ```ts
+   guests: {
+     select: {
+       id: true,
+       approved: true,
+       checkedInAt: true,
+       status: true,
+       // Newsletter opt-in fields (admin-only response)
+       mailingListOptIn: true,
+       swcOptIn: true,
+       swcCaOptIn: true,
+       swcAuOptIn: true,
+       swcEuOptIn: true,
+       swcUkOptIn: true,
+       swcBrOptIn: true,
+     },
+   },
+   ```
+
+2. In the per-event formatting block (around line 689), compute counts. **Only count guests with `status !== 'INVITED'`** — matching how `rsvpCount` is computed (invited bulk guests haven't actually submitted the RSVP form). This is the same fake-detection-friendly filter the codebase already uses.
+
+3. Add a `newsletterSignups` field to the returned event object, **but only when `req.isAdminViewing` is true** (don't leak the field at all to partners):
+
+   ```ts
+   // inside formattedEvents map
+   const submittedGuests = event.guests.filter(g => g.status !== 'INVITED');
+   const newsletterSignups = req.isAdminViewing ? {
+     pizzadao: submittedGuests.filter(g => g.mailingListOptIn).length,
+     swc: submittedGuests.filter(g => g.swcOptIn).length,
+     swcCa: submittedGuests.filter(g => g.swcCaOptIn).length,
+     swcAu: submittedGuests.filter(g => g.swcAuOptIn).length,
+     swcEu: submittedGuests.filter(g => g.swcEuOptIn).length,
+     swcUk: submittedGuests.filter(g => g.swcUkOptIn).length,
+     swcBr: submittedGuests.filter(g => g.swcBrOptIn).length,
+   } : undefined;
+
+   return {
+     // ... existing fields ...
+     newsletterSignups, // undefined for non-admins, dropped by JSON.stringify
+   };
+   ```
+
+### Frontend — types
+
+**File**: `frontend/src/types.ts`
+
+Add optional field to `SponsorDashboardEvent` (around line 1265, near the existing `photoCount`):
+
+```ts
+newsletterSignups?: {
+  pizzadao: number;
+  swc: number;
+  swcCa: number;
+  swcAu: number;
+  swcEu: number;
+  swcUk: number;
+  swcBr: number;
+};
+```
+
+Field is optional because partners won't receive it.
+
+### Frontend — PartnerDashboardPage
+
+**File**: `frontend/src/pages/PartnerDashboardPage.tsx`
+
+#### Aggregate stats grid
+
+Inside the existing stats-computation block (around line 568, `allEvents.length > 0 && (() => { ... })()`), add aggregated newsletter sums **only when `dashboardData?.isAdmin`**:
+
+```ts
+const isAdmin = dashboardData?.isAdmin === true;
+const newsletterTotals = isAdmin ? allEvents.reduce((acc, e) => {
+  const n = e.newsletterSignups;
+  if (n) {
+    acc.pizzadao += n.pizzadao;
+    acc.swc += n.swc;
+    acc.swcCa += n.swcCa;
+    acc.swcAu += n.swcAu;
+    acc.swcEu += n.swcEu;
+    acc.swcUk += n.swcUk;
+    acc.swcBr += n.swcBr;
+  }
+  return acc;
+}, { pizzadao: 0, swc: 0, swcCa: 0, swcAu: 0, swcEu: 0, swcUk: 0, swcBr: 0 }) : null;
+const swcTotal = newsletterTotals
+  ? newsletterTotals.swc + newsletterTotals.swcCa + newsletterTotals.swcAu + newsletterTotals.swcEu + newsletterTotals.swcUk + newsletterTotals.swcBr
+  : 0;
+```
+
+Then render two new tiles **after the partner-link-clicks tile** (so before the SWC `withVenue`/`withBudget`/`completion` cluster), wrapped in `{isAdmin && newsletterTotals && (...)}`:
+
+- **PizzaDAO Newsletter** tile — uses `Mail` icon from `lucide-react`, shows `newsletterTotals.pizzadao.toLocaleString()`.
+- **SWC Newsletter** tile — uses `Send` (or `Mail`) icon, shows `swcTotal.toLocaleString()` as the headline number, then a breakdown sub-list under a divider styled like the existing partner-link-clicks breakdown. Show one line per SWC variant that has count > 0, formatted like:
+
+  ```
+  Global  12   CA 3   AU 1
+  ```
+
+  Use the labels:
+  - `swc` → "Global"
+  - `swcCa` → "Canada"
+  - `swcAu` → "Australia"
+  - `swcEu` → "Europe"
+  - `swcUk` → "UK"
+  - `swcBr` → "Brazil"
+
+Use the same Tailwind classes the existing tiles use (`bg-theme-card border border-theme-stroke rounded-xl p-4`, etc.) so the new tiles match visually.
+
+Update the grid wrapper class to fit 6 tiles in a non-SWC view too: change `lg:grid-cols-4` so it expands when admin tiles are present. Suggested:
+
+- Non-SWC + admin: `grid-cols-2 md:grid-cols-3 lg:grid-cols-6` (6 tiles: Events, Total RSVPs, Impressions, Clicks, PizzaDAO, SWC)
+- SWC + admin: keep `lg:grid-cols-5` for the original cluster and let the 2 admin tiles wrap (or expand to `lg:grid-cols-7` if it fits)
+- Non-admin: unchanged (`lg:grid-cols-4` non-SWC / `lg:grid-cols-5` SWC)
+
+Pick whichever wrapping looks clean at common widths — verify in the Vercel preview.
+
+#### Per-EventCard row
+
+In the `EventCard` component (starts around line 810), thread `isAdmin` down via a prop (the parent passes it from `dashboardData?.isAdmin`).
+
+After the existing impressions/clicks row (around line 1060), add:
+
+```tsx
+{isAdmin && event.newsletterSignups && (
+  (() => {
+    const n = event.newsletterSignups;
+    const swcSum = n.swc + n.swcCa + n.swcAu + n.swcEu + n.swcUk + n.swcBr;
+    if (n.pizzadao === 0 && swcSum === 0) return null;
+    return (
+      <div className="flex items-center gap-3 text-xs text-theme-text-muted">
+        {n.pizzadao > 0 && (
+          <span className="flex items-center gap-1.5">
+            <Mail size={12} />
+            <span>PizzaDAO: <span className="font-semibold text-theme-text">{n.pizzadao}</span></span>
+          </span>
+        )}
+        {swcSum > 0 && (
+          <span className="flex items-center gap-1.5">
+            <Send size={12} />
+            <span>SWC: <span className="font-semibold text-theme-text">{swcSum}</span></span>
+          </span>
+        )}
+      </div>
+    );
+  })()
+)}
+```
+
+Don't render anything for events with zero signups (avoid empty noise on every card).
+
+### i18n
+
+The two new stat-tile titles ("PizzaDAO Newsletter", "SWC Newsletter") and per-region labels should ideally go through `useTranslation('partner')` if the rest of the dashboard does (it does — `t('dashboard.totalRsvps')` etc.). Add new keys to `frontend/src/i18n/locales/en/partner.json` (and the other 6 locales — copy English for now, mark non-EN as TODO). Keys to add:
+
+- `dashboard.newsletterPizzadao` = "PizzaDAO Newsletter"
+- `dashboard.newsletterSwc` = "SWC Newsletter"
+- `dashboard.newsletterSwcRegion.global` = "Global"
+- `dashboard.newsletterSwcRegion.canada` = "Canada"
+- `dashboard.newsletterSwcRegion.australia` = "Australia"
+- `dashboard.newsletterSwcRegion.europe` = "Europe"
+- `dashboard.newsletterSwcRegion.uk` = "UK"
+- `dashboard.newsletterSwcRegion.brazil` = "Brazil"
+- `eventCard.newsletterPizzadao` = "PizzaDAO" (short label for per-card row)
+- `eventCard.newsletterSwc` = "SWC"
+
+If the file structure makes the i18n addition heavy, English-only hardcoded strings are acceptable for the first cut — Snax can localize in a follow-up if it ships clean.
+
+## Files Modified
+
+- `backend/src/routes/sponsor-user.routes.ts` — add opt-in columns to guests select; compute and conditionally include `newsletterSignups` in response (admin-only).
+- `frontend/src/types.ts` — add `newsletterSignups` optional field to `SponsorDashboardEvent`.
+- `frontend/src/pages/PartnerDashboardPage.tsx` — two new admin-only stat tiles; per-EventCard admin-only signup row; thread `isAdmin` prop down.
+- `frontend/src/i18n/locales/en/partner.json` (+ other 6 locales) — new translation keys.
+
+## Verification
+
+- [ ] Log in as a sponsor user (non-admin) → confirm no PizzaDAO/SWC tiles appear in stats grid AND no signup row on EventCards.
+- [ ] Log in as an admin (Snax's account) → confirm both tiles appear in stats grid showing real counts.
+- [ ] Filter to `tag=swc` as admin → confirm SWC tile shows breakdown with per-region numbers.
+- [ ] Filter to `tag=pizzadao` as admin → confirm PizzaDAO tile shows a non-zero number (PizzaDAO mailing-list signups across all GPP events).
+- [ ] Inspect network response on `/api/sponsor/events` as a non-admin → confirm `newsletterSignups` field is absent (not just zeroed) for defense in depth.
+- [ ] Per-EventCard row hides itself when both PizzaDAO and SWC counts are zero (don't clutter cards with empty rows).
+
+## Notes / Open Questions
+
+- Counts include all guests with `status !== 'INVITED'`. This matches `rsvpCount` semantics — INVITED bulk guests haven't actually submitted the RSVP form, so their opt-in booleans are default-false and shouldn't be counted regardless.
+- We don't filter by `submitted_via` (link/host/host-checkin/rsvp/api). All submission paths contribute. If Snax later wants only `link`/`rsvp`/`api` (excluding host-added), that's a one-line filter change.
+- No DB migration. All columns already exist (per `backend/prisma/schema.prisma` lines 224–230).
+- No new Supabase column-level SELECT grants needed — the backend reads these via Prisma using the service role.


### PR DESCRIPTION
## Summary

- Admin-only "PizzaDAO Newsletter" and "SWC Newsletter" tiles in the `/partner` stats grid; SWC tile includes a per-region breakdown (Global / Canada / Australia / Europe / UK / Brazil).
- Admin-only per-EventCard newsletter signup row (hidden when both counts are zero).
- Defense-in-depth gating: backend omits `newsletterSignups` entirely from non-admin responses; frontend renders only when `dashboardData.isAdmin`.

Plan: `plans/olive-92973-admin-newsletter-counts.md`. No DB migration — opt-in columns already exist in `parties`/`guests`.

## Test plan

- [ ] Log in as a partner (non-admin) on `/partner` preview → no new tiles visible, no newsletter row on EventCards, and `GET /api/sponsor/events` response has no `newsletterSignups` field.
- [ ] Log in as admin → both tiles render; SWC tile shows per-region breakdown for variants with >0 signups.
- [ ] Filter `?tag=pizzadao` as admin → PizzaDAO tile shows non-zero across GPP events.
- [ ] Filter `?tag=swc` as admin → SWC tile dominates.
- [ ] EventCard rows hide cleanly when an event has 0 signups (no empty noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)