### PR TITLE
feat(olive-10562): kill-switch infrastructure for opt-in A/B test (Phase 1)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1295,6 +1295,20 @@ model AppConfig {
 }
 
 // ============================================
+// Experiment Flags (kill switches)
+// ============================================
+
+model ExperimentFlag {
+  key         String   @id
+  enabled     Boolean  @default(false)
+  description String?
+  updatedAt   DateTime @default(now()) @map("updated_at") @db.Timestamptz
+  updatedBy   String?  @map("updated_by")
+
+  @@map("experiment_flags")
+}
+
+// ============================================
 // Quiz Models
 // ============================================
 

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -838,4 +838,45 @@ router.get('/experiments/optin-ab', requireAuth, async (req: AuthRequest, res: R
   }
 });
 
+router.get('/experiments/flags', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const flags = await prisma.experimentFlag.findMany({ orderBy: { key: 'asc' } });
+    res.set('Cache-Control', 'no-store');
+    res.json({ flags });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch('/experiments/flags/:key', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const { key } = req.params;
+    const { enabled } = req.body ?? {};
+    if (typeof enabled !== 'boolean') {
+      throw new AppError('enabled (boolean) is required', 400, 'VALIDATION_ERROR');
+    }
+    const existing = await prisma.experimentFlag.findUnique({ where: { key } });
+    if (!existing) {
+      throw new AppError('Flag not found', 404, 'NOT_FOUND');
+    }
+    const updated = await prisma.experimentFlag.update({
+      where: { key },
+      data: {
+        enabled,
+        updatedAt: new Date(),
+        updatedBy: req.userEmail ?? null,
+      },
+    });
+    res.json({ flag: updated });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/frontend/src/components/underboss/OptinABTab.tsx
+++ b/frontend/src/components/underboss/OptinABTab.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Loader2, RefreshCw } from 'lucide-react';
-import { fetchOptinABResults } from '../../lib/api';
-import type { OptinABResults, OptinABArm } from '../../lib/api';
+import { fetchOptinABResults, fetchExperimentFlags, setExperimentFlag } from '../../lib/api';
+import type { OptinABResults, OptinABArm, ExperimentFlag } from '../../lib/api';
+import { Checkbox } from '../Checkbox';
+
+const FLAG_KEY = 'optin_ab_pizzadao_partners';
 
 // MDE sample-size targets (per arm).
 const N_10PP = 330;
@@ -99,6 +102,10 @@ export function OptinABTab() {
   const [data, setData] = useState<OptinABResults | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [flag, setFlag] = useState<ExperimentFlag | null>(null);
+  const [flagLoading, setFlagLoading] = useState(true);
+  const [showConfirm, setShowConfirm] = useState<null | { nextEnabled: boolean }>(null);
+  const [flipping, setFlipping] = useState(false);
 
   async function load() {
     setLoading(true);
@@ -115,6 +122,17 @@ export function OptinABTab() {
 
   useEffect(() => {
     void load();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      setFlagLoading(true);
+      const flags = await fetchExperimentFlags();
+      if (flags) {
+        setFlag(flags.find((f) => f.key === FLAG_KEY) ?? null);
+      }
+      setFlagLoading(false);
+    })();
   }, []);
 
   const control = data?.arms.find((a) => a.arm === 'control');
@@ -163,6 +181,73 @@ export function OptinABTab() {
 
       {error && !loading && (
         <p className="text-theme-text-muted text-center py-8">{error}</p>
+      )}
+
+      <div className="mt-6 mb-6 p-4 border border-theme-stroke rounded-xl bg-theme-surface">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-sm font-semibold text-theme-text">Experiment kill switch</div>
+            <div className="text-xs text-theme-text-muted mt-1">
+              {flagLoading ? 'Loading…' : flag?.description ?? 'Flag not found'}
+            </div>
+            {flag && (
+              <div className="text-[11px] text-theme-text-faint mt-2">
+                Last changed {new Date(flag.updatedAt).toLocaleString()}
+                {flag.updatedBy ? ` by ${flag.updatedBy}` : ''}
+              </div>
+            )}
+          </div>
+          <Checkbox
+            checked={!!flag?.enabled}
+            onChange={() => {
+              if (!flag || flagLoading || flipping) return;
+              setShowConfirm({ nextEnabled: !flag.enabled });
+            }}
+            label={flag?.enabled ? 'ON' : 'OFF'}
+            labelClassName={`text-sm font-semibold ${flag?.enabled ? 'text-[#E52828]' : 'text-theme-text-muted'}`}
+            disabled={!flag || flagLoading || flipping}
+          />
+        </div>
+      </div>
+
+      {showConfirm && flag && (
+        <div
+          className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+          onClick={() => !flipping && setShowConfirm(null)}
+        >
+          <div className="card p-6 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold text-theme-text mb-2">
+              Turn experiment {showConfirm.nextEnabled ? 'ON' : 'OFF'}?
+            </h3>
+            <p className="text-sm text-theme-text-secondary mb-4">
+              {showConfirm.nextEnabled
+                ? 'Variant arm will start receiving traffic on US (swc) RSVPs. ~50% of new RSVPs on swc-tagged events will see the combined PizzaDAO + partners checkbox.'
+                : 'All US (swc) RSVPs revert to the two-checkbox baseline. Existing variant-bucketed guests keep their assignment for edit-RSVP and analytics.'}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowConfirm(null)}
+                disabled={flipping}
+                className="px-4 py-2 text-sm text-theme-text-secondary hover:bg-white/40 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={async () => {
+                  setFlipping(true);
+                  const updated = await setExperimentFlag(FLAG_KEY, showConfirm.nextEnabled);
+                  if (updated) setFlag(updated);
+                  setFlipping(false);
+                  setShowConfirm(null);
+                }}
+                disabled={flipping}
+                className="px-4 py-2 text-sm font-medium bg-[#E52828] text-white rounded-lg hover:bg-[#CC2020] disabled:opacity-50"
+              >
+                {flipping ? 'Saving…' : `Turn ${showConfirm.nextEnabled ? 'ON' : 'OFF'}`}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {data && control && variant && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3491,6 +3491,41 @@ export async function fetchOptinABResults(): Promise<OptinABResults | null> {
   }
 }
 
+export interface ExperimentFlag {
+  key: string;
+  enabled: boolean;
+  description: string | null;
+  updatedAt: string;
+  updatedBy: string | null;
+}
+
+export async function fetchExperimentFlags(): Promise<ExperimentFlag[] | null> {
+  try {
+    const res = await apiRequest<{ flags: ExperimentFlag[] }>('/api/admin/experiments/flags', {
+      method: 'GET',
+      requireAuth: true,
+    });
+    return res.flags;
+  } catch (error) {
+    console.error('Error fetching experiment flags:', error);
+    return null;
+  }
+}
+
+export async function setExperimentFlag(key: string, enabled: boolean): Promise<ExperimentFlag | null> {
+  try {
+    const res = await apiRequest<{ flag: ExperimentFlag }>(`/api/admin/experiments/flags/${encodeURIComponent(key)}`, {
+      method: 'PATCH',
+      body: { enabled },
+      requireAuth: true,
+    });
+    return res.flag;
+  } catch (error) {
+    console.error('Error setting experiment flag:', error);
+    return null;
+  }
+}
+
 // ── Guest Scorecard ──
 
 export interface ScorecardItem {

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -2033,4 +2033,18 @@ export async function saveUserPreferences(
   }
 }
 
+export async function getExperimentFlag(key: string): Promise<boolean> {
+  try {
+    const { data, error } = await supabase
+      .from('experiment_flags')
+      .select('enabled')
+      .eq('key', key)
+      .single();
+    if (error || !data) return false;
+    return data.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
 // ============================================

--- a/supabase/migrations/20260518_create_experiment_flags.sql
+++ b/supabase/migrations/20260518_create_experiment_flags.sql
@@ -1,0 +1,38 @@
+-- Generic experiment / feature flag registry.
+-- Each row is a single named on/off switch. Public clients can SELECT
+-- (key, enabled) so the RSVP form can gate experiments without a backend
+-- round-trip. Writes go through the backend (service_role) only.
+
+CREATE TABLE IF NOT EXISTS experiment_flags (
+  key         TEXT PRIMARY KEY,
+  enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+  description TEXT,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by  TEXT
+);
+
+-- Seed parmesan-98989 with the experiment OFF. Snax flips it on from /admin
+-- once SWC legal sign-off is in hand.
+INSERT INTO experiment_flags (key, enabled, description)
+VALUES (
+  'optin_ab_pizzadao_partners',
+  false,
+  'parmesan-98989: combined PizzaDAO+SWC opt-in checkbox A/B test (US swc events). When OFF, all swc RSVPs render the two-checkbox baseline and no optin_ab_variant is written.'
+) ON CONFLICT (key) DO NOTHING;
+
+-- Column-level public read of just (key, enabled). description / updated_at /
+-- updated_by stay admin-only via the backend endpoint.
+GRANT SELECT (key, enabled) ON experiment_flags TO anon, authenticated;
+
+-- All writes go through the backend (service_role bypasses RLS / grants).
+-- Do not GRANT UPDATE / INSERT / DELETE to anon or authenticated.
+
+-- RLS: enable and add a permissive SELECT policy for the two readable columns.
+-- The column-level GRANT above is the actual hardening; RLS is added per the
+-- February 2026 security-audit pattern so the table isn't an exception to the
+-- lockdown convention.
+ALTER TABLE experiment_flags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can read experiment flags"
+  ON experiment_flags FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary
- Generic `experiment_flags(key, enabled, description, updated_at, updated_by)` table with public column-level SELECT (key, enabled) and admin-only writes via service_role.
- Backend: `GET /api/admin/experiments/flags` + `PATCH /api/admin/experiments/flags/:key`, both admin-gated.
- Frontend: `getExperimentFlag(key)` public read helper (fail-closed) + admin client helpers.
- Kill-switch toggle panel in `/admin` -> Experiments tab with confirmation modal and "last changed by X at T".
- Seed row `optin_ab_pizzadao_partners` ships with `enabled = false` (kill switch armed but harmless).

## Pre-merge checklist
- [ ] Apply migration `20260518_create_experiment_flags.sql` to prod via Supabase MCP.
- [ ] After merge: redeploy backend (`cd backend && vercel --prod --scope pizza-dao`).
- [ ] Verify in `/admin` -> Experiments: toggle renders OFF with description text. Click -> confirmation modal opens. Confirm -> flag flips and `updated_by` shows admin email.

## Phase 2 follow-up (do not include in this PR)
After this merges, add the flag-gate to the parmesan-98989 branch:
- File: `frontend/src/hooks/useRSVPForm.ts` (on `parmesan-98989-combined-optin` branch)
- Change: convert the sync `useState` variant initializer into preservation-only + async `useEffect` that calls `getExperimentFlag('optin_ab_pizzadao_partners')` before rolling.
- ~25 lines. See `plans/olive-10562-optin-ab-kill-switch.md` §5 for exact code.

## Emergency off switch
If the admin UI is broken, flip the flag via direct SQL:
`UPDATE experiment_flags SET enabled = false WHERE key = 'optin_ab_pizzadao_partners';`

## Test plan
- [ ] Toggle defaults to OFF on first load.
- [ ] Admin: non-admin auth -> 403 from PATCH. Unauthenticated -> 401.
- [ ] Public read: `SELECT enabled FROM experiment_flags WHERE key = '...'` works without auth (and returns false initially).
- [ ] Toggle ON -> confirmation modal with "ON" copy. Confirm -> flag flips, `updated_at` and `updated_by` populate.
- [ ] Toggle OFF -> confirmation modal with "OFF" copy. Confirm -> flag flips back.
- [ ] Fail-closed: simulated supabase 500 -> `getExperimentFlag` returns false (caller sees "not enabled").