### PR TITLE
truffle-90229: clarify funding language on rejected + listed GPP callouts

### DIFF
--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -186,7 +186,7 @@ export const GPPDashboardTab: React.FC = () => {
               className="btn-primary flex items-center gap-2"
             >
               {saving ? <Loader2 size={16} className="animate-spin" /> : null}
-              List My Event
+              List My Event Without Funding
             </button>
             <button
               onClick={async () => {
@@ -222,7 +222,7 @@ export const GPPDashboardTab: React.FC = () => {
       {party.underbossStatus === 'listed' && (
         <div className="card p-6 border border-green-500/30 bg-green-500/5">
           <p className="text-sm text-green-400">
-            Your event is listed as a Community event on the site.
+            Your event is listed as a Community event on the site. These are self funded events that will not be funded by PizzaDAO.
           </p>
         </div>
       )}

--- a/plans/truffle-90229-rejected-button-rename.md
+++ b/plans/truffle-90229-rejected-button-rename.md
@@ -1,0 +1,21 @@
+# truffle-90229: Clarify funding language on rejected and listed GPP dashboard callouts
+
+**Priority:** P3
+**Type:** Copy change
+
+## Problem
+On the GPP dashboard, the rejected-status and listed-status callouts both refer to the "list without funding" path, but neither makes the funding/no-funding distinction explicit. Hosts have to infer it from the surrounding sentence. Tightening the copy on both callouts removes ambiguity.
+
+## Files modified
+- `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx`
+
+## Changes
+1. **Rejected callout primary button** (line 189): rename `List My Event` → `List My Event Without Funding`.
+2. **Listed callout body** (line 225): append `These are self funded events that will not be funded by PizzaDAO.` after the existing `Your event is listed as a Community event on the site.`
+
+No handler, styling, or routing changes.
+
+## Verification
+1. Vercel preview builds
+2. On the GPP dashboard for an event with `underbossStatus = 'rejected'`, primary button now reads "List My Event Without Funding"; clicking it still flips status to `listed`
+3. After it flips, the listed callout shows both sentences


### PR DESCRIPTION
## Summary
- Rename rejected-status primary button from "List My Event" to "List My Event Without Funding" so the trade-off is explicit.
- Append "These are self funded events that will not be funded by PizzaDAO." to the listed-status callout so hosts know what they signed up for after flipping.
- Pure copy change. Handler still calls `updateUnderbossStatus(party.id, 'listed')`.

## Test plan
- [ ] Vercel preview builds
- [ ] For an event with `underbossStatus = 'rejected'`, primary button reads "List My Event Without Funding"
- [ ] Clicking the button still flips status to `listed`
- [ ] Post-flip, the listed callout shows both sentences

🤖 Generated with [Claude Code](https://claude.com/claude-code)