### PR TITLE
mushroom-31723: accept approved=null in PATCH /guests/:id/approve

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -806,17 +806,18 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
       throw new AppError('You do not have access to the guests tab', 403, 'TAB_ACCESS_DENIED');
     }
 
-    if (typeof approved !== 'boolean') {
-      throw new AppError('approved must be a boolean', 400, 'VALIDATION_ERROR');
+    if (approved !== null && typeof approved !== 'boolean') {
+      throw new AppError('approved must be a boolean or null', 400, 'VALIDATION_ERROR');
     }
 
     // Only reconcile status when row is PENDING — avoid clobbering WAITLISTED.
+    // When approved===null (restore-to-pending), leave status alone.
     const existing = await prisma.guest.findUnique({
       where: { id: guestId, partyId },
       select: { status: true },
     });
-    const updateData: { approved: boolean; status?: 'CONFIRMED' | 'DECLINED' } = { approved };
-    if (existing?.status === 'PENDING') {
+    const updateData: { approved: boolean | null; status?: 'CONFIRMED' | 'DECLINED' } = { approved };
+    if (existing?.status === 'PENDING' && approved !== null) {
       updateData.status = approved ? 'CONFIRMED' : 'DECLINED';
     }
 
@@ -825,9 +826,12 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
       data: updateData,
     });
 
-    // Trigger appropriate webhook
-    const event = approved ? 'guest.approved' : 'guest.declined';
-    await triggerWebhook(event, { guest, partyId }, req.userId!);
+    // Trigger appropriate webhook. Skip when approved===null (restore-to-pending
+    // is neither an approval nor a decline).
+    if (approved !== null) {
+      const event = approved ? 'guest.approved' : 'guest.declined';
+      await triggerWebhook(event, { guest, partyId }, req.userId!);
+    }
 
     // Send approval email with QR code if guest is approved and has an email
     if (approved && guest.email) {


### PR DESCRIPTION
## Summary

Follow-up to #377. Lets the frontend restore-from-rejected flow (PR #383) send `approved=null` to bump a guest back to a pending/needs-re-approval state, instead of jumping straight to CONFIRMED.

- Validator now accepts `boolean | null`
- Status reconciliation skipped when `approved=null` (was incorrectly forcing DECLINED via the ternary)
- Webhook emission skipped when `approved=null` (neither approval nor decline)

## Test plan

- [ ] PATCH with `{approved: null}` on a rejected (`approved=false`) guest → DB shows `approved=null`, `status` unchanged
- [ ] PATCH with `{approved: null}` on a PENDING guest → DB shows `approved=null`, `status` still PENDING (not DECLINED)
- [ ] PATCH with `{approved: true}` and `{approved: false}` still work as before
- [ ] No webhook event fires for the null case