### PR TITLE
salami-37613: rsv.pizza URL on line 3 of share-RSVP tweet

### DIFF
--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -44,8 +44,7 @@ function buildShareText(base: string, handles: string[], maxLen: number): string
 export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode, twitterHandles = [], country, calendarSlot }: ShareRSVPProps) {
   const { t } = useTranslation('rsvp');
   const city = eventName.replace(/^Global Pizza Party\s*/i, '') || eventName;
-  const eventUrl = `https://rsv.pizza/${customUrl || inviteCode}`;
-  const baseText = `${countryNameToFlag(country)}\u{1F355}\u{1F973}\nI'm going to the Global Pizza Party in ${city}!`;
+  const baseText = `${countryNameToFlag(country)}\u{1F355}\u{1F973}\nI'm going to the Global Pizza Party in ${city}!\nrsv.pizza/${customUrl || inviteCode}`;
 
   // Build deduplicated handles list, always starting with Pizza_DAO
   const allHandles = ['Pizza_DAO', ...twitterHandles];
@@ -61,7 +60,7 @@ export function ShareRSVP({ eventName, eventImageUrl, customUrl, inviteCode, twi
   const shareText = buildShareText(baseText, uniqueHandles, 250);
 
   const handleShareX = () => {
-    const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(eventUrl)}`;
+    const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`;
     window.open(intentUrl, '_blank');
   };
 


### PR DESCRIPTION
## Summary
- Move event URL from the Twitter intent `&url=` param (which X appends at the end of the tweet) into the tweet body as the third line.
- Format URL as `rsv.pizza/<slug>` (no `https://`).
- Drop the now-unused `eventUrl` constant.

## Resulting tweet
```
{flag}🍕🥳
I'm going to the Global Pizza Party in {city}!
rsv.pizza/{customUrl-or-inviteCode}

@Pizza_DAO @handle2 @handle3
```

## Test plan
- [ ] Vercel preview: complete an RSVP, click "Share on X" — confirm tweet body shows URL on line 3 and X does not append a duplicate URL at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)