### PR TITLE
feat(arugula-38633): payments DB foundation (PR 1/5)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,12 @@ model User {
   defaultLikedBeverages      String[]
   defaultDislikedBeverages   String[]
   defaultAddress             String?
+
+  // Payout preferences (arugula-38633)
+  preferredPayoutMethod String? @map("preferred_payout_method")
+  payoutWalletAddress   String? @map("payout_wallet_address")
+  payoutBankDetails     Json?   @map("payout_bank_details")
+
   createdAt                  DateTime @default(now())
   updatedAt                  DateTime @updatedAt
 
@@ -35,6 +41,7 @@ model User {
   magicLinks   MagicLink[]
   apiKeys      ApiKey[]
   aiPhoneCalls AIPhoneCall[]
+  payouts      Payout[]
 }
 
 model Party {
@@ -214,6 +221,7 @@ model Party {
   quizQuestions         QuizQuestion[]
   slugAliases           SlugAlias[]
   scorecardItems        GuestScorecardItem[]
+  payouts               Payout[]
 
   @@map("parties")
 }
@@ -1390,4 +1398,96 @@ model GuestScorecardItem {
   @@index([guestId, partyId])
   @@index([partyId])
   @@map("guest_scorecard_items")
+}
+
+// ============================================
+// Host Payouts (arugula-38633)
+// ============================================
+// String fields (not Prisma enums) for status/payoutMethod to match the
+// project convention — see Admin.role, Party.status, etc. CHECK constraints
+// at the DB layer enforce allowed values.
+
+model Payout {
+  id                  String    @id @default(uuid()) @db.Uuid
+  partyId             String    @map("party_id") @db.Uuid
+  party               Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  hostUserId          String    @map("host_user_id")
+  host                User      @relation(fields: [hostUserId], references: [id], onDelete: Restrict)
+
+  originalAmount      Decimal   @map("original_amount") @db.Decimal(12, 2)
+  originalCurrency    String    @map("original_currency")
+  exchangeRate        Decimal   @map("exchange_rate") @db.Decimal(18, 6)
+  extractedAmountUsd  Decimal   @map("extracted_amount_usd") @db.Decimal(12, 2)
+  finalAmountUsd      Decimal   @map("final_amount_usd") @db.Decimal(12, 2)
+
+  status              String    @default("pending")
+  payoutMethod        String    @map("payout_method")
+
+  payoutWalletAddress String?   @map("payout_wallet_address")
+  payoutBankDetails   Json?     @map("payout_bank_details")
+  mercuryCardId       String?   @map("mercury_card_id")
+  mercuryCardLast4    String?   @map("mercury_card_last4")
+
+  hostNotes           String?   @map("host_notes")
+  adminNotes          String?   @map("admin_notes")
+  rejectionReason     String?   @map("rejection_reason")
+
+  reviewedBy          String?   @map("reviewed_by")
+  reviewedAt          DateTime? @map("reviewed_at") @db.Timestamptz
+  paidAt              DateTime? @map("paid_at") @db.Timestamptz
+
+  transactionHash     String?   @map("transaction_hash")
+  wireReference       String?   @map("wire_reference")
+
+  createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt           DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+
+  documents           PayoutDocument[]
+  audits              PayoutAudit[]
+
+  @@index([partyId])
+  @@index([hostUserId])
+  @@index([status])
+  @@index([createdAt(sort: Desc)])
+  @@map("payouts")
+}
+
+model PayoutDocument {
+  id            String   @id @default(uuid()) @db.Uuid
+  payoutId      String   @map("payout_id") @db.Uuid
+  payout        Payout   @relation(fields: [payoutId], references: [id], onDelete: Cascade)
+  kind          String   // 'pizza' | 'receipt'
+  url           String
+  fileName      String   @map("file_name")
+  fileSize      Int      @map("file_size")
+  mimeType      String   @map("mime_type")
+  ocrAmount     Decimal? @map("ocr_amount") @db.Decimal(12, 2)
+  ocrCurrency   String?  @map("ocr_currency")
+  ocrConfidence Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
+  ocrRaw        Json?    @map("ocr_raw")
+  ocrError      String?  @map("ocr_error")
+  sortOrder     Int      @default(0) @map("sort_order")
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([payoutId])
+  @@map("payout_documents")
+}
+
+model PayoutAudit {
+  id          String   @id @default(uuid()) @db.Uuid
+  payoutId    String   @map("payout_id") @db.Uuid
+  payout      Payout   @relation(fields: [payoutId], references: [id], onDelete: Cascade)
+  action      String
+  oldStatus   String?  @map("old_status")
+  newStatus   String?  @map("new_status")
+  oldAmount   Decimal? @map("old_amount") @db.Decimal(12, 2)
+  newAmount   Decimal? @map("new_amount") @db.Decimal(12, 2)
+  actorEmail  String   @map("actor_email")
+  actorKind   String   @map("actor_kind")
+  note        String?
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([payoutId])
+  @@index([createdAt(sort: Desc)])
+  @@map("payout_audit")
 }

--- a/supabase/migrations/20260517_create_payouts.sql
+++ b/supabase/migrations/20260517_create_payouts.sql
@@ -82,7 +82,7 @@ CREATE TABLE payout_audit (
   old_amount  NUMERIC(12, 2),
   new_amount  NUMERIC(12, 2),
   actor_email TEXT NOT NULL,
-  actor_kind  TEXT NOT NULL CHECK (actor_kind IN ('admin','superadmin','payment_admin','host','system')),
+  actor_kind  TEXT NOT NULL CHECK (actor_kind IN ('admin','super_admin','payment_admin','host','system')),
   note        TEXT,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/supabase/migrations/20260517_create_payouts.sql
+++ b/supabase/migrations/20260517_create_payouts.sql
@@ -1,0 +1,127 @@
+-- ============================================
+-- Host Payouts (arugula-38633)
+-- ============================================
+-- Reimbursement requests from hosts: upload photos -> OCR -> approve -> payout.
+-- Three payout rails: Mercury debit card (admin-mediated), manual wire, USDC on Base.
+-- All writes go through the backend (service_role bypasses RLS); anon/authenticated
+-- never read these tables directly, so we REVOKE per the Feb 2026 security audit pattern.
+-- ============================================
+
+-- 1. Payouts table (one row per reimbursement request)
+CREATE TABLE payouts (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id              UUID NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  host_user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  -- Amount tracking (always store ALL three: original, USD, and "final" after admin edits)
+  original_amount       NUMERIC(12, 2) NOT NULL,
+  original_currency     TEXT NOT NULL,
+  exchange_rate         NUMERIC(18, 6) NOT NULL,  -- locked at submission time
+  extracted_amount_usd  NUMERIC(12, 2) NOT NULL,  -- OCR sum, converted at submission
+  final_amount_usd      NUMERIC(12, 2) NOT NULL,  -- after host manual override + admin edits
+  -- Status: pending | approved | rejected | paid | failed
+  status                TEXT NOT NULL DEFAULT 'pending'
+                          CHECK (status IN ('pending','approved','rejected','paid','failed')),
+  -- Payout method: mercury_card | wire | usdc_base
+  payout_method         TEXT NOT NULL
+                          CHECK (payout_method IN ('mercury_card','wire','usdc_base')),
+  -- Method-specific payout target (one of these populated based on method)
+  payout_wallet_address TEXT,                 -- 0x... for usdc_base
+  payout_bank_details   JSONB,                -- {accountHolder, routing, account, swift, iban, bankName, address, ...} for wire
+  mercury_card_id       TEXT,                 -- Mercury card ID (if recorded — optional, may be null for fully-manual flow)
+  mercury_card_last4    TEXT,                 -- Mercury card last 4 digits (shown to host)
+  -- Notes
+  host_notes            TEXT,
+  admin_notes           TEXT,
+  rejection_reason      TEXT,
+  -- Approval / execution tracking
+  reviewed_by           TEXT,                 -- admin email
+  reviewed_at           TIMESTAMPTZ,
+  paid_at               TIMESTAMPTZ,
+  -- Method-specific receipt/proof
+  transaction_hash      TEXT,                 -- Base tx hash for usdc_base
+  wire_reference        TEXT,                 -- bank reference number for wire
+  -- Metadata
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_payouts_party_id     ON payouts (party_id);
+CREATE INDEX idx_payouts_host_user_id ON payouts (host_user_id);
+CREATE INDEX idx_payouts_status       ON payouts (status);
+CREATE INDEX idx_payouts_created_at   ON payouts (created_at DESC);
+
+-- 2. Payout documents (photos: pizza shot + receipt(s))
+CREATE TABLE payout_documents (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  payout_id       UUID NOT NULL REFERENCES payouts(id) ON DELETE CASCADE,
+  kind            TEXT NOT NULL CHECK (kind IN ('pizza','receipt')),
+  url             TEXT NOT NULL,             -- Supabase Storage public URL
+  file_name       TEXT NOT NULL,
+  file_size       INTEGER NOT NULL,
+  mime_type       TEXT NOT NULL,
+  -- OCR results (only populated for kind='receipt')
+  ocr_amount      NUMERIC(12, 2),
+  ocr_currency    TEXT,
+  ocr_confidence  NUMERIC(3, 2),             -- 0.00-1.00
+  ocr_raw         JSONB,                     -- full OpenAI response for debugging
+  ocr_error       TEXT,
+  sort_order      INTEGER NOT NULL DEFAULT 0,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_payout_documents_payout_id ON payout_documents (payout_id);
+
+-- 3. Payout audit log (mirrors party_status_audit pattern from pizzaiolo-97053)
+CREATE TABLE payout_audit (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  payout_id   UUID NOT NULL REFERENCES payouts(id) ON DELETE CASCADE,
+  action      TEXT NOT NULL
+                CHECK (action IN ('create','approve','reject','edit_amount','mark_paid','mark_failed','retry','cancel')),
+  old_status  TEXT,
+  new_status  TEXT,
+  old_amount  NUMERIC(12, 2),
+  new_amount  NUMERIC(12, 2),
+  actor_email TEXT NOT NULL,
+  actor_kind  TEXT NOT NULL CHECK (actor_kind IN ('admin','superadmin','payment_admin','host','system')),
+  note        TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_payout_audit_payout_id  ON payout_audit (payout_id);
+CREATE INDEX idx_payout_audit_created_at ON payout_audit (created_at DESC);
+
+-- 4. Host payout preferences on users table
+ALTER TABLE users ADD COLUMN preferred_payout_method TEXT
+  CHECK (preferred_payout_method IN ('mercury_card','wire','usdc_base'));
+ALTER TABLE users ADD COLUMN payout_wallet_address TEXT;
+ALTER TABLE users ADD COLUMN payout_bank_details JSONB;
+-- No stripe_cardholder_id needed — Mercury doesn't require per-host KYC enrollment.
+
+-- 5. Permissions: per the Feb 2026 security audit, all writes go through the
+-- backend (service_role bypasses RLS). anon/authenticated NEVER need to read
+-- these tables directly. Audit log is service_role only.
+REVOKE ALL ON payouts           FROM anon, authenticated;
+REVOKE ALL ON payout_documents  FROM anon, authenticated;
+REVOKE ALL ON payout_audit      FROM anon, authenticated;
+
+ALTER TABLE payouts          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payout_documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payout_audit     ENABLE ROW LEVEL SECURITY;
+
+-- 6. New users columns: backend reads via Prisma (service_role), so column-level
+-- GRANTs to anon/authenticated are NOT needed here. Confirmed no frontend code
+-- reads users.* directly via supabase-js — all user data flows through the
+-- backend /api/user routes. If that changes, add GRANT SELECT.
+
+-- 7. Deletion log triggers (matches existing pattern in 20260429_create_deletion_log.sql)
+CREATE TRIGGER trg_deletion_log_payouts           BEFORE DELETE ON payouts          FOR EACH ROW EXECUTE FUNCTION log_deletion();
+CREATE TRIGGER trg_deletion_log_payout_documents  BEFORE DELETE ON payout_documents FOR EACH ROW EXECUTE FUNCTION log_deletion();
+
+-- 8. updated_at trigger for payouts
+CREATE OR REPLACE FUNCTION update_payouts_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_payouts_updated_at BEFORE UPDATE ON payouts
+  FOR EACH ROW EXECUTE FUNCTION update_payouts_updated_at();


### PR DESCRIPTION
## Summary

First of 5 PRs implementing the host payments / reimbursements app (`arugula-38633`). **Schema-only — no routes, services, or UI yet.** This PR just lays the DB foundation so the subsequent PRs have something to PATCH/SELECT.

## Plan

See [`plans/arugula-38633-payments-app.md`](https://github.com/PizzaDAO/rsv-pizza/blob/master/plans/arugula-38633-payments-app.md) — §3 (data model) and §9 PR 1 are the relevant sections.

## What's in this PR

### New migration
`supabase/migrations/20260517_create_payouts.sql`:

- **`payouts`** — one row per reimbursement request. Tracks original amount + currency, locked exchange rate, OCR-extracted USD, final USD (after host/admin edits), status (`pending|approved|rejected|paid|failed`), method (`mercury_card|wire|usdc_base`), method-specific target columns (wallet / bank JSONB / Mercury card refs), reviewer + paid-at timestamps, transaction hash / wire reference.
- **`payout_documents`** — uploaded pizza + receipt photos (Supabase Storage URLs) + per-receipt OCR results (amount, currency, confidence, raw OpenAI response).
- **`payout_audit`** — every status transition / amount edit, mirroring the `party_status_audit` pattern from `pizzaiolo-97053`.
- 4 indexes on `payouts`, 1 on `payout_documents`, 2 on `payout_audit`.
- `users` gains: `preferred_payout_method`, `payout_wallet_address`, `payout_bank_details`.
- All 3 new tables: `REVOKE ALL FROM anon, authenticated` + RLS enabled (service_role only — matches Feb 2026 security audit pattern).
- Deletion-log triggers on `payouts` and `payout_documents` (reusing existing `log_deletion()` function).
- `updated_at` trigger on `payouts`.

### Prisma schema
`backend/prisma/schema.prisma`:

- Adds `Payout`, `PayoutDocument`, `PayoutAudit` models.
- `User` gains the 3 payout-preference fields + `payouts Payout[]` relation.
- `Party` gains `payouts Payout[]` relation.
- Uses `String` for `status` / `payoutMethod` (with DB CHECK constraints) to match the project convention — no Prisma enums (none exist in this codebase).
- No `stripe_cardholder_id` — Mercury (admin-mediated) sidesteps Stripe Issuing's per-cardholder KYC entirely.

## Deviations from the plan

- Migration filename uses today's date: `20260517_create_payouts.sql` (plan said `20260601`).
- `users` column GRANTs to anon/authenticated intentionally omitted — confirmed no frontend code queries `users` directly via supabase-js; all user data flows through backend Prisma (service_role). Comment in migration documents this.

## CRITICAL: Apply migration to production BEFORE merging subsequent PRs

Per `CLAUDE.md`: **preview deploys share production backend + DB**. Once PR 2+ start adding backend code that reads `prisma.payout.*`, every backend query will 500 until the migration is applied (Prisma schema ≠ DB schema).

**This PR alone is safe to merge first**, because no backend code references the new tables yet. Apply via `mcp__supabase-pizzadao__apply_migration` immediately after merge, then proceed with PR 2.

## Test plan

- [ ] Vercel preview builds cleanly (no TypeScript errors from `prisma generate`)
- [ ] After merge: apply `20260517_create_payouts.sql` via Supabase MCP
- [ ] Confirm `\dt payouts payout_documents payout_audit` show
- [ ] Confirm `\dp payouts` shows no anon/authenticated grants
- [ ] Confirm `users.preferred_payout_method`, `payout_wallet_address`, `payout_bank_details` columns exist
- [ ] Insert + delete a fake payout row, confirm `deletion_log` captures it

🤖 Generated with [Claude Code](https://claude.com/claude-code)