### PR TITLE
deep-dish-24998: restyle /partners to match /gpp

### DIFF
--- a/frontend/src/pages/PartnersPage.tsx
+++ b/frontend/src/pages/PartnersPage.tsx
@@ -1,8 +1,22 @@
 import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Loader2 } from 'lucide-react';
-import { Layout } from '../components/Layout';
+import { GPPClouds } from '../components/GPPClouds';
 import { fetchGppPartners, GPPPartner } from '../lib/api';
+
+/* ── colour tokens (from the 2026 flyer) ────────────────── */
+const C = {
+  skyTop:    '#7EC8E3',
+  skyBot:    '#B6E4F7',
+  red:       '#E52828',
+  redHover:  '#CC2020',
+  green:     '#2E7D32',
+  yellow:    '#FFD600',
+  darkText:  '#1a1a1a',
+  mutedText: '#555',
+  cardBg:    'rgba(255,255,255,0.92)',
+  cardBorder:'rgba(0,0,0,0.08)',
+};
 
 export function PartnersPage() {
   const [partners, setPartners] = useState<GPPPartner[]>([]);
@@ -31,7 +45,12 @@ export function PartnersPage() {
   const totalEvents = partners.reduce((sum, p) => sum + p.eventCount, 0);
 
   return (
-    <>
+    <div
+      className="min-h-screen relative overflow-hidden"
+      style={{ background: `linear-gradient(180deg, ${C.skyTop} 0%, ${C.skyBot} 100%)` }}
+    >
+      <GPPClouds />
+
       <Helmet>
         <title>GPP Partners | RSV.Pizza</title>
         <meta
@@ -40,12 +59,68 @@ export function PartnersPage() {
         />
       </Helmet>
 
-      <Layout>
+      {/* ─── LIGHT HEADER ─── */}
+      <header className="border-b border-black/10 relative z-50 overflow-visible" style={{ background: 'rgba(255,255,255,0.95)' }}>
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+          <a href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+            <img src="/logo.png" alt="RSV.Pizza" className="h-8 sm:h-10" />
+            <span
+              className="hidden sm:inline"
+              style={{ fontFamily: "'Bangers', cursive", fontSize: '1.3rem', color: C.darkText }}
+            >
+              RSV.Pizza
+            </span>
+          </a>
+        </div>
+      </header>
+
+      {/* ─── HERO ─── */}
+      <div className="relative z-10 max-w-6xl mx-auto px-4 pt-10 md:pt-16 pb-6 text-center">
+        <h1
+          className="mb-3"
+          style={{
+            fontFamily: "'Bangers', cursive",
+            fontSize: 'clamp(2.5rem, 6vw, 4.5rem)',
+            color: C.darkText,
+            letterSpacing: '0.02em',
+            lineHeight: 1.05,
+          }}
+        >
+          GPP Partners
+        </h1>
+        <p
+          className="max-w-2xl mx-auto text-base md:text-lg mb-6"
+          style={{ color: C.mutedText }}
+        >
+          The brands powering the 2026 Global Pizza Party — slinging slices in cities around the world.
+        </p>
+
+        {!loading && !error && partners.length > 0 && (
+          <div className="flex justify-center">
+            <div
+              className="rounded-full px-5 py-2 border shadow-sm"
+              style={{
+                background: C.cardBg,
+                borderColor: C.cardBorder,
+                color: C.darkText,
+              }}
+            >
+              <span className="text-sm font-semibold">
+                {partners.length.toLocaleString()} partners across{' '}
+                {totalEvents.toLocaleString()} events
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ─── BODY ─── */}
+      <div className="relative z-10 max-w-6xl mx-auto px-4 pb-16">
         {loading && (
-          <div className="flex items-center justify-center py-24">
+          <div className="flex items-center justify-center py-20">
             <div className="flex flex-col items-center gap-3">
-              <Loader2 size={36} className="animate-spin text-[#E52828]" />
-              <span className="text-sm font-medium text-theme-text-faint">
+              <Loader2 size={36} className="animate-spin" style={{ color: C.red }} />
+              <span className="text-sm font-medium" style={{ color: C.mutedText }}>
                 Loading partners...
               </span>
             </div>
@@ -53,13 +128,16 @@ export function PartnersPage() {
         )}
 
         {error && !loading && (
-          <div className="flex items-center justify-center py-24 px-6">
-            <div className="flex flex-col items-center gap-3 bg-theme-surface rounded-2xl p-8 border border-theme-stroke">
-              <p className="text-red-500 font-medium">{error}</p>
+          <div className="flex items-center justify-center py-16 px-6">
+            <div
+              className="flex flex-col items-center gap-3 rounded-2xl p-8 border shadow-lg"
+              style={{ background: C.cardBg, borderColor: C.cardBorder }}
+            >
+              <p className="font-medium" style={{ color: C.red }}>{error}</p>
               <button
                 onClick={loadPartners}
-                className="px-5 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5"
-                style={{ background: '#E52828' }}
+                className="px-5 py-2 rounded-xl text-sm font-semibold text-white transition-all hover:-translate-y-0.5"
+                style={{ background: C.red }}
               >
                 Retry
               </button>
@@ -68,65 +146,67 @@ export function PartnersPage() {
         )}
 
         {!loading && !error && partners.length === 0 && (
-          <div className="flex items-center justify-center py-24 px-6">
-            <p className="text-sm text-theme-text-faint">
-              No partners yet — check back soon
-            </p>
+          <div className="flex items-center justify-center py-20 px-6">
+            <div
+              className="rounded-2xl px-6 py-5 border shadow-sm"
+              style={{ background: C.cardBg, borderColor: C.cardBorder }}
+            >
+              <p className="text-sm" style={{ color: C.mutedText }}>
+                No partners yet — check back soon
+              </p>
+            </div>
           </div>
         )}
 
         {!loading && !error && partners.length > 0 && (
-          <div className="max-w-6xl mx-auto px-6 py-8">
-            <div className="flex justify-center mb-6">
-              <div className="bg-theme-surface border border-theme-stroke rounded-full px-5 py-2">
-                <span className="text-sm font-semibold">
-                  {partners.length.toLocaleString()} partners across{' '}
-                  {totalEvents.toLocaleString()} events
-                </span>
-              </div>
-            </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+            {partners.map((partner) => {
+              const tile = (
+                <div
+                  className="aspect-square flex items-center justify-center p-4 rounded-2xl border shadow-lg transition-transform duration-200 hover:scale-105"
+                  style={{ background: C.cardBg, borderColor: C.cardBorder }}
+                >
+                  <img
+                    src={partner.logoUrl}
+                    alt={partner.name}
+                    className="max-w-full max-h-full object-contain"
+                    loading="lazy"
+                  />
+                </div>
+              );
 
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-              {partners.map((partner) => {
-                const tile = (
-                  <div className="bg-theme-surface aspect-square flex items-center justify-center p-4 rounded-2xl border border-theme-stroke">
-                    <img
-                      src={partner.logoUrl}
-                      alt={partner.name}
-                      className="max-w-full max-h-full object-contain"
-                      loading="lazy"
-                    />
+              return (
+                <div key={`${partner.name}-${partner.logoUrl}`} className="flex flex-col">
+                  {partner.website ? (
+                    <a
+                      href={partner.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block"
+                    >
+                      {tile}
+                    </a>
+                  ) : (
+                    tile
+                  )}
+                  <div
+                    className="text-xs mt-2 text-center font-semibold"
+                    style={{ color: C.darkText }}
+                  >
+                    {partner.name}
                   </div>
-                );
-
-                return (
-                  <div key={`${partner.name}-${partner.logoUrl}`} className="flex flex-col">
-                    {partner.website ? (
-                      <a
-                        href={partner.website}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="block"
-                      >
-                        {tile}
-                      </a>
-                    ) : (
-                      tile
-                    )}
-                    <div className="text-xs text-theme-text-faint mt-2 text-center">
-                      {partner.name}
-                    </div>
-                    <div className="text-[10px] text-theme-text-faint mt-1 text-center opacity-70">
+                  <div className="mt-1 flex justify-center">
+                    <span className="inline-block text-[10px] font-semibold rounded-full px-2 py-0.5 bg-[#E52828]/10 text-[#E52828]">
                       in {partner.eventCount.toLocaleString()}{' '}
                       {partner.eventCount === 1 ? 'event' : 'events'}
-                    </div>
+                    </span>
                   </div>
-                );
-              })}
-            </div>
+                </div>
+              );
+            })}
           </div>
         )}
-      </Layout>
-    </>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restyles `frontend/src/pages/PartnersPage.tsx` to match the GPP landing page visual identity (`/gpp`).
- Sky-gradient background + `<GPPClouds />` decorative layer.
- Reuses the `C` color tokens, light header (logo + Bangers wordmark, no language switcher), Bangers hero heading + subheading, translucent-white stats pill.
- Grid tiles converted to translucent white cards with `hover:scale-105` and dark-on-light text; event-count rendered as a red `bg-[#E52828]/10` pill.
- Loading / error / empty states restyled to fit the sky gradient.
- Data fetching (`fetchGppPartners`), routing, `Helmet`, `target=_blank rel=noopener noreferrer`, and `loading="lazy"` all preserved.
- No backend, API, or route changes. Single-file diff.

## Plan
Task `deep-dish-24998` — restyle PartnersPage to match GPPLandingPage.

## Preview
- https://rsvpizza-git-deep-dish-24998-partners-restyle-pizza-dao.vercel.app/partners

## Test plan
- [ ] Vercel preview deploys cleanly.
- [ ] `/partners` renders with sky gradient + clouds + Bangers heading.
- [ ] Partner tiles show translucent white cards with red event-count pills.
- [ ] Logos still link out (`target=_blank`) when `partner.website` is set.
- [ ] Empty / loading / error states display correctly on the sky background.