### PR TITLE
garlic-43340: Add 'Get Approved' auto-checklist item

### DIFF
--- a/backend/src/routes/checklist.routes.ts
+++ b/backend/src/routes/checklist.routes.ts
@@ -42,7 +42,7 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
     // 2. venue_added: party.address is set (picking a venue or filling the location autocomplete both write address)
     const party = await prisma.party.findUnique({
       where: { id: partyId },
-      select: { address: true, addressIsCityDefault: true, venueName: true, coHosts: true, userId: true, region: true, selectedPizzerias: true, user: { select: { email: true, name: true } } },
+      select: { address: true, addressIsCityDefault: true, venueName: true, coHosts: true, userId: true, region: true, selectedPizzerias: true, underbossStatus: true, user: { select: { email: true, name: true } } },
     });
 
     // 3. budget_submitted: budget_items has items for this party
@@ -100,6 +100,7 @@ router.get('/:partyId/checklist', async (req: AuthRequest, res: Response, next: 
       budget_submitted: budgetItemCount > 0,
       team_built: teamBuilt,
       pizzerias_selected: pizzeriasSelected,
+      underboss_reviewed: !!party?.underbossStatus && party.underbossStatus !== 'pending',
     };
 
     // Check if defaults have been seeded — compare against checklist_defaults count

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X, Lock, type LucideIcon } from 'lucide-react';
+import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X, Lock, ShieldCheck, type LucideIcon } from 'lucide-react';
 import { usePizza } from '../../contexts/PizzaContext';
 import { getChecklist, seedChecklist, updateUnderbossStatus, toggleChecklistItem } from '../../lib/api';
 import { AutoCompleteStates, ChecklistItem } from '../../types';
@@ -55,6 +55,7 @@ export const GPPDashboardTab: React.FC = () => {
     'Prepare for the Party': ClipboardCheck,
     'Post to Socials': Megaphone,
     'Throw the Party': Rocket,
+    'Get Approved': ShieldCheck,
   };
 
   const goToTab = (tab: string) => {

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -55,7 +55,7 @@ export const GPPDashboardTab: React.FC = () => {
     'Prepare for the Party': ClipboardCheck,
     'Post to Socials': Megaphone,
     'Throw the Party': Rocket,
-    'Get Approved': ShieldCheck,
+    'Get reviewed for funding': ShieldCheck,
   };
 
   const goToTab = (tab: string) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -970,6 +970,7 @@ export interface AutoCompleteStates {
   budget_submitted: boolean;
   team_built?: boolean;
   pizzerias_selected?: boolean;
+  underboss_reviewed?: boolean;
 }
 
 export interface ChecklistData {

--- a/supabase/migrations/20260517_add_get_approved_checklist_default.sql
+++ b/supabase/migrations/20260517_add_get_approved_checklist_default.sql
@@ -1,18 +1,18 @@
--- garlic-43340: Add "Get Approved" auto-completing default checklist item
+-- garlic-43340: Add "Get reviewed for funding" auto-completing default checklist item
 -- Auto-completes when parties.underboss_status is any non-pending value.
 
 INSERT INTO checklist_defaults (name, due_date, is_auto, auto_rule, link_tab, sort_order)
-VALUES ('Get Approved', '2026-05-19', true, 'underboss_reviewed', NULL, 10)
+VALUES ('Get reviewed for funding', '2026-05-19', true, 'underboss_reviewed', NULL, 10)
 ON CONFLICT (name) DO NOTHING;
 
 -- Backfill: insert into checklist_items for existing GPP events that don't yet have this row.
 -- (The GET handler short-circuits seeding once an event has any defaults, so existing events
 -- won't get the row automatically.)
 INSERT INTO checklist_items (id, party_id, name, due_date, is_auto, auto_rule, link_tab, sort_order, is_default, completed, created_at, updated_at)
-SELECT gen_random_uuid(), p.id, 'Get Approved', '2026-05-19'::date, true, 'underboss_reviewed', NULL, 10, true, false, now(), now()
+SELECT gen_random_uuid(), p.id, 'Get reviewed for funding', '2026-05-19'::date, true, 'underboss_reviewed', NULL, 10, true, false, now(), now()
 FROM parties p
 WHERE p.event_type = 'gpp'
   AND NOT EXISTS (
     SELECT 1 FROM checklist_items ci
-    WHERE ci.party_id = p.id AND ci.name = 'Get Approved'
+    WHERE ci.party_id = p.id AND ci.name = 'Get reviewed for funding'
   );

--- a/supabase/migrations/20260517_add_get_approved_checklist_default.sql
+++ b/supabase/migrations/20260517_add_get_approved_checklist_default.sql
@@ -1,0 +1,18 @@
+-- garlic-43340: Add "Get Approved" auto-completing default checklist item
+-- Auto-completes when parties.underboss_status is any non-pending value.
+
+INSERT INTO checklist_defaults (name, due_date, is_auto, auto_rule, link_tab, sort_order)
+VALUES ('Get Approved', '2026-05-19', true, 'underboss_reviewed', NULL, 10)
+ON CONFLICT (name) DO NOTHING;
+
+-- Backfill: insert into checklist_items for existing GPP events that don't yet have this row.
+-- (The GET handler short-circuits seeding once an event has any defaults, so existing events
+-- won't get the row automatically.)
+INSERT INTO checklist_items (id, party_id, name, due_date, is_auto, auto_rule, link_tab, sort_order, is_default, completed, created_at, updated_at)
+SELECT gen_random_uuid(), p.id, 'Get Approved', '2026-05-19'::date, true, 'underboss_reviewed', NULL, 10, true, false, now(), now()
+FROM parties p
+WHERE p.event_type = 'gpp'
+  AND NOT EXISTS (
+    SELECT 1 FROM checklist_items ci
+    WHERE ci.party_id = p.id AND ci.name = 'Get Approved'
+  );


### PR DESCRIPTION
## Summary
- New default checklist item "Get Approved" with deadline 2026-05-19
- Auto-completes when `parties.underboss_status` is any non-pending value (approved/rejected/listed/hidden)
- SQL migration seeds the new default + backfills `checklist_items` for existing GPP events (the GET-handler seeder short-circuits once an event has any defaults, so existing events need explicit backfill)
- Backend adds `underboss_reviewed` to `autoCompleteStates`; frontend adds optional type field + dashboard icon

## Deploy order
1. Apply SQL migration via Supabase MCP (`mcp__supabase-pizzadao__apply_migration`) — adds default row + backfills existing GPP events
2. Merge this PR to master so backend auto-deploys (adds `underboss_reviewed` to computed states)
3. Frontend preview will reflect auto-check behavior once backend is on master (previews talk to prod backend per CLAUDE.md)

## Test plan
- [ ] Open dashboard for a GPP event with `underboss_status='pending'` — "Get Approved" row appears, unchecked, deadline "May 19" shown
- [ ] Open standalone `/checklist` tab — same item appears with Auto pill, disabled checkbox, "Due May 19"
- [ ] In Supabase SQL: `UPDATE parties SET underboss_status='approved' WHERE id='<test-id>'` -> reload, row becomes checked with strikethrough
- [ ] Repeat with `'rejected'`, `'listed'`, `'hidden'` — each leaves row checked
- [ ] Set back to `'pending'` — row unchecks
- [ ] After 2026-05-19, if still pending, deadline turns red (overdue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)