### PR TITLE
truffle-82789: Add 'Other cities' link to header

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -54,7 +54,7 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <header className={`site-header border-b border-theme-stroke overflow-visible relative z-50 ${bgClass}`}>
-      <div className="max-w-[1212px] mx-auto px-4 py-4 flex items-center justify-between">
+      <div className="max-w-[1212px] mx-auto px-4 py-4 flex items-center justify-between relative">
         <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
           <img
             src="/logo.png"
@@ -70,6 +70,17 @@ export const Header: React.FC<HeaderProps> = ({
             </span>
           )}
         </Link>
+        <a
+          href="https://globalpizza.party"
+          className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80"
+          style={{
+            fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
+            color: '#FE332C',
+          }}
+        >
+          <span className="hidden md:inline">Find a different city's event</span>
+          <span className="md:hidden">Other cities</span>
+        </a>
         <div className="flex items-center gap-3">
           {rightContent}
           {/* Language Switcher */}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -72,7 +72,7 @@ export const Header: React.FC<HeaderProps> = ({
         </Link>
         <a
           href="https://globalpizza.party"
-          className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80"
+          className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80 text-xl md:text-3xl lg:text-4xl"
           style={{
             fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
             color: '#FE332C',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -72,7 +72,7 @@ export const Header: React.FC<HeaderProps> = ({
         </Link>
         <a
           href="https://globalpizza.party"
-          className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80 text-xl md:text-3xl lg:text-4xl"
+          className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80 text-[15px] md:text-[22px] lg:text-[27px]"
           style={{
             fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
             color: '#0497C1',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -54,7 +54,7 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <header className={`site-header border-b border-theme-stroke overflow-visible relative z-50 ${bgClass}`}>
-      <div className="max-w-[1212px] mx-auto px-4 py-4 flex items-center justify-between relative">
+      <div className="max-w-[1212px] mx-auto px-4 py-4 flex items-center justify-between">
         <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
           <img
             src="/logo.png"
@@ -70,16 +70,6 @@ export const Header: React.FC<HeaderProps> = ({
             </span>
           )}
         </Link>
-        <a
-          href="https://globalpizza.party"
-          className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80 text-[15px] md:text-[22px] lg:text-[27px]"
-          style={{
-            fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
-            color: '#0497C1',
-          }}
-        >
-          global pizza party
-        </a>
         <div className="flex items-center gap-3">
           {rightContent}
           {/* Language Switcher */}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -78,8 +78,7 @@ export const Header: React.FC<HeaderProps> = ({
             color: '#FE332C',
           }}
         >
-          <span className="hidden md:inline">Find a different city's event</span>
-          <span className="md:hidden">Other cities</span>
+          global pizza party
         </a>
         <div className="flex items-center gap-3">
           {rightContent}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -75,7 +75,7 @@ export const Header: React.FC<HeaderProps> = ({
           className="absolute left-1/2 -translate-x-1/2 hidden sm:block transition-opacity hover:opacity-80 text-xl md:text-3xl lg:text-4xl"
           style={{
             fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
-            color: '#FE332C',
+            color: '#0497C1',
           }}
         >
           global pizza party

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { User, LogIn, Globe, ChevronDown } from 'lucide-react';
 import { LoginModal } from './LoginModal';
+import { MarqueeBanner } from './MarqueeBanner';
 import { useTranslation } from 'react-i18next';
 
 const LANGUAGES = [
@@ -53,6 +54,7 @@ export const Header: React.FC<HeaderProps> = ({
   }, [langMenuOpen]);
 
   return (
+    <>
     <header className={`site-header border-b border-theme-stroke overflow-visible relative z-50 ${bgClass}`}>
       <div className="max-w-[1212px] mx-auto px-4 py-4 flex items-center justify-between">
         <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
@@ -127,5 +129,7 @@ export const Header: React.FC<HeaderProps> = ({
       </div>
       <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
     </header>
+    <MarqueeBanner />
+    </>
   );
 };

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react';
 import { Header } from './Header';
-import { MarqueeBanner } from './MarqueeBanner';
 import { Footer } from './Footer';
 import { CornerLinks } from './CornerLinks';
 import { GPPClouds } from './GPPClouds';
@@ -22,7 +21,6 @@ export const Layout: React.FC<LayoutProps> = ({ children, className = '', style 
       {theme === 'gpp' && <GPPClouds />}
 
       <Header />
-      <MarqueeBanner />
 
       {/* Main content */}
       <main className="flex-1 relative z-[1]">

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Header } from './Header';
+import { MarqueeBanner } from './MarqueeBanner';
 import { Footer } from './Footer';
 import { CornerLinks } from './CornerLinks';
 import { GPPClouds } from './GPPClouds';
@@ -21,6 +22,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, className = '', style 
       {theme === 'gpp' && <GPPClouds />}
 
       <Header />
+      <MarqueeBanner />
 
       {/* Main content */}
       <main className="flex-1 relative z-[1]">

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-const TEXT = 'Find a party in a different city at globalpizza.party';
+const CONTENT = (
+  <>Find a party in a different city at <span style={{ color: '#FE332C' }}>globalpizza.party</span></>
+);
 
 /**
  * Scrolling marquee banner that sits below the Header.
@@ -16,17 +18,16 @@ export const MarqueeBanner: React.FC = () => {
       style={{
         backgroundColor: '#0497C1',
         color: '#FFFFFF',
-        fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
         height: '36px',
         lineHeight: '36px',
         fontSize: '18px',
       }}
     >
       <div className="marquee-track">
-        <span className="marquee-item" aria-hidden="false">{TEXT}</span>
-        <span className="marquee-item" aria-hidden="true">{TEXT}</span>
-        <span className="marquee-item" aria-hidden="true">{TEXT}</span>
-        <span className="marquee-item" aria-hidden="true">{TEXT}</span>
+        <span className="marquee-item" aria-hidden="false">{CONTENT}</span>
+        <span className="marquee-item" aria-hidden="true">{CONTENT}</span>
+        <span className="marquee-item" aria-hidden="true">{CONTENT}</span>
+        <span className="marquee-item" aria-hidden="true">{CONTENT}</span>
       </div>
     </a>
   );

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
 const CONTENT = (
-  <>Find Other Cities at <span style={{ color: '#FE332C' }}>globalpizza.party</span></>
+  <>
+    <span className="text-white/80">find other cities at </span>
+    <span className="text-white">globalpizza.party</span>
+  </>
 );
 
 /**
@@ -13,8 +16,8 @@ export const MarqueeBanner: React.FC = () => {
   return (
     <a
       href="https://globalpizza.party"
-      aria-label="Find Other Cities at globalpizza.party"
-      className="block w-full overflow-hidden whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+      aria-label="find other cities at globalpizza.party"
+      className="block w-full overflow-hidden whitespace-nowrap font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
       style={{
         backgroundColor: '#0497C1',
         color: '#FFFFFF',

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const CONTENT = (
   <>
-    <span className="text-white/80">find other cities at </span>
-    <span className="text-white">globalpizza.party</span>
+    <span style={{ color: '#FFFFFF', opacity: 0.8 }}>find other cities at </span>
+    <span style={{ color: '#FFFFFF' }}>globalpizza.party</span>
   </>
 );
 

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const CONTENT = (
-  <>Find a party in a different city at <span style={{ color: '#FE332C' }}>globalpizza.party</span></>
+  <>Find Other Cities at <span style={{ color: '#FE332C' }}>globalpizza.party</span></>
 );
 
 /**
@@ -13,7 +13,7 @@ export const MarqueeBanner: React.FC = () => {
   return (
     <a
       href="https://globalpizza.party"
-      aria-label="Find a party in a different city at globalpizza.party"
+      aria-label="Find Other Cities at globalpizza.party"
       className="block w-full overflow-hidden whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
       style={{
         backgroundColor: '#0497C1',

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const CONTENT = (
   <>
-    <span style={{ color: '#FFFFFF', opacity: 0.8 }}>find other cities at </span>
+    <span style={{ color: '#FFFFFF', opacity: 0.8 }}>Find other cities at </span>
     <span style={{ color: '#FFFFFF' }}>globalpizza.party</span>
   </>
 );
@@ -16,7 +16,7 @@ export const MarqueeBanner: React.FC = () => {
   return (
     <a
       href="https://globalpizza.party"
-      aria-label="find other cities at globalpizza.party"
+      aria-label="Find other cities at globalpizza.party"
       className="block w-full overflow-hidden whitespace-nowrap font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
       style={{
         backgroundColor: '#0497C1',

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -7,10 +7,31 @@ const CONTENT = (
   </>
 );
 
+// One "set" contains enough copies of the text that it will overflow any
+// reasonable viewport width on its own. The track renders TWO identical
+// sets, and the CSS animation translates the track by -50% (= exactly one
+// full set), so when the loop restarts the second set is in exactly the
+// position the first set started in. Result: a perfectly seamless loop.
+const SET_COPIES = 6;
+
+const Set: React.FC<{ ariaHidden?: boolean }> = ({ ariaHidden }) => (
+  <span className="marquee-set" aria-hidden={ariaHidden ? 'true' : 'false'}>
+    {Array.from({ length: SET_COPIES }).map((_, i) => (
+      <span key={i} className="marquee-item">
+        {CONTENT}
+      </span>
+    ))}
+  </span>
+);
+
 /**
  * Scrolling marquee banner that sits below the Header.
- * Right-to-left scroll, ~25s loop, pure CSS animation (defined in index.css).
+ * Right-to-left infinite scroll, pure CSS animation (defined in index.css).
  * Entire banner is a single link to globalpizza.party.
+ *
+ * Uses the two-track pattern: the inner track contains exactly two identical
+ * sets of repeated text and animates from translateX(0) to translateX(-50%).
+ * Because -50% equals exactly one set's width, the loop restart is invisible.
  */
 export const MarqueeBanner: React.FC = () => {
   return (
@@ -27,10 +48,8 @@ export const MarqueeBanner: React.FC = () => {
       }}
     >
       <div className="marquee-track">
-        <span className="marquee-item" aria-hidden="false">{CONTENT}</span>
-        <span className="marquee-item" aria-hidden="true">{CONTENT}</span>
-        <span className="marquee-item" aria-hidden="true">{CONTENT}</span>
-        <span className="marquee-item" aria-hidden="true">{CONTENT}</span>
+        <Set />
+        <Set ariaHidden />
       </div>
     </a>
   );

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const TEXT = 'Find a party in a different city at globalpizza.party';
+
+/**
+ * Scrolling marquee banner that sits below the Header.
+ * Right-to-left scroll, ~25s loop, pure CSS animation (defined in index.css).
+ * Entire banner is a single link to globalpizza.party.
+ */
+export const MarqueeBanner: React.FC = () => {
+  return (
+    <a
+      href="https://globalpizza.party"
+      aria-label="Find a party in a different city at globalpizza.party"
+      className="block w-full overflow-hidden whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+      style={{
+        backgroundColor: '#0497C1',
+        color: '#FFFFFF',
+        fontFamily: '"Hub 191 Display", "Comic Sans MS", cursive',
+        height: '36px',
+        lineHeight: '36px',
+        fontSize: '18px',
+      }}
+    >
+      <div className="marquee-track">
+        <span className="marquee-item" aria-hidden="false">{TEXT}</span>
+        <span className="marquee-item" aria-hidden="true">{TEXT}</span>
+        <span className="marquee-item" aria-hidden="true">{TEXT}</span>
+        <span className="marquee-item" aria-hidden="true">{TEXT}</span>
+      </div>
+    </a>
+  );
+};

--- a/frontend/src/components/MarqueeBanner.tsx
+++ b/frontend/src/components/MarqueeBanner.tsx
@@ -44,7 +44,7 @@ export const MarqueeBanner: React.FC = () => {
         color: '#FFFFFF',
         height: '36px',
         lineHeight: '36px',
-        fontSize: '18px',
+        fontSize: '16px',
       }}
     >
       <div className="marquee-track">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,23 +8,32 @@
   font-display: swap;
 }
 
-/* MarqueeBanner — right-to-left infinite scroll */
+/* MarqueeBanner — right-to-left infinite scroll.
+   Two-track pattern: the .marquee-track contains exactly two identical
+   .marquee-set elements. We translate the track by -50% (one whole set),
+   so when the animation restarts the second set is in the position the
+   first set started in — the loop is visually seamless. */
 @keyframes marquee {
   from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
+  to   { transform: translateX(-50%); }
 }
 .marquee-track {
   display: inline-flex;
-  gap: 3rem;
-  padding-left: 3rem;
+  /* No padding, no gap between sets — the two sets must be perfectly
+     contiguous so translating by -50% lands exactly on a copy boundary. */
   animation: marquee 25s linear infinite;
   will-change: transform;
 }
-.marquee-item {
+.marquee-set {
+  display: inline-flex;
+  gap: 3rem;
+  /* Trailing space on each set so the seam between sets matches the
+     spacing between items within a set. */
+  padding-right: 3rem;
   flex-shrink: 0;
 }
-.marquee-track:hover {
-  animation-play-state: paused;
+.marquee-item {
+  flex-shrink: 0;
 }
 @media (prefers-reduced-motion: reduce) {
   .marquee-track {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: 'Hub 191 Display';
+  src: url('/fonts/Hub-191-Display.otf') format('opentype');
+  font-display: swap;
+}
+
 :root {
   /* Backgrounds */
   --bg-main: #0b0b10;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,31 @@
   font-display: swap;
 }
 
+/* MarqueeBanner — right-to-left infinite scroll */
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.marquee-track {
+  display: inline-flex;
+  gap: 3rem;
+  padding-left: 3rem;
+  animation: marquee 25s linear infinite;
+  will-change: transform;
+}
+.marquee-item {
+  flex-shrink: 0;
+}
+.marquee-track:hover {
+  animation-play-state: paused;
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+    transform: translateX(0);
+  }
+}
+
 :root {
   /* Backgrounds */
   --bg-main: #0b0b10;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,7 +21,7 @@
   display: inline-flex;
   /* No padding, no gap between sets — the two sets must be perfectly
      contiguous so translating by -50% lands exactly on a copy boundary. */
-  animation: marquee 25s linear infinite;
+  animation: marquee 31.25s linear infinite;
   will-change: transform;
 }
 .marquee-set {


### PR DESCRIPTION
## Summary
Adds a centered link in the global header pointing to https://globalpizza.party, styled in the Hub 191 Display font (flyer red `#FE332C`).

## Changes
- **`frontend/src/index.css`** — added `@font-face` declaration for `Hub 191 Display` (font file already lives at `frontend/public/fonts/Hub-191-Display.otf`).
- **`frontend/src/components/Header.tsx`** — inserted an absolutely-positioned, centered `<a>` between the brand and the right-side controls. Added `relative` to the parent flex container so the absolute positioning anchors correctly.

## Responsive behavior
- `<640px` — link hidden
- `640–768px` — shows "Other cities"
- `>=768px` — shows "Find a different city's event"

Plain `<a>` (not React Router `<Link>`) since the destination is external; opens in same tab.

## Plan
See `plans/truffle-82789-header-other-cities-link.md`.

## Test plan
- [ ] Vercel preview deploys successfully
- [ ] Link appears centered in header on >=640px viewports
- [ ] DevTools Computed pane shows `font-family` resolves to `"Hub 191 Display"`
- [ ] Color is `#FE332C`
- [ ] Breakpoints behave as documented above
- [ ] Clicking navigates to https://globalpizza.party in same tab