### PR TITLE
stromboli-14555: funnel-coverage + per-visitor saturation heuristics

### DIFF
--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -18,6 +18,8 @@ import {
   checkLowHourEntropy,
   checkRapidIntersubmission,
   checkCrossEventWallet,
+  checkLowFunnelCoverage,
+  checkHighPerVisitorRsvpSaturation,
   scoreEvent,
   buildSybilWalletSet,
   tierFromScore,
@@ -25,6 +27,7 @@ import {
   type FakeDetectionGuest,
   type FakeDetectionParty,
   type FakeDetectionLinkClick,
+  type FakeDetectionFunnelEvent,
 } from './fakeDetection.js';
 
 // ============================================
@@ -49,6 +52,17 @@ function makeGuest(overrides: Partial<FakeDetectionGuest> = {}): FakeDetectionGu
     roles: [],
     pizzeriaRankings: ['da Michele', 'Sorbillo'],
     suggestedPizzerias: [{ name: 'da Michele' }],
+    ...overrides,
+  };
+}
+
+function makeFunnelEvent(
+  overrides: Partial<FakeDetectionFunnelEvent> = {},
+): FakeDetectionFunnelEvent {
+  return {
+    visitorHash: 'visitor-default',
+    step: 'rsvp_opened',
+    createdAt: new Date('2026-04-01T12:00:00Z'),
     ...overrides,
   };
 }
@@ -387,6 +401,98 @@ describe('checkCrossEventWallet', () => {
   });
 });
 
+describe('checkLowFunnelCoverage', () => {
+  it('does not fire below min n=30', () => {
+    const guests = Array.from({ length: 20 }, () => makeGuest());
+    const funnel = Array.from({ length: 20 }, (_, i) =>
+      makeFunnelEvent({ visitorHash: `v${i}`, step: 'rsvp_opened' }),
+    );
+    expect(checkLowFunnelCoverage(guests, funnel).fired).toBe(false);
+  });
+  it('fires for Ilemela-like sparse funnel (7 unique visitors / 100 RSVPs)', () => {
+    const guests = Array.from({ length: 100 }, () => makeGuest());
+    const funnel = Array.from({ length: 7 }, (_, i) =>
+      makeFunnelEvent({ visitorHash: `v${i}`, step: 'rsvp_opened' }),
+    );
+    const result = checkLowFunnelCoverage(guests, funnel);
+    expect(result.fired).toBe(true);
+    expect(result.evidence?.uniqueVisitors).toBe(7);
+    expect(result.evidence?.linkRsvpCount).toBe(100);
+  });
+  it('does not fire for Lilongwe-like healthy funnel (8 unique visitors / 44 RSVPs = 0.18)', () => {
+    const guests = Array.from({ length: 44 }, () => makeGuest());
+    const funnel = Array.from({ length: 8 }, (_, i) =>
+      makeFunnelEvent({ visitorHash: `v${i}`, step: 'rsvp_opened' }),
+    );
+    expect(checkLowFunnelCoverage(guests, funnel).fired).toBe(false);
+  });
+  it('ignores non-opened steps in coverage count', () => {
+    const guests = Array.from({ length: 40 }, () => makeGuest());
+    // 20 unique visitors but all on a non-opened step → coverage = 0
+    const funnel = Array.from({ length: 20 }, (_, i) =>
+      makeFunnelEvent({ visitorHash: `v${i}`, step: 'rsvp_submitted' }),
+    );
+    expect(checkLowFunnelCoverage(guests, funnel).fired).toBe(true);
+  });
+});
+
+describe('checkHighPerVisitorRsvpSaturation', () => {
+  it('does not fire when there is no funnel data', () => {
+    const guests = Array.from({ length: 10 }, () => makeGuest());
+    expect(checkHighPerVisitorRsvpSaturation(guests, []).fired).toBe(false);
+  });
+  it('fires when one visitor temporally matches 6 distinct guests within ±10 min', () => {
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const guests = Array.from({ length: 6 }, (_, i) =>
+      makeGuest({
+        id: `g${i}`,
+        submittedAt: new Date(base + i * 60_000), // 6 guests spaced 1 min apart
+      }),
+    );
+    const funnel = [
+      makeFunnelEvent({
+        visitorHash: 'padder',
+        step: 'rsvp_opened',
+        createdAt: new Date(base + 2 * 60_000), // mid-window — all 6 within ±10 min
+      }),
+    ];
+    const result = checkHighPerVisitorRsvpSaturation(guests, funnel);
+    expect(result.fired).toBe(true);
+    expect(result.evidence?.max).toBe(6);
+    expect(result.evidence?.visitorHash).toBe('padder'.slice(0, 8));
+  });
+  it('does not fire when each visitor only matches 1-2 guests', () => {
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    // 6 guests an hour apart → each is in its own ±10 min window
+    const guests = Array.from({ length: 6 }, (_, i) =>
+      makeGuest({ id: `g${i}`, submittedAt: new Date(base + i * 3600_000) }),
+    );
+    // Each visitor lines up with one guest
+    const funnel = Array.from({ length: 6 }, (_, i) =>
+      makeFunnelEvent({
+        visitorHash: `v${i}`,
+        step: 'rsvp_opened',
+        createdAt: new Date(base + i * 3600_000),
+      }),
+    );
+    expect(checkHighPerVisitorRsvpSaturation(guests, funnel).fired).toBe(false);
+  });
+  it('does not match a funnel event >10 min away from any guest', () => {
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const guests = Array.from({ length: 6 }, (_, i) =>
+      makeGuest({ id: `g${i}`, submittedAt: new Date(base + i * 60_000) }),
+    );
+    const funnel = [
+      makeFunnelEvent({
+        visitorHash: 'faraway',
+        step: 'rsvp_opened',
+        createdAt: new Date(base + 60 * 60_000), // 60 min later — outside window
+      }),
+    ];
+    expect(checkHighPerVisitorRsvpSaturation(guests, funnel).fired).toBe(false);
+  });
+});
+
 describe('buildSybilWalletSet', () => {
   it('includes wallets with ≥4 parties AND ≥2 distinct names', () => {
     const rows = [
@@ -472,17 +578,29 @@ describe('scoreEvent — integration fixtures', () => {
         }),
       ),
     ];
-    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests);
+    // Sparse funnel: 5 unique visitors / 95 RSVPs = 5.3% coverage → low_funnel_coverage fires.
+    // One visitor lined up at base — temporally matches >=5 of the rapid-fire RSVPs
+    // within ±10 min → high_per_visitor_rsvp_saturation fires.
+    const funnel: FakeDetectionFunnelEvent[] = [
+      makeFunnelEvent({ visitorHash: 'padder', step: 'rsvp_opened', createdAt: new Date(base) }),
+      makeFunnelEvent({ visitorHash: 'v1', step: 'rsvp_opened', createdAt: new Date(base) }),
+      makeFunnelEvent({ visitorHash: 'v2', step: 'rsvp_opened', createdAt: new Date(base) }),
+      makeFunnelEvent({ visitorHash: 'v3', step: 'rsvp_opened', createdAt: new Date(base) }),
+      makeFunnelEvent({ visitorHash: 'v4', step: 'rsvp_opened', createdAt: new Date(base) }),
+    ];
+    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests, funnel);
     // Should fire: 1 cap_fill, 2 low_domain_entropy, 3 sig_collapse,
     // 4a wallet_too_low, 6 host_self, 7 pizzeria_blank, 8 wallet_source_null,
-    // 9 one_word_name, 10 firstname_digits, 12 low_hour_entropy, 13 rapid_intersubmission
-    // = 15+10+15+8+20+5+5+5+5+7+8 = 103 → clamped to 100
+    // 9 one_word_name, 10 firstname_digits, 12 low_hour_entropy, 13 rapid_intersubmission,
+    // 15 low_funnel_coverage, 16 high_per_visitor_rsvp_saturation
     expect(row.score).toBeGreaterThanOrEqual(70);
     expect(row.tier).toBe('high');
     const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
     expect(firedIds).toContain('cap_fill_no_waitlist');
     expect(firedIds).toContain('sig_collapse');
     expect(firedIds).toContain('host_self_rsvp_mismatch');
+    expect(firedIds).toContain('low_funnel_coverage');
+    expect(firedIds).toContain('high_per_visitor_rsvp_saturation');
   });
 
   it('"Lilongwe-like" clean event scores ≤10', () => {
@@ -524,8 +642,20 @@ describe('scoreEvent — integration fixtures', () => {
         suggestedPizzerias: [{ name: 'Local Pizza' }],
       }),
     );
-    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests);
+    // Healthy funnel: 35 RSVPs and 35 distinct visitors (1:1 coverage), each
+    // funnel event time-aligned with its own guest → neither funnel flag fires.
+    const funnel: FakeDetectionFunnelEvent[] = Array.from({ length: 35 }, (_, i) =>
+      makeFunnelEvent({
+        visitorHash: `lilongwe-v${i}`,
+        step: 'rsvp_opened',
+        createdAt: new Date(base + i * 3600000 * 4),
+      }),
+    );
+    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests, funnel);
     expect(row.score).toBeLessThanOrEqual(10);
     expect(row.tier === 'clean' || row.tier === 'low').toBe(true);
+    const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
+    expect(firedIds).not.toContain('low_funnel_coverage');
+    expect(firedIds).not.toContain('high_per_visitor_rsvp_saturation');
   });
 });

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -47,6 +47,12 @@ export interface FakeDetectionLinkClick {
   clickedAt: Date;
 }
 
+export interface FakeDetectionFunnelEvent {
+  visitorHash: string;
+  step: string;
+  createdAt: Date;
+}
+
 export interface FlagResult {
   id: string;
   name: string;
@@ -94,6 +100,8 @@ export const WEIGHTS = {
   low_hour_entropy: 7,
   rapid_intersubmission: 8,
   cross_event_wallet: 15,
+  low_funnel_coverage: 10,
+  high_per_visitor_rsvp_saturation: 15,
 } as const;
 
 // ============================================
@@ -541,6 +549,74 @@ export function checkCrossEventWallet(
   );
 }
 
+/**
+ * 15. low_funnel_coverage — unique `rsvp_opened` visitors are too few relative to direct RSVPs.
+ * Indicates RSVPs were not preceded by real page-open events (bot/scripted submissions).
+ */
+export function checkLowFunnelCoverage(
+  guests: FakeDetectionGuest[],
+  funnelEvents: FakeDetectionFunnelEvent[],
+): FlagResult {
+  const id = 'low_funnel_coverage';
+  const n = guests.length;
+  if (n < 30) return flag(id, false, `n=${n} below 30`);
+  const opened = funnelEvents.filter(e => e.step === 'rsvp_opened');
+  const uniqueVisitors = new Set(opened.map(e => e.visitorHash)).size;
+  const ratio = uniqueVisitors / n;
+  const fired = ratio < 0.15;
+  return flag(
+    id,
+    fired,
+    `coverage=${uniqueVisitors}/${n} (${(ratio * 100).toFixed(1)}%)`,
+    { uniqueVisitors, linkRsvpCount: n, ratio },
+  );
+}
+
+/**
+ * 16. high_per_visitor_rsvp_saturation — one visitor's funnel timestamps temporally match many guest submissions.
+ * Temporal join: for each visitorHash's funnel `createdAt` values, count distinct guests whose
+ * `submittedAt` is within ±10 min of any of that visitor's funnel timestamps. Fires if max ≥ 5.
+ * (Needed because the unique index on (partyId, visitorHash, step) caps naive per-visitor row counts at 2.)
+ */
+export function checkHighPerVisitorRsvpSaturation(
+  guests: FakeDetectionGuest[],
+  funnelEvents: FakeDetectionFunnelEvent[],
+): FlagResult {
+  const id = 'high_per_visitor_rsvp_saturation';
+  if (funnelEvents.length === 0 || guests.length === 0) {
+    return flag(id, false, 'no funnel data');
+  }
+  const TEN_MIN = 10 * 60 * 1000;
+  const byVisitor = new Map<string, number[]>();
+  for (const e of funnelEvents) {
+    const arr = byVisitor.get(e.visitorHash) ?? [];
+    arr.push(e.createdAt.getTime());
+    byVisitor.set(e.visitorHash, arr);
+  }
+  let max = 0;
+  let worstVisitor = '';
+  for (const [visitor, timestamps] of byVisitor) {
+    const matched = new Set<string>();
+    for (const g of guests) {
+      const gms = g.submittedAt.getTime();
+      if (timestamps.some(t => Math.abs(t - gms) <= TEN_MIN)) {
+        matched.add(g.id ?? `${g.email ?? g.name}-${gms}`);
+      }
+    }
+    if (matched.size > max) {
+      max = matched.size;
+      worstVisitor = visitor;
+    }
+  }
+  const fired = max >= 5;
+  return flag(
+    id,
+    fired,
+    `max=${max} guests matched to one device`,
+    { max, visitorHash: worstVisitor.slice(0, 8) },
+  );
+}
+
 // ============================================
 // Aggregator
 // ============================================
@@ -558,6 +634,7 @@ export function scoreEvent(
   linkClicks: FakeDetectionLinkClick[],
   sybilWallets: Set<string>,
   maxGuests: number | null,
+  funnelEvents: FakeDetectionFunnelEvent[] = [],
 ): FakeDetectionRow {
   const guests = filterDirectRsvps(allGuests);
 
@@ -577,6 +654,8 @@ export function scoreEvent(
     checkLowHourEntropy(guests, party),
     checkRapidIntersubmission(guests),
     checkCrossEventWallet(guests, sybilWallets),
+    checkLowFunnelCoverage(guests, funnelEvents),
+    checkHighPerVisitorRsvpSaturation(guests, funnelEvents),
   ];
 
   const score = Math.min(

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -466,6 +466,9 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
         linkClicks: {
           select: { clickedAt: true },
         },
+        rsvpFunnelEvents: {
+          select: { visitorHash: true, step: true, createdAt: true },
+        },
       },
     });
 
@@ -506,6 +509,11 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
         p.linkClicks.map(c => ({ clickedAt: c.clickedAt })),
         sybilWallets,
         p.maxGuests,
+        p.rsvpFunnelEvents.map(e => ({
+          visitorHash: e.visitorHash,
+          step: e.step,
+          createdAt: e.createdAt,
+        })),
       ),
     );
 


### PR DESCRIPTION
## Summary
Two new fake-detection heuristics exploiting the existing `rsvp_funnel_events` table — no schema migration, no new instrumentation.

- **`low_funnel_coverage`** (weight 10): fires when `unique rsvp_opened visitors / direct-RSVP count < 0.15`, min n=30. RSVPs without genuine page-open events upstream.
- **`high_per_visitor_rsvp_saturation`** (weight 15): temporal join — for each visitor's funnel timestamps, count distinct guests whose `submittedAt` is within ±10 min. Fires when any visitor matches ≥5 guests.

The naive "rows per visitor ≥ 5" form cannot fire today: the unique constraint `@@unique([partyId, visitorHash, step])` caps per-visitor rows at 2. Temporal join handles that and is more accurate anyway.

Wires `rsvpFunnelEvents` into the underboss Prisma `select` block and forwards it to `scoreEvent` as the 6th positional arg (default `[]` so old call sites keep working).

## Calibration
- **Naivasha** (coverage 0.04, 1 visitor padding many guests) → both fire (+25)
- **Ilemela** (coverage 0.07, saturated at 100) → `low_funnel_coverage` fires
- **Lilongwe** (coverage 0.18, healthy 1:1 visitor↔guest) → neither fires

## Tests
- 8 new unit tests (4 per heuristic) cover min n, step filter, temporal window, multi-visitor non-saturation, and missing funnel data
- Existing Ilemela-like integration test now also fires both funnel flags
- Existing Lilongwe-like integration test passes with healthy 1:1 funnel data — no false positives

`fakeDetection.test.ts`: 53 passing (was 45). Other 5 unrelated pre-existing route-mock failures already exist on master.

## Test plan
- [ ] CI passes (vitest + tsc)
- [ ] After merge, manually deploy backend (`cd backend && vercel --prod --scope pizza-dao`)
- [ ] Verify Naivasha + Ilemela jump in tier on `/underboss/all/fake-detection` after deploy
- [ ] Verify Lilongwe's score is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)