### PR TITLE
sausage-24183: frontend for bulk-DM hosts via Telegram bot

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -2,10 +2,11 @@
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { User, Lock, Image as ImageIcon, FileText, Loader2, X, Square as SquareIcon, Trash2, Calendar, Play, DollarSign, Wand2, MessageCircle } from 'lucide-react';
+import { User, Lock, Image as ImageIcon, FileText, Loader2, X, Square as SquareIcon, Trash2, Calendar, Play, DollarSign, Wand2, MessageCircle, Send, Check } from 'lucide-react';
 import { IconInput } from './IconInput';
 import { usePizza } from '../contexts/PizzaContext';
 import { updateParty, uploadEventImage, deleteParty } from '../lib/supabase';
+import { mintHostTelegramConnectToken, disconnectHostTelegram } from '../lib/api';
 import { CustomUrlInput } from './CustomUrlInput';
 import { LocationAutocomplete } from './LocationAutocomplete';
 import { TimePickerInput } from './TimePickerInput';
@@ -49,6 +50,40 @@ export const EventDetailsTab: React.FC = () => {
   const [nftChain, setNftChain] = useState<string>('base');
   const [telegramGroup, setTelegramGroup] = useState('');
   const [turtleRolesEnabled, setTurtleRolesEnabled] = useState(false);
+
+  // Host Telegram bot connection (sausage-24183)
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const isHostTelegramConnected = !!party?.hostTelegramChatId;
+
+  const handleConnectHostTelegram = async () => {
+    if (!party) return;
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      const response = await mintHostTelegramConnectToken(party.id);
+      window.open(response.deeplink, '_blank', 'noopener');
+    } catch (err: any) {
+      setConnectError(t('partner:hostConnect.connectError') as string);
+      console.error('Failed to mint host telegram connect token', err);
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnectHostTelegram = async () => {
+    if (!party) return;
+    setDisconnecting(true);
+    try {
+      await disconnectHostTelegram(party.id);
+      await loadParty(party.inviteCode);
+    } catch (err) {
+      console.error('Failed to disconnect host telegram', err);
+    } finally {
+      setDisconnecting(false);
+    }
+  };
 
   const [showOptionalFields, setShowOptionalFields] = useState(false);
 
@@ -884,6 +919,44 @@ export const EventDetailsTab: React.FC = () => {
                 }}
                 placeholder="Telegram group link (e.g. https://t.me/+abc123)"
               />
+
+              {/* Host Telegram bot connection (sausage-24183) */}
+              <div>
+                {!isHostTelegramConnected ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleConnectHostTelegram}
+                      disabled={connecting}
+                      className="flex items-center gap-2 bg-[#E52828] hover:bg-[#cc2222] disabled:opacity-40 disabled:cursor-not-allowed text-white px-5 py-2.5 rounded-xl text-sm font-medium transition-colors"
+                    >
+                      {connecting ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+                      {t('partner:hostConnect.buttonConnect')}
+                    </button>
+                    <p className="text-xs text-white/40 mt-1.5">
+                      {t('partner:hostConnect.helperConnect')}
+                    </p>
+                    {connectError && (
+                      <p className="text-xs text-red-400 mt-1.5">{connectError}</p>
+                    )}
+                  </>
+                ) : (
+                  <div className="flex items-center justify-between gap-3 py-2">
+                    <div className="flex items-center gap-2 text-sm text-green-500">
+                      <Check size={16} />
+                      <span>{t('partner:hostConnect.connected')}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleDisconnectHostTelegram}
+                      disabled={disconnecting}
+                      className="text-xs text-white/40 hover:text-white/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {disconnecting ? t('partner:hostConnect.disconnecting') : t('partner:hostConnect.disconnect')}
+                    </button>
+                  </div>
+                )}
+              </div>
 
               <Checkbox
                 checked={turtleRolesEnabled}

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -4,8 +4,39 @@ import { useTranslation, Trans } from 'react-i18next';
 import { X, Search, Check, AlertCircle, Loader2, Send, ChevronDown, MessageSquare } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { fetchTelegramGroups, TelegramGroup } from '../../lib/telegram';
-import { sendTelegramBroadcast, sendTelegramTest, BroadcastResult } from '../../lib/api';
+import {
+  sendTelegramBroadcast,
+  sendTelegramTest,
+  sendHostTelegramBroadcast,
+  sendHostTelegramTest,
+  BroadcastResult,
+} from '../../lib/api';
 import type { UnderbossEvent } from '../../types';
+
+/** Extract a city name from a GPP event's name ("Global Pizza Party <city>"). */
+function extractCityFromEvent(ev: UnderbossEvent): string {
+  const match = ev.name.match(/Global Pizza Party\s+(.+)/i);
+  return match ? match[1].trim() : ev.name;
+}
+
+type RecipientMode = 'groups' | 'hosts' | 'both';
+
+interface HostRow {
+  partyId: string;
+  city: string;
+  hostName: string;
+  hostTelegram: string | null;
+  connected: boolean;
+}
+
+interface SendStats {
+  sent: number;
+  failed: number;
+  blockedHosts: number;
+}
+
+// Tag results with their bucket so the "Both" mode can render two sections.
+type TaggedResult = BroadcastResult & { kind: 'group' | 'host' };
 
 /** Normalize a city name for fuzzy matching (strip accents, suffixes, etc.) */
 function normalizeCity(name: string): string {
@@ -108,8 +139,12 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
   const [loadingGroups, setLoadingGroups] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
+  // Recipient mode (groups, hosts, or both)
+  const [recipientMode, setRecipientMode] = useState<RecipientMode>('groups');
+
   // Selection & filtering
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedHostPartyIds, setSelectedHostPartyIds] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
   const [regionFilter, setRegionFilter] = useState<string>('all');
   const [regionDropdownOpen, setRegionDropdownOpen] = useState(false);
@@ -120,11 +155,12 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
 
   // State flow
   const [viewState, setViewState] = useState<ViewState>('compose');
-  const [results, setResults] = useState<BroadcastResult[]>([]);
-  const [sendStats, setSendStats] = useState({ sent: 0, failed: 0 });
+  const [results, setResults] = useState<TaggedResult[]>([]);
+  const [sendStats, setSendStats] = useState<SendStats>({ sent: 0, failed: 0, blockedHosts: 0 });
 
-  // Test message
+  // Test message (groups + hosts share these states; the active chat/party is keyed by id)
   const [testingChatId, setTestingChatId] = useState<string | null>(null);
+  const [testingHostPartyId, setTestingHostPartyId] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<{ chatId: string; success: boolean; error?: string } | null>(null);
 
   // Load groups on mount
@@ -162,13 +198,10 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
   const hostTelegramByGroupId = useMemo(() => {
     const map: Record<string, string> = {};
     if (!events || events.length === 0) return map;
-    // Extract event city from "Global Pizza Party <city>" naming convention
     const eventCities: { city: string; handle: string }[] = [];
     for (const ev of events) {
       if (!ev.hostTelegram) continue;
-      const match = ev.name.match(/Global Pizza Party\s+(.+)/i);
-      const city = match ? match[1].trim() : ev.name;
-      eventCities.push({ city, handle: ev.hostTelegram });
+      eventCities.push({ city: extractCityFromEvent(ev), handle: ev.hostTelegram });
     }
     for (const g of groups) {
       const found = eventCities.find(ec => citiesMatch(ec.city, g.city));
@@ -230,6 +263,96 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
 
   const allFilteredSelected = filteredGroups.length > 0 && filteredGroups.every(g => selectedIds.has(g.groupId));
 
+  // ===== Host rows (sausage-24183) =====
+
+  // Build the list of selectable hosts from the events prop. Only events whose
+  // host has either a Telegram handle or a connected bot chat_id are included
+  // (others have no way for an underboss to reach them via this tool).
+  const hostRows = useMemo<HostRow[]>(() => {
+    if (!events || events.length === 0) return [];
+    let rows: HostRow[] = events
+      .filter(e => e.host && (e.hostTelegram || e.hostTelegramConnected))
+      .map(e => ({
+        partyId: e.id,
+        city: extractCityFromEvent(e),
+        hostName: e.host?.name || (t('telegram.unknownHost') as string),
+        hostTelegram: e.hostTelegram || null,
+        connected: !!e.hostTelegramConnected,
+      }));
+
+    // Mirror the groups list: filter by pre-selected cities when present.
+    if (preSelectedCities && preSelectedCities.length > 0) {
+      rows = rows.filter(r => preSelectedCities.some(pc => citiesMatch(pc, r.city)));
+    }
+
+    // Search filter (city or host name). Host events don't carry a region, so
+    // skip the region filter in this mode (per plan).
+    if (search.trim()) {
+      const q = search.toLowerCase().trim();
+      rows = rows.filter(
+        r => r.city.toLowerCase().includes(q) || r.hostName.toLowerCase().includes(q)
+      );
+    }
+
+    return rows;
+  }, [events, preSelectedCities, search, t]);
+
+  // Auto-select hosts whose event city matches one of the pre-selected cities,
+  // but only those that are actually connected (disabled checkboxes can't be
+  // selected by the user, so we shouldn't auto-select them either).
+  useEffect(() => {
+    if (!preSelectedCities || preSelectedCities.length === 0) return;
+    if (hostRows.length === 0) return;
+    const matchingIds = new Set<string>();
+    for (const r of hostRows) {
+      if (r.connected && preSelectedCities.some(pc => citiesMatch(pc, r.city))) {
+        matchingIds.add(r.partyId);
+      }
+    }
+    if (matchingIds.size > 0) {
+      setSelectedHostPartyIds(prev => {
+        const next = new Set(prev);
+        matchingIds.forEach(id => next.add(id));
+        return next;
+      });
+    }
+    // We intentionally only run when hostRows or preSelectedCities change.
+  }, [hostRows, preSelectedCities]);
+
+  const connectedHostRows = useMemo(() => hostRows.filter(r => r.connected), [hostRows]);
+  const allFilteredHostsSelected =
+    connectedHostRows.length > 0 &&
+    connectedHostRows.every(r => selectedHostPartyIds.has(r.partyId));
+
+  const toggleHost = (partyId: string, connected: boolean) => {
+    if (!connected) return;
+    setSelectedHostPartyIds(prev => {
+      const next = new Set(prev);
+      if (next.has(partyId)) {
+        next.delete(partyId);
+      } else {
+        next.add(partyId);
+      }
+      return next;
+    });
+  };
+
+  const selectAllHosts = () => {
+    setSelectedHostPartyIds(prev => {
+      const next = new Set(prev);
+      connectedHostRows.forEach(r => next.add(r.partyId));
+      return next;
+    });
+  };
+
+  const deselectAllHosts = () => {
+    setSelectedHostPartyIds(prev => {
+      const next = new Set(prev);
+      connectedHostRows.forEach(r => next.delete(r.partyId));
+      return next;
+    });
+  };
+
   // Build selected groups array for API (dedup by groupId to prevent spam)
   const selectedGroups = useMemo(() => {
     const seen = new Set<string>();
@@ -263,27 +386,80 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
     return dupes;
   }, [groups]);
 
-  // Send broadcast
-  const handleSend = async () => {
-    if (selectedGroups.length === 0 || !message.trim()) return;
+  // Build host-broadcast payload from selected, connected host rows.
+  const selectedHostsPayload = useMemo(() => {
+    return hostRows
+      .filter(r => selectedHostPartyIds.has(r.partyId) && r.connected)
+      .map(r => ({ partyId: r.partyId, city: r.city, hostName: r.hostName }));
+  }, [hostRows, selectedHostPartyIds]);
 
-    const confirmed = window.confirm(
-      t('telegram.confirmSend', { count: selectedGroups.length })
-    );
+  // The "send" CTA is enabled only when the active mode has at least one
+  // recipient AND there is a message to send.
+  const sendDisabled =
+    !message.trim() ||
+    (recipientMode === 'groups' && selectedIds.size === 0) ||
+    (recipientMode === 'hosts' && selectedHostPartyIds.size === 0) ||
+    (recipientMode === 'both' && selectedIds.size === 0 && selectedHostPartyIds.size === 0);
+
+  // Send broadcast — dispatches to one or both backends depending on mode.
+  const handleSend = async () => {
+    if (sendDisabled) return;
+
+    const groupCount = selectedGroups.length;
+    const hostCount = selectedHostsPayload.length;
+
+    let confirmMsg: string;
+    if (recipientMode === 'groups') {
+      confirmMsg = t('telegram.confirmSend', { count: groupCount }) as string;
+    } else if (recipientMode === 'hosts') {
+      confirmMsg = t('telegram.confirmSendHosts', { count: hostCount }) as string;
+    } else {
+      // Both — show both counts.
+      confirmMsg = `${t('telegram.confirmSend', { count: groupCount })} ${t('telegram.confirmSendHosts', { count: hostCount })}`;
+    }
+
+    const confirmed = window.confirm(confirmMsg);
     if (!confirmed) return;
 
     setViewState('sending');
 
-    try {
-      const response = await sendTelegramBroadcast(selectedGroups, message, parseMode);
-      setResults(response.results);
-      setSendStats({ sent: response.sent, failed: response.failed });
-      setViewState('results');
-    } catch (err: any) {
-      setResults([]);
-      setSendStats({ sent: 0, failed: selectedGroups.length });
-      setViewState('results');
+    const allResults: TaggedResult[] = [];
+    let totalSent = 0;
+    let totalFailed = 0;
+    let blockedHostCount = 0;
+
+    if (recipientMode === 'groups' || recipientMode === 'both') {
+      if (selectedGroups.length > 0) {
+        try {
+          const r = await sendTelegramBroadcast(selectedGroups, message, parseMode);
+          allResults.push(...r.results.map(res => ({ ...res, kind: 'group' as const })));
+          totalSent += r.sent;
+          totalFailed += r.failed;
+        } catch (err: any) {
+          totalFailed += selectedGroups.length;
+        }
+      }
     }
+
+    if (recipientMode === 'hosts' || recipientMode === 'both') {
+      if (selectedHostsPayload.length > 0) {
+        try {
+          const r = await sendHostTelegramBroadcast(selectedHostsPayload, message, parseMode);
+          allResults.push(...r.results.map(res => ({ ...res, kind: 'host' as const })));
+          totalSent += r.sent;
+          totalFailed += r.failed;
+          blockedHostCount = r.results.filter(
+            x => x.error === 'Host blocked the bot — disconnected'
+          ).length;
+        } catch (err: any) {
+          totalFailed += selectedHostsPayload.length;
+        }
+      }
+    }
+
+    setResults(allResults);
+    setSendStats({ sent: totalSent, failed: totalFailed, blockedHosts: blockedHostCount });
+    setViewState('results');
   };
 
   // Send test to a single group
@@ -303,6 +479,25 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
       setTestResult({ chatId: group.groupId, success: false, error: err.message });
     } finally {
       setTestingChatId(null);
+    }
+  };
+
+  // Send a per-row test DM to a single host (sausage-24183).
+  const handleHostTest = async (row: HostRow) => {
+    setTestingHostPartyId(row.partyId);
+    setTestResult(null);
+
+    let testMsg = message;
+    testMsg = testMsg.replace(/\{city\}/g, row.city);
+    testMsg = testMsg.replace(/\{hostName\}/g, row.hostName);
+
+    try {
+      const result = await sendHostTelegramTest(row.partyId, testMsg, parseMode);
+      setTestResult(result);
+    } catch (err: any) {
+      setTestResult({ chatId: row.partyId, success: false, error: err.message });
+    } finally {
+      setTestingHostPartyId(null);
     }
   };
 
@@ -353,8 +548,26 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
           {/* Compose view */}
           {!loadingGroups && !loadError && viewState === 'compose' && (
             <div className="space-y-6">
-              {/* Duplicate groupId warning */}
-              {duplicateGroupWarnings.length > 0 && (
+              {/* Recipients toggle (sausage-24183) */}
+              <div className="flex items-center gap-1 bg-theme-surface border border-theme-stroke rounded-xl p-1 w-fit">
+                {(['groups', 'hosts', 'both'] as const).map(mode => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => setRecipientMode(mode)}
+                    className={`px-4 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                      recipientMode === mode
+                        ? 'bg-[#E52828] text-white'
+                        : 'text-theme-text-faint hover:text-theme-text'
+                    }`}
+                  >
+                    {t(`telegram.recipients.${mode}`)}
+                  </button>
+                ))}
+              </div>
+
+              {/* Duplicate groupId warning — only relevant for group mode */}
+              {(recipientMode === 'groups' || recipientMode === 'both') && duplicateGroupWarnings.length > 0 && (
                 <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl px-4 py-3">
                   <div className="flex items-start gap-2">
                     <AlertCircle size={16} className="text-yellow-500 flex-shrink-0 mt-0.5" />
@@ -376,6 +589,7 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
               )}
 
               {/* Group Selector Section */}
+              {(recipientMode === 'groups' || recipientMode === 'both') && (
               <div>
                 <div className="flex items-center justify-between mb-3">
                   <h4 className="text-sm font-medium text-theme-text">
@@ -569,6 +783,171 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                   </div>
                 )}
               </div>
+              )}
+
+              {/* Hosts Selector Section (sausage-24183) */}
+              {(recipientMode === 'hosts' || recipientMode === 'both') && (
+                <div>
+                  <div className="flex items-center justify-between mb-3">
+                    <h4 className="text-sm font-medium text-theme-text">
+                      {t('telegram.hostsList.title')}
+                      <span className="ml-2 text-theme-text-faint font-normal">
+                        {t('telegram.selectedOf', {
+                          selected: selectedHostPartyIds.size,
+                          total: connectedHostRows.length,
+                        })}
+                      </span>
+                    </h4>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={selectAllHosts}
+                        className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
+                      >
+                        {t('telegram.selectAll')}
+                      </button>
+                      <span className="text-theme-text-faint text-xs">/</span>
+                      <button
+                        onClick={deselectAllHosts}
+                        className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
+                      >
+                        {t('telegram.deselectAll')}
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Search input (region filter skipped — host events don't carry region) */}
+                  {recipientMode === 'hosts' && (
+                    <div className="flex gap-2 mb-3">
+                      <div className="flex-1">
+                        <IconInput
+                          icon={Search}
+                          iconSize={14}
+                          type="text"
+                          placeholder={t('telegram.searchPlaceholder')}
+                          value={search}
+                          onChange={(e) => setSearch(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Hosts list */}
+                  <div className="border border-theme-stroke rounded-xl overflow-hidden">
+                    <div className="max-h-[280px] overflow-y-auto">
+                      {hostRows.length === 0 ? (
+                        <div className="px-4 py-8 text-center text-sm text-theme-text-faint">
+                          {t('telegram.hostsList.noConnectedHosts')}
+                        </div>
+                      ) : (
+                        <>
+                          <div className="flex items-center gap-3 px-4 py-2 bg-theme-surface border-b border-theme-stroke text-xs text-theme-text-faint font-medium sticky top-0">
+                            <div className="w-5 flex-shrink-0">
+                              <button
+                                onClick={allFilteredHostsSelected ? deselectAllHosts : selectAllHosts}
+                                disabled={connectedHostRows.length === 0}
+                                className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors ${
+                                  allFilteredHostsSelected
+                                    ? 'bg-red-500 border-red-500'
+                                    : 'border-theme-stroke-hover hover:border-theme-text-faint'
+                                } disabled:opacity-30 disabled:cursor-not-allowed`}
+                              >
+                                {allFilteredHostsSelected && <Check size={10} className="text-white" />}
+                              </button>
+                            </div>
+                            <div className="flex-1 grid grid-cols-4 gap-2">
+                              <span>{t('telegram.tableHeaders.city')}</span>
+                              <span>{t('telegram.tableHeaders.host')}</span>
+                              <span>{t('telegram.tableHeaders.hostTg')}</span>
+                              <span>{t('telegram.tableHeaders.status')}</span>
+                            </div>
+                            <div className="w-14 text-right">{t('telegram.tableHeaders.test')}</div>
+                          </div>
+                          {hostRows.map(row => {
+                            const isSelected = selectedHostPartyIds.has(row.partyId);
+                            const checkboxAriaLabel = row.connected
+                              ? `${row.city} ${row.hostName}`
+                              : `${row.city} ${row.hostName} — ${t('telegram.hostsList.notConnected')}`;
+                            return (
+                              <div
+                                key={row.partyId}
+                                className={`flex items-center gap-3 px-4 py-2.5 border-b border-theme-stroke last:border-b-0 transition-colors ${
+                                  row.connected ? 'cursor-pointer' : 'cursor-default opacity-70'
+                                } ${isSelected ? 'bg-red-500/5' : 'hover:bg-theme-surface'}`}
+                                onClick={() => toggleHost(row.partyId, row.connected)}
+                              >
+                                <div className="w-5 flex-shrink-0">
+                                  <div
+                                    role="checkbox"
+                                    aria-checked={isSelected}
+                                    aria-label={checkboxAriaLabel}
+                                    aria-disabled={!row.connected}
+                                    className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors ${
+                                      isSelected
+                                        ? 'bg-red-500 border-red-500'
+                                        : 'border-theme-stroke-hover'
+                                    } ${!row.connected ? 'opacity-30' : ''}`}
+                                  >
+                                    {isSelected && <Check size={10} className="text-white" />}
+                                  </div>
+                                </div>
+                                <div className="flex-1 grid grid-cols-4 gap-2 text-sm">
+                                  <span className="text-theme-text truncate">{row.city}</span>
+                                  <span className="text-theme-text-secondary truncate">{row.hostName}</span>
+                                  <span className="text-theme-text-faint truncate">
+                                    {row.hostTelegram ? (
+                                      <a
+                                        href={`https://t.me/${row.hostTelegram.replace(/^@/, '')}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-purple-400 hover:text-purple-300 transition-colors"
+                                        title="DM host on Telegram"
+                                        onClick={(e) => e.stopPropagation()}
+                                      >
+                                        @{row.hostTelegram.replace(/^@/, '')}
+                                      </a>
+                                    ) : (
+                                      '—'
+                                    )}
+                                  </span>
+                                  <span>
+                                    {row.connected ? (
+                                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-green-500/15 text-green-600">
+                                        <Check size={10} />
+                                        {t('telegram.hostsList.connected')}
+                                      </span>
+                                    ) : (
+                                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-yellow-500/15 text-yellow-600">
+                                        {t('telegram.hostsList.notConnected')}
+                                      </span>
+                                    )}
+                                  </span>
+                                </div>
+                                <div className="w-14 text-right">
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      if (message.trim() && row.connected) handleHostTest(row);
+                                    }}
+                                    disabled={!message.trim() || !row.connected || testingHostPartyId === row.partyId}
+                                    className="text-xs text-theme-text-faint hover:text-red-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                    title={row.connected ? (message.trim() ? t('telegram.testTitle') as string : t('telegram.writeMessageFirst') as string) : t('telegram.hostsList.notConnected') as string}
+                                  >
+                                    {testingHostPartyId === row.partyId ? (
+                                      <Loader2 size={12} className="animate-spin inline" />
+                                    ) : (
+                                      t('telegram.test')
+                                    )}
+                                  </button>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {/* Message Section */}
               <div>
@@ -617,11 +996,13 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
               <div className="flex justify-end">
                 <button
                   onClick={handleSend}
-                  disabled={selectedIds.size === 0 || !message.trim()}
+                  disabled={sendDisabled}
                   className="flex items-center gap-2 bg-[#E52828] hover:bg-[#cc2222] disabled:opacity-40 disabled:cursor-not-allowed text-white px-5 py-2.5 rounded-xl text-sm font-medium transition-colors"
                 >
                   <Send size={14} />
-                  {t('telegram.sendToGroups', { count: selectedIds.size })}
+                  {recipientMode === 'groups' && t('telegram.sendToGroups', { count: selectedIds.size })}
+                  {recipientMode === 'hosts' && t('telegram.sendToHosts', { count: selectedHostPartyIds.size })}
+                  {recipientMode === 'both' && t('telegram.sendToBoth', { groups: selectedIds.size, hosts: selectedHostPartyIds.size })}
                 </button>
               </div>
             </div>
@@ -632,7 +1013,9 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
             <div className="flex flex-col items-center justify-center py-16">
               <Loader2 size={32} className="animate-spin text-red-500 mb-4" />
               <p className="text-theme-text font-medium mb-1">
-                {t('telegram.sendingToGroups', { count: selectedGroups.length })}
+                {recipientMode === 'hosts'
+                  ? t('telegram.sendingToGroups', { count: selectedHostsPayload.length })
+                  : t('telegram.sendingToGroups', { count: selectedGroups.length + (recipientMode === 'both' ? selectedHostsPayload.length : 0) })}
               </p>
               <p className="text-sm text-theme-text-faint">
                 {t('telegram.sendingSubtext')}
@@ -643,6 +1026,18 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
           {/* Results view */}
           {viewState === 'results' && (
             <div className="space-y-5">
+              {/* Blocked-host warning banner (sausage-24183 — locked-in decision) */}
+              {sendStats.blockedHosts > 0 && (
+                <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl px-4 py-3">
+                  <div className="flex items-start gap-2">
+                    <AlertCircle size={16} className="text-yellow-500 flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-yellow-600">
+                      {t('telegram.results.blockedWarning', { count: sendStats.blockedHosts })}
+                    </p>
+                  </div>
+                </div>
+              )}
+
               {/* Summary */}
               <div className="flex items-center gap-4 justify-center py-4">
                 <div className="text-center">
@@ -656,35 +1051,128 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                 </div>
               </div>
 
-              {/* Results list */}
-              <div className="border border-theme-stroke rounded-xl overflow-hidden">
-                <div className="max-h-[350px] overflow-y-auto">
-                  {results.map((r, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center gap-3 px-4 py-2.5 border-b border-theme-stroke last:border-b-0"
-                    >
-                      <div className="flex-shrink-0">
-                        {r.success ? (
-                          <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center">
-                            <Check size={12} className="text-green-600" />
-                          </div>
-                        ) : (
-                          <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center">
-                            <X size={12} className="text-red-500" />
-                          </div>
-                        )}
+              {/* Results list — split into Groups / Hosts sections when mode is "both" */}
+              {recipientMode === 'both' ? (
+                <>
+                  {results.some(r => r.kind === 'group') && (
+                    <div>
+                      <h4 className="text-xs font-medium text-theme-text-faint mb-2 uppercase tracking-wide">
+                        {t('telegram.results.groupsSection')}
+                      </h4>
+                      <div className="border border-theme-stroke rounded-xl overflow-hidden">
+                        <div className="max-h-[200px] overflow-y-auto">
+                          {results.filter(r => r.kind === 'group').map((r, i) => (
+                            <div
+                              key={`group-${i}`}
+                              className="flex items-center gap-3 px-4 py-2.5 border-b border-theme-stroke last:border-b-0"
+                            >
+                              <div className="flex-shrink-0">
+                                {r.success ? (
+                                  <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center">
+                                    <Check size={12} className="text-green-600" />
+                                  </div>
+                                ) : (
+                                  <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center">
+                                    <X size={12} className="text-red-500" />
+                                  </div>
+                                )}
+                              </div>
+                              <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
+                              {r.error && (
+                                <span className="text-xs text-red-400 max-w-[200px] truncate" title={r.error}>
+                                  {r.error}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                      <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
-                      {r.error && (
-                        <span className="text-xs text-red-400 max-w-[200px] truncate" title={r.error}>
-                          {r.error}
-                        </span>
-                      )}
                     </div>
-                  ))}
+                  )}
+                  {results.some(r => r.kind === 'host') && (
+                    <div>
+                      <h4 className="text-xs font-medium text-theme-text-faint mb-2 uppercase tracking-wide">
+                        {t('telegram.results.hostsSection')}
+                      </h4>
+                      <div className="border border-theme-stroke rounded-xl overflow-hidden">
+                        <div className="max-h-[200px] overflow-y-auto">
+                          {results.filter(r => r.kind === 'host').map((r, i) => {
+                            const isBlocked = r.error === 'Host blocked the bot — disconnected';
+                            return (
+                              <div
+                                key={`host-${i}`}
+                                className={`flex items-center gap-3 px-4 py-2.5 border-b border-theme-stroke last:border-b-0 ${
+                                  isBlocked ? 'bg-yellow-500/5' : ''
+                                }`}
+                              >
+                                <div className="flex-shrink-0">
+                                  {r.success ? (
+                                    <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center">
+                                      <Check size={12} className="text-green-600" />
+                                    </div>
+                                  ) : isBlocked ? (
+                                    <div className="w-5 h-5 rounded-full bg-yellow-500/20 flex items-center justify-center">
+                                      <AlertCircle size={12} className="text-yellow-600" />
+                                    </div>
+                                  ) : (
+                                    <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center">
+                                      <X size={12} className="text-red-500" />
+                                    </div>
+                                  )}
+                                </div>
+                                <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
+                                {r.error && (
+                                  <span className={`text-xs max-w-[200px] truncate ${isBlocked ? 'text-yellow-600' : 'text-red-400'}`} title={r.error}>
+                                    {r.error}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="border border-theme-stroke rounded-xl overflow-hidden">
+                  <div className="max-h-[350px] overflow-y-auto">
+                    {results.map((r, i) => {
+                      const isBlocked = r.kind === 'host' && r.error === 'Host blocked the bot — disconnected';
+                      return (
+                        <div
+                          key={i}
+                          className={`flex items-center gap-3 px-4 py-2.5 border-b border-theme-stroke last:border-b-0 ${
+                            isBlocked ? 'bg-yellow-500/5' : ''
+                          }`}
+                        >
+                          <div className="flex-shrink-0">
+                            {r.success ? (
+                              <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center">
+                                <Check size={12} className="text-green-600" />
+                              </div>
+                            ) : isBlocked ? (
+                              <div className="w-5 h-5 rounded-full bg-yellow-500/20 flex items-center justify-center">
+                                <AlertCircle size={12} className="text-yellow-600" />
+                              </div>
+                            ) : (
+                              <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center">
+                                <X size={12} className="text-red-500" />
+                              </div>
+                            )}
+                          </div>
+                          <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
+                          {r.error && (
+                            <span className={`text-xs max-w-[200px] truncate ${isBlocked ? 'text-yellow-600' : 'text-red-400'}`} title={r.error}>
+                              {r.error}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
+              )}
 
               {/* Done button */}
               <div className="flex justify-center">

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -142,6 +142,8 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     eventbriteUrl: dbParty.eventbrite_url || null,
     externalLinks: dbParty.external_links || [],
     telegramGroup: dbParty.telegram_group || null,
+    hostTelegramChatId: dbParty.host_telegram_chat_id ? String(dbParty.host_telegram_chat_id) : null,
+    hostTelegramLinkToken: dbParty.host_telegram_link_token || null,
     underbossStatus: (dbParty.underboss_status as any) || null,
     turtleRolesEnabled: dbParty.turtle_roles_enabled || false,
     guests,

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -337,7 +337,34 @@
       "country": "Land",
       "underboss": "Underboss",
       "hostTg": "Gastgeber TG",
-      "test": "Test"
+      "test": "Test",
+      "host": "Host",
+      "status": "Status"
+    },
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
   },
   "eventRow": {
@@ -391,5 +418,13 @@
     "reset": "Zurücksetzen",
     "download": "Herunterladen",
     "generating": "Erstellen..."
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   }
 }

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -336,13 +336,48 @@
     "sendingToGroups_other": "Sending to {{count}} groups...",
     "sendingSubtext": "This may take a moment",
     "done": "Done",
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
     "tableHeaders": {
       "city": "City",
       "country": "Country",
       "underboss": "Underboss",
       "hostTg": "Host TG",
-      "test": "Test"
+      "test": "Test",
+      "host": "Host",
+      "status": "Status"
+    },
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   },
   "eventRow": {
     "notesPlaceholder": "Underboss notes...",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -337,7 +337,34 @@
       "country": "País",
       "underboss": "Underboss",
       "hostTg": "TG Anfitrión",
-      "test": "Prueba"
+      "test": "Prueba",
+      "host": "Host",
+      "status": "Status"
+    },
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
   },
   "eventRow": {
@@ -391,5 +418,13 @@
     "reset": "Restablecer",
     "download": "Descargar",
     "generating": "Generando..."
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   }
 }

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -337,7 +337,34 @@
       "country": "Pays",
       "underboss": "Underboss",
       "hostTg": "TG de l'hôte",
-      "test": "Test"
+      "test": "Test",
+      "host": "Host",
+      "status": "Status"
+    },
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
   },
   "eventRow": {
@@ -391,5 +418,13 @@
     "reset": "Réinitialiser",
     "download": "Télécharger",
     "generating": "Génération..."
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   }
 }

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -337,7 +337,34 @@
       "country": "国",
       "underboss": "Underboss",
       "hostTg": "ホストTG",
-      "test": "テスト"
+      "test": "テスト",
+      "host": "Host",
+      "status": "Status"
+    },
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
   },
   "eventRow": {
@@ -391,5 +418,13 @@
     "reset": "リセット",
     "download": "ダウンロード",
     "generating": "生成中..."
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   }
 }

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -337,7 +337,34 @@
       "country": "País",
       "underboss": "Underboss",
       "hostTg": "TG do Anfitrião",
-      "test": "Teste"
+      "test": "Teste",
+      "host": "Host",
+      "status": "Status"
+    },
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
   },
   "eventRow": {
@@ -391,5 +418,13 @@
     "reset": "Restaurar",
     "download": "Baixar",
     "generating": "Gerando..."
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   }
 }

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -337,7 +337,34 @@
       "country": "国家",
       "underboss": "Underboss",
       "hostTg": "主办人 TG",
-      "test": "测试"
+      "test": "测试",
+      "host": "Host",
+      "status": "Status"
+    },
+    "recipients": {
+      "label": "Recipients",
+      "groups": "Groups",
+      "hosts": "Hosts",
+      "both": "Both"
+    },
+    "hostsList": {
+      "title": "Select Hosts",
+      "noConnectedHosts": "No hosts have connected their Telegram yet",
+      "notConnected": "Not connected",
+      "connected": "Connected"
+    },
+    "unknownHost": "Unknown host",
+    "sendToHosts": "Send to {{count}} host",
+    "sendToHosts_other": "Send to {{count}} hosts",
+    "sendToBoth": "Send to {{groups}} group + {{hosts}} host",
+    "sendToBoth_other": "Send to {{groups}} groups + {{hosts}} hosts",
+    "confirmSendHosts": "Send this DM to {{count}} host?",
+    "confirmSendHosts_other": "Send this DM to {{count}} hosts?",
+    "results": {
+      "groupsSection": "Group chats",
+      "hostsSection": "Host DMs",
+      "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
     }
   },
   "eventRow": {
@@ -391,5 +418,13 @@
     "reset": "重置",
     "download": "下载",
     "generating": "生成中..."
+  },
+  "hostConnect": {
+    "buttonConnect": "Connect your Telegram to receive PizzaDAO DMs",
+    "helperConnect": "Click to open Telegram. Tap Start in the bot to confirm. We'll only DM you about your event.",
+    "connected": "Telegram connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting...",
+    "connectError": "Couldn't generate connect link — please try again"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -174,6 +174,7 @@ export interface UpdatePartyData {
   country?: string | null;
   expectedGuests?: number | null;
   telegramGroup?: string | null;
+  hostTelegramLinkToken?: string | null;
   turtleRolesEnabled?: boolean;
 }
 
@@ -279,6 +280,7 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       country: data.country,
       expectedGuests: data.expectedGuests,
       telegramGroup: data.telegramGroup,
+      hostTelegramLinkToken: data.hostTelegramLinkToken,
       turtleRolesEnabled: data.turtleRolesEnabled,
     },
   });
@@ -2990,6 +2992,52 @@ export async function sendTelegramTest(
   return apiRequest<BroadcastResult>('/api/underboss/telegram/test', {
     method: 'POST',
     body: { chatId, message, parseMode },
+  });
+}
+
+// Host Telegram (bot-DM) API functions — backed by sausage-24183 backend routes.
+
+export interface BroadcastHost {
+  partyId: string;
+  city: string;
+  hostName: string;
+}
+
+export async function sendHostTelegramBroadcast(
+  hosts: BroadcastHost[],
+  message: string,
+  parseMode: 'HTML' | 'Markdown' | 'None' = 'None'
+): Promise<BroadcastResponse> {
+  return apiRequest<BroadcastResponse>('/api/underboss/telegram/host-broadcast', {
+    method: 'POST',
+    body: { hosts, message, parseMode },
+  });
+}
+
+export async function sendHostTelegramTest(
+  partyId: string,
+  message: string,
+  parseMode: 'HTML' | 'Markdown' | 'None' = 'None'
+): Promise<BroadcastResult> {
+  return apiRequest<BroadcastResult>('/api/underboss/telegram/host-test', {
+    method: 'POST',
+    body: { partyId, message, parseMode },
+  });
+}
+
+export async function mintHostTelegramConnectToken(
+  partyId: string
+): Promise<{ token: string; deeplink: string }> {
+  return apiRequest<{ token: string; deeplink: string }>(`/api/parties/${partyId}/connect-token`, {
+    method: 'POST',
+  });
+}
+
+export async function disconnectHostTelegram(
+  partyId: string
+): Promise<{ success: boolean }> {
+  return apiRequest<{ success: boolean }>(`/api/parties/${partyId}/host-telegram`, {
+    method: 'DELETE',
   });
 }
 

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -697,6 +697,9 @@ export interface DbParty {
   external_links?: Array<{label: string; url: string}>;
   // Telegram group
   telegram_group?: string | null;
+  // Host Telegram bot connection
+  host_telegram_chat_id?: string | null; // serialized as string from API (BigInt)
+  host_telegram_link_token?: string | null;
   // Underboss status
   underboss_status?: string | null;
   // Turtle role selection toggle
@@ -763,6 +766,7 @@ export const SAFE_PARTY_COLUMNS = `
   hidden_gpp_photos, extra_gpp_photos,
   quiz_enabled,
   telegram_group,
+  host_telegram_chat_id, host_telegram_link_token,
   turtle_roles_enabled,
   underboss_status,
   flyer_config,
@@ -1720,6 +1724,7 @@ export async function updateParty(
     eventbrite_url?: string | null;
     external_links?: Array<{label: string; url: string}>;
     telegram_group?: string | null;
+    host_telegram_link_token?: string | null;
     turtle_roles_enabled?: boolean;
   }
 ): Promise<boolean> {
@@ -1792,6 +1797,7 @@ export async function updateParty(
         eventbriteUrl: updates.eventbrite_url,
         externalLinks: updates.external_links,
         telegramGroup: updates.telegram_group,
+        hostTelegramLinkToken: updates.host_telegram_link_token,
         turtleRolesEnabled: updates.turtle_roles_enabled,
       });
       return true;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -290,6 +290,8 @@ export interface Party {
   eventbriteUrl?: string | null;
   externalLinks?: Array<{label: string; url: string}>;
   telegramGroup?: string | null;
+  hostTelegramChatId?: string | null;
+  hostTelegramLinkToken?: string | null;
   underbossStatus?: UnderbossStatus | null;
   turtleRolesEnabled?: boolean;
 }
@@ -1026,6 +1028,7 @@ export interface UnderbossEvent {
   country?: string | null;
   host: { name: string | null; email: string | null };
   hostTelegram?: string | null;
+  hostTelegramConnected?: boolean;
   coHosts: any[];
   progress: UnderbossEventProgress;
   guestCount: number;


### PR DESCRIPTION
## Summary

PR 2 (frontend half) of **sausage-24183**: bulk-DM city hosts via the PizzaDAO Telegram bot, lifting the existing TelegramBroadcast modal from groups-only to groups / hosts / both.

- **Depends on #336** (backend). Runtime calls (`POST /api/underboss/telegram/host-broadcast`, `POST /api/parties/:id/connect-token`, etc.) will 404 on this preview until PR #336 lands and the backend deploys to prod — that's expected per the plan.
- DB migration adding `parties.host_telegram_chat_id` (BIGINT) and `parties.host_telegram_link_token` (VARCHAR UNIQUE) was already applied to prod alongside PR #336's setup.
- This PR is **frontend only** — no `backend/` files touched.

Plan: [`plans/sausage-24183-bulk-dm-hosts.md`](https://github.com/PizzaDAO/rsv-pizza/blob/master/plans/sausage-24183-bulk-dm-hosts.md).

## What changed

### Types / API plumbing (the 7-place dance for the new fields)
- `frontend/src/types.ts` — added `hostTelegramChatId`, `hostTelegramLinkToken` to `Party`, and `hostTelegramConnected?: boolean` to `UnderbossEvent`.
- `frontend/src/lib/supabase.ts` — extended `DbParty` (`host_telegram_chat_id`, `host_telegram_link_token`), appended both columns to `SAFE_PARTY_COLUMNS`, and added `host_telegram_link_token` to the `updateParty` field whitelist. `host_telegram_chat_id` is intentionally not in the write whitelist — it's webhook-only.
- `frontend/src/lib/api.ts` — added `hostTelegramLinkToken` to `UpdatePartyData` and the `updatePartyApi` PATCH body. New helpers: `sendHostTelegramBroadcast`, `sendHostTelegramTest`, `mintHostTelegramConnectToken`, `disconnectHostTelegram`, plus a `BroadcastHost` interface.
- `frontend/src/contexts/PizzaContext.tsx` — `dbPartyToParty` mapper now surfaces both new fields (chat_id stringified to dodge BigInt JSON serialization).

### UI: host-side connect button
- `frontend/src/components/EventDetailsTab.tsx` — directly below the existing Telegram **group** input, a new red "Connect your Telegram to receive PizzaDAO DMs" CTA. Click → mint connect token → `window.open(deeplink, '_blank', 'noopener')` to launch Telegram. Once connected (`party.hostTelegramChatId` non-null), the CTA swaps for a green "Telegram connected" status row with a right-aligned "Disconnect" link. Errors surface inline.

### UI: TelegramBroadcast modal (the big one)
- `frontend/src/components/underboss/TelegramBroadcast.tsx`:
  - New three-segment **Recipients** pill (Groups | Hosts | Both) at the top of the compose body.
  - The existing group selector renders only when `recipientMode === 'groups' || 'both'`.
  - New **Hosts** section renders when `recipientMode === 'hosts' || 'both'`. Source: `events` prop. Columns: checkbox (disabled when not connected, ARIA-labelled), City, Host name, Host @ (clickable `t.me/<handle>` fallback), Status badge (green "Connected" / amber "Not connected"), and a per-row Test button that calls `sendHostTelegramTest`.
  - Auto-selects hosts whose city matches `preSelectedCities`, but only the connected ones.
  - `handleSend` dispatches to one or both endpoints depending on mode and merges results into a single tagged-results list (`kind: 'group' | 'host'`).
  - Results view splits into "Group chats" / "Host DMs" sections when mode is `both`.
  - **Locked-in blocked-bot warning** — when the backend reports `error === 'Host blocked the bot — disconnected'` on host results, the affected row is flagged amber and an amber banner at the top of the results view says "N host(s) blocked the bot and were disconnected. Consider reaching out another way."
  - `extractCityFromEvent` helper extracted to module scope so both the group table's "Host TG" column and the new hosts table share the same `"Global Pizza Party <city>"` regex.

### i18n
- All 7 locales (`en/de/es/fr/ja/pt/zh`) get the new `telegram.recipients.*`, `telegram.hostsList.*`, `telegram.sendToHosts*`, `telegram.sendToBoth*`, `telegram.confirmSendHosts*`, `telegram.tableHeaders.{host,status}`, `telegram.results.{groupsSection,hostsSection,blockedWarning,blockedWarning_other}`, and the top-level `hostConnect.*` keys. English values are shipped in all locales as placeholders per the plan — translation is a follow-up sweep. Existing localized keys are untouched (non-destructive merge).

## Files changed

- `frontend/src/components/EventDetailsTab.tsx`
- `frontend/src/components/underboss/TelegramBroadcast.tsx`
- `frontend/src/contexts/PizzaContext.tsx`
- `frontend/src/lib/api.ts`
- `frontend/src/lib/supabase.ts`
- `frontend/src/types.ts`
- `frontend/src/i18n/locales/{en,de,es,fr,ja,pt,zh}/partner.json`

## Test plan

- [x] `cd frontend && npx tsc --noEmit` passes
- [x] `cd frontend && npx vite build` succeeds
- [x] JSON parse of all 7 partner.json files succeeds
- [ ] Vercel preview deploys successfully
- [ ] (post-#336 merge) Host side: log into `/host/<invite>/details`, click "Connect your Telegram", verify Telegram opens with `/start <token>` deeplink, tap Start, verify the button swaps to green "Telegram connected".
- [ ] (post-#336 merge) Disconnect: click Disconnect from the connected state, verify it reverts.
- [ ] (post-#336 merge) Underboss broadcast Groups mode: regression — works exactly as before.
- [ ] (post-#336 merge) Underboss broadcast Hosts mode: select a connected host, click "Send to 1 host", verify the DM arrives.
- [ ] (post-#336 merge) Underboss broadcast Both mode: select a group + a host, verify both receive the message and the results view shows separate sections.
- [ ] (post-#336 merge) Blocked-host banner: have the test host block the bot, send a broadcast, verify the amber banner appears and the row is flagged amber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)