### PR TITLE
basil-43499: co_host_twitter_handles_missing heuristic

### DIFF
--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -20,6 +20,7 @@ import {
   checkCrossEventWallet,
   checkLowFunnelCoverage,
   checkHighPerVisitorRsvpSaturation,
+  checkCoHostTwitterHandlesMissing,
   scoreEvent,
   buildSybilWalletSet,
   tierFromScore,
@@ -79,6 +80,7 @@ function makeParty(overrides: Partial<FakeDetectionParty> = {}): FakeDetectionPa
     createdAt: new Date('2026-03-01T10:00:00Z'),
     underbossStatus: 'pending',
     user: { name: 'Host Person', email: 'host@example.com' },
+    coHosts: [],
     ...overrides,
   };
 }
@@ -490,6 +492,95 @@ describe('checkHighPerVisitorRsvpSaturation', () => {
       }),
     ];
     expect(checkHighPerVisitorRsvpSaturation(guests, funnel).fired).toBe(false);
+  });
+});
+
+describe('checkCoHostTwitterHandlesMissing', () => {
+  it('does not fire when co_hosts is empty', () => {
+    const party = makeParty({ coHosts: [] });
+    expect(checkCoHostTwitterHandlesMissing(party).fired).toBe(false);
+  });
+
+  it('does not fire with only 1 filtered co-host (below min n=2)', () => {
+    const party = makeParty({
+      coHosts: [{ name: 'Solo Host', twitter: null }],
+    });
+    expect(checkCoHostTwitterHandlesMissing(party).fired).toBe(false);
+  });
+
+  it('does not fire when all 4 co-hosts have twitter handles', () => {
+    const party = makeParty({
+      coHosts: [
+        { name: 'A', twitter: 'a_handle' },
+        { name: 'B', twitter: 'b_handle' },
+        { name: 'C', twitter: 'c_handle' },
+        { name: 'D', twitter: 'd_handle' },
+      ],
+    });
+    expect(checkCoHostTwitterHandlesMissing(party).fired).toBe(false);
+  });
+
+  it('fires when 2/4 (50%) co-hosts are missing twitter', () => {
+    const party = makeParty({
+      coHosts: [
+        { name: 'A', twitter: 'a_handle' },
+        { name: 'B', twitter: 'b_handle' },
+        { name: 'C', twitter: null },
+        { name: 'D', twitter: '' },
+      ],
+    });
+    const result = checkCoHostTwitterHandlesMissing(party);
+    expect(result.fired).toBe(true);
+    expect(result.evidence?.missingCount).toBe(2);
+    expect(result.evidence?.filteredTotal).toBe(4);
+  });
+
+  it('does not fire at exactly 25% (threshold is strict >)', () => {
+    const party = makeParty({
+      coHosts: [
+        { name: 'A', twitter: 'a_handle' },
+        { name: 'B', twitter: 'b_handle' },
+        { name: 'C', twitter: 'c_handle' },
+        { name: 'D', twitter: null },
+      ],
+    });
+    const result = checkCoHostTwitterHandlesMissing(party);
+    expect(result.fired).toBe(false);
+    expect(result.evidence?.missingRatio).toBe(0.25);
+  });
+
+  it('fires when underboss entry excluded brings ratio above threshold', () => {
+    // 4 raw co-hosts, but 1 is isUnderboss → filtered = 3, 1 missing → 33% → fires
+    const party = makeParty({
+      coHosts: [
+        { name: 'A', twitter: 'a_handle' },
+        { name: 'B', twitter: 'b_handle' },
+        { name: 'C', twitter: null },
+        { name: 'D', isUnderboss: true, twitter: null },
+      ],
+    });
+    const result = checkCoHostTwitterHandlesMissing(party);
+    expect(result.fired).toBe(true);
+    expect(result.evidence?.filteredTotal).toBe(3);
+    expect(result.evidence?.missingCount).toBe(1);
+  });
+
+  it('does not fire when partner entries (no twitter) are correctly excluded', () => {
+    // 5 raw co-hosts: 3 partners without twitter + 2 real with twitter
+    // Filtered = 2 real entries, both with twitter → 0/2 missing → doesn't fire.
+    const party = makeParty({
+      coHosts: [
+        { name: 'World Pizza Champions', twitter: null, isPartner: true },
+        { name: 'ENS', twitter: null, isPartner: true },
+        { name: 'PizzaDAO', twitter: null, isPartner: true },
+        { name: 'Real Host A', twitter: 'real_a' },
+        { name: 'Real Host B', twitter: 'real_b' },
+      ],
+    });
+    const result = checkCoHostTwitterHandlesMissing(party);
+    expect(result.fired).toBe(false);
+    expect(result.evidence?.filteredTotal).toBe(2);
+    expect(result.evidence?.missingCount).toBe(0);
   });
 });
 

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -30,6 +30,13 @@ export interface FakeDetectionGuest {
   suggestedPizzerias: unknown; // jsonb
 }
 
+export interface FakeDetectionCoHost {
+  name?: string | null;
+  twitter?: string | null;
+  isUnderboss?: boolean;
+  isPartner?: boolean;
+}
+
 export interface FakeDetectionParty {
   id: string;
   name: string;
@@ -41,6 +48,7 @@ export interface FakeDetectionParty {
   createdAt: Date;
   underbossStatus: string | null;
   user: { id?: string; name: string | null; email: string | null } | null;
+  coHosts?: unknown; // jsonb — array of co-host objects; validated inside checks
 }
 
 export interface FakeDetectionLinkClick {
@@ -102,6 +110,7 @@ export const WEIGHTS = {
   cross_event_wallet: 15,
   low_funnel_coverage: 10,
   high_per_visitor_rsvp_saturation: 15,
+  co_host_twitter_handles_missing: 12,
 } as const;
 
 // ============================================
@@ -617,6 +626,51 @@ export function checkHighPerVisitorRsvpSaturation(
   );
 }
 
+/**
+ * 17. co_host_twitter_handles_missing — among "real" co-hosts (excluding internal
+ * underboss entries and partner-brand entries), too many are missing a twitter
+ * handle. Real volunteer co-hosts almost always have an X/Twitter handle attached;
+ * a high missing-rate suggests placeholder/padded co-hosts.
+ *
+ * Filters out `isUnderboss === true` and `isPartner === true` entries (their
+ * twitter handles are often empty by design).
+ *
+ * Fires when filtered set has ≥2 entries and missing/filtered > 0.25.
+ */
+export function checkCoHostTwitterHandlesMissing(party: FakeDetectionParty): FlagResult {
+  const id = 'co_host_twitter_handles_missing';
+  const raw = Array.isArray(party.coHosts) ? party.coHosts : [];
+  // Narrow to plain objects and exclude underboss/partner entries.
+  const filtered: FakeDetectionCoHost[] = raw
+    .filter((h): h is FakeDetectionCoHost => typeof h === 'object' && h !== null)
+    .filter(h => h.isUnderboss !== true && h.isPartner !== true);
+
+  const filteredTotal = filtered.length;
+  if (filteredTotal < 2) {
+    return flag(id, false, `filteredTotal=${filteredTotal} below min n=2`);
+  }
+
+  const missingEntries = filtered.filter(h => {
+    const t = typeof h.twitter === 'string' ? h.twitter.trim() : '';
+    return t.length === 0;
+  });
+  const missingCount = missingEntries.length;
+  const missingRatio = missingCount / filteredTotal;
+  const fired = missingRatio > 0.25;
+
+  const missingNames = missingEntries
+    .map(h => (typeof h.name === 'string' ? h.name : ''))
+    .filter(n => n.length > 0)
+    .slice(0, 10);
+
+  return flag(
+    id,
+    fired,
+    `${missingCount}/${filteredTotal} (${(missingRatio * 100).toFixed(1)}%) co-hosts missing twitter`,
+    { missingCount, filteredTotal, missingRatio, missingNames },
+  );
+}
+
 // ============================================
 // Aggregator
 // ============================================
@@ -656,6 +710,7 @@ export function scoreEvent(
     checkCrossEventWallet(guests, sybilWallets),
     checkLowFunnelCoverage(guests, funnelEvents),
     checkHighPerVisitorRsvpSaturation(guests, funnelEvents),
+    checkCoHostTwitterHandlesMissing(party),
   ];
 
   const score = Math.min(

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -442,6 +442,7 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
         maxGuests: true,
         createdAt: true,
         underbossStatus: true,
+        coHosts: true,
         user: { select: { id: true, name: true, email: true } },
         guests: {
           select: {
@@ -487,6 +488,7 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
           user: p.user
             ? { id: p.user.id, name: p.user.name, email: p.user.email }
             : null,
+          coHosts: p.coHosts,
         },
         p.guests.map(g => ({
           id: g.id,


### PR DESCRIPTION
## Summary

Adds a new fake-detection heuristic, `co_host_twitter_handles_missing`, to the GPP review queue. Real volunteer co-hosts almost always have an X/Twitter handle attached — a high missing-rate among real co-hosts is a signal of placeholder/padded entries.

**Simplified design** — pure in-memory check inside the existing `scoreEvent` pipeline. No external API calls, no new DB table, no cron job, no migration, no new dependencies.

### Heuristic spec

- Reads `parties.co_hosts` (existing `jsonb` column on the Party model)
- Filters out entries with `isUnderboss === true` or `isPartner === true` (their twitter handles are often empty by design)
- Fires when the filtered set has at least 2 entries AND `missing / filteredTotal > 0.25` (strict >25%)
- **Weight**: 12
- **Min n**: 2 entries in filtered set
- **Evidence**: `{ missingCount, filteredTotal, missingRatio, missingNames }`

### Files changed (3)

- `backend/src/lib/fakeDetection.ts` — `WEIGHTS.co_host_twitter_handles_missing = 12`, `FakeDetectionCoHost` type, `coHosts?: unknown` on `FakeDetectionParty`, new `checkCoHostTwitterHandlesMissing` function, appended to `scoreEvent` flags array.
- `backend/src/lib/fakeDetection.test.ts` — added `coHosts: []` default on `makeParty()`, new `describe('checkCoHostTwitterHandlesMissing')` block with 7 cases.
- `backend/src/routes/underboss.routes.ts` — `coHosts: true` in the `GET /fake-detection` Prisma select; `coHosts: p.coHosts` in the per-party `FakeDetectionParty` map.

### Worked example (Naivasha, from the prior investigation)

co_hosts = [PizzaDAO (twitter: pizza_dao), World Pizza Champions (isPartner), Eric Ndungu (twitter: top254_), Peri Peri Pacino (isUnderboss), ENS (isPartner)]
- Filtered = [PizzaDAO, Eric Ndungu] = 2 entries
- Missing = 0/2 = 0% → heuristic does NOT fire ✓

## Test plan

- [x] `npm test -- --run fakeDetection` — 60 tests pass (including 7 new cases)
- [x] `tsc --noEmit` — no new errors introduced (pre-existing `sharp` + `auth.test.ts` errors only)
- [ ] Vercel frontend preview ✓
- [ ] After merge: deploy backend from master, verify `GET /api/underboss/fake-detection` returns rows with the new flag in `flags[]`