### PR TITLE
feat(diavola-18718): underboss-added partners read-only for hosts

### DIFF
--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -577,6 +577,16 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
       throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
     }
 
+    // Lock underboss-added partners as read-only for non-privileged users
+    const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
+    if (existingSponsor.addedByUnderboss && !userIsPrivileged) {
+      throw new AppError(
+        'Underboss-added partners are read-only — manage via /underboss',
+        403,
+        'PARTNER_READONLY'
+      );
+    }
+
     // Validate status if provided
     const validStatuses = ['todo', 'asked', 'yes', 'billed', 'paid', 'stuck', 'alum', 'skip'];
     if (status && !validStatuses.includes(status)) {
@@ -595,10 +605,6 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
       throw new AppError(`Invalid category. Must be one of: ${validCategories.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
 
-    // Protect contact fields for underboss-added sponsors from non-privileged users
-    const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
-    const stripContactFields = existingSponsor.addedByUnderboss && !userIsPrivileged;
-
     const sponsor = await prisma.sponsor.update({
       where: { id: sponsorId },
       data: {
@@ -608,10 +614,10 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
         ...(brandInstagram !== undefined && { brandInstagram: brandInstagram?.trim() || null }),
         ...(brandDescription !== undefined && { brandDescription: brandDescription?.trim() || null }),
         ...(pointPerson !== undefined && { pointPerson: pointPerson?.trim() || null }),
-        ...(!stripContactFields && contactName !== undefined && { contactName: contactName?.trim() || null }),
-        ...(!stripContactFields && contactEmail !== undefined && { contactEmail: contactEmail?.trim()?.toLowerCase() || null }),
-        ...(!stripContactFields && contactPhone !== undefined && { contactPhone: contactPhone?.trim() || null }),
-        ...(!stripContactFields && contactTwitter !== undefined && { contactTwitter: contactTwitter?.trim() || null }),
+        ...(contactName !== undefined && { contactName: contactName?.trim() || null }),
+        ...(contactEmail !== undefined && { contactEmail: contactEmail?.trim()?.toLowerCase() || null }),
+        ...(contactPhone !== undefined && { contactPhone: contactPhone?.trim() || null }),
+        ...(contactTwitter !== undefined && { contactTwitter: contactTwitter?.trim() || null }),
         ...(telegram !== undefined && { telegram: telegram?.trim() || null }),
         ...(status !== undefined && { status }),
         ...(amount !== undefined && { amount: amount !== null && amount !== '' ? amount : null }),
@@ -655,6 +661,16 @@ router.delete('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthRequ
 
     if (!existingSponsor) {
       throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
+    }
+
+    // Lock underboss-added partners as read-only for non-privileged users
+    const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
+    if (existingSponsor.addedByUnderboss && !userIsPrivileged) {
+      throw new AppError(
+        'Underboss-added partners are read-only — manage via /underboss',
+        403,
+        'PARTNER_READONLY'
+      );
     }
 
     await prisma.$transaction(async (tx) => {

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -13,6 +13,7 @@ import {
   getUnifiedSponsors,
   ensureUnderbossSponsors,
   updateSponsorUser,
+  fetchUnderbossMe,
 } from '../../lib/api';
 import { SponsorPipeline } from './SponsorPipeline';
 import { SponsorList } from './SponsorList';
@@ -35,6 +36,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isPrivileged, setIsPrivileged] = useState(false);
 
   // Form state
   const [showForm, setShowForm] = useState(false);
@@ -100,6 +102,26 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
     loadUnifiedPartners();
   }, [loadData, loadUnifiedPartners]);
 
+  // Detect whether the current user can manage underboss-added partners
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const me = await fetchUnderbossMe();
+        if (!cancelled) {
+          setIsPrivileged(!!me?.isAdmin || !!me?.isUnderboss);
+        }
+      } catch {
+        if (!cancelled) {
+          setIsPrivileged(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Reload unified partners when sponsors change
   useEffect(() => {
     loadUnifiedPartners();
@@ -107,6 +129,12 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
 
   // Handle form submission
   const handleFormSubmit = async (formData: PartnerFormData, coHostData?: { name: string; website: string; twitter: string; instagram: string; logoUrl: string; avatarUrl?: string }) => {
+    // Block edits to underboss-added partners for non-privileged users (belt-and-suspenders)
+    if (editingSponsor?.addedByUnderboss && !isPrivileged) {
+      setShowForm(false);
+      setEditingSponsor(null);
+      return;
+    }
     const data = extractSponsorData(formData);
     // Capture pre-edit snapshot for flyer-regen decision (only matters when editing)
     const previousSponsor = editingSponsor;
@@ -184,6 +212,10 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
   const handleDelete = async (sponsorId: string) => {
     // Capture sponsor before removing it so we can check if flyer needs regen
     const deletedSponsor = sponsors.find(s => s.id === sponsorId);
+    // Block deletes of underboss-added partners for non-privileged users (belt-and-suspenders)
+    if (deletedSponsor?.addedByUnderboss && !isPrivileged) {
+      return;
+    }
     const success = await deleteSponsor(partyId, sponsorId);
     if (success) {
       setSponsors(prev => prev.filter(s => s.id !== sponsorId));
@@ -201,6 +233,10 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
 
   // Handle editing
   const handleEdit = (sponsor: Sponsor) => {
+    // Block edits to underboss-added partners for non-privileged users (belt-and-suspenders)
+    if (sponsor.addedByUnderboss && !isPrivileged) {
+      return;
+    }
     setEditingSponsor(sponsor);
     setShowForm(true);
   };
@@ -221,6 +257,10 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
 
   // Handle inline status change with optimistic update
   const handleStatusChange = async (sponsor: Sponsor, newStatus: SponsorStatus) => {
+    // Block status changes on underboss-added partners for non-privileged users (belt-and-suspenders)
+    if (sponsor.addedByUnderboss && !isPrivileged) {
+      return;
+    }
     const oldStatus = sponsor.status;
 
     // Optimistic update
@@ -377,6 +417,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
         onStatusChange={handleStatusChange}
         isLoading={isRefreshing}
         avatarUrls={sponsorAvatarUrls}
+        isPrivileged={isPrivileged}
       />
 
       {/* Brand Description Order (Unified) */}

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ChevronUp, ChevronDown, Edit2, Trash2, ExternalLink,
-  Mail, Phone, User, Building2, Calendar, Globe
+  Mail, Phone, User, Building2, Calendar, Globe, Lock, X
 } from 'lucide-react';
 import { Sponsor, SponsorStatus, SPONSOR_CATEGORIES } from '../../types';
 import { PartnerIntakeButton } from './PartnerIntakeButton';
@@ -17,6 +17,7 @@ interface SponsorListProps {
   onStatusChange: (sponsor: Sponsor, newStatus: SponsorStatus) => void;
   isLoading?: boolean;
   avatarUrls?: Record<string, string>;
+  isPrivileged?: boolean;
 }
 
 type SortField = 'name' | 'status' | 'amount' | 'lastContactedAt' | 'createdAt';
@@ -44,12 +45,13 @@ const STATUS_ORDER: Record<SponsorStatus, number> = {
   skip: 7,
 };
 
-export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpdate, onStatusChange, isLoading, avatarUrls }: SponsorListProps) {
+export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpdate, onStatusChange, isLoading, avatarUrls, isPrivileged = false }: SponsorListProps) {
   const { t } = useTranslation('host');
   const [sortField, setSortField] = useState<SortField>('createdAt');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [filterStatus, setFilterStatus] = useState<SponsorStatus | 'all'>('all');
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [readOnlyDetailsSponsor, setReadOnlyDetailsSponsor] = useState<Sponsor | null>(null);
 
   const filteredAndSortedSponsors = useMemo(() => {
     let result = [...sponsors];
@@ -225,6 +227,7 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
           <tbody>
             {filteredAndSortedSponsors.map(sponsor => {
               const statusConfig = STATUS_CONFIG[sponsor.status];
+              const isLocked = !!sponsor.addedByUnderboss && !isPrivileged;
               return (
                 <tr
                   key={sponsor.id}
@@ -232,17 +235,26 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                 >
                   {/* Status */}
                   <td className="p-3">
-                    <select
-                      value={sponsor.status}
-                      onChange={(e) => onStatusChange(sponsor, e.target.value as SponsorStatus)}
-                      className={`status-pill rounded-full pl-2.5 pr-6 py-0.5 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-[#ff393a] cursor-pointer ${statusConfig.bgColor} ${statusConfig.color}`}
-                    >
-                      {Object.entries(STATUS_CONFIG).map(([status, config]) => (
-                        <option key={status} value={status} className="bg-theme-header text-theme-text">
-                          {t(config.labelKey)}
-                        </option>
-                      ))}
-                    </select>
+                    {isLocked ? (
+                      <span
+                        className={`inline-flex items-center justify-center rounded-full px-2.5 py-0.5 text-xs font-medium ${statusConfig.bgColor} ${statusConfig.color}`}
+                        title={t('sponsors.globalPartnerReadOnly')}
+                      >
+                        {t(statusConfig.labelKey)}
+                      </span>
+                    ) : (
+                      <select
+                        value={sponsor.status}
+                        onChange={(e) => onStatusChange(sponsor, e.target.value as SponsorStatus)}
+                        className={`status-pill rounded-full pl-2.5 pr-6 py-0.5 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-[#ff393a] cursor-pointer ${statusConfig.bgColor} ${statusConfig.color}`}
+                      >
+                        {Object.entries(STATUS_CONFIG).map(([status, config]) => (
+                          <option key={status} value={status} className="bg-theme-header text-theme-text">
+                            {t(config.labelKey)}
+                          </option>
+                        ))}
+                      </select>
+                    )}
                   </td>
 
                   {/* Sponsor Name & Organization */}
@@ -349,29 +361,43 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                   {/* Actions */}
                   <td className="p-3">
                     <div className="flex items-center justify-end gap-1">
-                      <PartnerIntakeButton
-                        sponsor={sponsor}
-                        partyId={partyId}
-                        onUpdate={onSponsorUpdate}
-                      />
-                      <button
-                        onClick={() => onEdit(sponsor)}
-                        className="p-1.5 text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover rounded transition-colors"
-                        title="Edit"
-                      >
-                        <Edit2 size={16} />
-                      </button>
-                      <button
-                        onClick={() => handleDeleteClick(sponsor.id)}
-                        className={`p-1.5 rounded transition-colors ${
-                          deleteConfirm === sponsor.id
-                            ? 'bg-red-500/20 text-red-400'
-                            : 'text-theme-text-muted hover:text-red-400 hover:bg-red-500/10'
-                        }`}
-                        title={deleteConfirm === sponsor.id ? 'Click again to confirm' : 'Delete'}
-                      >
-                        <Trash2 size={16} />
-                      </button>
+                      {!isLocked && (
+                        <PartnerIntakeButton
+                          sponsor={sponsor}
+                          partyId={partyId}
+                          onUpdate={onSponsorUpdate}
+                        />
+                      )}
+                      {isLocked ? (
+                        <button
+                          onClick={() => setReadOnlyDetailsSponsor(sponsor)}
+                          className="p-1.5 text-purple-400 hover:text-purple-300 hover:bg-purple-500/10 rounded transition-colors"
+                          title={t('sponsors.globalPartnerReadOnly')}
+                        >
+                          <Lock size={16} />
+                        </button>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => onEdit(sponsor)}
+                            className="p-1.5 text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover rounded transition-colors"
+                            title="Edit"
+                          >
+                            <Edit2 size={16} />
+                          </button>
+                          <button
+                            onClick={() => handleDeleteClick(sponsor.id)}
+                            className={`p-1.5 rounded transition-colors ${
+                              deleteConfirm === sponsor.id
+                                ? 'bg-red-500/20 text-red-400'
+                                : 'text-theme-text-muted hover:text-red-400 hover:bg-red-500/10'
+                            }`}
+                            title={deleteConfirm === sponsor.id ? 'Click again to confirm' : 'Delete'}
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        </>
+                      )}
                     </div>
                   </td>
                 </tr>
@@ -380,6 +406,91 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
           </tbody>
         </table>
       </div>
+
+      {/* Read-only details modal for underboss-added partners */}
+      {readOnlyDetailsSponsor && (() => {
+        const s = readOnlyDetailsSponsor;
+        const statusConfig = STATUS_CONFIG[s.status];
+        return (
+          <div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+            onClick={() => setReadOnlyDetailsSponsor(null)}
+          >
+            <div
+              className="card bg-theme-header border-theme-stroke max-w-lg w-full max-h-[90vh] overflow-y-auto"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between p-4 border-b border-theme-stroke">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Lock size={16} className="text-purple-400 flex-shrink-0" />
+                  <h3 className="text-base font-semibold text-theme-text truncate">{s.name}</h3>
+                </div>
+                <button
+                  onClick={() => setReadOnlyDetailsSponsor(null)}
+                  className="p-1.5 text-theme-text-muted hover:text-theme-text rounded transition-colors flex-shrink-0"
+                  aria-label="Close"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+              <div className="p-4 space-y-4">
+                <p className="text-xs text-purple-400 flex items-center gap-1">
+                  <Globe size={12} /> {t('sponsors.globalPartnerReadOnly')}
+                </p>
+
+                {s.logoUrl && (
+                  <div>
+                    <div className="text-xs text-theme-text-muted uppercase tracking-wider mb-1">Logo</div>
+                    <img
+                      src={cdnUrl(s.logoUrl)}
+                      alt=""
+                      className="w-20 h-20 rounded-lg object-cover bg-theme-surface border border-theme-stroke"
+                    />
+                  </div>
+                )}
+
+                <div>
+                  <div className="text-xs text-theme-text-muted uppercase tracking-wider mb-1">{t('sponsors.status')}</div>
+                  <span
+                    className={`inline-flex items-center justify-center rounded-full px-2.5 py-0.5 text-xs font-medium ${statusConfig.bgColor} ${statusConfig.color}`}
+                  >
+                    {t(statusConfig.labelKey)}
+                  </span>
+                </div>
+
+                {s.brandDescription && (
+                  <div>
+                    <div className="text-xs text-theme-text-muted uppercase tracking-wider mb-1">Brand Description</div>
+                    <p className="text-sm text-theme-text whitespace-pre-wrap">{s.brandDescription}</p>
+                  </div>
+                )}
+
+                {s.website && (
+                  <div>
+                    <div className="text-xs text-theme-text-muted uppercase tracking-wider mb-1">Website</div>
+                    <a
+                      href={s.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-theme-text-secondary hover:text-theme-text inline-flex items-center gap-1 break-all"
+                    >
+                      {s.website}
+                      <ExternalLink size={12} className="flex-shrink-0" />
+                    </a>
+                  </div>
+                )}
+
+                {s.amount !== null && s.amount !== undefined && (
+                  <div>
+                    <div className="text-xs text-theme-text-muted uppercase tracking-wider mb-1">{t('sponsors.amount')}</div>
+                    <p className="text-sm text-theme-text font-medium">{formatCurrency(s.amount)}</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -273,6 +273,7 @@
     "brandDescriptionOrder": "Brand Description Order",
     "dragToReorder": "(drag to reorder on event page)",
     "global": "Global",
+    "globalPartnerReadOnly": "Global partner — managed via /underboss",
     "tryAgain": "Try Again",
     "noPartnersYet": "No partners yet",
     "noPartnersDesc": "Add your first partner to start tracking your fundraising pipeline.",

--- a/plans/diavola-18718-underboss-partner-readonly.md
+++ b/plans/diavola-18718-underboss-partner-readonly.md
@@ -1,0 +1,94 @@
+# diavola-18718 — Underboss-added partners are read-only for hosts
+
+**Priority:** P2
+**Branch:** `diavola-18718-underboss-readonly`
+**Worktree:** `.claude/worktrees/diavola-18718-underboss-readonly/`
+
+## Problem
+
+Partners that get bulk-created on a host's event via the `/underboss` auto-sync (where `Sponsor.addedByUnderboss === true`) are global resources and shouldn't be host-editable. Today the backend half-protects them — contact fields are stripped on GET and ignored on PATCH for non-privileged users — but hosts can still:
+
+- Edit `name`, `website`, `brandDescription`, `logoUrl`, `status`, `amount`, etc.
+- Change pipeline status via the inline status pill in `SponsorList`.
+- Delete the partner outright (no DELETE gate at all).
+- See edit/trash icons in the UI with no indication these are global.
+
+Snax wants these partners **fully read-only** for hosts. The full unlock stays with `/underboss` (`isUnderboss` or `super_admin`).
+
+## Approach
+
+Two layers, both required:
+
+1. **Backend (authoritative gate)** — return `403` on PATCH and DELETE when the sponsor has `addedByUnderboss=true` and the caller is not super-admin / underboss. Drop the now-redundant contact-field stripping in PATCH.
+2. **Frontend (affordance)** — hide edit/delete actions and lock the status pill on underboss-added rows for non-privileged users; show a "Global Partner" indicator with a hint that it's managed via `/underboss`.
+
+GET responses are left as-is — sponsors still appear in the host's list (read-only) so they show on the flyer / brand-desc list and the host knows they're confirmed.
+
+## Files to modify
+
+### Backend
+
+**`backend/src/routes/sponsor.routes.ts`**
+
+1. Add a small helper near the top (or inline in each handler):
+   ```ts
+   const userIsPrivileged = await isSuperAdmin(req.userEmail) || await isUnderboss(req.userEmail);
+   ```
+2. **PATCH `/:partyId/sponsors/:sponsorId`** (line 533): after the `existingSponsor` fetch, if `existingSponsor.addedByUnderboss && !userIsPrivileged` → throw `new AppError('Underboss-added partners are read-only — manage via /underboss', 403, 'PARTNER_READONLY')`. Then remove the existing `stripContactFields` logic and `!stripContactFields &&` guards on lines 598–614 (no longer reachable).
+3. **DELETE `/:partyId/sponsors/:sponsorId`** (line 635): after the `existingSponsor` fetch, same 403 gate.
+4. **GET `/:partyId/sponsors/:sponsorId`** (line 496) and **GET `/:partyId/sponsors`** (line 11): leave the contact-info stripping as-is. Hosts still see the row, but contact info stays hidden.
+
+### Frontend
+
+**`frontend/src/components/sponsors/SponsorCRM.tsx`**
+
+1. Add `isPrivileged` state (default `false`). On mount, call `fetchUnderbossMe()` (already exported from `lib/api.ts`) and set `isPrivileged = result.isAdmin || result.isUnderboss`. Tolerate non-2xx (treat as not privileged).
+2. Pass `isPrivileged` into `<SponsorList ... isPrivileged={isPrivileged} />`.
+3. In `handleEdit` (line 203): early-return if `sponsor.addedByUnderboss && !isPrivileged` (belt-and-suspenders — button will already be hidden).
+4. In `handleStatusChange` (line 223): same early-return.
+5. In `handleDelete` (line 184): same early-return.
+6. `handleFormSubmit` (line 109) — also early-return for safety if user somehow opened the form for an underboss-added sponsor while non-privileged.
+
+**`frontend/src/components/sponsors/SponsorList.tsx`**
+
+1. Add `isPrivileged?: boolean` to `SponsorListProps` (default `false`).
+2. In the actions cell (lines 350–376), wrap edit and delete buttons in `{(!sponsor.addedByUnderboss || isPrivileged) && (...)}`. When the buttons are hidden, render a `Lock` icon (lucide, `text-purple-400`, `title={t('sponsors.globalPartnerReadOnly')}`) so the row doesn't look broken. Clicking the lock should open a **read-only details modal** for the partner — re-use `PartnerForm` if practical by adding a `readOnly` prop that disables every input/submit button, OR render a simpler read-only summary panel showing name, brand description, website, logo, status, and amount. Either approach is fine — pick whichever is less invasive. Modal close behavior follows existing patterns (backdrop click + `z-50`).
+3. In the status `<select>` (lines 235–245): when `sponsor.addedByUnderboss && !isPrivileged`, render the status as a static pill (re-use `STATUS_CONFIG` styling) instead of an editable select. Keep dimensions consistent with the select to avoid layout shift.
+4. Keep the existing "Global partner" label in the Contact cell (line 318) — it's complementary.
+
+**`frontend/src/i18n/locales/en/host.json`** (and any peer locale files if the agent has time, but EN is the only must-have):
+
+- Add `sponsors.globalPartnerReadOnly`: `"Global partner — managed via /underboss"` (or similar concise copy).
+
+### No DB changes
+
+`addedByUnderboss` already exists on the `Sponsor` model (migration `20260510_add_added_by_underboss.sql`, Prisma `schema.prisma:910`). No new column, no Supabase migration, no `dbPartyToParty` updates — `Sponsor` doesn't flow through `PizzaContext`.
+
+## Verification
+
+1. **Backend types compile & lint**: `cd backend && npm run typecheck` (or `npx tsc --noEmit`).
+2. **Frontend types compile**: `cd frontend && npm run typecheck`.
+3. **Manual test on Vercel preview** (`https://rsvpizza-git-diavola-18718-underboss-readonly-pizza-dao.vercel.app`):
+   - Pick a GPP event with at least one underboss-added partner (any tag-matched partner that auto-synced).
+   - **As a normal host** (not Snax — log in as a non-underboss email if possible; otherwise simulate by checking against `isUnderbossMe()`): visit `/host/{slug}` → Partners tab.
+     - The underboss-added partner row appears, but edit and trash icons are gone and the status pill is non-interactive. Lock icon visible.
+     - Direct PATCH via `curl` to `/api/parties/.../sponsors/{id}` returns `403 PARTNER_READONLY`.
+     - Direct DELETE returns `403`.
+   - **As Snax (super-admin/underboss)**: same partner is still fully editable, edit/delete icons present, status pill interactive, PATCH/DELETE succeed.
+   - Non-underboss-added partners on the same event remain fully editable for hosts.
+
+## Acceptance
+
+- Host sees underboss-added partner in the list but cannot edit, delete, or change its status.
+- Backend rejects host PATCH/DELETE with 403.
+- Super-admin / underboss workflow is unchanged.
+- No regression on host-created partners.
+
+## Notes for implementation agent
+
+- Branch from `master`. Use the worktree path above.
+- Frontend uses `IconInput`, `Checkbox`, etc. but this task doesn't introduce new inputs — no new form fields needed.
+- `fetchUnderbossMe()` already exists in `frontend/src/lib/api.ts:2516`. The endpoint is auth-required; if the user isn't logged in it'll throw — wrap the call in a try/catch and default `isPrivileged=false`.
+- The flyer-regen logic in `handleFormSubmit` / `handleDelete` / `handleStatusChange` (calls to `triggerFlyerRegen`) is unaffected — those code paths simply won't run for read-only partners.
+- Per `[[architecture_two_checklist_renderers]]`-style audit instinct: search for any other component that renders/edits sponsors before declaring done. Likely just `SponsorList` and `PartnerForm`, but grep `addedByUnderboss` across `frontend/src` for completeness.
+- Open a **draft** PR. Title: `feat(diavola-18718): underboss-added partners read-only for hosts`. PR body should include the verification checklist above.


### PR DESCRIPTION
## Summary

Lock partners added by `/underboss` auto-sync (`Sponsor.addedByUnderboss === true`) as fully read-only for hosts. The full unlock stays with `/underboss` (`isUnderboss` or `super_admin`).

- **Backend (authoritative)** — `PATCH /api/parties/:partyId/sponsors/:sponsorId` and `DELETE` now return `403 PARTNER_READONLY` when the sponsor is `addedByUnderboss` and the caller is not super-admin/underboss.
- **Backend** — Removed the now-redundant per-field `stripContactFields` logic in PATCH (superseded by the full 403 gate).
- **Frontend** — `SponsorCRM` calls `fetchUnderbossMe()` and derives `isPrivileged`; passes it to `SponsorList`. Edit/delete/intake action buttons are hidden for underboss-added rows; the inline status `<select>` is replaced with a static pill matching `STATUS_CONFIG` styling. A `Lock` icon (purple) replaces the actions and opens a read-only details modal showing name, logo, status, brand description, website, and amount.
- **Frontend** — Defensive early-returns in `handleEdit`, `handleDelete`, `handleStatusChange`, and `handleFormSubmit` for the same condition.
- **i18n** — Added `sponsors.globalPartnerReadOnly` to `en/host.json`.

No DB migration. `addedByUnderboss` already exists on `Sponsor`.

## Preview

https://rsvpizza-git-diavola-18718-underboss-readonly-pizza-dao.vercel.app

**Note:** Backend changes will NOT take effect on the preview (backend deploys only from `master`). Frontend gating will work on preview; the 403s only apply after merge.

## Verification

### Host POV (non-privileged user)
- [ ] Underboss-added partner row appears in `/host/{slug}` Partners tab
- [ ] Edit and trash icons are absent
- [ ] Status pill is non-interactive (no dropdown)
- [ ] `Lock` icon visible — clicking it opens read-only details modal
- [ ] Modal shows name, logo, status, brand description, website, amount; close via backdrop or X
- [ ] After merge: direct `curl -X PATCH .../sponsors/{id}` returns `403 PARTNER_READONLY`
- [ ] After merge: direct `curl -X DELETE .../sponsors/{id}` returns `403`

### Privileged POV (super-admin / underboss)
- [ ] Same partner shows edit and trash icons
- [ ] Status pill is interactive
- [ ] PATCH and DELETE still succeed

### No regression
- [ ] Non-underboss-added partners on the same event remain fully editable for hosts

## Test plan

- [ ] Open a GPP event with at least one auto-synced underboss partner as a non-privileged host
- [ ] Confirm UI gating per the checklist above
- [ ] As Snax (super-admin), confirm full editing still works