### PR TITLE
parmesan-65146: manual upload replacement on logo cleanup

### DIFF
--- a/backend/src/routes/logoAudit.routes.ts
+++ b/backend/src/routes/logoAudit.routes.ts
@@ -1,5 +1,7 @@
 import { Router, Response, NextFunction } from 'express';
+import express from 'express';
 import { createClient } from '@supabase/supabase-js';
+import sharp from 'sharp';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
@@ -8,6 +10,11 @@ import { syncPartnerToAllEvents, syncAutoSponsorsToAllEvents } from '../helpers/
 import crypto from 'crypto';
 
 const router = Router();
+
+// The global JSON body parser in index.ts uses the default 100kb limit, which
+// is too small for the base64-encoded replacement upload. Bump just this
+// router to 8mb (raw file capped at 5mb below; base64 inflates ~33%).
+router.use(express.json({ limit: '8mb' }));
 
 const supabaseAdmin = createClient(
   process.env.SUPABASE_URL!,
@@ -390,6 +397,122 @@ router.post('/apply', requireAuth, requireGraphicsAdminAuth, async (req: AuthReq
         } catch (err) {
           console.error('partnerSync failed after logo cleanup for SponsorUser', su.id, err);
           // Continue — the direct Sponsor.logoUrl updates above still applied.
+        }
+      }
+    }
+
+    invalidateAuditCache();
+
+    res.json({
+      newUrl,
+      sponsorsUpdated: sponsorUpdate.count,
+      sponsorUserUpdated,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * POST /api/admin/logo-bg-audit/apply-upload
+ * Body: { logoUrl: string, fileBase64: string, contentType: 'image/png' | 'image/jpeg' }
+ *
+ * Manual override: instead of auto-stripping the white background, the
+ * graphics admin uploads a replacement file from disk. Validates the file,
+ * uploads to Supabase storage, and updates every Sponsor.logoUrl AND every
+ * SponsorUser.coHostLogoUrl matching the original URL. If a SponsorUser was
+ * updated, re-syncs to linked events.
+ */
+router.post('/apply-upload', requireAuth, requireGraphicsAdminAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { logoUrl, fileBase64, contentType } = req.body || {};
+
+    if (typeof logoUrl !== 'string' || !logoUrl) {
+      throw new AppError('logoUrl is required', 400, 'VALIDATION_ERROR');
+    }
+    if (typeof fileBase64 !== 'string' || !fileBase64) {
+      throw new AppError('fileBase64 is required', 400, 'VALIDATION_ERROR');
+    }
+    if (contentType !== 'image/png' && contentType !== 'image/jpeg') {
+      throw new AppError(
+        'contentType must be image/png or image/jpeg',
+        400,
+        'VALIDATION_ERROR'
+      );
+    }
+
+    // Decode base64
+    let buffer: Buffer;
+    try {
+      buffer = Buffer.from(fileBase64, 'base64');
+    } catch {
+      throw new AppError('Invalid base64 payload', 400, 'VALIDATION_ERROR');
+    }
+    if (buffer.length === 0) {
+      throw new AppError('Empty file payload', 400, 'VALIDATION_ERROR');
+    }
+    const MAX_BYTES = 5 * 1024 * 1024;
+    if (buffer.length > MAX_BYTES) {
+      throw new AppError('File exceeds 5 MB limit', 413, 'PAYLOAD_TOO_LARGE');
+    }
+
+    // Sanity-check the image actually parses
+    try {
+      await sharp(buffer).metadata();
+    } catch {
+      throw new AppError('Invalid image', 400, 'INVALID_IMAGE');
+    }
+
+    // Upload to Supabase storage
+    const ext = contentType === 'image/png' ? 'png' : 'jpg';
+    const fileName = `sponsor-logos/${Date.now()}-manual-${crypto.randomBytes(4).toString('hex')}.${ext}`;
+    const { error: uploadError } = await supabaseAdmin.storage
+      .from(BUCKET)
+      .upload(fileName, buffer, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType,
+      });
+    if (uploadError) {
+      console.error('Supabase upload failed:', uploadError);
+      throw new AppError(`Storage upload failed: ${uploadError.message}`, 500, 'UPLOAD_FAILED');
+    }
+
+    const { data: urlData } = supabaseAdmin.storage.from(BUCKET).getPublicUrl(fileName);
+    const newUrl = urlData.publicUrl;
+    if (!newUrl) {
+      throw new AppError('Failed to get public URL for uploaded logo', 500, 'UPLOAD_NO_URL');
+    }
+
+    // Update Sponsor rows
+    const sponsorUpdate = await prisma.sponsor.updateMany({
+      where: { logoUrl },
+      data: { logoUrl: newUrl },
+    });
+
+    // Update SponsorUser rows (master records)
+    const sponsorUsers = await prisma.sponsorUser.findMany({
+      where: { coHostLogoUrl: logoUrl },
+    });
+    let sponsorUserUpdated = false;
+    for (const su of sponsorUsers) {
+      await prisma.sponsorUser.update({
+        where: { id: su.id },
+        data: { coHostLogoUrl: newUrl },
+      });
+      sponsorUserUpdated = true;
+
+      const updated = await prisma.sponsorUser.findUnique({ where: { id: su.id } });
+      if (updated) {
+        try {
+          if (updated.autoCoHost) {
+            await syncPartnerToAllEvents(updated as any);
+          } else if (updated.autoSponsor) {
+            await syncAutoSponsorsToAllEvents(updated as any);
+          }
+        } catch (err) {
+          console.error('partnerSync failed after logo upload for SponsorUser', su.id, err);
+          // Continue — direct Sponsor.logoUrl updates still applied.
         }
       }
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3550,6 +3550,49 @@ export async function applyLogoBgFix(
 }
 
 /**
+ * Manual replacement: upload a graphics-admin-supplied file from disk to
+ * replace the original logo, instead of auto-stripping the white background.
+ * Reads the File via FileReader, strips the data-URL prefix, and POSTs the
+ * raw base64 to the backend.
+ */
+export async function applyLogoBgFixUpload(
+  originalUrl: string,
+  file: File
+): Promise<{ newUrl: string; sponsorsUpdated: number; sponsorUserUpdated: boolean }> {
+  const fileBase64 = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read file as data URL'));
+        return;
+      }
+      const commaIdx = result.indexOf(',');
+      if (commaIdx < 0) {
+        reject(new Error('Unexpected FileReader output'));
+        return;
+      }
+      resolve(result.slice(commaIdx + 1));
+    };
+    reader.onerror = () => reject(reader.error || new Error('FileReader error'));
+    reader.readAsDataURL(file);
+  });
+
+  return apiRequest<{ newUrl: string; sponsorsUpdated: number; sponsorUserUpdated: boolean }>(
+    '/api/admin/logo-bg-audit/apply-upload',
+    {
+      method: 'POST',
+      requireAuth: true,
+      body: {
+        logoUrl: originalUrl,
+        fileBase64,
+        contentType: file.type,
+      },
+    }
+  );
+}
+
+/**
  * Fetch the stripped-background preview PNG as a Blob. Use URL.createObjectURL()
  * on the result to bind it to an <img src>. We can't use a raw URL because the
  * endpoint requires Bearer auth, and <img> won't send Authorization headers.

--- a/frontend/src/pages/AdminLogoCleanup.tsx
+++ b/frontend/src/pages/AdminLogoCleanup.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { Loader2, Shield, Check, X, ArrowRight, AlertCircle } from 'lucide-react';
+import { Loader2, Shield, Check, X, ArrowRight, AlertCircle, Upload } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import { useAuth } from '../contexts/AuthContext';
 import {
   fetchUnderbossMe,
   fetchLogoBgAudit,
   applyLogoBgFix,
+  applyLogoBgFixUpload,
   fetchLogoBgPreviewBlob,
   type LogoCleanupItem,
 } from '../lib/api';
@@ -78,6 +79,168 @@ function PreviewImage({ logoUrl }: { logoUrl: string }) {
       alt="Suggested stripped logo"
       className="max-h-40 max-w-full object-contain"
     />
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+interface CleanupCardProps {
+  item: LogoCleanupItem;
+  isApplying: boolean;
+  onApprove: (item: LogoCleanupItem) => void;
+  onApproveUpload: (item: LogoCleanupItem, file: File) => void;
+  onSkip: (item: LogoCleanupItem) => void;
+}
+
+function CleanupCard({ item, isApplying, onApprove, onApproveUpload, onSkip }: CleanupCardProps) {
+  const [stagedFile, setStagedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Manage object URL lifecycle for the staged-file preview.
+  useEffect(() => {
+    if (!stagedFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const obj = URL.createObjectURL(stagedFile);
+    setPreviewUrl(obj);
+    return () => {
+      URL.revokeObjectURL(obj);
+    };
+  }, [stagedFile]);
+
+  const handleFilePick = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files && e.target.files[0];
+    if (f) setStagedFile(f);
+    // Reset the input so picking the same file twice re-triggers onChange.
+    e.target.value = '';
+  };
+
+  const handleClearStaged = () => {
+    setStagedFile(null);
+  };
+
+  const syncLabel = item.sponsorUserId
+    ? `Sync: master record${item.sponsorUserName ? ` (${item.sponsorUserName})` : ''}`
+    : 'Sync: one-off';
+  const partnerNames = Array.from(
+    new Set(item.sponsors.map((s) => s.partnerName).filter(Boolean))
+  );
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 sm:p-5">
+      <div className="flex flex-col sm:flex-row gap-4 items-stretch">
+        <div
+          className="flex-1 rounded-xl overflow-hidden flex items-center justify-center min-h-[140px] p-3"
+          style={CHECKERBOARD_STYLE}
+        >
+          <img
+            src={item.logoUrl}
+            alt="Original logo"
+            className="max-h-40 max-w-full object-contain"
+          />
+        </div>
+        <div className="flex items-center justify-center text-white/40">
+          <ArrowRight size={20} />
+        </div>
+        <div
+          className="flex-1 rounded-xl overflow-hidden flex items-center justify-center min-h-[140px] p-3 relative"
+          style={CHECKERBOARD_STYLE}
+        >
+          {stagedFile && previewUrl ? (
+            <>
+              <img
+                src={previewUrl}
+                alt="Replacement upload preview"
+                className="max-h-40 max-w-full object-contain"
+              />
+              <button
+                onClick={handleClearStaged}
+                disabled={isApplying}
+                title="Discard upload"
+                className="absolute top-1 right-1 rounded-full bg-black/60 hover:bg-black/80 text-white/80 p-1 disabled:opacity-40"
+              >
+                <X size={12} />
+              </button>
+            </>
+          ) : (
+            <PreviewImage logoUrl={item.logoUrl} />
+          )}
+        </div>
+      </div>
+
+      {stagedFile && (
+        <div className="mt-2 text-xs text-white/50">
+          Uploaded: <span className="text-white/80">{stagedFile.name}</span>{' '}
+          <span className="text-white/40">({formatBytes(stagedFile.size)})</span>
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+        <div className="text-sm">
+          <div className="font-medium text-white">
+            {partnerNames.join(', ') || '(unnamed)'}
+          </div>
+          <div className="text-white/50 mt-0.5">
+            {item.eventCount} event{item.eventCount === 1 ? '' : 's'}
+            {item.eventCount > 0 && (
+              <span className="text-white/30">
+                {' '}
+                &middot; {item.sponsors.slice(0, 4).map((s) => s.partyCity || s.partyName).join(', ')}
+                {item.sponsors.length > 4 ? `, +${item.sponsors.length - 4} more` : ''}
+              </span>
+            )}
+          </div>
+          <div className="text-xs text-white/40 mt-1">
+            {syncLabel}
+            <span className="ml-2 inline-block rounded bg-white/[0.04] px-1.5 py-0.5 border border-white/10">
+              {item.classification === 'white_bg_png' ? 'white-bg PNG' : 'JPEG white'}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex gap-2 flex-wrap">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg"
+            onChange={handleFilePick}
+            className="hidden"
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isApplying}
+            className="px-3 py-2 rounded-lg text-sm bg-white/[0.04] text-white/70 border border-white/10 hover:bg-white/[0.07] disabled:opacity-40 transition-colors inline-flex items-center gap-1.5"
+          >
+            <Upload size={14} /> {stagedFile ? 'Change file' : 'Upload replacement'}
+          </button>
+          <button
+            onClick={() => onSkip(item)}
+            disabled={isApplying}
+            className="px-3 py-2 rounded-lg text-sm bg-white/[0.04] text-white/70 border border-white/10 hover:bg-white/[0.07] disabled:opacity-40 transition-colors inline-flex items-center gap-1.5"
+          >
+            <X size={14} /> Skip
+          </button>
+          <button
+            onClick={() => (stagedFile ? onApproveUpload(item, stagedFile) : onApprove(item))}
+            disabled={isApplying}
+            className="px-3 py-2 rounded-lg text-sm bg-emerald-500/20 text-emerald-300 border border-emerald-500/30 hover:bg-emerald-500/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1.5"
+          >
+            {isApplying ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Check size={14} />
+            )}
+            {stagedFile ? 'Approve uploaded file' : 'Approve & replace'}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -187,6 +350,29 @@ export function AdminLogoCleanup() {
     }
   };
 
+  const handleApproveUpload = async (item: LogoCleanupItem, file: File) => {
+    if (applying.has(item.logoUrl)) return;
+    setApplying((prev) => new Set(prev).add(item.logoUrl));
+    try {
+      const res = await applyLogoBgFixUpload(item.logoUrl, file);
+      pushToast(
+        `Replaced with upload. ${res.sponsorsUpdated} sponsor${res.sponsorsUpdated === 1 ? '' : 's'} updated${
+          res.sponsorUserUpdated ? ' (master record synced)' : ''
+        }.`,
+        'success'
+      );
+      setRemoved((prev) => new Set(prev).add(item.logoUrl));
+    } catch (e: any) {
+      pushToast(e?.message || 'Failed to upload replacement', 'error');
+    } finally {
+      setApplying((prev) => {
+        const next = new Set(prev);
+        next.delete(item.logoUrl);
+        return next;
+      });
+    }
+  };
+
   const handleSkip = (item: LogoCleanupItem) => {
     setRemoved((prev) => new Set(prev).add(item.logoUrl));
   };
@@ -258,89 +444,16 @@ export function AdminLogoCleanup() {
               </div>
             ) : (
               <div className="space-y-4">
-                {visibleItems.map((item) => {
-                  const isApplying = applying.has(item.logoUrl);
-                  const syncLabel = item.sponsorUserId
-                    ? `Sync: master record${item.sponsorUserName ? ` (${item.sponsorUserName})` : ''}`
-                    : 'Sync: one-off';
-                  const partnerNames = Array.from(
-                    new Set(item.sponsors.map((s) => s.partnerName).filter(Boolean))
-                  );
-                  return (
-                    <div
-                      key={item.logoUrl}
-                      className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 sm:p-5"
-                    >
-                      <div className="flex flex-col sm:flex-row gap-4 items-stretch">
-                        <div
-                          className="flex-1 rounded-xl overflow-hidden flex items-center justify-center min-h-[140px] p-3"
-                          style={CHECKERBOARD_STYLE}
-                        >
-                          <img
-                            src={item.logoUrl}
-                            alt="Original logo"
-                            className="max-h-40 max-w-full object-contain"
-                          />
-                        </div>
-                        <div className="flex items-center justify-center text-white/40">
-                          <ArrowRight size={20} />
-                        </div>
-                        <div
-                          className="flex-1 rounded-xl overflow-hidden flex items-center justify-center min-h-[140px] p-3"
-                          style={CHECKERBOARD_STYLE}
-                        >
-                          <PreviewImage logoUrl={item.logoUrl} />
-                        </div>
-                      </div>
-
-                      <div className="mt-4 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
-                        <div className="text-sm">
-                          <div className="font-medium text-white">
-                            {partnerNames.join(', ') || '(unnamed)'}
-                          </div>
-                          <div className="text-white/50 mt-0.5">
-                            {item.eventCount} event{item.eventCount === 1 ? '' : 's'}
-                            {item.eventCount > 0 && (
-                              <span className="text-white/30">
-                                {' '}
-                                &middot; {item.sponsors.slice(0, 4).map((s) => s.partyCity || s.partyName).join(', ')}
-                                {item.sponsors.length > 4 ? `, +${item.sponsors.length - 4} more` : ''}
-                              </span>
-                            )}
-                          </div>
-                          <div className="text-xs text-white/40 mt-1">
-                            {syncLabel}
-                            <span className="ml-2 inline-block rounded bg-white/[0.04] px-1.5 py-0.5 border border-white/10">
-                              {item.classification === 'white_bg_png' ? 'white-bg PNG' : 'JPEG white'}
-                            </span>
-                          </div>
-                        </div>
-
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => handleSkip(item)}
-                            disabled={isApplying}
-                            className="px-3 py-2 rounded-lg text-sm bg-white/[0.04] text-white/70 border border-white/10 hover:bg-white/[0.07] disabled:opacity-40 transition-colors inline-flex items-center gap-1.5"
-                          >
-                            <X size={14} /> Skip
-                          </button>
-                          <button
-                            onClick={() => handleApprove(item)}
-                            disabled={isApplying}
-                            className="px-3 py-2 rounded-lg text-sm bg-emerald-500/20 text-emerald-300 border border-emerald-500/30 hover:bg-emerald-500/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1.5"
-                          >
-                            {isApplying ? (
-                              <Loader2 size={14} className="animate-spin" />
-                            ) : (
-                              <Check size={14} />
-                            )}
-                            Approve & replace
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
+                {visibleItems.map((item) => (
+                  <CleanupCard
+                    key={item.logoUrl}
+                    item={item}
+                    isApplying={applying.has(item.logoUrl)}
+                    onApprove={handleApprove}
+                    onApproveUpload={handleApproveUpload}
+                    onSkip={handleSkip}
+                  />
+                ))}
               </div>
             )}
           </>


### PR DESCRIPTION
## Summary

- New backend endpoint `POST /api/admin/logo-bg-audit/apply-upload` (graphics-admin gated) accepts a base64 PNG/JPEG (5 MB cap, Sharp parse-check), uploads to Supabase storage, updates `Sponsor.logoUrl` + `SponsorUser.coHostLogoUrl`, runs the same `partnerSync` as the existing `/apply` path, and invalidates the audit cache.
- New UI: third button on every `/admin/logo-cleanup` card — **Upload replacement**. Picking a file stashes it in card-local state, swaps the suggested-preview pane for the uploaded file on the same checkerboard background, shows name/size, and flips the **Approve** button to **Approve uploaded file**. A small X clears the staged file. No staged file = existing auto-strip behavior.
- No new backend deps (base64 in JSON; router-scoped `express.json({ limit: '8mb' })` since the global default is 100kb).

## Deploy notes

- **Backend must merge to `master` and be redeployed** (`cd backend && vercel --prod --scope pizza-dao`) before the new button works against the preview frontend — preview deploys talk to the production backend.

## Test plan

- [ ] Open `/admin/logo-cleanup` as a graphics admin; existing approve / skip still work.
- [ ] Click **Upload replacement** on a card, pick a PNG → preview swaps to the uploaded image; name + size show; clearing (X) reverts to the auto-strip preview.
- [ ] **Approve uploaded file** replaces the canonical logo (verify Sponsor row + SponsorUser master record + linked events).
- [ ] Reject paths: non-image content-type → 400; >5 MB → 413; corrupt image bytes → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)