### PR TITLE
feat(arugula-38633): add payment_admin role (PR 2/5)

### DIFF
--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -17,7 +17,7 @@ vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
 // Set JWT_SECRET before importing auth module
 process.env.JWT_SECRET = JWT_SECRET;
 
-import { requireAuth, optionalAuth, isSuperAdmin, AuthRequest } from './auth.js';
+import { requireAuth, optionalAuth, isAdmin, isSuperAdmin, isPaymentAdmin, isFullAdmin, AuthRequest } from './auth.js';
 import { errorHandler } from './error.js';
 
 function createTestApp(middleware: any) {
@@ -196,5 +196,126 @@ describe('isSuperAdmin', () => {
     expect(mockPrisma.admin.findUnique).toHaveBeenCalledWith({
       where: { email: 'admin@example.com' },
     });
+  });
+});
+
+describe('isAdmin (tightened — excludes payment_admin)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for role=admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+    expect(await isAdmin('admin@example.com')).toBe(true);
+  });
+
+  it('returns true for role=super_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'super@example.com',
+      role: 'super_admin',
+    });
+    expect(await isAdmin('super@example.com')).toBe(true);
+  });
+
+  // Behavioral change (arugula-38633 PR 2): payment_admin must NOT pass isAdmin.
+  it('returns false for role=payment_admin (behavioral change)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'finance@example.com',
+      role: 'payment_admin',
+    });
+    expect(await isAdmin('finance@example.com')).toBe(false);
+  });
+
+  it('returns false when there is no admin row', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue(null);
+    expect(await isAdmin('nobody@example.com')).toBe(false);
+  });
+
+  it('returns false for undefined email', async () => {
+    expect(await isAdmin(undefined)).toBe(false);
+    expect(mockPrisma.admin.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('isPaymentAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for role=payment_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'finance@example.com',
+      role: 'payment_admin',
+    });
+    expect(await isPaymentAdmin('finance@example.com')).toBe(true);
+  });
+
+  it('returns true for role=admin (full admins also get in)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+    expect(await isPaymentAdmin('admin@example.com')).toBe(true);
+  });
+
+  it('returns true for role=super_admin (full admins also get in)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'super@example.com',
+      role: 'super_admin',
+    });
+    expect(await isPaymentAdmin('super@example.com')).toBe(true);
+  });
+
+  it('returns false for non-admin email (no admin row)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue(null);
+    expect(await isPaymentAdmin('user@example.com')).toBe(false);
+  });
+
+  it('returns false for undefined email', async () => {
+    expect(await isPaymentAdmin(undefined)).toBe(false);
+    expect(mockPrisma.admin.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('isFullAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for role=admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+    expect(await isFullAdmin('admin@example.com')).toBe(true);
+  });
+
+  it('returns true for role=super_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'super@example.com',
+      role: 'super_admin',
+    });
+    expect(await isFullAdmin('super@example.com')).toBe(true);
+  });
+
+  it('returns false for role=payment_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'finance@example.com',
+      role: 'payment_admin',
+    });
+    expect(await isFullAdmin('finance@example.com')).toBe(false);
+  });
+
+  it('returns false when there is no admin row', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue(null);
+    expect(await isFullAdmin('user@example.com')).toBe(false);
+  });
+
+  it('returns false for undefined email', async () => {
+    expect(await isFullAdmin(undefined)).toBe(false);
+    expect(mockPrisma.admin.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -8,11 +8,14 @@ export interface AuthRequest extends Request {
   userEmail?: string;
 }
 
-// Check if the user is any kind of admin (DB-backed)
+// Check if the user is a full admin (DB-backed): role IN ('admin', 'super_admin').
+// IMPORTANT: This was tightened on 2026-05-17 (arugula-38633 PR 2) to exclude the
+// new 'payment_admin' role. payment_admin gates ONLY the future /payments dashboard
+// and must NOT be treated as a regular admin anywhere else in the system.
 export async function isAdmin(email?: string): Promise<boolean> {
   if (!email) return false;
   const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
-  return !!admin;
+  return admin?.role === 'admin' || admin?.role === 'super_admin';
 }
 
 // Check if the user is a super admin (DB-backed)
@@ -20,6 +23,28 @@ export async function isSuperAdmin(email?: string): Promise<boolean> {
   if (!email) return false;
   const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
   return admin?.role === 'super_admin';
+}
+
+// Check if the user is allowed in the host-payments dashboard: returns true for
+// payment_admin, admin, OR super_admin. Full admins always get in too.
+export async function isPaymentAdmin(email?: string): Promise<boolean> {
+  if (!email) return false;
+  const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
+  return (
+    admin?.role === 'payment_admin' ||
+    admin?.role === 'admin' ||
+    admin?.role === 'super_admin'
+  );
+}
+
+// Explicit "full admin powers needed" check: returns true ONLY for the two
+// legacy full-admin roles. Use this when you want to be unambiguous that
+// payment_admin should NOT qualify. Equivalent to the current isAdmin() but
+// semantically clearer at the callsite.
+export async function isFullAdmin(email?: string): Promise<boolean> {
+  if (!email) return false;
+  const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
+  return admin?.role === 'admin' || admin?.role === 'super_admin';
 }
 
 // Check if the user is an active underboss (DB-backed)

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -71,7 +71,15 @@ router.post('/add', requireAuth, async (req: AuthRequest, res: Response, next: N
     }
 
     const normalizedEmail = email.trim().toLowerCase();
-    const adminRole = role === 'super_admin' ? 'super_admin' : 'admin';
+    // Accepted role values: 'admin' (default), 'super_admin', 'payment_admin'.
+    // payment_admin (added arugula-38633 PR 2) gates the host-payments dashboard
+    // but is NOT treated as a regular admin elsewhere — see isAdmin() in auth.ts.
+    const adminRole =
+      role === 'super_admin'
+        ? 'super_admin'
+        : role === 'payment_admin'
+          ? 'payment_admin'
+          : 'admin';
 
     const existing = await prisma.admin.findUnique({ where: { email: normalizedEmail } });
     if (existing) {

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "Keine Admins gefunden",
     "superAdmin": "Super-Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Admin entfernen",
     "tableHeaders": {
       "email": "E-Mail",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "No admins found",
     "superAdmin": "Super Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Remove admin",
     "tableHeaders": {
       "email": "Email",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "No se encontraron administradores",
     "superAdmin": "Super Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Eliminar administrador",
     "tableHeaders": {
       "email": "Email",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "Aucun administrateur trouvé",
     "superAdmin": "Super administrateur",
     "admin": "Administrateur",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Supprimer l'administrateur",
     "tableHeaders": {
       "email": "E-mail",

--- a/frontend/src/i18n/locales/ja/admin.json
+++ b/frontend/src/i18n/locales/ja/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "管理者が見つかりません",
     "superAdmin": "スーパー管理者",
     "admin": "管理者",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "管理者を削除",
     "tableHeaders": {
       "email": "メール",

--- a/frontend/src/i18n/locales/ko/admin.json
+++ b/frontend/src/i18n/locales/ko/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "관리자가 없습니다",
     "superAdmin": "슈퍼 관리자",
     "admin": "관리자",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "관리자 제거",
     "tableHeaders": {
       "email": "이메일",

--- a/frontend/src/i18n/locales/pt/admin.json
+++ b/frontend/src/i18n/locales/pt/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "Nenhum admin encontrado",
     "superAdmin": "Super Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Remover admin",
     "tableHeaders": {
       "email": "E-mail",

--- a/frontend/src/i18n/locales/zh/admin.json
+++ b/frontend/src/i18n/locales/zh/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "未找到管理员",
     "superAdmin": "超级管理员",
     "admin": "管理员",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "移除管理员",
     "tableHeaders": {
       "email": "邮箱",

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -59,6 +59,7 @@ export function AdminPage() {
   const [admins, setAdmins] = useState<AdminUser[]>([]);
   const [newEmail, setNewEmail] = useState('');
   const [newName, setNewName] = useState('');
+  const [newRole, setNewRole] = useState<'admin' | 'super_admin' | 'payment_admin'>('admin');
   const [addingAdmin, setAddingAdmin] = useState(false);
   const [adminMessage, setAdminMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -415,11 +416,16 @@ export function AdminPage() {
     setAddingAdmin(true);
     setAdminMessage(null);
     try {
-      const admin = await addAdmin({ email: newEmail.trim(), name: newName.trim() || undefined });
+      const admin = await addAdmin({
+        email: newEmail.trim(),
+        name: newName.trim() || undefined,
+        role: newRole,
+      });
       setAdmins((prev) => [...prev, admin]);
       setNewEmail('');
       setNewName('');
-      setAdminMessage({ type: 'success', text: `Added ${admin.email} as admin` });
+      setNewRole('admin');
+      setAdminMessage({ type: 'success', text: `Added ${admin.email} as ${admin.role}` });
     } catch (err: any) {
       setAdminMessage({ type: 'error', text: err.message || 'Failed to add admin' });
     } finally {
@@ -637,6 +643,43 @@ export function AdminPage() {
                     {t('admins.addAdmin')}
                   </button>
                 </div>
+                <div className="mt-3 flex flex-col gap-2">
+                  <div className="flex flex-wrap gap-4 text-sm">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="newAdminRole"
+                        value="admin"
+                        checked={newRole === 'admin'}
+                        onChange={() => setNewRole('admin')}
+                      />
+                      <span>{t('admins.admin')}</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="newAdminRole"
+                        value="super_admin"
+                        checked={newRole === 'super_admin'}
+                        onChange={() => setNewRole('super_admin')}
+                      />
+                      <span>{t('admins.superAdmin')}</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="newAdminRole"
+                        value="payment_admin"
+                        checked={newRole === 'payment_admin'}
+                        onChange={() => setNewRole('payment_admin')}
+                      />
+                      <span>{t('admins.paymentAdmin')}</span>
+                    </label>
+                  </div>
+                  {newRole === 'payment_admin' && (
+                    <p className="text-xs text-white/40">{t('admins.paymentAdminDesc')}</p>
+                  )}
+                </div>
               </form>
             )}
 
@@ -666,10 +709,16 @@ export function AdminPage() {
                           className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
                             admin.role === 'super_admin'
                               ? 'bg-red-100 text-red-700 border border-red-300'
-                              : 'bg-blue-100 text-blue-700 border border-blue-300'
+                              : admin.role === 'payment_admin'
+                                ? 'bg-emerald-100 text-emerald-700 border border-emerald-300'
+                                : 'bg-blue-100 text-blue-700 border border-blue-300'
                           }`}
                         >
-                          {admin.role === 'super_admin' ? t('admins.superAdmin') : t('admins.admin')}
+                          {admin.role === 'super_admin'
+                            ? t('admins.superAdmin')
+                            : admin.role === 'payment_admin'
+                              ? t('admins.paymentAdmin')
+                              : t('admins.admin')}
                         </span>
                       </td>
                       <td className="px-4 py-3 text-theme-text-muted">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1122,7 +1122,7 @@ export interface FakeDetectionResponse {
 export interface AdminUser {
   id: string;
   email: string;
-  role: 'super_admin' | 'admin';
+  role: 'super_admin' | 'admin' | 'payment_admin';
   name: string | null;
   createdBy: string | null;
   createdAt: string;


### PR DESCRIPTION
## Summary

PR 2 of 5 for the host-payments / reimbursements feature (arugula-38633). Plumbs the new `payment_admin` admin role end-to-end. **No payment routes or UI yet** — those land in PRs 3-5.

This PR is **independent of PR 1** (#356, the DB migration / Prisma models) and can merge in either order.

### Backend
- `isPaymentAdmin(email)` — returns true for `payment_admin`, `admin`, or `super_admin`
- `isFullAdmin(email)` — explicit "full admin only" check (true for `admin` / `super_admin`, false for `payment_admin`)
- **Tightens `isAdmin()`** — now returns true only when `role IN ('admin', 'super_admin')`. Before this change, `isAdmin()` was `return !!admin`, which would have let `payment_admin` rows through to every admin-gated route once such rows started existing. **See behavioral change section below.**
- `POST /api/admin/add` accepts `'payment_admin'` as a role value (validation was a ternary picking between `'super_admin'` and `'admin'`; extended to three-way)
- New tests in `auth.test.ts` covering all three helpers + the `isAdmin` tightening

### Frontend
- `AdminUser.role` union extended to include `'payment_admin'`
- `AdminPage` Add-Admin form gains a third radio option ("Payment Admin") visible to super-admins, with a short description that appears when selected
- Existing role badge in the admins table renders `payment_admin` with an emerald pill
- i18n: added `paymentAdmin` label + `paymentAdminDesc` description to `en` admin.json with English placeholders mirrored to all 7 other locales (de/es/fr/ja/ko/pt/zh) — flagged for translators

## Behavioral change — `isAdmin()` tightening

Before: `isAdmin()` returned true for ANY row in `admins` (i.e. `!!admin`).
After: `isAdmin()` returns true only when `admin.role IN ('admin','super_admin')`.

Now that `payment_admin` rows can exist, the old behavior would have silently granted them access to every admin-gated route. The role is supposed to gate the future `/payments` dashboard ONLY. I grepped every `isAdmin(` callsite in `backend/src/` and confirmed each is gating functionality `payment_admin` should NOT have:

| File | Line | Gate | Correct that `payment_admin` is excluded? |
|---|---:|---|---|
| `helpers/partyAccess.ts` | 80 | `canUserEditParty` — admin override | YES (payment_admin can't edit parties per plan §7) |
| `helpers/partyAccess.ts` | 151 | `canUserViewParty` — admin override | YES |
| `middleware/sponsorAuth.ts` | 32 | Sponsor-route auth bypass for admins | YES |
| `routes/admin.routes.ts` | 38 | `GET /api/admin/list` | YES (payment_admin shouldn't manage admins) |
| `routes/admin.routes.ts` | 136 | `GET /api/admin/gpp-nft` | YES |
| `routes/admin.routes.ts` | 728 | (other admin-only route) | YES |
| `routes/event.routes.ts` | 375 | Admin-as-host override | YES |
| `routes/gpp.routes.ts` | 668 | Admin/underboss visibility | YES |
| `routes/graphics-admin.routes.ts` | 11, 35, 76 | Graphics admin management | YES |
| `routes/quiz-template.routes.ts` | 14, 34, 81, 116, 135 | Quiz template CRUD | YES |
| `routes/shipping.routes.ts` | 27, 74 | Shipping dashboard admin override | YES |
| `routes/sponsor-user.routes.ts` | 16, 79, 155, 278, 410, 468 | Sponsor user management | YES |
| `routes/telegram.routes.ts` | 31 | Telegram admin override | YES |
| `routes/underboss.routes.ts` | 41, 276, 792, 993, 1146, 1234, 1262, 1428, 1479, 1544 | Underboss dashboard admin override | YES |

Every callsite gates functionality that `payment_admin` is intentionally NOT supposed to have. Tightening is correct everywhere. If a `payment_admin` row is added and tries to hit any of these routes, they'll now correctly get 403.

`isSuperAdmin()` is unchanged. `helpers/partyAccess.ts` retains its existing `isAdmin` calls (which now correctly exclude payment_admin per plan §7).

## Notes for reviewers

- i18n: non-English locales got English placeholders for `paymentAdmin` / `paymentAdminDesc`. Translators should fill these in.
- No new DB columns, no Prisma changes, no new routes. This PR is purely role-plumbing.
- Independent of PR 1 (#356 — the DB migration). Either order is fine.

## Test plan
- [x] `npx vitest run backend/src/middleware/auth.test.ts` — 28/28 pass (14 pre-existing + 14 new)
- [x] Backend `npx tsc --noEmit` — clean for source files (one pre-existing TS quirk in auth.test.ts `jwt.sign` signature, runtime-fine)
- [x] Frontend `npx tsc --noEmit` — clean
- [ ] Vercel preview deploys and `/` returns 200
- [ ] Manually create a `payment_admin` row in staging and confirm `/api/admin/me` returns `role: 'payment_admin'` but `/api/admin/list` returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)