### PR TITLE
mozzarella-37882: underboss top stats reflect EventTable filters

### DIFF
--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Search, ArrowUpDown, ThumbsUp, ThumbsDown, ChevronDown, Check, X, DollarSign } from 'lucide-react';
@@ -17,6 +17,7 @@ interface EventTableProps {
   onBulkAction?: () => void;
   onTelegramBroadcast?: (cities: string[]) => void;
   partnerTags?: string[];
+  onFilteredEventsChange?: (events: UnderbossEvent[]) => void;
 }
 
 type SortField = 'name' | 'date' | 'guestCount' | 'progress';
@@ -87,7 +88,7 @@ function FilterPill({
   );
 }
 
-export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, onTelegramBroadcast, partnerTags = [] }: EventTableProps) {
+export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, onTelegramBroadcast, partnerTags = [], onFilteredEventsChange }: EventTableProps) {
   const { t } = useTranslation('partner');
   const [search, setSearch] = useState('');
   const [sortField, setSortField] = useState<SortField>('date');
@@ -241,6 +242,10 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
 
     return result;
   }, [events, search, sortField, sortDir, progressIncludes, progressExcludes, regionFilter, showRegion, tagFilter, rsvpComparator, rsvpThreshold]);
+
+  useEffect(() => {
+    onFilteredEventsChange?.(filteredEvents);
+  }, [filteredEvents, onFilteredEventsChange]);
 
   const availableTags = useMemo(
     () => Array.from(new Set(events.flatMap((e) => e.eventTags ?? []))).sort(),

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -71,6 +71,8 @@ export function UnderbossDashboard() {
   // Tab state
   const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection'>('events');
 
+  const [tableFilteredEvents, setTableFilteredEvents] = useState<UnderbossEvent[] | null>(null);
+
   // Telegram broadcast modal state
   const [showBroadcast, setShowBroadcast] = useState(false);
   const [broadcastCities, setBroadcastCities] = useState<string[]>([]);
@@ -101,6 +103,24 @@ export function UnderbossDashboard() {
       events: filteredEvents,
     };
   }, [allData, selectedRegions, availableRegions.length]);
+
+  const displayData = useMemo(() => {
+    if (!filteredData) return null;
+    if (activeTab !== 'events' || !tableFilteredEvents) return filteredData;
+    return {
+      ...filteredData,
+      stats: recomputeStats(tableFilteredEvents),
+      events: tableFilteredEvents,
+    };
+  }, [filteredData, activeTab, tableFilteredEvents]);
+
+  useEffect(() => {
+    if (activeTab !== 'events') setTableFilteredEvents(null);
+  }, [activeTab]);
+
+  useEffect(() => {
+    setTableFilteredEvents(null);
+  }, [allData]);
 
   // Derive the region label for the header
   const regionLabel = useMemo(() => {
@@ -272,7 +292,7 @@ export function UnderbossDashboard() {
     );
   }
 
-  if (!filteredData) return null;
+  if (!filteredData || !displayData) return null;
 
   const showMultiSelect = availableRegions.length > 1;
   const showRegionColumn = selectedRegions.length > 1;
@@ -390,7 +410,7 @@ export function UnderbossDashboard() {
 
         {/* Stats */}
         <section className="mb-8">
-          <RegionStats stats={filteredData.stats} />
+          <RegionStats stats={displayData.stats} />
         </section>
 
         {/* Events / Cities Tabs */}
@@ -404,7 +424,7 @@ export function UnderbossDashboard() {
                   : 'text-theme-text-muted hover:text-theme-text-secondary'
               }`}
             >
-              {t('underbossDashboard.tabs.events')} ({filteredData.events.length})
+              {t('underbossDashboard.tabs.events')} ({displayData.events.length})
               {activeTab === 'events' && (
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}
@@ -453,7 +473,7 @@ export function UnderbossDashboard() {
           </div>
 
           {activeTab === 'events' && (
-            <EventTable events={filteredData.events} showRegion={showRegionColumn} onEventUpdate={handleEventUpdate} onBulkAction={() => loadDashboard(true)} onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }} partnerTags={partnerTags} />
+            <EventTable events={filteredData.events} showRegion={showRegionColumn} onEventUpdate={handleEventUpdate} onBulkAction={() => loadDashboard(true)} onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }} partnerTags={partnerTags} onFilteredEventsChange={setTableFilteredEvents} />
           )}
 
           {activeTab === 'cities' && (


### PR DESCRIPTION
## Summary

The `/underboss` region-level stat cards (Events, Total RSVPs, Invited, Approved, With Venue, With Budget, plus Completion Rates) and the Events tab count now follow EventTable's in-table filters (search, progress thumbs-up/down pills, approved/rejected/hidden/listed pills, country select, tag select, RSVP threshold) — not just the region multi-select.

Cities tab and Partners tab keep their current behavior (region-only stats).

## Changes

- `frontend/src/components/underboss/EventTable.tsx` — adds optional `onFilteredEventsChange` prop and a `useEffect` that pushes `filteredEvents` up to the parent.
- `frontend/src/pages/UnderbossDashboard.tsx` — adds `tableFilteredEvents` state, a `displayData` memo that recomputes stats from those events when the Events tab is active, and resets the state on tab/data changes.

## Test plan

- [ ] `/underboss` Events tab: typing in the search box updates the top stat cards and the `Events (N)` tab count.
- [ ] Toggling progress pills (e.g. Venue thumbs-up) shrinks the stat numbers to match the filtered subset.
- [ ] Approved/Rejected/Hidden/Listed filters affect the stats.
- [ ] Country select, tag select, RSVP threshold filters all flow into the stats.
- [ ] Clearing filters restores the region-level totals.
- [ ] Switching to Cities or Partners tab shows region-only stats (no in-table-filter influence).
- [ ] Switching the region multi-select still works as before.