### PR TITLE
blackolive-74932: fake-event detection composite review queue

### DIFF
--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shannon,
+  fieldSignature,
+  filterDirectRsvps,
+  checkCapFillNoWaitlist,
+  checkLowDomainEntropy,
+  checkSigCollapse,
+  checkWalletTooLow,
+  checkWalletTooHighReuse,
+  checkWalletReuse,
+  checkHostSelfRsvpMismatch,
+  checkPizzeriaFieldsBlank,
+  checkWalletSourceAllNull,
+  checkOneWordName,
+  checkFirstnameDigitsEmail,
+  checkDayGapPattern,
+  checkLowHourEntropy,
+  checkRapidIntersubmission,
+  checkCrossEventWallet,
+  scoreEvent,
+  buildSybilWalletSet,
+  tierFromScore,
+  WEIGHTS,
+  type FakeDetectionGuest,
+  type FakeDetectionParty,
+  type FakeDetectionLinkClick,
+} from './fakeDetection.js';
+
+// ============================================
+// Fixture helpers
+// ============================================
+
+function makeGuest(overrides: Partial<FakeDetectionGuest> = {}): FakeDetectionGuest {
+  return {
+    id: 'g-' + Math.random().toString(36).slice(2, 9),
+    name: 'Mario Rossi',
+    email: 'mario@example.com',
+    ethereumAddress: null,
+    submittedAt: new Date('2026-04-01T12:00:00Z'),
+    submittedVia: 'link',
+    waitlistPosition: null,
+    walletSource: null,
+    likedToppings: ['mushroom'],
+    dislikedToppings: [],
+    likedBeverages: [],
+    dislikedBeverages: [],
+    dietaryRestrictions: [],
+    roles: [],
+    pizzeriaRankings: ['da Michele', 'Sorbillo'],
+    suggestedPizzerias: [{ name: 'da Michele' }],
+    ...overrides,
+  };
+}
+
+function makeParty(overrides: Partial<FakeDetectionParty> = {}): FakeDetectionParty {
+  return {
+    id: 'party-1',
+    name: 'Global Pizza Party Test',
+    customUrl: 'test',
+    country: 'IT',
+    region: 'western-europe',
+    timezone: 'Europe/Rome',
+    maxGuests: 100,
+    createdAt: new Date('2026-03-01T10:00:00Z'),
+    underbossStatus: 'pending',
+    user: { name: 'Host Person', email: 'host@example.com' },
+    ...overrides,
+  };
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+describe('shannon', () => {
+  it('returns 0 for empty input', () => {
+    expect(shannon([])).toBe(0);
+  });
+  it('returns 0 for single-value uniform input', () => {
+    expect(shannon(['a', 'a', 'a'])).toBe(0);
+  });
+  it('returns 1 for two equally likely values', () => {
+    expect(shannon(['a', 'b'])).toBeCloseTo(1);
+  });
+  it('uses log base 2', () => {
+    // 4 distinct equally likely values → entropy = log2(4) = 2
+    expect(shannon(['a', 'b', 'c', 'd'])).toBeCloseTo(2);
+  });
+});
+
+describe('fieldSignature', () => {
+  it('produces equal signatures regardless of array order', () => {
+    const a = makeGuest({ likedToppings: ['mushroom', 'pepperoni'], roles: ['x', 'y'] });
+    const b = makeGuest({ likedToppings: ['pepperoni', 'mushroom'], roles: ['y', 'x'] });
+    expect(fieldSignature(a)).toBe(fieldSignature(b));
+  });
+  it('produces different signatures for different content', () => {
+    const a = makeGuest({ likedToppings: ['mushroom'] });
+    const b = makeGuest({ likedToppings: ['pepperoni'] });
+    expect(fieldSignature(a)).not.toBe(fieldSignature(b));
+  });
+});
+
+describe('filterDirectRsvps', () => {
+  it('keeps link/rsvp/api and drops invite/host/host-checkin', () => {
+    const guests = [
+      makeGuest({ submittedVia: 'link' }),
+      makeGuest({ submittedVia: 'rsvp' }),
+      makeGuest({ submittedVia: 'api' }),
+      makeGuest({ submittedVia: 'invite' }),
+      makeGuest({ submittedVia: 'host' }),
+      makeGuest({ submittedVia: 'host-checkin' }),
+    ];
+    expect(filterDirectRsvps(guests).length).toBe(3);
+  });
+});
+
+// ============================================
+// Per-heuristic edge cases
+// ============================================
+
+describe('checkCapFillNoWaitlist', () => {
+  it('does not fire below min n', () => {
+    const guests = Array.from({ length: 19 }, () => makeGuest());
+    expect(checkCapFillNoWaitlist(guests, 20).fired).toBe(false);
+  });
+  it('fires when ≥90% full and zero waitlist', () => {
+    const guests = Array.from({ length: 90 }, () => makeGuest());
+    expect(checkCapFillNoWaitlist(guests, 100).fired).toBe(true);
+  });
+  it('does not fire when there is a waitlist', () => {
+    const guests = Array.from({ length: 90 }, (_, i) =>
+      makeGuest({ waitlistPosition: i >= 88 ? i - 87 : null }),
+    );
+    expect(checkCapFillNoWaitlist(guests, 100).fired).toBe(false);
+  });
+  it('does not fire without maxGuests', () => {
+    const guests = Array.from({ length: 50 }, () => makeGuest());
+    expect(checkCapFillNoWaitlist(guests, null).fired).toBe(false);
+  });
+});
+
+describe('checkLowDomainEntropy', () => {
+  it('does not fire below min n', () => {
+    const guests = Array.from({ length: 10 }, () => makeGuest({ email: 'a@b.com' }));
+    expect(checkLowDomainEntropy(guests).fired).toBe(false);
+  });
+  it('fires when all emails share one domain', () => {
+    const guests = Array.from({ length: 30 }, (_, i) => makeGuest({ email: `user${i}@spam.com` }));
+    expect(checkLowDomainEntropy(guests).fired).toBe(true);
+  });
+  it('does not fire with diverse domains', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ email: `user@d${i}.com` }),
+    );
+    expect(checkLowDomainEntropy(guests).fired).toBe(false);
+  });
+});
+
+describe('checkSigCollapse', () => {
+  it('fires when signatures collapse to one', () => {
+    const guests = Array.from({ length: 30 }, () => makeGuest({ likedToppings: ['x'] }));
+    expect(checkSigCollapse(guests).fired).toBe(true);
+  });
+  it('does not fire when signatures are diverse', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ likedToppings: [`topping${i}`] }),
+    );
+    expect(checkSigCollapse(guests).fired).toBe(false);
+  });
+});
+
+describe('checkWalletTooLow', () => {
+  it('fires when <5% have wallets', () => {
+    const guests = Array.from({ length: 50 }, () => makeGuest({ ethereumAddress: null }));
+    expect(checkWalletTooLow(guests).fired).toBe(true);
+  });
+  it('does not fire when wallet ratio is healthy', () => {
+    const guests = Array.from({ length: 50 }, (_, i) =>
+      makeGuest({ ethereumAddress: `0x${i.toString(16).padStart(40, '0')}` }),
+    );
+    expect(checkWalletTooLow(guests).fired).toBe(false);
+  });
+});
+
+describe('checkWalletTooHighReuse', () => {
+  it('fires when ≥95% have wallets and reuse >30%', () => {
+    const guests = Array.from({ length: 50 }, (_, i) =>
+      makeGuest({ ethereumAddress: i < 25 ? '0xshared' : `0x${i}` }),
+    );
+    expect(checkWalletTooHighReuse(guests).fired).toBe(true);
+  });
+  it('does not fire when wallet count below 95%', () => {
+    const guests = Array.from({ length: 50 }, (_, i) =>
+      makeGuest({ ethereumAddress: i < 25 ? `0x${i}` : null }),
+    );
+    expect(checkWalletTooHighReuse(guests).fired).toBe(false);
+  });
+});
+
+describe('checkWalletReuse', () => {
+  it('fires when 10%+ of wallets are duplicates', () => {
+    const guests = [
+      ...Array.from({ length: 9 }, () => makeGuest({ ethereumAddress: '0xshared' })),
+      makeGuest({ ethereumAddress: '0xshared' }),
+      ...Array.from({ length: 5 }, (_, i) => makeGuest({ ethereumAddress: `0x${i}` })),
+    ];
+    expect(checkWalletReuse(guests).fired).toBe(true);
+  });
+  it('does not fire with all-unique wallets', () => {
+    const guests = Array.from({ length: 15 }, (_, i) =>
+      makeGuest({ ethereumAddress: `0x${i.toString(16).padStart(40, '0')}` }),
+    );
+    expect(checkWalletReuse(guests).fired).toBe(false);
+  });
+});
+
+describe('checkHostSelfRsvpMismatch', () => {
+  it('fires for a sub-60s RSVP with non-matching name', () => {
+    const party = makeParty({
+      createdAt: new Date('2026-03-01T10:00:00Z'),
+      user: { name: 'Alice Host', email: 'alice@host.com' },
+    });
+    const guests = [
+      makeGuest({
+        name: 'Some Other Name',
+        email: 'other@x.com',
+        submittedAt: new Date('2026-03-01T10:00:30Z'),
+      }),
+    ];
+    expect(checkHostSelfRsvpMismatch(guests, party).fired).toBe(true);
+  });
+  it('does not fire when name matches host', () => {
+    const party = makeParty({
+      createdAt: new Date('2026-03-01T10:00:00Z'),
+      user: { name: 'Alice Host', email: 'alice@host.com' },
+    });
+    const guests = [
+      makeGuest({
+        name: 'Alice Host',
+        email: 'something@else.com',
+        submittedAt: new Date('2026-03-01T10:00:30Z'),
+      }),
+    ];
+    expect(checkHostSelfRsvpMismatch(guests, party).fired).toBe(false);
+  });
+  it('does not fire when delta exceeds 60s', () => {
+    const party = makeParty({
+      createdAt: new Date('2026-03-01T10:00:00Z'),
+      user: { name: 'Alice Host', email: 'alice@host.com' },
+    });
+    const guests = [
+      makeGuest({
+        name: 'Mystery Name',
+        email: 'rando@x.com',
+        submittedAt: new Date('2026-03-01T10:02:00Z'),
+      }),
+    ];
+    expect(checkHostSelfRsvpMismatch(guests, party).fired).toBe(false);
+  });
+});
+
+describe('checkPizzeriaFieldsBlank', () => {
+  it('fires when nearly all pizzeria fields are empty', () => {
+    const guests = Array.from({ length: 30 }, () =>
+      makeGuest({ pizzeriaRankings: [], suggestedPizzerias: [] }),
+    );
+    expect(checkPizzeriaFieldsBlank(guests).fired).toBe(true);
+  });
+  it('does not fire when guests fill the fields', () => {
+    const guests = Array.from({ length: 30 }, () =>
+      makeGuest({ pizzeriaRankings: ['x', 'y'], suggestedPizzerias: [{ name: 'z' }] }),
+    );
+    expect(checkPizzeriaFieldsBlank(guests).fired).toBe(false);
+  });
+});
+
+describe('checkWalletSourceAllNull', () => {
+  it('fires when every walletSource is null', () => {
+    const guests = Array.from({ length: 30 }, () => makeGuest({ walletSource: null }));
+    expect(checkWalletSourceAllNull(guests).fired).toBe(true);
+  });
+  it('does not fire when any walletSource is set', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ walletSource: i === 0 ? 'privy' : null }),
+    );
+    expect(checkWalletSourceAllNull(guests).fired).toBe(false);
+  });
+});
+
+describe('checkOneWordName', () => {
+  it('fires when >20% of names are single-word', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ name: i < 10 ? 'Mario' : 'Mario Rossi' }),
+    );
+    expect(checkOneWordName(guests).fired).toBe(true);
+  });
+  it('does not fire with mostly multi-word names', () => {
+    const guests = Array.from({ length: 30 }, () => makeGuest({ name: 'Mario Rossi' }));
+    expect(checkOneWordName(guests).fired).toBe(false);
+  });
+});
+
+describe('checkFirstnameDigitsEmail', () => {
+  it('fires when >95% of emails match firstname+digits and domains low entropy', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ email: `mario${i}@spam.com` }),
+    );
+    expect(checkFirstnameDigitsEmail(guests).fired).toBe(true);
+  });
+  it('does not fire when emails are realistic', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ email: `mario.rossi${i}@gmail.com` }),
+    );
+    expect(checkFirstnameDigitsEmail(guests).fired).toBe(false);
+  });
+});
+
+describe('checkDayGapPattern', () => {
+  it('skips cleanly when link_clicks is empty', () => {
+    const guests = Array.from({ length: 30 }, () => makeGuest());
+    const party = makeParty();
+    expect(checkDayGapPattern(guests, party, []).fired).toBe(false);
+  });
+  it('fires when ≥2 zero days are bracketed by 5+ RSVP days and no click spike', () => {
+    const party = makeParty({ timezone: null });
+    // Day 1: 6 RSVPs, Days 2-3: 0 RSVPs, Day 4: 6 RSVPs
+    const guests: FakeDetectionGuest[] = [
+      ...Array.from({ length: 6 }, () => makeGuest({ submittedAt: new Date('2026-04-01T12:00:00Z') })),
+      ...Array.from({ length: 14 }, (_, i) => makeGuest({ submittedAt: new Date('2026-04-01T13:00:00Z') })),
+      ...Array.from({ length: 6 }, () => makeGuest({ submittedAt: new Date('2026-04-04T12:00:00Z') })),
+    ];
+    // Some click data exists but none on the zero days
+    const linkClicks: FakeDetectionLinkClick[] = [
+      { clickedAt: new Date('2026-04-01T12:00:00Z') },
+      { clickedAt: new Date('2026-04-04T12:00:00Z') },
+    ];
+    expect(checkDayGapPattern(guests, party, linkClicks).fired).toBe(true);
+  });
+});
+
+describe('checkLowHourEntropy', () => {
+  it('fires when all submissions cluster into one hour', () => {
+    const guests = Array.from({ length: 30 }, () =>
+      makeGuest({ submittedAt: new Date('2026-04-01T12:30:00Z') }),
+    );
+    expect(checkLowHourEntropy(guests, makeParty({ timezone: null })).fired).toBe(true);
+  });
+  it('does not fire when hours are spread', () => {
+    const guests = Array.from({ length: 24 }, (_, i) =>
+      makeGuest({
+        submittedAt: new Date(`2026-04-01T${i.toString().padStart(2, '0')}:00:00Z`),
+      }),
+    );
+    expect(checkLowHourEntropy(guests, makeParty({ timezone: null })).fired).toBe(false);
+  });
+});
+
+describe('checkRapidIntersubmission', () => {
+  it('fires when median delta ≤ 60s', () => {
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ submittedAt: new Date(base + i * 30000) }), // 30s apart
+    );
+    expect(checkRapidIntersubmission(guests).fired).toBe(true);
+  });
+  it('does not fire when submissions are well-spaced', () => {
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ submittedAt: new Date(base + i * 3600000) }), // 1 hour apart
+    );
+    expect(checkRapidIntersubmission(guests).fired).toBe(false);
+  });
+});
+
+describe('checkCrossEventWallet', () => {
+  it('fires when any guest wallet is in the sybil set', () => {
+    const sybils = new Set(['0xbadwallet']);
+    const guests = [makeGuest({ ethereumAddress: '0xbadwallet' })];
+    expect(checkCrossEventWallet(guests, sybils).fired).toBe(true);
+  });
+  it('does not fire when no guest wallet is sybil', () => {
+    const sybils = new Set(['0xbadwallet']);
+    const guests = [makeGuest({ ethereumAddress: '0xgoodwallet' })];
+    expect(checkCrossEventWallet(guests, sybils).fired).toBe(false);
+  });
+});
+
+describe('buildSybilWalletSet', () => {
+  it('includes wallets with ≥4 parties AND ≥2 distinct names', () => {
+    const rows = [
+      {
+        ethereumAddress: '0xbad',
+        partyIds: ['p1', 'p2', 'p3', 'p4'],
+        names: ['alice', 'bob'],
+      },
+      // Only 3 parties — excluded
+      {
+        ethereumAddress: '0xnotenough',
+        partyIds: ['p1', 'p2', 'p3'],
+        names: ['x', 'y', 'z'],
+      },
+      // 4 parties but only 1 name — excluded
+      {
+        ethereumAddress: '0xsamename',
+        partyIds: ['p1', 'p2', 'p3', 'p4'],
+        names: ['alice', 'alice'],
+      },
+    ];
+    const set = buildSybilWalletSet(rows);
+    expect(set.has('0xbad')).toBe(true);
+    expect(set.has('0xnotenough')).toBe(false);
+    expect(set.has('0xsamename')).toBe(false);
+  });
+});
+
+describe('tierFromScore', () => {
+  it('maps scores to tiers', () => {
+    expect(tierFromScore(0)).toBe('clean');
+    expect(tierFromScore(9)).toBe('clean');
+    expect(tierFromScore(10)).toBe('low');
+    expect(tierFromScore(29)).toBe('low');
+    expect(tierFromScore(30)).toBe('medium');
+    expect(tierFromScore(59)).toBe('medium');
+    expect(tierFromScore(60)).toBe('high');
+    expect(tierFromScore(100)).toBe('high');
+  });
+});
+
+// ============================================
+// Integration: "Ilemela-like" vs "Lilongwe-like"
+// ============================================
+
+describe('scoreEvent — integration fixtures', () => {
+  it('"Ilemela-like" event scores ≥70', () => {
+    // Padded event: 95 RSVPs against 100 cap, zero waitlist, one shared domain,
+    // identical field signature, no wallets, blank pizzeria fields, single-word
+    // names, firstname+digits emails, host-self RSVP under different name,
+    // submissions all within one hour, ~30s apart.
+    const party = makeParty({
+      id: 'ilemela',
+      name: 'GPP Ilemela',
+      maxGuests: 100,
+      timezone: 'Africa/Dar_es_Salaam',
+      createdAt: new Date('2026-03-01T10:00:00Z'),
+      user: { name: 'Real Host Name', email: 'realhost@example.com' },
+    });
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const guests: FakeDetectionGuest[] = [
+      // host self-RSVP with mismatched name, 10s after event creation
+      makeGuest({
+        name: 'Fake Imposter',
+        email: 'fake@imposter.com',
+        submittedAt: new Date('2026-03-01T10:00:10Z'),
+        walletSource: null,
+        pizzeriaRankings: [],
+        suggestedPizzerias: [],
+        likedToppings: [],
+        ethereumAddress: null,
+      }),
+      ...Array.from({ length: 94 }, (_, i) =>
+        makeGuest({
+          name: `Name${i}`, // one-word
+          email: `mario${i}@spam.com`, // firstname+digits, one domain
+          submittedAt: new Date(base + i * 30000), // 30s apart
+          walletSource: null,
+          pizzeriaRankings: [],
+          suggestedPizzerias: [],
+          likedToppings: [], // identical signatures
+          ethereumAddress: null,
+        }),
+      ),
+    ];
+    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests);
+    // Should fire: 1 cap_fill, 2 low_domain_entropy, 3 sig_collapse,
+    // 4a wallet_too_low, 6 host_self, 7 pizzeria_blank, 8 wallet_source_null,
+    // 9 one_word_name, 10 firstname_digits, 12 low_hour_entropy, 13 rapid_intersubmission
+    // = 15+10+15+8+20+5+5+5+5+7+8 = 103 → clamped to 100
+    expect(row.score).toBeGreaterThanOrEqual(70);
+    expect(row.tier).toBe('high');
+    const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
+    expect(firedIds).toContain('cap_fill_no_waitlist');
+    expect(firedIds).toContain('sig_collapse');
+    expect(firedIds).toContain('host_self_rsvp_mismatch');
+  });
+
+  it('"Lilongwe-like" clean event scores ≤10', () => {
+    // Realistic event: 35 RSVPs, diverse emails, diverse field signatures,
+    // healthy wallet ratio, real names, no rapid bursts.
+    const party = makeParty({
+      id: 'lilongwe',
+      name: 'GPP Lilongwe',
+      maxGuests: 60,
+      timezone: 'Africa/Blantyre',
+      createdAt: new Date('2026-03-01T10:00:00Z'),
+      user: { name: 'Lilongwe Host', email: 'lilongwe@host.com' },
+    });
+    const domains = ['gmail.com', 'yahoo.com', 'outlook.com', 'protonmail.com', 'icloud.com'];
+    const firstNames = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank', 'Grace'];
+    const lastNames = ['Banda', 'Phiri', 'Mwale', 'Tembo', 'Nyirenda'];
+    const toppingSets = [
+      ['mushroom'],
+      ['pepperoni', 'olives'],
+      ['ham', 'pineapple'],
+      ['margherita'],
+      ['vegetarian', 'spinach'],
+      ['anchovy'],
+      ['sausage', 'peppers'],
+      ['four-cheese'],
+      ['arugula', 'prosciutto'],
+      ['basil'],
+    ];
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const guests: FakeDetectionGuest[] = Array.from({ length: 35 }, (_, i) =>
+      makeGuest({
+        name: `${firstNames[i % firstNames.length]} ${lastNames[i % lastNames.length]}`,
+        email: `${firstNames[i % firstNames.length].toLowerCase()}.${lastNames[i % lastNames.length].toLowerCase()}@${domains[i % domains.length]}`,
+        submittedAt: new Date(base + i * 3600000 * 4), // 4 hours apart → spread over days
+        walletSource: i % 3 === 0 ? 'privy' : null,
+        ethereumAddress: i % 3 === 0 ? `0x${i.toString(16).padStart(40, '0')}` : null,
+        likedToppings: toppingSets[i % toppingSets.length],
+        pizzeriaRankings: ['da Tonino', 'Pizza Hut'],
+        suggestedPizzerias: [{ name: 'Local Pizza' }],
+      }),
+    );
+    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests);
+    expect(row.score).toBeLessThanOrEqual(10);
+    expect(row.tier === 'clean' || row.tier === 'low').toBe(true);
+  });
+});

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -1,0 +1,621 @@
+/**
+ * Fake-event detection — composite review queue (blackolive-74932)
+ *
+ * Pure functions, one per heuristic, plus `scoreEvent` aggregator.
+ * No DB access — caller supplies pre-fetched data.
+ *
+ * Plan: plans/blackolive-74932-fake-detection.md
+ */
+
+// ============================================
+// Types
+// ============================================
+
+export interface FakeDetectionGuest {
+  id?: string;
+  name: string;
+  email: string | null;
+  ethereumAddress: string | null;
+  submittedAt: Date;
+  submittedVia: string;
+  waitlistPosition: number | null;
+  walletSource: string | null;
+  likedToppings: string[];
+  dislikedToppings: string[];
+  likedBeverages: string[];
+  dislikedBeverages: string[];
+  dietaryRestrictions: string[];
+  roles: string[];
+  pizzeriaRankings: string[];
+  suggestedPizzerias: unknown; // jsonb
+}
+
+export interface FakeDetectionParty {
+  id: string;
+  name: string;
+  customUrl: string | null;
+  country: string | null;
+  region: string | null;
+  timezone: string | null;
+  maxGuests: number | null;
+  createdAt: Date;
+  underbossStatus: string | null;
+  user: { id?: string; name: string | null; email: string | null } | null;
+}
+
+export interface FakeDetectionLinkClick {
+  clickedAt: Date;
+}
+
+export interface FlagResult {
+  id: string;
+  name: string;
+  fired: boolean;
+  weight: number;
+  detail: string;
+  evidence?: Record<string, unknown>;
+}
+
+export type Tier = 'high' | 'medium' | 'low' | 'clean';
+
+export interface FakeDetectionRow {
+  id: string;
+  name: string;
+  customUrl: string | null;
+  country: string | null;
+  region: string | null;
+  underbossStatus: string | null;
+  hostName: string | null;
+  hostEmail: string | null;
+  rsvpCount: number;
+  maxGuests: number | null;
+  score: number;
+  tier: Tier;
+  flags: FlagResult[];
+}
+
+// ============================================
+// Weights (tunable without code surgery)
+// ============================================
+
+export const WEIGHTS = {
+  cap_fill_no_waitlist: 15,
+  low_domain_entropy: 10,
+  sig_collapse: 15,
+  wallet_too_low: 8,
+  wallet_too_high_reuse: 8,
+  wallet_reuse: 10,
+  host_self_rsvp_mismatch: 20,
+  pizzeria_fields_blank: 5,
+  wallet_source_all_null: 5,
+  one_word_name: 5,
+  firstname_digits_email: 5,
+  day_gap_pattern: 7,
+  low_hour_entropy: 7,
+  rapid_intersubmission: 8,
+  cross_event_wallet: 15,
+} as const;
+
+// ============================================
+// Helpers
+// ============================================
+
+/** Shannon entropy (log base 2). Returns 0 for empty input. */
+export function shannon(values: string[]): number {
+  if (values.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  const n = values.length;
+  let h = 0;
+  for (const c of counts.values()) {
+    const p = c / n;
+    h -= p * Math.log2(p);
+  }
+  return h;
+}
+
+/** Canonical field signature — arrays sorted before stringify. */
+export function fieldSignature(g: FakeDetectionGuest): string {
+  return JSON.stringify([
+    [...g.likedToppings].sort(),
+    [...g.dislikedToppings].sort(),
+    [...g.likedBeverages].sort(),
+    [...g.dislikedBeverages].sort(),
+    [...g.dietaryRestrictions].sort(),
+    [...g.roles].sort(),
+  ]);
+}
+
+/** Extract domain (lowercase, trimmed) from an email. Returns empty string if no email. */
+function emailDomain(email: string | null): string {
+  if (!email) return '';
+  const at = email.lastIndexOf('@');
+  if (at === -1) return '';
+  return email.slice(at + 1).trim().toLowerCase();
+}
+
+/** Get the local hour (0–23) of a timestamp in a given IANA timezone. */
+function localHour(date: Date, timezone: string | null): number {
+  if (!timezone) {
+    return date.getUTCHours();
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: '2-digit',
+      hour12: false,
+    });
+    const parts = fmt.formatToParts(date);
+    const hourPart = parts.find(p => p.type === 'hour');
+    if (!hourPart) return date.getUTCHours();
+    const h = parseInt(hourPart.value, 10);
+    // Intl can emit "24" for midnight in some implementations — normalize.
+    return Number.isFinite(h) ? h % 24 : date.getUTCHours();
+  } catch {
+    return date.getUTCHours();
+  }
+}
+
+/** Get the local date string (YYYY-MM-DD) of a timestamp in a given IANA timezone. */
+function localDateKey(date: Date, timezone: string | null): string {
+  if (!timezone) {
+    return date.toISOString().slice(0, 10);
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    return fmt.format(date); // en-CA → YYYY-MM-DD
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
+/** Filter to direct RSVPs only (link/rsvp/api) — exclude invites/host/check-in. */
+export function filterDirectRsvps(guests: FakeDetectionGuest[]): FakeDetectionGuest[] {
+  return guests.filter(g => ['link', 'rsvp', 'api'].includes(g.submittedVia));
+}
+
+// ============================================
+// Per-heuristic functions
+// All accept the already-filtered direct-RSVP guest array.
+// Each returns { fired, weight, detail, evidence? }.
+// ============================================
+
+function flag(
+  id: keyof typeof WEIGHTS,
+  fired: boolean,
+  detail: string,
+  evidence?: Record<string, unknown>,
+): FlagResult {
+  return {
+    id,
+    name: id,
+    fired,
+    weight: WEIGHTS[id],
+    detail,
+    evidence,
+  };
+}
+
+/** 1. cap_fill_no_waitlist — capacity ≥90% full but zero waitlist. */
+export function checkCapFillNoWaitlist(
+  guests: FakeDetectionGuest[],
+  maxGuests: number | null,
+): FlagResult {
+  const id = 'cap_fill_no_waitlist';
+  const n = guests.length;
+  if (n < 20 || !maxGuests || maxGuests <= 0) {
+    return flag(id, false, `n=${n}, maxGuests=${maxGuests ?? 'null'} — below threshold`);
+  }
+  const fill = n / maxGuests;
+  const waitlistCount = guests.filter(g => g.waitlistPosition !== null && g.waitlistPosition > 0).length;
+  const fired = fill >= 0.9 && waitlistCount === 0;
+  return flag(
+    id,
+    fired,
+    `fill=${(fill * 100).toFixed(1)}%, waitlist=${waitlistCount}`,
+    { fill, waitlistCount, n, maxGuests },
+  );
+}
+
+/** 2. low_domain_entropy — email domains are too uniform. */
+export function checkLowDomainEntropy(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'low_domain_entropy';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const domains = guests.map(g => emailDomain(g.email)).filter(d => d.length > 0);
+  if (domains.length === 0) return flag(id, false, 'no emails');
+  const h = shannon(domains);
+  const fired = h < 0.2;
+  return flag(id, fired, `entropy=${h.toFixed(3)}`, { entropy: h, domainCount: domains.length });
+}
+
+/** 3. sig_collapse — field signatures collapse to ≤ a few distinct patterns. */
+export function checkSigCollapse(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'sig_collapse';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const sigCounts = new Map<string, number>();
+  for (const g of guests) {
+    const s = fieldSignature(g);
+    sigCounts.set(s, (sigCounts.get(s) ?? 0) + 1);
+  }
+  const unique = sigCounts.size;
+  const sortedCounts = [...sigCounts.values()].sort((a, b) => b - a);
+  const top3 = sortedCounts.slice(0, 3).reduce((a, b) => a + b, 0);
+  const uniqueRatio = unique / n;
+  const top3Share = top3 / n;
+  const fired = uniqueRatio < 0.2 || top3Share > 0.7;
+  return flag(
+    id,
+    fired,
+    `unique=${unique}/${n} (${(uniqueRatio * 100).toFixed(1)}%), top3=${(top3Share * 100).toFixed(1)}%`,
+    { unique, top3, uniqueRatio, top3Share, n },
+  );
+}
+
+/** 4a. wallet_too_low — almost nobody connected a wallet. */
+export function checkWalletTooLow(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'wallet_too_low';
+  const n = guests.length;
+  if (n < 30) return flag(id, false, `n=${n} below 30`);
+  const walletCount = guests.filter(g => g.ethereumAddress && g.ethereumAddress.length > 0).length;
+  const ratio = walletCount / n;
+  const fired = ratio < 0.05;
+  return flag(id, fired, `wallets=${walletCount}/${n} (${(ratio * 100).toFixed(1)}%)`, { walletCount, n, ratio });
+}
+
+/** 4b. wallet_too_high_reuse — everyone has a wallet but lots of reuse. */
+export function checkWalletTooHighReuse(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'wallet_too_high_reuse';
+  const n = guests.length;
+  if (n < 30) return flag(id, false, `n=${n} below 30`);
+  const walletAddrs = guests
+    .map(g => (g.ethereumAddress ?? '').toLowerCase())
+    .filter(a => a.length > 0);
+  const walletCount = walletAddrs.length;
+  if (walletCount === 0) return flag(id, false, 'no wallets');
+  const uniqueWallets = new Set(walletAddrs).size;
+  const walletRatio = walletCount / n;
+  const reuse = (walletCount - uniqueWallets) / walletCount;
+  const fired = walletRatio > 0.95 && reuse > 0.3;
+  return flag(
+    id,
+    fired,
+    `wallets=${(walletRatio * 100).toFixed(1)}% of RSVPs, reuse=${(reuse * 100).toFixed(1)}%`,
+    { walletRatio, reuse, walletCount, uniqueWallets, n },
+  );
+}
+
+/** 5. wallet_reuse — same wallet address used multiple times on the same event. */
+export function checkWalletReuse(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'wallet_reuse';
+  const n = guests.length;
+  if (n < 10) return flag(id, false, `n=${n} below 10`);
+  const ethSubs = guests
+    .map(g => (g.ethereumAddress ?? '').toLowerCase())
+    .filter(a => a.length > 0);
+  if (ethSubs.length === 0) return flag(id, false, 'no wallets');
+  const uniqueEth = new Set(ethSubs).size;
+  const reuse = (ethSubs.length - uniqueEth) / Math.max(ethSubs.length, 1);
+  const fired = reuse >= 0.1;
+  return flag(
+    id,
+    fired,
+    `${ethSubs.length} wallets, ${uniqueEth} unique, reuse=${(reuse * 100).toFixed(1)}%`,
+    { ethSubs: ethSubs.length, uniqueEth, reuse },
+  );
+}
+
+/** 6. host_self_rsvp_mismatch — host RSVPed within 60s of event create under a different name. */
+export function checkHostSelfRsvpMismatch(
+  guests: FakeDetectionGuest[],
+  party: FakeDetectionParty,
+): FlagResult {
+  const id = 'host_self_rsvp_mismatch';
+  const hostName = (party.user?.name ?? '').trim().toLowerCase();
+  const hostEmail = (party.user?.email ?? '').trim().toLowerCase();
+  if (!party.createdAt) return flag(id, false, 'no createdAt');
+  const createdAtMs = party.createdAt.getTime();
+
+  const matches: { guestName: string; deltaSec: number }[] = [];
+  for (const g of guests) {
+    const deltaSec = (g.submittedAt.getTime() - createdAtMs) / 1000;
+    if (deltaSec < 0 || deltaSec > 60) continue;
+    const gName = (g.name ?? '').trim().toLowerCase();
+    const gEmail = (g.email ?? '').trim().toLowerCase();
+    // Mismatch = neither name nor email matches the host
+    const nameMatch = hostName !== '' && gName === hostName;
+    const emailMatch = hostEmail !== '' && gEmail === hostEmail;
+    if (!nameMatch && !emailMatch) {
+      matches.push({ guestName: g.name, deltaSec });
+    }
+  }
+  const fired = matches.length > 0;
+  return flag(
+    id,
+    fired,
+    fired
+      ? `${matches.length} sub-60s RSVP(s) with name mismatch (host=${hostName || hostEmail || 'unknown'})`
+      : 'no sub-60s name-mismatch RSVPs',
+    fired ? { matches: matches.slice(0, 5) } : undefined,
+  );
+}
+
+/** 7. pizzeria_fields_blank — almost no RSVPs filled pizzeria rankings or suggestions. */
+export function checkPizzeriaFieldsBlank(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'pizzeria_fields_blank';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  let blankRankings = 0;
+  let blankSuggested = 0;
+  for (const g of guests) {
+    if (!Array.isArray(g.pizzeriaRankings) || g.pizzeriaRankings.length === 0) blankRankings++;
+    const sp = g.suggestedPizzerias;
+    if (!Array.isArray(sp) || sp.length === 0) blankSuggested++;
+  }
+  const r1 = blankRankings / n;
+  const r2 = blankSuggested / n;
+  const fired = r1 > 0.95 && r2 > 0.95;
+  return flag(
+    id,
+    fired,
+    `blankRankings=${(r1 * 100).toFixed(1)}%, blankSuggested=${(r2 * 100).toFixed(1)}%`,
+    { blankRankings, blankSuggested, n },
+  );
+}
+
+/** 8. wallet_source_all_null — every wallet_source is null. */
+export function checkWalletSourceAllNull(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'wallet_source_all_null';
+  const n = guests.length;
+  if (n < 30) return flag(id, false, `n=${n} below 30`);
+  const allNull = guests.every(g => g.walletSource === null);
+  return flag(id, allNull, allNull ? 'every walletSource is null' : 'some walletSource set', { n });
+}
+
+/** 9. one_word_name — too many single-word guest names. */
+export function checkOneWordName(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'one_word_name';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  let oneWord = 0;
+  for (const g of guests) {
+    const name = (g.name ?? '').trim();
+    if (name.length === 0) continue;
+    const wordCount = name.split(/\s+/).filter(w => w.length > 0).length;
+    if (wordCount === 1) oneWord++;
+  }
+  const ratio = oneWord / n;
+  const fired = ratio > 0.2;
+  return flag(id, fired, `${oneWord}/${n} (${(ratio * 100).toFixed(1)}%) one-word names`, { oneWord, n, ratio });
+}
+
+/** 10. firstname_digits_email — emails follow firstname+digits pattern and domains are low-entropy. */
+export function checkFirstnameDigitsEmail(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'firstname_digits_email';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const emails = guests.map(g => (g.email ?? '').toLowerCase()).filter(e => e.length > 0);
+  if (emails.length === 0) return flag(id, false, 'no emails');
+  // firstname (letters) + digits (one or more) @ domain
+  const pattern = /^[a-z]+\d+@/;
+  const matches = emails.filter(e => pattern.test(e)).length;
+  const ratio = matches / n;
+  const domains = emails.map(e => e.slice(e.lastIndexOf('@') + 1)).filter(d => d.length > 0);
+  const domainEntropy = shannon(domains);
+  const fired = ratio > 0.95 && domainEntropy < 0.5;
+  return flag(
+    id,
+    fired,
+    `match=${(ratio * 100).toFixed(1)}%, domainEntropy=${domainEntropy.toFixed(3)}`,
+    { matches, n, ratio, domainEntropy },
+  );
+}
+
+/**
+ * 11. day_gap_pattern — RSVP timeline has zero days bracketed by ≥5-RSVP days,
+ * with no link_click spike on the zero days.
+ * Skips cleanly when link_clicks is empty (older events).
+ */
+export function checkDayGapPattern(
+  guests: FakeDetectionGuest[],
+  party: FakeDetectionParty,
+  linkClicks: FakeDetectionLinkClick[],
+): FlagResult {
+  const id = 'day_gap_pattern';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  if (!linkClicks || linkClicks.length === 0) {
+    return flag(id, false, 'no link_clicks data — skipping');
+  }
+  const tz = party.timezone;
+
+  // Bucket RSVPs by local-date
+  const rsvpByDay = new Map<string, number>();
+  for (const g of guests) {
+    const k = localDateKey(g.submittedAt, tz);
+    rsvpByDay.set(k, (rsvpByDay.get(k) ?? 0) + 1);
+  }
+  // Bucket clicks the same way
+  const clicksByDay = new Map<string, number>();
+  for (const c of linkClicks) {
+    const k = localDateKey(c.clickedAt, tz);
+    clicksByDay.set(k, (clicksByDay.get(k) ?? 0) + 1);
+  }
+
+  // Build contiguous day series from min RSVP date to max RSVP date
+  const days = [...rsvpByDay.keys()].sort();
+  if (days.length === 0) return flag(id, false, 'no RSVP days');
+  const start = new Date(days[0] + 'T00:00:00Z').getTime();
+  const end = new Date(days[days.length - 1] + 'T00:00:00Z').getTime();
+  const series: { day: string; rsvps: number; clicks: number }[] = [];
+  for (let t = start; t <= end; t += 86400000) {
+    const d = new Date(t).toISOString().slice(0, 10);
+    series.push({ day: d, rsvps: rsvpByDay.get(d) ?? 0, clicks: clicksByDay.get(d) ?? 0 });
+  }
+  if (series.length < 4) return flag(id, false, `series length ${series.length} too short`);
+
+  // Scan for [≥5 RSVPs] [≥2 consecutive zero RSVPs with no click spike] [≥5 RSVPs]
+  for (let i = 1; i <= series.length - 3; i++) {
+    if (series[i - 1].rsvps < 5) continue;
+    // Find the zero-run starting at i
+    let j = i;
+    while (j < series.length && series[j].rsvps === 0) j++;
+    const runLen = j - i;
+    if (runLen < 2) continue;
+    if (j >= series.length) continue;
+    if (series[j].rsvps < 5) continue;
+    // No click spike (we consider a "spike" as ≥3 clicks) during the zero days
+    const anySpike = series.slice(i, j).some(d => d.clicks >= 3);
+    if (!anySpike) {
+      return flag(
+        id,
+        true,
+        `${runLen}-day RSVP gap (${series[i].day}..${series[j - 1].day}) bracketed by ≥5-RSVP days with no click spike`,
+        { gapStart: series[i].day, gapEnd: series[j - 1].day, runLen },
+      );
+    }
+  }
+  return flag(id, false, 'no qualifying day-gap pattern');
+}
+
+/** 12. low_hour_entropy — submissions cluster into too few local hours. */
+export function checkLowHourEntropy(
+  guests: FakeDetectionGuest[],
+  party: FakeDetectionParty,
+): FlagResult {
+  const id = 'low_hour_entropy';
+  const n = guests.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const hours = guests.map(g => String(localHour(g.submittedAt, party.timezone)));
+  const h = shannon(hours);
+  const fired = h < 1.5;
+  return flag(id, fired, `localHourEntropy=${h.toFixed(3)}`, { entropy: h, n });
+}
+
+/** 13. rapid_intersubmission — median delta between consecutive RSVPs is ≤ 60s. */
+export function checkRapidIntersubmission(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'rapid_intersubmission';
+  const n = guests.length;
+  if (n < 30) return flag(id, false, `n=${n} below 30`);
+  const sorted = [...guests].sort((a, b) => a.submittedAt.getTime() - b.submittedAt.getTime());
+  const deltas: number[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    deltas.push((sorted[i].submittedAt.getTime() - sorted[i - 1].submittedAt.getTime()) / 1000);
+  }
+  if (deltas.length === 0) return flag(id, false, 'no deltas');
+  const sortedDeltas = [...deltas].sort((a, b) => a - b);
+  const mid = Math.floor(sortedDeltas.length / 2);
+  const median =
+    sortedDeltas.length % 2 === 0
+      ? (sortedDeltas[mid - 1] + sortedDeltas[mid]) / 2
+      : sortedDeltas[mid];
+  const fired = median <= 60;
+  return flag(id, fired, `medianDeltaSec=${median.toFixed(1)}`, { medianDeltaSec: median, n: deltas.length });
+}
+
+/** 14. cross_event_wallet — any guest wallet appears on the sybil-wallet set. */
+export function checkCrossEventWallet(
+  guests: FakeDetectionGuest[],
+  sybilWallets: Set<string>,
+): FlagResult {
+  const id = 'cross_event_wallet';
+  const matched: string[] = [];
+  for (const g of guests) {
+    const addr = (g.ethereumAddress ?? '').toLowerCase();
+    if (addr && sybilWallets.has(addr)) {
+      matched.push(addr);
+    }
+  }
+  const fired = matched.length > 0;
+  return flag(
+    id,
+    fired,
+    fired ? `${matched.length} sybil wallet(s) on this event` : 'no sybil wallets',
+    fired ? { wallets: matched.slice(0, 5) } : undefined,
+  );
+}
+
+// ============================================
+// Aggregator
+// ============================================
+
+export function tierFromScore(score: number): Tier {
+  if (score >= 60) return 'high';
+  if (score >= 30) return 'medium';
+  if (score >= 10) return 'low';
+  return 'clean';
+}
+
+export function scoreEvent(
+  party: FakeDetectionParty,
+  allGuests: FakeDetectionGuest[],
+  linkClicks: FakeDetectionLinkClick[],
+  sybilWallets: Set<string>,
+  maxGuests: number | null,
+): FakeDetectionRow {
+  const guests = filterDirectRsvps(allGuests);
+
+  const flags: FlagResult[] = [
+    checkCapFillNoWaitlist(guests, maxGuests),
+    checkLowDomainEntropy(guests),
+    checkSigCollapse(guests),
+    checkWalletTooLow(guests),
+    checkWalletTooHighReuse(guests),
+    checkWalletReuse(guests),
+    checkHostSelfRsvpMismatch(guests, party),
+    checkPizzeriaFieldsBlank(guests),
+    checkWalletSourceAllNull(guests),
+    checkOneWordName(guests),
+    checkFirstnameDigitsEmail(guests),
+    checkDayGapPattern(guests, party, linkClicks),
+    checkLowHourEntropy(guests, party),
+    checkRapidIntersubmission(guests),
+    checkCrossEventWallet(guests, sybilWallets),
+  ];
+
+  const score = Math.min(
+    100,
+    flags.filter(f => f.fired).reduce((sum, f) => sum + f.weight, 0),
+  );
+
+  return {
+    id: party.id,
+    name: party.name,
+    customUrl: party.customUrl,
+    country: party.country,
+    region: party.region,
+    underbossStatus: party.underbossStatus,
+    hostName: party.user?.name ?? null,
+    hostEmail: party.user?.email ?? null,
+    rsvpCount: guests.length,
+    maxGuests,
+    score,
+    tier: tierFromScore(score),
+    flags,
+  };
+}
+
+/**
+ * Build the sybil-wallet set from the raw cross-event aggregation rows.
+ * A wallet is sybil if it appears on ≥4 total events under ≥2 distinct names
+ * (the threshold Snax confirmed: ≥4 events, ≥2 names).
+ */
+export function buildSybilWalletSet(
+  rows: { ethereumAddress: string; partyIds: string[]; names: string[] }[],
+): Set<string> {
+  const set = new Set<string>();
+  for (const row of rows) {
+    const distinctParties = new Set(row.partyIds).size;
+    const distinctNames = new Set(row.names.map(n => n.trim().toLowerCase()).filter(n => n.length > 0)).size;
+    if (distinctParties >= 4 && distinctNames >= 2) {
+      set.add(row.ethereumAddress.toLowerCase());
+    }
+  }
+  return set;
+}

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -6,6 +6,7 @@ import crypto from 'crypto';
 import { addPartnerToParty, removePartnerFromParty, getAutoCoHostPartners } from '../helpers/partnerSync.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { writeStatusAudit, ActorKind } from '../helpers/statusAudit.js';
+import { scoreEvent, buildSybilWalletSet } from '../lib/fakeDetection.js';
 
 // Extend Request to include underboss
 interface UnderbossRequest extends AuthRequest {
@@ -385,6 +386,143 @@ router.patch('/city-statuses', requireAuth, requireUnderbossAuth, async (req: Un
     });
 
     res.json({ success: true, cityStatus: result });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ============================================
+// Fake-event detection review queue (blackolive-74932)
+// NOTE: Must be registered BEFORE /:region catch-all
+// ============================================
+
+// GET /api/underboss/fake-detection - Composite risk score queue for GPP events
+router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const isAdminUser = req.underboss!.regions.includes('__admin__');
+    if (!isAdminUser && req.underboss!.regions.length === 0) {
+      throw new AppError('Not authorized for any region', 403, 'FORBIDDEN');
+    }
+
+    // Same scope as /:region: admins see all, regional underbosses see their regions only.
+    const whereClause: { eventType: 'gpp'; region?: { in: string[] } } = { eventType: 'gpp' };
+    if (!isAdminUser) {
+      whereClause.region = { in: req.underboss!.regions };
+    }
+
+    // Cross-event wallet pre-pass — one raw query, then Set lookup per event.
+    // A wallet is "sybil" when it appears on ≥4 distinct events under ≥2 distinct trimmed-lower names.
+    const sybilRows = await prisma.$queryRaw<
+      Array<{ ethereum_address: string; party_ids: string[]; names: string[] }>
+    >`
+      SELECT
+        lower(ethereum_address) AS ethereum_address,
+        array_agg(DISTINCT party_id::text) AS party_ids,
+        array_agg(DISTINCT lower(trim(name))) AS names
+      FROM guests
+      WHERE ethereum_address IS NOT NULL
+        AND submitted_via IN ('link','rsvp','api')
+      GROUP BY lower(ethereum_address)
+      HAVING COUNT(DISTINCT party_id) >= 4
+    `;
+    const sybilWallets = buildSybilWalletSet(
+      sybilRows.map(r => ({
+        ethereumAddress: r.ethereum_address,
+        partyIds: r.party_ids,
+        names: r.names,
+      })),
+    );
+
+    const parties = await prisma.party.findMany({
+      where: whereClause,
+      select: {
+        id: true,
+        name: true,
+        customUrl: true,
+        country: true,
+        region: true,
+        timezone: true,
+        maxGuests: true,
+        createdAt: true,
+        underbossStatus: true,
+        user: { select: { id: true, name: true, email: true } },
+        guests: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            ethereumAddress: true,
+            submittedAt: true,
+            submittedVia: true,
+            waitlistPosition: true,
+            walletSource: true,
+            likedToppings: true,
+            dislikedToppings: true,
+            likedBeverages: true,
+            dislikedBeverages: true,
+            dietaryRestrictions: true,
+            roles: true,
+            pizzeriaRankings: true,
+            suggestedPizzerias: true,
+          },
+        },
+        linkClicks: {
+          select: { clickedAt: true },
+        },
+      },
+    });
+
+    const rows: ReturnType<typeof scoreEvent>[] = parties.map(p =>
+      scoreEvent(
+        {
+          id: p.id,
+          name: p.name,
+          customUrl: p.customUrl,
+          country: p.country,
+          region: p.region,
+          timezone: p.timezone,
+          maxGuests: p.maxGuests,
+          createdAt: p.createdAt ?? new Date(0),
+          underbossStatus: p.underbossStatus ?? null,
+          user: p.user
+            ? { id: p.user.id, name: p.user.name, email: p.user.email }
+            : null,
+        },
+        p.guests.map(g => ({
+          id: g.id,
+          name: g.name,
+          email: g.email,
+          ethereumAddress: g.ethereumAddress,
+          submittedAt: g.submittedAt,
+          submittedVia: g.submittedVia,
+          waitlistPosition: g.waitlistPosition,
+          walletSource: g.walletSource,
+          likedToppings: g.likedToppings,
+          dislikedToppings: g.dislikedToppings,
+          likedBeverages: g.likedBeverages,
+          dislikedBeverages: g.dislikedBeverages,
+          dietaryRestrictions: g.dietaryRestrictions,
+          roles: g.roles,
+          pizzeriaRankings: g.pizzeriaRankings,
+          suggestedPizzerias: g.suggestedPizzerias,
+        })),
+        p.linkClicks.map(c => ({ clickedAt: c.clickedAt })),
+        sybilWallets,
+        p.maxGuests,
+      ),
+    );
+
+    rows.sort((a, b) => b.score - a.score);
+
+    res.json({
+      rows,
+      meta: {
+        totalEvents: rows.length,
+        sybilWalletCount: sybilWallets.size,
+        scope: isAdminUser ? 'admin' : 'regions',
+        regions: isAdminUser ? null : req.underboss!.regions,
+      },
+    });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/underboss/FakeDetectionTable.tsx
+++ b/frontend/src/components/underboss/FakeDetectionTable.tsx
@@ -1,0 +1,336 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, ArrowUpDown, ExternalLink, Loader2, Search } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
+import { fetchFakeDetection } from '../../lib/api';
+import type { FakeDetectionResponse, FakeDetectionRow, FakeDetectionTier } from '../../types';
+
+type SortField = 'score' | 'name' | 'rsvps' | 'country';
+type SortDir = 'asc' | 'desc';
+
+const TIER_TINT: Record<FakeDetectionTier, string> = {
+  high: 'bg-red-500/10 hover:bg-red-500/20',
+  medium: 'bg-amber-500/10 hover:bg-amber-500/20',
+  low: 'bg-yellow-500/5 hover:bg-yellow-500/10',
+  clean: 'hover:bg-theme-surface',
+};
+
+const TIER_SCORE_COLOR: Record<FakeDetectionTier, string> = {
+  high: 'text-red-500',
+  medium: 'text-amber-500',
+  low: 'text-yellow-500',
+  clean: 'text-theme-text-muted',
+};
+
+const TIER_LABEL: Record<FakeDetectionTier, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+  clean: 'Clean',
+};
+
+function FlagPill({ flag }: { flag: FakeDetectionRow['flags'][number] }) {
+  if (!flag.fired) return null;
+  return (
+    <span
+      title={`${flag.name} (+${flag.weight}) — ${flag.detail}`}
+      className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono bg-red-500/20 text-red-300 border border-red-500/30"
+    >
+      {flag.name}
+    </span>
+  );
+}
+
+export function FakeDetectionTable() {
+  const { t } = useTranslation('admin');
+  const [data, setData] = useState<FakeDetectionResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [sortField, setSortField] = useState<SortField>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [tierFilters, setTierFilters] = useState<Record<FakeDetectionTier, boolean>>({
+    high: true,
+    medium: true,
+    low: true,
+    clean: false,
+  });
+  const [countryFilter, setCountryFilter] = useState<string>('all');
+  const [onlyFlagged, setOnlyFlagged] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchFakeDetection()
+      .then((resp) => {
+        if (cancelled) return;
+        setData(resp);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const countries = useMemo(() => {
+    if (!data) return [];
+    return Array.from(new Set(data.rows.map((r) => r.country).filter((c): c is string => !!c))).sort();
+  }, [data]);
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+    let rows = data.rows;
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.customUrl?.toLowerCase().includes(q) ||
+          r.country?.toLowerCase().includes(q) ||
+          r.region?.toLowerCase().includes(q) ||
+          r.hostName?.toLowerCase().includes(q) ||
+          r.hostEmail?.toLowerCase().includes(q),
+      );
+    }
+
+    rows = rows.filter((r) => tierFilters[r.tier]);
+
+    if (countryFilter !== 'all') {
+      rows = rows.filter((r) => r.country === countryFilter);
+    }
+
+    if (onlyFlagged) {
+      rows = rows.filter((r) => r.flags.some((f) => f.fired));
+    }
+
+    rows = [...rows].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'score':
+          cmp = a.score - b.score;
+          break;
+        case 'name':
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case 'rsvps':
+          cmp = a.rsvpCount - b.rsvpCount;
+          break;
+        case 'country':
+          cmp = (a.country ?? '').localeCompare(b.country ?? '');
+          break;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+
+    return rows;
+  }, [data, search, sortField, sortDir, tierFilters, countryFilter, onlyFlagged]);
+
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir(field === 'score' ? 'desc' : 'asc');
+    }
+  }
+
+  function SortHeader({ field, children }: { field: SortField; children: React.ReactNode }) {
+    return (
+      <th
+        className="py-2 px-3 text-left cursor-pointer hover:bg-theme-surface transition-colors select-none"
+        onClick={() => toggleSort(field)}
+      >
+        <div className="flex items-center gap-1">
+          {children}
+          <ArrowUpDown
+            size={12}
+            className={sortField === field ? 'text-theme-text' : 'text-theme-text-faint'}
+          />
+        </div>
+      </th>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-theme-text-muted">
+        <Loader2 size={20} className="animate-spin mr-2" />
+        {t('fakeDetection.loading', 'Computing risk scores…')}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-16 text-red-500">
+        <AlertCircle size={20} className="mr-2" />
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="space-y-4">
+      {/* Search + counts */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="max-w-sm flex-1 min-w-[240px]">
+          <IconInput
+            icon={Search}
+            iconSize={14}
+            type="text"
+            value={search}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
+            placeholder={t('fakeDetection.searchPlaceholder', 'Search event, city, host…')}
+            className="bg-theme-surface border border-theme-stroke rounded-lg pr-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+          />
+        </div>
+        <div className="text-xs text-theme-text-faint whitespace-nowrap">
+          {t('fakeDetection.showingOf', {
+            filtered: filtered.length,
+            total: data.rows.length,
+            defaultValue: '{{filtered}} of {{total}} events',
+          })}
+          {' · '}
+          {t('fakeDetection.sybilWallets', {
+            count: data.meta.sybilWalletCount,
+            defaultValue: '{{count}} sybil wallets',
+          })}
+        </div>
+      </div>
+
+      {/* Filter pills */}
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-xs text-theme-text-faint uppercase tracking-wide">
+          {t('fakeDetection.tier', 'Tier')}:
+        </span>
+        {(['high', 'medium', 'low', 'clean'] as FakeDetectionTier[]).map((tier) => (
+          <Checkbox
+            key={tier}
+            checked={tierFilters[tier]}
+            onChange={() => setTierFilters((prev) => ({ ...prev, [tier]: !prev[tier] }))}
+            label={`${TIER_LABEL[tier]} (${data.rows.filter((r) => r.tier === tier).length})`}
+            size={14}
+            labelClassName={`text-xs ${TIER_SCORE_COLOR[tier]}`}
+          />
+        ))}
+        <span className="text-xs text-theme-text-faint uppercase tracking-wide ml-2">
+          {t('fakeDetection.country', 'Country')}:
+        </span>
+        <select
+          value={countryFilter}
+          onChange={(e) => setCountryFilter(e.target.value)}
+          className="bg-theme-surface border border-theme-stroke rounded-lg px-2 py-1 text-xs text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+        >
+          <option value="all">{t('fakeDetection.allCountries', 'All')}</option>
+          {countries.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+        <Checkbox
+          checked={onlyFlagged}
+          onChange={() => setOnlyFlagged((v) => !v)}
+          label={t('fakeDetection.onlyFlagged', 'Only flagged')}
+          size={14}
+          labelClassName="text-xs text-theme-text"
+        />
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto border border-theme-stroke rounded-lg">
+        <table className="w-full text-sm">
+          <thead className="bg-theme-surface text-theme-text-muted text-xs uppercase tracking-wide">
+            <tr>
+              <SortHeader field="name">{t('fakeDetection.columns.event', 'Event')}</SortHeader>
+              <th className="py-2 px-3 text-left">{t('fakeDetection.columns.slug', 'Slug')}</th>
+              <SortHeader field="rsvps">{t('fakeDetection.columns.rsvps', 'RSVPs')}</SortHeader>
+              <SortHeader field="score">{t('fakeDetection.columns.score', 'Score')}</SortHeader>
+              <th className="py-2 px-3 text-left">{t('fakeDetection.columns.flags', 'Fired flags')}</th>
+              <th className="py-2 px-3 text-left">{t('fakeDetection.columns.status', 'Status')}</th>
+              <th className="py-2 px-3 text-left">{t('fakeDetection.columns.details', 'Details')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={7} className="py-8 px-3 text-center text-theme-text-muted">
+                  {t('fakeDetection.noResults', 'No events match the current filters.')}
+                </td>
+              </tr>
+            )}
+            {filtered.map((row) => (
+              <tr
+                key={row.id}
+                className={`border-t border-theme-stroke transition-colors ${TIER_TINT[row.tier]}`}
+              >
+                <td className="py-2 px-3 align-top">
+                  <div className="font-medium text-theme-text">{row.name}</div>
+                  <div className="text-xs text-theme-text-faint">
+                    {[row.region, row.country].filter(Boolean).join(' · ')}
+                  </div>
+                </td>
+                <td className="py-2 px-3 align-top">
+                  {row.customUrl ? (
+                    <a
+                      href={`https://rsv.pizza/${row.customUrl}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-mono text-xs text-theme-text-muted hover:text-theme-text underline-offset-2 hover:underline"
+                    >
+                      {row.customUrl}
+                    </a>
+                  ) : (
+                    <span className="text-theme-text-faint text-xs">—</span>
+                  )}
+                </td>
+                <td className="py-2 px-3 align-top text-theme-text-muted">
+                  {row.rsvpCount}
+                  {row.maxGuests ? <span className="text-theme-text-faint">/{row.maxGuests}</span> : null}
+                </td>
+                <td className="py-2 px-3 align-top">
+                  <span className={`text-2xl font-semibold ${TIER_SCORE_COLOR[row.tier]}`}>
+                    {row.score}
+                  </span>
+                </td>
+                <td className="py-2 px-3 align-top max-w-md">
+                  <div className="flex flex-wrap gap-1">
+                    {row.flags.filter((f) => f.fired).map((f) => (
+                      <FlagPill key={f.id} flag={f} />
+                    ))}
+                  </div>
+                </td>
+                <td className="py-2 px-3 align-top text-xs text-theme-text-muted">
+                  {row.underbossStatus ?? 'pending'}
+                </td>
+                <td className="py-2 px-3 align-top">
+                  {row.customUrl ? (
+                    <a
+                      href={`https://rsv.pizza/${row.customUrl}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-theme-text-muted hover:text-theme-text"
+                      title={t('fakeDetection.openEvent', 'Open event page')}
+                    >
+                      <ExternalLink size={14} />
+                    </a>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -6,3 +6,4 @@ export { TelegramBroadcast } from './TelegramBroadcast';
 export { CitiesTable } from './CitiesTable';
 export { PartnerManager } from './PartnerManager';
 export { FunnelTab } from './FunnelTab';
+export { FakeDetectionTable } from './FakeDetectionTable';

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -127,7 +127,29 @@
     "tabs": {
       "events": "Events",
       "cities": "Cities",
-      "partners": "Partners"
+      "partners": "Partners",
+      "fakeDetection": "Fake Detection"
+    }
+  },
+  "fakeDetection": {
+    "loading": "Computing risk scores…",
+    "searchPlaceholder": "Search event, city, host…",
+    "showingOf": "{{filtered}} of {{total}} events",
+    "sybilWallets": "{{count}} sybil wallets",
+    "tier": "Tier",
+    "country": "Country",
+    "allCountries": "All",
+    "onlyFlagged": "Only flagged",
+    "noResults": "No events match the current filters.",
+    "openEvent": "Open event page",
+    "columns": {
+      "event": "Event",
+      "slug": "Slug",
+      "rsvps": "RSVPs",
+      "score": "Score",
+      "flags": "Fired flags",
+      "status": "Status",
+      "details": "Details"
     }
   },
   "graphics": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -2525,6 +2525,11 @@ export async function fetchUnderbossDashboard(
   region: GPPRegion | 'all'
 ): Promise<UnderbossDashboardData> {
   return apiRequest<UnderbossDashboardData>(`/api/underboss/${region}`);
+}
+
+// Fetch fake-event detection review queue (blackolive-74932)
+export async function fetchFakeDetection(): Promise<FakeDetectionResponse> {
+  return apiRequest<FakeDetectionResponse>('/api/underboss/fake-detection');
 }
 
 // Update host status on an event (underboss auth)

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -6,7 +6,7 @@ import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, C
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager } from '../components/underboss';
+import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, FakeDetectionTable } from '../components/underboss';
 import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
@@ -69,7 +69,7 @@ export function UnderbossDashboard() {
   const [availableRegions, setAvailableRegions] = useState<string[]>([]);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners'>('events');
+  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection'>('events');
 
   // Telegram broadcast modal state
   const [showBroadcast, setShowBroadcast] = useState(false);
@@ -435,6 +435,19 @@ export function UnderbossDashboard() {
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}
             </button>
+            <button
+              onClick={() => setActiveTab('fake-detection')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'fake-detection'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              {t('underbossDashboard.tabs.fakeDetection')}
+              {activeTab === 'fake-detection' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
           </div>
 
           {activeTab === 'events' && (
@@ -449,6 +462,9 @@ export function UnderbossDashboard() {
             <PartnerManager isAdmin={isAdmin} events={allData?.events} onSyncComplete={() => loadDashboard(true)} onFlyerRegenNeeded={handleFlyerRegenForTag} />
           )}
 
+          {activeTab === 'fake-detection' && (
+            <FakeDetectionTable />
+          )}
 
         </section>
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1076,6 +1076,47 @@ export interface UnderbossDashboardData {
   events: UnderbossEvent[];
 }
 
+// ============================================
+// Fake-event detection (blackolive-74932)
+// ============================================
+
+export type FakeDetectionTier = 'high' | 'medium' | 'low' | 'clean';
+
+export interface FakeFlag {
+  id: string;
+  name: string;
+  fired: boolean;
+  weight: number;
+  detail: string;
+  evidence?: Record<string, unknown>;
+}
+
+export interface FakeDetectionRow {
+  id: string;
+  name: string;
+  customUrl: string | null;
+  country: string | null;
+  region: string | null;
+  underbossStatus: string | null;
+  hostName: string | null;
+  hostEmail: string | null;
+  rsvpCount: number;
+  maxGuests: number | null;
+  score: number;
+  tier: FakeDetectionTier;
+  flags: FakeFlag[];
+}
+
+export interface FakeDetectionResponse {
+  rows: FakeDetectionRow[];
+  meta: {
+    totalEvents: number;
+    sybilWalletCount: number;
+    scope: 'admin' | 'regions';
+    regions: string[] | null;
+  };
+}
+
 // Admin Management types
 
 export interface AdminUser {


### PR DESCRIPTION
## Summary

Adds a composite **risk-score review queue** to the underboss dashboard so admins can triage suspect GPP events without manual SQL.

- New backend endpoint: `GET /api/underboss/fake-detection` (admin + underboss auth, same regional scoping as `/me`)
- 14 transparent heuristics, each binary, with explicit weights exported as a `WEIGHTS` const for easy tuning
- Composite `score = min(100, sum(weight for fired flag))`
- Tier labels: high (≥60) / medium (30–59) / low (10–29) / clean (<10)
- New Underboss Dashboard tab "Fake Detection" rendering a sortable, filterable table with per-row fired-flag pills
- No new DB columns, no migrations, no infra

Full architecture and per-heuristic rules in [`plans/blackolive-74932-fake-detection.md`](./plans/blackolive-74932-fake-detection.md).

## Snax's decisions baked in
1. **Read-only** — never auto-changes `underboss_status`. No bulk-action button in v1.
2. **Underboss visibility** — admins see all events; regional underbosses see only their assigned regions.
3. **Cross-event wallet threshold** — fires when a wallet appears on ≥4 distinct events under ≥2 distinct trimmed-lower names.
4. **Day-gap heuristic + empty `link_clicks`** — skips cleanly (`fired: false`); does not fire on absence of click data.

## Calibration targets (manual verification)

- Ilemela score **≥ 70**, fires cap_fill_no_waitlist + sig_collapse + host_self_rsvp_mismatch
- Bulawayo, Blantyre, Naivasha, Hyderabad: all score **≥ 30** (in queue)
- Blantyre fires `cross_event_wallet`
- Lilongwe ≤ 10, Abuja ≤ 10 (controls)

## Screenshots

_To be added once Snax can sign in and exercise the UI on the Vercel preview._

## Test plan

- [ ] `npm test` in `backend/` — all 45 `fakeDetection.test.ts` tests pass (already verified locally)
- [ ] Sign in as admin on the Vercel preview, navigate to `/underboss`, click "Fake Detection" tab
- [ ] Verify Ilemela is at the top of the table with score ≥ 70 and the expected flags fired
- [ ] Verify Lilongwe and Abuja appear in "Clean" tier (≤10) or are hidden by default
- [ ] Tier filter, country filter, "only flagged" toggle, search all work
- [ ] Click a custom-URL link in a row → public event page opens in new tab
- [ ] Regional underboss test (non-admin): only events in their assigned regions appear
- [ ] Endpoint latency on full GPP dataset < 2 s

## Deploy notes

- **Frontend** auto-deploys on this branch (Vercel preview).
- **Backend** only deploys from `master`, so the `/fake-detection` endpoint will 404 on the preview frontend until this PR is merged AND the backend Vercel project is manually redeployed (`cd backend && vercel --prod --scope pizza-dao`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)