### PR TITLE
feat(quattro-formaggi-91682): broaden tag filter + restyle download button

### DIFF
--- a/frontend/src/components/promo/SocialComposer.tsx
+++ b/frontend/src/components/promo/SocialComposer.tsx
@@ -151,7 +151,7 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
   };
 
   const partnerXHandles = (party.coHosts ?? [])
-    .filter(c => c.isPartner && c.twitter && c.twitter.trim())
+    .filter(c => c.showOnEvent === true && c.twitter && c.twitter.trim())
     .map(c => ({
       id: c.id,
       name: c.name,
@@ -218,7 +218,7 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
             <button
               type="button"
               onClick={handleDownloadImage}
-              className="absolute bottom-2 right-2 flex items-center gap-1 bg-black/70 hover:bg-black/90 text-theme-text text-xs font-medium px-2 py-1 rounded-lg transition-colors backdrop-blur-sm"
+              className="absolute bottom-2 right-2 flex items-center gap-1 bg-gray-200 hover:bg-gray-300 text-gray-900 text-xs font-medium px-2 py-1 rounded-lg transition-colors shadow-sm"
             >
               <Download size={12} />
               {t('promo.downloadImage')}


### PR DESCRIPTION
## Summary
Follow-up polish to slice-63708. Two small tweaks in `SocialComposer.tsx`:

1. **Broaden the partner-tag filter.** The X-tab "Tag your partners in the image" block was only listing co-hosts flagged `isPartner`, which excluded visible co-hosts like ScopeLift on `/philadelphia` (a regular co-host with a Twitter handle). Changed the filter to `c.showOnEvent === true && c.twitter && c.twitter.trim()` so any visible co-host with a handle shows up. Strict `=== true` matches the EventPage convention (older rows without the field stay hidden).
2. **Restyle the Download Image button.** The dark translucent button overlay was unreadable on light flyer art. Swapped to opaque light gray (`bg-gray-200 hover:bg-gray-300`) + dark text (`text-gray-900`), dropped `backdrop-blur-sm`, added `shadow-sm` so it still pops at the flyer edge.

No i18n changes — `promo.tagYourPartners` / `promo.tagYourPartnersHint` still read naturally with the broader filter.

## Test plan
- [ ] Load `/host/<philadelphia-invite>/promo` on the preview → Social Media → X tab
- [ ] Confirm ScopeLift now appears in the partner tag list
- [ ] Confirm co-hosts with `showOnEvent: false` do NOT appear
- [ ] Confirm Download Image button is light gray, opaque, and readable against a light flyer
- [ ] Confirm the tag block still hides on Instagram/Facebook/LinkedIn tabs
- [ ] Confirm the tag block still hides on events with no qualifying co-hosts

## Vercel preview
https://rsvpizza-git-quattro-formaggi-91682-promo-polish-pizza-dao.vercel.app