### PR TITLE
neapolitan-49573: move tag-copy buttons left, icon-only

### DIFF
--- a/frontend/src/components/promo/SocialComposer.tsx
+++ b/frontend/src/components/promo/SocialComposer.tsx
@@ -243,6 +243,19 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
           <div className="space-y-1.5">
             {partnerXHandles.map(p => (
               <div key={p.id} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleCopyHandle(p.id, p.handle)}
+                  aria-label={t('promo.copy')}
+                  title={t('promo.copy')}
+                  className="flex-shrink-0 p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted hover:text-theme-text transition-colors"
+                >
+                  {copiedHandle === p.id ? (
+                    <Check size={16} className="text-green-400" />
+                  ) : (
+                    <Copy size={16} />
+                  )}
+                </button>
                 {p.avatarUrl ? (
                   <img
                     src={p.avatarUrl}
@@ -258,17 +271,6 @@ export const SocialComposer: React.FC<SocialComposerProps> = ({ party }) => {
                   <div className="text-sm text-theme-text truncate">{p.name}</div>
                   <div className="text-xs text-theme-text-muted truncate">@{p.handle}</div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => handleCopyHandle(p.id, p.handle)}
-                  className="text-xs text-theme-text-muted hover:text-theme-text-secondary transition-colors flex items-center gap-1 px-2 py-1 rounded"
-                >
-                  {copiedHandle === p.id ? (
-                    <><Check size={12} className="text-green-400" /> {t('promo.copied')}</>
-                  ) : (
-                    <><Copy size={12} /> {t('promo.copy')}</>
-                  )}
-                </button>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
Restructures the per-row layout in the "Tag your partners in the image" helper on the Promo widget's X/Twitter tab. The copy button now sits to the **left** of the avatar and is **icon-only** — no visible "Copy" / "Copied" label. Accessibility is preserved via `aria-label` + `title` (both reuse the existing `promo.copy` i18n key). The 2s copied-state still flashes a green check icon as the sole feedback.

Only `frontend/src/components/promo/SocialComposer.tsx` changes; no i18n keys added.

## Test plan
- [ ] Load Philadelphia event Promo widget → Social Media → X tab.
- [ ] Confirm each partner row now reads `[copy icon] [avatar] [name] @handle` (copy icon on the far left).
- [ ] Click the copy icon → it swaps to a green check for ~1.5s, then back to the copy icon. No visible text label.
- [ ] Hover the copy icon → tooltip says "Copy".
- [ ] Paste — clipboard contains the bare handle (no leading `@`).

## Preview
https://rsvpizza-git-neapolitan-49573-tag-copy-icon-left-pizza-dao.vercel.app