### PR TITLE
feat(arugula-34107): /admin tabs + Experiments tab with opt-in A/B results

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -782,4 +782,60 @@ router.get('/funnel-stats', requireAuth, async (req: AuthRequest, res: Response,
   }
 });
 
+// GET /api/admin/experiments/optin-ab — parmesan-98989 combined opt-in A/B results (admin only)
+router.get('/experiments/optin-ab', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const rows = await prisma.$queryRaw<Array<{
+      arm: string;
+      n: number;
+      pizzadao_optins: number;
+      pizzadao_optin_pct: number | string;
+      swc_optins: number;
+      swc_optin_pct: number | string;
+    }>>`
+      SELECT
+        g.optin_ab_variant AS arm,
+        COUNT(*)::int                                                        AS n,
+        COUNT(*) FILTER (WHERE g.mailing_list_opt_in)::int                   AS pizzadao_optins,
+        COALESCE(ROUND(100.0 * COUNT(*) FILTER (WHERE g.mailing_list_opt_in)
+                             / NULLIF(COUNT(*), 0), 2), 0)                   AS pizzadao_optin_pct,
+        COUNT(*) FILTER (WHERE g.swc_opt_in)::int                            AS swc_optins,
+        COALESCE(ROUND(100.0 * COUNT(*) FILTER (WHERE g.swc_opt_in)
+                             / NULLIF(COUNT(*), 0), 2), 0)                   AS swc_optin_pct
+      FROM guests g
+      JOIN parties p ON p.id = g.party_id
+      WHERE 'swc' = ANY(p.event_tags)
+        AND g.optin_ab_variant IN ('control', 'variant')
+        AND g.submitted_via = 'link'
+        AND (g.status IS NULL OR g.status != 'INVITED')
+      GROUP BY g.optin_ab_variant
+      ORDER BY g.optin_ab_variant;
+    `;
+
+    const byArm = new Map<string, typeof rows[number]>();
+    for (const r of rows) byArm.set(r.arm, r);
+
+    const arms = (['control', 'variant'] as const).map((arm) => {
+      const r = byArm.get(arm);
+      return {
+        arm,
+        n: r ? Number(r.n) : 0,
+        pizzadaoOptins: r ? Number(r.pizzadao_optins) : 0,
+        pizzadaoOptinPct: r ? Number(r.pizzadao_optin_pct) : 0,
+        swcOptins: r ? Number(r.swc_optins) : 0,
+        swcOptinPct: r ? Number(r.swc_optin_pct) : 0,
+      };
+    });
+
+    res.set('Cache-Control', 'no-store');
+    res.json({ arms });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/frontend/src/components/underboss/OptinABTab.tsx
+++ b/frontend/src/components/underboss/OptinABTab.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, RefreshCw } from 'lucide-react';
+import { fetchOptinABResults } from '../../lib/api';
+import type { OptinABResults, OptinABArm } from '../../lib/api';
+
+// MDE sample-size targets (per arm).
+const N_10PP = 330;
+const N_5PP = 1400;
+
+// Two-proportion z-test (two-sided). Ported verbatim from
+// scripts/check-optin-ab-results.js on the parmesan-98989 branch so CLI
+// and UI cannot disagree.
+function zScore(p1: number, n1: number, p2: number, n2: number): number {
+  if (!n1 || !n2) return 0;
+  const pPool = (p1 * n1 + p2 * n2) / (n1 + n2);
+  const se = Math.sqrt(pPool * (1 - pPool) * (1 / n1 + 1 / n2));
+  if (!se) return 0;
+  return (p1 - p2) / se;
+}
+
+// Two-sided p-value via Abramowitz & Stegun 7.1.26 erf approximation.
+function pValueFromZ(z: number): number {
+  const abs = Math.abs(z);
+  const t = 1 / (1 + 0.3275911 * (abs / Math.SQRT2));
+  const erf =
+    1 -
+    (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592) *
+      t *
+      Math.exp(-((abs / Math.SQRT2) ** 2));
+  const oneSided = 1 - 0.5 * (1 + erf);
+  return 2 * oneSided;
+}
+
+function sigLabel(p: number): '***' | '**' | '*' | 'n.s.' {
+  if (p < 0.001) return '***';
+  if (p < 0.01) return '**';
+  if (p < 0.05) return '*';
+  return 'n.s.';
+}
+
+function ArmBlock({ arm }: { arm: OptinABArm }) {
+  const title = arm.arm === 'control' ? 'Control' : 'Variant';
+  return (
+    <div className="bg-theme-surface border border-theme-stroke rounded-xl p-4">
+      <div className="flex items-baseline justify-between mb-3">
+        <h4 className="text-base font-semibold text-theme-text">{title}</h4>
+        <span className="text-xs text-theme-text-muted">N = {arm.n.toLocaleString()}</span>
+      </div>
+      <div className="space-y-1 text-sm text-theme-text-secondary">
+        <div>
+          PizzaDAO opt-in:{' '}
+          <span className="text-theme-text font-medium">
+            {arm.pizzadaoOptins.toLocaleString()} ({arm.pizzadaoOptinPct}%)
+          </span>
+        </div>
+        <div>
+          SWC opt-in:{' '}
+          <span className="text-theme-text font-medium">
+            {arm.swcOptins.toLocaleString()} ({arm.swcOptinPct}%)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SampleSizeBar({ arm }: { arm: OptinABArm }) {
+  const title = arm.arm === 'control' ? 'Control' : 'Variant';
+  const pct = Math.min(arm.n / N_5PP, 1) * 100;
+  const tickPct10 = (N_10PP / N_5PP) * 100;
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-1 text-xs text-theme-text-muted">
+        <span>{title}</span>
+        <span>
+          {arm.n.toLocaleString()} / {N_5PP.toLocaleString()}
+        </span>
+      </div>
+      <div className="relative h-3 bg-white/30 border border-theme-stroke rounded-full overflow-hidden">
+        <div
+          className="h-full bg-[#E52828] transition-all"
+          style={{ width: `${pct}%` }}
+        />
+        <div
+          className="absolute top-0 bottom-0 border-l border-theme-text-muted/60"
+          style={{ left: `${tickPct10}%` }}
+        />
+      </div>
+      <div className="flex justify-between text-[10px] text-theme-text-faint mt-1">
+        <span>0</span>
+        <span style={{ marginLeft: `${tickPct10 - 6}%` }}>10pp MDE: {N_10PP}</span>
+        <span>5pp MDE: {N_5PP.toLocaleString()}</span>
+      </div>
+    </div>
+  );
+}
+
+export function OptinABTab() {
+  const [data, setData] = useState<OptinABResults | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    const result = await fetchOptinABResults();
+    if (!result) {
+      setError('Failed to load opt-in A/B results');
+      setData(null);
+    } else {
+      setData(result);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const control = data?.arms.find((a) => a.arm === 'control');
+  const variant = data?.arms.find((a) => a.arm === 'variant');
+
+  let sigLine: string;
+  if (!control || !variant || !control.n || !variant.n) {
+    sigLine = 'Insufficient data';
+  } else {
+    const pC = control.pizzadaoOptins / control.n;
+    const pV = variant.pizzadaoOptins / variant.n;
+    const z = zScore(pC, control.n, pV, variant.n);
+    const p = pValueFromZ(z);
+    const deltaPp = (pV - pC) * 100;
+    const sign = deltaPp >= 0 ? '+' : '';
+    sigLine = `Variant vs. Control (PizzaDAO opt-in): ${sign}${deltaPp.toFixed(2)} pp, p = ${p.toFixed(4)} (${sigLabel(p)})`;
+  }
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-start justify-between mb-1 gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-theme-text">
+            PizzaDAO + Partners Opt-in A/B (parmesan-98989)
+          </h3>
+          <p className="text-xs text-theme-text-muted mt-1">
+            swc-tagged events, real RSVP submissions only
+          </p>
+        </div>
+        <button
+          onClick={() => void load()}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/60 hover:bg-white/80 border border-theme-stroke text-sm text-theme-text-secondary disabled:opacity-50 transition-colors"
+          title="Refresh"
+        >
+          {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+          Refresh
+        </button>
+      </div>
+
+      {loading && !data && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-theme-text-muted" />
+        </div>
+      )}
+
+      {error && !loading && (
+        <p className="text-theme-text-muted text-center py-8">{error}</p>
+      )}
+
+      {data && control && variant && (
+        <div className="mt-4 space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ArmBlock arm={control} />
+            <ArmBlock arm={variant} />
+          </div>
+
+          <div className="text-sm text-theme-text-secondary border-t border-theme-stroke pt-4">
+            {sigLine}
+          </div>
+
+          <div className="space-y-4">
+            <SampleSizeBar arm={control} />
+            <SampleSizeBar arm={variant} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3438,6 +3438,31 @@ export async function fetchFunnelStats(regions?: string[]): Promise<FunnelStats 
   }
 }
 
+export interface OptinABArm {
+  arm: 'control' | 'variant';
+  n: number;
+  pizzadaoOptins: number;
+  pizzadaoOptinPct: number;
+  swcOptins: number;
+  swcOptinPct: number;
+}
+
+export interface OptinABResults {
+  arms: OptinABArm[];
+}
+
+export async function fetchOptinABResults(): Promise<OptinABResults | null> {
+  try {
+    return await apiRequest<OptinABResults>('/api/admin/experiments/optin-ab', {
+      method: 'GET',
+      requireAuth: true,
+    });
+  } catch (error) {
+    console.error('Error fetching opt-in A/B results:', error);
+    return null;
+  }
+}
+
 // ── Guest Scorecard ──
 
 export interface ScorecardItem {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -7,6 +7,7 @@ import { GPPClouds } from '../components/GPPClouds';
 import { IconInput } from '../components/IconInput';
 import { CopyEmailButton } from '../components/CopyEmailButton';
 import { FunnelTab } from '../components/underboss/FunnelTab';
+import { OptinABTab } from '../components/underboss/OptinABTab';
 import {
   Shield, ShieldCheck, UserPlus, Trash2, Loader2,
   Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp, Download, Palette,
@@ -116,6 +117,8 @@ export function AdminPage() {
   const [savingDesc, setSavingDesc] = useState(false);
   const [descMessage, setDescMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [showCustomized, setShowCustomized] = useState(false);
+
+  const [activeTab, setActiveTab] = useState<'admin' | 'experiments'>('admin');
 
   const isSuperAdmin = currentRole === 'super_admin';
 
@@ -575,6 +578,37 @@ export function AdminPage() {
             </div>
           </div>
 
+          <div className="border-b border-theme-stroke mb-6 flex gap-6">
+            <button
+              onClick={() => setActiveTab('admin')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'admin'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              Admin
+              {activeTab === 'admin' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
+            <button
+              onClick={() => setActiveTab('experiments')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'experiments'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              Experiments
+              {activeTab === 'experiments' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
+          </div>
+
+          {activeTab === 'admin' && (
+            <>
           {/* Export Events CSV */}
           <div className="mb-6">
             <button
@@ -1355,6 +1389,14 @@ export function AdminPage() {
             </h2>
             <FunnelTab regions={[]} />
           </section>
+            </>
+          )}
+
+          {activeTab === 'experiments' && (
+            <section className="mb-10">
+              <OptinABTab />
+            </section>
+          )}
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- Adds tab nav to /admin (Admin | Experiments) - all existing admin tooling stays under the "Admin" tab (default).
- New Experiments tab with a panel for parmesan-98989: per-arm N, PizzaDAO + SWC opt-in counts/rates, two-proportion z-test, sample-size progress vs 5pp and 10pp MDE targets.
- New backend endpoint GET /api/admin/experiments/optin-ab (admin-gated, prisma.$queryRaw).

## Pre-merge / post-merge notes
- [ ] No DB migrations. Column already in prod.
- [ ] Endpoint won't work on this preview (backend deploys from master only) - test runtime after merge.
- [ ] After merge: redeploy backend (`cd backend && vercel --prod --scope pizza-dao`).
- [ ] Verify CLI/UI parity post-merge: `node scripts/check-optin-ab-results.js` numbers must match the Experiments tab.

## Test plan
- [ ] /admin loads with Admin tab selected by default; all existing sections visible.
- [ ] Click Experiments tab; panel renders without console errors; loading spinner then data (or empty state if no rows yet).
- [ ] Refresh button re-fetches.
- [ ] Auth: non-admin gets 403 from the endpoint.
- [ ] Mobile: arm summary collapses to single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)