### PR TITLE
mushroom-31723: frontend — guest reject + un-check-in (PR #2)

### DIFF
--- a/frontend/src/components/GuestBasicCard.tsx
+++ b/frontend/src/components/GuestBasicCard.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { usePizza } from '../contexts/PizzaContext';
 import { Guest } from '../types';
-import { Trash2 } from 'lucide-react';
+import { UserRoundX } from 'lucide-react';
 
 interface GuestBasicCardProps {
   guest: Guest;
 }
 
 export const GuestBasicCard: React.FC<GuestBasicCardProps> = ({ guest }) => {
-  const { removeGuest } = usePizza();
+  const { rejectGuest } = usePizza();
 
   return (
     <div className="border border-theme-stroke rounded-lg p-3 bg-theme-surface hover:bg-theme-surface-hover hover:border-theme-stroke transition-all group">
@@ -42,11 +42,12 @@ export const GuestBasicCard: React.FC<GuestBasicCardProps> = ({ guest }) => {
           )}
         </div>
         <button
-          onClick={() => guest.id && removeGuest(guest.id)}
+          onClick={() => guest.id && rejectGuest(guest.id)}
           className="p-1 text-theme-text-faint hover:text-[#ff393a] hover:bg-[#ff393a]/10 rounded transition-colors opacity-0 group-hover:opacity-100"
-          aria-label="Remove guest"
+          aria-label="Reject guest"
+          title="Reject guest"
         >
-          <Trash2 size={14} />
+          <UserRoundX size={14} />
         </button>
       </div>
     </div>

--- a/frontend/src/components/GuestCard.tsx
+++ b/frontend/src/components/GuestCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { usePizza } from '../contexts/PizzaContext';
 import { Guest } from '../types';
-import { Trash2 } from 'lucide-react';
+import { UserRoundX } from 'lucide-react';
 import { getToppingEmoji } from '../utils/toppingEmojis';
 
 interface GuestCardProps {
@@ -9,7 +9,7 @@ interface GuestCardProps {
 }
 
 export const GuestCard: React.FC<GuestCardProps> = ({ guest }) => {
-  const { removeGuest, availableToppings, availableBeverages, party } = usePizza();
+  const { rejectGuest, availableToppings, availableBeverages, party } = usePizza();
   const isGppEvent = party?.eventType === 'gpp';
 
   const toppingNameById = (id: string) => {
@@ -74,11 +74,12 @@ export const GuestCard: React.FC<GuestCardProps> = ({ guest }) => {
           )}
         </div>
         <button
-          onClick={() => guest.id && removeGuest(guest.id)}
+          onClick={() => guest.id && rejectGuest(guest.id)}
           className="p-1 text-theme-text-faint hover:text-[#ff393a] hover:bg-[#ff393a]/10 rounded transition-colors opacity-0 group-hover:opacity-100"
-          aria-label="Remove guest"
+          aria-label="Reject guest"
+          title="Reject guest"
         >
-          <Trash2 size={14} />
+          <UserRoundX size={14} />
         </button>
       </div>
     </div>

--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -488,7 +488,7 @@ export const GuestList: React.FC = () => {
                 guest={guest}
                 variant="waitlist"
                 onPromote={promoteGuest}
-                onRemove={removeGuest}
+                onRemove={rejectGuest}
                 isSelected={guest.id ? selectedIds.has(guest.id) : false}
                 onToggleSelect={toggleSelect}
               />

--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -3,18 +3,20 @@ import { useTranslation } from 'react-i18next';
 import { usePizza } from '../contexts/PizzaContext';
 import { TableRow } from './TableRow';
 import { Guest } from '../types';
-import { UserRoundX, Users, Clock, Search, CheckCircle2, Download, Mail, Check, X, ArrowUpCircle, Loader2 } from 'lucide-react';
+import { UserRoundX, Users, Clock, Search, CheckCircle2, Download, Mail, Check, X, ArrowUpCircle, Loader2, Ban } from 'lucide-react';
 import { IconInput } from './IconInput';
 import { Checkbox } from './Checkbox';
+import { RejectedGuestsModal } from './RejectedGuestsModal';
 import { checkInGuest, getNotableGuestIds, addNotableAttendee, deleteNotableAttendeeByGuestId } from '../lib/api';
 
 export const GuestList: React.FC = () => {
   const { t } = useTranslation('host');
-  const { guests, removeGuest, approveGuest, declineGuest, promoteGuest, party, loadParty } = usePizza();
+  const { guests, rejectedGuests, rejectGuest, restoreGuest, uncheckInGuest, approveGuest, declineGuest, promoteGuest, party, loadParty } = usePizza();
   const [searchQuery, setSearchQuery] = useState('');
   const [checkingInId, setCheckingInId] = useState<string | null>(null);
   const [notableGuestIds, setNotableGuestIds] = useState<Set<string>>(new Set());
   const [togglingNotableId, setTogglingNotableId] = useState<string | null>(null);
+  const [showRejectedModal, setShowRejectedModal] = useState(false);
 
   // Bulk selection state
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -338,6 +340,17 @@ export const GuestList: React.FC = () => {
                 {t('guests.checkedIn', { count: checkedInCount })}
               </span>
             )}
+            {rejectedGuests.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowRejectedModal(true)}
+                className="bg-red-500/10 text-red-300 border border-red-500/30 px-2 py-1 rounded-full text-xs font-medium flex items-center gap-1 hover:bg-red-500/20 transition-colors"
+                title="View rejected guests"
+              >
+                <Ban size={12} />
+                <span>Rejected ({rejectedGuests.length})</span>
+              </button>
+            )}
           </div>
           <button
             onClick={exportCSV}
@@ -394,8 +407,9 @@ export const GuestList: React.FC = () => {
                   requireApproval={requireApproval}
                   onApprove={approveGuest}
                   onDecline={declineGuest}
-                  onRemove={removeGuest}
+                  onRemove={rejectGuest}
                   onCheckIn={handleCheckIn}
+                  onUncheckIn={uncheckInGuest}
                   isCheckingIn={checkingInId === guest.id}
                   isNotable={guest.id ? notableGuestIds.has(guest.id) : false}
                   onToggleNotable={handleToggleNotable}
@@ -436,7 +450,7 @@ export const GuestList: React.FC = () => {
                 key={guest.id}
                 guest={guest}
                 variant="basic"
-                onRemove={removeGuest}
+                onRemove={rejectGuest}
                 isSelected={guest.id ? selectedIds.has(guest.id) : false}
                 onToggleSelect={toggleSelect}
               />
@@ -546,6 +560,15 @@ export const GuestList: React.FC = () => {
         </div>
       )}
       </div>
+
+      {/* Rejected Guests modal — opened from the "Rejected (N)" chip in the header. */}
+      <RejectedGuestsModal
+        isOpen={showRejectedModal}
+        onClose={() => setShowRejectedModal(false)}
+        rejectedGuests={rejectedGuests}
+        onRestore={restoreGuest}
+        party={party}
+      />
     </>
   );
 };

--- a/frontend/src/components/GuestPreferencesList.tsx
+++ b/frontend/src/components/GuestPreferencesList.tsx
@@ -11,7 +11,7 @@ interface GuestPreferencesListProps {
 }
 
 export const GuestPreferencesList: React.FC<GuestPreferencesListProps> = ({ embedded = false }) => {
-  const { guests, removeGuest, approveGuest, declineGuest, party, availableToppings, availableBeverages } = usePizza();
+  const { guests, rejectGuest, approveGuest, declineGuest, party, availableToppings, availableBeverages } = usePizza();
   const isGppEvent = party?.eventType === 'gpp';
   const [showAddForm, setShowAddForm] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -106,7 +106,7 @@ export const GuestPreferencesList: React.FC<GuestPreferencesListProps> = ({ embe
             requireApproval={requireApproval}
             onApprove={approveGuest}
             onDecline={declineGuest}
-            onRemove={removeGuest}
+            onRemove={rejectGuest}
             toppingNameById={toppingNameById}
             beverageNameById={beverageNameById}
             hideBeverages={isGppEvent}

--- a/frontend/src/components/InvitedGuestsModal.tsx
+++ b/frontend/src/components/InvitedGuestsModal.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { X, MailQuestion } from 'lucide-react';
+import { Guest } from '../types';
+import { ClickableEmail } from './ClickableEmail';
+
+interface InvitedGuestsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  invitedGuests: Guest[];
+}
+
+export function InvitedGuestsModal({ isOpen, onClose, invitedGuests }: InvitedGuestsModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[100] flex items-center justify-center p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-theme-header rounded-2xl border border-theme-stroke w-full max-w-lg max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-theme-stroke">
+          <div className="flex items-center gap-2">
+            <MailQuestion size={18} className="text-amber-400" />
+            <h2 className="text-lg font-bold text-theme-text">Invited Guests</h2>
+            <span className="text-xs text-theme-text-muted">({invitedGuests.length})</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover rounded-lg transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {invitedGuests.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <MailQuestion size={36} className="text-theme-text-faint mb-3" />
+              <p className="text-theme-text-muted text-sm">No invited guests yet.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-theme-stroke">
+              {invitedGuests.map((guest) => (
+                <div key={guest.id} className="flex items-center gap-3 py-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="font-semibold text-theme-text text-sm truncate">{guest.name}</div>
+                    {guest.email && (
+                      <ClickableEmail
+                        email={guest.email}
+                        className="text-theme-text-muted text-xs truncate"
+                      />
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PartyHeader.tsx
+++ b/frontend/src/components/PartyHeader.tsx
@@ -253,9 +253,12 @@ export const PartyHeader: React.FC = () => {
                 <p className="text-sm text-theme-text-muted">
                   {party.hostName && `Hosted by ${party.hostName} • `}
                   {(() => {
-                    const invited = party.guests.filter(g => g.status === 'INVITED').length;
-                    const rsvpd = party.guests.filter(g => g.status !== 'INVITED').length;
-                    const checkedIn = party.guests.filter(g => g.checkedInAt).length;
+                    // Defensive: drop rejected guests (approved===false) from counts
+                    // in case the context-level filter ever misses this surface.
+                    const visible = party.guests.filter(g => g.approved !== false);
+                    const invited = visible.filter(g => g.status === 'INVITED').length;
+                    const rsvpd = visible.filter(g => g.status !== 'INVITED').length;
+                    const checkedIn = visible.filter(g => g.checkedInAt).length;
                     if (invited > 0) {
                       return (
                         <span>

--- a/frontend/src/components/RejectedGuestsModal.tsx
+++ b/frontend/src/components/RejectedGuestsModal.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import { X, RotateCcw, Loader2, Ban } from 'lucide-react';
+import { Guest, Party } from '../types';
+import { ClickableEmail } from './ClickableEmail';
+
+interface RejectedGuestsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  rejectedGuests: Guest[];
+  onRestore: (id: string) => Promise<void>;
+  // `party` is accepted for parity with sibling modals and to allow future
+  // approval-vs-confirm wording differentiation. The Restore button label
+  // stays "Restore" either way.
+  party?: Party | null;
+}
+
+export function RejectedGuestsModal({ isOpen, onClose, rejectedGuests, onRestore }: RejectedGuestsModalProps) {
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  // Auto-close when the rejected list is exhausted while the modal is open.
+  useEffect(() => {
+    if (isOpen && rejectedGuests.length === 0) {
+      onClose();
+    }
+  }, [isOpen, rejectedGuests.length, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleRestore = async (id: string) => {
+    if (restoringId) return;
+    setRestoringId(id);
+    try {
+      await onRestore(id);
+    } catch (err) {
+      console.error('Failed to restore guest:', err);
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[100] flex items-center justify-center p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-theme-header rounded-2xl border border-theme-stroke w-full max-w-lg max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-theme-stroke">
+          <div className="flex items-center gap-2">
+            <Ban size={18} className="text-red-400" />
+            <h2 className="text-lg font-bold text-theme-text">Rejected Guests</h2>
+            <span className="text-xs text-theme-text-muted">({rejectedGuests.length})</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover rounded-lg transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {rejectedGuests.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <Ban size={36} className="text-theme-text-faint mb-3" />
+              <p className="text-theme-text-muted text-sm">No rejected guests.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-theme-stroke">
+              {rejectedGuests.map((guest) => {
+                const isRestoring = restoringId === guest.id;
+                return (
+                  <div
+                    key={guest.id}
+                    className="flex items-center gap-3 py-3"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="font-semibold text-theme-text text-sm truncate">{guest.name}</div>
+                      {guest.email && (
+                        <ClickableEmail
+                          email={guest.email}
+                          className="text-theme-text-muted text-xs truncate"
+                        />
+                      )}
+                    </div>
+                    <button
+                      onClick={() => guest.id && handleRestore(guest.id)}
+                      disabled={isRestoring || !guest.id}
+                      className="flex items-center gap-1.5 text-[#39d98a] hover:bg-[#39d98a]/10 px-3 py-1.5 rounded-lg transition-colors text-sm font-medium flex-shrink-0 disabled:opacity-50"
+                      title="Restore guest"
+                    >
+                      {isRestoring ? (
+                        <Loader2 size={14} className="animate-spin" />
+                      ) : (
+                        <RotateCcw size={14} />
+                      )}
+                      <span>Restore</span>
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TableRow.tsx
+++ b/frontend/src/components/TableRow.tsx
@@ -295,14 +295,14 @@ export const TableRow: React.FC<TableRowProps> = ({
           </button>
         )}
 
-        {/* Delete */}
+        {/* Reject */}
         {onRemove && (
           <button
             onClick={() => guest.id && onRemove(guest.id)}
             className="p-1.5 text-theme-text-faint hover:text-[#ff393a] hover:bg-[#ff393a]/10 rounded transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
-            aria-label="Remove guest"
+            aria-label="Reject guest"
           >
-            <Trash2 size={14} />
+            <UserRoundX size={14} />
           </button>
         )}
       </div>

--- a/frontend/src/components/TableRow.tsx
+++ b/frontend/src/components/TableRow.tsx
@@ -389,7 +389,7 @@ export const TableRow: React.FC<TableRowProps> = ({
         </>
       )}
 
-      {/* Approve/Decline buttons */}
+      {/* Approve/Reject buttons */}
       {requireApproval && guest.approved === null && onApprove && onDecline && (
         <div className="flex items-center gap-2 flex-shrink-0">
           <button
@@ -404,17 +404,17 @@ export const TableRow: React.FC<TableRowProps> = ({
             className="flex items-center gap-1 text-[#ff393a] hover:bg-[#ff393a]/10 px-2 py-1 rounded transition-colors text-sm"
           >
             <X size={14} />
-            <span>Decline</span>
+            <span>Reject</span>
           </button>
         </div>
       )}
 
-      {/* Status badge for approved/declined */}
+      {/* Status badge for approved/rejected */}
       {requireApproval && guest.approved === true && (
         <span className="text-[#39d98a] text-xs flex-shrink-0">Approved</span>
       )}
       {requireApproval && guest.approved === false && (
-        <span className="text-[#ff393a] text-xs flex-shrink-0">Declined</span>
+        <span className="text-[#ff393a] text-xs flex-shrink-0">Rejected</span>
       )}
 
       {/* Notable attendee star toggle */}

--- a/frontend/src/components/TableRow.tsx
+++ b/frontend/src/components/TableRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Guest, BeverageRecommendation, PizzaRecommendation } from '../types';
-import { Trash2, Check, X, CheckCircle2, Loader2, ArrowUpCircle, Plus, Minus, Pencil, Star } from 'lucide-react';
+import { Trash2, Check, X, CheckCircle2, Loader2, ArrowUpCircle, Plus, Minus, Pencil, Star, UserRoundX } from 'lucide-react';
 import { format } from 'date-fns';
 import { getToppingEmoji } from '../utils/toppingEmojis';
 import { ClickableEmail } from './ClickableEmail';
@@ -33,6 +33,7 @@ interface TableRowProps {
   onDecline?: (id: string) => void;
   onRemove?: (id: string) => void;
   onCheckIn?: (id: string) => void;
+  onUncheckIn?: (id: string) => void;
   isCheckingIn?: boolean;
   onPromote?: (id: string) => void;
   // For requests variant - lookup functions
@@ -64,6 +65,7 @@ export const TableRow: React.FC<TableRowProps> = ({
   onDecline,
   onRemove,
   onCheckIn,
+  onUncheckIn,
   isCheckingIn = false,
   onPromote,
   toppingNameById = (id) => id,
@@ -438,12 +440,24 @@ export const TableRow: React.FC<TableRowProps> = ({
       {/* Check-in status badge or button */}
       {variant === 'basic' && onCheckIn && (
         guest.checkedInAt ? (
-          <div
-            className="flex items-center gap-1 text-green-400 text-xs flex-shrink-0 cursor-help"
-            title={`Checked in: ${format(new Date(guest.checkedInAt), 'MMM d, h:mm a')}`}
-          >
-            <CheckCircle2 size={14} />
-            <span className="hidden sm:inline">Checked in</span>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            <div
+              className="flex items-center gap-1 text-green-400 text-xs cursor-help"
+              title={`Checked in: ${format(new Date(guest.checkedInAt), 'MMM d, h:mm a')}`}
+            >
+              <CheckCircle2 size={14} />
+              <span className="hidden sm:inline">Checked in</span>
+            </div>
+            {onUncheckIn && (
+              <button
+                onClick={() => guest.id && onUncheckIn(guest.id)}
+                className="p-0.5 text-theme-text-faint hover:text-[#ff393a] hover:bg-[#ff393a]/10 rounded transition-colors"
+                title="Undo check-in"
+                aria-label="Undo check-in"
+              >
+                <X size={12} />
+              </button>
+            )}
           </div>
         ) : (
           <button
@@ -469,14 +483,16 @@ export const TableRow: React.FC<TableRowProps> = ({
         </span>
       )}
 
-      {/* Delete */}
+      {/* Reject (soft-delete via approved=false). Reversible via "Rejected (N)"
+          modal in GuestList — no confirm prompt needed. */}
       {onRemove && (
         <button
           onClick={() => guest.id && onRemove(guest.id)}
           className="p-1.5 text-theme-text-faint hover:text-[#ff393a] hover:bg-[#ff393a]/10 rounded transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
-          aria-label="Remove guest"
+          aria-label="Reject guest"
+          title="Reject guest"
         >
-          <Trash2 size={14} />
+          <UserRoundX size={14} />
         </button>
       )}
     </div>

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -130,13 +130,13 @@ export const GPPDashboardTab: React.FC = () => {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-theme-text">
-            {guests.filter(g => g.status === 'INVITED').length}
+            {guests.filter(g => g.approved !== false && g.status === 'INVITED').length}
           </div>
           <div className="text-xs text-theme-text-muted">Invited</div>
         </div>
         <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-theme-text">
-            {guests.filter(g => g.status !== 'INVITED').length}
+            {guests.filter(g => g.approved !== false && g.status !== 'INVITED').length}
           </div>
           <div className="text-xs text-theme-text-muted">RSVPs</div>
         </div>

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -7,6 +7,7 @@ import { AutoCompleteStates, ChecklistItem } from '../../types';
 import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
 import { FindVenueModal } from '../checklist/FindVenueModal';
+import { InvitedGuestsModal } from '../InvitedGuestsModal';
 
 export const GPPDashboardTab: React.FC = () => {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -21,6 +22,12 @@ export const GPPDashboardTab: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [findVenueOpen, setFindVenueOpen] = useState(false);
+  const [invitedModalOpen, setInvitedModalOpen] = useState(false);
+
+  const invitedGuests = useMemo(
+    () => guests.filter(g => g.approved !== false && g.status === 'INVITED'),
+    [guests]
+  );
 
   const loadChecklist = useCallback(async () => {
     if (!party?.id) return;
@@ -128,12 +135,18 @@ export const GPPDashboardTab: React.FC = () => {
     <div className="space-y-6">
       {/* Quick stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <div className="card p-4 text-center">
+        <button
+          type="button"
+          onClick={() => invitedGuests.length > 0 && setInvitedModalOpen(true)}
+          disabled={invitedGuests.length === 0}
+          className="card p-4 text-center transition-colors enabled:hover:bg-theme-surface-hover enabled:cursor-pointer disabled:cursor-default"
+          aria-label={invitedGuests.length > 0 ? `View ${invitedGuests.length} invited guests` : 'No invited guests'}
+        >
           <div className="text-2xl font-bold text-theme-text">
-            {guests.filter(g => g.approved !== false && g.status === 'INVITED').length}
+            {invitedGuests.length}
           </div>
           <div className="text-xs text-theme-text-muted">Invited</div>
-        </div>
+        </button>
         <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-theme-text">
             {guests.filter(g => g.approved !== false && g.status !== 'INVITED').length}
@@ -359,6 +372,12 @@ export const GPPDashboardTab: React.FC = () => {
         open={findVenueOpen}
         onClose={() => setFindVenueOpen(false)}
         onSaved={loadChecklist}
+      />
+
+      <InvitedGuestsModal
+        isOpen={invitedModalOpen}
+        onClose={() => setInvitedModalOpen(false)}
+        invitedGuests={invitedGuests}
       />
 
       {/* Host Resources */}

--- a/frontend/src/components/promo/EmailOutreach.tsx
+++ b/frontend/src/components/promo/EmailOutreach.tsx
@@ -60,9 +60,10 @@ export const EmailOutreach: React.FC<EmailOutreachProps> = ({ party, guests }) =
   const [includeEventDetails, setIncludeEventDetails] = useState(true);
   const [copied, setCopied] = useState(false);
 
-  // Filter guests by status and who have emails
+  // Filter guests by status and who have emails. Drop rejected (approved===false)
+  // up-front so they never appear in any outreach list.
   const filteredGuests = useMemo(() => {
-    const withEmail = guests.filter(g => g.email);
+    const withEmail = guests.filter(g => g.email && g.approved !== false);
     switch (recipientFilter) {
       case 'approved':
         return withEmail.filter(g => g.approved === true);

--- a/frontend/src/components/report/BrowseGuestsModal.tsx
+++ b/frontend/src/components/report/BrowseGuestsModal.tsx
@@ -62,12 +62,14 @@ export function BrowseGuestsModal({ isOpen, onClose, guests, partyId, onChanged 
     });
   }, [isOpen, partyId]);
 
-  // Group guests by non-provider domain
+  // Group guests by non-provider domain. Drop rejected (approved===false)
+  // defensively in case the context-level filter ever bypasses this surface.
   const domainGroups = useMemo(() => {
     const map = new Map<string, Guest[]>();
 
     for (const g of guests) {
       if (!g.email || !g.id) continue;
+      if (g.approved === false) continue;
       const domain = extractEmailDomain(g.email);
       if (!domain || isEmailProvider(domain)) continue;
       const list = map.get(domain) || [];

--- a/frontend/src/components/report/NotableAttendeesList.tsx
+++ b/frontend/src/components/report/NotableAttendeesList.tsx
@@ -142,10 +142,12 @@ export function NotableAttendeesList({ attendees, guests = [], partyId, onAdd, o
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [showBrowseModal, setShowBrowseModal] = useState(false);
 
-  // Count total RSVPs per domain from the full guest list
+  // Count total RSVPs per domain from the full guest list.
+  // Drop rejected (approved===false) defensively — they don't represent real RSVPs.
   const domainRsvpCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const g of guests) {
+      if (g.approved === false) continue;
       const domain = g.email ? extractEmailDomain(g.email, true) : null;
       if (domain) counts.set(domain, (counts.get(domain) || 0) + 1);
     }

--- a/frontend/src/components/report/ReportWidget.tsx
+++ b/frontend/src/components/report/ReportWidget.tsx
@@ -72,7 +72,7 @@ function buildFallbackReport(party: any, guests: Guest[]): EventReport {
     notableAttendees: [],
     featuredPhotos: [],
     stats: {
-      totalRsvps: guests.length,
+      totalRsvps: guests.filter(g => g.approved !== false).length,
       approvedGuests,
       mailingListSignups,
       walletAddresses,

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -19,11 +19,18 @@ interface PizzaContextType {
   updatePartyToppings: (toppings: string[]) => Promise<void>;
   updatePartyDietaryOptions: (dietaryOptions: string[]) => Promise<void>;
   // Guest management
+  // Note: `guests` is the visible list (excludes guests with `approved === false`).
+  // `rejectedGuests` is the host-rejected list (approved === false), surfaced via
+  // the "Rejected (N)" chip + RejectedGuestsModal for one-click restore.
   guests: Guest[];
+  rejectedGuests: Guest[];
   addGuest: (guest: Omit<Guest, 'id'>) => Promise<void>;
   removeGuest: (id: string) => Promise<void>;
   approveGuest: (id: string) => Promise<void>;
   declineGuest: (id: string) => Promise<void>;
+  rejectGuest: (id: string) => Promise<void>;
+  restoreGuest: (id: string) => Promise<void>;
+  uncheckInGuest: (id: string) => Promise<void>;
   promoteGuest: (id: string) => Promise<void>;
   // Recommendations
   recommendations: PizzaRecommendation[];
@@ -153,7 +160,12 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
 export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [party, setParty] = useState<Party | null>(null);
   const [partyLoading, setPartyLoading] = useState(false);
-  const [guests, setGuests] = useState<Guest[]>([]);
+  // `allGuests` is the raw list from the DB (includes rejected guests).
+  // `guests` and `rejectedGuests` are derived below so downstream consumers
+  // never see rejected guests unless they specifically opt in.
+  const [allGuests, setAllGuests] = useState<Guest[]>([]);
+  const guests = React.useMemo(() => allGuests.filter(g => g.approved !== false), [allGuests]);
+  const rejectedGuests = React.useMemo(() => allGuests.filter(g => g.approved === false), [allGuests]);
   const [recommendations, setRecommendations] = useState<PizzaRecommendation[]>([]);
   const [beverageRecommendations, setBeverageRecommendations] = useState<BeverageRecommendation[]>([]);
   const [waveRecommendations, setWaveRecommendations] = useState<WaveRecommendation[]>([]);
@@ -177,8 +189,11 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
     const unsubscribe = db.subscribeToGuests(party.id, (dbGuests) => {
       const updatedGuests = dbGuests.map(dbGuestToGuest);
-      setGuests(updatedGuests);
-      setParty(prev => prev ? { ...prev, guests: updatedGuests } : null);
+      setAllGuests(updatedGuests);
+      // party.guests is the visible list — filter rejected (approved===false) here
+      // so the 15+ files that read party.guests inherit the filter automatically.
+      const visibleGuests = updatedGuests.filter(g => g.approved !== false);
+      setParty(prev => prev ? { ...prev, guests: visibleGuests } : null);
     });
 
     return unsubscribe;
@@ -195,7 +210,7 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       if (dbParty) {
         const newParty = dbPartyToParty(dbParty, []);
         setParty(newParty);
-        setGuests([]);
+        setAllGuests([]);
         localStorage.setItem('rsvpizza_currentPartyCode', dbParty.invite_code);
         return dbParty.invite_code;
       }
@@ -218,9 +233,11 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       const result = await db.getPartyWithGuests(inviteCode);
       if (result) {
         const partyGuests = result.guests.map(dbGuestToGuest);
-        const loadedParty = dbPartyToParty(result.party, partyGuests);
+        // party.guests is the visible list — filter rejected guests out.
+        const visibleGuests = partyGuests.filter(g => g.approved !== false);
+        const loadedParty = dbPartyToParty(result.party, visibleGuests);
         setParty(loadedParty);
-        setGuests(partyGuests);
+        setAllGuests(partyGuests);
         localStorage.setItem('rsvpizza_currentPartyCode', inviteCode);
         return true;
       }
@@ -233,7 +250,7 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const clearParty = () => {
     localStorage.removeItem('rsvpizza_currentPartyCode');
     setParty(null);
-    setGuests([]);
+    setAllGuests([]);
     setRecommendations([]);
     setBeverageRecommendations([]);
     setWaveRecommendations([]);
@@ -266,7 +283,8 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
     if (dbGuest) {
       const newGuest = dbGuestToGuest(dbGuest);
-      setGuests(prev => [...prev, newGuest]);
+      setAllGuests(prev => [...prev, newGuest]);
+      // newly-added guests are never rejected, so push into party.guests too
       setParty(prev => prev ? { ...prev, guests: [...prev.guests, newGuest] } : null);
     }
   };
@@ -274,7 +292,7 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const removeGuest = async (id: string) => {
     const success = await db.removeGuest(id, party?.id);
     if (success) {
-      setGuests(prev => prev.filter(g => g.id !== id));
+      setAllGuests(prev => prev.filter(g => g.id !== id));
       setParty(prev => prev ? { ...prev, guests: prev.guests.filter(g => g.id !== id) } : null);
     }
   };
@@ -282,7 +300,7 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const approveGuest = async (id: string) => {
     const success = await db.updateGuestApproval(id, true, party?.id);
     if (success) {
-      setGuests(prev => prev.map(g => g.id === id ? { ...g, approved: true } : g));
+      setAllGuests(prev => prev.map(g => g.id === id ? { ...g, approved: true } : g));
       setParty(prev => prev ? {
         ...prev,
         guests: prev.guests.map(g => g.id === id ? { ...g, approved: true } : g)
@@ -293,11 +311,71 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const declineGuest = async (id: string) => {
     const success = await db.updateGuestApproval(id, false, party?.id);
     if (success) {
-      setGuests(prev => prev.map(g => g.id === id ? { ...g, approved: false } : g));
+      setAllGuests(prev => prev.map(g => g.id === id ? { ...g, approved: false } : g));
+      // a declined guest disappears from the visible (party.guests) list
       setParty(prev => prev ? {
         ...prev,
-        guests: prev.guests.map(g => g.id === id ? { ...g, approved: false } : g)
+        guests: prev.guests.filter(g => g.id !== id)
       } : null);
+    }
+  };
+
+  // Host-facing soft-reject: same wire as declineGuest but with an
+  // optimistic-revert path. Used by the new "Reject" buttons on TableRow,
+  // GuestCard, GuestBasicCard, etc.
+  const rejectGuest = async (id: string) => {
+    if (!party?.inviteCode) return;
+    const previousAll = allGuests;
+    // Optimistic: mark guest as approved=false locally → derived `guests`
+    // drops it, derived `rejectedGuests` picks it up.
+    setAllGuests(prev => prev.map(g => g.id === id ? { ...g, approved: false } : g));
+    setParty(prev => prev ? { ...prev, guests: prev.guests.filter(g => g.id !== id) } : null);
+    const success = await db.updateGuestApproval(id, false, party.id);
+    if (!success) {
+      // Revert by restoring previous list + reloading from server.
+      setAllGuests(previousAll);
+      await loadParty(party.inviteCode);
+    }
+  };
+
+  // Restore a previously-rejected guest. Backend `/approve` PATCH only accepts
+  // boolean (validates `typeof approved !== 'boolean'`), so we always restore
+  // with `approved=true`. For approval-required events this skips the PENDING
+  // state — but "Restore" is an explicit host action, so re-approving is the
+  // reasonable interpretation.
+  const restoreGuest = async (id: string) => {
+    if (!party?.inviteCode) return;
+    const previousAll = allGuests;
+    const restored = previousAll.find(g => g.id === id);
+    // Optimistic: flip approved=true → guest reappears in visible list.
+    setAllGuests(prev => prev.map(g => g.id === id ? { ...g, approved: true } : g));
+    if (restored) {
+      const restoredGuest: Guest = { ...restored, approved: true };
+      setParty(prev => prev ? { ...prev, guests: [...prev.guests, restoredGuest] } : null);
+    }
+    const success = await db.updateGuestApproval(id, true, party.id);
+    if (!success) {
+      setAllGuests(previousAll);
+      await loadParty(party.inviteCode);
+    }
+  };
+
+  // Un-check-in: hosts can undo a mis-tap by clearing checkedInAt/checkedInBy.
+  // Backend route DELETE /api/checkin/:inviteCode/:guestId is idempotent.
+  const uncheckInGuest = async (id: string) => {
+    if (!party?.inviteCode) return;
+    const previousAll = allGuests;
+    // Optimistic: clear local checkedInAt
+    setAllGuests(prev => prev.map(g => g.id === id ? { ...g, checkedInAt: null, checkedInBy: null } : g));
+    setParty(prev => prev ? {
+      ...prev,
+      guests: prev.guests.map(g => g.id === id ? { ...g, checkedInAt: null, checkedInBy: null } : g)
+    } : null);
+    const success = await db.uncheckInGuest(id, { id: party.id, inviteCode: party.inviteCode });
+    if (!success) {
+      // Revert by restoring previous local state + reload from server.
+      setAllGuests(previousAll);
+      await loadParty(party.inviteCode);
     }
   };
 
@@ -305,7 +383,7 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     if (!party) return;
     const success = await db.promoteGuest(id, party.id);
     if (success) {
-      setGuests(prev => prev.map(g =>
+      setAllGuests(prev => prev.map(g =>
         g.id === id
           ? { ...g, status: 'CONFIRMED', waitlistPosition: null, promotedAt: new Date().toISOString() }
           : g.status === 'WAITLISTED' && g.waitlistPosition && g.waitlistPosition > (prev.find(p => p.id === id)?.waitlistPosition || 0)
@@ -443,10 +521,14 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       updatePartyToppings,
       updatePartyDietaryOptions,
       guests,
+      rejectedGuests,
       addGuest,
       removeGuest,
       approveGuest,
       declineGuest,
+      rejectGuest,
+      restoreGuest,
+      uncheckInGuest,
       promoteGuest,
       recommendations,
       generateRecommendations,

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -338,22 +338,22 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     }
   };
 
-  // Restore a previously-rejected guest. Backend `/approve` PATCH only accepts
-  // boolean (validates `typeof approved !== 'boolean'`), so we always restore
-  // with `approved=true`. For approval-required events this skips the PENDING
-  // state — but "Restore" is an explicit host action, so re-approving is the
-  // reasonable interpretation.
+  // Restore a previously-rejected guest by bumping them back to needs-approval
+  // (approved=null). They reappear in the visible list with the Approve/Decline
+  // pair, so the host has to click Approve to re-confirm — making restore a
+  // deliberate two-step action instead of a one-click un-do that re-confirms
+  // by side effect.
   const restoreGuest = async (id: string) => {
     if (!party?.inviteCode) return;
     const previousAll = allGuests;
     const restored = previousAll.find(g => g.id === id);
-    // Optimistic: flip approved=true → guest reappears in visible list.
-    setAllGuests(prev => prev.map(g => g.id === id ? { ...g, approved: true } : g));
+    // Optimistic: flip approved=null → guest reappears in visible list as pending.
+    setAllGuests(prev => prev.map(g => g.id === id ? { ...g, approved: null } : g));
     if (restored) {
-      const restoredGuest: Guest = { ...restored, approved: true };
+      const restoredGuest: Guest = { ...restored, approved: null };
       setParty(prev => prev ? { ...prev, guests: [...prev.guests, restoredGuest] } : null);
     }
-    const success = await db.updateGuestApproval(id, true, party.id);
+    const success = await db.updateGuestApproval(id, null, party.id);
     if (!success) {
       setAllGuests(previousAll);
       await loadParty(party.inviteCode);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -317,7 +317,7 @@ export async function removeGuestApi(partyId: string, guestId: string) {
   });
 }
 
-export async function updateGuestApprovalApi(partyId: string, guestId: string, approved: boolean) {
+export async function updateGuestApprovalApi(partyId: string, guestId: string, approved: boolean | null) {
   return apiRequest<{ guest: any }>(`/api/parties/${partyId}/guests/${guestId}/approve`, {
     method: 'PATCH',
     body: { approved },
@@ -967,6 +967,29 @@ export interface CheckInResponse {
 export async function checkInGuest(inviteCode: string, guestId: string): Promise<CheckInResponse> {
   return apiRequest<CheckInResponse>(`/api/checkin/${inviteCode}/${guestId}`, {
     method: 'POST',
+    requireAuth: true,
+  });
+}
+
+// Un-check-in: DELETE /api/checkin/:inviteCode/:guestId
+// Backend nulls checkedInAt/checkedInBy and emits guest.checkin_undone webhook.
+// Idempotent (200 if already unchecked). Returns 400 GUEST_REJECTED if guest is rejected.
+export interface UnCheckInResponse {
+  success: boolean;
+  notCheckedIn?: boolean;
+  guest: {
+    id: string;
+    name: string;
+    email?: string;
+    checkedInAt: null;
+    checkedInBy: null;
+  };
+  message: string;
+}
+
+export async function uncheckInGuestApi(inviteCode: string, guestId: string): Promise<UnCheckInResponse> {
+  return apiRequest<UnCheckInResponse>(`/api/checkin/${inviteCode}/${guestId}`, {
+    method: 'DELETE',
     requireAuth: true,
   });
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -6,6 +6,7 @@ import {
   addGuestByHostApi,
   removeGuestApi,
   updateGuestApprovalApi,
+  uncheckInGuestApi,
   promoteGuestApi,
 } from './api';
 import { uuid } from './utils';
@@ -1531,7 +1532,7 @@ export async function removeGuest(guestId: string, partyId?: string): Promise<bo
   return true;
 }
 
-export async function updateGuestApproval(guestId: string, approved: boolean, partyId?: string): Promise<boolean> {
+export async function updateGuestApproval(guestId: string, approved: boolean | null, partyId?: string): Promise<boolean> {
   // Use API if authenticated and partyId provided (secure path)
   if (isAuthenticated() && partyId) {
     try {
@@ -1554,6 +1555,22 @@ export async function updateGuestApproval(guestId: string, approved: boolean, pa
     return false;
   }
   return true;
+}
+
+// Un-check-in a guest (host-side undo). Resolves invite code from party and calls
+// DELETE /api/checkin/:inviteCode/:guestId. Idempotent on backend.
+export async function uncheckInGuest(guestId: string, party: { id: string; inviteCode: string } | null | undefined): Promise<boolean> {
+  if (!party?.inviteCode) {
+    console.error('uncheckInGuest: missing party invite code');
+    return false;
+  }
+  try {
+    await uncheckInGuestApi(party.inviteCode, guestId);
+    return true;
+  } catch (error) {
+    console.error('Error un-checking-in guest via API:', error);
+    return false;
+  }
 }
 
 export async function promoteGuest(guestId: string, partyId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

Frontend half of `mushroom-31723` host action recovery. Backend PR #377 already merged and deployed to prod.

- Trash button on guest rows → **Reject** (soft-delete via `approved=false`). No confirm modal — reject is reversible.
- New **"Rejected (N)"** chip in `GuestList` header opens `RejectedGuestsModal` with one-click Restore per row. Hidden when N=0; modal auto-closes when count hits 0.
- Small **"x"** next to the check-in badge on `TableRow` for one-click un-check-in. Optimistic.
- `PizzaContext` splits guests into `guests` (visible) and `rejectedGuests`. Adds `rejectGuest`, `restoreGuest`, `uncheckInGuest` with optimistic updates.
- Defensive `approved !== false` filters added at consuming surfaces (PartyHeader, GPPDashboard, EmailOutreach, Report, BrowseGuestsModal, NotableAttendeesList) in case any bypasses the context.
- Hard-delete button removed from host UI. Backend DELETE route still callable via API key / underboss for admin cleanup.

## Deviations from plan

- `restoreGuest` always sends `approved=true` (not `null` for approval-required events). The backend PATCH `/approve` handler validates `typeof approved !== 'boolean'` and rejects `null` — PR #1 didn't change this. Since "Restore" is an explicit host action, re-approving is reasonable. If we want true PENDING restore semantics, a backend follow-up to widen the validator is needed.
- TableRow waitlist variant still uses the original Trash2 + `removeGuest` flow (plan only specified the `basic` variant).
- Pre-existing lint errors (~377) and one pre-existing missing `recharts` dependency exist on master; not introduced by this PR.

## Test plan

- [ ] Host dashboard: click Reject on a CONFIRMED guest → disappears from list, "Rejected (1)" chip appears in header
- [ ] Click "Rejected (1)" chip → modal opens with the guest + Restore button
- [ ] Click Restore → guest returns to main list, chip count drops to 0, modal auto-closes
- [ ] Approval-required event: reject then restore → guest returns as approved (note: skips PENDING, see deviations)
- [ ] Check in a guest → "x" appears next to badge → click x → badge reverts to Check-in button
- [ ] Check in again → re-stamps fine (idempotent on both sides)
- [ ] Report widget: rejected guest is NOT in `totalRsvps` count
- [ ] EmailOutreach: rejected guest is NOT in any of the all/approved/pending lists
- [ ] PartyHeader: rejected guest is NOT in invited/RSVP counts