### PR TITLE
quattro-formaggi-22961: Find a Venue checklist opens address modal

### DIFF
--- a/frontend/src/components/checklist/ChecklistTab.tsx
+++ b/frontend/src/components/checklist/ChecklistTab.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../lib/api';
 import { ChecklistItemRow } from './ChecklistItemRow';
 import { ChecklistItemForm } from './ChecklistItemForm';
+import { FindVenueModal } from './FindVenueModal';
 
 interface ChecklistTabProps {
   partyId: string;
@@ -32,6 +33,7 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
   const [showForm, setShowForm] = useState(false);
   const [saving, setSaving] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
+  const [findVenueOpen, setFindVenueOpen] = useState(false);
 
   const navigate = useNavigate();
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -97,6 +99,10 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
   };
 
   const handleNavigate = (tab: string) => {
+    if (tab === 'venue') {
+      setFindVenueOpen(true);
+      return;
+    }
     if (inviteCode) {
       if (tab === 'details') {
         navigate(`/host/${inviteCode}`);
@@ -211,6 +217,12 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
           saving={saving}
         />
       )}
+
+      <FindVenueModal
+        open={findVenueOpen}
+        onClose={() => setFindVenueOpen(false)}
+        onSaved={loadChecklist}
+      />
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (

--- a/frontend/src/components/checklist/FindVenueModal.tsx
+++ b/frontend/src/components/checklist/FindVenueModal.tsx
@@ -1,0 +1,114 @@
+import React, { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, X } from 'lucide-react';
+import { LocationAutocomplete } from '../LocationAutocomplete';
+import { usePizza } from '../../contexts/PizzaContext';
+import { updateParty } from '../../lib/supabase';
+
+interface FindVenueModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved?: () => void | Promise<void>;
+}
+
+export const FindVenueModal: React.FC<FindVenueModalProps> = ({ open, onClose, onSaved }) => {
+  const { t } = useTranslation('host');
+  const { party, loadParty } = usePizza();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pendingCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
+
+  if (!open || !party) return null;
+
+  const handlePlaceSelected = async (
+    address: string,
+    venueName: string | null,
+    placeId: string | null,
+  ) => {
+    if (!party || saving) return;
+    const coords = pendingCoordsRef.current;
+    pendingCoordsRef.current = null;
+    setSaving(true);
+    setError(null);
+    try {
+      const success = await updateParty(party.id, {
+        address: address.trim() || null,
+        venue_name: venueName || null,
+        latitude: coords?.lat ?? null,
+        longitude: coords?.lng ?? null,
+        ...(placeId ? { place_id: placeId } : {}),
+      });
+      if (!success) {
+        setError(t('venue.findVenueSaveError'));
+        return;
+      }
+      if (party.inviteCode) {
+        await loadParty(party.inviteCode);
+      }
+      if (onSaved) {
+        await onSaved();
+      }
+      onClose();
+    } catch (err) {
+      console.error('Failed to save venue address:', err);
+      setError(t('venue.findVenueSaveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl p-6 w-full max-w-md relative"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('venue.cancel')}
+          className="absolute right-4 top-4 text-theme-text-faint hover:text-theme-text transition-colors"
+        >
+          <X size={18} />
+        </button>
+        <h2 className="text-xl font-bold text-theme-text mb-2 pr-8">
+          {t('venue.findVenueModalTitle')}
+        </h2>
+        <p className="text-sm text-theme-text-secondary mb-5">
+          {t('venue.findVenueModalSubtitle')}
+        </p>
+
+        <LocationAutocomplete
+          value=""
+          onChange={() => { /* committed via onPlaceSelected */ }}
+          onLocationSelected={(loc) => {
+            pendingCoordsRef.current = loc;
+          }}
+          onPlaceSelected={(address, venueName, placeId) => {
+            handlePlaceSelected(address, venueName, placeId);
+          }}
+          placeholder={t('venue.findVenueModalPlaceholder')}
+          disabled={saving}
+        />
+
+        {saving && (
+          <div className="flex items-center gap-2 text-sm text-theme-text-muted mt-4">
+            <Loader2 size={14} className="animate-spin" />
+            {t('venue.saving')}
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-400 mt-3">{error}</p>
+        )}
+
+        <p className="text-xs text-theme-text-muted mt-5">
+          {t('venue.findVenueModalCta')}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X, Lock, type LucideIcon } from 'lucide-react';
 import { usePizza } from '../../contexts/PizzaContext';
@@ -6,6 +6,7 @@ import { getChecklist, seedChecklist, updateUnderbossStatus, toggleChecklistItem
 import { AutoCompleteStates, ChecklistItem } from '../../types';
 import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
+import { FindVenueModal } from '../checklist/FindVenueModal';
 
 export const GPPDashboardTab: React.FC = () => {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -19,28 +20,28 @@ export const GPPDashboardTab: React.FC = () => {
   const [showCompleted, setShowCompleted] = useState(false);
   const [saving, setSaving] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [findVenueOpen, setFindVenueOpen] = useState(false);
+
+  const loadChecklist = useCallback(async () => {
+    if (!party?.id) return;
+    let data = await getChecklist(party.id);
+    // If not yet seeded, seed defaults so due dates propagate from checklist_defaults
+    if (data && !data.seeded) {
+      const seedResult = await seedChecklist(party.id);
+      if (seedResult) {
+        const refreshed = await getChecklist(party.id);
+        if (refreshed) data = refreshed;
+      }
+    }
+    setAutoStates(data?.autoCompleteStates ?? null);
+    setDbItems(data?.items ?? []);
+    setLoading(false);
+  }, [party?.id]);
 
   useEffect(() => {
     if (!party?.id) return;
-    let cancelled = false;
-    (async () => {
-      let data = await getChecklist(party.id);
-      // If not yet seeded, seed defaults so due dates propagate from checklist_defaults
-      if (data && !data.seeded) {
-        const seedResult = await seedChecklist(party.id);
-        if (seedResult) {
-          const refreshed = await getChecklist(party.id);
-          if (refreshed) data = refreshed;
-        }
-      }
-      if (!cancelled) {
-        setAutoStates(data?.autoCompleteStates ?? null);
-        setDbItems(data?.items ?? []);
-        setLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [party?.id]);
+    loadChecklist();
+  }, [party?.id, loadChecklist]);
 
   // Map known item names to Lucide icons
   const ICON_MAP: Record<string, LucideIcon> = {
@@ -93,7 +94,8 @@ export const GPPDashboardTab: React.FC = () => {
         done,
         tab: item.linkTab,
         onClick: item.name === 'Build a Team' ? () => setHostsExpanded(prev => !prev) :
-                 item.name === 'Find Partners' ? () => goToTab('partners') : undefined,
+                 item.name === 'Find Partners' ? () => goToTab('partners') :
+                 item.name === 'Find a Venue' ? () => setFindVenueOpen(true) : undefined,
         icon: ICON_MAP[item.name] ?? ClipboardCheck,
         dueDate: item.dueDate ? item.dueDate.split('T')[0] : null,
       };
@@ -352,6 +354,12 @@ export const GPPDashboardTab: React.FC = () => {
           </div>
         )}
       </div>
+
+      <FindVenueModal
+        open={findVenueOpen}
+        onClose={() => setFindVenueOpen(false)}
+        onSaved={loadChecklist}
+      />
 
       {/* Host Resources */}
       <HostResources />

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -205,6 +205,11 @@
     "removeStaffConfirm": "Are you sure you want to remove this staff member?"
   },
   "venue": {
+    "findVenueModalTitle": "Find a Venue",
+    "findVenueModalSubtitle": "Search for an address or named venue. We'll save it to your event.",
+    "findVenueModalPlaceholder": "Search for an address or venue...",
+    "findVenueModalCta": "Picking a result saves the venue and ticks this checklist item.",
+    "findVenueSaveError": "Could not save the venue. Please try again.",
     "venueOptions": "Venue Options",
     "addVenue": "Add Venue",
     "noVenueOptionsYet": "No venue options yet",


### PR DESCRIPTION
## Summary
- Replaces the venue-tab navigation for the "Find a Venue" checklist item with a shared `FindVenueModal` that wraps `LocationAutocomplete`. Picking a result saves `address`, `venue_name`, `latitude`, `longitude` (plus `place_id` when present) via `updateParty`, and the existing pesto-58917 auto-rule then ticks the checklist row on refresh.
- Both checklist renderers change: `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx` (extended the `Build a Team` / `Find Partners` row-onClick ternary with a `Find a Venue` case and hoisted the seeded-checklist fetch into a `loadChecklist` callback so it can be reused as `onSaved`) and `frontend/src/components/checklist/ChecklistTab.tsx` (special-cased `tab === 'venue'` in `handleNavigate` to open the modal instead of routing).
- The standalone `venue` tab itself is untouched — every other `linkTab` in the checklist still navigates as before. English-only i18n keys added under `venue.*` in `frontend/src/i18n/locales/en/host.json`.

Plan: `plans/quattro-formaggi-22961-checklist-venue-modal.md`

## Test plan
- [ ] Modal opens when clicking the "Find a Venue" row in the GPP dashboard checklist
- [ ] Modal opens when clicking the "Find a Venue" row (or its external-link icon) in the standalone ChecklistTab
- [ ] Picking a Google Places result writes `address`, `venue_name`, `latitude`, `longitude` (verify in DB / network panel)
- [ ] The "Find a Venue" checklist item auto-ticks after save (pesto-58917 auto-rule)
- [ ] Refreshing the page preserves the saved address and the ticked checklist row
- [ ] Clicking outside the modal (or the X button) closes it without saving
- [ ] Other checklist items with `linkTab` (e.g. "Create Event", "Select Pizzeria") still navigate to their tabs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)