### PR TITLE
deep-dish-19925: restrict fake detection to admins only

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -400,15 +400,12 @@ router.patch('/city-statuses', requireAuth, requireUnderbossAuth, async (req: Un
 router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {
     const isAdminUser = req.underboss!.regions.includes('__admin__');
-    if (!isAdminUser && req.underboss!.regions.length === 0) {
-      throw new AppError('Not authorized for any region', 403, 'FORBIDDEN');
+    if (!isAdminUser) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
     }
 
-    // Same scope as /:region: admins see all, regional underbosses see their regions only.
-    const whereClause: { eventType: 'gpp'; region?: { in: string[] } } = { eventType: 'gpp' };
-    if (!isAdminUser) {
-      whereClause.region = { in: req.underboss!.regions };
-    }
+    // Admin-only: see all GPP events.
+    const whereClause: { eventType: 'gpp' } = { eventType: 'gpp' };
 
     // Cross-event wallet pre-pass — one raw query, then Set lookup per event.
     // A wallet is "sybil" when it appears on ≥4 distinct events under ≥2 distinct trimmed-lower names.

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -435,19 +435,21 @@ export function UnderbossDashboard() {
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}
             </button>
-            <button
-              onClick={() => setActiveTab('fake-detection')}
-              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
-                activeTab === 'fake-detection'
-                  ? 'text-theme-text'
-                  : 'text-theme-text-muted hover:text-theme-text-secondary'
-              }`}
-            >
-              {t('underbossDashboard.tabs.fakeDetection')}
-              {activeTab === 'fake-detection' && (
-                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
-              )}
-            </button>
+            {isAdmin && (
+              <button
+                onClick={() => setActiveTab('fake-detection')}
+                className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                  activeTab === 'fake-detection'
+                    ? 'text-theme-text'
+                    : 'text-theme-text-muted hover:text-theme-text-secondary'
+                }`}
+              >
+                {t('underbossDashboard.tabs.fakeDetection')}
+                {activeTab === 'fake-detection' && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+                )}
+              </button>
+            )}
           </div>
 
           {activeTab === 'events' && (
@@ -462,7 +464,7 @@ export function UnderbossDashboard() {
             <PartnerManager isAdmin={isAdmin} events={allData?.events} onSyncComplete={() => loadDashboard(true)} onFlyerRegenNeeded={handleFlyerRegenForTag} />
           )}
 
-          {activeTab === 'fake-detection' && (
+          {isAdmin && activeTab === 'fake-detection' && (
             <FakeDetectionTable />
           )}
 


### PR DESCRIPTION
## Summary
Restricts the just-shipped Fake Detection feature (PR #351, blackolive-74932) to admins only. Regional underbosses no longer see the tab or get data from the endpoint.

- Backend `GET /api/underboss/fake-detection`: returns **HTTP 403** with `{"error":{"message":"Admin access required","code":"FORBIDDEN"}}` for any non-admin caller (was: regional underbosses got a region-filtered query through; only zero-region accounts were blocked).
- Frontend `UnderbossDashboard`: the "Fake Detection" tab button and tab body are now wrapped in `{isAdmin && ...}`. Reuses the existing `isAdmin` state already populated from `fetchUnderbossMe().isAdmin` — no new auth plumbing.
- Dead non-admin `whereClause.region = {...}` branch removed since admin is now guaranteed past the guard.

Plan: `plans/deep-dish-19925-admin-only-fake-detection.md`

Follow-up to: #351

## Test plan
- [ ] **Non-admin underboss → 403**
  ```bash
  curl -i -H "Authorization: Bearer <non-admin-underboss-jwt>" \
    https://rsvpizza-git-deep-dish-19925-admin-only-fd-pizza-dao.vercel.app/api/underboss/fake-detection
  # expect: HTTP/2 403
  # body:   {"error":{"message":"Admin access required","code":"FORBIDDEN"}}
  ```
  (Note: backend only deploys from master, so this curl must be run against production after merge + manual backend redeploy.)
- [ ] **Admin → 200 with `{ rows, meta }`**
  ```bash
  curl -i -H "Authorization: Bearer <admin-jwt>" \
    https://api.rsv.pizza/api/underboss/fake-detection
  ```
- [ ] Admin login at `/underboss` on the preview → "Fake Detection" tab visible + functional
- [ ] Non-admin underboss login at `/underboss` on the preview → only **Events / Cities / Partners** tabs shown, no Fake Detection button
- [ ] `fakeDetection` unit tests still green (verified locally — all pass)

## Constraints honoured
- No new middleware file, no new types, no migrations, no i18n changes
- Exactly 2 files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)