### PR TITLE
fix(mozzarella-36112): partner dashboard 'All tags' GPP-only

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -534,7 +534,8 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       // PizzaDAO: show all GPP events (created via /gpp flow)
       where.eventType = 'gpp';
     } else if (req.isAdminViewing) {
-      // Admin with no tag filter — show events that have at least one eventTag
+      // Admin with no tag filter — show all GPP events that have at least one eventTag
+      where.eventType = 'gpp';
       where.NOT = { eventTags: { equals: [] } };
     }
 


### PR DESCRIPTION
## Summary
- Admin "All tags" view on /partner was pulling every event with any eventTag (~624 events including legacy non-GPP events tagged with pfp/audit/old partner campaigns)
- Adds `eventType = 'gpp'` to the admin-no-tag branch in the sponsor /events route so it matches the semantics of the `pizzadao` tag branch right above it

## Deploy notes
- Backend-only change — preview frontends talk to the prod backend, so this won't be visible on the PR's Vercel preview until merged + `cd backend && vercel --prod --scope pizza-dao`

## Test plan
- [ ] Log into /partner as admin
- [ ] Click "All tags" — event count drops to GPP-only
- [ ] Each tag chip still filters correctly
- [ ] Non-admin partner view unchanged

Task: mozzarella-36112