### PR TITLE
fix(garlic-37944): sync cohost tab permission lists with host's tabs

### DIFF
--- a/backend/src/helpers/partyAccess.ts
+++ b/backend/src/helpers/partyAccess.ts
@@ -32,6 +32,7 @@ export const VALID_TAB_IDS = [
   'gpp',
   'promo',
   'flyer',
+  'print',
   'apps',
 ] as const;
 

--- a/frontend/src/lib/tabPermissions.ts
+++ b/frontend/src/lib/tabPermissions.ts
@@ -15,6 +15,8 @@ import {
   ListChecks,
   Package,
   Megaphone,
+  FileImage,
+  Printer,
   LayoutGrid,
 } from 'lucide-react';
 import { CoHost } from '../types';
@@ -37,6 +39,7 @@ export type TabId =
   | 'gpp'
   | 'promo'
   | 'flyer'
+  | 'print'
   | 'apps';
 
 export interface HostTab {
@@ -67,6 +70,8 @@ export const ALL_HOST_TABS: HostTab[] = [
   { id: 'checklist', label: 'Checklist', icon: ListChecks },
   { id: 'gpp', label: 'Party Kit', icon: Package },
   { id: 'promo', label: 'Promo', icon: Megaphone },
+  { id: 'flyer', label: 'Flyer', icon: FileImage },
+  { id: 'print', label: 'Print', icon: Printer },
   { id: 'apps', label: 'Apps', icon: LayoutGrid },
 ];
 


### PR DESCRIPTION
## Summary
- Add `flyer` and `print` entries to `ALL_HOST_TABS` so the cohost permission picker UI shows checkboxes for them
- Add `print` to backend `VALID_TAB_IDS` so the validator accepts it in `allowedTabs`
- Add `print` to the `TabId` union in `tabPermissions.ts`

## Why
Host dashboard renders 19 tabs but the cohost permission system only knew about 17 (UI) / 18 (backend). Any cohost whose permissions had been customized silently lost Flyer access; nobody could grant Print.

## Test plan
- [ ] Vercel preview loads
- [ ] Open an event as owner, go to HostsManager, click a cohost's permissions — Flyer and Print checkboxes appear
- [ ] Toggle Flyer + Print on for a cohost, save — backend accepts (no validation error)
- [ ] Log in as that cohost — Flyer + Print tabs visible