### PR TITLE
feat(arugula-38633): payout execution rails (PR 5/5)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,8 @@
     "nanoid": "^5.0.5",
     "sharp": "^0.33.5",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "viem": "^2.44.4"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -46,6 +46,7 @@ import hostTelegramRoutes from './routes/host-telegram.routes.js';
 import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
+import adminPayoutRoutes from './routes/admin-payout.routes.js';
 import graphicsAdminRoutes from './routes/graphics-admin.routes.js';
 import logoAuditRoutes from './routes/logoAudit.routes.js';
 import { sponsorUserAdminRouter, sponsorDashboardRouter } from './routes/sponsor-user.routes.js';
@@ -116,6 +117,7 @@ app.use('/api/rsvp', rsvpLimiter);
 
 // Routes
 app.use('/api/admin/logo-bg-audit', logoAuditRoutes); // Graphics-admin logo cleanup (before /api/admin catch-all)
+app.use('/api/admin/payouts', adminPayoutRoutes); // Host payouts admin dashboard (before /api/admin catch-all)
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/telegram/webhook', telegramWebhookRoutes); // Telegram inbound webhook (no auth — secret-token header gate)

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -17,7 +17,7 @@ vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
 // Set JWT_SECRET before importing auth module
 process.env.JWT_SECRET = JWT_SECRET;
 
-import { requireAuth, optionalAuth, isSuperAdmin, AuthRequest } from './auth.js';
+import { requireAuth, optionalAuth, isAdmin, isSuperAdmin, isPaymentAdmin, isFullAdmin, AuthRequest } from './auth.js';
 import { errorHandler } from './error.js';
 
 function createTestApp(middleware: any) {
@@ -196,5 +196,126 @@ describe('isSuperAdmin', () => {
     expect(mockPrisma.admin.findUnique).toHaveBeenCalledWith({
       where: { email: 'admin@example.com' },
     });
+  });
+});
+
+describe('isAdmin (tightened — excludes payment_admin)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for role=admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+    expect(await isAdmin('admin@example.com')).toBe(true);
+  });
+
+  it('returns true for role=super_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'super@example.com',
+      role: 'super_admin',
+    });
+    expect(await isAdmin('super@example.com')).toBe(true);
+  });
+
+  // Behavioral change (arugula-38633 PR 2): payment_admin must NOT pass isAdmin.
+  it('returns false for role=payment_admin (behavioral change)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'finance@example.com',
+      role: 'payment_admin',
+    });
+    expect(await isAdmin('finance@example.com')).toBe(false);
+  });
+
+  it('returns false when there is no admin row', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue(null);
+    expect(await isAdmin('nobody@example.com')).toBe(false);
+  });
+
+  it('returns false for undefined email', async () => {
+    expect(await isAdmin(undefined)).toBe(false);
+    expect(mockPrisma.admin.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('isPaymentAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for role=payment_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'finance@example.com',
+      role: 'payment_admin',
+    });
+    expect(await isPaymentAdmin('finance@example.com')).toBe(true);
+  });
+
+  it('returns true for role=admin (full admins also get in)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+    expect(await isPaymentAdmin('admin@example.com')).toBe(true);
+  });
+
+  it('returns true for role=super_admin (full admins also get in)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'super@example.com',
+      role: 'super_admin',
+    });
+    expect(await isPaymentAdmin('super@example.com')).toBe(true);
+  });
+
+  it('returns false for non-admin email (no admin row)', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue(null);
+    expect(await isPaymentAdmin('user@example.com')).toBe(false);
+  });
+
+  it('returns false for undefined email', async () => {
+    expect(await isPaymentAdmin(undefined)).toBe(false);
+    expect(mockPrisma.admin.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('isFullAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for role=admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+    expect(await isFullAdmin('admin@example.com')).toBe(true);
+  });
+
+  it('returns true for role=super_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'super@example.com',
+      role: 'super_admin',
+    });
+    expect(await isFullAdmin('super@example.com')).toBe(true);
+  });
+
+  it('returns false for role=payment_admin', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue({
+      email: 'finance@example.com',
+      role: 'payment_admin',
+    });
+    expect(await isFullAdmin('finance@example.com')).toBe(false);
+  });
+
+  it('returns false when there is no admin row', async () => {
+    mockPrisma.admin.findUnique.mockResolvedValue(null);
+    expect(await isFullAdmin('user@example.com')).toBe(false);
+  });
+
+  it('returns false for undefined email', async () => {
+    expect(await isFullAdmin(undefined)).toBe(false);
+    expect(mockPrisma.admin.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -8,11 +8,14 @@ export interface AuthRequest extends Request {
   userEmail?: string;
 }
 
-// Check if the user is any kind of admin (DB-backed)
+// Check if the user is a full admin (DB-backed): role IN ('admin', 'super_admin').
+// IMPORTANT: This was tightened on 2026-05-17 (arugula-38633 PR 2) to exclude the
+// new 'payment_admin' role. payment_admin gates ONLY the future /payments dashboard
+// and must NOT be treated as a regular admin anywhere else in the system.
 export async function isAdmin(email?: string): Promise<boolean> {
   if (!email) return false;
   const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
-  return !!admin;
+  return admin?.role === 'admin' || admin?.role === 'super_admin';
 }
 
 // Check if the user is a super admin (DB-backed)
@@ -20,6 +23,28 @@ export async function isSuperAdmin(email?: string): Promise<boolean> {
   if (!email) return false;
   const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
   return admin?.role === 'super_admin';
+}
+
+// Check if the user is allowed in the host-payments dashboard: returns true for
+// payment_admin, admin, OR super_admin. Full admins always get in too.
+export async function isPaymentAdmin(email?: string): Promise<boolean> {
+  if (!email) return false;
+  const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
+  return (
+    admin?.role === 'payment_admin' ||
+    admin?.role === 'admin' ||
+    admin?.role === 'super_admin'
+  );
+}
+
+// Explicit "full admin powers needed" check: returns true ONLY for the two
+// legacy full-admin roles. Use this when you want to be unambiguous that
+// payment_admin should NOT qualify. Equivalent to the current isAdmin() but
+// semantically clearer at the callsite.
+export async function isFullAdmin(email?: string): Promise<boolean> {
+  if (!email) return false;
+  const admin = await prisma.admin.findUnique({ where: { email: email.toLowerCase() } });
+  return admin?.role === 'admin' || admin?.role === 'super_admin';
 }
 
 // Check if the user is an active underboss (DB-backed)

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1,0 +1,860 @@
+/**
+ * Admin host-payouts dashboard routes.
+ *
+ * Mounted at `/api/admin/payouts` (see backend/src/index.ts).
+ *
+ * Auth model:
+ *  - All endpoints require `requireAuth` + `requireAnyAdminOrPaymentAdmin`
+ *    (admin / super_admin / payment_admin).
+ *  - For mutating endpoints (PATCH, approve, reject, mark-paid, execute), a
+ *    `payment_admin` actor CANNOT operate on a payout whose `hostUserId`
+ *    matches their own user id — see `assertNotSelfPayout()`. Full admins
+ *    (admin / super_admin) are exempt from this restriction.
+ *
+ * Execute Payout (POST /:id/execute) is intentionally a 501 stub here — PR 5
+ * wires in the actual Mercury / wire / USDC-via-Privy execution paths.
+ */
+import { Router, Request, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import {
+  requireAuth,
+  AuthRequest,
+  isPaymentAdmin,
+  isFullAdmin,
+} from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+
+const router = Router();
+
+const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed'] as const;
+const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
+
+type AdminActorKind = 'admin' | 'superadmin' | 'payment_admin';
+
+/**
+ * Loads the admin row + the currently-authenticated user's id (used for
+ * self-payout restriction). Returns `null` for either if the lookup fails.
+ */
+async function loadActor(req: AuthRequest): Promise<{
+  email: string;
+  adminRole: string;
+  actorKind: AdminActorKind;
+  userId: string | null;
+  isFull: boolean;
+}> {
+  const email = req.userEmail?.toLowerCase();
+  if (!email) {
+    throw new AppError('Missing actor email', 401, 'UNAUTHORIZED');
+  }
+
+  const admin = await prisma.admin.findUnique({
+    where: { email },
+    select: { role: true },
+  });
+  if (!admin) {
+    // Shouldn't happen because requireAnyAdminOrPaymentAdmin guards earlier,
+    // but defensive.
+    throw new AppError('Admin record not found', 403, 'FORBIDDEN');
+  }
+
+  const actorKind: AdminActorKind =
+    admin.role === 'super_admin' ? 'superadmin' :
+    admin.role === 'payment_admin' ? 'payment_admin' :
+    'admin';
+
+  // Self-payout restriction needs the user id linked to this email so we can
+  // compare to payout.hostUserId. Best-effort lookup — many admins are not
+  // also hosts, in which case there's nothing to compare.
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+
+  return {
+    email,
+    adminRole: admin.role,
+    actorKind,
+    userId: user?.id ?? null,
+    isFull: actorKind !== 'payment_admin',
+  };
+}
+
+/**
+ * Middleware: allow admin / super_admin / payment_admin only.
+ * Composed inline as we need access to req.userEmail set by requireAuth.
+ */
+async function requireAnyAdminOrPaymentAdmin(
+  req: AuthRequest,
+  _res: Response,
+  next: NextFunction
+) {
+  try {
+    if (!(await isPaymentAdmin(req.userEmail))) {
+      throw new AppError('Payments admin access required', 403, 'FORBIDDEN');
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * payment_admin cannot approve / edit / execute their own payouts. Full admins
+ * (admin / super_admin) bypass this check.
+ */
+function assertNotSelfPayout(
+  actor: { actorKind: AdminActorKind; userId: string | null; isFull: boolean },
+  payoutHostUserId: string,
+) {
+  if (actor.isFull) return;
+  if (actor.userId && actor.userId === payoutHostUserId) {
+    throw new AppError(
+      'payment_admin cannot operate on a payout they would receive',
+      403,
+      'SELF_PAYOUT_FORBIDDEN',
+    );
+  }
+}
+
+function escapeCSV(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Build a Prisma `where` clause from query-string filters. */
+function buildPayoutWhere(query: Request['query']): any {
+  const where: any = {};
+
+  const status = query.status;
+  if (typeof status === 'string' && status !== 'all' && ALLOWED_PAYOUT_STATUSES.includes(status as any)) {
+    where.status = status;
+  }
+
+  const method = query.payoutMethod;
+  if (typeof method === 'string' && method !== 'all' && ALLOWED_PAYOUT_METHODS.includes(method as any)) {
+    where.payoutMethod = method;
+  }
+
+  const partyId = query.partyId;
+  if (typeof partyId === 'string' && partyId.trim().length > 0) {
+    where.partyId = partyId.trim();
+  }
+
+  const hostEmail = query.hostEmail;
+  if (typeof hostEmail === 'string' && hostEmail.trim().length > 0) {
+    where.host = {
+      email: { contains: hostEmail.trim().toLowerCase(), mode: 'insensitive' as const },
+    };
+  }
+
+  const currency = query.currency;
+  if (typeof currency === 'string' && currency !== 'all' && currency.trim().length > 0) {
+    where.originalCurrency = currency.trim().toUpperCase();
+  }
+
+  const dateFrom = query.dateFrom;
+  const dateTo = query.dateTo;
+  if (typeof dateFrom === 'string' || typeof dateTo === 'string') {
+    where.createdAt = {} as any;
+    if (typeof dateFrom === 'string' && dateFrom) {
+      where.createdAt.gte = new Date(dateFrom);
+    }
+    if (typeof dateTo === 'string' && dateTo) {
+      where.createdAt.lte = new Date(dateTo);
+    }
+  }
+
+  return where;
+}
+
+/** Shape a Prisma payout row for the API response. */
+function serializePayout(row: any): any {
+  return {
+    id: row.id,
+    partyId: row.partyId,
+    hostUserId: row.hostUserId,
+    originalAmount: Number(row.originalAmount),
+    originalCurrency: row.originalCurrency,
+    exchangeRate: Number(row.exchangeRate),
+    extractedAmountUsd: Number(row.extractedAmountUsd),
+    finalAmountUsd: Number(row.finalAmountUsd),
+    status: row.status,
+    payoutMethod: row.payoutMethod,
+    payoutWalletAddress: row.payoutWalletAddress,
+    payoutBankDetails: row.payoutBankDetails,
+    mercuryCardId: row.mercuryCardId,
+    mercuryCardLast4: row.mercuryCardLast4,
+    hostNotes: row.hostNotes,
+    adminNotes: row.adminNotes,
+    rejectionReason: row.rejectionReason,
+    reviewedBy: row.reviewedBy,
+    reviewedAt: row.reviewedAt ? row.reviewedAt.toISOString() : null,
+    paidAt: row.paidAt ? row.paidAt.toISOString() : null,
+    transactionHash: row.transactionHash,
+    wireReference: row.wireReference,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    documents: (row.documents || []).map((d: any) => ({
+      id: d.id,
+      kind: d.kind,
+      url: d.url,
+      fileName: d.fileName,
+      fileSize: d.fileSize,
+      mimeType: d.mimeType,
+      ocrAmount: d.ocrAmount == null ? null : Number(d.ocrAmount),
+      ocrCurrency: d.ocrCurrency,
+      ocrConfidence: d.ocrConfidence == null ? null : Number(d.ocrConfidence),
+      ocrError: d.ocrError,
+      sortOrder: d.sortOrder,
+    })),
+    party: row.party
+      ? {
+          id: row.party.id,
+          name: row.party.name,
+          inviteCode: row.party.inviteCode,
+          customUrl: row.party.customUrl,
+        }
+      : undefined,
+    host: row.host
+      ? {
+          id: row.host.id,
+          name: row.host.name,
+          email: row.host.email,
+        }
+      : undefined,
+    audits: row.audits
+      ? row.audits.map((a: any) => ({
+          id: a.id,
+          action: a.action,
+          oldStatus: a.oldStatus,
+          newStatus: a.newStatus,
+          oldAmount: a.oldAmount == null ? null : Number(a.oldAmount),
+          newAmount: a.newAmount == null ? null : Number(a.newAmount),
+          actorEmail: a.actorEmail,
+          actorKind: a.actorKind,
+          note: a.note,
+          createdAt: a.createdAt.toISOString(),
+        }))
+      : undefined,
+  };
+}
+
+// ============================================
+// GET /api/admin/payouts/export.csv
+//   - Must be declared BEFORE GET /:id so the literal path wins.
+// ============================================
+router.get(
+  '/export.csv',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const where = buildPayoutWhere(req.query);
+      const rows = await prisma.payout.findMany({
+        where,
+        include: {
+          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          host: { select: { id: true, name: true, email: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      const headers = [
+        'Payout ID',
+        'Created At',
+        'Status',
+        'Method',
+        'Host Name',
+        'Host Email',
+        'Party Name',
+        'Party Invite Code',
+        'Original Amount',
+        'Original Currency',
+        'Exchange Rate',
+        'Extracted USD',
+        'Final USD',
+        'Reviewed By',
+        'Reviewed At',
+        'Paid At',
+        'Wire Reference',
+        'Transaction Hash',
+        'Mercury Card Last4',
+        'Admin Notes',
+        'Rejection Reason',
+      ];
+      const csvRows = [headers.join(',')];
+
+      for (const r of rows) {
+        const row = [
+          escapeCSV(r.id),
+          escapeCSV(r.createdAt.toISOString()),
+          escapeCSV(r.status),
+          escapeCSV(r.payoutMethod),
+          escapeCSV(r.host?.name || ''),
+          escapeCSV(r.host?.email || ''),
+          escapeCSV(r.party?.name || ''),
+          escapeCSV(r.party?.inviteCode || ''),
+          escapeCSV(String(Number(r.originalAmount))),
+          escapeCSV(r.originalCurrency || ''),
+          escapeCSV(String(Number(r.exchangeRate))),
+          escapeCSV(String(Number(r.extractedAmountUsd))),
+          escapeCSV(String(Number(r.finalAmountUsd))),
+          escapeCSV(r.reviewedBy || ''),
+          escapeCSV(r.reviewedAt ? r.reviewedAt.toISOString() : ''),
+          escapeCSV(r.paidAt ? r.paidAt.toISOString() : ''),
+          escapeCSV(r.wireReference || ''),
+          escapeCSV(r.transactionHash || ''),
+          escapeCSV(r.mercuryCardLast4 || ''),
+          escapeCSV(r.adminNotes || ''),
+          escapeCSV(r.rejectionReason || ''),
+        ];
+        csvRows.push(row.join(','));
+      }
+
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', 'attachment; filename=host-payouts-export.csv');
+      res.send(csvRows.join('\n'));
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// GET /api/admin/payouts — list with filters + totals + cursor pagination
+// ============================================
+router.get(
+  '/',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const where = buildPayoutWhere(req.query);
+
+      const rawLimit = parseInt(String(req.query.limit ?? '50'), 10);
+      const limit = Math.min(
+        Math.max(Number.isFinite(rawLimit) ? rawLimit : 50, 1),
+        100,
+      );
+
+      const cursor = typeof req.query.cursor === 'string' && req.query.cursor.length > 0
+        ? req.query.cursor
+        : undefined;
+
+      const findArgs: any = {
+        where,
+        include: {
+          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          host: { select: { id: true, name: true, email: true } },
+          documents: { orderBy: { sortOrder: 'asc' } },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: limit + 1,
+      };
+      if (cursor) {
+        findArgs.cursor = { id: cursor };
+        findArgs.skip = 1;
+      }
+
+      const rows = await prisma.payout.findMany(findArgs);
+
+      let nextCursor: string | null = null;
+      const page = rows.slice(0, limit);
+      if (rows.length > limit) {
+        nextCursor = page[page.length - 1]?.id ?? null;
+      }
+
+      // Totals — computed over the filtered set (NOT just the current page),
+      // so the dashboard pills reflect the user's current filters.
+      const allFiltered = await prisma.payout.findMany({
+        where,
+        select: {
+          status: true,
+          payoutMethod: true,
+          finalAmountUsd: true,
+          createdAt: true,
+          paidAt: true,
+        },
+      });
+
+      const byStatus: Record<string, number> = {};
+      const byMethod: Record<string, number> = {};
+      let totalUsdPending = 0;
+      let totalUsdPaid = 0;
+      let totalUsdThisMonth = 0;
+      let sumUsd = 0;
+      let awaitingReview = 0;
+
+      const now = new Date();
+      const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+      for (const r of allFiltered) {
+        byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+        byMethod[r.payoutMethod] = (byMethod[r.payoutMethod] || 0) + 1;
+        const usd = Number(r.finalAmountUsd);
+        sumUsd += usd;
+        if (r.status === 'pending') {
+          totalUsdPending += usd;
+          awaitingReview += 1;
+        } else if (r.status === 'paid') {
+          totalUsdPaid += usd;
+          if (r.paidAt && r.paidAt >= startOfMonth) {
+            totalUsdThisMonth += usd;
+          }
+        }
+      }
+
+      const avgUsd = allFiltered.length > 0 ? sumUsd / allFiltered.length : 0;
+
+      res.json({
+        payouts: page.map(serializePayout),
+        nextCursor,
+        totals: {
+          byStatus,
+          byMethod,
+          totalUsdPending,
+          totalUsdPaid,
+          totalUsdThisMonth,
+          avgUsd,
+          awaitingReview,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// GET /api/admin/payouts/:id — full detail incl. audit history
+// ============================================
+router.get(
+  '/:id',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const row = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        include: {
+          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          host: { select: { id: true, name: true, email: true } },
+          documents: { orderBy: { sortOrder: 'asc' } },
+          audits: { orderBy: { createdAt: 'desc' } },
+        },
+      });
+
+      if (!row) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+
+      res.json({ payout: serializePayout(row) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// PATCH /api/admin/payouts/:id — edit amount / notes / method / target
+// ============================================
+router.patch(
+  '/:id',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: {
+          id: true,
+          status: true,
+          hostUserId: true,
+          finalAmountUsd: true,
+        },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status === 'paid') {
+        throw new AppError('Cannot edit a payout that is already paid', 400, 'ALREADY_PAID');
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const data: any = {};
+      const {
+        finalAmountUsd,
+        adminNotes,
+        payoutMethod,
+        payoutWalletAddress,
+        payoutBankDetails,
+      } = req.body || {};
+
+      let amountChanged = false;
+      let oldAmount: number | null = null;
+      let newAmount: number | null = null;
+
+      if (finalAmountUsd !== undefined) {
+        const parsed = Number(finalAmountUsd);
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          throw new AppError('finalAmountUsd must be a non-negative number', 400, 'VALIDATION_ERROR');
+        }
+        oldAmount = Number(existing.finalAmountUsd);
+        newAmount = parsed;
+        if (oldAmount !== newAmount) {
+          amountChanged = true;
+          data.finalAmountUsd = parsed;
+        }
+      }
+
+      if (adminNotes !== undefined) {
+        data.adminNotes = adminNotes === null ? null : String(adminNotes);
+      }
+
+      if (payoutMethod !== undefined) {
+        if (!ALLOWED_PAYOUT_METHODS.includes(payoutMethod)) {
+          throw new AppError('Invalid payoutMethod', 400, 'VALIDATION_ERROR');
+        }
+        data.payoutMethod = payoutMethod;
+      }
+
+      if (payoutWalletAddress !== undefined) {
+        data.payoutWalletAddress = payoutWalletAddress === null
+          ? null
+          : String(payoutWalletAddress).trim();
+      }
+
+      if (payoutBankDetails !== undefined) {
+        data.payoutBankDetails = payoutBankDetails;
+      }
+
+      if (Object.keys(data).length === 0) {
+        throw new AppError('No editable fields supplied', 400, 'VALIDATION_ERROR');
+      }
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data,
+          include: {
+            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            host: { select: { id: true, name: true, email: true } },
+            documents: { orderBy: { sortOrder: 'asc' } },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        if (amountChanged) {
+          await tx.payoutAudit.create({
+            data: {
+              payoutId: existing.id,
+              action: 'edit_amount',
+              oldAmount: oldAmount as any,
+              newAmount: newAmount as any,
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: typeof req.body?.note === 'string' ? req.body.note : null,
+            },
+          });
+        }
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/approve
+// ============================================
+router.post(
+  '/:id/approve',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'pending') {
+        throw new AppError(
+          `Can only approve a pending payout (current status: ${existing.status})`,
+          400,
+          'INVALID_STATE',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const { note, autoExecute } = req.body || {};
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: {
+            status: 'approved',
+            reviewedBy: actor.email,
+            reviewedAt: new Date(),
+          },
+          include: {
+            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            host: { select: { id: true, name: true, email: true } },
+            documents: { orderBy: { sortOrder: 'asc' } },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'approve',
+            oldStatus: 'pending',
+            newStatus: 'approved',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: typeof note === 'string' ? note : null,
+          },
+        });
+
+        return row;
+      });
+
+      // autoExecute is plumbed through but execution itself lands in PR 5.
+      // For now we just log the intent — no payout rail fires.
+      if (autoExecute) {
+        console.log(
+          `[admin-payout] approve+autoExecute requested for payout=${existing.id} ` +
+            `actor=${actor.email} — execution wired in PR 5, no-op for now`,
+        );
+      }
+
+      res.json({
+        payout: serializePayout(updated),
+        autoExecuteDeferred: !!autoExecute,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/reject
+// ============================================
+router.post(
+  '/:id/reject',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status === 'paid') {
+        throw new AppError('Cannot reject a paid payout', 400, 'INVALID_STATE');
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const reason = typeof req.body?.rejectionReason === 'string'
+        ? req.body.rejectionReason.trim()
+        : '';
+      if (!reason) {
+        throw new AppError('rejectionReason is required', 400, 'VALIDATION_ERROR');
+      }
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: {
+            status: 'rejected',
+            rejectionReason: reason,
+            reviewedBy: actor.email,
+            reviewedAt: new Date(),
+          },
+          include: {
+            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            host: { select: { id: true, name: true, email: true } },
+            documents: { orderBy: { sortOrder: 'asc' } },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'reject',
+            oldStatus: existing.status,
+            newStatus: 'rejected',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: reason,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/mark-paid — manual override (out-of-band)
+// ============================================
+router.post(
+  '/:id/mark-paid',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status === 'paid') {
+        throw new AppError('Payout is already paid', 400, 'INVALID_STATE');
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const {
+        wireReference,
+        transactionHash,
+        mercuryCardLast4,
+        mercuryCardId,
+        note,
+      } = req.body || {};
+
+      const data: any = {
+        status: 'paid',
+        paidAt: new Date(),
+      };
+      if (wireReference !== undefined) {
+        data.wireReference = wireReference == null ? null : String(wireReference).trim();
+      }
+      if (transactionHash !== undefined) {
+        data.transactionHash = transactionHash == null ? null : String(transactionHash).trim();
+      }
+      if (mercuryCardLast4 !== undefined) {
+        data.mercuryCardLast4 = mercuryCardLast4 == null ? null : String(mercuryCardLast4).trim();
+      }
+      if (mercuryCardId !== undefined) {
+        data.mercuryCardId = mercuryCardId == null ? null : String(mercuryCardId).trim();
+      }
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data,
+          include: {
+            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            host: { select: { id: true, name: true, email: true } },
+            documents: { orderBy: { sortOrder: 'asc' } },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'mark_paid',
+            oldStatus: existing.status,
+            newStatus: 'paid',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: typeof note === 'string' ? note : null,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/execute — STUB (PR 5 will implement)
+//
+// Validates role + payout state, then returns 501 Not Implemented. PR 5 will
+// replace the body of this handler with the actual Mercury / wire / USDC
+// (Privy server-wallet) execution logic.
+// ============================================
+router.post(
+  '/:id/execute',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true, payoutMethod: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'approved') {
+        throw new AppError(
+          `Can only execute an approved payout (current status: ${existing.status})`,
+          400,
+          'INVALID_STATE',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      // Intentional stub — full implementation lands in PR 5.
+      res.status(501).json({
+        error: {
+          code: 'NOT_IMPLEMENTED',
+          message:
+            'Payout execution is wired in PR 5 (Mercury / wire / USDC-via-Privy). ' +
+            'Use POST /:id/mark-paid for manual overrides in the meantime.',
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// Re-export the helper so other backend code (e.g. PR 5 execute route) can
+// reuse the composed guard without re-deriving it.
+export { requireAnyAdminOrPaymentAdmin, isFullAdmin };
+
+export default router;

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -23,6 +23,10 @@ import {
   isFullAdmin,
 } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
+import {
+  sendUsdcPayment,
+  getUsdcDailyCapStatus,
+} from '../services/usdc-base.service.js';
 
 const router = Router();
 
@@ -634,18 +638,60 @@ router.post(
         return row;
       });
 
-      // autoExecute is plumbed through but execution itself lands in PR 5.
-      // For now we just log the intent — no payout rail fires.
+      // autoExecute (PR 5): synchronously execute after approval — only for
+      // usdc_base, since wire + mercury_card require body refs (wireReference,
+      // mercuryCardLast4) which the approve call doesn't carry. For those two,
+      // we log + no-op (the admin will hit execute separately with refs).
+      let autoExecuted = false;
+      let autoExecuteSkippedReason: string | null = null;
+      let result = updated;
+
       if (autoExecute) {
-        console.log(
-          `[admin-payout] approve+autoExecute requested for payout=${existing.id} ` +
-            `actor=${actor.email} — execution wired in PR 5, no-op for now`,
-        );
+        if (updated.payoutMethod === 'usdc_base') {
+          try {
+            result = await executePayout({
+              payoutId: existing.id,
+              actor: { email: actor.email, actorKind: actor.actorKind },
+              body: {},
+            });
+            autoExecuted = true;
+          } catch (err: any) {
+            // Execution failed but approval already happened — surface the
+            // error to the client. executePayout already wrote audit + flipped
+            // status to failed for usdc_base.
+            console.error(
+              `[admin-payout] autoExecute after approve failed for ${existing.id}: ` +
+                (err?.message || err),
+            );
+            // Re-fetch so client sees the failed state.
+            const refreshed = await prisma.payout.findUnique({
+              where: { id: existing.id },
+              include: {
+                party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+                host: { select: { id: true, name: true, email: true } },
+                documents: { orderBy: { sortOrder: 'asc' } },
+                audits: { orderBy: { createdAt: 'desc' } },
+              },
+            });
+            if (refreshed) result = refreshed;
+            autoExecuteSkippedReason = err?.message || 'execution failed';
+          }
+        } else {
+          autoExecuteSkippedReason =
+            `autoExecute not supported for ${updated.payoutMethod} — ` +
+            `requires admin-supplied refs at execute time`;
+          console.log(
+            `[admin-payout] approve+autoExecute for payout=${existing.id} ` +
+              `method=${updated.payoutMethod}: ${autoExecuteSkippedReason}`,
+          );
+        }
       }
 
       res.json({
-        payout: serializePayout(updated),
-        autoExecuteDeferred: !!autoExecute,
+        payout: serializePayout(result),
+        autoExecuteDeferred: !!autoExecute && !autoExecuted,
+        autoExecuted,
+        autoExecuteSkippedReason,
       });
     } catch (error) {
       next(error);
@@ -807,11 +853,245 @@ router.post(
 );
 
 // ============================================
-// POST /api/admin/payouts/:id/execute — STUB (PR 5 will implement)
+// GET /api/admin/payouts/usdc-daily-cap-remaining
+//   - Used by the UI to show "Daily cap remaining: $Y" before USDC execute.
+//   - Must be declared BEFORE POST /:id/execute (literal path) but it's a GET
+//     so route order doesn't actually collide; declaring it here keeps the
+//     "USDC execution" section coherent.
+// ============================================
+router.get(
+  '/usdc-daily-cap-remaining',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const status = await getUsdcDailyCapStatus();
+      res.json(status);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+/**
+ * Shared executor used by both the explicit POST /:id/execute route and the
+ * `autoExecute: true` branch of POST /:id/approve. Branches on payoutMethod
+ * and writes the success/failure status + audit row in a single Prisma
+ * transaction (so we can't leave status updated without an audit trail or
+ * vice versa).
+ *
+ * For `usdc_base` the on-chain send happens BEFORE the DB transaction
+ * (because waiting for a Base receipt can take 10-30s and we don't want to
+ * hold a Postgres tx open that long). On send-failure we still open a tiny
+ * tx to flip status -> failed + write the audit row, so the operator sees
+ * the failure in the UI.
+ *
+ * Wire + Mercury are pure DB writes (admin has already executed the payment
+ * out-of-band via bank portal / Mercury dashboard).
+ */
+async function executePayout(params: {
+  payoutId: string;
+  actor: {
+    email: string;
+    actorKind: AdminActorKind;
+  };
+  body: any;
+}) {
+  const { payoutId, actor, body } = params;
+
+  const existing = await prisma.payout.findUnique({
+    where: { id: payoutId },
+    select: {
+      id: true,
+      status: true,
+      hostUserId: true,
+      payoutMethod: true,
+      finalAmountUsd: true,
+      payoutWalletAddress: true,
+    },
+  });
+  if (!existing) {
+    throw new AppError('Payout not found', 404, 'NOT_FOUND');
+  }
+  if (existing.status !== 'approved') {
+    throw new AppError(
+      `Can only execute an approved payout (current status: ${existing.status})`,
+      400,
+      'INVALID_STATE',
+    );
+  }
+
+  const finalAmountUsd = Number(existing.finalAmountUsd);
+
+  if (existing.payoutMethod === 'usdc_base') {
+    if (!existing.payoutWalletAddress) {
+      throw new AppError(
+        'USDC payout has no recipient wallet address set',
+        400,
+        'MISSING_WALLET_ADDRESS',
+      );
+    }
+
+    try {
+      const result = await sendUsdcPayment(existing.payoutWalletAddress, finalAmountUsd);
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: {
+            status: 'paid',
+            paidAt: new Date(),
+            transactionHash: result.txHash,
+          },
+          include: {
+            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            host: { select: { id: true, name: true, email: true } },
+            documents: { orderBy: { sortOrder: 'asc' } },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'mark_paid',
+            oldStatus: 'approved',
+            newStatus: 'paid',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: `USDC on Base sent: tx ${result.txHash}, ` +
+              `from ${result.fromAddress} to ${result.toAddress}, ` +
+              `$${result.amountUsd.toFixed(2)}`,
+          },
+        });
+        return row;
+      });
+      return updated;
+    } catch (err: any) {
+      // Flip to failed + record the error so the admin UI shows what happened.
+      const errMsg = err?.message || String(err);
+      console.error(`[admin-payout] USDC execute failed for ${existing.id}: ${errMsg}`);
+      await prisma.$transaction(async (tx) => {
+        await tx.payout.update({
+          where: { id: existing.id },
+          data: { status: 'failed' },
+        });
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'mark_failed',
+            oldStatus: 'approved',
+            newStatus: 'failed',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: `USDC send failed: ${errMsg.slice(0, 500)}`,
+          },
+        });
+      });
+      throw new AppError(`USDC payout failed: ${errMsg}`, 502, 'USDC_SEND_FAILED');
+    }
+  }
+
+  if (existing.payoutMethod === 'wire') {
+    const wireRef = typeof body?.wireReference === 'string' ? body.wireReference.trim() : '';
+    if (!wireRef) {
+      throw new AppError('wireReference is required for wire payouts', 400, 'MISSING_WIRE_REFERENCE');
+    }
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const row = await tx.payout.update({
+        where: { id: existing.id },
+        data: {
+          status: 'paid',
+          paidAt: new Date(),
+          wireReference: wireRef,
+        },
+        include: {
+          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          host: { select: { id: true, name: true, email: true } },
+          documents: { orderBy: { sortOrder: 'asc' } },
+          audits: { orderBy: { createdAt: 'desc' } },
+        },
+      });
+      await tx.payoutAudit.create({
+        data: {
+          payoutId: existing.id,
+          action: 'mark_paid',
+          oldStatus: 'approved',
+          newStatus: 'paid',
+          actorEmail: actor.email,
+          actorKind: actor.actorKind,
+          note: `Wire executed out-of-band, reference: ${wireRef}` +
+            (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : ''),
+        },
+      });
+      return row;
+    });
+    return updated;
+  }
+
+  if (existing.payoutMethod === 'mercury_card') {
+    const last4Raw = typeof body?.mercuryCardLast4 === 'string' ? body.mercuryCardLast4.trim() : '';
+    if (!/^\d{4}$/.test(last4Raw)) {
+      throw new AppError(
+        'mercuryCardLast4 must be exactly 4 digits',
+        400,
+        'INVALID_MERCURY_LAST4',
+      );
+    }
+    const cardId = typeof body?.mercuryCardId === 'string' && body.mercuryCardId.trim()
+      ? body.mercuryCardId.trim()
+      : null;
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const row = await tx.payout.update({
+        where: { id: existing.id },
+        data: {
+          status: 'paid',
+          paidAt: new Date(),
+          mercuryCardLast4: last4Raw,
+          mercuryCardId: cardId,
+        },
+        include: {
+          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          host: { select: { id: true, name: true, email: true } },
+          documents: { orderBy: { sortOrder: 'asc' } },
+          audits: { orderBy: { createdAt: 'desc' } },
+        },
+      });
+      await tx.payoutAudit.create({
+        data: {
+          payoutId: existing.id,
+          action: 'mark_paid',
+          oldStatus: 'approved',
+          newStatus: 'paid',
+          actorEmail: actor.email,
+          actorKind: actor.actorKind,
+          note: `Mercury card issued via dashboard, last4=${last4Raw}` +
+            (cardId ? `, id=${cardId}` : '') +
+            (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : ''),
+        },
+      });
+      return row;
+    });
+    return updated;
+  }
+
+  throw new AppError(
+    `Unknown payout method: ${existing.payoutMethod}`,
+    400,
+    'INVALID_PAYOUT_METHOD',
+  );
+}
+
+// ============================================
+// POST /api/admin/payouts/:id/execute — REAL execution (PR 5)
 //
-// Validates role + payout state, then returns 501 Not Implemented. PR 5 will
-// replace the body of this handler with the actual Mercury / wire / USDC
-// (Privy server-wallet) execution logic.
+// Idempotent: rejects unless status === 'approved' (already-paid payouts get
+// 400, not a double-send). Branches on payoutMethod:
+//   - usdc_base    → sendUsdcPayment via Privy server-wallet
+//   - wire         → body.wireReference REQUIRED, status -> paid
+//   - mercury_card → body.mercuryCardLast4 REQUIRED (4 digits), status -> paid
+// All paths write a payout_audit row atomically with the status update.
 // ============================================
 router.post(
   '/:id/execute',
@@ -822,9 +1102,8 @@ router.post(
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true, payoutMethod: true },
+        select: { id: true, status: true, hostUserId: true },
       });
-
       if (!existing) {
         throw new AppError('Payout not found', 404, 'NOT_FOUND');
       }
@@ -835,18 +1114,15 @@ router.post(
           'INVALID_STATE',
         );
       }
-
       assertNotSelfPayout(actor, existing.hostUserId);
 
-      // Intentional stub — full implementation lands in PR 5.
-      res.status(501).json({
-        error: {
-          code: 'NOT_IMPLEMENTED',
-          message:
-            'Payout execution is wired in PR 5 (Mercury / wire / USDC-via-Privy). ' +
-            'Use POST /:id/mark-paid for manual overrides in the meantime.',
-        },
+      const updated = await executePayout({
+        payoutId: existing.id,
+        actor: { email: actor.email, actorKind: actor.actorKind },
+        body: req.body || {},
       });
+
+      res.json({ payout: serializePayout(updated) });
     } catch (error) {
       next(error);
     }

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -71,7 +71,15 @@ router.post('/add', requireAuth, async (req: AuthRequest, res: Response, next: N
     }
 
     const normalizedEmail = email.trim().toLowerCase();
-    const adminRole = role === 'super_admin' ? 'super_admin' : 'admin';
+    // Accepted role values: 'admin' (default), 'super_admin', 'payment_admin'.
+    // payment_admin (added arugula-38633 PR 2) gates the host-payments dashboard
+    // but is NOT treated as a regular admin elsewhere — see isAdmin() in auth.ts.
+    const adminRole =
+      role === 'super_admin'
+        ? 'super_admin'
+        : role === 'payment_admin'
+          ? 'payment_admin'
+          : 'admin';
 
     const existing = await prisma.admin.findUnique({ where: { email: normalizedEmail } });
     if (existing) {

--- a/backend/src/services/usdc-base.service.ts
+++ b/backend/src/services/usdc-base.service.ts
@@ -1,0 +1,258 @@
+/**
+ * USDC-on-Base payment service (arugula-38633, PR 5).
+ *
+ * Sends USDC from a Privy server-wallet to a recipient on Base mainnet. The
+ * wallet itself is provisioned out-of-band by `scripts/create-payout-server-wallet.js`;
+ * this service only signs and broadcasts transfers against the existing wallet id
+ * stored in `USDC_PAYOUT_PRIVY_WALLET_ID`.
+ *
+ * Pre-flight safety (defense in depth — every check runs every time):
+ *   1. recipient `toAddress` must be a valid 0x address (viem `isAddress`)
+ *   2. `amountUsd` > 0 and ≤ USDC_PAYOUT_MAX_USD env (default 200)
+ *   3. HARD ceiling `amountUsd` ≤ $1000 regardless of env (cannot be overridden)
+ *   4. wallet USDC balance ≥ `amountUsd` (read from Base via public RPC)
+ *   5. running 24h sum of paid USDC payouts + `amountUsd` ≤ USDC_PAYOUT_DAILY_CAP_USD
+ *      (default $2000) — queried from the `payouts` table
+ *
+ * On submit we wait for the tx receipt and confirm `status === 'success'` before
+ * returning. Caller is responsible for updating the payout row to status=paid
+ * with the returned `txHash`.
+ *
+ * NEVER logs private keys (Privy holds them); does log addresses + amounts +
+ * tx hashes for auditability.
+ */
+import {
+  createPublicClient,
+  http,
+  encodeFunctionData,
+  parseUnits,
+  isAddress,
+  type Hex,
+} from 'viem';
+import { base } from 'viem/chains';
+import { PrivyClient } from '@privy-io/server-auth';
+import { prisma } from '../config/database.js';
+
+const USDC_BASE_ADDRESS: Hex = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_DECIMALS = 6;
+const BASE_CAIP2 = 'eip155:8453' as const;
+const HARD_PER_TX_CEILING_USD = 1000;
+const DEFAULT_PER_TX_CAP_USD = 200;
+const DEFAULT_DAILY_CAP_USD = 2000;
+const TX_RECEIPT_TIMEOUT_MS = 90_000;
+
+const ERC20_TRANSFER_ABI = [
+  {
+    inputs: [
+      { name: 'recipient', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    name: 'transfer',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export interface SendUsdcResult {
+  txHash: `0x${string}`;
+  fromAddress: `0x${string}`;
+  toAddress: `0x${string}`;
+  amountUsd: number;
+}
+
+function getEnvNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function getRpcUrl(): string {
+  return process.env.BASE_RPC_URL || 'https://mainnet.base.org';
+}
+
+function getPublicClient() {
+  return createPublicClient({ chain: base, transport: http(getRpcUrl()) });
+}
+
+let privyClient: PrivyClient | null = null;
+function getPrivyClient(): PrivyClient {
+  if (privyClient) return privyClient;
+  const id = process.env.PRIVY_APP_ID;
+  const secret = process.env.PRIVY_APP_SECRET;
+  if (!id || !secret) {
+    throw new Error('Privy credentials missing (PRIVY_APP_ID / PRIVY_APP_SECRET)');
+  }
+  privyClient = new PrivyClient(id, secret);
+  return privyClient;
+}
+
+function getPayoutWalletId(): string {
+  const id = process.env.USDC_PAYOUT_PRIVY_WALLET_ID;
+  if (!id) {
+    throw new Error(
+      'USDC_PAYOUT_PRIVY_WALLET_ID not set. Run scripts/create-payout-server-wallet.js and add the result to Vercel env.',
+    );
+  }
+  return id;
+}
+
+/** Fetch the payout server-wallet's on-chain address from Privy. */
+async function getPayoutWalletAddress(): Promise<`0x${string}`> {
+  const wallet = await getPrivyClient().walletApi.getWallet({ id: getPayoutWalletId() });
+  if (!wallet.address || !isAddress(wallet.address)) {
+    throw new Error(`Privy returned no/invalid address for wallet ${getPayoutWalletId()}`);
+  }
+  return wallet.address as `0x${string}`;
+}
+
+/** Read the live USDC balance (in USD, decimal) of the payout wallet on Base. */
+export async function getPayoutWalletBalanceUsd(): Promise<{ address: `0x${string}`; balanceUsd: number }> {
+  const address = await getPayoutWalletAddress();
+  const publicClient = getPublicClient();
+  const balanceRaw = (await publicClient.readContract({
+    address: USDC_BASE_ADDRESS,
+    abi: ERC20_TRANSFER_ABI,
+    functionName: 'balanceOf',
+    args: [address],
+  })) as bigint;
+  return { address, balanceUsd: Number(balanceRaw) / 10 ** USDC_DECIMALS };
+}
+
+/**
+ * Running 24h total of completed USDC payouts (used for daily-cap enforcement).
+ * Pure read — does NOT include the in-flight payout being checked.
+ */
+export async function getUsdcUsedInLast24h(): Promise<number> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const rows = await prisma.payout.findMany({
+    where: {
+      payoutMethod: 'usdc_base',
+      status: 'paid',
+      paidAt: { gt: since },
+    },
+    select: { finalAmountUsd: true },
+  });
+  return rows.reduce((sum, r) => sum + Number(r.finalAmountUsd), 0);
+}
+
+export interface UsdcDailyCapStatus {
+  usedUsd: number;
+  capUsd: number;
+  remainingUsd: number;
+}
+
+export async function getUsdcDailyCapStatus(): Promise<UsdcDailyCapStatus> {
+  const capUsd = getEnvNumber('USDC_PAYOUT_DAILY_CAP_USD', DEFAULT_DAILY_CAP_USD);
+  const usedUsd = await getUsdcUsedInLast24h();
+  return {
+    usedUsd,
+    capUsd,
+    remainingUsd: Math.max(0, capUsd - usedUsd),
+  };
+}
+
+/**
+ * Send `amountUsd` USDC from the payout server-wallet to `toAddress` on Base.
+ * Throws on any pre-flight failure or on-chain revert. Caller must persist the
+ * resulting `txHash` on the payout row.
+ */
+export async function sendUsdcPayment(toAddress: string, amountUsd: number): Promise<SendUsdcResult> {
+  // 1. Address validation
+  if (!toAddress || !isAddress(toAddress)) {
+    throw new Error(`Invalid recipient address: ${toAddress}`);
+  }
+  const recipient = toAddress as `0x${string}`;
+
+  // 2. Amount range checks
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+    throw new Error(`Invalid payout amount: ${amountUsd}`);
+  }
+  const perTxCapUsd = getEnvNumber('USDC_PAYOUT_MAX_USD', DEFAULT_PER_TX_CAP_USD);
+  if (amountUsd > perTxCapUsd) {
+    throw new Error(
+      `Amount $${amountUsd.toFixed(2)} exceeds per-tx cap of $${perTxCapUsd.toFixed(2)} (USDC_PAYOUT_MAX_USD)`,
+    );
+  }
+
+  // 3. Hard ceiling — defense in depth even if env is misconfigured high
+  if (amountUsd > HARD_PER_TX_CEILING_USD) {
+    throw new Error(
+      `Amount $${amountUsd.toFixed(2)} exceeds hard per-tx ceiling of $${HARD_PER_TX_CEILING_USD} (code constant)`,
+    );
+  }
+
+  // 4. Balance pre-flight (also resolves wallet address used for `from`)
+  const { address: fromAddress, balanceUsd } = await getPayoutWalletBalanceUsd();
+  if (balanceUsd < amountUsd) {
+    throw new Error(
+      `Insufficient USDC balance: wallet has $${balanceUsd.toFixed(2)}, payout needs $${amountUsd.toFixed(2)} ` +
+        `(fund ${fromAddress} on Base)`,
+    );
+  }
+
+  // 5. Daily cap
+  const dailyCapUsd = getEnvNumber('USDC_PAYOUT_DAILY_CAP_USD', DEFAULT_DAILY_CAP_USD);
+  const usedUsd = await getUsdcUsedInLast24h();
+  if (usedUsd + amountUsd > dailyCapUsd) {
+    throw new Error(
+      `Daily USDC cap exceeded: $${usedUsd.toFixed(2)} already paid in last 24h + $${amountUsd.toFixed(2)} > ` +
+        `$${dailyCapUsd.toFixed(2)} cap (USDC_PAYOUT_DAILY_CAP_USD)`,
+    );
+  }
+
+  // Encode ERC-20 transfer calldata via viem
+  const amountUnits = parseUnits(amountUsd.toFixed(USDC_DECIMALS), USDC_DECIMALS);
+  const data = encodeFunctionData({
+    abi: ERC20_TRANSFER_ABI,
+    functionName: 'transfer',
+    args: [recipient, amountUnits],
+  });
+
+  console.log(
+    `[usdc-base] sending payout: from=${fromAddress} to=${recipient} amount=$${amountUsd.toFixed(2)} ` +
+      `dailyUsed=$${usedUsd.toFixed(2)}/cap=$${dailyCapUsd.toFixed(2)} balance=$${balanceUsd.toFixed(2)}`,
+  );
+
+  // Sign + send via Privy server-wallet (broadcasts onto Base for us)
+  const privy = getPrivyClient();
+  const sendResult = await privy.walletApi.ethereum.sendTransaction({
+    walletId: getPayoutWalletId(),
+    caip2: BASE_CAIP2,
+    transaction: {
+      to: USDC_BASE_ADDRESS,
+      data,
+      value: '0x0',
+    },
+  });
+
+  const txHash = sendResult.hash as `0x${string}`;
+  console.log(`[usdc-base] broadcast tx ${txHash}; waiting for receipt...`);
+
+  // Wait for confirmation via public Base RPC (Privy returns hash but not receipt)
+  const publicClient = getPublicClient();
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: txHash,
+    timeout: TX_RECEIPT_TIMEOUT_MS,
+  });
+  if (receipt.status !== 'success') {
+    throw new Error(`USDC transfer reverted on-chain: tx ${txHash}, status=${receipt.status}`);
+  }
+
+  console.log(`[usdc-base] confirmed tx ${txHash} block=${receipt.blockNumber}`);
+
+  return {
+    txHash,
+    fromAddress,
+    toAddress: recipient,
+    amountUsd,
+  };
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { DisplayPage } from './pages/DisplayPage';
 import { UnderbossDashboard } from './pages/UnderbossDashboard';
 import { ShippingDashboard } from './pages/ShippingDashboard';
 import { AdminPage } from './pages/AdminPage';
+import { PaymentsAdminPage } from './pages/PaymentsAdminPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
 import { PostComposerPage } from './pages/PostComposerPage';
@@ -55,6 +56,8 @@ function App() {
             <Route path="/map" element={<EventsMapPage />} />
             {/* /partners must come before /:slug */}
             <Route path="/partners" element={<PartnersPage />} />
+            {/* /payments must come before /:slug */}
+            <Route path="/payments" element={<PaymentsAdminPage />} />
             <Route path="/account" element={<AccountPage />} />
             <Route path="/auth/verify" element={<AuthVerifyPage />} />
             <Route path="/report/:slug" element={<PublicReportPage />} />

--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Check, X, DollarSign, Loader2 } from 'lucide-react';
+
+interface BulkActionsBarProps {
+  selectedCount: number;
+  onApprove: () => void;
+  onReject: () => void;
+  onMarkPaid: () => void;
+  onClear: () => void;
+  busy?: boolean;
+}
+
+export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
+  selectedCount,
+  onApprove,
+  onReject,
+  onMarkPaid,
+  onClear,
+  busy = false,
+}) => {
+  if (selectedCount === 0) return null;
+  return (
+    <div className="sticky top-[7rem] z-10 bg-theme-text/95 text-white rounded-xl px-4 py-3 mb-3 shadow-lg flex items-center gap-3 flex-wrap">
+      <span className="text-sm font-medium">{selectedCount} selected</span>
+      <div className="ml-auto flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={onApprove}
+          disabled={busy}
+          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
+        >
+          {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+          Approve
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          disabled={busy}
+          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
+        >
+          <X size={14} />
+          Reject
+        </button>
+        <button
+          type="button"
+          onClick={onMarkPaid}
+          disabled={busy}
+          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+        >
+          <DollarSign size={14} />
+          Mark paid
+        </button>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-sm text-white/60 hover:text-white px-2 py-1"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { DollarSign, Calendar, TrendingUp, Inbox } from 'lucide-react';
+import type { AdminPayoutTotals } from '../../types';
+import { formatUsd } from '../payments-shared';
+
+interface PaymentsStatsCardsProps {
+  totals: AdminPayoutTotals | null;
+  loading?: boolean;
+}
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tone?: 'default' | 'amber' | 'emerald';
+}
+
+const StatCard: React.FC<StatCardProps> = ({ icon, label, value, tone = 'default' }) => {
+  const toneClass =
+    tone === 'amber' ? 'border-amber-300 bg-amber-50' :
+    tone === 'emerald' ? 'border-emerald-300 bg-emerald-50' :
+    'border-theme-stroke bg-theme-surface';
+  return (
+    <div className={`rounded-xl border p-4 ${toneClass}`}>
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-theme-text-muted mb-1">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="text-xl font-semibold text-theme-text">{value}</div>
+    </div>
+  );
+};
+
+export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, loading }) => {
+  if (loading || !totals) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="rounded-xl border border-theme-stroke bg-theme-surface p-4 animate-pulse h-20" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+      <StatCard
+        icon={<DollarSign size={14} />}
+        label="Pending"
+        value={formatUsd(totals.totalUsdPending)}
+        tone="amber"
+      />
+      <StatCard
+        icon={<Calendar size={14} />}
+        label="Paid this month"
+        value={formatUsd(totals.totalUsdThisMonth)}
+        tone="emerald"
+      />
+      <StatCard
+        icon={<TrendingUp size={14} />}
+        label="Avg payout"
+        value={formatUsd(totals.avgUsd)}
+      />
+      <StatCard
+        icon={<Inbox size={14} />}
+        label="Awaiting review"
+        value={String(totals.awaitingReview)}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -27,6 +27,21 @@ interface PayoutReviewModalProps {
     mercuryCardId?: string;
     note?: string;
   }) => Promise<void> | void;
+  /**
+   * Execute payout (PR 5). For USDC → no body, server sends via Privy.
+   * For wire / mercury_card → admin-supplied refs.
+   */
+  onExecute: (body: {
+    wireReference?: string;
+    mercuryCardLast4?: string;
+    mercuryCardId?: string;
+    note?: string;
+  }) => Promise<void> | void;
+  /**
+   * Optional fetcher for the USDC daily-cap-remaining hint. Only called when
+   * the admin opens the USDC execute confirmation. Returns null if unavailable.
+   */
+  fetchUsdcCapRemaining?: () => Promise<{ usedUsd: number; capUsd: number; remainingUsd: number } | null>;
   /** Re-open (clear rejected/failed) — uses mark-paid plumbing or a future endpoint. */
   onReopen?: () => Promise<void> | void;
   busy?: boolean;
@@ -41,6 +56,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onSaveAmount,
   onSaveAdminNotes,
   onMarkPaid,
+  onExecute,
+  fetchUsdcCapRemaining,
   onReopen,
   busy = false,
 }) => {
@@ -58,6 +75,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const [cardLast4, setCardLast4] = useState('');
   const [cardId, setCardId] = useState('');
   const [paidNote, setPaidNote] = useState('');
+
+  // Execute-payout (PR 5) — method-specific confirmation form
+  const [showExecuteForm, setShowExecuteForm] = useState(false);
+  const [execWireRef, setExecWireRef] = useState('');
+  const [execCardLast4, setExecCardLast4] = useState('');
+  const [execCardId, setExecCardId] = useState('');
+  const [execNote, setExecNote] = useState('');
+  const [usdcCap, setUsdcCap] = useState<
+    { usedUsd: number; capUsd: number; remainingUsd: number } | null
+  >(null);
+  const [usdcCapLoading, setUsdcCapLoading] = useState(false);
 
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
 
@@ -83,6 +111,29 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const isApproved = payout.status === 'approved';
   const isPaid = payout.status === 'paid';
   const isClosed = payout.status === 'rejected' || payout.status === 'failed';
+
+  // For Mercury, last4 must be exactly 4 digits before the button enables.
+  const execMercuryValid = /^\d{4}$/.test(execCardLast4.trim());
+  const execWireValid = execWireRef.trim().length > 0;
+
+  async function openExecuteForm() {
+    setShowExecuteForm(true);
+    setExecWireRef('');
+    setExecCardLast4('');
+    setExecCardId('');
+    setExecNote('');
+    if (payout.payoutMethod === 'usdc_base' && fetchUsdcCapRemaining) {
+      setUsdcCapLoading(true);
+      try {
+        const cap = await fetchUsdcCapRemaining();
+        setUsdcCap(cap);
+      } catch {
+        setUsdcCap(null);
+      } finally {
+        setUsdcCapLoading(false);
+      }
+    }
+  }
 
   return (
     <div
@@ -411,6 +462,129 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               </div>
             )}
 
+            {/* Execute payout form (PR 5) */}
+            {showExecuteForm && (
+              <div className="rounded-xl border border-emerald-300 p-3 bg-emerald-50 text-sm space-y-2">
+                <h3 className="font-semibold text-emerald-900 mb-1">Execute payout</h3>
+
+                {payout.payoutMethod === 'usdc_base' && (
+                  <div className="space-y-2">
+                    <p className="text-emerald-900">
+                      Send <strong>{formatUsd(Number(payout.finalAmountUsd))}</strong> USDC on Base to:
+                    </p>
+                    <p className="font-mono text-xs break-all text-emerald-900/80 bg-white/50 px-2 py-1.5 rounded">
+                      {payout.payoutWalletAddress || '(no address set — cannot execute)'}
+                    </p>
+                    <div className="text-xs text-emerald-800">
+                      {usdcCapLoading ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Loader2 size={10} className="animate-spin" /> Checking daily cap…
+                        </span>
+                      ) : usdcCap ? (
+                        <>
+                          Daily cap remaining: <strong>{formatUsd(usdcCap.remainingUsd)}</strong>{' '}
+                          (${usdcCap.usedUsd.toFixed(2)} used of ${usdcCap.capUsd.toFixed(2)} in last 24h)
+                        </>
+                      ) : (
+                        <span className="text-emerald-800/70">Daily cap status unavailable.</span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {payout.payoutMethod === 'wire' && (
+                  <div className="space-y-2">
+                    <p className="text-emerald-900">
+                      Confirm that the {formatUsd(Number(payout.finalAmountUsd))} wire has been sent
+                      out-of-band, then enter the wire reference number for the audit trail.
+                    </p>
+                    <IconInput
+                      icon={Pencil}
+                      placeholder="Wire reference number (required)"
+                      value={execWireRef}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExecWireRef(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                {payout.payoutMethod === 'mercury_card' && (
+                  <div className="space-y-2">
+                    <p className="text-emerald-900">
+                      Confirm that the {formatUsd(Number(payout.finalAmountUsd))} Mercury virtual card
+                      has been issued via the Mercury dashboard, then record the last 4 digits below.
+                    </p>
+                    <IconInput
+                      icon={Pencil}
+                      placeholder="Card last 4 digits (required, exactly 4 numbers)"
+                      value={execCardLast4}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        setExecCardLast4(e.target.value.replace(/\D/g, '').slice(0, 4))
+                      }
+                      inputMode="numeric"
+                      maxLength={4}
+                    />
+                    <IconInput
+                      icon={Pencil}
+                      placeholder="Mercury card id (optional)"
+                      value={execCardId}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExecCardId(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                {payout.payoutMethod !== 'usdc_base' && (
+                  <IconInput
+                    icon={Pencil}
+                    placeholder="Note (optional)"
+                    value={execNote}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExecNote(e.target.value)}
+                  />
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      if (payout.payoutMethod === 'wire' && !execWireValid) return;
+                      if (payout.payoutMethod === 'mercury_card' && !execMercuryValid) return;
+                      if (payout.payoutMethod === 'usdc_base' && !payout.payoutWalletAddress) return;
+                      await onExecute({
+                        wireReference: payout.payoutMethod === 'wire' ? execWireRef.trim() : undefined,
+                        mercuryCardLast4:
+                          payout.payoutMethod === 'mercury_card' ? execCardLast4.trim() : undefined,
+                        mercuryCardId:
+                          payout.payoutMethod === 'mercury_card' && execCardId.trim()
+                            ? execCardId.trim()
+                            : undefined,
+                        note: execNote.trim() || undefined,
+                      });
+                      setShowExecuteForm(false);
+                    }}
+                    disabled={
+                      busy ||
+                      (payout.payoutMethod === 'wire' && !execWireValid) ||
+                      (payout.payoutMethod === 'mercury_card' && !execMercuryValid) ||
+                      (payout.payoutMethod === 'usdc_base' && !payout.payoutWalletAddress)
+                    }
+                    className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
+                  >
+                    {busy && <Loader2 size={12} className="animate-spin" />}
+                    {payout.payoutMethod === 'usdc_base' ? 'Send Payout' :
+                      payout.payoutMethod === 'wire' ? 'Confirm wire sent' :
+                      'Confirm card issued'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowExecuteForm(false)}
+                    disabled={busy}
+                    className="px-3 py-1.5 rounded-lg text-xs text-theme-text-secondary hover:bg-theme-surface-hover disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
             {/* Mark paid form */}
             {showMarkPaidForm && (
               <div className="rounded-xl border border-blue-300 p-3 bg-blue-50 text-sm space-y-2">
@@ -512,12 +686,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             <>
               <button
                 type="button"
-                disabled
-                title="Payout execution is wired in PR 5"
-                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-theme-surface-hover text-theme-text-faint text-sm font-medium cursor-not-allowed"
+                onClick={openExecuteForm}
+                disabled={busy || selfPayoutBlocked || showExecuteForm}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
               >
                 <Send size={14} />
-                Execute Payout (PR 5)
+                Execute Payout
               </button>
               <button
                 type="button"

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,0 +1,601 @@
+import React, { useEffect, useState } from 'react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { ClickableEmail } from '../ClickableEmail';
+import type { AdminPayoutDetail, PayoutAuditEntry } from '../../types';
+import {
+  PayoutStatusPill,
+  PayoutMethodIcon,
+  PAYOUT_METHOD_LABELS,
+  formatUsd,
+  formatOriginalCurrency,
+} from '../payments-shared';
+
+interface PayoutReviewModalProps {
+  payout: AdminPayoutDetail;
+  /** When set, indicates the actor would be paying themselves — disables mutate buttons. */
+  selfPayoutBlocked?: boolean;
+  onClose: () => void;
+  onApprove: (note?: string) => Promise<void> | void;
+  onReject: (reason: string) => Promise<void> | void;
+  onSaveAmount: (newAmount: number, note?: string) => Promise<void> | void;
+  onSaveAdminNotes: (notes: string) => Promise<void> | void;
+  onMarkPaid: (refs: {
+    wireReference?: string;
+    transactionHash?: string;
+    mercuryCardLast4?: string;
+    mercuryCardId?: string;
+    note?: string;
+  }) => Promise<void> | void;
+  /** Re-open (clear rejected/failed) — uses mark-paid plumbing or a future endpoint. */
+  onReopen?: () => Promise<void> | void;
+  busy?: boolean;
+}
+
+export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
+  payout,
+  selfPayoutBlocked,
+  onClose,
+  onApprove,
+  onReject,
+  onSaveAmount,
+  onSaveAdminNotes,
+  onMarkPaid,
+  onReopen,
+  busy = false,
+}) => {
+  const [editingAmount, setEditingAmount] = useState(false);
+  const [draftAmount, setDraftAmount] = useState(String(payout.finalAmountUsd));
+  const [adminNotes, setAdminNotes] = useState(payout.adminNotes ?? '');
+  const [adminNotesDirty, setAdminNotesDirty] = useState(false);
+
+  const [showRejectForm, setShowRejectForm] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  const [showMarkPaidForm, setShowMarkPaidForm] = useState(false);
+  const [wireRef, setWireRef] = useState('');
+  const [txHash, setTxHash] = useState('');
+  const [cardLast4, setCardLast4] = useState('');
+  const [cardId, setCardId] = useState('');
+  const [paidNote, setPaidNote] = useState('');
+
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        if (lightboxUrl) setLightboxUrl(null);
+        else onClose();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, lightboxUrl]);
+
+  const receipts = payout.documents.filter((d) => d.kind === 'receipt');
+  const pizzas = payout.documents.filter((d) => d.kind === 'pizza');
+  const allPhotos = [...pizzas, ...receipts];
+
+  const ocrSum = receipts.reduce((sum, r) => sum + (Number(r.ocrAmount) || 0), 0);
+
+  const isPending = payout.status === 'pending';
+  const isApproved = payout.status === 'approved';
+  const isPaid = payout.status === 'paid';
+  const isClosed = payout.status === 'rejected' || payout.status === 'failed';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-6xl max-h-[95vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="text-lg font-semibold text-theme-text">
+                Payout {payout.id.slice(0, 8)}
+              </h2>
+              <PayoutStatusPill status={payout.status} size="md" />
+              <PayoutMethodIcon method={payout.payoutMethod} showLabel />
+            </div>
+            <div className="text-xs text-theme-text-muted mt-0.5">
+              {payout.host.name || '—'} ·{' '}
+              {payout.host.email ? <ClickableEmail email={payout.host.email} /> : '—'} ·{' '}
+              <a
+                href={`/host/${payout.party.inviteCode}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                {payout.party.name}
+              </a>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {selfPayoutBlocked && (
+          <div className="mx-5 mt-3 px-3 py-2 rounded-lg bg-amber-50 border border-amber-300 text-sm text-amber-800 flex items-center gap-2">
+            <AlertTriangle size={14} />
+            You are the host on this payout. Payment admins cannot approve/edit their own payouts.
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto grid grid-cols-1 md:grid-cols-2 gap-4 p-5">
+          {/* Left: photo gallery */}
+          <section>
+            <h3 className="text-sm font-semibold text-theme-text mb-2">
+              Photos ({allPhotos.length})
+            </h3>
+            {allPhotos.length === 0 && (
+              <p className="text-sm text-theme-text-faint">No photos attached.</p>
+            )}
+            <div className="grid grid-cols-3 gap-2">
+              {allPhotos.map((doc) => (
+                <button
+                  key={doc.id}
+                  type="button"
+                  onClick={() => setLightboxUrl(doc.url)}
+                  className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
+                  title={doc.fileName}
+                >
+                  <img src={doc.url} alt={doc.fileName} className="w-full h-full object-cover" loading="lazy" />
+                  <span
+                    className={`absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
+                      doc.kind === 'receipt' ? 'bg-amber-500 text-white' : 'bg-emerald-500 text-white'
+                    }`}
+                  >
+                    {doc.kind}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {/* Right: details */}
+          <section className="space-y-4">
+            {/* Amount */}
+            <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-semibold text-theme-text">Amount</h3>
+                {!isPaid && !editingAmount && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDraftAmount(String(payout.finalAmountUsd));
+                      setEditingAmount(true);
+                    }}
+                    disabled={selfPayoutBlocked || busy}
+                    className="inline-flex items-center gap-1 text-xs text-theme-text-secondary hover:text-theme-text disabled:opacity-50"
+                  >
+                    <Pencil size={12} />
+                    Edit
+                  </button>
+                )}
+              </div>
+              {editingAmount ? (
+                <div className="flex items-center gap-2">
+                  <IconInput
+                    icon={DollarSign}
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    placeholder="Final USD amount"
+                    value={draftAmount}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDraftAmount(e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      const n = Number(draftAmount);
+                      if (!Number.isFinite(n) || n < 0) return;
+                      await onSaveAmount(n);
+                      setEditingAmount(false);
+                    }}
+                    disabled={busy}
+                    className="px-3 py-2 rounded-lg bg-[#E52828] text-white text-sm disabled:opacity-50"
+                  >
+                    {busy ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditingAmount(false)}
+                    className="px-3 py-2 rounded-lg text-sm text-theme-text-secondary hover:bg-theme-surface-hover"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <div>
+                  <div className="text-2xl font-semibold text-theme-text">
+                    {formatUsd(Number(payout.finalAmountUsd))}
+                  </div>
+                  {payout.originalCurrency && payout.originalCurrency.toUpperCase() !== 'USD' && (
+                    <div className="text-xs text-theme-text-muted mt-0.5">
+                      Original: {formatOriginalCurrency(Number(payout.originalAmount), payout.originalCurrency)} ·{' '}
+                      Rate: {Number(payout.exchangeRate).toFixed(4)} · Extracted: {formatUsd(Number(payout.extractedAmountUsd))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Per-receipt OCR */}
+            {receipts.length > 0 && (
+              <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+                <h3 className="text-sm font-semibold text-theme-text mb-2">Receipts ({receipts.length})</h3>
+                <ul className="space-y-1.5">
+                  {receipts.map((r) => {
+                    const conf = r.ocrConfidence ?? 0;
+                    const lowConf = conf > 0 && conf < 0.8;
+                    return (
+                      <li key={r.id} className="flex items-center gap-2 text-sm">
+                        <span
+                          className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                            r.ocrError ? 'bg-red-500' :
+                            lowConf ? 'bg-amber-500' :
+                            conf >= 0.8 ? 'bg-emerald-500' :
+                            'bg-gray-400'
+                          }`}
+                        />
+                        <span className="text-theme-text-muted flex-1 truncate">{r.fileName}</span>
+                        {r.ocrError ? (
+                          <span className="text-xs text-red-600">{r.ocrError}</span>
+                        ) : r.ocrAmount != null && r.ocrCurrency ? (
+                          <>
+                            <span className="text-theme-text font-medium">
+                              {formatOriginalCurrency(Number(r.ocrAmount), r.ocrCurrency)}
+                            </span>
+                            <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
+                              {(conf * 100).toFixed(0)}%
+                            </span>
+                          </>
+                        ) : (
+                          <span className="text-xs text-theme-text-faint">no OCR</span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="text-xs text-theme-text-muted mt-2 border-t border-theme-stroke pt-2">
+                  Sum of OCR amounts (in their own currencies, not normalized): {ocrSum.toFixed(2)}
+                </div>
+              </div>
+            )}
+
+            {/* Payout target */}
+            <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface text-sm space-y-1">
+              <h3 className="font-semibold text-theme-text mb-1">{PAYOUT_METHOD_LABELS[payout.payoutMethod]}</h3>
+              {payout.payoutMethod === 'usdc_base' && payout.payoutWalletAddress && (
+                <div className="font-mono text-xs break-all text-theme-text-secondary">
+                  {payout.payoutWalletAddress}
+                </div>
+              )}
+              {payout.payoutMethod === 'wire' && payout.payoutBankDetails && (
+                <pre className="text-xs text-theme-text-secondary whitespace-pre-wrap font-mono">
+                  {JSON.stringify(payout.payoutBankDetails, null, 2)}
+                </pre>
+              )}
+              {payout.payoutMethod === 'mercury_card' && (
+                <div className="text-xs text-theme-text-secondary">
+                  {payout.mercuryCardLast4
+                    ? `Card issued — ending in ••••${payout.mercuryCardLast4}`
+                    : 'No card issued yet — issue via Mercury dashboard, then mark paid with the last 4.'}
+                </div>
+              )}
+            </div>
+
+            {/* Host notes */}
+            {payout.hostNotes && (
+              <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface text-sm">
+                <h3 className="font-semibold text-theme-text mb-1">Host notes</h3>
+                <p className="text-theme-text-secondary whitespace-pre-wrap">{payout.hostNotes}</p>
+              </div>
+            )}
+
+            {/* Admin notes (editable) */}
+            <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+              <h3 className="font-semibold text-theme-text mb-2 text-sm">Admin notes</h3>
+              <IconInput
+                icon={Pencil}
+                multiline
+                rows={3}
+                placeholder="Internal notes (visible to admins only)"
+                value={adminNotes}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  setAdminNotes(e.target.value);
+                  setAdminNotesDirty(true);
+                }}
+              />
+              {adminNotesDirty && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await onSaveAdminNotes(adminNotes);
+                    setAdminNotesDirty(false);
+                  }}
+                  disabled={busy || selfPayoutBlocked}
+                  className="mt-2 px-3 py-1.5 rounded-lg bg-[#E52828] text-white text-xs disabled:opacity-50"
+                >
+                  {busy ? 'Saving…' : 'Save notes'}
+                </button>
+              )}
+            </div>
+
+            {/* Status timeline */}
+            <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+              <h3 className="font-semibold text-theme-text mb-2 text-sm">Audit trail</h3>
+              <ul className="space-y-1.5 text-xs">
+                {payout.audits.length === 0 && (
+                  <li className="text-theme-text-faint">No audit entries.</li>
+                )}
+                {payout.audits.map((a) => (
+                  <AuditEntry key={a.id} entry={a} />
+                ))}
+              </ul>
+            </div>
+
+            {/* Receipts for already-paid payouts */}
+            {isPaid && (
+              <div className="rounded-xl border border-emerald-300 p-3 bg-emerald-50 text-sm">
+                <h3 className="font-semibold text-emerald-900 mb-1">Payment receipt</h3>
+                {payout.transactionHash && (
+                  <a
+                    href={`https://basescan.org/tx/${payout.transactionHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-emerald-800 hover:underline break-all"
+                  >
+                    {payout.transactionHash}
+                    <ExternalLink size={12} />
+                  </a>
+                )}
+                {payout.wireReference && (
+                  <div className="text-emerald-800">Wire reference: {payout.wireReference}</div>
+                )}
+                {payout.mercuryCardLast4 && (
+                  <div className="text-emerald-800">
+                    Mercury card ••••{payout.mercuryCardLast4}
+                    {payout.mercuryCardId && <span className="text-emerald-700/70 ml-2">id: {payout.mercuryCardId}</span>}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Reject form */}
+            {showRejectForm && (
+              <div className="rounded-xl border border-red-300 p-3 bg-red-50 text-sm">
+                <h3 className="font-semibold text-red-900 mb-2">Reject this payout</h3>
+                <IconInput
+                  icon={X}
+                  multiline
+                  rows={2}
+                  placeholder="Reason (shown to host)"
+                  value={rejectReason}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setRejectReason(e.target.value)}
+                />
+                <div className="flex gap-2 mt-2">
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      if (!rejectReason.trim()) return;
+                      await onReject(rejectReason.trim());
+                      setShowRejectForm(false);
+                      setRejectReason('');
+                    }}
+                    disabled={busy || !rejectReason.trim()}
+                    className="px-3 py-1.5 rounded-lg bg-red-500 text-white text-xs disabled:opacity-50"
+                  >
+                    Confirm reject
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowRejectForm(false)}
+                    className="px-3 py-1.5 rounded-lg text-xs text-theme-text-secondary hover:bg-theme-surface-hover"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Mark paid form */}
+            {showMarkPaidForm && (
+              <div className="rounded-xl border border-blue-300 p-3 bg-blue-50 text-sm space-y-2">
+                <h3 className="font-semibold text-blue-900 mb-1">Mark as paid (manual)</h3>
+                {payout.payoutMethod === 'wire' && (
+                  <IconInput
+                    icon={Pencil}
+                    placeholder="Wire reference number"
+                    value={wireRef}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setWireRef(e.target.value)}
+                  />
+                )}
+                {payout.payoutMethod === 'usdc_base' && (
+                  <IconInput
+                    icon={Pencil}
+                    placeholder="Transaction hash (0x...)"
+                    value={txHash}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTxHash(e.target.value)}
+                  />
+                )}
+                {payout.payoutMethod === 'mercury_card' && (
+                  <>
+                    <IconInput
+                      icon={Pencil}
+                      placeholder="Card last 4 digits"
+                      value={cardLast4}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCardLast4(e.target.value)}
+                    />
+                    <IconInput
+                      icon={Pencil}
+                      placeholder="Mercury card id (optional)"
+                      value={cardId}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCardId(e.target.value)}
+                    />
+                  </>
+                )}
+                <IconInput
+                  icon={Pencil}
+                  placeholder="Note (optional)"
+                  value={paidNote}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPaidNote(e.target.value)}
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await onMarkPaid({
+                        wireReference: wireRef.trim() || undefined,
+                        transactionHash: txHash.trim() || undefined,
+                        mercuryCardLast4: cardLast4.trim() || undefined,
+                        mercuryCardId: cardId.trim() || undefined,
+                        note: paidNote.trim() || undefined,
+                      });
+                      setShowMarkPaidForm(false);
+                    }}
+                    disabled={busy}
+                    className="px-3 py-1.5 rounded-lg bg-blue-500 text-white text-xs disabled:opacity-50"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowMarkPaidForm(false)}
+                    className="px-3 py-1.5 rounded-lg text-xs text-theme-text-secondary hover:bg-theme-surface-hover"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Footer actions */}
+        <div className="border-t border-theme-stroke px-5 py-3 flex items-center gap-2 flex-wrap bg-theme-surface">
+          {isPending && (
+            <>
+              <button
+                type="button"
+                onClick={() => onApprove()}
+                disabled={busy || selfPayoutBlocked}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
+              >
+                {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                Approve
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowRejectForm(true)}
+                disabled={busy || selfPayoutBlocked}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
+              >
+                <X size={14} />
+                Reject
+              </button>
+            </>
+          )}
+          {isApproved && (
+            <>
+              <button
+                type="button"
+                disabled
+                title="Payout execution is wired in PR 5"
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-theme-surface-hover text-theme-text-faint text-sm font-medium cursor-not-allowed"
+              >
+                <Send size={14} />
+                Execute Payout (PR 5)
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowMarkPaidForm(true)}
+                disabled={busy || selfPayoutBlocked}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+              >
+                <DollarSign size={14} />
+                Mark paid (manual)
+              </button>
+            </>
+          )}
+          {isClosed && onReopen && (
+            <button
+              type="button"
+              onClick={() => onReopen()}
+              disabled={busy || selfPayoutBlocked}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-theme-surface-hover hover:bg-theme-stroke text-theme-text text-sm font-medium disabled:opacity-50"
+            >
+              <RefreshCw size={14} />
+              Re-open
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-auto px-4 py-2 rounded-lg text-theme-text-secondary hover:bg-theme-surface-hover text-sm"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {/* Lightbox */}
+      {lightboxUrl && (
+        <div
+          className="fixed inset-0 z-[60] bg-black/80 flex items-center justify-center p-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setLightboxUrl(null);
+          }}
+        >
+          <img
+            src={lightboxUrl}
+            alt=""
+            className="max-w-full max-h-full object-contain"
+            onClick={(e) => e.stopPropagation()}
+          />
+          <button
+            type="button"
+            onClick={() => setLightboxUrl(null)}
+            className="absolute top-4 right-4 text-white/80 hover:text-white p-2 rounded-full bg-black/40"
+            aria-label="Close lightbox"
+          >
+            <X size={20} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const AuditEntry: React.FC<{ entry: PayoutAuditEntry }> = ({ entry }) => {
+  const when = new Date(entry.createdAt).toLocaleString();
+  return (
+    <li className="flex items-start gap-2 text-theme-text-secondary">
+      <span className="text-theme-text-faint w-32 flex-shrink-0">{when}</span>
+      <span className="flex-1">
+        <span className="font-medium text-theme-text">{entry.action}</span>
+        {entry.oldStatus && entry.newStatus && (
+          <> · {entry.oldStatus} → {entry.newStatus}</>
+        )}
+        {entry.oldAmount != null && entry.newAmount != null && (
+          <> · ${entry.oldAmount} → ${entry.newAmount}</>
+        )}
+        <> by <span className="text-theme-text">{entry.actorEmail}</span></>
+        {entry.note && <div className="text-theme-text-muted text-xs">{entry.note}</div>}
+      </span>
+    </li>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Search, Mail, X } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import type { AdminPayoutFilters, PayoutMethod, PayoutStatus } from '../../types';
+import { PAYOUT_METHOD_LABELS } from '../payments-shared';
+
+interface PayoutsFilterBarProps {
+  filters: AdminPayoutFilters;
+  onChange: (next: AdminPayoutFilters) => void;
+  onReset: () => void;
+  availableCurrencies: string[];
+}
+
+const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'failed', label: 'Failed' },
+];
+
+const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [
+  { value: 'all', label: 'All methods' },
+  { value: 'mercury_card', label: PAYOUT_METHOD_LABELS.mercury_card },
+  { value: 'wire', label: PAYOUT_METHOD_LABELS.wire },
+  { value: 'usdc_base', label: PAYOUT_METHOD_LABELS.usdc_base },
+];
+
+/**
+ * Sticky filter bar at the top of the admin payouts dashboard. All updates are
+ * pushed via `onChange` so the parent can refire `listAdminPayouts(filters)`.
+ *
+ * Cursor is intentionally NOT a prop here — when filters change the parent
+ * should reset cursor to undefined.
+ */
+export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
+  filters,
+  onChange,
+  onReset,
+  availableCurrencies,
+}) => {
+  const update = (patch: Partial<AdminPayoutFilters>) => {
+    onChange({ ...filters, ...patch, cursor: undefined });
+  };
+
+  return (
+    <div className="sticky top-0 z-20 bg-theme-surface/95 backdrop-blur-sm border border-theme-stroke rounded-xl p-4 mb-4 shadow-sm">
+      {/* Status tab strip */}
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        {STATUS_TABS.map((tab) => {
+          const active = (filters.status ?? 'all') === tab.value;
+          return (
+            <button
+              key={tab.value}
+              type="button"
+              onClick={() => update({ status: tab.value })}
+              className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                active
+                  ? 'bg-[#E52828] text-white'
+                  : 'bg-theme-surface-hover text-theme-text-secondary hover:bg-theme-stroke'
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-2 items-start">
+        {/* Host search */}
+        <div className="md:col-span-2">
+          <IconInput
+            icon={Mail}
+            type="search"
+            placeholder="Filter by host email"
+            value={filters.hostEmail || ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ hostEmail: e.target.value })}
+          />
+        </div>
+
+        {/* Party ID search */}
+        <div>
+          <IconInput
+            icon={Search}
+            type="search"
+            placeholder="Party ID"
+            value={filters.partyId || ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ partyId: e.target.value })}
+          />
+        </div>
+
+        {/* Method dropdown */}
+        <div>
+          <select
+            value={filters.payoutMethod ?? 'all'}
+            onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
+            className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+            aria-label="Filter by payout method"
+          >
+            {METHOD_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Currency dropdown */}
+        <div>
+          <select
+            value={filters.currency ?? 'all'}
+            onChange={(e) => update({ currency: e.target.value })}
+            className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+            aria-label="Filter by currency"
+          >
+            <option value="all">All currencies</option>
+            {availableCurrencies.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-col md:flex-row md:items-end gap-2 mt-3">
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-theme-text-muted">From</label>
+          <input
+            type="date"
+            value={filters.dateFrom || ''}
+            onChange={(e) => update({ dateFrom: e.target.value })}
+            className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+            aria-label="Date from"
+          />
+          <label className="text-xs text-theme-text-muted">To</label>
+          <input
+            type="date"
+            value={filters.dateTo || ''}
+            onChange={(e) => update({ dateTo: e.target.value })}
+            className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+            aria-label="Date to"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={onReset}
+          className="ml-auto inline-flex items-center gap-1 text-sm text-theme-text-muted hover:text-theme-text px-3 py-2 rounded-lg hover:bg-theme-surface-hover"
+        >
+          <X size={14} />
+          Reset filters
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { Check, X, Pencil, Eye, DollarSign, Send, Loader2 } from 'lucide-react';
+import type { AdminPayout, PayoutStatus } from '../../types';
+import { PayoutRow } from '../payments-shared';
+
+interface PayoutsTableProps {
+  payouts: AdminPayout[];
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  onToggleSelectAll: () => void;
+  onRowClick: (payout: AdminPayout) => void;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  onEdit: (payout: AdminPayout) => void;
+  onMarkPaid: (payout: AdminPayout) => void;
+  busyRowId?: string | null;
+  loading?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+}
+
+/** Status-dependent action menu rendered in the trailing cell. */
+function ActionsCell({
+  payout,
+  busy,
+  onApprove,
+  onReject,
+  onEdit,
+  onMarkPaid,
+}: {
+  payout: AdminPayout;
+  busy: boolean;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  onEdit: (payout: AdminPayout) => void;
+  onMarkPaid: (payout: AdminPayout) => void;
+}) {
+  const status: PayoutStatus = payout.status;
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onEdit(payout)}
+        className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-secondary"
+        title="View / Edit"
+        disabled={busy}
+      >
+        <Eye size={15} />
+      </button>
+
+      {status === 'pending' && (
+        <>
+          <button
+            type="button"
+            onClick={() => onApprove(payout.id)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
+            title="Approve"
+          >
+            {busy ? <Loader2 size={15} className="animate-spin" /> : <Check size={15} />}
+          </button>
+          <button
+            type="button"
+            onClick={() => onReject(payout.id)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-red-50 text-red-600 disabled:opacity-50"
+            title="Reject"
+          >
+            <X size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={() => onEdit(payout)}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-secondary"
+            title="Edit amount"
+            disabled={busy}
+          >
+            <Pencil size={15} />
+          </button>
+        </>
+      )}
+
+      {status === 'approved' && (
+        <>
+          <button
+            type="button"
+            disabled
+            className="p-1.5 rounded-md text-theme-text-faint cursor-not-allowed"
+            title="Execute Payout — wired in PR 5"
+          >
+            <Send size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={() => onMarkPaid(payout)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-blue-50 text-blue-600 disabled:opacity-50"
+            title="Mark paid (manual)"
+          >
+            <DollarSign size={15} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export const PayoutsTable: React.FC<PayoutsTableProps> = ({
+  payouts,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
+  onRowClick,
+  onApprove,
+  onReject,
+  onEdit,
+  onMarkPaid,
+  busyRowId,
+  loading,
+  loadingMore,
+  onLoadMore,
+  hasMore,
+}) => {
+  const allSelected = payouts.length > 0 && payouts.every((p) => selectedIds.has(p.id));
+
+  return (
+    <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
+              <th className="px-3 py-3 w-10">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={onToggleSelectAll}
+                  aria-label="Select all"
+                  className="rounded border-theme-stroke-hover bg-theme-surface"
+                />
+              </th>
+              <th className="px-3 py-3 w-14"></th>
+              <th className="px-3 py-3 font-medium">Host</th>
+              <th className="px-3 py-3 font-medium">Party</th>
+              <th className="px-3 py-3 font-medium">Submitted</th>
+              <th className="px-3 py-3 font-medium">Amount</th>
+              <th className="px-3 py-3 font-medium">Method</th>
+              <th className="px-3 py-3 font-medium">Status</th>
+              <th className="px-3 py-3 font-medium text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && payouts.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-3 py-12 text-center text-theme-text-muted">
+                  <Loader2 size={20} className="inline-block animate-spin mr-2" />
+                  Loading payouts…
+                </td>
+              </tr>
+            )}
+            {!loading && payouts.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-3 py-12 text-center text-theme-text-faint">
+                  No payouts match these filters.
+                </td>
+              </tr>
+            )}
+            {payouts.map((p) => (
+              <PayoutRow
+                key={p.id}
+                payout={p}
+                showAdminColumns
+                selectable
+                selected={selectedIds.has(p.id)}
+                onSelectToggle={() => onToggleSelect(p.id)}
+                onClick={() => onRowClick(p)}
+                actions={
+                  <ActionsCell
+                    payout={p}
+                    busy={busyRowId === p.id}
+                    onApprove={onApprove}
+                    onReject={onReject}
+                    onEdit={onEdit}
+                    onMarkPaid={onMarkPaid}
+                  />
+                }
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {hasMore && (
+        <div className="border-t border-theme-stroke p-3 flex justify-center">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-theme-surface-hover hover:bg-theme-stroke text-sm font-medium text-theme-text disabled:opacity-50"
+          >
+            {loadingMore && <Loader2 size={14} className="animate-spin" />}
+            Load more
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -13,6 +13,8 @@ interface PayoutsTableProps {
   onReject: (id: string) => void;
   onEdit: (payout: AdminPayout) => void;
   onMarkPaid: (payout: AdminPayout) => void;
+  /** Opens the modal so the admin can execute via the method-specific confirmation form. */
+  onExecute: (payout: AdminPayout) => void;
   busyRowId?: string | null;
   loading?: boolean;
   loadingMore?: boolean;
@@ -28,6 +30,7 @@ function ActionsCell({
   onReject,
   onEdit,
   onMarkPaid,
+  onExecute,
 }: {
   payout: AdminPayout;
   busy: boolean;
@@ -35,6 +38,7 @@ function ActionsCell({
   onReject: (id: string) => void;
   onEdit: (payout: AdminPayout) => void;
   onMarkPaid: (payout: AdminPayout) => void;
+  onExecute: (payout: AdminPayout) => void;
 }) {
   const status: PayoutStatus = payout.status;
   return (
@@ -85,11 +89,12 @@ function ActionsCell({
         <>
           <button
             type="button"
-            disabled
-            className="p-1.5 rounded-md text-theme-text-faint cursor-not-allowed"
-            title="Execute Payout — wired in PR 5"
+            onClick={() => onExecute(payout)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
+            title="Execute Payout"
           >
-            <Send size={15} />
+            {busy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
           </button>
           <button
             type="button"
@@ -116,6 +121,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
   onReject,
   onEdit,
   onMarkPaid,
+  onExecute,
   busyRowId,
   loading,
   loadingMore,
@@ -182,6 +188,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
                     onReject={onReject}
                     onEdit={onEdit}
                     onMarkPaid={onMarkPaid}
+                    onExecute={onExecute}
                   />
                 }
               />

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -1,0 +1,5 @@
+export { PayoutsFilterBar } from './PayoutsFilterBar';
+export { PayoutsTable } from './PayoutsTable';
+export { PayoutReviewModal } from './PayoutReviewModal';
+export { PaymentsStatsCards } from './PaymentsStatsCards';
+export { BulkActionsBar } from './BulkActionsBar';

--- a/frontend/src/components/payments-shared/PayoutMethodIcon.tsx
+++ b/frontend/src/components/payments-shared/PayoutMethodIcon.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { CreditCard, Banknote, Coins } from 'lucide-react';
+import type { PayoutMethod } from '../../types';
+
+interface PayoutMethodIconProps {
+  method: PayoutMethod;
+  size?: number;
+  showLabel?: boolean;
+  className?: string;
+}
+
+export const PAYOUT_METHOD_LABELS: Record<PayoutMethod, string> = {
+  mercury_card: 'Mercury Card',
+  wire: 'Wire Transfer',
+  usdc_base: 'USDC (Base)',
+};
+
+/**
+ * Renders an icon (and optional label) for a payout method. Shared between the
+ * host-facing PayoutsList (PR 3) and the admin PayoutsTable (PR 4).
+ */
+export const PayoutMethodIcon: React.FC<PayoutMethodIconProps> = ({
+  method,
+  size = 16,
+  showLabel = false,
+  className = '',
+}) => {
+  let Icon = CreditCard;
+  if (method === 'wire') Icon = Banknote;
+  else if (method === 'usdc_base') Icon = Coins;
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      <Icon size={size} className="text-theme-text-secondary" />
+      {showLabel && (
+        <span className="text-sm text-theme-text-secondary">{PAYOUT_METHOD_LABELS[method]}</span>
+      )}
+    </span>
+  );
+};

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import type { AdminPayout, Payout } from '../../types';
+import { ClickableEmail } from '../ClickableEmail';
+import { PayoutStatusPill } from './PayoutStatusPill';
+import { PayoutMethodIcon } from './PayoutMethodIcon';
+import { formatPayoutAmount } from './formatPayoutAmount';
+
+interface PayoutRowProps {
+  /**
+   * A Payout (host view) or AdminPayout (admin view, with embedded host +
+   * party info). Admin-mode columns are only rendered when the row carries
+   * the AdminPayout fields AND `showAdminColumns` is true.
+   */
+  payout: Payout | AdminPayout;
+  /** Render host-info columns (admin dashboard). */
+  showAdminColumns?: boolean;
+  /** Render a leading checkbox column (bulk-actions). */
+  selectable?: boolean;
+  selected?: boolean;
+  onSelectToggle?: () => void;
+  /** Row click handler (open detail modal). */
+  onClick?: () => void;
+  /** Extra cell rendered at the end of the row (admin actions menu). */
+  actions?: React.ReactNode;
+}
+
+/**
+ * Shared payout row primitive. Used as a `<tr>` in both the host PayoutsList
+ * (PR 3) and the admin PayoutsTable (PR 4). Props toggle which columns appear
+ * so we don't end up with two divergent row implementations (see the
+ * "two checklist renderers" precedent).
+ */
+export const PayoutRow: React.FC<PayoutRowProps> = ({
+  payout,
+  showAdminColumns = false,
+  selectable = false,
+  selected = false,
+  onSelectToggle,
+  onClick,
+  actions,
+}) => {
+  const admin = payout as AdminPayout;
+  const firstPizza = (payout.documents || []).find((d) => d.kind === 'pizza');
+  const thumbUrl = firstPizza?.url || null;
+
+  const submittedAbs = new Date(payout.createdAt).toLocaleString();
+  const submittedRel = relativeTime(new Date(payout.createdAt));
+
+  return (
+    <tr
+      className={`border-b border-theme-stroke transition-colors ${onClick ? 'cursor-pointer hover:bg-theme-surface-hover' : ''}`}
+      onClick={onClick}
+    >
+      {selectable && (
+        <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onSelectToggle?.()}
+            className="rounded border-theme-stroke-hover bg-theme-surface"
+            aria-label="Select payout"
+          />
+        </td>
+      )}
+      <td className="px-3 py-3 w-14">
+        {thumbUrl ? (
+          <img
+            src={thumbUrl}
+            alt=""
+            className="w-10 h-10 rounded object-cover border border-theme-stroke"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-10 h-10 rounded border border-dashed border-theme-stroke" />
+        )}
+      </td>
+
+      {showAdminColumns && admin.host && (
+        <td className="px-3 py-3 text-sm">
+          <div className="font-medium text-theme-text">{admin.host.name || '—'}</div>
+          {admin.host.email && (
+            <div className="text-xs text-theme-text-muted">
+              <ClickableEmail email={admin.host.email} />
+            </div>
+          )}
+        </td>
+      )}
+
+      {showAdminColumns && admin.party && (
+        <td className="px-3 py-3 text-sm">
+          <a
+            href={`/host/${admin.party.inviteCode}`}
+            className="text-theme-text hover:underline"
+            onClick={(e) => e.stopPropagation()}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {admin.party.name}
+          </a>
+        </td>
+      )}
+
+      <td className="px-3 py-3 text-sm text-theme-text-secondary">
+        <div title={submittedAbs}>{submittedRel}</div>
+        <div className="text-xs text-theme-text-faint">{submittedAbs}</div>
+      </td>
+
+      <td className="px-3 py-3 text-sm text-theme-text">
+        <div className="font-medium">
+          {formatPayoutAmount(
+            Number(payout.finalAmountUsd),
+            Number(payout.originalAmount),
+            payout.originalCurrency,
+          )}
+        </div>
+      </td>
+
+      <td className="px-3 py-3">
+        <PayoutMethodIcon method={payout.payoutMethod} />
+      </td>
+
+      <td className="px-3 py-3">
+        <PayoutStatusPill status={payout.status} />
+      </td>
+
+      {actions && (
+        <td className="px-3 py-3 text-right" onClick={(e) => e.stopPropagation()}>
+          {actions}
+        </td>
+      )}
+    </tr>
+  );
+};
+
+/** Small "x minutes / hours / days ago" formatter. */
+function relativeTime(date: Date): string {
+  const diff = Date.now() - date.getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}

--- a/frontend/src/components/payments-shared/PayoutStatusPill.tsx
+++ b/frontend/src/components/payments-shared/PayoutStatusPill.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { PayoutStatus } from '../../types';
+
+interface PayoutStatusPillProps {
+  status: PayoutStatus;
+  size?: 'sm' | 'md';
+}
+
+/**
+ * Status pill used by both the host PayoutsList (PR 3) and the admin
+ * PayoutsTable (PR 4). Single source of truth for status colors + labels so
+ * we don't end up with the "two checklist renderers" drift bug.
+ */
+const STATUS_STYLES: Record<PayoutStatus, { bg: string; text: string; border: string; label: string }> = {
+  pending: {
+    bg: 'bg-amber-100',
+    text: 'text-amber-800',
+    border: 'border-amber-300',
+    label: 'Pending',
+  },
+  approved: {
+    bg: 'bg-blue-100',
+    text: 'text-blue-800',
+    border: 'border-blue-300',
+    label: 'Approved',
+  },
+  paid: {
+    bg: 'bg-emerald-100',
+    text: 'text-emerald-800',
+    border: 'border-emerald-300',
+    label: 'Paid',
+  },
+  rejected: {
+    bg: 'bg-red-100',
+    text: 'text-red-800',
+    border: 'border-red-300',
+    label: 'Rejected',
+  },
+  failed: {
+    bg: 'bg-rose-100',
+    text: 'text-rose-800',
+    border: 'border-rose-300',
+    label: 'Failed',
+  },
+};
+
+export const PayoutStatusPill: React.FC<PayoutStatusPillProps> = ({ status, size = 'sm' }) => {
+  const style = STATUS_STYLES[status] || STATUS_STYLES.pending;
+  const sizeClass = size === 'md' ? 'px-2.5 py-1 text-sm' : 'px-2 py-0.5 text-xs';
+  return (
+    <span
+      className={`inline-block rounded-full font-medium border ${sizeClass} ${style.bg} ${style.text} ${style.border}`}
+    >
+      {style.label}
+    </span>
+  );
+};

--- a/frontend/src/components/payments-shared/formatPayoutAmount.ts
+++ b/frontend/src/components/payments-shared/formatPayoutAmount.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared payout-amount formatters used by both the host PayoutsList (PR 3) and
+ * the admin PayoutsTable (PR 4). Keeping a single source so the two views
+ * never disagree on what "$15.75 USD (€14.00 EUR)" should look like.
+ */
+
+const USD_FMT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatUsd(amount: number | null | undefined): string {
+  if (amount == null || !Number.isFinite(Number(amount))) return '—';
+  return USD_FMT.format(Number(amount));
+}
+
+/**
+ * Format an original-currency amount. Falls back to a plain numeric format if
+ * Intl.NumberFormat doesn't recognize the currency code (common for niche
+ * receipts).
+ */
+export function formatOriginalCurrency(amount: number, currency: string): string {
+  try {
+    const fmt = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    return fmt.format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency.toUpperCase()}`;
+  }
+}
+
+/**
+ * Combined formatter: "$15.75 USD (€14.00 EUR)" style. If the original
+ * currency is USD (or matches the USD amount) we just return the USD form
+ * with no parenthetical footnote.
+ */
+export function formatPayoutAmount(
+  usdAmount: number,
+  originalAmount?: number | null,
+  originalCurrency?: string | null,
+): string {
+  const usd = formatUsd(usdAmount);
+  if (originalAmount == null || !originalCurrency || originalCurrency.toUpperCase() === 'USD') {
+    return usd;
+  }
+  return `${usd} (${formatOriginalCurrency(originalAmount, originalCurrency)})`;
+}

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -1,0 +1,4 @@
+export { PayoutStatusPill } from './PayoutStatusPill';
+export { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from './PayoutMethodIcon';
+export { PayoutRow } from './PayoutRow';
+export { formatPayoutAmount, formatUsd, formatOriginalCurrency } from './formatPayoutAmount';

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "Keine Admins gefunden",
     "superAdmin": "Super-Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Admin entfernen",
     "tableHeaders": {
       "email": "E-Mail",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "No admins found",
     "superAdmin": "Super Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Remove admin",
     "tableHeaders": {
       "email": "Email",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "No se encontraron administradores",
     "superAdmin": "Super Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Eliminar administrador",
     "tableHeaders": {
       "email": "Email",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "Aucun administrateur trouvé",
     "superAdmin": "Super administrateur",
     "admin": "Administrateur",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Supprimer l'administrateur",
     "tableHeaders": {
       "email": "E-mail",

--- a/frontend/src/i18n/locales/ja/admin.json
+++ b/frontend/src/i18n/locales/ja/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "管理者が見つかりません",
     "superAdmin": "スーパー管理者",
     "admin": "管理者",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "管理者を削除",
     "tableHeaders": {
       "email": "メール",

--- a/frontend/src/i18n/locales/ko/admin.json
+++ b/frontend/src/i18n/locales/ko/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "관리자가 없습니다",
     "superAdmin": "슈퍼 관리자",
     "admin": "관리자",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "관리자 제거",
     "tableHeaders": {
       "email": "이메일",

--- a/frontend/src/i18n/locales/pt/admin.json
+++ b/frontend/src/i18n/locales/pt/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "Nenhum admin encontrado",
     "superAdmin": "Super Admin",
     "admin": "Admin",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "Remover admin",
     "tableHeaders": {
       "email": "E-mail",

--- a/frontend/src/i18n/locales/zh/admin.json
+++ b/frontend/src/i18n/locales/zh/admin.json
@@ -29,6 +29,8 @@
     "noAdmins": "未找到管理员",
     "superAdmin": "超级管理员",
     "admin": "管理员",
+    "paymentAdmin": "Payment Admin",
+    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
     "removeAdmin": "移除管理员",
     "tableHeaders": {
       "email": "邮箱",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -3590,6 +3590,111 @@ export async function applyLogoBgFixUpload(
       },
     }
   );
+}
+
+// ============================================
+// Admin Host Payouts (arugula-38633 — PR 4)
+// ============================================
+
+function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
+  if (!filters) return '';
+  const params = new URLSearchParams();
+  if (filters.status && filters.status !== 'all') params.set('status', filters.status);
+  if (filters.payoutMethod && filters.payoutMethod !== 'all') params.set('payoutMethod', filters.payoutMethod);
+  if (filters.partyId) params.set('partyId', filters.partyId);
+  if (filters.hostEmail) params.set('hostEmail', filters.hostEmail);
+  if (filters.currency && filters.currency !== 'all') params.set('currency', filters.currency);
+  if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
+  if (filters.dateTo) params.set('dateTo', filters.dateTo);
+  if (filters.cursor) params.set('cursor', filters.cursor);
+  if (filters.limit) params.set('limit', String(filters.limit));
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+export async function listAdminPayouts(filters?: AdminPayoutFilters): Promise<AdminPayoutsResponse> {
+  return apiRequest<AdminPayoutsResponse>(`/api/admin/payouts${buildPayoutQuery(filters)}`);
+}
+
+export async function getAdminPayout(id: string): Promise<AdminPayoutDetail> {
+  const res = await apiRequest<{ payout: AdminPayoutDetail }>(`/api/admin/payouts/${id}`);
+  return res.payout;
+}
+
+export async function updateAdminPayout(
+  id: string,
+  fields: {
+    finalAmountUsd?: number;
+    adminNotes?: string | null;
+    payoutMethod?: PayoutMethod;
+    payoutWalletAddress?: string | null;
+    payoutBankDetails?: BankDetails | null;
+    note?: string;
+  },
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}`, {
+    method: 'PATCH',
+    body: fields,
+  });
+  return res.payout;
+}
+
+export async function approveAdminPayout(
+  id: string,
+  opts?: { note?: string; autoExecute?: boolean },
+): Promise<{ payout: AdminPayout; autoExecuteDeferred: boolean }> {
+  return apiRequest(`/api/admin/payouts/${id}/approve`, {
+    method: 'POST',
+    body: { note: opts?.note, autoExecute: opts?.autoExecute },
+  });
+}
+
+export async function rejectAdminPayout(id: string, rejectionReason: string): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/reject`, {
+    method: 'POST',
+    body: { rejectionReason },
+  });
+  return res.payout;
+}
+
+export async function markAdminPayoutPaid(
+  id: string,
+  refs: {
+    wireReference?: string;
+    transactionHash?: string;
+    mercuryCardLast4?: string;
+    mercuryCardId?: string;
+    note?: string;
+  },
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/mark-paid`, {
+    method: 'POST',
+    body: refs,
+  });
+  return res.payout;
+}
+
+/**
+ * Triggers the CSV export endpoint and downloads the file to the browser.
+ * Returns nothing — fires a download via a temporary <a> element.
+ */
+export async function exportAdminPayoutsCsv(filters?: AdminPayoutFilters): Promise<void> {
+  const token = localStorage.getItem('authToken');
+  if (!token) throw new Error('Not authenticated');
+  const url = `${API_URL}/api/admin/payouts/export.csv${buildPayoutQuery(filters)}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`CSV export failed: ${res.status}`);
+  }
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = `host-payouts-${new Date().toISOString().split('T')[0]}.csv`;
+  a.click();
+  URL.revokeObjectURL(objectUrl);
 }
 
 /**

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3675,6 +3675,41 @@ export async function markAdminPayoutPaid(
 }
 
 /**
+ * Execute an approved payout (PR 5). Body shape is method-specific:
+ *   - usdc_base    → no body required; server sends via Privy server-wallet
+ *   - wire         → { wireReference: string } REQUIRED
+ *   - mercury_card → { mercuryCardLast4: 'NNNN', mercuryCardId?: string, note?: string } REQUIRED
+ * Returns the updated payout. Throws on any server-side validation/execution failure.
+ */
+export async function executeAdminPayout(
+  id: string,
+  body: {
+    wireReference?: string;
+    mercuryCardLast4?: string;
+    mercuryCardId?: string;
+    note?: string;
+  } = {},
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/execute`, {
+    method: 'POST',
+    body,
+  });
+  return res.payout;
+}
+
+/**
+ * Get the running 24h USDC payout usage + remaining cap (PR 5). Used to render
+ * the "Daily cap remaining: $X" hint before the admin confirms a USDC execute.
+ */
+export async function getUsdcDailyCapRemaining(): Promise<{
+  usedUsd: number;
+  capUsd: number;
+  remainingUsd: number;
+}> {
+  return apiRequest('/api/admin/payouts/usdc-daily-cap-remaining');
+}
+
+/**
  * Triggers the CSV export endpoint and downloads the file to the browser.
  * Returns nothing — fires a download via a temporary <a> element.
  */

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -9,7 +9,7 @@ import { CopyEmailButton } from '../components/CopyEmailButton';
 import { FunnelTab } from '../components/underboss/FunnelTab';
 import {
   Shield, ShieldCheck, UserPlus, Trash2, Loader2,
-  Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp, Download, Palette,
+  Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp, Download, Palette, DollarSign, ArrowRight,
 } from 'lucide-react';
 import {
   fetchAdminMe, fetchAdminList, addAdmin, removeAdmin,
@@ -582,7 +582,7 @@ export function AdminPage() {
           </div>
 
           {/* Export Events CSV */}
-          <div className="mb-6">
+          <div className="mb-6 flex items-center gap-2 flex-wrap">
             <button
               onClick={handleExportEventsCsv}
               disabled={exportingCsv}
@@ -591,6 +591,15 @@ export function AdminPage() {
               {exportingCsv ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
               {t('page.exportEventsCsv')}
             </button>
+            {/* Link to /payments (admin, super_admin, payment_admin) — arugula-38633 PR 4 */}
+            <a
+              href="/payments"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-50 text-emerald-800 text-sm font-medium hover:bg-emerald-100 border border-emerald-300"
+            >
+              <DollarSign size={16} />
+              Manage Host Payouts
+              <ArrowRight size={14} />
+            </a>
           </div>
 
           {/* Admin Management */}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -59,6 +59,7 @@ export function AdminPage() {
   const [admins, setAdmins] = useState<AdminUser[]>([]);
   const [newEmail, setNewEmail] = useState('');
   const [newName, setNewName] = useState('');
+  const [newRole, setNewRole] = useState<'admin' | 'super_admin' | 'payment_admin'>('admin');
   const [addingAdmin, setAddingAdmin] = useState(false);
   const [adminMessage, setAdminMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -415,11 +416,16 @@ export function AdminPage() {
     setAddingAdmin(true);
     setAdminMessage(null);
     try {
-      const admin = await addAdmin({ email: newEmail.trim(), name: newName.trim() || undefined });
+      const admin = await addAdmin({
+        email: newEmail.trim(),
+        name: newName.trim() || undefined,
+        role: newRole,
+      });
       setAdmins((prev) => [...prev, admin]);
       setNewEmail('');
       setNewName('');
-      setAdminMessage({ type: 'success', text: `Added ${admin.email} as admin` });
+      setNewRole('admin');
+      setAdminMessage({ type: 'success', text: `Added ${admin.email} as ${admin.role}` });
     } catch (err: any) {
       setAdminMessage({ type: 'error', text: err.message || 'Failed to add admin' });
     } finally {
@@ -637,6 +643,43 @@ export function AdminPage() {
                     {t('admins.addAdmin')}
                   </button>
                 </div>
+                <div className="mt-3 flex flex-col gap-2">
+                  <div className="flex flex-wrap gap-4 text-sm">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="newAdminRole"
+                        value="admin"
+                        checked={newRole === 'admin'}
+                        onChange={() => setNewRole('admin')}
+                      />
+                      <span>{t('admins.admin')}</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="newAdminRole"
+                        value="super_admin"
+                        checked={newRole === 'super_admin'}
+                        onChange={() => setNewRole('super_admin')}
+                      />
+                      <span>{t('admins.superAdmin')}</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="newAdminRole"
+                        value="payment_admin"
+                        checked={newRole === 'payment_admin'}
+                        onChange={() => setNewRole('payment_admin')}
+                      />
+                      <span>{t('admins.paymentAdmin')}</span>
+                    </label>
+                  </div>
+                  {newRole === 'payment_admin' && (
+                    <p className="text-xs text-white/40">{t('admins.paymentAdminDesc')}</p>
+                  )}
+                </div>
               </form>
             )}
 
@@ -666,10 +709,16 @@ export function AdminPage() {
                           className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
                             admin.role === 'super_admin'
                               ? 'bg-red-100 text-red-700 border border-red-300'
-                              : 'bg-blue-100 text-blue-700 border border-blue-300'
+                              : admin.role === 'payment_admin'
+                                ? 'bg-emerald-100 text-emerald-700 border border-emerald-300'
+                                : 'bg-blue-100 text-blue-700 border border-blue-300'
                           }`}
                         >
-                          {admin.role === 'super_admin' ? t('admins.superAdmin') : t('admins.admin')}
+                          {admin.role === 'super_admin'
+                            ? t('admins.superAdmin')
+                            : admin.role === 'payment_admin'
+                              ? t('admins.paymentAdmin')
+                              : t('admins.admin')}
                         </span>
                       </td>
                       <td className="px-4 py-3 text-theme-text-muted">

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -10,6 +10,8 @@ import {
   rejectAdminPayout,
   updateAdminPayout,
   markAdminPayoutPaid,
+  executeAdminPayout,
+  getUsdcDailyCapRemaining,
   exportAdminPayoutsCsv,
 } from '../lib/api';
 import type {
@@ -344,6 +346,7 @@ export function PaymentsAdminPage() {
           onReject={handleRowReject}
           onEdit={openDetail}
           onMarkPaid={handleRowMarkPaid}
+          onExecute={openDetail}
           busyRowId={rowBusyId}
           loading={loading}
           loadingMore={loadingMore}
@@ -433,6 +436,34 @@ export function PaymentsAdminPage() {
                 setErrorMsg(err.message || 'Mark-paid failed');
               } finally {
                 setModalBusy(false);
+              }
+            }}
+            onExecute={async (body) => {
+              setModalBusy(true);
+              try {
+                await executeAdminPayout(detail.id, body);
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+                await refresh();
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Execute failed');
+                // Refresh anyway — USDC failure flips status to 'failed' server-side.
+                try {
+                  const fresh = await getAdminPayout(detail.id);
+                  setDetail(fresh);
+                  await refresh();
+                } catch {
+                  /* ignore */
+                }
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            fetchUsdcCapRemaining={async () => {
+              try {
+                return await getUsdcDailyCapRemaining();
+              } catch {
+                return null;
               }
             }}
           />

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1,0 +1,445 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { ShieldX, Loader2, DollarSign, Download } from 'lucide-react';
+import { Layout } from '../components/Layout';
+import {
+  fetchAdminMe,
+  listAdminPayouts,
+  getAdminPayout,
+  approveAdminPayout,
+  rejectAdminPayout,
+  updateAdminPayout,
+  markAdminPayoutPaid,
+  exportAdminPayoutsCsv,
+} from '../lib/api';
+import type {
+  AdminPayout,
+  AdminPayoutDetail,
+  AdminPayoutFilters,
+  AdminPayoutTotals,
+} from '../types';
+import { formatUsd } from '../components/payments-shared';
+import {
+  PayoutsFilterBar,
+  PayoutsTable,
+  PayoutReviewModal,
+  PaymentsStatsCards,
+  BulkActionsBar,
+} from '../components/payments-admin';
+
+type RoleState =
+  | { kind: 'loading' }
+  | { kind: 'denied' }
+  | { kind: 'allowed'; role: 'admin' | 'super_admin' | 'payment_admin'; email: string };
+
+const DEFAULT_FILTERS: AdminPayoutFilters = {
+  status: 'all',
+  payoutMethod: 'all',
+  currency: 'all',
+};
+
+export function PaymentsAdminPage() {
+  const [role, setRole] = useState<RoleState>({ kind: 'loading' });
+  const [filters, setFilters] = useState<AdminPayoutFilters>(DEFAULT_FILTERS);
+  const [payouts, setPayouts] = useState<AdminPayout[]>([]);
+  const [totals, setTotals] = useState<AdminPayoutTotals | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Selection (bulk actions)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+
+  // Detail modal
+  const [detail, setDetail] = useState<AdminPayoutDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [modalBusy, setModalBusy] = useState(false);
+  const [rowBusyId, setRowBusyId] = useState<string | null>(null);
+
+  // CSV export
+  const [exporting, setExporting] = useState(false);
+
+  // Role gate
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const me = await fetchAdminMe();
+        if (cancelled) return;
+        const r = me.role;
+        if (me.isAdmin && (r === 'admin' || r === 'super_admin' || r === 'payment_admin')) {
+          setRole({ kind: 'allowed', role: r, email: me.email || '' });
+        } else {
+          setRole({ kind: 'denied' });
+        }
+      } catch {
+        if (!cancelled) setRole({ kind: 'denied' });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const loadPage = useCallback(async (f: AdminPayoutFilters, append = false) => {
+    if (append) setLoadingMore(true);
+    else setLoading(true);
+    setErrorMsg(null);
+    try {
+      const res = await listAdminPayouts(f);
+      setPayouts((prev) => (append ? [...prev, ...res.payouts] : res.payouts));
+      setTotals(res.totals);
+      setNextCursor(res.nextCursor);
+    } catch (err: any) {
+      setErrorMsg(err.message || 'Failed to load payouts');
+    } finally {
+      if (append) setLoadingMore(false);
+      else setLoading(false);
+    }
+  }, []);
+
+  // Re-load when filters change (and we're allowed)
+  useEffect(() => {
+    if (role.kind !== 'allowed') return;
+    loadPage(filters, false);
+  }, [filters, role.kind, loadPage]);
+
+  const availableCurrencies = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of payouts) {
+      if (p.originalCurrency) set.add(p.originalCurrency.toUpperCase());
+    }
+    return Array.from(set).sort();
+  }, [payouts]);
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    setSelectedIds((prev) => {
+      if (prev.size === payouts.length && payouts.length > 0) return new Set();
+      return new Set(payouts.map((p) => p.id));
+    });
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+  }
+
+  async function refresh() {
+    await loadPage(filters, false);
+  }
+
+  async function openDetail(p: AdminPayout) {
+    setDetail(null);
+    setDetailLoading(true);
+    try {
+      const d = await getAdminPayout(p.id);
+      setDetail(d);
+    } catch (err: any) {
+      setErrorMsg(err.message || 'Failed to load payout');
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  function closeDetail() {
+    setDetail(null);
+  }
+
+  async function handleRowApprove(id: string) {
+    setRowBusyId(id);
+    try {
+      await approveAdminPayout(id);
+      await refresh();
+    } catch (err: any) {
+      setErrorMsg(err.message || 'Approve failed');
+    } finally {
+      setRowBusyId(null);
+    }
+  }
+
+  async function handleRowReject(id: string) {
+    const reason = window.prompt('Rejection reason (visible to host):');
+    if (!reason || !reason.trim()) return;
+    setRowBusyId(id);
+    try {
+      await rejectAdminPayout(id, reason.trim());
+      await refresh();
+    } catch (err: any) {
+      setErrorMsg(err.message || 'Reject failed');
+    } finally {
+      setRowBusyId(null);
+    }
+  }
+
+  async function handleRowMarkPaid(p: AdminPayout) {
+    setDetail(null);
+    setDetailLoading(true);
+    try {
+      const d = await getAdminPayout(p.id);
+      setDetail(d);
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  async function handleBulkApprove() {
+    if (selectedIds.size === 0) return;
+    if (!window.confirm(`Approve ${selectedIds.size} payouts?`)) return;
+    setBulkBusy(true);
+    try {
+      for (const id of Array.from(selectedIds)) {
+        await approveAdminPayout(id).catch(() => null);
+      }
+      clearSelection();
+      await refresh();
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  async function handleBulkReject() {
+    if (selectedIds.size === 0) return;
+    const reason = window.prompt('Rejection reason (applied to all selected):');
+    if (!reason || !reason.trim()) return;
+    setBulkBusy(true);
+    try {
+      for (const id of Array.from(selectedIds)) {
+        await rejectAdminPayout(id, reason.trim()).catch(() => null);
+      }
+      clearSelection();
+      await refresh();
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  async function handleBulkMarkPaid() {
+    if (selectedIds.size === 0) return;
+    if (!window.confirm(`Mark ${selectedIds.size} payouts as paid (no transaction refs)?`)) return;
+    setBulkBusy(true);
+    try {
+      for (const id of Array.from(selectedIds)) {
+        await markAdminPayoutPaid(id, { note: 'bulk mark-paid' }).catch(() => null);
+      }
+      clearSelection();
+      await refresh();
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  async function handleExportCsv() {
+    setExporting(true);
+    try {
+      await exportAdminPayoutsCsv(filters);
+    } catch (err: any) {
+      setErrorMsg(err.message || 'CSV export failed');
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  // Loading guard
+  if (role.kind === 'loading') {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center py-32">
+          <Loader2 size={32} className="animate-spin text-theme-text-muted" />
+        </div>
+      </Layout>
+    );
+  }
+
+  if (role.kind === 'denied') {
+    return (
+      <Layout>
+        <Helmet>
+          <title>Payments — Access Denied | RSV.Pizza</title>
+        </Helmet>
+        <div className="flex flex-col items-center justify-center px-4 py-32">
+          <ShieldX size={48} className="text-red-400/60 mb-4" />
+          <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
+          <p className="text-theme-text-muted text-center max-w-md">
+            The host payments dashboard is only available to admins and payment admins.
+          </p>
+        </div>
+      </Layout>
+    );
+  }
+
+  const meUserId = ''; // not needed client-side — backend enforces self-payout block
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>Host Payments | RSV.Pizza</title>
+      </Helmet>
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6 flex-wrap">
+          <div className="w-10 h-10 rounded-xl bg-emerald-500/15 flex items-center justify-center">
+            <DollarSign size={20} className="text-emerald-600" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-2xl font-bold text-theme-text">Host Payments</h1>
+            <p className="text-sm text-theme-text-muted">
+              Review, approve, and pay out host reimbursements ({role.role.replace('_', ' ')})
+            </p>
+          </div>
+          {totals && totals.totalUsdPending > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-100 text-amber-800 border border-amber-300 text-sm font-medium">
+              {formatUsd(totals.totalUsdPending)} pending
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleExportCsv}
+            disabled={exporting}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke hover:bg-theme-surface-hover text-sm text-theme-text disabled:opacity-50"
+          >
+            {exporting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+            Export CSV
+          </button>
+        </div>
+
+        <PaymentsStatsCards totals={totals} loading={loading && !totals} />
+
+        <PayoutsFilterBar
+          filters={filters}
+          onChange={setFilters}
+          onReset={() => setFilters(DEFAULT_FILTERS)}
+          availableCurrencies={availableCurrencies}
+        />
+
+        <BulkActionsBar
+          selectedCount={selectedIds.size}
+          onApprove={handleBulkApprove}
+          onReject={handleBulkReject}
+          onMarkPaid={handleBulkMarkPaid}
+          onClear={clearSelection}
+          busy={bulkBusy}
+        />
+
+        {errorMsg && (
+          <div className="mb-3 px-4 py-2 rounded-lg text-sm bg-red-100 text-red-700 border border-red-300">
+            {errorMsg}
+          </div>
+        )}
+
+        <PayoutsTable
+          payouts={payouts}
+          selectedIds={selectedIds}
+          onToggleSelect={toggleSelect}
+          onToggleSelectAll={toggleSelectAll}
+          onRowClick={openDetail}
+          onApprove={handleRowApprove}
+          onReject={handleRowReject}
+          onEdit={openDetail}
+          onMarkPaid={handleRowMarkPaid}
+          busyRowId={rowBusyId}
+          loading={loading}
+          loadingMore={loadingMore}
+          onLoadMore={() => loadPage({ ...filters, cursor: nextCursor || undefined }, true)}
+          hasMore={!!nextCursor}
+        />
+
+        {detailLoading && (
+          <div className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm flex items-center justify-center">
+            <Loader2 size={32} className="animate-spin text-white" />
+          </div>
+        )}
+
+        {detail && (
+          <PayoutReviewModal
+            payout={detail}
+            // Self-payout block is enforced server-side; if the actor's email
+            // matches the host's, surface a visual cue. (Backend will return
+            // 403 if they try anyway.)
+            selfPayoutBlocked={
+              role.kind === 'allowed' &&
+              role.role === 'payment_admin' &&
+              !!detail.host.email &&
+              detail.host.email.toLowerCase() === role.email.toLowerCase()
+            }
+            busy={modalBusy}
+            onClose={closeDetail}
+            onApprove={async (note) => {
+              setModalBusy(true);
+              try {
+                await approveAdminPayout(detail.id, { note });
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+                await refresh();
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Approve failed');
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            onReject={async (reason) => {
+              setModalBusy(true);
+              try {
+                await rejectAdminPayout(detail.id, reason);
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+                await refresh();
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Reject failed');
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            onSaveAmount={async (newAmount, note) => {
+              setModalBusy(true);
+              try {
+                await updateAdminPayout(detail.id, { finalAmountUsd: newAmount, note });
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+                await refresh();
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Save failed');
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            onSaveAdminNotes={async (notes) => {
+              setModalBusy(true);
+              try {
+                await updateAdminPayout(detail.id, { adminNotes: notes });
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Save failed');
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            onMarkPaid={async (refs) => {
+              setModalBusy(true);
+              try {
+                await markAdminPayoutPaid(detail.id, refs);
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+                await refresh();
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Mark-paid failed');
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+          />
+        )}
+        {/* meUserId placeholder to silence unused-warning while client-side comparison stays optional */}
+        <input type="hidden" value={meUserId} />
+      </main>
+    </Layout>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1122,7 +1122,7 @@ export interface FakeDetectionResponse {
 export interface AdminUser {
   id: string;
   email: string;
-  role: 'super_admin' | 'admin';
+  role: 'super_admin' | 'admin' | 'payment_admin';
   name: string | null;
   createdBy: string | null;
   createdAt: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1362,3 +1362,122 @@ export interface UnifiedPartner {
   website: string | null;
   sortOrder: number;
 }
+
+// ============================================
+// Host Payouts (arugula-38633)
+// ============================================
+export type PayoutStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'failed';
+export type PayoutMethod = 'mercury_card' | 'wire' | 'usdc_base';
+
+export interface PayoutDocument {
+  id: string;
+  kind: 'pizza' | 'receipt';
+  url: string;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  ocrAmount: number | null;
+  ocrCurrency: string | null;
+  ocrConfidence: number | null;
+  ocrError: string | null;
+  sortOrder: number;
+}
+
+export interface BankDetails {
+  accountHolderName?: string;
+  bankName?: string;
+  bankAddress?: string;
+  routingNumber?: string;
+  accountNumber?: string;
+  iban?: string;
+  swift?: string;
+  notes?: string;
+}
+
+export interface PayoutAuditEntry {
+  id: string;
+  action: 'create' | 'approve' | 'reject' | 'edit_amount' | 'mark_paid' | 'mark_failed' | 'retry' | 'cancel';
+  oldStatus: string | null;
+  newStatus: string | null;
+  oldAmount: number | null;
+  newAmount: number | null;
+  actorEmail: string;
+  actorKind: 'admin' | 'superadmin' | 'payment_admin' | 'host' | 'system';
+  note: string | null;
+  createdAt: string;
+}
+
+export interface Payout {
+  id: string;
+  partyId: string;
+  hostUserId: string;
+  originalAmount: number;
+  originalCurrency: string;
+  exchangeRate: number;
+  extractedAmountUsd: number;
+  finalAmountUsd: number;
+  status: PayoutStatus;
+  payoutMethod: PayoutMethod;
+  payoutWalletAddress: string | null;
+  payoutBankDetails: BankDetails | null;
+  mercuryCardId: string | null;
+  mercuryCardLast4: string | null;
+  hostNotes: string | null;
+  adminNotes: string | null;
+  rejectionReason: string | null;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
+  paidAt: string | null;
+  transactionHash: string | null;
+  wireReference: string | null;
+  createdAt: string;
+  updatedAt: string;
+  documents: PayoutDocument[];
+}
+
+// Admin-list payout: includes embedded party + host info
+export interface AdminPayout extends Payout {
+  party: {
+    id: string;
+    name: string;
+    inviteCode: string;
+    customUrl: string | null;
+  };
+  host: {
+    id: string;
+    name: string | null;
+    email: string | null;
+  };
+}
+
+export interface AdminPayoutDetail extends AdminPayout {
+  audits: PayoutAuditEntry[];
+}
+
+export interface AdminPayoutFilters {
+  status?: PayoutStatus | 'all';
+  payoutMethod?: PayoutMethod | 'all';
+  partyId?: string;
+  hostEmail?: string;
+  currency?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface AdminPayoutTotals {
+  byStatus: Record<string, number>;
+  byMethod: Record<string, number>;
+  totalUsdPending: number;
+  totalUsdPaid: number;
+  totalUsdThisMonth: number;
+  avgUsd: number;
+  awaitingReview: number;
+}
+
+export interface AdminPayoutsResponse {
+  payouts: AdminPayout[];
+  nextCursor: string | null;
+  totals: AdminPayoutTotals;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "nanoid": "^5.0.5",
         "sharp": "^0.33.5",
         "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^5.0.1"
+        "swagger-ui-express": "^5.0.1",
+        "viem": "^2.44.4"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",

--- a/scripts/check-payout-wallet-balance.js
+++ b/scripts/check-payout-wallet-balance.js
@@ -1,0 +1,72 @@
+/**
+ * Quick USDC-on-Base balance check for the payout server-wallet
+ * (arugula-38633, PR 5). Pure read — no transactions.
+ *
+ * Usage:
+ *   node scripts/check-payout-wallet-balance.js
+ *
+ * Required env (loaded from backend/.env):
+ *   - PRIVY_APP_ID
+ *   - PRIVY_APP_SECRET
+ *   - USDC_PAYOUT_PRIVY_WALLET_ID (created by scripts/create-payout-server-wallet.js)
+ *   - BASE_RPC_URL (optional; defaults to https://mainnet.base.org)
+ */
+
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '..', 'backend', '.env') });
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_DECIMALS = 6;
+
+async function main() {
+  const PRIVY_APP_ID = process.env.PRIVY_APP_ID;
+  const PRIVY_APP_SECRET = process.env.PRIVY_APP_SECRET;
+  const WALLET_ID = process.env.USDC_PAYOUT_PRIVY_WALLET_ID;
+  const RPC_URL = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
+
+  if (!PRIVY_APP_ID || !PRIVY_APP_SECRET) {
+    console.error('ERROR: PRIVY_APP_ID and PRIVY_APP_SECRET must be set in backend/.env');
+    process.exit(1);
+  }
+  if (!WALLET_ID) {
+    console.error('ERROR: USDC_PAYOUT_PRIVY_WALLET_ID not set. Run scripts/create-payout-server-wallet.js first.');
+    process.exit(1);
+  }
+
+  const { PrivyClient } = require('@privy-io/server-auth');
+  const { createPublicClient, http } = require('viem');
+  const { base } = require('viem/chains');
+
+  const client = new PrivyClient(PRIVY_APP_ID, PRIVY_APP_SECRET);
+  const wallet = await client.walletApi.getWallet({ id: WALLET_ID });
+
+  console.log('Wallet ID:      ' + wallet.id);
+  console.log('Wallet Address: ' + wallet.address);
+  console.log('RPC URL:        ' + RPC_URL);
+  console.log('');
+
+  const publicClient = createPublicClient({ chain: base, transport: http(RPC_URL) });
+
+  const balanceRaw = await publicClient.readContract({
+    address: USDC_BASE,
+    abi: [
+      {
+        inputs: [{ name: 'account', type: 'address' }],
+        name: 'balanceOf',
+        outputs: [{ name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ],
+    functionName: 'balanceOf',
+    args: [wallet.address],
+  });
+
+  const balance = Number(balanceRaw) / 10 ** USDC_DECIMALS;
+  console.log('USDC Balance:   $' + balance.toFixed(2));
+}
+
+main().catch((err) => {
+  console.error('Failed to read wallet balance:', err);
+  process.exit(2);
+});

--- a/scripts/create-payout-server-wallet.js
+++ b/scripts/create-payout-server-wallet.js
@@ -1,0 +1,77 @@
+/**
+ * One-shot Privy server-wallet provisioning for USDC payouts (arugula-38633, PR 5).
+ *
+ * Creates an Ethereum-chain Privy server-wallet that the backend will use to send
+ * USDC on Base. Snax runs this ONCE per environment, then pastes the printed wallet
+ * id into Vercel as `USDC_PAYOUT_PRIVY_WALLET_ID`, and funds the printed address
+ * with USDC out-of-band from treasury.
+ *
+ * Idempotency: if `USDC_PAYOUT_PRIVY_WALLET_ID` is already set, the script refuses
+ * to create another. Set `FORCE_NEW_WALLET=1` to override (rare — only when rotating).
+ *
+ * Usage:
+ *   node scripts/create-payout-server-wallet.js
+ *
+ * Required env (loaded from backend/.env):
+ *   - PRIVY_APP_ID
+ *   - PRIVY_APP_SECRET
+ *
+ * Output: prints the new wallet's id + address + next-step instructions.
+ *
+ * DO NOT run this unless instructed. This creates a real Privy wallet that
+ * will hold real funds.
+ */
+
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '..', 'backend', '.env') });
+
+async function main() {
+  const PRIVY_APP_ID = process.env.PRIVY_APP_ID;
+  const PRIVY_APP_SECRET = process.env.PRIVY_APP_SECRET;
+  const EXISTING = process.env.USDC_PAYOUT_PRIVY_WALLET_ID;
+  const FORCE = process.env.FORCE_NEW_WALLET === '1';
+
+  if (!PRIVY_APP_ID || !PRIVY_APP_SECRET) {
+    console.error('ERROR: PRIVY_APP_ID and PRIVY_APP_SECRET must be set in backend/.env');
+    process.exit(1);
+  }
+
+  if (EXISTING && !FORCE) {
+    console.error('REFUSING TO CREATE: USDC_PAYOUT_PRIVY_WALLET_ID is already set:');
+    console.error('  ' + EXISTING);
+    console.error('');
+    console.error('If you really want to rotate the payout wallet, re-run with FORCE_NEW_WALLET=1.');
+    console.error('Be aware: any USDC remaining on the OLD wallet will be stranded until you sweep.');
+    process.exit(2);
+  }
+
+  // Lazy require so the env-check error path is fast even without deps installed.
+  const { PrivyClient } = require('@privy-io/server-auth');
+  const client = new PrivyClient(PRIVY_APP_ID, PRIVY_APP_SECRET);
+
+  console.log('Creating new Privy server-wallet (chainType=ethereum)...');
+  const wallet = await client.walletApi.createWallet({ chainType: 'ethereum' });
+
+  console.log('');
+  console.log('  Wallet ID:      ' + wallet.id);
+  console.log('  Wallet Address: ' + wallet.address);
+  console.log('  Chain Type:     ' + wallet.chainType);
+  console.log('');
+  console.log('Next steps:');
+  console.log('  1. Add to Vercel backend env (Production + Preview):');
+  console.log('     USDC_PAYOUT_PRIVY_WALLET_ID=' + wallet.id);
+  console.log('  2. Fund the wallet with USDC on Base (token 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913):');
+  console.log('     send treasury USDC to ' + wallet.address);
+  console.log('  3. (Recommended) Set caps in Vercel backend env:');
+  console.log('     USDC_PAYOUT_MAX_USD=200');
+  console.log('     USDC_PAYOUT_DAILY_CAP_USD=2000');
+  console.log('  4. Verify the wallet balance with:');
+  console.log('     node scripts/check-payout-wallet-balance.js');
+  console.log('');
+  console.log('Save the wallet id somewhere safe — if you lose it the wallet is orphaned in Privy.');
+}
+
+main().catch((err) => {
+  console.error('Failed to create Privy server-wallet:', err);
+  process.exit(3);
+});


### PR DESCRIPTION
## Summary

**PR 5 of 5** in the arugula-38633 host-payments sequence. Replaces the 501 `/execute` stub from PR 4 with real execution for all three payout rails:

- **USDC on Base** — Privy server-wallet signs + broadcasts an ERC-20 `transfer` to the host's wallet, viem encodes the calldata, we wait for the on-chain receipt before flipping `status='paid'` and recording `transaction_hash`. On failure, status flips to `failed` with an audit row.
- **Wire** — admin asserts the wire was sent out-of-band and provides `wireReference`. Status -> `paid` with audit.
- **Mercury card** — admin issues the virtual card via Mercury's dashboard and records `mercuryCardLast4` (exactly 4 digits) + optional `mercuryCardId`. Status -> `paid` with audit.

Idempotent: rejects unless `status === 'approved'`. Frontend now shows the Execute Payout button with a method-specific confirmation form (USDC shows the live daily-cap remaining).

**Depends on PRs 2 (#360) + 4 (#376) merging into umbrella first.** PR 4's branch is currently merged into this one to make the diff render coherently in preview.

## Files

**Provisioning scripts (one-shot, Snax runs):**
- `scripts/create-payout-server-wallet.js` — creates the Privy server-wallet. Idempotent (refuses if `USDC_PAYOUT_PRIVY_WALLET_ID` already set, unless `FORCE_NEW_WALLET=1`).
- `scripts/check-payout-wallet-balance.js` — reads USDC-on-Base balance for the configured wallet.

**Backend:**
- `backend/src/services/usdc-base.service.ts` — `sendUsdcPayment(to, amountUsd)` via Privy `walletApi.ethereum.sendTransaction` on Base (CAIP-2 `eip155:8453`). Pre-flight: address validation (viem `isAddress`), per-tx cap (`USDC_PAYOUT_MAX_USD`, default 200), hard ceiling $1000 in code regardless of env, balance check via Base RPC, daily cap (`USDC_PAYOUT_DAILY_CAP_USD`, default 2000) computed from `SUM(final_amount_usd) WHERE method='usdc_base' AND status='paid' AND paidAt > now()-24h`. Also exports `getUsdcDailyCapStatus()`.
- `backend/src/routes/admin-payout.routes.ts` — replaces the 501 stub with real execution; adds `GET /api/admin/payouts/usdc-daily-cap-remaining`; extends `POST /approve` to actually execute when `autoExecute: true` AND method is `usdc_base`.
- `backend/package.json` — adds `viem` as a backend dep (it's already in frontend; backend needs its own).

**Frontend:**
- `frontend/src/lib/api.ts` — adds `executeAdminPayout(id, body)` and `getUsdcDailyCapRemaining()`.
- `frontend/src/components/payments-admin/PayoutReviewModal.tsx` — enables Execute Payout (replaces the disabled "(PR 5)" button), adds method-specific confirmation form with USDC daily-cap hint.
- `frontend/src/components/payments-admin/PayoutsTable.tsx` — enables row-level Execute action.
- `frontend/src/pages/PaymentsAdminPage.tsx` — wires `onExecute` + `fetchUsdcCapRemaining` to the modal.

## Setup checklist (Snax, before this can do anything in prod)

- [ ] `cd backend && npm install` (picks up viem)
- [ ] `node scripts/create-payout-server-wallet.js` — note the printed wallet ID + address
- [ ] In Vercel backend project (Preview + Production envs), set:
  - `USDC_PAYOUT_PRIVY_WALLET_ID=<id from script>`
  - `USDC_PAYOUT_MAX_USD=200` (or your preferred per-tx cap; hard ceiling $1000 in code)
  - `USDC_PAYOUT_DAILY_CAP_USD=2000` (or your preferred 24h cap)
- [ ] Confirm `BASE_RPC_URL` is set (defaults to `https://mainnet.base.org` if not — fine for low volume)
- [ ] Send USDC (Base, contract `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) from treasury to the wallet address
- [ ] `node scripts/check-payout-wallet-balance.js` to confirm funded
- [ ] Re-deploy backend so the new env vars take effect
- [ ] (Optional) Approve+execute a $1 test payout to a known test wallet end-to-end

## Preview limitation

Vercel preview can't fully exercise USDC execution until the env vars above are set on the backend Vercel project (which serves both preview + prod). Wire and Mercury rails *will* work in preview since they're pure DB writes. UI changes are testable immediately in preview.

## Risk note

This is money-movement code. The pre-flight stack:

1. Recipient address validated via viem `isAddress`
2. Amount > 0 and ≤ env per-tx cap
3. Hard code ceiling at $1000 regardless of env (cannot be bypassed by setting `USDC_PAYOUT_MAX_USD=99999`)
4. Live on-chain balance check via Base RPC
5. 24h cumulative cap from DB (counts only `paid` rows)
6. Privy holds the key — no `PAYMENT_WALLET_PRIVATE_KEY` env var
7. On-chain `waitForTransactionReceipt` confirms `status='success'` before we flip the DB row

Idempotency comes from the `status='approved'` gate — already-paid payouts return 400, not double-send. Status updates + audit rows are written in a single Prisma transaction so we can't leave one without the other.

## Test plan

- [ ] Preview frontend renders Execute Payout enabled for `approved` payouts (verified in build)
- [ ] Click Execute Payout on a USDC payout: confirmation shows "Daily cap remaining: $X" (live from new endpoint)
- [ ] Click Execute Payout on a wire payout: wire reference input required, button disabled until non-empty
- [ ] Click Execute Payout on a Mercury payout: last4 input accepts only 4 digits, button disabled otherwise
- [ ] Once env vars set on backend: $1 USDC send to test wallet, verify tx on Basescan + `transaction_hash` populated on row
- [ ] Verify re-execute attempt on `paid` row returns 400 (idempotency)
- [ ] Verify over-per-tx-cap and over-daily-cap attempts blocked
- [ ] Verify `autoExecute: true` on `/approve` for usdc_base executes synchronously; wire + Mercury return `autoExecuted: false` with skipped reason

Once PR 2 (#360) + PR 4 (#376) merge into umbrella, this diff will narrow to just the PR 5 files.