### PR TITLE
quattro-formaggi-88980: sort /partner by event created date

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -787,6 +787,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         slug: event.customUrl || event.inviteCode,
         reportPublicSlug: event.reportPublished ? (event.reportPublicSlug || event.customUrl || event.inviteCode) : null,
         date: event.date,
+        createdAt: event.createdAt,
         timezone: event.timezone,
         address: event.address,
         venueName: event.venueName,

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -409,9 +409,7 @@ export function PartnerDashboardPage() {
     const sorted = [...filtered].sort((a, b) => {
       switch (sortBy) {
         case 'date-asc':
-          if (!a.date) return 1;
-          if (!b.date) return -1;
-          return new Date(a.date).getTime() - new Date(b.date).getTime();
+          return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
         case 'rsvps':
           return (b.rsvpCount || 0) - (a.rsvpCount || 0);
         case 'clicks':
@@ -420,9 +418,7 @@ export function PartnerDashboardPage() {
           return (a.name || '').localeCompare(b.name || '');
         case 'date-desc':
         default:
-          if (!a.date) return 1;
-          if (!b.date) return -1;
-          return new Date(b.date).getTime() - new Date(a.date).getTime();
+          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       }
     });
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1253,6 +1253,7 @@ export interface SponsorDashboardEvent {
   slug: string;
   reportPublicSlug: string | null;
   date: string | null;
+  createdAt: string;
   timezone: string | null;
   address: string | null;
   venueName: string | null;


### PR DESCRIPTION
## Summary
- The sort dropdown's Newest/Oldest options on `/partner` (PartnerDashboardPage) now sort by `Party.createdAt` (the event-record creation timestamp) instead of `event.date` (the scheduled event date), so recently-added events surface at the top regardless of when they're scheduled.
- Dropdown labels are unchanged; only the sort semantics shift. Backend response shape gains `createdAt`, and `SponsorDashboardEvent` picks up the matching non-nullable field.

## Test plan
- [ ] Default sort puts most-recently-created events first
- [ ] Switching to "Oldest" shows earliest-created events first
- [ ] Other sort options (RSVPs, Clicks, Name) unaffected