### PR TITLE
salami-50612: readable fired-flag pills on fake-detection tab

### DIFF
--- a/frontend/src/components/underboss/FakeDetectionTable.tsx
+++ b/frontend/src/components/underboss/FakeDetectionTable.tsx
@@ -32,14 +32,39 @@ const TIER_LABEL: Record<FakeDetectionTier, string> = {
   clean: 'Clean',
 };
 
+const FLAG_LABELS: Record<string, string> = {
+  cap_fill_no_waitlist: 'Cap fill, no waitlist',
+  low_domain_entropy: 'Low email-domain entropy',
+  sig_collapse: 'Field signature collapse',
+  wallet_too_low: 'Too few wallets',
+  wallet_too_high_reuse: 'Wallet reuse (high)',
+  wallet_reuse: 'Wallet reuse',
+  host_self_rsvp_mismatch: 'Host self-RSVP mismatch',
+  pizzeria_fields_blank: 'Pizzeria fields blank',
+  wallet_source_all_null: 'Wallet source all null',
+  one_word_name: 'One-word event name',
+  firstname_digits_email: 'Firstname+digits emails',
+  day_gap_pattern: 'Day-gap pattern',
+  low_hour_entropy: 'Low hour-of-day entropy',
+  rapid_intersubmission: 'Rapid inter-submission',
+  cross_event_wallet: 'Cross-event sybil wallet',
+  high_per_visitor_rsvp_saturation: 'High per-visitor RSVP saturation',
+  low_funnel_coverage: 'Low funnel coverage',
+};
+
+function flagLabel(name: string): string {
+  return FLAG_LABELS[name] ?? name.replace(/_/g, ' ');
+}
+
 function FlagPill({ flag }: { flag: FakeDetectionRow['flags'][number] }) {
   if (!flag.fired) return null;
   return (
     <span
-      title={`${flag.name} (+${flag.weight}) — ${flag.detail}`}
-      className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono bg-red-500/20 text-red-300 border border-red-500/30"
+      title={`${flag.name} — ${flag.detail}`}
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500/15 text-red-700 border border-red-500/30"
     >
-      {flag.name}
+      <span>{flagLabel(flag.name)}</span>
+      <span className="text-red-700/60 tabular-nums">+{flag.weight}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Bumps fired-flag pill text from 10px mono -> 12px sans
- Switches text color from washed `red-300` to high-contrast `red-700` (the screenshot Snax shared showed pink-on-pink on light surface)
- Replaces snake_case ids (`wallet_source_all_null`) with human labels via a small `FLAG_LABELS` map; falls back to underscore->space for any new heuristic
- Surfaces the heuristic `+weight` inline (muted) so admins can prioritize without hovering each pill

Single file: `frontend/src/components/underboss/FakeDetectionTable.tsx`. No backend, no i18n, no migration.

## Test plan
- [ ] Open Vercel preview -> /underboss -> Fake Detection tab
- [ ] Pills are visibly larger and readable from normal viewing distance
- [ ] Labels read as English (e.g., "Wallet source all null"), not snake_case
- [ ] Each pill shows `+N` weight inline
- [ ] Hover tooltip still shows raw id + detail
- [ ] High-tier rows still tint red

Generated with [Claude Code](https://claude.com/claude-code)