### PR TITLE
pepperoni-33539: 'Show all events' toggle on /map with status colors

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -1,8 +1,10 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { randomBytes } from 'crypto';
 import { Prisma } from '@prisma/client';
+import jwt from 'jsonwebtoken';
 import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
+import { isAdmin, isUnderboss } from '../middleware/auth.js';
 import { getAutoCoHostPartners, addPartnerToParty } from '../helpers/partnerSync.js';
 
 const router = Router();
@@ -645,12 +647,38 @@ router.get('/events/by-city/:citySlug', async (req: Request, res: Response, next
 // GET /api/gpp/events - List all GPP events (for admin/public listing)
 router.get('/events', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { limit = '500', offset = '0', city, country, region } = req.query;
+    const { limit = '500', offset = '0', city, country, region, statuses } = req.query;
+
+    // Determine whether to include rejected/hidden statuses.
+    // The `?statuses=all` and legacy `?includeAll=1` params both request all-statuses,
+    // but the request is only honored when the caller is an authenticated
+    // underboss/admin. Unauthenticated callers silently fall back to the
+    // filtered (non-rejected, non-hidden) view — no 401, preserving backwards compat.
+    const requestedAllStatuses = statuses === 'all' || req.query.includeAll === '1';
+    let includeAllStatuses = false;
+    if (requestedAllStatuses) {
+      const authHeader = req.headers.authorization;
+      if (authHeader && authHeader.startsWith('Bearer ')) {
+        const token = authHeader.slice(7);
+        const secret = process.env.JWT_SECRET;
+        if (secret) {
+          try {
+            const decoded = jwt.verify(token, secret) as { userId: string; email: string };
+            const email = decoded.email;
+            if (email && (await isAdmin(email) || await isUnderboss(email))) {
+              includeAllStatuses = true;
+            }
+          } catch {
+            // Bad/expired token — silently fall back to the filtered view
+          }
+        }
+      }
+    }
 
     const where: any = { eventType: 'gpp' };
     if (req.query.curated === '1') {
       where.underbossStatus = { in: ['approved', 'listed'] };
-    } else if (req.query.includeAll === '1') {
+    } else if (includeAllStatuses) {
       // moderator view — no underbossStatus filter; returns rejected/hidden too
     } else {
       where.underbossStatus = { notIn: ['rejected', 'hidden'] };

--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -8,6 +8,35 @@ interface GPPEventsMapProps {
   canModerate?: boolean;
 }
 
+// Semantic colors keyed on underbossStatus. Keep in sync with STATUS_LEGEND
+// in EventsMapPage.tsx so the legend matches the marker colors.
+const STATUS_COLORS: Record<string, string> = {
+  approved: '#22c55e',
+  listed: '#3b82f6',
+  pending: '#eab308',
+  rejected: '#ef4444',
+  hidden: '#6b7280',
+};
+
+function statusColor(status?: string | null): string {
+  if (!status) return STATUS_COLORS.pending;
+  return STATUS_COLORS[status] || STATUS_COLORS.pending;
+}
+
+function makeMarkerIcon(status?: string | null): google.maps.Icon {
+  const color = statusColor(status);
+  const svg = encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">` +
+      `<circle cx="16" cy="16" r="11" fill="${color}" stroke="white" stroke-width="3"/>` +
+      `</svg>`
+  );
+  return {
+    url: `data:image/svg+xml;utf8,${svg}`,
+    scaledSize: new google.maps.Size(32, 32),
+    anchor: new google.maps.Point(16, 16),
+  };
+}
+
 export default function GPPEventsMap({
   events,
   height = '100%',
@@ -147,18 +176,24 @@ export default function GPPEventsMap({
 
         let actionsHtml = '';
         if (canModerate) {
-          if (event.underbossStatus === 'approved') {
+          // Status pill — shown for every moderator-visible event so the
+          // marker color is interpretable in the InfoWindow too.
+          const statusKey = event.underbossStatus || 'pending';
+          const statusColorHex = statusColor(statusKey);
+          const statusPillHtml = `<span style="background:${statusColorHex}1a;color:${statusColorHex};font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600;text-transform:capitalize">${statusKey}</span>`;
+          if (statusKey === 'approved') {
             actionsHtml = `
-              <span style="background:#dcfce7;color:#16a34a;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Approved</span>
+              ${statusPillHtml}
               <button data-action="reject" data-event-id="${event.id}" style="background:none;border:none;color:#dc2626;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark rejected</button>
             `;
-          } else if (event.underbossStatus === 'rejected') {
+          } else if (statusKey === 'rejected') {
             actionsHtml = `
-              <span style="background:#fee2e2;color:#dc2626;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600">Rejected</span>
+              ${statusPillHtml}
               <button data-action="approve" data-event-id="${event.id}" style="background:none;border:none;color:#16a34a;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark approved</button>
             `;
           } else {
             actionsHtml = `
+              ${statusPillHtml}
               <button data-action="approve" data-event-id="${event.id}" style="background:#16a34a;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Approve</button>
               <button data-action="reject" data-event-id="${event.id}" style="background:#dc2626;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Reject</button>
             `;
@@ -225,14 +260,10 @@ export default function GPPEventsMap({
 
         infoWindow.setContent(buildInfoContent(updated));
 
-        if (action === 'reject') {
-          const marker = markerByEventIdRef.current.get(eventId);
-          if (marker) {
-            clustererRef.current?.removeMarker(marker);
-            marker.setMap(null);
-            markerByEventIdRef.current.delete(eventId);
-            markersRef.current = markersRef.current.filter((m) => m !== marker);
-          }
+        const marker = markerByEventIdRef.current.get(eventId);
+        if (marker) {
+          // Update the marker icon to reflect the new status color
+          marker.setIcon(makeMarkerIcon(updated.underbossStatus));
         }
       }
 
@@ -271,11 +302,7 @@ export default function GPPEventsMap({
         const marker = new google.maps.Marker({
           position,
           title: event.name,
-          icon: {
-            url: '/molto-benny-btc.svg',
-            scaledSize: new google.maps.Size(38, 38),
-            anchor: new google.maps.Point(19, 38),
-          },
+          icon: makeMarkerIcon(event.underbossStatus),
         });
 
         const eventId = event.id;

--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -6,6 +6,11 @@ interface GPPEventsMapProps {
   events: GPPEventMapItem[];
   height?: string;
   canModerate?: boolean;
+  // When true, markers are rendered as status-colored circles (admin/underboss
+  // view). When false, the public Benny pizza icon is used to preserve brand on
+  // the public /map view. Defaults to false so the public landing page stays
+  // on-brand even if a caller forgets to pass it.
+  isModerator?: boolean;
 }
 
 // Semantic colors keyed on underbossStatus. Keep in sync with STATUS_LEGEND
@@ -41,6 +46,7 @@ export default function GPPEventsMap({
   events,
   height = '100%',
   canModerate = false,
+  isModerator = false,
 }: GPPEventsMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
@@ -260,10 +266,12 @@ export default function GPPEventsMap({
 
         infoWindow.setContent(buildInfoContent(updated));
 
-        const marker = markerByEventIdRef.current.get(eventId);
-        if (marker) {
-          // Update the marker icon to reflect the new status color
-          marker.setIcon(makeMarkerIcon(updated.underbossStatus));
+        if (isModerator) {
+          const marker = markerByEventIdRef.current.get(eventId);
+          if (marker) {
+            // Update the marker icon to reflect the new status color
+            marker.setIcon(makeMarkerIcon(updated.underbossStatus));
+          }
         }
       }
 
@@ -302,7 +310,13 @@ export default function GPPEventsMap({
         const marker = new google.maps.Marker({
           position,
           title: event.name,
-          icon: makeMarkerIcon(event.underbossStatus),
+          icon: isModerator
+            ? makeMarkerIcon(event.underbossStatus)
+            : {
+                url: '/molto-benny-btc.svg',
+                scaledSize: new google.maps.Size(38, 38),
+                anchor: new google.maps.Point(19, 38),
+              },
         });
 
         const eventId = event.id;
@@ -390,7 +404,7 @@ export default function GPPEventsMap({
     script.onload = () => initMap();
     script.onerror = () => setError(true);
     document.head.appendChild(script);
-  }, [validEvents, canModerate]);
+  }, [validEvents, canModerate, isModerator]);
 
   if (error) {
     return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3344,7 +3344,10 @@ interface GPPEventsApiPayload {
 export async function fetchGppEventsForMap(force?: boolean, curated?: boolean, includeAll?: boolean): Promise<GPPEventMapItem[]> {
   const params: string[] = ['limit=2000'];
   if (curated) params.push('curated=1');
-  if (includeAll) params.push('includeAll=1');
+  // `statuses=all` is the auth-gated path on the backend — only returns
+  // rejected/hidden events when the caller is an authenticated underboss/admin.
+  // Unauthenticated callers silently fall back to the filtered view.
+  if (includeAll) params.push('statuses=all');
   if (force) params.push(`_t=${Date.now()}`);
   const url = `/api/gpp/events?${params.join('&')}`;
   const data = await apiRequest<GPPEventsApiPayload>(url, {

--- a/frontend/src/pages/EventsMapPage.tsx
+++ b/frontend/src/pages/EventsMapPage.tsx
@@ -499,6 +499,7 @@ export function EventsMapPage() {
                 events={canModerate ? filteredEvents : events}
                 height="calc(100vh - 64px)"
                 canModerate={canModerate}
+                isModerator={!!canModerate}
               />
             )}
           </Suspense>

--- a/frontend/src/pages/EventsMapPage.tsx
+++ b/frontend/src/pages/EventsMapPage.tsx
@@ -11,6 +11,16 @@ const GPPEventsMap = lazy(() => import('../components/GPPEventsMap'));
 const STATUS_FILTER_KEYS = ['approved', 'pending', 'listed', 'rejected'] as const;
 type StatusFilterKey = (typeof STATUS_FILTER_KEYS)[number];
 
+// Semantic colors used by the marker icons + legend, keyed on underbossStatus.
+// Keep in sync with STATUS_COLORS in GPPEventsMap.tsx.
+const STATUS_LEGEND: { key: string; label: string; color: string }[] = [
+  { key: 'approved', label: 'Approved', color: '#22c55e' },
+  { key: 'listed', label: 'Listed', color: '#3b82f6' },
+  { key: 'pending', label: 'Pending', color: '#eab308' },
+  { key: 'rejected', label: 'Rejected', color: '#ef4444' },
+  { key: 'hidden', label: 'Hidden', color: '#6b7280' },
+];
+
 export function EventsMapPage() {
   const { user, loading: authLoading } = useAuth();
   const [events, setEvents] = useState<GPPEventMapItem[]>([]);
@@ -19,6 +29,9 @@ export function EventsMapPage() {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [canModerate, setCanModerate] = useState<boolean | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  // Moderator-only: toggle between curated (approved+listed) and all-events
+  // (including rejected/hidden). Drives the backend `?statuses=all` request.
+  const [showAll, setShowAll] = useState(false);
 
   // Filter state (only renders for moderators, but declared unconditionally for hook rules)
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -29,10 +42,13 @@ export function EventsMapPage() {
   const [tagFilter, setTagFilter] = useState('all');
   const [countryFilter, setCountryFilter] = useState('all');
 
-  const loadEvents = (moderator: boolean) => {
+  const loadEvents = (moderator: boolean, includeAll: boolean) => {
     setLoading(true);
     setError(null);
-    fetchGppEventsForMap(false, !moderator, moderator)
+    // Non-moderators always get the curated (approved+listed) view.
+    // Moderators see the filtered (non-rejected/hidden) view by default and
+    // can opt into the all-events view via the "Show all events" toggle.
+    fetchGppEventsForMap(false, !moderator, moderator && includeAll)
       .then((data) => {
         setEvents(data);
         setLoading(false);
@@ -48,7 +64,11 @@ export function EventsMapPage() {
     if (isRefreshing) return;
     setIsRefreshing(true);
     try {
-      const data = await fetchGppEventsForMap(true, !canModerate, !!canModerate);
+      const data = await fetchGppEventsForMap(
+        true,
+        !canModerate,
+        !!canModerate && showAll
+      );
       setEvents(data);
     } catch (err) {
       console.error('Failed to refresh events:', err);
@@ -62,7 +82,7 @@ export function EventsMapPage() {
 
     if (!user) {
       setCanModerate(false);
-      loadEvents(false);
+      loadEvents(false, false);
       return;
     }
 
@@ -71,16 +91,27 @@ export function EventsMapPage() {
         const me = await fetchUnderbossMe();
         const isMod = !!(me.isAdmin || me.isUnderboss);
         setCanModerate(isMod);
-        loadEvents(isMod);
+        loadEvents(isMod, showAll);
       } catch (err) {
         console.error('Failed to check moderator status:', err);
         setCanModerate(false);
-        loadEvents(false);
+        loadEvents(false, false);
       }
     }
 
     resolveModeratorStatus();
+    // showAll intentionally omitted — toggle handled by separate effect below
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, authLoading]);
+
+  // Re-fetch when the moderator toggles "Show all events" on/off.
+  // Skips the initial mount (handled by the auth effect above) and any
+  // non-moderator render (toggle is hidden for non-mods).
+  useEffect(() => {
+    if (canModerate === null || !canModerate) return;
+    loadEvents(true, showAll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAll]);
 
   // Debounce search input (200ms) — mirrors EventTable behavior.
   useEffect(() => {
@@ -248,12 +279,47 @@ export function EventsMapPage() {
               <div className="flex flex-col items-center gap-3 bg-white rounded-2xl p-8 shadow-lg">
                 <p className="text-red-600 font-medium">{error}</p>
                 <button
-                  onClick={() => loadEvents(!!canModerate)}
+                  onClick={() => loadEvents(!!canModerate, !!canModerate && showAll)}
                   className="px-5 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5"
                   style={{ background: '#E52828' }}
                 >
                   Retry
                 </button>
+              </div>
+            </div>
+          )}
+
+          {/* "Show all events" toggle — moderators only */}
+          {canModerate && !loading && !error && (
+            <div className="absolute top-3 right-3 z-10">
+              <button
+                onClick={() => setShowAll((v) => !v)}
+                className="bg-white/90 backdrop-blur-sm rounded-full px-4 py-2 shadow-lg border border-white/50 text-sm font-semibold text-gray-800 hover:bg-white transition"
+                aria-pressed={showAll}
+              >
+                {showAll ? 'Show approved only' : 'Show all events'}
+              </button>
+            </div>
+          )}
+
+          {/* Status legend — moderator-only, shown when viewing all events */}
+          {canModerate && showAll && !loading && !error && (
+            <div className="absolute bottom-3 left-3 z-10">
+              <div className="bg-white/90 backdrop-blur-sm rounded-xl px-3 py-2 shadow-lg border border-white/50">
+                <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold mb-1.5">
+                  Status
+                </div>
+                <div className="flex flex-col gap-1">
+                  {STATUS_LEGEND.map((s) => (
+                    <div key={s.key} className="flex items-center gap-2">
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-full border border-white"
+                        style={{ background: s.color }}
+                      />
+                      <span className="text-xs text-gray-800">{s.label}</span>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           )}

--- a/plans/pepperoni-33539-map-all-events.md
+++ b/plans/pepperoni-33539-map-all-events.md
@@ -1,0 +1,192 @@
+# pepperoni-33539: Add "Show all events" toggle to /map with status color-coding
+
+**Priority:** P2
+**Branch:** `pepperoni-33539-map-all-events`
+
+## Feature
+
+The existing `/map` page (`frontend/src/pages/EventsMapPage.tsx`) is underboss-gated and currently shows only events whose `underbossStatus` is NOT `rejected` or `hidden`. Snax wants:
+
+1. A **"Show all events"** toggle button on `/map` that, when on, displays every GPP event regardless of status (including `rejected`, `hidden`, `pending`).
+2. **Markers color-coded by status** using semantic colors:
+   - `approved` → green `#22c55e`
+   - `listed` → blue `#3b82f6`
+   - `pending` (null or "pending") → yellow `#eab308`
+   - `rejected` → red `#ef4444`
+   - `hidden` → gray `#6b7280`
+3. A **legend** so the colors are interpretable.
+
+Since the page is already underboss-gated and the existing backend `/api/gpp/events` endpoint is unauthenticated, the backend needs an auth-gated query param to safely return rejected/hidden events.
+
+## Status values (confirmed)
+
+From `backend/src/routes/gpp.routes.ts` and `frontend/src/components/underboss/EventCard.tsx`:
+`approved`, `listed`, `rejected`, `hidden`, `pending` (often stored as `null`).
+
+## Changes
+
+### 1. Backend — `backend/src/routes/gpp.routes.ts`
+
+The `GET /api/gpp/events` handler at ~line 632 currently hardcodes:
+```ts
+const where: any = { eventType: 'gpp', underbossStatus: { notIn: ['rejected', 'hidden'] } };
+```
+
+Add an optional `?statuses=all` query param. When present **AND** the request is made by an authenticated underboss/admin user, skip the `notIn` filter so all events come back:
+
+```ts
+const { limit = '500', offset = '0', city, country, region, statuses } = req.query;
+
+let includeAllStatuses = false;
+if (statuses === 'all') {
+  // Check auth — only underboss/admin can see rejected/hidden
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice(7);
+    try {
+      const supabaseUser = await verifySupabaseToken(token); // existing helper, see other routes
+      const me = await prisma.user.findUnique({
+        where: { id: supabaseUser.id },
+        select: { isAdmin: true, isUnderboss: true },
+      });
+      if (me?.isAdmin || me?.isUnderboss) {
+        includeAllStatuses = true;
+      }
+    } catch {
+      // Bad token — silently fall back to filtered view; don't 401
+    }
+  }
+}
+
+const where: any = { eventType: 'gpp' };
+if (!includeAllStatuses) {
+  where.underbossStatus = { notIn: ['rejected', 'hidden'] };
+}
+// ... rest of city/country/region filters unchanged
+```
+
+**Check** how other routes in this file (or in `underboss.routes.ts`) verify the Supabase auth token to confirm the exact helper name and import path. Mirror that pattern. If `gpp.routes.ts` doesn't already import auth helpers, look in `backend/src/middleware/` for `requireUnderboss`/`requireAuth` middleware and follow the same pattern as a route that uses optional auth — if no such pattern exists, add the verification inline as shown above using whatever Supabase admin client / JWT helper the codebase already uses.
+
+Also ensure `formatGppEvent` (around line 583) includes `underbossStatus` in the response. It already does (`underbossStatus: event.underbossStatus || 'pending'`), so verify it's exposed in the API payload that the frontend consumes.
+
+### 2. Frontend API — `frontend/src/lib/api.ts`
+
+- Add `underbossStatus` field to `GPPEventMapItem` interface (~line 3255):
+  ```ts
+  export interface GPPEventMapItem {
+    // ...existing fields
+    underbossStatus: string;  // 'approved' | 'listed' | 'pending' | 'rejected' | 'hidden'
+  }
+  ```
+- Add `underbossStatus` to the `GPPEventApiResponse` interface if not already there.
+- Update `fetchGppEventsForMap` (~line 3291) to accept an `includeAllStatuses: boolean` parameter:
+  ```ts
+  export async function fetchGppEventsForMap(includeAllStatuses = false): Promise<GPPEventMapItem[]> {
+    const qs = includeAllStatuses ? '?limit=500&statuses=all' : '?limit=500';
+    const data = await apiRequest<GPPEventsApiPayload>(`/api/gpp/events${qs}`, {
+      requireAuth: includeAllStatuses, // need auth token to get rejected/hidden
+    });
+    return (data.events || []).map((e) => ({
+      // ...existing mapping
+      underbossStatus: e.underbossStatus || 'pending',
+    }));
+  }
+  ```
+  Verify `requireAuth: true` causes `apiRequest` to attach the Supabase Bearer token — check how other authed calls (e.g., `fetchUnderbossMe`) use the helper.
+
+### 3. Frontend page — `frontend/src/pages/EventsMapPage.tsx`
+
+- Add `const [showAll, setShowAll] = useState(false);` state.
+- Change `loadEvents` to accept the flag and pass it through:
+  ```ts
+  const loadEvents = (includeAll: boolean) => {
+    setLoading(true);
+    setError(null);
+    fetchGppEventsForMap(includeAll)
+      .then(setEvents)
+      .catch((err) => setError(err.message || 'Failed to load events'))
+      .finally(() => setLoading(false));
+  };
+  ```
+- Call `loadEvents(showAll)` initially and whenever `showAll` flips. Use a separate `useEffect` keyed on `[showAll, authorized]` so toggling re-fetches.
+- Add a toggle button next to the floating stats badge (top of the map area):
+  ```tsx
+  <button
+    onClick={() => setShowAll((v) => !v)}
+    className="bg-white/90 backdrop-blur-sm rounded-full px-4 py-2 shadow-lg border border-white/50 text-sm font-semibold text-gray-800 hover:bg-white transition"
+  >
+    {showAll ? 'Show approved only' : 'Show all events'}
+  </button>
+  ```
+  Position it near the existing stats badge (top center) — small, non-intrusive. Stats badge should update to reflect filtered count.
+- When `showAll === true`, render a **legend** in the bottom-left corner with a small dot + label for each of the 5 statuses.
+
+### 4. Frontend map — `frontend/src/components/GPPEventsMap.tsx`
+
+Replace the static Benny pizza icon with a per-marker colored circle SVG keyed on `underbossStatus`:
+
+```ts
+const STATUS_COLORS: Record<string, string> = {
+  approved: '#22c55e',
+  listed:   '#3b82f6',
+  pending:  '#eab308',
+  rejected: '#ef4444',
+  hidden:   '#6b7280',
+};
+
+function makeMarkerIcon(status: string): google.maps.Icon {
+  const color = STATUS_COLORS[status] || STATUS_COLORS.pending;
+  const svg = encodeURIComponent(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+      <circle cx="16" cy="16" r="11" fill="${color}" stroke="white" stroke-width="3"/>
+    </svg>
+  `);
+  return {
+    url: `data:image/svg+xml;utf8,${svg}`,
+    scaledSize: new google.maps.Size(32, 32),
+    anchor: new google.maps.Point(16, 16),
+  };
+}
+```
+
+Update the marker creation loop (~line 157) to use `makeMarkerIcon(event.underbossStatus)` instead of the hardcoded `molto-benny-btc.svg`.
+
+Also extend `GPPEventsMapProps` if needed — but since `events` already carries `underbossStatus` once the API change lands, no new prop is required.
+
+Add the status to the InfoWindow `buildInfoContent` (a small badge near the RSVP pill):
+```ts
+const statusHtml = `<span style="background:${color}20;color:${color};font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:500">${event.underbossStatus}</span>`;
+```
+
+**Cluster renderer:** the existing red cluster bubble (#FF0029) is fine for "all events" view too — clustering is about density, not status. Leave it alone.
+
+## Files to modify
+
+- `backend/src/routes/gpp.routes.ts` — auth-gated `?statuses=all`, ensure `underbossStatus` in response
+- `frontend/src/lib/api.ts` — add `underbossStatus` to `GPPEventMapItem`, accept `includeAllStatuses` param
+- `frontend/src/pages/EventsMapPage.tsx` — toggle button, legend, refetch on toggle
+- `frontend/src/components/GPPEventsMap.tsx` — per-marker colored icon, status in InfoWindow
+
+## Verification
+
+1. Local: `cd frontend && npm run typecheck && npm run build`
+2. Local: `cd backend && npm run build`
+3. Sign in as underboss, visit `/map`:
+   - Default view shows ~current count, all markers approved-green or listed-blue
+   - Click "Show all events" → marker count jumps, pending/rejected/hidden markers appear in their colors
+   - Legend appears showing the 5 colors
+   - Toggling back hides the rejected/hidden markers
+4. Verify a logged-out (or non-underboss) request to `/api/gpp/events?statuses=all` returns the **filtered** list (param silently ignored without auth — no 401).
+
+## Critical project gotchas
+
+- **Backend deploys from master only.** Preview frontends call the production backend. The backend changes (`?statuses=all`) MUST be deployed to prod before the toggle works on the preview URL. Coordinate with Snax — they'll merge & deploy backend before testing preview, OR Snax can test locally with `npm run dev` on backend.
+- Preview frontend without backend deploy → toggle button will appear but only return the filtered list (the param is silently ignored).
+- Use **relative paths** for `Write`/`Edit` calls inside the worktree (per memory: absolute paths leak to main repo with `isolation: "worktree"`).
+- No DB schema changes — `underbossStatus` already exists on `parties`. No migration needed.
+
+## Out of scope
+
+- No changes to the public `/gpp` landing-page map.
+- No changes to which events count as "approved" / which appear publicly — only the underboss map view changes.
+- No notifications, no bulk-action UI on the map.


### PR DESCRIPTION
## Summary

Adds a moderator-only "Show all events" toggle to `/map` plus semantic status color-coding on every marker.

- **Backend** (`backend/src/routes/gpp.routes.ts`): adds optional `?statuses=all` query param on `GET /api/gpp/events`. The param is auth-gated — only honored when the caller is an authenticated underboss or admin. Unauthenticated callers silently fall back to the filtered (non-rejected/hidden) view, preserving backwards compat (no 401). The legacy `?includeAll=1` param is now auth-gated too (previously anyone could request rejected/hidden events).
- **Frontend API** (`frontend/src/lib/api.ts`): `fetchGppEventsForMap`'s `includeAll` flag now sends `statuses=all` instead of `includeAll=1`. The bearer token is auto-attached when present.
- **Page** (`frontend/src/pages/EventsMapPage.tsx`): new `showAll` toggle button (top-right) for moderators flips between curated (non-rejected/hidden) and all-events views. A legend (bottom-left) appears when "Show all" is active. A second `useEffect` re-fetches when the toggle flips.
- **Map** (`frontend/src/components/GPPEventsMap.tsx`): replaces the static Benny pizza icon with a per-marker colored SVG circle keyed on `underbossStatus`:
  - approved → green `#22c55e`
  - listed → blue `#3b82f6`
  - pending → yellow `#eab308`
  - rejected → red `#ef4444`
  - hidden → gray `#6b7280`

  InfoWindow now shows a status pill for every moderator-visible event. Approve/reject actions update the marker color in place instead of removing the marker (it now turns red instead of disappearing).

## Files changed

- `backend/src/routes/gpp.routes.ts` — auth-gated `?statuses=all` (mirrors `optionalAuth` JWT pattern from `middleware/auth.ts`)
- `frontend/src/lib/api.ts` — switch to `statuses=all` query param
- `frontend/src/pages/EventsMapPage.tsx` — toggle button, legend, refetch effect
- `frontend/src/components/GPPEventsMap.tsx` — `STATUS_COLORS` + `makeMarkerIcon`, status pill in InfoWindow, in-place marker recolor on action

## Vercel preview

https://rsvpizza-git-pepperoni-33539-map-all-events-pizza-dao.vercel.app/map

## Important deploy note

**Backend changes only ship to production from `master`.** Preview frontends call the production backend, so the toggle button will be visible on the preview URL but won't return `rejected`/`hidden` events until this PR's backend changes are deployed to prod. Until then, toggling "Show all" on the preview will silently return the same filtered set as the default view. Marker color-coding, legend, and toggle UI will all work — only the additional rejected/hidden markers depend on backend deploy.

## Test plan

- [ ] Sign in as underboss on the deployed preview, visit `/map`
- [ ] Verify markers render with status colors (green/blue/yellow), default view excludes red/gray
- [ ] Click "Show all events" — button label flips to "Show approved only", legend appears bottom-left
- [ ] After backend deploy, verify additional rejected (red) / hidden (gray) markers appear
- [ ] Click an approved marker → InfoWindow shows green "Approved" pill + "Mark rejected" link
- [ ] Click "Reject" on a pending marker → marker recolors to red in place (no longer disappears)
- [ ] Confirm `curl -I https://api.rsv.pizza/api/gpp/events?statuses=all` (unauthenticated) returns the **filtered** event list — no 401, no rejected/hidden leak
- [ ] Confirm non-moderator login on `/map` does not see the toggle button

🤖 Generated with [Claude Code](https://claude.com/claude-code)