### PR TITLE
feat(nduja-58792): BPD livestream backend + overlay/control pages

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1391,3 +1391,20 @@ model GuestScorecardItem {
   @@index([partyId])
   @@map("guest_scorecard_items")
 }
+
+model StreamRegistrant {
+  id               String    @id @default(uuid()) @db.Uuid
+  email            String
+  partyId          String?   @map("party_id") @db.Uuid
+  zoomMeetingId    String    @map("zoom_meeting_id")
+  zoomRegistrantId String?   @map("zoom_registrant_id")
+  zoomJoinUrl      String?   @map("zoom_join_url")
+  displayName      String?   @map("display_name")
+  emailSentAt      DateTime? @map("email_sent_at") @db.Timestamptz
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@unique([email, zoomMeetingId], map: "stream_registrants_email_meeting_unique")
+  @@index([zoomMeetingId], map: "stream_registrants_meeting_idx")
+  @@map("stream_registrants")
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -53,6 +53,7 @@ import quizTemplateRoutes from './routes/quiz-template.routes.js';
 import { quizHostRouter, quizPublicRouter } from './routes/quiz.routes.js';
 import onesheetRoutes from './routes/onesheet.routes.js';
 import scorecardRoutes from './routes/scorecard.routes.js';
+import zoomStreamRoutes from './routes/zoom-stream.routes.js';
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -141,6 +142,7 @@ app.use('/api/parties', budgetRoutes); // Budget routes (host only)
 app.use('/api/parties', checklistRoutes); // Checklist routes (host only)
 app.use('/api/parties', reportRoutes); // Report routes (includes public report viewing)
 app.use('/api/parties', quizHostRouter); // Quiz CRUD routes (host only, before partyRoutes)
+app.use('/api/zoom-stream', zoomStreamRoutes); // Bitcoin Pizza Day livestream (underboss-only)
 app.use('/api/parties', partyRoutes); // Party routes have global auth (must be last /api/parties router)
 app.use('/api/rsvp', rsvpRoutes);
 app.use('/api/preferences', preferencesRoutes); // Public preferences (used during RSVP)

--- a/backend/src/routes/zoom-stream.routes.ts
+++ b/backend/src/routes/zoom-stream.routes.ts
@@ -1,0 +1,390 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isAdmin, isUnderboss } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { registerForMeeting } from '../services/zoom.service.js';
+
+const router = Router();
+
+async function requireUnderbossLike(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const email = req.userEmail;
+    if (!email) {
+      throw new AppError('Authentication required', 401, 'UNAUTHORIZED');
+    }
+    if (await isAdmin(email)) return next();
+    if (await isUnderboss(email)) return next();
+    const gfx = await prisma.graphicsAdmin.findUnique({
+      where: { email: email.toLowerCase() },
+    });
+    if (gfx) return next();
+    throw new AppError('Not authorized', 403, 'FORBIDDEN');
+  } catch (error) {
+    next(error);
+  }
+}
+
+function getMeetingId(): string {
+  const id = process.env.ZOOM_STREAM_MEETING_ID;
+  if (!id) {
+    throw new AppError('ZOOM_STREAM_MEETING_ID not configured', 500, 'CONFIG_ERROR');
+  }
+  return id;
+}
+
+interface CoHostEntry {
+  email?: string;
+  name?: string;
+  canEdit?: boolean;
+}
+
+interface CollectedEmail {
+  email: string; // lowercased, trimmed
+  firstName: string;
+  lastName?: string;
+  displayName: string;
+  partyId: string;
+}
+
+function splitName(name: string | null | undefined): { firstName: string; lastName?: string } {
+  if (!name) return { firstName: 'Pizza', lastName: 'Host' };
+  const trimmed = name.trim();
+  if (!trimmed) return { firstName: 'Pizza', lastName: 'Host' };
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return { firstName: parts[0] };
+  return { firstName: parts[0], lastName: parts.slice(1).join(' ') };
+}
+
+async function collectApprovedEmails(): Promise<CollectedEmail[]> {
+  const parties = await prisma.party.findMany({
+    where: { underbossStatus: 'approved' },
+    select: {
+      id: true,
+      user: { select: { email: true, name: true } },
+      coHosts: true,
+    },
+  });
+
+  const byEmail = new Map<string, CollectedEmail>();
+  for (const p of parties) {
+    const hostEmail = (p.user?.email || '').trim().toLowerCase();
+    if (hostEmail) {
+      const { firstName, lastName } = splitName(p.user?.name);
+      if (!byEmail.has(hostEmail)) {
+        byEmail.set(hostEmail, {
+          email: hostEmail,
+          firstName,
+          lastName,
+          displayName: p.user?.name || hostEmail,
+          partyId: p.id,
+        });
+      }
+    }
+
+    const coHosts = (p.coHosts as CoHostEntry[] | null) || [];
+    if (Array.isArray(coHosts)) {
+      for (const h of coHosts) {
+        const e = (h?.email || '').trim().toLowerCase();
+        if (!e) continue;
+        if (byEmail.has(e)) continue;
+        const { firstName, lastName } = splitName(h?.name);
+        byEmail.set(e, {
+          email: e,
+          firstName,
+          lastName,
+          displayName: h?.name || e,
+          partyId: p.id,
+        });
+      }
+    }
+  }
+
+  return Array.from(byEmail.values());
+}
+
+// Zoom rate limit is 10 req/sec on paid plans — cap concurrent registrations to 5.
+async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<Array<{ item: T; result?: R; error?: Error }>> {
+  const results: Array<{ item: T; result?: R; error?: Error }> = [];
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      const item = items[idx];
+      try {
+        const result = await fn(item);
+        results[idx] = { item, result };
+      } catch (error) {
+        results[idx] = { item, error: error as Error };
+      }
+    }
+  }
+
+  const workers = Array(Math.min(limit, items.length)).fill(0).map(worker);
+  await Promise.all(workers);
+  return results;
+}
+
+// POST /api/zoom-stream/sync — register approved hosts + co-hosts with Zoom
+router.post('/sync', requireAuth, requireUnderbossLike, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const dryRun = !!req.body?.dryRun;
+    const meetingId = getMeetingId();
+
+    const collected = await collectApprovedEmails();
+
+    if (dryRun) {
+      // Filter out already-registered for accurate "would register" count.
+      const existing = await prisma.streamRegistrant.findMany({
+        where: { zoomMeetingId: meetingId },
+        select: { email: true },
+      });
+      const existingSet = new Set(existing.map(r => r.email.toLowerCase()));
+      const wouldRegister = collected.filter(c => !existingSet.has(c.email));
+      return res.json({
+        dryRun: true,
+        meetingId,
+        totalUniqueEmails: collected.length,
+        wouldRegister: wouldRegister.length,
+        wouldSkip: collected.length - wouldRegister.length,
+        sample: wouldRegister.slice(0, 25).map(c => ({ email: c.email, displayName: c.displayName })),
+      });
+    }
+
+    // Find which emails are already in stream_registrants for this meeting.
+    const existing = await prisma.streamRegistrant.findMany({
+      where: { zoomMeetingId: meetingId },
+      select: { email: true },
+    });
+    const existingSet = new Set(existing.map(r => r.email.toLowerCase()));
+
+    const toRegister = collected.filter(c => !existingSet.has(c.email));
+
+    const results = await runWithConcurrency(toRegister, 5, async (entry) => {
+      const reg = await registerForMeeting({
+        meetingId,
+        email: entry.email,
+        firstName: entry.firstName,
+        lastName: entry.lastName,
+      });
+
+      await prisma.streamRegistrant.upsert({
+        where: {
+          email_zoomMeetingId: {
+            email: entry.email,
+            zoomMeetingId: meetingId,
+          },
+        },
+        create: {
+          email: entry.email,
+          partyId: entry.partyId,
+          zoomMeetingId: meetingId,
+          zoomRegistrantId: reg.registrantId,
+          zoomJoinUrl: reg.joinUrl,
+          displayName: entry.displayName,
+        },
+        update: {
+          zoomRegistrantId: reg.registrantId,
+          zoomJoinUrl: reg.joinUrl,
+          displayName: entry.displayName,
+          partyId: entry.partyId,
+        },
+      });
+
+      return reg;
+    });
+
+    const registered = results.filter(r => !r.error).length;
+    const errors = results
+      .filter(r => r.error)
+      .map(r => ({ email: r.item.email, error: r.error!.message }));
+
+    res.json({
+      meetingId,
+      totalUniqueEmails: collected.length,
+      registered,
+      skipped: existingSet.size,
+      errors,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+async function sendInviteEmail(
+  email: string,
+  displayName: string,
+  joinUrl: string,
+): Promise<void> {
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (!resendApiKey) {
+    throw new Error('RESEND_API_KEY not configured');
+  }
+
+  const firstName = (displayName || '').split(/\s+/)[0] || 'there';
+
+  const emailHtml = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>You're on the Bitcoin Pizza Day broadcast</title>
+      </head>
+      <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
+          <h1 style="color: #ffffff; font-size: 26px; margin: 0 0 10px 0;">You're on the Bitcoin Pizza Day broadcast</h1>
+          <p style="color: rgba(255,255,255,0.8); font-size: 16px; margin: 0;">May 22, 2026 — 3:00 PM Eastern</p>
+        </div>
+
+        <p style="font-size: 16px; margin-bottom: 20px;">Hi ${firstName},</p>
+
+        <p style="font-size: 16px; margin-bottom: 20px;">
+          You're confirmed for the Global Pizza Party live broadcast on May 22, 2026 at 3:00 PM Eastern.
+        </p>
+
+        <p style="font-size: 16px; margin-bottom: 20px;">
+          Your camera turns on automatically when you join — your party will appear in the broadcast gallery alongside parties from cities around the world. Your mic stays muted unless we cue you.
+        </p>
+
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="${joinUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-weight: 600; font-size: 16px;">
+            Join Bitcoin Pizza Day
+          </a>
+          <p style="margin-top: 12px; font-size: 13px; color: #888;">This link is unique to you and skips the waiting room.</p>
+        </div>
+
+        <div style="background: #fff4e6; padding: 20px; border-radius: 12px; margin: 30px 0;">
+          <h3 style="margin: 0 0 10px 0; color: #ff6b35; font-size: 16px;">Tips:</h3>
+          <ul style="margin: 0; padding-left: 20px; color: #666;">
+            <li>Point your camera at the party (people, pizza, the room).</li>
+            <li>Mute background music if any.</li>
+            <li>We'll DM you in Telegram if we want to bring you on mic.</li>
+          </ul>
+        </div>
+
+        <div style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 30px; text-align: center; color: #666; font-size: 13px;">
+          <p>See you on May 22.</p>
+          <p style="margin-top: 12px;">— PizzaDAO</p>
+        </div>
+      </body>
+    </html>
+  `;
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: 'RSV.Pizza <noreply@rsv.pizza>',
+      to: [email],
+      subject: 'Your party is on the Bitcoin Pizza Day global broadcast',
+      html: emailHtml,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Resend API error: ${error}`);
+  }
+}
+
+// POST /api/zoom-stream/send-invites — Resend personalized join links to registrants
+router.post('/send-invites', requireAuth, requireUnderbossLike, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const dryRun = !!req.body?.dryRun;
+    const force = !!req.body?.force;
+    const meetingId = getMeetingId();
+
+    const where = force
+      ? { zoomMeetingId: meetingId, zoomJoinUrl: { not: null } }
+      : { zoomMeetingId: meetingId, emailSentAt: null, zoomJoinUrl: { not: null } };
+
+    const rows = await prisma.streamRegistrant.findMany({
+      where,
+      select: {
+        id: true,
+        email: true,
+        displayName: true,
+        zoomJoinUrl: true,
+        emailSentAt: true,
+      },
+    });
+
+    if (dryRun) {
+      return res.json({
+        dryRun: true,
+        meetingId,
+        wouldSend: rows.length,
+        sample: rows.slice(0, 25).map(r => ({ email: r.email, displayName: r.displayName })),
+      });
+    }
+
+    const results = await runWithConcurrency(rows, 5, async (row) => {
+      await sendInviteEmail(row.email, row.displayName || row.email, row.zoomJoinUrl!);
+      await prisma.streamRegistrant.update({
+        where: { id: row.id },
+        data: { emailSentAt: new Date() },
+      });
+    });
+
+    const sent = results.filter(r => !r.error).length;
+    const errors = results
+      .filter(r => r.error)
+      .map(r => ({ email: r.item.email, error: r.error!.message }));
+
+    res.json({ meetingId, sent, errors });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/zoom-stream/status — counts for the producer admin panel
+router.get('/status', requireAuth, requireUnderbossLike, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const meetingId = getMeetingId();
+
+    const [collected, registrants, lastSent, lastCreated] = await Promise.all([
+      collectApprovedEmails(),
+      prisma.streamRegistrant.findMany({
+        where: { zoomMeetingId: meetingId },
+        select: { emailSentAt: true },
+      }),
+      prisma.streamRegistrant.findFirst({
+        where: { zoomMeetingId: meetingId, emailSentAt: { not: null } },
+        orderBy: { emailSentAt: 'desc' },
+        select: { emailSentAt: true },
+      }),
+      prisma.streamRegistrant.findFirst({
+        where: { zoomMeetingId: meetingId },
+        orderBy: { createdAt: 'desc' },
+        select: { createdAt: true },
+      }),
+    ]);
+
+    const unsentCount = registrants.filter(r => !r.emailSentAt).length;
+
+    res.json({
+      meetingId,
+      totalApprovedHostsAndCohosts: collected.length,
+      registeredCount: registrants.length,
+      unsentCount,
+      lastSyncAt: lastCreated?.createdAt?.toISOString() ?? null,
+      lastSendAt: lastSent?.emailSentAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/services/zoom.service.ts
+++ b/backend/src/services/zoom.service.ts
@@ -1,0 +1,146 @@
+const ZOOM_API_BASE = 'https://api.zoom.us/v2';
+const ZOOM_OAUTH_URL = 'https://zoom.us/oauth/token';
+
+// Refresh token at ~55min mark (Zoom tokens are 1hr) to give a safety margin.
+const TOKEN_REFRESH_BEFORE_EXPIRY_MS = 5 * 60 * 1000;
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+export async function getZoomAccessToken(): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt > now + TOKEN_REFRESH_BEFORE_EXPIRY_MS) {
+    return cachedToken.token;
+  }
+
+  const accountId = process.env.ZOOM_ACCOUNT_ID;
+  const clientId = process.env.ZOOM_CLIENT_ID;
+  const clientSecret = process.env.ZOOM_CLIENT_SECRET;
+  if (!accountId || !clientId || !clientSecret) {
+    throw new Error('Zoom credentials not configured (ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, ZOOM_CLIENT_SECRET)');
+  }
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  const body = new URLSearchParams({
+    grant_type: 'account_credentials',
+    account_id: accountId,
+  }).toString();
+
+  const res = await fetch(ZOOM_OAUTH_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Zoom OAuth failed (${res.status}): ${text}`);
+  }
+
+  const data = (await res.json()) as { access_token: string; expires_in: number };
+  if (!data.access_token) {
+    throw new Error('Zoom OAuth response missing access_token');
+  }
+
+  cachedToken = {
+    token: data.access_token,
+    expiresAt: now + (data.expires_in ?? 3600) * 1000,
+  };
+  return cachedToken.token;
+}
+
+interface RegisterParams {
+  meetingId: string;
+  email: string;
+  firstName: string;
+  lastName?: string;
+}
+
+interface RegisterResult {
+  registrantId: string;
+  joinUrl: string;
+}
+
+async function findExistingRegistrant(
+  meetingId: string,
+  email: string,
+  token: string,
+): Promise<RegisterResult | null> {
+  const normalized = email.trim().toLowerCase();
+  let pageToken: string | undefined;
+
+  do {
+    const url = new URL(`${ZOOM_API_BASE}/meetings/${meetingId}/registrants`);
+    url.searchParams.set('status', 'approved');
+    url.searchParams.set('page_size', '300');
+    if (pageToken) url.searchParams.set('next_page_token', pageToken);
+
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Zoom registrant lookup failed (${res.status}): ${text}`);
+    }
+
+    const data = (await res.json()) as {
+      registrants?: Array<{ id?: string; email?: string; join_url?: string }>;
+      next_page_token?: string;
+    };
+
+    const match = (data.registrants || []).find(
+      (r) => (r.email || '').trim().toLowerCase() === normalized,
+    );
+    if (match && match.id && match.join_url) {
+      return { registrantId: match.id, joinUrl: match.join_url };
+    }
+
+    pageToken = data.next_page_token || undefined;
+  } while (pageToken);
+
+  return null;
+}
+
+export async function registerForMeeting(
+  params: RegisterParams,
+): Promise<RegisterResult> {
+  const { meetingId, email, firstName, lastName } = params;
+  const token = await getZoomAccessToken();
+
+  const res = await fetch(`${ZOOM_API_BASE}/meetings/${meetingId}/registrants`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      first_name: firstName,
+      last_name: lastName ?? '',
+    }),
+  });
+
+  if (res.ok) {
+    const data = (await res.json()) as { registrant_id?: string; id?: string; join_url?: string };
+    const registrantId = data.registrant_id || data.id || '';
+    const joinUrl = data.join_url || '';
+    if (!registrantId || !joinUrl) {
+      throw new Error('Zoom registration response missing registrant_id or join_url');
+    }
+    return { registrantId, joinUrl };
+  }
+
+  // Zoom returns 300 with "Meeting registrant has already registered" or 409 on duplicates.
+  if (res.status === 300 || res.status === 409) {
+    const existing = await findExistingRegistrant(meetingId, email, token);
+    if (existing) return existing;
+    const text = await res.text();
+    throw new Error(`Zoom duplicate registration but no existing registrant found: ${text}`);
+  }
+
+  const text = await res.text();
+  throw new Error(`Zoom registration failed (${res.status}): ${text}`);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,8 @@ function SponsorIntakeRedirect() {
 
 const GraphicsDashboard = React.lazy(() => import('./pages/GraphicsDashboard').then(m => ({ default: m.GraphicsDashboard })));
 const GraphicsFlyerEdit = React.lazy(() => import('./pages/GraphicsFlyerEdit').then(m => ({ default: m.GraphicsFlyerEdit })));
+const StreamOverlay = React.lazy(() => import('./pages/StreamOverlay').then(m => ({ default: m.StreamOverlay })));
+const StreamControl = React.lazy(() => import('./pages/StreamControl').then(m => ({ default: m.StreamControl })));
 
 function App() {
   return (
@@ -77,6 +79,9 @@ function App() {
             <Route path="/graphics/:slug/edit" element={<Suspense fallback={null}><GraphicsFlyerEdit /></Suspense>} />
             <Route path="/post" element={<PostComposerPage />} />
             <Route path="/onesheet/:slug" element={<OneSheetPage />} />
+            {/* /stream/* must come before /:slug */}
+            <Route path="/stream/overlay" element={<Suspense fallback={null}><StreamOverlay /></Suspense>} />
+            <Route path="/stream/control" element={<Suspense fallback={null}><StreamControl /></Suspense>} />
             <Route path="/raleigh" element={<Navigate to="/durham" replace />} />
             <Route path="/cmohhr0640003jp047krjarz0" element={<Navigate to="/nashville" replace />} />
             {/* Catch-all route for custom URLs - must be last */}

--- a/frontend/src/pages/StreamControl.tsx
+++ b/frontend/src/pages/StreamControl.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useRef, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Loader2, Shield, Radio, EyeOff, User, Briefcase, MapPin, AtSign } from 'lucide-react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+import { LoginModal } from '../components/LoginModal';
+import { IconInput } from '../components/IconInput';
+import { useAuth } from '../contexts/AuthContext';
+import { fetchUnderbossMe } from '../lib/api';
+import { supabase } from '../lib/supabase';
+
+const CHANNEL_NAME = 'stream-overlay-bpd-2026';
+
+interface SpeakerForm {
+  name: string;
+  role: string;
+  city: string;
+  xHandle: string;
+}
+
+export function StreamControl() {
+  const { user, loading: authLoading } = useAuth();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  const [form, setForm] = useState<SpeakerForm>({ name: '', role: '', city: '', xHandle: '' });
+  const [currentSpeaker, setCurrentSpeaker] = useState<SpeakerForm | null>(null);
+  const [lastAction, setLastAction] = useState<{ kind: 'push' | 'clear'; at: Date } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+  const [channelReady, setChannelReady] = useState(false);
+
+  // Auth-gate: underboss / admin / graphics admin only.
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      setAuthorized(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const me = await fetchUnderbossMe();
+        if (cancelled) return;
+        const ok = !!(me.isAdmin || me.isUnderboss || me.isGraphicsAdmin);
+        setAuthorized(ok);
+        if (!ok) setAuthError('You are not authorized to use the stream control panel.');
+      } catch (err: any) {
+        if (cancelled) return;
+        setAuthorized(false);
+        setAuthError(err?.message || 'Failed to verify access');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  // Subscribe to the same broadcast channel so we can confirm what's currently showing.
+  useEffect(() => {
+    if (authorized !== true) return;
+    const channel = supabase.channel(CHANNEL_NAME);
+    channel
+      .on('broadcast', { event: 'speaker.set' }, (msg: any) => {
+        const p = msg?.payload || {};
+        setCurrentSpeaker({
+          name: p.name || '',
+          role: p.role || '',
+          city: p.city || '',
+          xHandle: p.xHandle || '',
+        });
+      })
+      .on('broadcast', { event: 'speaker.clear' }, () => {
+        setCurrentSpeaker(null);
+      })
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') setChannelReady(true);
+      });
+    channelRef.current = channel;
+    return () => {
+      supabase.removeChannel(channel);
+      channelRef.current = null;
+      setChannelReady(false);
+    };
+  }, [authorized]);
+
+  async function pushSpeaker() {
+    if (!channelRef.current || !channelReady) return;
+    if (!form.name.trim()) return;
+    setBusy(true);
+    try {
+      await channelRef.current.send({
+        type: 'broadcast',
+        event: 'speaker.set',
+        payload: {
+          name: form.name.trim(),
+          role: form.role.trim(),
+          city: form.city.trim(),
+          xHandle: form.xHandle.trim().replace(/^@/, ''),
+        },
+      });
+      setCurrentSpeaker({ ...form });
+      setLastAction({ kind: 'push', at: new Date() });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clearSpeaker() {
+    if (!channelRef.current || !channelReady) return;
+    setBusy(true);
+    try {
+      await channelRef.current.send({
+        type: 'broadcast',
+        event: 'speaker.clear',
+        payload: {},
+      });
+      setCurrentSpeaker(null);
+      setLastAction({ kind: 'clear', at: new Date() });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Not logged in
+  if (!authLoading && !user) {
+    return (
+      <div className="min-h-screen flex flex-col bg-[#0a0a0a] text-white">
+        <Header />
+        <main className="flex-1 flex items-center justify-center px-4">
+          <div className="max-w-md text-center">
+            <Shield size={48} className="mx-auto mb-4 text-red-500/60" />
+            <h1 className="text-2xl font-bold mb-2">Stream Control</h1>
+            <p className="text-white/60 mb-6">Sign in with your underboss email to access the producer panel.</p>
+            <button
+              onClick={() => setShowLoginModal(true)}
+              className="inline-flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-6 py-3 rounded-xl font-medium transition-colors"
+            >
+              Sign in
+            </button>
+          </div>
+        </main>
+        <Footer />
+        <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      </div>
+    );
+  }
+
+  if (authLoading || authorized === null) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0a0a0a] text-white">
+        <Loader2 className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (authorized === false) {
+    return (
+      <div className="min-h-screen flex flex-col bg-[#0a0a0a] text-white">
+        <Header />
+        <main className="flex-1 flex items-center justify-center px-4">
+          <div className="max-w-md text-center">
+            <Shield size={48} className="mx-auto mb-4 text-red-500/60" />
+            <h1 className="text-2xl font-bold mb-2">Not authorized</h1>
+            <p className="text-white/60">{authError || 'You do not have access to the stream control panel.'}</p>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0a0a0a] text-white">
+      <Helmet>
+        <title>Stream Control — Bitcoin Pizza Day</title>
+      </Helmet>
+      <Header />
+      <main className="flex-1 px-4 py-10">
+        <div className="max-w-xl mx-auto">
+          <div className="flex items-center gap-3 mb-2">
+            <Radio className="text-red-500" />
+            <h1 className="text-3xl font-extrabold">Stream Control</h1>
+          </div>
+          <p className="text-white/50 mb-8">
+            Push lower-third updates to the OBS overlay (<code className="text-white/70">/stream/overlay</code>).
+            Channel: <code className="text-white/70">{CHANNEL_NAME}</code>
+            <span className="ml-2 text-xs">
+              {channelReady ? <span className="text-green-400">● live</span> : <span className="text-yellow-400">connecting…</span>}
+            </span>
+          </p>
+
+          <div className="space-y-3 mb-6">
+            <IconInput
+              icon={User}
+              placeholder="Speaker name (e.g. Pia Mancini)"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-white placeholder-white/30 focus:outline-none focus:border-white/30"
+            />
+            <IconInput
+              icon={Briefcase}
+              placeholder="Role (e.g. Host of Buenos Aires Party)"
+              value={form.role}
+              onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))}
+              className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-white placeholder-white/30 focus:outline-none focus:border-white/30"
+            />
+            <IconInput
+              icon={MapPin}
+              placeholder="City"
+              value={form.city}
+              onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+              className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-white placeholder-white/30 focus:outline-none focus:border-white/30"
+            />
+            <IconInput
+              icon={AtSign}
+              placeholder="X handle (optional, without @)"
+              value={form.xHandle}
+              onChange={(e) => setForm((f) => ({ ...f, xHandle: e.target.value }))}
+              className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-white placeholder-white/30 focus:outline-none focus:border-white/30"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-3 mb-8">
+            <button
+              onClick={pushSpeaker}
+              disabled={busy || !channelReady || !form.name.trim()}
+              className="inline-flex items-center gap-2 bg-red-500 hover:bg-red-600 disabled:bg-white/10 disabled:text-white/40 text-white px-5 py-3 rounded-xl font-semibold transition-colors"
+            >
+              <Radio size={18} />
+              Push speaker to overlay
+            </button>
+            <button
+              onClick={clearSpeaker}
+              disabled={busy || !channelReady}
+              className="inline-flex items-center gap-2 bg-white/10 hover:bg-white/20 disabled:bg-white/5 disabled:text-white/30 text-white px-5 py-3 rounded-xl font-semibold transition-colors"
+            >
+              <EyeOff size={18} />
+              Hide lower-third
+            </button>
+          </div>
+
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+            <div className="text-xs uppercase tracking-widest text-white/40 mb-2">Currently showing</div>
+            {currentSpeaker ? (
+              <div>
+                <div className="text-xl font-bold">{currentSpeaker.name}</div>
+                <div className="text-white/70">
+                  {currentSpeaker.role}
+                  {currentSpeaker.role && currentSpeaker.city ? ' — ' : ''}
+                  {currentSpeaker.city}
+                </div>
+                {currentSpeaker.xHandle && (
+                  <div className="text-white/50 text-sm">@{currentSpeaker.xHandle.replace(/^@/, '')}</div>
+                )}
+              </div>
+            ) : (
+              <div className="text-white/40 italic">Lower-third hidden</div>
+            )}
+            {lastAction && (
+              <div className="mt-3 text-xs text-white/40">
+                Last action: {lastAction.kind === 'push' ? 'pushed speaker' : 'cleared'} at {lastAction.at.toLocaleTimeString()}
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export default StreamControl;

--- a/frontend/src/pages/StreamOverlay.tsx
+++ b/frontend/src/pages/StreamOverlay.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useRef, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+const CHANNEL_NAME = 'stream-overlay-bpd-2026';
+const COUNTER_POLL_MS = 8000;
+const PHOTO_ROTATE_MS = 8000;
+
+interface Speaker {
+  name?: string;
+  role?: string;
+  city?: string;
+  xHandle?: string;
+}
+
+interface Counters {
+  cities: number;
+  donationsUsd: number | null;
+  photoUrls: string[];
+}
+
+async function fetchCounters(): Promise<Counters> {
+  const { count: cityCount } = await supabase
+    .from('parties')
+    .select('id', { count: 'exact', head: true })
+    .eq('underboss_status', 'approved');
+
+  // Donations: sum succeeded donations across approved parties. Approved party ids
+  // first, then sum donations for those parties.
+  let donationsUsd: number | null = null;
+  try {
+    const { data: approvedIds } = await supabase
+      .from('parties')
+      .select('id')
+      .eq('underboss_status', 'approved');
+    const ids = (approvedIds || []).map((r: any) => r.id);
+    if (ids.length > 0) {
+      const { data: donRows } = await supabase
+        .from('donations')
+        .select('amount, status, party_id')
+        .in('party_id', ids)
+        .eq('status', 'succeeded');
+      if (donRows) {
+        donationsUsd = donRows.reduce((s: number, d: any) => s + Number(d.amount || 0), 0);
+      } else {
+        donationsUsd = 0;
+      }
+    } else {
+      donationsUsd = 0;
+    }
+  } catch {
+    donationsUsd = null;
+  }
+
+  let photoUrls: string[] = [];
+  try {
+    const { data: photoRows } = await supabase
+      .from('photos')
+      .select('url, party_id, parties!inner(underboss_status)')
+      .eq('status', 'approved')
+      .eq('parties.underboss_status', 'approved')
+      .order('created_at', { ascending: false })
+      .limit(60);
+    if (photoRows) {
+      photoUrls = photoRows.map((r: any) => r.url).filter(Boolean);
+    }
+  } catch {
+    photoUrls = [];
+  }
+
+  return {
+    cities: cityCount ?? 0,
+    donationsUsd,
+    photoUrls,
+  };
+}
+
+export function StreamOverlay() {
+  const [counters, setCounters] = useState<Counters>({ cities: 0, donationsUsd: null, photoUrls: [] });
+  const [speaker, setSpeaker] = useState<Speaker | null>(null);
+  const [photoIdx, setPhotoIdx] = useState(0);
+  const photoUrlsRef = useRef<string[]>([]);
+
+  // Force a transparent body so OBS Browser Source captures only the overlay layer.
+  useEffect(() => {
+    const prevBg = document.body.style.background;
+    const prevHtmlBg = document.documentElement.style.background;
+    document.body.style.background = 'transparent';
+    document.documentElement.style.background = 'transparent';
+    const style = document.createElement('style');
+    style.setAttribute('data-stream-overlay', 'true');
+    style.textContent = `
+      html, body, #root { background: transparent !important; }
+      body { margin: 0; padding: 0; }
+    `;
+    document.head.appendChild(style);
+    return () => {
+      document.body.style.background = prevBg;
+      document.documentElement.style.background = prevHtmlBg;
+      const el = document.querySelector('style[data-stream-overlay]');
+      if (el) el.remove();
+    };
+  }, []);
+
+  // Counters polling
+  useEffect(() => {
+    let mounted = true;
+    async function tick() {
+      try {
+        const c = await fetchCounters();
+        if (mounted) {
+          setCounters(c);
+          photoUrlsRef.current = c.photoUrls;
+        }
+      } catch {
+        // ignore — keep last values
+      }
+    }
+    tick();
+    const t = setInterval(tick, COUNTER_POLL_MS);
+    return () => {
+      mounted = false;
+      clearInterval(t);
+    };
+  }, []);
+
+  // Photo rotation
+  useEffect(() => {
+    const t = setInterval(() => {
+      setPhotoIdx((i) => {
+        const urls = photoUrlsRef.current;
+        if (urls.length === 0) return 0;
+        return (i + 1) % urls.length;
+      });
+    }, PHOTO_ROTATE_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  // Realtime: lower-third speaker
+  useEffect(() => {
+    const channel = supabase.channel(CHANNEL_NAME);
+    channel
+      .on('broadcast', { event: 'speaker.set' }, (msg: any) => {
+        const p = msg?.payload || {};
+        setSpeaker({
+          name: p.name,
+          role: p.role,
+          city: p.city,
+          xHandle: p.xHandle,
+        });
+      })
+      .on('broadcast', { event: 'speaker.clear' }, () => {
+        setSpeaker(null);
+      })
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  const currentPhoto = counters.photoUrls[photoIdx] || null;
+
+  const formatUsd = (cents: number) => {
+    const dollars = cents / 100;
+    if (dollars >= 1_000_000) return `$${(dollars / 1_000_000).toFixed(1)}M`;
+    if (dollars >= 1_000) return `$${(dollars / 1_000).toFixed(0)}k`;
+    return `$${Math.round(dollars).toLocaleString()}`;
+  };
+
+  return (
+    <div className="fixed inset-0 w-screen h-screen text-white pointer-events-none overflow-hidden" style={{ background: 'transparent' }}>
+      {/* Top-left branding lockup */}
+      <div className="fixed top-6 left-6">
+        <div className="backdrop-blur-md bg-black/40 rounded-2xl border border-white/10 px-5 py-3 flex items-center gap-3">
+          <div className="text-3xl leading-none">🍕</div>
+          <div className="leading-tight">
+            <div className="text-xs uppercase tracking-widest text-white/60">PizzaDAO presents</div>
+            <div className="text-lg font-extrabold">Bitcoin Pizza Day 2026</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Top-right counters */}
+      <div className="fixed top-6 right-6">
+        <div className="backdrop-blur-md bg-black/40 rounded-2xl border border-white/10 px-6 py-4 flex flex-col items-end gap-3 min-w-[260px]">
+          <div className="flex flex-col items-end">
+            <div className="text-5xl font-extrabold tabular-nums">{counters.cities.toLocaleString()}</div>
+            <div className="text-xs uppercase tracking-widest text-white/60">cities celebrating</div>
+          </div>
+          {counters.donationsUsd !== null && counters.donationsUsd > 0 && (
+            <div className="flex flex-col items-end">
+              <div className="text-3xl font-extrabold tabular-nums">{formatUsd(counters.donationsUsd)}</div>
+              <div className="text-xs uppercase tracking-widest text-white/60">raised for charity</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Bottom-right rotating photo */}
+      {currentPhoto && (
+        <div className="fixed bottom-6 right-6">
+          <div className="backdrop-blur-md bg-black/40 rounded-2xl border border-white/10 p-2 overflow-hidden">
+            <img
+              key={currentPhoto}
+              src={currentPhoto}
+              alt=""
+              className="block w-[320px] h-[240px] object-cover rounded-xl transition-opacity duration-700"
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Bottom lower-third */}
+      <div
+        className={`fixed left-6 transition-all duration-500 ease-out ${
+          speaker ? 'bottom-10 opacity-100 translate-y-0' : '-bottom-40 opacity-0 translate-y-10'
+        }`}
+        style={{ maxWidth: '60vw' }}
+      >
+        <div className="backdrop-blur-md bg-black/55 rounded-2xl border border-white/10 px-8 py-5">
+          {speaker?.name && (
+            <div className="text-5xl font-extrabold leading-tight">{speaker.name}</div>
+          )}
+          {(speaker?.role || speaker?.city) && (
+            <div className="text-xl text-white/80 mt-1">
+              {speaker?.role || ''}
+              {speaker?.role && speaker?.city ? ' — ' : ''}
+              {speaker?.city || ''}
+            </div>
+          )}
+          {speaker?.xHandle && (
+            <div className="text-lg text-white/60 mt-1">@{speaker.xHandle.replace(/^@/, '')}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default StreamOverlay;

--- a/migrations/2026-05-17-stream-registrants.sql
+++ b/migrations/2026-05-17-stream-registrants.sql
@@ -1,0 +1,22 @@
+-- nduja-58792: Bitcoin Pizza Day livestream Zoom registrants table
+-- Service-role / backend only; no anon or authenticated grants.
+
+CREATE TABLE IF NOT EXISTS stream_registrants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL,
+  party_id UUID REFERENCES parties(id) ON DELETE SET NULL,
+  zoom_meeting_id TEXT NOT NULL,
+  zoom_registrant_id TEXT,
+  zoom_join_url TEXT,
+  display_name TEXT,
+  email_sent_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT stream_registrants_email_meeting_unique UNIQUE (email, zoom_meeting_id)
+);
+
+CREATE INDEX IF NOT EXISTS stream_registrants_email_idx ON stream_registrants (lower(email));
+CREATE INDEX IF NOT EXISTS stream_registrants_meeting_idx ON stream_registrants (zoom_meeting_id);
+
+-- RLS on, no policies = deny-all for anon/authenticated. Service role bypasses RLS.
+ALTER TABLE stream_registrants ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Bitcoin Pizza Day livestream infrastructure on the rsvpizza side.
- **Backend**: Zoom S2S OAuth service + sync/send-invites/status routes that auto-register approved-event hosts and co-hosts, then Resend their personalized waiting-room-bypass join links.
- **Frontend**: `/stream/overlay` (public, transparent OBS browser source) + `/stream/control` (auth-gated producer admin) connected via Supabase Realtime broadcast channel for live lower-third updates.
- **New table**: `stream_registrants` (service-role only, RLS on, no anon access).
- Plan: `plans/nduja-58792-bpd-stream-backend.md`
- Architecture doc: [`gpp.day/stream/stack`](https://github.com/PizzaDAO/gpp/pull/17)

## Files
- New: `backend/src/services/zoom.service.ts`, `backend/src/routes/zoom-stream.routes.ts`, `frontend/src/pages/StreamOverlay.tsx`, `frontend/src/pages/StreamControl.tsx`, `migrations/2026-05-17-stream-registrants.sql`
- Modified: `backend/src/index.ts` (route registration BEFORE partyRoutes), `backend/prisma/schema.prisma` (StreamRegistrant model), `frontend/src/App.tsx` (two new routes)

## Required follow-ups (BEFORE this works end-to-end)
- [ ] **Apply migration** via Supabase MCP (`apply_migration` on `znpiwdvvsqaxuskpfleo` using `migrations/2026-05-17-stream-registrants.sql`)
- [ ] **Set Zoom env vars** on backend Vercel (project `prj_uxgTwR4ENIePs4qck5PQVMA2kzQB`):
  - `ZOOM_ACCOUNT_ID`
  - `ZOOM_CLIENT_ID`
  - `ZOOM_CLIENT_SECRET`
  - `ZOOM_STREAM_MEETING_ID`
- [ ] **Zoom marketplace app** must have scopes `meeting:write:admin` and `meeting:read:admin`
- [ ] **`npx prisma generate`** before backend build (Vercel runs this on deploy)
- [ ] Verify `donations` + `photos` anon SELECT grants for the overlay counters; if blocked by Feb 2026 security audit, fallback is a public backend `/api/zoom-stream/counters` route (overlay already hides those cards gracefully if data is missing)

## Test plan
- [ ] Preview deploy builds (frontend autodeploys per branch; backend stays on prod)
- [ ] `/stream/overlay` loads on preview with transparent background (ThemeProvider override works)
- [ ] `/stream/control` requires underboss/admin auth
- [ ] After backend deploy + migration + env vars: `POST /api/zoom-stream/sync` with `{dryRun: true}` returns sensible counts of approved-event hosts + co-hosts
- [ ] Single-recipient test: register Snax's email, click join link, confirm Zoom waiting-room bypass
- [ ] `/stream/control` push speaker → `/stream/overlay` shows lower-third within ~1s
- [ ] Open `/stream/overlay` as Browser Source in OBS at 1920x1080 — no scrollbars, no chrome, clean overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)