### PR TITLE
diavola-46885: hide auto-added underboss/admin co-hosts from host edit panel

### DIFF
--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -27,6 +27,13 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   // Co-hosts state — includes ALL co-hosts (manual + protected)
   const [coHosts, setCoHosts] = useState<CoHost[]>(initialCoHosts);
 
+  // Visible co-hosts: filter out protected entries (auto-added underboss/partner)
+  // from the host's edit panel. Backend preserves them server-side on PATCH.
+  const visibleCoHosts = React.useMemo(
+    () => coHosts.filter(h => !isProtected(h)),
+    [coHosts]
+  );
+
   // Sync from props when enriched data arrives asynchronously
   useEffect(() => {
     setCoHosts(initialCoHosts);
@@ -295,12 +302,16 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
     await saveCoHostsArray(newCoHosts);
   };
 
-  const handleDragStart = (index: number) => {
+  const handleDragStart = (id: string) => {
+    const index = coHosts.findIndex(h => h.id === id);
+    if (index === -1) return;
     setDraggedIndex(index);
   };
 
-  const handleDragOver = (e: React.DragEvent, index: number) => {
+  const handleDragOver = (e: React.DragEvent, id: string) => {
     e.preventDefault();
+    const index = coHosts.findIndex(h => h.id === id);
+    if (index === -1) return;
     if (draggedIndex === null || draggedIndex === index) return;
 
     const newCoHosts = [...coHosts];
@@ -346,17 +357,17 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
           </div>
         )}
 
-        {/* Co-Hosts (manual + protected) */}
-        {coHosts.map((coHost, index) => {
-          const protected_ = isProtected(coHost);
+        {/* Co-Hosts (visible only — protected/auto-added entries are hidden from host UI) */}
+        {visibleCoHosts.map((coHost) => {
+          const fullIndex = coHosts.findIndex(h => h.id === coHost.id);
           return (
           <div
             key={coHost.id}
             draggable
-            onDragStart={() => handleDragStart(index)}
-            onDragOver={(e) => handleDragOver(e, index)}
+            onDragStart={() => handleDragStart(coHost.id)}
+            onDragOver={(e) => handleDragOver(e, coHost.id)}
             onDragEnd={handleDragEnd}
-            className={`p-3 bg-white/5 rounded-xl border ${protected_ ? 'border-white/20' : 'border-white/10'} transition-all cursor-move ${draggedIndex === index ? 'opacity-50' : 'opacity-100'
+            className={`p-3 bg-white/5 rounded-xl border border-white/10 transition-all cursor-move ${draggedIndex === fullIndex ? 'opacity-50' : 'opacity-100'
               }`}
           >
             {/* Top row: identity + remove button */}
@@ -374,12 +385,6 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <p className="text-white font-medium truncate">{coHost.name}</p>
-                  {coHost.isPartner && (
-                    <span className="text-[10px] font-semibold bg-purple-500/20 text-purple-300 px-1.5 py-0.5 rounded-full whitespace-nowrap">Partner</span>
-                  )}
-                  {coHost.isUnderboss && (
-                    <span className="text-[10px] font-semibold bg-blue-500/20 text-blue-300 px-1.5 py-0.5 rounded-full whitespace-nowrap">Auto</span>
-                  )}
                 </div>
                 {coHost.email && (
                   <p className="text-white/50 text-xs truncate">{coHost.email}</p>
@@ -404,53 +409,41 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                   )}
                 </div>
               </div>
-              {protected_ ? (
-                <div className="shrink-0 text-white/20 cursor-not-allowed" title="Auto-added hosts cannot be removed">
-                  <X size={18} />
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => removeCoHost(coHost.id)}
-                  className="text-[#ff393a] hover:text-[#ff5a5b] shrink-0"
-                >
-                  <X size={18} />
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => removeCoHost(coHost.id)}
+                className="text-[#ff393a] hover:text-[#ff5a5b] shrink-0"
+              >
+                <X size={18} />
+              </button>
             </div>
             {/* Bottom row: controls */}
             <div className="flex items-center gap-3 mt-2 pl-9">
-              {!protected_ && (
-                <Checkbox
-                  checked={coHost.showOnEvent !== false}
-                  onChange={() => toggleCoHostShowOnEvent(coHost.id)}
-                  label="Show"
-                  size={16}
-                  labelClassName="text-xs font-medium text-white/60"
-                />
-              )}
-              {!protected_ && (
-                <>
-                  <Checkbox
-                    checked={coHost.canEdit === true}
-                    onChange={() => toggleCoHostCanEdit(coHost.id)}
-                    label="Editor"
-                    size={16}
-                    labelClassName="text-xs font-medium text-white/60"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => startEditingHost(coHost)}
-                    className="text-white/50 hover:text-white text-sm font-medium"
-                  >
-                    Edit
-                  </button>
-                </>
-              )}
+              <Checkbox
+                checked={coHost.showOnEvent !== false}
+                onChange={() => toggleCoHostShowOnEvent(coHost.id)}
+                label="Show"
+                size={16}
+                labelClassName="text-xs font-medium text-white/60"
+              />
+              <Checkbox
+                checked={coHost.canEdit === true}
+                onChange={() => toggleCoHostCanEdit(coHost.id)}
+                label="Editor"
+                size={16}
+                labelClassName="text-xs font-medium text-white/60"
+              />
+              <button
+                type="button"
+                onClick={() => startEditingHost(coHost)}
+                className="text-white/50 hover:text-white text-sm font-medium"
+              >
+                Edit
+              </button>
             </div>
 
-            {/* Tab permissions expander (only when canEdit is true and not protected) */}
-            {coHost.canEdit && !protected_ && (
+            {/* Tab permissions expander (only when canEdit is true) */}
+            {coHost.canEdit && (
               <div className="mt-2 pl-9">
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Auto-added underboss (region admins) and partner (sponsor-sync) co-hosts no longer appear in the host's HostsManager edit panel.
- DB and public-facing views are unchanged. Backend already preserves protected entries server-side on PATCH (`party.routes.ts:472`), so removing them from the client payload is safe.

## Test plan
- [ ] On a GPP event with a region underboss auto-added, log in as the event host -> HostsManager should NOT list the underboss.
- [ ] On a GPP event with a partner auto-added (e.g. avax tag), confirm the partner is hidden in HostsManager.
- [ ] Public event page still shows public co-hosts (those with `showOnEvent: true`).
- [ ] Add / edit / reorder / remove a manual co-host - all work.
- [ ] After any save, re-fetch the party and confirm underboss/partner entries are still in DB `co_hosts`.

Generated with [Claude Code](https://claude.com/claude-code)