### PR TITLE
feat(mushroom-36006): regional opt-in A/B (Phase 1) — CA/AU/EU/UK/BR infra

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -782,57 +782,84 @@ router.get('/funnel-stats', requireAuth, async (req: AuthRequest, res: Response,
   }
 });
 
-// GET /api/admin/experiments/optin-ab — parmesan-98989 combined opt-in A/B results (admin only)
+// mushroom-36006: regional opt-in A/B registry. Kept in sync with
+// frontend/src/lib/optinAbRegions.ts. Each entry pairs an event tag with the
+// per-region `swc_*_opt_in` boolean column on `guests`.
+const OPTIN_AB_REGIONS: Array<{ tag: string; label: string; optInColumn: string }> = [
+  { tag: 'swc',        label: 'US',        optInColumn: 'swc_opt_in'    },
+  { tag: 'swccanada',  label: 'Canada',    optInColumn: 'swc_ca_opt_in' },
+  { tag: 'swcau',      label: 'Australia', optInColumn: 'swc_au_opt_in' },
+  { tag: 'swceu',      label: 'EU',        optInColumn: 'swc_eu_opt_in' },
+  { tag: 'swcuk',      label: 'UK',        optInColumn: 'swc_uk_opt_in' },
+  { tag: 'swcbr',      label: 'Brazil',    optInColumn: 'swc_br_opt_in' },
+];
+
+// GET /api/admin/experiments/optin-ab — mushroom-36006 per-region combined opt-in A/B results (admin only)
 router.get('/experiments/optin-ab', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     if (!(await isAdmin(req.userEmail))) {
       throw new AppError('Admin access required', 403, 'FORBIDDEN');
     }
 
-    const rows = await prisma.$queryRaw<Array<{
+    const valuesList = OPTIN_AB_REGIONS
+      .map((r) => `('${r.tag.replace(/'/g, "''")}')`)
+      .join(', ');
+    const swcOptinCases = OPTIN_AB_REGIONS
+      .map((r) => `(region.tag = '${r.tag.replace(/'/g, "''")}' AND g.${r.optInColumn})`)
+      .join(' OR ');
+
+    const sql = `
+      SELECT
+        region.tag                                                            AS region_tag,
+        g.optin_ab_variant                                                    AS arm,
+        COUNT(*)::int                                                         AS n,
+        COUNT(*) FILTER (WHERE g.mailing_list_opt_in)::int                    AS pizzadao_optins,
+        COALESCE(ROUND(100.0 * COUNT(*) FILTER (WHERE g.mailing_list_opt_in)
+                             / NULLIF(COUNT(*), 0), 2), 0)                    AS pizzadao_optin_pct,
+        COUNT(*) FILTER (WHERE ${swcOptinCases})::int                         AS swc_optins,
+        COALESCE(ROUND(100.0 * COUNT(*) FILTER (WHERE ${swcOptinCases})
+                             / NULLIF(COUNT(*), 0), 2), 0)                    AS swc_optin_pct
+      FROM (VALUES ${valuesList}) AS region(tag)
+      JOIN parties p ON region.tag = ANY(p.event_tags)
+      JOIN guests  g ON g.party_id = p.id
+      WHERE g.optin_ab_variant IN ('control', 'variant')
+        AND g.submitted_via = 'link'
+        AND (g.status IS NULL OR g.status != 'INVITED')
+      GROUP BY region.tag, g.optin_ab_variant
+      ORDER BY region.tag, g.optin_ab_variant
+    `;
+
+    const rows = await prisma.$queryRawUnsafe<Array<{
+      region_tag: string;
       arm: string;
       n: number;
       pizzadao_optins: number;
       pizzadao_optin_pct: number | string;
       swc_optins: number;
       swc_optin_pct: number | string;
-    }>>`
-      SELECT
-        g.optin_ab_variant AS arm,
-        COUNT(*)::int                                                        AS n,
-        COUNT(*) FILTER (WHERE g.mailing_list_opt_in)::int                   AS pizzadao_optins,
-        COALESCE(ROUND(100.0 * COUNT(*) FILTER (WHERE g.mailing_list_opt_in)
-                             / NULLIF(COUNT(*), 0), 2), 0)                   AS pizzadao_optin_pct,
-        COUNT(*) FILTER (WHERE g.swc_opt_in)::int                            AS swc_optins,
-        COALESCE(ROUND(100.0 * COUNT(*) FILTER (WHERE g.swc_opt_in)
-                             / NULLIF(COUNT(*), 0), 2), 0)                   AS swc_optin_pct
-      FROM guests g
-      JOIN parties p ON p.id = g.party_id
-      WHERE 'swc' = ANY(p.event_tags)
-        AND g.optin_ab_variant IN ('control', 'variant')
-        AND g.submitted_via = 'link'
-        AND (g.status IS NULL OR g.status != 'INVITED')
-      GROUP BY g.optin_ab_variant
-      ORDER BY g.optin_ab_variant;
-    `;
+    }>>(sql);
 
-    const byArm = new Map<string, typeof rows[number]>();
-    for (const r of rows) byArm.set(r.arm, r);
+    const byKey = new Map<string, typeof rows[number]>();
+    for (const r of rows) byKey.set(`${r.region_tag}|${r.arm}`, r);
 
-    const arms = (['control', 'variant'] as const).map((arm) => {
-      const r = byArm.get(arm);
-      return {
-        arm,
-        n: r ? Number(r.n) : 0,
-        pizzadaoOptins: r ? Number(r.pizzadao_optins) : 0,
-        pizzadaoOptinPct: r ? Number(r.pizzadao_optin_pct) : 0,
-        swcOptins: r ? Number(r.swc_optins) : 0,
-        swcOptinPct: r ? Number(r.swc_optin_pct) : 0,
-      };
-    });
+    const regions = OPTIN_AB_REGIONS.map((region) => ({
+      tag: region.tag,
+      label: region.label,
+      arms: (['control', 'variant'] as const).map((arm) => {
+        const r = byKey.get(`${region.tag}|${arm}`);
+        return {
+          arm,
+          n: r ? Number(r.n) : 0,
+          pizzadaoOptins: r ? Number(r.pizzadao_optins) : 0,
+          pizzadaoOptinPct: r ? Number(r.pizzadao_optin_pct) : 0,
+          swcOptins: r ? Number(r.swc_optins) : 0,
+          swcOptinPct: r ? Number(r.swc_optin_pct) : 0,
+        };
+      }),
+    }));
 
     res.set('Cache-Control', 'no-store');
-    res.json({ arms });
+    res.json({ regions });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/underboss/OptinABTab.tsx
+++ b/frontend/src/components/underboss/OptinABTab.tsx
@@ -1,18 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { fetchOptinABResults, fetchExperimentFlags, setExperimentFlag } from '../../lib/api';
-import type { OptinABResults, OptinABArm, ExperimentFlag } from '../../lib/api';
+import type { OptinABResults, OptinABRegion, OptinABArm, ExperimentFlag } from '../../lib/api';
 import { Checkbox } from '../Checkbox';
+import { REGIONAL_OPTIN_AB } from '../../lib/optinAbRegions';
+import type { RegionalOptinAbConfig } from '../../lib/optinAbRegions';
 
-const FLAG_KEY = 'optin_ab_pizzadao_partners';
-
-// MDE sample-size targets (per arm).
 const N_10PP = 330;
 const N_5PP = 1400;
 
-// Two-proportion z-test (two-sided). Ported verbatim from
-// scripts/check-optin-ab-results.js on the parmesan-98989 branch so CLI
-// and UI cannot disagree.
 function zScore(p1: number, n1: number, p2: number, n2: number): number {
   if (!n1 || !n2) return 0;
   const pPool = (p1 * n1 + p2 * n2) / (n1 + n2);
@@ -21,7 +17,6 @@ function zScore(p1: number, n1: number, p2: number, n2: number): number {
   return (p1 - p2) / se;
 }
 
-// Two-sided p-value via Abramowitz & Stegun 7.1.26 erf approximation.
 function pValueFromZ(z: number): number {
   const abs = Math.abs(z);
   const t = 1 / (1 + 0.3275911 * (abs / Math.SQRT2));
@@ -39,6 +34,17 @@ function sigLabel(p: number): '***' | '**' | '*' | 'n.s.' {
   if (p < 0.01) return '**';
   if (p < 0.05) return '*';
   return 'n.s.';
+}
+
+function computeSigLine(control: OptinABArm | undefined, variant: OptinABArm | undefined): string {
+  if (!control || !variant || !control.n || !variant.n) return 'Insufficient data';
+  const pC = control.pizzadaoOptins / control.n;
+  const pV = variant.pizzadaoOptins / variant.n;
+  const z = zScore(pC, control.n, pV, variant.n);
+  const p = pValueFromZ(z);
+  const deltaPp = (pV - pC) * 100;
+  const sign = deltaPp >= 0 ? '+' : '';
+  return `Variant vs. Control (PizzaDAO opt-in): ${sign}${deltaPp.toFixed(2)} pp, p = ${p.toFixed(4)} (${sigLabel(p)})`;
 }
 
 function ArmBlock({ arm }: { arm: OptinABArm }) {
@@ -98,13 +104,96 @@ function SampleSizeBar({ arm }: { arm: OptinABArm }) {
   );
 }
 
+function RegionAnalyticsPanel({ region }: { region: OptinABRegion }) {
+  const control = region.arms.find((a) => a.arm === 'control');
+  const variant = region.arms.find((a) => a.arm === 'variant');
+  const sigLine = computeSigLine(control, variant);
+
+  return (
+    <div className="card p-6">
+      <h4 className="text-base font-semibold text-theme-text mb-1">
+        {region.label} <span className="text-xs text-theme-text-muted font-normal">({region.tag})</span>
+      </h4>
+      <p className="text-xs text-theme-text-muted mb-4">
+        {region.tag}-tagged events, real RSVP submissions only
+      </p>
+
+      {control && variant && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ArmBlock arm={control} />
+            <ArmBlock arm={variant} />
+          </div>
+
+          <div className="text-sm text-theme-text-secondary border-t border-theme-stroke pt-4">
+            {sigLine}
+          </div>
+
+          <div className="space-y-4">
+            <SampleSizeBar arm={control} />
+            <SampleSizeBar arm={variant} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RegionToggleRow({
+  region,
+  flag,
+  flagLoading,
+  flipping,
+  onRequestFlip,
+}: {
+  region: RegionalOptinAbConfig;
+  flag: ExperimentFlag | null;
+  flagLoading: boolean;
+  flipping: boolean;
+  onRequestFlip: (nextEnabled: boolean) => void;
+}) {
+  return (
+    <div className="p-4 border border-theme-stroke rounded-xl bg-theme-surface">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-theme-text">
+            {region.label} <span className="text-xs text-theme-text-muted font-normal">({region.tag})</span>
+          </div>
+          <div className="text-xs text-theme-text-muted mt-1">
+            {flagLoading ? 'Loading…' : flag?.description ?? 'Flag not found'}
+          </div>
+          {flag && (
+            <div className="text-[11px] text-theme-text-faint mt-2">
+              Last changed {new Date(flag.updatedAt).toLocaleString()}
+              {flag.updatedBy ? ` by ${flag.updatedBy}` : ''}
+            </div>
+          )}
+        </div>
+        <Checkbox
+          checked={!!flag?.enabled}
+          onChange={() => {
+            if (!flag || flagLoading || flipping) return;
+            onRequestFlip(!flag.enabled);
+          }}
+          label={flag?.enabled ? 'ON' : 'OFF'}
+          labelClassName={`text-sm font-semibold ${flag?.enabled ? 'text-[#E52828]' : 'text-theme-text-muted'}`}
+          disabled={!flag || flagLoading || flipping}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function OptinABTab() {
   const [data, setData] = useState<OptinABResults | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [flag, setFlag] = useState<ExperimentFlag | null>(null);
-  const [flagLoading, setFlagLoading] = useState(true);
-  const [showConfirm, setShowConfirm] = useState<null | { nextEnabled: boolean }>(null);
+  const [flagsByKey, setFlagsByKey] = useState<Map<string, ExperimentFlag>>(new Map());
+  const [flagsLoading, setFlagsLoading] = useState(true);
+  const [showConfirm, setShowConfirm] = useState<null | {
+    region: RegionalOptinAbConfig;
+    nextEnabled: boolean;
+  }>(null);
   const [flipping, setFlipping] = useState(false);
 
   async function load() {
@@ -120,109 +209,81 @@ export function OptinABTab() {
     setLoading(false);
   }
 
+  async function loadFlags() {
+    setFlagsLoading(true);
+    const flags = await fetchExperimentFlags();
+    const map = new Map<string, ExperimentFlag>();
+    if (flags) {
+      for (const f of flags) map.set(f.key, f);
+    }
+    setFlagsByKey(map);
+    setFlagsLoading(false);
+  }
+
   useEffect(() => {
     void load();
   }, []);
 
   useEffect(() => {
-    (async () => {
-      setFlagLoading(true);
-      const flags = await fetchExperimentFlags();
-      if (flags) {
-        setFlag(flags.find((f) => f.key === FLAG_KEY) ?? null);
-      }
-      setFlagLoading(false);
-    })();
+    void loadFlags();
   }, []);
 
-  const control = data?.arms.find((a) => a.arm === 'control');
-  const variant = data?.arms.find((a) => a.arm === 'variant');
-
-  let sigLine: string;
-  if (!control || !variant || !control.n || !variant.n) {
-    sigLine = 'Insufficient data';
-  } else {
-    const pC = control.pizzadaoOptins / control.n;
-    const pV = variant.pizzadaoOptins / variant.n;
-    const z = zScore(pC, control.n, pV, variant.n);
-    const p = pValueFromZ(z);
-    const deltaPp = (pV - pC) * 100;
-    const sign = deltaPp >= 0 ? '+' : '';
-    sigLine = `Variant vs. Control (PizzaDAO opt-in): ${sign}${deltaPp.toFixed(2)} pp, p = ${p.toFixed(4)} (${sigLabel(p)})`;
+  const regionsByTag = new Map<string, OptinABRegion>();
+  if (data) {
+    for (const r of data.regions) regionsByTag.set(r.tag, r);
   }
 
   return (
-    <div className="card p-6">
-      <div className="flex items-start justify-between mb-1 gap-3">
-        <div>
-          <h3 className="text-lg font-semibold text-theme-text">
-            PizzaDAO + Partners Opt-in A/B (parmesan-98989)
-          </h3>
-          <p className="text-xs text-theme-text-muted mt-1">
-            swc-tagged events, real RSVP submissions only
-          </p>
-        </div>
-        <button
-          onClick={() => void load()}
-          disabled={loading}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/60 hover:bg-white/80 border border-theme-stroke text-sm text-theme-text-secondary disabled:opacity-50 transition-colors"
-          title="Refresh"
-        >
-          {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
-          Refresh
-        </button>
-      </div>
-
-      {loading && !data && (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-6 h-6 animate-spin text-theme-text-muted" />
-        </div>
-      )}
-
-      {error && !loading && (
-        <p className="text-theme-text-muted text-center py-8">{error}</p>
-      )}
-
-      <div className="mt-6 mb-6 p-4 border border-theme-stroke rounded-xl bg-theme-surface">
-        <div className="flex items-start justify-between gap-4">
+    <div className="space-y-6">
+      <div className="card p-6">
+        <div className="flex items-start justify-between mb-1 gap-3">
           <div>
-            <div className="text-sm font-semibold text-theme-text">Experiment kill switch</div>
-            <div className="text-xs text-theme-text-muted mt-1">
-              {flagLoading ? 'Loading…' : flag?.description ?? 'Flag not found'}
-            </div>
-            {flag && (
-              <div className="text-[11px] text-theme-text-faint mt-2">
-                Last changed {new Date(flag.updatedAt).toLocaleString()}
-                {flag.updatedBy ? ` by ${flag.updatedBy}` : ''}
-              </div>
-            )}
+            <h3 className="text-lg font-semibold text-theme-text">
+              PizzaDAO + Partners Opt-in A/B — Experiment kill switches
+            </h3>
+            <p className="text-xs text-theme-text-muted mt-1">
+              One toggle per SWC region. Variant arm starts receiving traffic when ON.
+            </p>
           </div>
-          <Checkbox
-            checked={!!flag?.enabled}
-            onChange={() => {
-              if (!flag || flagLoading || flipping) return;
-              setShowConfirm({ nextEnabled: !flag.enabled });
-            }}
-            label={flag?.enabled ? 'ON' : 'OFF'}
-            labelClassName={`text-sm font-semibold ${flag?.enabled ? 'text-[#E52828]' : 'text-theme-text-muted'}`}
-            disabled={!flag || flagLoading || flipping}
-          />
+          <button
+            onClick={() => void load()}
+            disabled={loading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/60 hover:bg-white/80 border border-theme-stroke text-sm text-theme-text-secondary disabled:opacity-50 transition-colors"
+            title="Refresh"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+            Refresh
+          </button>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          {REGIONAL_OPTIN_AB.map((region) => (
+            <RegionToggleRow
+              key={region.flagKey}
+              region={region}
+              flag={flagsByKey.get(region.flagKey) ?? null}
+              flagLoading={flagsLoading}
+              flipping={flipping}
+              onRequestFlip={(nextEnabled) => setShowConfirm({ region, nextEnabled })}
+            />
+          ))}
         </div>
       </div>
 
-      {showConfirm && flag && (
+      {showConfirm && (
         <div
           className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
           onClick={() => !flipping && setShowConfirm(null)}
         >
           <div className="card p-6 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-semibold text-theme-text mb-2">
-              Turn experiment {showConfirm.nextEnabled ? 'ON' : 'OFF'}?
+              Turn {showConfirm.region.label} ({showConfirm.region.tag}) experiment{' '}
+              {showConfirm.nextEnabled ? 'ON' : 'OFF'}?
             </h3>
             <p className="text-sm text-theme-text-secondary mb-4">
               {showConfirm.nextEnabled
-                ? 'Variant arm will start receiving traffic on US (swc) RSVPs. ~50% of new RSVPs on swc-tagged events will see the combined PizzaDAO + partners checkbox.'
-                : 'All US (swc) RSVPs revert to the two-checkbox baseline. Existing variant-bucketed guests keep their assignment for edit-RSVP and analytics.'}
+                ? `Variant arm will start receiving traffic on ${showConfirm.region.label} (${showConfirm.region.tag}) RSVPs. ~50% of new RSVPs on ${showConfirm.region.tag}-tagged events will see the combined PizzaDAO + partners checkbox.`
+                : `All ${showConfirm.region.label} (${showConfirm.region.tag}) RSVPs revert to the two-checkbox baseline. Existing variant-bucketed guests keep their assignment for edit-RSVP and analytics.`}
             </p>
             <div className="flex justify-end gap-2">
               <button
@@ -235,8 +296,17 @@ export function OptinABTab() {
               <button
                 onClick={async () => {
                   setFlipping(true);
-                  const updated = await setExperimentFlag(FLAG_KEY, showConfirm.nextEnabled);
-                  if (updated) setFlag(updated);
+                  const updated = await setExperimentFlag(
+                    showConfirm.region.flagKey,
+                    showConfirm.nextEnabled,
+                  );
+                  if (updated) {
+                    setFlagsByKey((prev) => {
+                      const next = new Map(prev);
+                      next.set(updated.key, updated);
+                      return next;
+                    });
+                  }
                   setFlipping(false);
                   setShowConfirm(null);
                 }}
@@ -250,21 +320,33 @@ export function OptinABTab() {
         </div>
       )}
 
-      {data && control && variant && (
-        <div className="mt-4 space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <ArmBlock arm={control} />
-            <ArmBlock arm={variant} />
-          </div>
+      {loading && !data && (
+        <div className="card p-6 flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-theme-text-muted" />
+        </div>
+      )}
 
-          <div className="text-sm text-theme-text-secondary border-t border-theme-stroke pt-4">
-            {sigLine}
-          </div>
+      {error && !loading && (
+        <div className="card p-6">
+          <p className="text-theme-text-muted text-center py-4">{error}</p>
+        </div>
+      )}
 
-          <div className="space-y-4">
-            <SampleSizeBar arm={control} />
-            <SampleSizeBar arm={variant} />
-          </div>
+      {data && (
+        <div className="space-y-6">
+          {REGIONAL_OPTIN_AB.map((region) => {
+            const regionData =
+              regionsByTag.get(region.tag) ??
+              ({
+                tag: region.tag,
+                label: region.label,
+                arms: [
+                  { arm: 'control', n: 0, pizzadaoOptins: 0, pizzadaoOptinPct: 0, swcOptins: 0, swcOptinPct: 0 },
+                  { arm: 'variant', n: 0, pizzadaoOptins: 0, pizzadaoOptinPct: 0, swcOptins: 0, swcOptinPct: 0 },
+                ],
+              } as OptinABRegion);
+            return <RegionAnalyticsPanel key={region.tag} region={regionData} />;
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/i18n/locales/pt/rsvp.json
+++ b/frontend/src/i18n/locales/pt/rsvp.json
@@ -11,6 +11,7 @@
     "swcJoin": "Participar do Stand with Crypto",
     "swcNotify": "Notifique-me sobre eventos Stand With Crypto.",
     "swcBrNotify": "Notifique-me sobre eventos da Juntos por Cripto.",
+    "combinedOptIn": "Receba novidades da PizzaDAO + nossos parceiros",
     "ethconfDiscount": "Envie-me um desconto ETHConf",
     "next": "Próximo",
     "selectTurtles": "Selecione as suas tartarugas"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3478,8 +3478,14 @@ export interface OptinABArm {
   swcOptinPct: number;
 }
 
-export interface OptinABResults {
+export interface OptinABRegion {
+  tag: string;
+  label: string;
   arms: OptinABArm[];
+}
+
+export interface OptinABResults {
+  regions: OptinABRegion[];
 }
 
 export async function fetchOptinABResults(): Promise<OptinABResults | null> {

--- a/frontend/src/lib/optinAbRegions.ts
+++ b/frontend/src/lib/optinAbRegions.ts
@@ -1,0 +1,78 @@
+export interface RegionalOptinAbConfig {
+  tag: string;
+  label: string;
+  flagKey: string;
+  modalNamespace: 'swcModal' | 'swcCaModal' | 'swcAuModal' | 'swcEuModal' | 'swcUkModal' | 'swcBrModal';
+  termsKey: 'termsConditions' | 'termsOfService';
+  privacyUrl: string;
+  termsUrl: string;
+  swcOptInField: 'swcOptIn' | 'swcCaOptIn' | 'swcAuOptIn' | 'swcEuOptIn' | 'swcUkOptIn' | 'swcBrOptIn';
+}
+
+export const REGIONAL_OPTIN_AB: RegionalOptinAbConfig[] = [
+  {
+    tag: 'swc',
+    label: 'US',
+    flagKey: 'optin_ab_pizzadao_partners',
+    modalNamespace: 'swcModal',
+    termsKey: 'termsConditions',
+    privacyUrl: 'https://www.standwithcrypto.org/privacy',
+    termsUrl: 'https://www.standwithcrypto.org/terms-of-service',
+    swcOptInField: 'swcOptIn',
+  },
+  {
+    tag: 'swccanada',
+    label: 'Canada',
+    flagKey: 'optin_ab_pizzadao_partners_ca',
+    modalNamespace: 'swcCaModal',
+    termsKey: 'termsOfService',
+    privacyUrl: 'https://www.standwithcrypto.org/ca/privacy',
+    termsUrl: 'https://www.standwithcrypto.org/ca/terms-of-service',
+    swcOptInField: 'swcCaOptIn',
+  },
+  {
+    tag: 'swcau',
+    label: 'Australia',
+    flagKey: 'optin_ab_pizzadao_partners_au',
+    modalNamespace: 'swcAuModal',
+    termsKey: 'termsOfService',
+    privacyUrl: 'https://www.standwithcrypto.org/au/privacy',
+    termsUrl: 'https://www.standwithcrypto.org/au/terms-of-service',
+    swcOptInField: 'swcAuOptIn',
+  },
+  {
+    tag: 'swceu',
+    label: 'EU',
+    flagKey: 'optin_ab_pizzadao_partners_eu',
+    modalNamespace: 'swcEuModal',
+    termsKey: 'termsOfService',
+    privacyUrl: 'https://www.standwithcrypto.org/eu/en/privacy',
+    termsUrl: 'https://www.standwithcrypto.org/eu/en/terms-of-service',
+    swcOptInField: 'swcEuOptIn',
+  },
+  {
+    tag: 'swcuk',
+    label: 'UK',
+    flagKey: 'optin_ab_pizzadao_partners_uk',
+    modalNamespace: 'swcUkModal',
+    termsKey: 'termsOfService',
+    privacyUrl: 'https://www.standwithcrypto.org/gb/en/privacy',
+    termsUrl: 'https://www.standwithcrypto.org/gb/en/terms-of-service',
+    swcOptInField: 'swcUkOptIn',
+  },
+  {
+    tag: 'swcbr',
+    label: 'Brazil',
+    flagKey: 'optin_ab_pizzadao_partners_br',
+    modalNamespace: 'swcBrModal',
+    termsKey: 'termsOfService',
+    privacyUrl: 'https://www.juntosporcripto.org/br/privacy',
+    termsUrl: 'https://www.juntosporcripto.org/br/terms-of-service',
+    swcOptInField: 'swcBrOptIn',
+  },
+];
+
+export function findActiveRegion(eventTags: string[] | null | undefined): RegionalOptinAbConfig | null {
+  if (!eventTags || eventTags.length === 0) return null;
+  return REGIONAL_OPTIN_AB.find((r) => eventTags.includes(r.tag)) ?? null;
+}

--- a/supabase/migrations/20260519_seed_regional_optin_ab_flags.sql
+++ b/supabase/migrations/20260519_seed_regional_optin_ab_flags.sql
@@ -1,0 +1,17 @@
+-- mushroom-36006: regional expansion of the parmesan-98989 combined PizzaDAO+SWC
+-- opt-in A/B test. Seeds one kill-switch flag per non-US SWC region (CA, AU, EU,
+-- UK, BR). All new flags default enabled=false; the US flag was seeded in
+-- 20260518_create_experiment_flags.sql and is unchanged here.
+
+INSERT INTO experiment_flags (key, enabled, description) VALUES
+  ('optin_ab_pizzadao_partners_ca', false,
+    'mushroom-36006: combined PizzaDAO+SWC opt-in A/B for swccanada-tagged events (Canada). When OFF, swccanada RSVPs render the two-checkbox baseline.'),
+  ('optin_ab_pizzadao_partners_au', false,
+    'mushroom-36006: combined PizzaDAO+SWC opt-in A/B for swcau-tagged events (Australia). When OFF, swcau RSVPs render the two-checkbox baseline.'),
+  ('optin_ab_pizzadao_partners_eu', false,
+    'mushroom-36006: combined PizzaDAO+SWC opt-in A/B for swceu-tagged events (EU). When OFF, swceu RSVPs render the two-checkbox baseline.'),
+  ('optin_ab_pizzadao_partners_uk', false,
+    'mushroom-36006: combined PizzaDAO+SWC opt-in A/B for swcuk-tagged events (UK). When OFF, swcuk RSVPs render the two-checkbox baseline.'),
+  ('optin_ab_pizzadao_partners_br', false,
+    'mushroom-36006: combined PizzaDAO+SWC opt-in A/B for swcbr-tagged events (Brazil). When OFF, swcbr RSVPs render the two-checkbox baseline.')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- New experiment_flags rows for CA / AU / EU / UK / BR opt-in A/B tests, all enabled=false.
- New `optinAbRegions.ts` registry: tag → flag key → modal namespace → SWC opt-in field.
- Backend endpoint `/api/admin/experiments/optin-ab` reshaped: `{ regions: [{ tag, label, arms }] }` (breaking; single consumer, deployed atomically).
- OptinABTab.tsx rewrite: 6 stacked kill-switch toggle rows + 6 stacked analytics panels.
- PT i18n: adds `step1.combinedOptIn` = "Receba novidades da PizzaDAO + nossos parceiros".

## Pre-merge checklist
- [ ] Apply migration ``20260519_seed_regional_optin_ab_flags.sql`` via Supabase MCP.
- [ ] After merge: redeploy backend (``cd backend && vercel --prod --scope pizza-dao``).
- [ ] Verify ``/admin`` → Experiments shows 6 toggle rows + 6 analytics panels (5 new regions show zero data; US shows current data).

## Phase 2 follow-up (do not include in this PR)
After this merges, add region-aware variant roll to the parmesan-98989-combined-optin branch:
- ``frontend/src/hooks/useRSVPForm.ts`` — use ``findActiveRegion()``, async fetch the matching flag, region-aware ``setCombinedOptIn`` switch on ``swcOptInField``.
- ``frontend/src/components/RSVPFormStep1.tsx`` — generalize variant conditional from ``form.isSwcEvent`` to ``form.activeRegionConfig``; pull modal copy/URLs from ``activeRegionConfig``.
See ``plans/mushroom-36006-optin-ab-regional-expansion.md`` §3 and §4.

## Emergency off switch
``UPDATE experiment_flags SET enabled = false WHERE key LIKE 'optin_ab_pizzadao_partners%';`` — kills all 6 regions.

## Test plan
- [ ] Admin: 6 toggle rows render. All 5 new regions show OFF, US shows its current state. Each row's description text correct.
- [ ] Flipping a regional toggle (e.g. Canada): confirmation modal mentions "Canada (swccanada)". Confirm → DB updates with ``updated_by``.
- [ ] ``GET /api/admin/experiments/optin-ab`` returns ``{ regions: [...6...] }`` with both arms per region (zero-filled where missing).
- [ ] Stacked analytics panels: 6 regions visible; each shows "Insufficient data" if N=0.
- [ ] No RSVP-form change anywhere (Phase 2 is on parmesan, not this PR).
- [ ] Mobile: panels collapse to single column.

## Note on CA tag
The Canadian event tag is ``swccanada`` (literal), not ``swcca``. The flag key suffix uses ``_ca`` for readability — matches existing ``swcCaOptIn`` / ``swcCaModal`` convention — but every event_tags filter (registry tag field, SQL VALUES list) uses ``swccanada``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)