### PR TITLE
salami-84382: admin-only partner dashboard time-series chart

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -933,3 +933,123 @@ sponsorDashboardRouter.post('/checklist/:itemId/toggle', requireAuth, requireSpo
     next(error);
   }
 });
+
+// GET /api/sponsor/events/timeseries - Admin-only time-series data (RSVPs / impressions / clicks per hour)
+// Buckets hour-by-hour across one of four ranges: 6hr / 24hr / 3d / 7d (default 24hr).
+sponsorDashboardRouter.get('/events/timeseries', requireAuth, requireSponsorAuth, async (req: SponsorRequest, res: Response, next: NextFunction) => {
+  try {
+    // Admin-only — partners do not see this chart
+    if (!req.isAdminViewing) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    // Range gating
+    const rangeParam = (req.query.range as string | undefined)?.trim().toLowerCase();
+    const validRanges = ['6hr', '24hr', '3d', '7d'] as const;
+    type RangeKey = typeof validRanges[number];
+    const range: RangeKey = (validRanges as readonly string[]).includes(rangeParam || '')
+      ? (rangeParam as RangeKey)
+      : '24hr';
+
+    const rangeHoursMap: Record<RangeKey, number> = {
+      '6hr': 6,
+      '24hr': 24,
+      '3d': 72,
+      '7d': 168,
+    };
+    const hoursBack = rangeHoursMap[range];
+    const sinceDate = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
+
+    // Resolve which events the chart should cover, using the same logic as GET /events
+    const queryTag = req.query.tag as string | undefined;
+    const tag = queryTag?.trim().toLowerCase() || undefined;
+
+    const where: any = {};
+    if (tag && tag !== 'pizzadao') {
+      where.eventTags = { has: tag };
+    } else if (tag === 'pizzadao') {
+      where.eventType = 'gpp';
+    } else {
+      // Admin with no tag filter — all GPP events that have at least one eventTag
+      where.eventType = 'gpp';
+      where.NOT = { eventTags: { equals: [] } };
+    }
+
+    const events = await prisma.party.findMany({
+      where,
+      select: { id: true },
+    });
+    const eventIds = events.map(e => e.id);
+
+    if (eventIds.length === 0) {
+      return res.json({
+        range,
+        bucket: 'hour' as const,
+        since: sinceDate.toISOString(),
+        points: [],
+      });
+    }
+
+    // Three hour-bucketed aggregations
+    const pageViewRows = await prisma.$queryRaw<{ bucket: Date; count: bigint }[]>`
+      SELECT date_trunc('hour', viewed_at) as bucket, COUNT(*)::bigint as count
+      FROM page_views
+      WHERE party_id::text IN (${Prisma.join(eventIds)})
+      AND viewed_at >= ${sinceDate}
+      GROUP BY bucket
+      ORDER BY bucket ASC
+    `;
+
+    const linkClickRows = await prisma.$queryRaw<{ bucket: Date; count: bigint }[]>`
+      SELECT date_trunc('hour', clicked_at) as bucket, COUNT(*)::bigint as count
+      FROM link_clicks
+      WHERE party_id::text IN (${Prisma.join(eventIds)})
+      AND clicked_at >= ${sinceDate}
+      GROUP BY bucket
+      ORDER BY bucket ASC
+    `;
+
+    const rsvpRows = await prisma.$queryRaw<{ bucket: Date; count: bigint }[]>`
+      SELECT date_trunc('hour', submitted_at) as bucket, COUNT(*)::bigint as count
+      FROM guests
+      WHERE party_id::text IN (${Prisma.join(eventIds)})
+      AND submitted_at >= ${sinceDate}
+      AND status != 'INVITED'
+      GROUP BY bucket
+      ORDER BY bucket ASC
+    `;
+
+    // Build a dense hour-aligned series so the chart has zero-value points (avoids visual gaps)
+    const startHour = new Date(sinceDate);
+    startHour.setMinutes(0, 0, 0);
+    const nowHour = new Date();
+    nowHour.setMinutes(0, 0, 0);
+
+    const rsvpMap = new Map<string, number>();
+    for (const r of rsvpRows) rsvpMap.set(new Date(r.bucket).toISOString(), Number(r.count));
+    const viewsMap = new Map<string, number>();
+    for (const r of pageViewRows) viewsMap.set(new Date(r.bucket).toISOString(), Number(r.count));
+    const clicksMap = new Map<string, number>();
+    for (const r of linkClickRows) clicksMap.set(new Date(r.bucket).toISOString(), Number(r.count));
+
+    const points: { timestamp: string; rsvps: number; impressions: number; clicks: number }[] = [];
+    for (let t = startHour.getTime(); t <= nowHour.getTime(); t += 60 * 60 * 1000) {
+      const iso = new Date(t).toISOString();
+      points.push({
+        timestamp: iso,
+        rsvps: rsvpMap.get(iso) || 0,
+        impressions: viewsMap.get(iso) || 0,
+        clicks: clicksMap.get(iso) || 0,
+      });
+    }
+
+    res.json({
+      range,
+      bucket: 'hour' as const,
+      since: sinceDate.toISOString(),
+      points,
+    });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-i18next": "^17.0.6",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.22.0",
+    "recharts": "^2.13.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "use-places-autocomplete": "^4.0.1",

--- a/frontend/src/components/partner/PartnerTimeSeriesChart.tsx
+++ b/frontend/src/components/partner/PartnerTimeSeriesChart.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  TooltipProps,
+} from 'recharts';
+import { Loader2 } from 'lucide-react';
+import {
+  fetchSponsorEventsTimeSeries,
+  type PartnerTimeSeriesRange,
+  type PartnerTimeSeriesPoint,
+} from '../../lib/api';
+
+interface PartnerTimeSeriesChartProps {
+  tag?: string | null;
+}
+
+const RANGES: PartnerTimeSeriesRange[] = ['6hr', '24hr', '3d', '7d'];
+
+const COLORS = {
+  rsvps: '#E52828',       // brand red
+  impressions: '#3B82F6', // blue
+  clicks: '#F59E0B',      // amber
+};
+
+function formatTickLabel(iso: string, range: PartnerTimeSeriesRange): string {
+  const d = new Date(iso);
+  if (range === '6hr' || range === '24hr') {
+    // Show time of day
+    return d.toLocaleTimeString(undefined, { hour: 'numeric', hour12: false });
+  }
+  // 3d / 7d: show short date + hour
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function formatFullTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function CustomTooltip({ active, payload, label }: TooltipProps<number, string>) {
+  if (!active || !payload || !payload.length || !label) return null;
+  return (
+    <div className="bg-theme-card border border-theme-stroke rounded-lg px-3 py-2 shadow-lg text-xs">
+      <div className="text-theme-text-muted mb-1.5">{formatFullTimestamp(label as string)}</div>
+      <div className="space-y-1">
+        {payload.map((entry) => (
+          <div key={entry.dataKey as string} className="flex items-center gap-2">
+            <span
+              className="w-2 h-2 rounded-full"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-theme-text-secondary">{entry.name}:</span>
+            <span className="text-theme-text font-semibold">
+              {typeof entry.value === 'number' ? entry.value.toLocaleString() : entry.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
+  const { t } = useTranslation('partner');
+  const [range, setRange] = useState<PartnerTimeSeriesRange>('24hr');
+  const [points, setPoints] = useState<PartnerTimeSeriesPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchSponsorEventsTimeSeries(range, tag || undefined)
+      .then((res) => {
+        if (cancelled) return;
+        setPoints(res.points || []);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error('Failed to load time series:', err);
+        setError(t('timeSeries.error'));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [range, tag, t]);
+
+  const hasData = useMemo(
+    () => points.some((p) => p.rsvps > 0 || p.impressions > 0 || p.clicks > 0),
+    [points]
+  );
+
+  return (
+    <div className="bg-theme-card border border-theme-stroke rounded-xl p-4 mb-6">
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
+        <div>
+          <h2 className="text-sm font-semibold text-theme-text">{t('timeSeries.title')}</h2>
+          <p className="text-xs text-theme-text-muted mt-0.5">{t('timeSeries.subtitle')}</p>
+        </div>
+        <div className="inline-flex items-center gap-1 bg-theme-input border border-theme-stroke rounded-lg p-0.5">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-2.5 py-1 text-xs rounded-md transition-colors ${
+                range === r
+                  ? 'bg-theme-stroke text-theme-text font-semibold'
+                  : 'text-theme-text-muted hover:text-theme-text'
+              }`}
+            >
+              {t(`timeSeries.range.${r}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="h-64 w-full">
+        {loading ? (
+          <div className="h-full w-full flex items-center justify-center text-theme-text-muted text-xs gap-2">
+            <Loader2 size={14} className="animate-spin" />
+            {t('timeSeries.loading')}
+          </div>
+        ) : error ? (
+          <div className="h-full w-full flex items-center justify-center text-red-500/80 text-xs">
+            {error}
+          </div>
+        ) : !hasData ? (
+          <div className="h-full w-full flex items-center justify-center text-theme-text-muted text-xs">
+            {t('timeSeries.empty')}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={points} margin={{ top: 8, right: 16, bottom: 4, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+              <XAxis
+                dataKey="timestamp"
+                tick={{ fontSize: 11, fill: 'rgba(255,255,255,0.6)' }}
+                stroke="rgba(255,255,255,0.2)"
+                tickFormatter={(v: string) => formatTickLabel(v, range)}
+                minTickGap={20}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 11, fill: 'rgba(255,255,255,0.6)' }}
+                stroke="rgba(255,255,255,0.2)"
+                width={36}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend
+                wrapperStyle={{ fontSize: 12 }}
+                iconType="circle"
+              />
+              <Line
+                type="monotone"
+                dataKey="rsvps"
+                name={t('timeSeries.rsvps')}
+                stroke={COLORS.rsvps}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="impressions"
+                name={t('timeSeries.impressions')}
+                stroke={COLORS.impressions}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="clicks"
+                name={t('timeSeries.clicks')}
+                stroke={COLORS.clicks}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PartnerTimeSeriesChart;

--- a/frontend/src/components/partner/PartnerTimeSeriesChart.tsx
+++ b/frontend/src/components/partner/PartnerTimeSeriesChart.tsx
@@ -73,12 +73,15 @@ function CustomTooltip({ active, payload, label }: TooltipProps<number, string>)
   );
 }
 
+type SeriesKey = 'impressions' | 'clicks' | 'rsvps';
+
 export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
   const { t } = useTranslation('partner');
   const [range, setRange] = useState<PartnerTimeSeriesRange>('24hr');
   const [points, setPoints] = useState<PartnerTimeSeriesPoint[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hidden, setHidden] = useState<Set<SeriesKey>>(new Set());
 
   useEffect(() => {
     let cancelled = false;
@@ -106,6 +109,27 @@ export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
     () => points.some((p) => p.rsvps > 0 || p.impressions > 0 || p.clicks > 0),
     [points]
   );
+
+  const yMax = useMemo(() => {
+    let max = 0;
+    for (const row of points) {
+      (['impressions', 'clicks', 'rsvps'] as const).forEach((k) => {
+        if (!hidden.has(k)) max = Math.max(max, row[k]);
+      });
+    }
+    return max || 1; // avoid degenerate [0,0] domain
+  }, [points, hidden]);
+
+  const toggleSeries = (e: any) => {
+    const key = e?.dataKey as SeriesKey | undefined;
+    if (!key) return;
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
 
   return (
     <div className="bg-theme-card border border-theme-stroke rounded-xl p-4 mb-6">
@@ -161,11 +185,13 @@ export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
                 tick={{ fontSize: 11, fill: 'rgba(255,255,255,0.6)' }}
                 stroke="rgba(255,255,255,0.2)"
                 width={36}
+                domain={[0, yMax]}
               />
               <Tooltip content={<CustomTooltip />} />
               <Legend
-                wrapperStyle={{ fontSize: 12 }}
+                wrapperStyle={{ fontSize: 12, cursor: 'pointer' }}
                 iconType="circle"
+                onClick={toggleSeries}
               />
               <Line
                 type="monotone"
@@ -175,6 +201,7 @@ export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
                 strokeWidth={2}
                 dot={false}
                 activeDot={{ r: 4 }}
+                hide={hidden.has('rsvps')}
               />
               <Line
                 type="monotone"
@@ -184,6 +211,7 @@ export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
                 strokeWidth={2}
                 dot={false}
                 activeDot={{ r: 4 }}
+                hide={hidden.has('impressions')}
               />
               <Line
                 type="monotone"
@@ -193,6 +221,7 @@ export function PartnerTimeSeriesChart({ tag }: PartnerTimeSeriesChartProps) {
                 strokeWidth={2}
                 dot={false}
                 activeDot={{ r: 4 }}
+                hide={hidden.has('clicks')}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -432,5 +432,21 @@
     "reset": "Reset",
     "download": "Download",
     "generating": "Generating..."
+  },
+  "timeSeries": {
+    "title": "Activity over time",
+    "subtitle": "RSVPs, impressions, and clicks across all events",
+    "rsvps": "RSVPs",
+    "impressions": "Impressions",
+    "clicks": "Clicks",
+    "range": {
+      "6hr": "6h",
+      "24hr": "24h",
+      "3d": "3d",
+      "7d": "7d"
+    },
+    "loading": "Loading chart...",
+    "error": "Failed to load chart data.",
+    "empty": "No activity in this range yet."
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3057,6 +3057,33 @@ export async function fetchSponsorEvents(tag?: string): Promise<SponsorDashboard
   return apiRequest<SponsorDashboardData>(`/api/sponsor/events${params}`);
 }
 
+// Admin-only time-series for partner dashboard chart
+export type PartnerTimeSeriesRange = '6hr' | '24hr' | '3d' | '7d';
+
+export interface PartnerTimeSeriesPoint {
+  timestamp: string;
+  rsvps: number;
+  impressions: number;
+  clicks: number;
+}
+
+export interface PartnerTimeSeriesResponse {
+  range: PartnerTimeSeriesRange;
+  bucket: 'hour';
+  since: string;
+  points: PartnerTimeSeriesPoint[];
+}
+
+export async function fetchSponsorEventsTimeSeries(
+  range: PartnerTimeSeriesRange = '24hr',
+  tag?: string
+): Promise<PartnerTimeSeriesResponse> {
+  const params = new URLSearchParams();
+  params.set('range', range);
+  if (tag) params.set('tag', tag);
+  return apiRequest<PartnerTimeSeriesResponse>(`/api/sponsor/events/timeseries?${params.toString()}`);
+}
+
 export async function toggleSponsorChecklistItem(itemId: string): Promise<{ item: SponsorChecklistItem }> {
   return apiRequest<{ item: SponsorChecklistItem }>(`/api/sponsor/checklist/${itemId}/toggle`, {
     method: 'POST',

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -22,6 +22,7 @@ import { fetchSheetCities } from '../lib/cities';
 import type { SheetCity } from '../lib/cities';
 import type { SponsorDashboardEvent, SponsorMeResponse, SponsorDashboardData, CoHost } from '../types';
 import { GPP_REGIONS } from '../types';
+import { PartnerTimeSeriesChart } from '../components/partner/PartnerTimeSeriesChart';
 
 interface DisplayPhoto {
   id: string;
@@ -756,6 +757,11 @@ export function PartnerDashboardPage() {
             </div>
           );
         })()}
+
+        {/* Admin-only time-series chart */}
+        {dashboardData?.isAdmin && (
+          <PartnerTimeSeriesChart tag={dashboardData?.tag} />
+        )}
 
         {/* Filters */}
         {allEvents.length > 0 && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,12 +63,16 @@
         "connectkit": "^1.9.1",
         "date-fns": "^4.1.0",
         "html5-qrcode": "^2.3.8",
+        "i18next": "^26.0.8",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
+        "react-i18next": "^17.0.6",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.0",
+        "recharts": "^2.13.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "use-places-autocomplete": "^4.0.1",
@@ -7142,6 +7146,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -11406,6 +11473,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -11459,6 +11647,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -11666,6 +11860,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -13346,6 +13550,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -13467,6 +13680,43 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iceberg-js": {
@@ -13595,6 +13845,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -17493,6 +17752,42 @@
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-i18next/node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
@@ -17567,6 +17862,37 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/react-transition-state": {
@@ -17650,6 +17976,59 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redaxios": {
       "version": "0.5.1",
@@ -19170,6 +19549,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -19799,6 +20184,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/viem": {
@@ -20637,6 +21044,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {


### PR DESCRIPTION
## Summary

- New backend route `GET /api/sponsor/events/timeseries` returns hour-bucketed counts of RSVPs (`guests.submitted_at` with `status != 'INVITED'`), impressions (`page_views.viewed_at`), and clicks (`link_clicks.clicked_at`) for the partner's events. Supports `range` = `6hr` / `24hr` / `3d` / `7d` (default `24hr`) and optional `tag` filter (same resolution logic as `/events`).
- New frontend component `PartnerTimeSeriesChart` (recharts `LineChart`) with brand-red RSVPs line (`#E52828`), blue impressions (`#3B82F6`), amber clicks (`#F59E0B`), a range chip toggle, full-timestamp tooltip, and empty / loading / error states.
- Wired into `PartnerDashboardPage` between the stats grid and the filter row.
- Frontend i18n keys (`timeSeries.*`) added to `en/partner.json` only — other locales will be picked up by the next i18n audit.
- `recharts@^2.13.0` added to `frontend/package.json`; npm workspaces hoisted to root `package-lock.json`.

## Admin-only

The chart is gated **both client- and server-side**:

- **Client**: rendered only when `dashboardData?.isAdmin === true`.
- **Server**: route returns `403 FORBIDDEN` unless `req.isAdminViewing` is truthy (`requireSponsorAuth` sets this only for admin users).

Non-admin partners never see the chart and cannot fetch the data.

## Deploy note

The backend endpoint must be merged to `master` before any preview branch will return real data — preview frontends hit production backend. Until merge, the chart on this preview will show `Failed to load chart data.`

## Verification

### Local

- [x] `cd backend && npx tsc --noEmit` — only pre-existing `auth.test.ts` error (not introduced by this PR)
- [x] `cd frontend && npm install` then `npm run build` — clean build, no errors
- [ ] Open `/partner` as an admin — chart renders between stats and filters
- [ ] Open `/partner` as a non-admin partner — chart is hidden
- [ ] Toggle 6hr / 24hr / 3d / 7d ranges — chart re-fetches and re-draws
- [ ] Hover a point — tooltip shows full timestamp + per-line counts

### Empty / edge cases

- [ ] No events for the tag — backend returns `{ points: [] }`; chart shows "No activity in this range yet."
- [ ] No activity in the selected range — same empty state
- [ ] Backend 403 (non-admin hitting endpoint directly) — chart shows error state

### Cross-check

- [ ] RSVP totals in the chart roughly match the "Total RSVPs" stat tile across recent ranges
- [ ] Impressions roughly match the "Impressions" stat tile for recent ranges
- [ ] Clicks roughly match "Partner Link Clicks" for recent ranges (note: the chart counts all `link_clicks` rows for the events, while the stats tile filters to the partner's named links — exact-match is not expected, just same order of magnitude)

## Vercel preview URL

Expected pattern: `https://rsvpizza-git-salami-84382-partner-timeseries-pizza-dao.vercel.app`

**Heads up:** the branch slug is 31 chars but the full subdomain `rsvpizza-git-salami-84382-partner-timeseries-pizza-dao` is 54 chars — under the 63-char DNS limit, so the preview should deploy cleanly. (Earlier rough estimate was wrong; the constant overhead is shorter than I counted.)

## Out of scope

Does not touch PR #269's `PartnerCharts.tsx` / `PartnerEventsMap.tsx`, CSV export, map view, or other open partner-area PRs. No DB migrations or column grants required (reads from existing `page_views`, `link_clicks`, `guests` columns).