### PR TITLE
parmesan-67529: refine saturation heuristic (kiosk false-positive fix)

### DIFF
--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -452,7 +452,7 @@ describe('checkHighPerVisitorRsvpSaturation', () => {
     const guests = Array.from({ length: 10 }, () => makeGuest());
     expect(checkHighPerVisitorRsvpSaturation(guests, []).fired).toBe(false);
   });
-  it('fires when one visitor temporally matches 6 distinct guests within ±10 min', () => {
+  it('fires when one visitor temporally matches 6 distinct guests within ±10 min (only visitor → secondMax=0)', () => {
     const base = new Date('2026-04-01T12:00:00Z').getTime();
     const guests = Array.from({ length: 6 }, (_, i) =>
       makeGuest({
@@ -470,6 +470,7 @@ describe('checkHighPerVisitorRsvpSaturation', () => {
     const result = checkHighPerVisitorRsvpSaturation(guests, funnel);
     expect(result.fired).toBe(true);
     expect(result.evidence?.max).toBe(6);
+    expect(result.evidence?.secondMax).toBe(0);
     expect(result.evidence?.visitorHash).toBe('padder'.slice(0, 8));
   });
   it('does not fire when each visitor only matches 1-2 guests', () => {
@@ -501,6 +502,89 @@ describe('checkHighPerVisitorRsvpSaturation', () => {
       }),
     ];
     expect(checkHighPerVisitorRsvpSaturation(guests, funnel).fired).toBe(false);
+  });
+
+  // parmesan-67529: ratio-based refinement to suppress QR-kiosk false positives.
+  // Build N visitors, each with one funnel timestamp centered in its own 2-hour
+  // slot; place K guests 1 min apart inside that slot, centered on the funnel
+  // event, so the visitor temporally matches all K guests within the ±10-min
+  // window. The resulting per-visitor counts array = [K1, K2, K3, ...] which
+  // is what we test against the ratio rule. Slots are far enough apart that no
+  // cross-slot matching occurs. Requires each K ≤ 21 (the ±10-min window).
+  function buildMatchScenario(counts: number[]): {
+    guests: FakeDetectionGuest[];
+    funnel: FakeDetectionFunnelEvent[];
+  } {
+    const base = new Date('2026-04-01T12:00:00Z').getTime();
+    const SLOT = 2 * 60 * 60_000;
+    const guests: FakeDetectionGuest[] = [];
+    const funnel: FakeDetectionFunnelEvent[] = [];
+    counts.forEach((k, vIdx) => {
+      const slotMid = base + vIdx * SLOT + 30 * 60_000; // 30 min into slot
+      const visitorHash = vIdx === 0 ? 'padder00' : `kiosk${vIdx}`;
+      // Funnel event at slot midpoint
+      funnel.push(
+        makeFunnelEvent({
+          visitorHash,
+          step: 'rsvp_opened',
+          createdAt: new Date(slotMid),
+        }),
+      );
+      // K guests 1 min apart centered on slotMid so |guest - funnel| ≤ (K-1)/2 min
+      const startOffsetMin = -Math.floor((k - 1) / 2);
+      for (let i = 0; i < k; i++) {
+        guests.push(
+          makeGuest({
+            id: `g-v${vIdx}-${i}`,
+            submittedAt: new Date(slotMid + (startOffsetMin + i) * 60_000),
+          }),
+        );
+      }
+    });
+    return { guests, funnel };
+  }
+
+  it('[10,10,10] flat (kiosk) distribution does NOT fire', () => {
+    const { guests, funnel } = buildMatchScenario([10, 10, 10]);
+    const r = checkHighPerVisitorRsvpSaturation(guests, funnel);
+    expect(r.fired).toBe(false);
+    expect(r.evidence?.max).toBe(10);
+    expect(r.evidence?.secondMax).toBe(10);
+  });
+
+  it('[13,8,6] padder shape (Owerri) DOES fire — ratio 1.625', () => {
+    const { guests, funnel } = buildMatchScenario([13, 8, 6]);
+    const r = checkHighPerVisitorRsvpSaturation(guests, funnel);
+    expect(r.fired).toBe(true);
+    expect(r.evidence?.max).toBe(13);
+    expect(r.evidence?.secondMax).toBe(8);
+    expect(r.evidence?.ratio).toBeCloseTo(13 / 8, 2);
+  });
+
+  it('[17,4,3] clear padder (Bwejuu) fires hard — ratio 4.25', () => {
+    const { guests, funnel } = buildMatchScenario([17, 4, 3]);
+    const r = checkHighPerVisitorRsvpSaturation(guests, funnel);
+    expect(r.fired).toBe(true);
+    expect(r.evidence?.max).toBe(17);
+    expect(r.evidence?.secondMax).toBe(4);
+    expect(r.evidence?.ratio).toBeCloseTo(17 / 4, 2);
+  });
+
+  it('[17,12,9] Ilemela-shape — ratio 1.42 below threshold, does NOT fire', () => {
+    const { guests, funnel } = buildMatchScenario([17, 12, 9]);
+    const r = checkHighPerVisitorRsvpSaturation(guests, funnel);
+    expect(r.fired).toBe(false);
+    expect(r.evidence?.max).toBe(17);
+    expect(r.evidence?.secondMax).toBe(12);
+  });
+
+  it('edge case: only one visitor matched ≥1 guest (secondMax=0) → fires', () => {
+    const { guests, funnel } = buildMatchScenario([6]);
+    const r = checkHighPerVisitorRsvpSaturation(guests, funnel);
+    expect(r.fired).toBe(true);
+    expect(r.evidence?.max).toBe(6);
+    expect(r.evidence?.secondMax).toBe(0);
+    expect(r.evidence?.ratio).toBe(null);
   });
 });
 
@@ -935,9 +1019,15 @@ describe('scoreEvent — integration fixtures', () => {
     // Should fire: cap_fill, low_domain_entropy, wallet_too_low, host_self,
     // pizzeria_blank, wallet_source_null, one_word_name, firstname_digits,
     // low_hour_entropy, rapid_intersubmission, low_funnel_coverage,
-    // high_per_visitor_rsvp_saturation, mailing_list_opt_in_extreme (all default=false),
-    // lsh_field_sig_cluster (identical sigs).
+    // mailing_list_opt_in_extreme (all default=false), lsh_field_sig_cluster
+    // (identical sigs).
     // (sig_collapse no longer in scoreEvent list — replaced by lsh_field_sig_cluster.)
+    // parmesan-67529: high_per_visitor_rsvp_saturation no longer fires here
+    // because all 5 funnel visitors line up at the same `base` timestamp →
+    // each matches the same large set of RSVPs → max == secondMax (ratio 1.0,
+    // below 1.5 threshold). The remaining 13 heuristics still saturate the
+    // score above 70. This is the desired post-refinement behavior: kiosk-shape
+    // flat distributions don't trip saturation.
     expect(row.score).toBeGreaterThanOrEqual(70);
     expect(row.tier).toBe('high');
     const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
@@ -947,7 +1037,7 @@ describe('scoreEvent — integration fixtures', () => {
     expect(firedIds).toContain('mailing_list_opt_in_extreme');
     expect(firedIds).toContain('host_self_rsvp_mismatch');
     expect(firedIds).toContain('low_funnel_coverage');
-    expect(firedIds).toContain('high_per_visitor_rsvp_saturation');
+    expect(firedIds).not.toContain('high_per_visitor_rsvp_saturation');
   });
 
   it('"Lilongwe-like" clean event scores ≤10', () => {

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -109,7 +109,7 @@ export const WEIGHTS = {
   rapid_intersubmission: 8,
   cross_event_wallet: 15,
   low_funnel_coverage: 10,
-  high_per_visitor_rsvp_saturation: 15,
+  high_per_visitor_rsvp_saturation: 20,
   mailing_list_opt_in_extreme: 7,
   name_token_zscore: 8,
   lsh_field_sig_cluster: 10,
@@ -664,8 +664,15 @@ export function checkLowFunnelCoverage(
 /**
  * 16. high_per_visitor_rsvp_saturation — one visitor's funnel timestamps temporally match many guest submissions.
  * Temporal join: for each visitorHash's funnel `createdAt` values, count distinct guests whose
- * `submittedAt` is within ±10 min of any of that visitor's funnel timestamps. Fires if max ≥ 5.
- * (Needed because the unique index on (partyId, visitorHash, step) caps naive per-visitor row counts at 2.)
+ * `submittedAt` is within ±10 min of any of that visitor's funnel timestamps.
+ *
+ * Refined in parmesan-67529: we now also track `secondMax` and require either
+ *   - only one visitor matched ≥1 guest (secondMax === 0), or
+ *   - the top visitor padded much harder than the runner-up (max / secondMax ≥ 1.5).
+ * This distinguishes the single-padder spike (Owerri [13,8,6], Bwejuu [17,4,3])
+ * from flat QR-kiosk distributions (NYC Pizza Temple [10,10,10], Santa Cruz
+ * [28,28,26]) where organizer phones happen to sit on the form during attendee
+ * submission bursts.
  */
 export function checkHighPerVisitorRsvpSaturation(
   guests: FakeDetectionGuest[],
@@ -683,6 +690,7 @@ export function checkHighPerVisitorRsvpSaturation(
     byVisitor.set(e.visitorHash, arr);
   }
   let max = 0;
+  let secondMax = 0;
   let worstVisitor = '';
   for (const [visitor, timestamps] of byVisitor) {
     const matched = new Set<string>();
@@ -693,16 +701,20 @@ export function checkHighPerVisitorRsvpSaturation(
       }
     }
     if (matched.size > max) {
+      secondMax = max;
       max = matched.size;
       worstVisitor = visitor;
+    } else if (matched.size > secondMax) {
+      secondMax = matched.size;
     }
   }
-  const fired = max >= 5;
+  const ratio = secondMax > 0 ? max / secondMax : Infinity;
+  const fired = max >= 5 && (secondMax === 0 || ratio >= 1.5);
   return flag(
     id,
     fired,
-    `max=${max} guests matched to one device`,
-    { max, visitorHash: worstVisitor.slice(0, 8) },
+    `max=${max}, secondMax=${secondMax} (ratio=${secondMax > 0 ? ratio.toFixed(2) : '∞'})`,
+    { max, secondMax, ratio: secondMax > 0 ? ratio : null, visitorHash: worstVisitor.slice(0, 8) },
   );
 }
 


### PR DESCRIPTION
## Summary
- `high_per_visitor_rsvp_saturation` was firing on QR-kiosk events where an organizer's phone happened to be on the form during a submission burst (NYC Pizza Temple `[10,10,10]`, Santa Cruz `[28,28,26]`). The naive `max >= 5` rule can't distinguish flat distributions from single-padder spikes.
- Track `secondMax` alongside `max` and require either `secondMax === 0` (only one matching visitor) **or** `max / secondMax >= 1.5` (single-padder shape) before firing. Padder shapes (Owerri `[13,8,6]` ratio 1.625, Bwejuu `[17,4,3]` ratio 4.25) still fire; flat kiosk distributions don't.
- Bump `WEIGHTS.high_per_visitor_rsvp_saturation` 15 → 20 to compensate for the tighter precision.

## Behavior matrix (new tests)
| Per-visitor counts | Shape       | Fires? |
| ------------------ | ----------- | ------ |
| `[10,10,10]`       | flat kiosk  | no     |
| `[13,8,6]`         | Owerri padder | yes (ratio 1.625) |
| `[17,4,3]`         | Bwejuu padder | yes (ratio 4.25) |
| `[17,12,9]`        | Ilemela-ish | no (ratio 1.42 — but other heuristics still score it high) |
| `[6]`              | only one visitor | yes (secondMax=0) |

## Test plan
- [x] `npx vitest run fakeDetection` — 97/97 pass
- [x] `npx tsc --noEmit` — no new errors (pre-existing unrelated errors only)
- [x] Ilemela integration test: saturation no longer fires there (flat funnel-shape fixture), other 13 heuristics still saturate the score >= 70
- [ ] Vercel preview deploy ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)