### PR TITLE
stuffed-crust-13319: gray logo cards on /partners

### DIFF
--- a/frontend/src/pages/PartnersPage.tsx
+++ b/frontend/src/pages/PartnersPage.tsx
@@ -15,6 +15,8 @@ const C = {
   darkText:  '#1a1a1a',
   mutedText: '#555',
   cardBg:    'rgba(255,255,255,0.92)',
+  // Logo tiles use a mid-gray so both white/cream and dark logos remain readable.
+  logoCardBg:'rgba(160,160,160,0.92)',
   cardBorder:'rgba(0,0,0,0.08)',
 };
 
@@ -164,7 +166,7 @@ export function PartnersPage() {
               const tile = (
                 <div
                   className="aspect-square flex items-center justify-center p-4 rounded-2xl border shadow-lg transition-transform duration-200 hover:scale-105"
-                  style={{ background: C.cardBg, borderColor: C.cardBorder }}
+                  style={{ background: C.logoCardBg, borderColor: C.cardBorder }}
                 >
                   <img
                     src={partner.logoUrl}
@@ -196,7 +198,7 @@ export function PartnersPage() {
                     {partner.name}
                   </div>
                   <div className="mt-1 flex justify-center">
-                    <span className="inline-block text-[10px] font-semibold rounded-full px-2 py-0.5 bg-[#E52828]/10 text-[#E52828]">
+                    <span className="inline-block text-[10px] font-bold rounded-full px-2 py-0.5 bg-[#E52828]/20 text-[#E52828]">
                       in {partner.eventCount.toLocaleString()}{' '}
                       {partner.eventCount === 1 ? 'event' : 'events'}
                     </span>


### PR DESCRIPTION
## Summary
- Changed `/partners` logo tile background from translucent white to a mid-gray (`rgba(160,160,160,0.92)`) so both dark and white/cream partner logos remain visible. Bumped the red event-count pill to `/20` + `font-bold` for better contrast against the gray. State cards (loading/error/empty) and the hero stat pill stay white as intended.

Preview: https://rsvpizza-git-stuffed-crust-13319-partners-gray-cards-pizza-dao.vercel.app/partners

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>