### PR TITLE
mushroom-31723: backend - guest reject + un-check-in (PR #1)

### DIFF
--- a/backend/src/routes/checkin.routes.ts
+++ b/backend/src/routes/checkin.routes.ts
@@ -3,6 +3,7 @@ import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest, isSuperAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { autoCompleteScorecardItem } from './scorecard.routes.js';
+import { triggerWebhook } from '../services/webhook.service.js';
 
 const router = Router();
 
@@ -271,6 +272,11 @@ router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: 
       throw new AppError('Guest not found', 404, 'GUEST_NOT_FOUND');
     }
 
+    // mushroom-31723: refuse to check in a guest the host has rejected.
+    if (guest.approved === false) {
+      throw new AppError('Guest was rejected', 400, 'GUEST_REJECTED');
+    }
+
     if (guest.checkedInAt) {
       return res.status(200).json({
         success: true,
@@ -305,6 +311,88 @@ router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: 
         checkedInBy: updatedGuest.checkedInBy,
       },
       message: `${updatedGuest.name} has been checked in!`,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/checkin/:inviteCode/:guestId — Host/co-host un-check-in (mushroom-31723)
+router.delete('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { inviteCode, guestId } = req.params;
+
+    const party = await findPartyByCode(inviteCode);
+    if (!party) {
+      throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+    }
+
+    const canCheckIn = await canUserCheckIn(party.id, req.userId, req.userEmail);
+    if (!canCheckIn) {
+      throw new AppError('You are not authorized to check in guests for this event', 403, 'UNAUTHORIZED');
+    }
+
+    const guest = await prisma.guest.findFirst({
+      where: { id: guestId, partyId: party.id },
+    });
+
+    if (!guest) {
+      throw new AppError('Guest not found', 404, 'GUEST_NOT_FOUND');
+    }
+
+    // Defense in depth: don't let a rejected guest's check-in state be toggled.
+    if (guest.approved === false) {
+      throw new AppError('Guest was rejected', 400, 'GUEST_REJECTED');
+    }
+
+    // Idempotent: if guest is not currently checked in, just report that and exit.
+    if (!guest.checkedInAt) {
+      return res.status(200).json({
+        success: true,
+        notCheckedIn: true,
+        guest: {
+          id: guest.id,
+          name: guest.name,
+          email: guest.email,
+          checkedInAt: null,
+          checkedInBy: null,
+        },
+        message: `${guest.name} was not checked in`,
+      });
+    }
+
+    const updatedGuest = await prisma.guest.update({
+      where: { id: guestId },
+      data: {
+        checkedInAt: null,
+        checkedInBy: null,
+      },
+    });
+
+    // Fire-and-forget webhook for guest.checkin_undone (mushroom-31723).
+    // The event type was added to WEBHOOK_EVENTS; subscribers must opt in
+    // via the existing webhook subscription UI/API.
+    try {
+      await triggerWebhook(
+        'guest.checkin_undone',
+        { guest: updatedGuest, partyId: party.id },
+        party.userId!
+      );
+    } catch (webhookErr) {
+      console.error('Webhook trigger failed (non-fatal):', webhookErr);
+    }
+
+    res.status(200).json({
+      success: true,
+      notCheckedIn: false,
+      guest: {
+        id: updatedGuest.id,
+        name: updatedGuest.name,
+        email: updatedGuest.email,
+        checkedInAt: updatedGuest.checkedInAt,
+        checkedInBy: updatedGuest.checkedInBy,
+      },
+      message: `${updatedGuest.name} has been un-checked in`,
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -78,7 +78,8 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
           },
         },
         _count: {
-          select: { guests: true },
+          // mushroom-31723: exclude rejected guests (approved=false) from the public count.
+          select: { guests: { where: { approved: { not: false } } } },
         },
       },
     });

--- a/backend/src/routes/raffle.routes.ts
+++ b/backend/src/routes/raffle.routes.ts
@@ -362,9 +362,10 @@ router.post('/:partyId/raffles/:raffleId/enter', async (req: AuthRequest, res: R
       throw new AppError('Raffle is not open for entries', 400, 'RAFFLE_NOT_OPEN');
     }
 
-    // Verify guest belongs to this party
+    // Verify guest belongs to this party. mushroom-31723: rejected guests
+    // (approved=false) cannot enter raffles.
     const guest = await prisma.guest.findFirst({
-      where: { id: guestId, partyId },
+      where: { id: guestId, partyId, approved: { not: false } },
     });
 
     if (!guest) {

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -24,7 +24,7 @@ router.get('/:inviteCode', async (req: Request, res: Response, next: NextFunctio
         maxGuests: true,
         user: { select: { name: true } },
         guests: {
-          select: { status: true },
+          select: { status: true, approved: true },
         },
       },
     });
@@ -43,7 +43,7 @@ router.get('/:inviteCode', async (req: Request, res: Response, next: NextFunctio
           maxGuests: true,
           user: { select: { name: true } },
           guests: {
-            select: { status: true },
+            select: { status: true, approved: true },
           },
         },
       });
@@ -68,7 +68,7 @@ router.get('/:inviteCode', async (req: Request, res: Response, next: NextFunctio
             maxGuests: true,
             user: { select: { name: true } },
             guests: {
-              select: { status: true },
+              select: { status: true, approved: true },
             },
           },
         });
@@ -81,13 +81,16 @@ router.get('/:inviteCode', async (req: Request, res: Response, next: NextFunctio
 
     const hostName = party.eventType === 'gpp' ? 'PizzaDAO' : (party.user?.name || null);
 
-    // Count confirmed guests (CONFIRMED or PENDING status)
+    // Count confirmed guests (CONFIRMED or PENDING status). Rejected guests
+    // (approved === false, see mushroom-31723) do not count toward capacity.
     const confirmedCount = party.guests.filter(
-      g => g.status === 'CONFIRMED' || g.status === 'PENDING'
+      g => (g.status === 'CONFIRMED' || g.status === 'PENDING') && g.approved !== false
     ).length;
 
-    // Count waitlisted guests
-    const waitlistCount = party.guests.filter(g => g.status === 'WAITLISTED').length;
+    // Count waitlisted guests (excluding rejected — mushroom-31723)
+    const waitlistCount = party.guests.filter(
+      g => g.status === 'WAITLISTED' && g.approved !== false
+    ).length;
 
     // Check if at capacity
     const isAtCapacity = party.maxGuests ? confirmedCount >= party.maxGuests : false;
@@ -368,11 +371,13 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       throw new AppError('RSVPs are closed for this party', 400, 'RSVP_CLOSED');
     }
 
-    // Count confirmed guests to check capacity
+    // Count confirmed guests to check capacity. Rejected guests
+    // (approved === false, see mushroom-31723) do not count toward capacity.
     const confirmedGuestCount = await prisma.guest.count({
       where: {
         partyId: party.id,
         status: { in: ['CONFIRMED', 'PENDING'] },
+        approved: { not: false },
       },
     });
 
@@ -389,6 +394,21 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       });
 
       if (existingGuest) {
+        // mushroom-31723: if the host has rejected this guest (approved=false),
+        // do NOT silently reactivate them. Return the generic "already RSVPd"
+        // response without mutating the row.
+        if (existingGuest.approved === false) {
+          return res.status(200).json({
+            success: true,
+            updated: false,
+            guest: {
+              id: existingGuest.id,
+              name: existingGuest.name,
+            },
+            message: 'Your RSVP has been updated!',
+          });
+        }
+
         // Determine new status for INVITED guests completing RSVP
         let newStatus = existingGuest.status;
         let newWaitlistPosition: number | null = null;
@@ -396,7 +416,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
           if (isAtCapacity) {
             newStatus = 'WAITLISTED';
             const maxPos = await prisma.guest.aggregate({
-              where: { partyId: party.id, status: 'WAITLISTED' },
+              where: { partyId: party.id, status: 'WAITLISTED', approved: { not: false } },
               _max: { waitlistPosition: true },
             });
             newWaitlistPosition = (maxPos._max.waitlistPosition || 0) + 1;
@@ -449,13 +469,14 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       }
     }
 
-    // If at capacity, get next waitlist position
+    // If at capacity, get next waitlist position (excluding rejected — mushroom-31723)
     let waitlistPosition: number | null = null;
     if (isAtCapacity) {
       const maxPosition = await prisma.guest.aggregate({
         where: {
           partyId: party.id,
           status: 'WAITLISTED',
+          approved: { not: false },
         },
         _max: { waitlistPosition: true },
       });

--- a/backend/src/routes/scorecard.routes.ts
+++ b/backend/src/routes/scorecard.routes.ts
@@ -50,13 +50,16 @@ async function findPartyByCode(inviteCode: string) {
   return party;
 }
 
-// Helper: find the authenticated user's guest record for a party
+// Helper: find the authenticated user's guest record for a party.
+// mushroom-31723: rejected guests (approved=false) are excluded so they
+// can't view or edit their scorecard.
 async function findGuestForUser(partyId: string, userEmail?: string) {
   if (!userEmail) return null;
   return prisma.guest.findFirst({
     where: {
       partyId,
       email: userEmail.toLowerCase(),
+      approved: { not: false },
     },
     select: { id: true, checkedInAt: true },
   });

--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -108,6 +108,10 @@ export function buildInviteEmail(
  * /api/v1/parties/{partyId}/guests:
  *   get:
  *     summary: List all guests for a party
+ *     description: |
+ *       Rejected guests (`approved=false`) are excluded by default
+ *       (mushroom-31723). Pass `?approved=false` explicitly to include them,
+ *       or omit the filter to get all non-rejected guests.
  *     tags: [Guests]
  *     security:
  *       - ApiKeyAuth: []
@@ -131,7 +135,7 @@ export function buildInviteEmail(
  *         name: approved
  *         schema:
  *           type: boolean
- *         description: Filter by approval status
+ *         description: Filter by approval status. When omitted, rejected guests (approved=false) are excluded.
  *     responses:
  *       200:
  *         description: List of guests
@@ -148,6 +152,10 @@ router.get('/', requireApiKey(SCOPES.GUESTS_READ), async (req: ApiKeyRequest, re
     const whereClause: any = { partyId };
     if (approvedFilter !== undefined) {
       whereClause.approved = approvedFilter === 'true' ? true : approvedFilter === 'false' ? false : null;
+    } else {
+      // mushroom-31723: by default, exclude rejected guests (approved=false)
+      // so they don't leak into integrations that aren't aware of soft-reject.
+      whereClause.approved = { not: false };
     }
 
     const [guests, total] = await Promise.all([

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -15,6 +15,7 @@ export const WEBHOOK_EVENTS = [
   'guest.removed',
   'guest.waitlisted',
   'guest.promoted',
+  'guest.checkin_undone', // mushroom-31723: emitted when a host un-checks-in a guest
 ] as const;
 
 export type WebhookEvent = typeof WEBHOOK_EVENTS[number];

--- a/plans/mushroom-31723-guest-rejection.md
+++ b/plans/mushroom-31723-guest-rejection.md
@@ -1,0 +1,67 @@
+# mushroom-31723 — Host action recovery: guest reject + un-check-in
+
+**Priority:** P2
+**Type:** Feature / UX
+**Branch:** `mushroom-31723-guest-rejection`
+
+## Problem
+
+Hosts can take two actions today with no in-app undo:
+
+1. **Hard-DELETE a guest** from three places (`GuestCard`, `GuestBasicCard`, `GuestList` via `TableRow`). A Calgary host just deleted a guest by accident; recovery exists only via `deletion_log` + manual SQL (`supabase/migrations/20260429_create_deletion_log.sql`) — terrible UX.
+2. **Check in a guest** from the host dashboard — once `checkedInAt` is stamped, the badge becomes static (`TableRow.tsx:440-447`). No way for the host to fix a mis-tap.
+
+We want both host-facing affordances to be reversible: replace delete with a soft-**reject** (keeps the row, hidden from default view, one-click restore), and add a one-click **un-check-in** on already-checked-in guests.
+
+## Approach — repurpose `approved=false`
+
+Use the existing `approved` boolean as the soft-rejection signal. No new column, no migration. `approved=false` means "host rejected" (hidden from default views); `approved=null` means "needs host action"; `approved=true` means "confirmed by host."
+
+## Decisions
+
+1. Trash button renamed to **"Reject"** universally. No confirm modal (reject is reversible).
+2. Reject does NOT touch `status`. Only `approved=false` carries the signal.
+3. Public RSVP endpoint filters `approved !== false` out of `PublicEvent.guests`.
+4. Hard-delete pulled from host UI entirely. Backend DELETE route stays for API keys + underboss only.
+
+## Backend PR #1 (this PR)
+
+### `backend/src/routes/rsvp.routes.ts`
+- Capacity counter (around line 84-87) currently filters by `status` only. Add `&& g.approved !== false` to BOTH the capacity counter and the waitlist position aggregator (around line 397-402). **Highest regression risk.**
+- Existing-guest-RSVP path (around line 391): if matched guest has `approved === false`, return the generic "already RSVPd" path — don't silently reactivate them.
+- `getEventBySlug` / public event payload: filter the `guests` array to `approved !== false` so rejected guests don't leak into `PublicEvent.guests`.
+
+### `backend/src/routes/checkin.routes.ts`
+- Manual host check-in (POST `/api/checkin/:inviteCode/:guestId`, around line 251): if `guest.approved === false`, throw `AppError('Guest was rejected', 400, 'GUEST_REJECTED')` before stamping `checkedInAt`.
+- **NEW route: DELETE `/api/checkin/:inviteCode/:guestId`** — un-check-in.
+  - Same auth as the POST.
+  - Sets `checkedInAt: null, checkedInBy: null`.
+  - Idempotent: if guest is not currently checked in, return 200 with a "not_checked_in" status, matching the POST's idempotent pattern.
+  - If `guest.approved === false`, return 400 `GUEST_REJECTED` (defense in depth).
+  - Emit webhook event `guest.checkin_undone` if the webhook infra supports new event types; if it requires a schema change to add a new event type, scope that down to: just stamp the DB change, leave a `// TODO(mushroom-31723): emit guest.checkin_undone webhook` comment, and proceed. Don't block on webhook wiring.
+
+### `backend/src/routes/raffle.routes.ts`
+- Raffle entry creation (around line 365-372): add `approved: { not: false }` to the guest lookup `where` so rejected guests can't enter raffles.
+
+### `backend/src/routes/scorecard.routes.ts`
+- `findGuestForUser` (around line 53-59): add `approved: { not: false }` so rejected guests can't view/edit their scorecard.
+
+### `backend/src/routes/v1/guests.ts`
+- GET list (around line 139): currently accepts an `approved` query param. When the param is absent, default to filtering `approved: { not: false }` so rejected guests are excluded by default. Document in the route's JSDoc: "Rejected guests (`approved=false`) are excluded by default. Pass `?approved=false` explicitly to include them."
+
+### `backend/src/routes/party.routes.ts`
+- DO NOT modify the PATCH `/:partyId/guests/:guestId/approve` handler — it already correctly leaves `status` alone when the row is not `PENDING`. Frontend will call it with `{ approved: false }` for reject and `{ approved: true | null }` for restore.
+- DO NOT remove the DELETE `/:partyId/guests/:guestId` route — it stays for the API-key / underboss escape hatch.
+
+## Verification (you must run before opening PR)
+
+1. `cd backend && npm run typecheck` (or whatever the project uses — check `backend/package.json` for the right script; common names: `typecheck`, `tsc`, `build`)
+2. `cd backend && npm run lint` if lint is wired
+3. `cd backend && npm run build` to confirm full TS compilation
+4. If a test suite exists for routes (`backend/src/**/*.test.ts` or similar), run the relevant ones
+
+## Out of scope (frontend PR #2 — DO NOT touch in this PR)
+
+- Any `frontend/` file. PR #2 will handle: `PizzaContext` filtering, `RejectedGuestsModal` component, `TableRow` reject button + uncheckin `×`, `GuestList` header chip, optimistic updates.
+- Don't change DB schema, Prisma, or migrations.
+- Don't change `dbGuestToGuest`, `DbGuest` interface, or `safeColumns` — Option A is zero-schema-change.


### PR DESCRIPTION
## Summary

Backend half of `mushroom-31723` host action recovery. See `plans/mushroom-31723-guest-rejection.md` for the full plan.

- Filters rejected guests (`approved=false`) out of: RSVP capacity counter, waitlist position aggregator, raffle entry lookups, scorecard lookups, public event `guestCount`, and `v1 GET /guests` (when no `approved` query param).
- Rejects check-in attempts on rejected guests (400 `GUEST_REJECTED`).
- Adds **DELETE `/api/checkin/:inviteCode/:guestId`** - host un-check-in. Idempotent. Same auth as the POST.
- Adds `guest.checkin_undone` to `WEBHOOK_EVENTS` and emits it on un-check-in (no schema change - `events` is `String[]`).
- No DB schema changes. No Prisma changes. No migration.
- Frontend wiring (Reject button, RejectedGuestsModal, undo on check-in badge) ships in PR #2 after this lands on master.

## Highest regression risk

`rsvp.routes.ts` capacity counter and waitlist position aggregator - if a rejected guest with `status='CONFIRMED'` still counted toward `maxGuests`, the next real RSVP would be incorrectly bounced to the waitlist. Filter added in both the GET and POST paths, plus the INVITED-completing-RSVP branch.

## Plan deviations

- `PublicEvent.guests` (mentioned in plan) doesn't exist - the public `/api/events/:slug` endpoint only returns `guestCount`. Filtered at the Prisma `_count` level instead.
- The plan said "leave a TODO comment if webhook infra requires schema change". Adding `guest.checkin_undone` is just appending a string to `WEBHOOK_EVENTS` (a TypeScript const tuple); the DB `webhooks.events` column is `String[]`, no schema change needed. Wired it directly.

## Test plan

- [ ] PATCH approve with `{approved:false}` against a CONFIRMED guest -> DB shows `approved=false`, `status` unchanged
- [ ] Subsequent GET on public `/api/events/:slug` -> `guestCount` excludes the rejected guest
- [ ] Subsequent v1 GET `/guests` with no `approved` param -> guest is NOT in the list
- [ ] Subsequent v1 GET `/guests?approved=false` -> guest IS in the list
- [ ] POST `/api/checkin/:inviteCode/:guestId` on the rejected guest -> 400 `GUEST_REJECTED`
- [ ] New DELETE `/api/checkin/:inviteCode/:guestId` on a checked-in guest -> 200, `checkedInAt` is null in DB
- [ ] DELETE on a not-checked-in guest -> 200 with `notCheckedIn: true`
- [ ] DELETE on a rejected guest -> 400 `GUEST_REJECTED`
- [ ] RSVP capacity: create event with `maxGuests=2`, add 2 CONFIRMED, reject one, new RSVP succeeds (not waitlisted)
- [ ] Raffle entry attempt by a rejected guest -> fails with `GUEST_NOT_FOUND`

## Pre-existing TS / test failures noted

- `tsc` errors in `lib/logoBackgroundStrip.ts`, `routes/logoAudit.routes.ts` (missing `sharp`), `middleware/auth.test.ts` (jsonwebtoken types), `routes/checklist.routes.ts`, `routes/host-telegram.routes.ts`, `routes/telegram*.routes.ts`, `routes/gpp.routes.ts`, `helpers/statusAudit.ts` - all Prisma schema-drift issues on master, not in the files this PR touches.
- 10 vitest failures in `rsvp.routes.test.ts`, `party.routes.test.ts`, `photo.routes.test.ts` - mocks don't include `slugAlias.findUnique` (called on master too), so any test that lets the route fall through to the alias lookup hits a TypeError. Pre-existing.