### PR TITLE
napoletana-92383: admin click-through on /partners "in X events"

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -320,8 +320,8 @@ app.get('/api', (req, res) => {
       "category": "community",
       "eventCount": 423,
       "events": [
-        { "slug": "london", "city": "London" },
-        { "slug": "saopaulo", "city": "São Paulo" }
+        { "slug": "london", "city": "London", "sponsorId": "clz0a1b2c3d4e5f6g7h8i9j0" },
+        { "slug": "saopaulo", "city": "São Paulo", "sponsorId": "clz0k1l2m3n4o5p6q7r8s9t0" }
       ]
     }
   ],

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -795,6 +795,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
         logoUrl: { not: null },
       },
       select: {
+        id: true,
         name: true,
         logoUrl: true,
         website: true,
@@ -841,7 +842,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
       brandInstagram: string | null;
       category: string | null;
       eventCount: number;
-      events: { slug: string; city: string }[];
+      events: { slug: string; city: string; sponsorId: string }[];
       // tie-break tracking
       bestSortOrder: number;
       bestCreatedAt: Date;
@@ -872,7 +873,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
         agg.eventCount += 1;
         // Cap events array at 500 to defend against pathological payload size.
         if (agg.events.length < 500 && slug) {
-          agg.events.push({ slug, city });
+          agg.events.push({ slug, city, sponsorId: s.id });
         }
         // Tie-break: prefer the representative row with lowest sortOrder; if tied,
         // prefer the more recent createdAt.
@@ -903,7 +904,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
           brandInstagram: s.brandInstagram,
           category: s.category,
           eventCount: 1,
-          events: slug ? [{ slug, city }] : [],
+          events: slug ? [{ slug, city, sponsorId: s.id }] : [],
           bestSortOrder: s.sortOrder,
           bestCreatedAt: s.createdAt,
         };

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import { usePizza } from '../../contexts/PizzaContext';
 import { getSponsors, createSponsor, updateSponsor, reorderSponsors } from '../../lib/api';
 import { getDateTimeInTimezone } from '../../utils/dateUtils';
@@ -286,6 +287,17 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
   useEffect(() => {
     loadSponsors();
   }, [loadSponsors]);
+
+  // Deep-link from /partners modal: ?openSponsor=<id> auto-opens that sponsor's edit modal
+  // once the sponsors list is loaded. Only fires when the URL param changes (or sponsors
+  // first arrive), not repeatedly.
+  const [searchParams] = useSearchParams();
+  const openSponsorId = searchParams.get('openSponsor');
+  useEffect(() => {
+    if (!openSponsorId || !sponsors.length) return;
+    const target = sponsors.find(s => s.id === openSponsorId);
+    if (target) setEditingSponsor(target);
+  }, [openSponsorId, sponsors]);
 
   /** Move a group logo left or right by swapping it with its neighbor in the group view. */
   const handleReorderLogo = useCallback(async (sponsorId: string, direction: -1 | 1, groupLogos: Sponsor[]) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3321,7 +3321,7 @@ export interface GPPPartner {
   brandInstagram: string | null;
   category: string | null;
   eventCount: number;
-  events: { slug: string; city: string }[];
+  events: { slug: string; city: string; sponsorId: string }[];
 }
 
 export interface GPPPartnersResponse {

--- a/frontend/src/pages/PartnersPage.tsx
+++ b/frontend/src/pages/PartnersPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { Loader2 } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 import { GPPClouds } from '../components/GPPClouds';
-import { fetchGppPartners, GPPPartner } from '../lib/api';
+import { fetchGppPartners, fetchUnderbossMe, GPPPartner } from '../lib/api';
 
 /* ── colour tokens (from the 2026 flyer) ────────────────── */
 const C = {
@@ -21,9 +22,20 @@ const C = {
 };
 
 export function PartnersPage() {
+  const navigate = useNavigate();
   const [partners, setPartners] = useState<GPPPartner[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Role detection (default to all-false — 401 / network errors are silent)
+  const [roles, setRoles] = useState<{ isAdmin: boolean; isUnderboss: boolean; isGraphicsAdmin: boolean }>({
+    isAdmin: false,
+    isUnderboss: false,
+    isGraphicsAdmin: false,
+  });
+
+  // Active modal partner (null = closed)
+  const [modalPartner, setModalPartner] = useState<GPPPartner | null>(null);
 
   const loadPartners = () => {
     setLoading(true);
@@ -43,6 +55,46 @@ export function PartnersPage() {
   useEffect(() => {
     loadPartners();
   }, []);
+
+  // Role check on mount. 401 / network errors -> logged-out user, default all-false.
+  useEffect(() => {
+    fetchUnderbossMe()
+      .then((me) => {
+        setRoles({
+          isAdmin: !!me.isAdmin,
+          isUnderboss: !!me.isUnderboss,
+          isGraphicsAdmin: !!me.isGraphicsAdmin,
+        });
+      })
+      .catch(() => {
+        // 401 for logged-out users is expected; ignore silently
+      });
+  }, []);
+
+  const canClick = roles.isAdmin || roles.isUnderboss || roles.isGraphicsAdmin;
+
+  // ESC closes modal
+  useEffect(() => {
+    if (!modalPartner) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setModalPartner(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [modalPartner]);
+
+  // Click on an event row inside the modal -> navigate based on role.
+  // Check isGraphicsAdmin FIRST (most specific role) — admins/underbosses who also
+  // hold the graphics-admin flag go to the flyer editor; everyone else goes to
+  // the public event page.
+  const handleEventClick = (slug: string, sponsorId: string) => {
+    if (roles.isGraphicsAdmin) {
+      navigate('/graphics/' + slug + '/edit?openSponsor=' + sponsorId);
+    } else {
+      navigate('/' + slug);
+    }
+    setModalPartner(null);
+  };
 
   const totalEvents = partners.reduce((sum, p) => sum + p.eventCount, 0);
 
@@ -177,6 +229,13 @@ export function PartnersPage() {
                 </div>
               );
 
+              const pillText = (
+                <>
+                  in {partner.eventCount.toLocaleString()}{' '}
+                  {partner.eventCount === 1 ? 'event' : 'events'}
+                </>
+              );
+
               return (
                 <div key={`${partner.name}-${partner.logoUrl}`} className="flex flex-col">
                   {partner.website ? (
@@ -198,10 +257,23 @@ export function PartnersPage() {
                     {partner.name}
                   </div>
                   <div className="mt-1 flex justify-center">
-                    <span className="inline-block text-[10px] font-bold rounded-full px-2 py-0.5 bg-[#E52828]/20 text-[#E52828]">
-                      in {partner.eventCount.toLocaleString()}{' '}
-                      {partner.eventCount === 1 ? 'event' : 'events'}
-                    </span>
+                    {canClick ? (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setModalPartner(partner);
+                        }}
+                        className="inline-block text-[10px] font-bold rounded-full px-2 py-0.5 bg-[#E52828]/20 text-[#E52828] cursor-pointer hover:scale-105 transition-transform"
+                      >
+                        {pillText}
+                      </button>
+                    ) : (
+                      <span className="inline-block text-[10px] font-bold rounded-full px-2 py-0.5 bg-[#E52828]/20 text-[#E52828]">
+                        {pillText}
+                      </span>
+                    )}
                   </div>
                 </div>
               );
@@ -209,6 +281,90 @@ export function PartnersPage() {
           </div>
         )}
       </div>
+
+      {/* ─── EVENTS MODAL (admin/underboss/graphics-admin only) ─── */}
+      {modalPartner && (
+        <div
+          className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+          onClick={() => setModalPartner(null)}
+        >
+          <div
+            className="bg-white rounded-2xl shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col relative overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Close button */}
+            <button
+              type="button"
+              onClick={() => setModalPartner(null)}
+              aria-label="Close"
+              className="absolute top-3 right-3 z-10 p-2 rounded-full hover:bg-black/5 transition-colors"
+              style={{ color: C.darkText }}
+            >
+              <X size={20} />
+            </button>
+
+            {/* Header */}
+            <div className="flex items-center gap-4 p-5 border-b" style={{ borderColor: C.cardBorder }}>
+              <div
+                className="flex-shrink-0 w-16 h-16 rounded-lg flex items-center justify-center p-2"
+                style={{ background: C.logoCardBg }}
+              >
+                <img
+                  src={modalPartner.logoUrl}
+                  alt={modalPartner.name}
+                  className="max-w-full max-h-full object-contain"
+                />
+              </div>
+              <div className="flex-1 min-w-0 pr-8">
+                <div
+                  className="truncate"
+                  style={{
+                    fontFamily: "'Bangers', cursive",
+                    fontSize: '1.6rem',
+                    color: C.darkText,
+                    letterSpacing: '0.02em',
+                    lineHeight: 1.1,
+                  }}
+                >
+                  {modalPartner.name}
+                </div>
+                <div className="text-xs mt-1" style={{ color: C.mutedText }}>
+                  in {modalPartner.eventCount.toLocaleString()}{' '}
+                  {modalPartner.eventCount === 1 ? 'event' : 'events'}
+                </div>
+              </div>
+            </div>
+
+            {/* Event list */}
+            <div className="overflow-y-auto max-h-[60vh]">
+              {modalPartner.events.length === 0 ? (
+                <div className="p-6 text-center text-sm" style={{ color: C.mutedText }}>
+                  No events to show.
+                </div>
+              ) : (
+                <ul className="divide-y" style={{ borderColor: C.cardBorder }}>
+                  {modalPartner.events.map((ev, idx) => (
+                    <li key={`${ev.sponsorId}-${idx}`}>
+                      <button
+                        type="button"
+                        onClick={() => handleEventClick(ev.slug, ev.sponsorId)}
+                        className="w-full text-left px-5 py-3 hover:bg-black/5 transition-colors flex items-center justify-between gap-3"
+                      >
+                        <span className="font-semibold text-sm truncate" style={{ color: C.darkText }}>
+                          {ev.city}
+                        </span>
+                        <span className="text-xs font-mono truncate" style={{ color: C.mutedText }}>
+                          /{ev.slug}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/plans/napoletana-92383-partners-admin-click.md
+++ b/plans/napoletana-92383-partners-admin-click.md
@@ -1,0 +1,107 @@
+# napoletana-92383: Admin click-through on /partners "in X events"
+
+**Priority**: P3
+**Type**: Feature
+**Branch**: `napoletana-92383-partners-admin-click`
+**Preview**: `https://rsvpizza-git-napoletana-92383-partners-admin-click-pizza-dao.vercel.app/partners`
+
+## Goal
+
+When an admin / underboss / graphics admin is logged in and visits `/partners`, make the "in N events" pill on each logo tile **clickable**. Clicking it opens a modal listing every event that lists that partner, with each event clickable:
+
+| Visitor role | Click on "in X events" | Click on event in modal |
+|---|---|---|
+| Public (logged out) | No-op (pill stays display-only) | — |
+| Admin / Underboss | Opens events modal | Navigates to `/{slug}` (the public event page) |
+| Graphics admin | Opens events modal | Navigates to `/graphics/{slug}/edit?openSponsor={sponsorId}` with that partner's edit modal pre-opened on the flyer generator |
+
+Single modal, role-dependent click targets — simpler than two flows.
+
+## Changes required
+
+### 1. Backend — `backend/src/routes/gpp.routes.ts`
+
+The current `GET /api/gpp/partners` response includes `events: [{slug, city}]` per partner. Extend each event entry to also carry `sponsorId` (the per-event `Sponsor` row id, which the graphics admin link needs to deep-link to the right modal).
+
+- In the `findMany` `select`, the `id` field on `Sponsor` is already implicit (Prisma always returns `id` unless `select` is restrictive). Confirm by re-reading the current `select`; if `id` isn't selected, add it.
+- In the aggregation loop, when appending an event to a partner's `events` array, also store `sponsorId: row.id`.
+- Update the `GPPPartner` response type doc in `backend/src/index.ts` (`<h2>Partners</h2>` block) to reflect the added field.
+
+### 2. Frontend — `frontend/src/lib/api.ts`
+
+Update the `GPPPartner` TypeScript interface — add `sponsorId: string` to the `events` array entry shape:
+
+```ts
+events: { slug: string; city: string; sponsorId: string }[];
+```
+
+### 3. Frontend — `frontend/src/pages/PartnersPage.tsx`
+
+#### Role detection
+- On mount, call `fetchAdminMe()` (already in `lib/api.ts:2410`). Pattern reference: `EventsMapPage.tsx:47` (`if (me.isAdmin || me.isUnderboss) { ... }`).
+- Store `{ isAdmin, isUnderboss, isGraphicsAdmin }` in component state. Default to all-false on 401 (the fetch fails for logged-out users — catch and silently default).
+- `canClick = isAdmin || isUnderboss || isGraphicsAdmin`.
+
+#### Tile rendering
+- When `canClick`, render the "in N events" pill as a `<button>` (not a `<span>`). Style: existing pill styling + `cursor-pointer hover:scale-105 transition-transform`. **Important**: stop event propagation on click so it doesn't trigger the outer `<a>` that wraps the tile.
+- When `!canClick`, leave the pill as a `<span>` (no behavior change).
+- Click handler: `setModalPartner(partner)`.
+
+#### Modal
+- Add a single modal component inline (don't create a new file). Use the project's standard modal pattern from CLAUDE.md: `fixed inset-0 z-50 bg-black/60 backdrop-blur-sm` backdrop + centered white card.
+- Backdrop click closes; ESC key closes; close button (X) in top-right.
+- Card content:
+  - Header: partner logo (small, 64x64 on gray bg square), partner name in Bangers font, "in N events" subhead.
+  - Scrollable list of events (`max-h-[60vh] overflow-y-auto`). Each row: city name + slug. On click, navigate based on role:
+    - `isGraphicsAdmin` (and NOT admin/underboss -> check `isGraphicsAdmin` first since it's the more specific role): `navigate('/graphics/' + slug + '/edit?openSponsor=' + sponsorId)`
+    - Otherwise: `navigate('/' + slug)`
+  - Use `react-router-dom`'s `useNavigate`.
+- Style the modal card so it looks coherent with the rest of the GPP visual identity: rounded-2xl, shadow-xl, padding, but white background (not gray - readability of the event list matters more than aesthetic consistency).
+
+### 4. Frontend — `frontend/src/components/flyer/FlyerGenerator.tsx`
+
+The flyer generator already has `const [editingSponsor, setEditingSponsor] = useState<Sponsor | null>(null);` (line 64). Add a `useEffect` that reads `?openSponsor=<id>` from `useSearchParams` on mount and, once `party?.sponsors` is loaded, sets `editingSponsor` to the matching one.
+
+```tsx
+import { useSearchParams } from 'react-router-dom';
+// ...
+const [searchParams] = useSearchParams();
+const openSponsorId = searchParams.get('openSponsor');
+useEffect(() => {
+  if (!openSponsorId || !party?.sponsors?.length) return;
+  const target = party.sponsors.find(s => s.id === openSponsorId);
+  if (target) setEditingSponsor(target);
+}, [openSponsorId, party?.sponsors]);
+```
+
+Place the effect near the other useEffect hooks at the top of the component. Don't run repeatedly - the dependency on `openSponsorId` ensures it only fires when the URL has the param.
+
+## Constraints
+
+- **Do NOT** change anything else on the partners page (gradient, header, hero, grid, gray-cards work that just shipped).
+- **Do NOT** add new components or new files. Modal is inline in `PartnersPage.tsx`.
+- **Do NOT** change the public response shape beyond adding `sponsorId` to event entries.
+- Reuse `fetchAdminMe` - don't roll a new role-check fetcher.
+- 401 from `fetchAdminMe` is normal for logged-out users - catch silently.
+
+## Verification
+
+1. `cd backend && npx tsc --noEmit` - passes.
+2. `cd frontend && npx tsc --noEmit` - passes.
+3. Hit `/api/gpp/partners` on local backend - confirm `sponsorId` appears on each event entry.
+4. Confirm public view: pill not clickable, no modal.
+5. Confirm logged-in admin view: pill clickable, modal opens, event link goes to `/{slug}`.
+6. Confirm graphics-admin view: pill clickable, modal opens, event link goes to `/graphics/{slug}/edit?openSponsor={id}` and that page opens the right sponsor's edit modal.
+
+## Deploy order
+
+Backend change is additive (new field on response). Frontend depends on it only for graphics admin path. Standard sequence:
+1. Merge PR -> backend deploys (`vercel --prod --scope pizza-dao`).
+2. Frontend auto-deploys.
+3. Verify all three role paths.
+
+## Out of scope / open questions
+
+1. **Bulk SponsorUser-level logo update.** Graphics admin currently has to fix one event's flyer at a time. If they want "update the logo everywhere at once", that's the `PartnerManager` in /underboss, not this feature. Could add a "edit master partner record" button in the modal for graphics admin in a follow-up.
+2. **City name cleanup.** Earlier curl showed cities like "Seoul  Give Your Agent a Pizza" - the "Global Pizza Party {City}" strip in the aggregator doesn't handle all naming variations. Separate task.
+3. **Stand With Crypto / Stand With Crypto EU dedupe collision.** Open Q4 from stromboli-48177.


### PR DESCRIPTION
## Summary

When an admin / underboss / graphics admin is logged in and visits `/partners`, the "in N events" pill on each partner tile is now clickable. It opens an inline modal listing every event that features that partner; each event row is also clickable.

- **Admin / underboss**: clicking an event in the modal navigates to `/{slug}` (the public event page).
- **Graphics admin**: clicking an event navigates to `/graphics/{slug}/edit?openSponsor={sponsorId}` which auto-opens that partner's edit modal in the flyer editor.
- **Public (logged-out)**: pill remains a non-clickable `<span>` — zero behavior change.

## Changes

- **Backend** (`backend/src/routes/gpp.routes.ts`, `backend/src/index.ts`): `/api/gpp/partners` response now includes `sponsorId` on each entry of every partner's `events` array (additive — no removed fields). API docs updated.
- **Frontend** (`frontend/src/lib/api.ts`): `GPPPartner.events[]` entry shape extended with `sponsorId: string`.
- **Frontend** (`frontend/src/pages/PartnersPage.tsx`): role detection via `fetchUnderbossMe()` (catches 401 silently for logged-out users), conditional `<button>` vs `<span>` pill, inline modal (standard project pattern: fixed backdrop + white card + ESC/backdrop-click close), role-aware event row click handler.
- **Frontend** (`frontend/src/components/flyer/FlyerGenerator.tsx`): `useSearchParams` hook reads `?openSponsor=<id>` on mount and, once the sponsor list is loaded, opens that sponsor's edit modal automatically. Fires only when the URL param or sponsor list changes.

## Deploy note

Backend must merge to `master` and redeploy (`cd backend && vercel --prod --scope pizza-dao`) **before** the graphics-admin path works on preview — the preview frontend talks to the production backend, and the new `sponsorId` field needs to exist there. The admin/underboss path works on preview immediately (it doesn't depend on the new field).

## Test plan

- [ ] Visit `/partners` logged out — pill is a non-clickable span, no modal opens
- [ ] Log in as admin — pill is clickable, modal opens, clicking an event navigates to `/{slug}`
- [ ] Log in as underboss — same behavior as admin
- [ ] Log in as graphics admin — clicking an event navigates to `/graphics/{slug}/edit?openSponsor={id}` and the right Sponsor's edit modal opens automatically
- [ ] ESC closes the modal; backdrop click closes the modal; X button closes the modal
- [ ] Pill click does not trigger the outer `<a>` tile (no website navigation)