### PR TITLE
sausage-32344: reject GPP signups within 80km of approved city

### DIFF
--- a/backend/src/lib/distance.ts
+++ b/backend/src/lib/distance.ts
@@ -1,0 +1,20 @@
+const R = 6371; // Earth radius in km
+
+/**
+ * Haversine distance between two lat/lng points, in kilometres.
+ */
+export function haversineKm(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const a2 =
+    sinDLat * sinDLat +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sinDLng * sinDLng;
+  const c = 2 * Math.atan2(Math.sqrt(a2), Math.sqrt(1 - a2));
+  return R * c;
+}

--- a/backend/src/lib/geocode.ts
+++ b/backend/src/lib/geocode.ts
@@ -1,0 +1,66 @@
+export interface GeocodeResult {
+  lat: number;
+  lng: number;
+  source: 'nominatim' | 'google';
+}
+
+/**
+ * Geocode a city name to lat/lng using Nominatim first, Google Maps as fallback.
+ * Returns null on any error or no result — never throws.
+ */
+export async function geocodeCity(city: string, country?: string | null): Promise<GeocodeResult | null> {
+  const query = country ? `${city}, ${country}` : city;
+
+  // --- Nominatim ---
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1`;
+    const resp = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'rsv.pizza-backend/1.0 (samgold24@gmail.com)',
+      },
+    });
+    clearTimeout(timer);
+    if (resp.ok) {
+      const data = await resp.json();
+      if (Array.isArray(data) && data.length > 0) {
+        const lat = parseFloat(data[0].lat);
+        const lng = parseFloat(data[0].lon);
+        if (!isNaN(lat) && !isNaN(lng)) {
+          return { lat, lng, source: 'nominatim' };
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[geocodeCity] Nominatim error:', err instanceof Error ? err.message : err);
+  }
+
+  // --- Google Maps fallback ---
+  const googleKey = process.env.GOOGLE_GEOCODING_API_KEY;
+  if (!googleKey) {
+    return null;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(query)}&key=${googleKey}`;
+    const resp = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.results && data.results.length > 0) {
+        const loc = data.results[0].geometry?.location;
+        if (loc && typeof loc.lat === 'number' && typeof loc.lng === 'number') {
+          return { lat: loc.lat, lng: loc.lng, source: 'google' };
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[geocodeCity] Google Maps error:', err instanceof Error ? err.message : err);
+  }
+
+  return null;
+}

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -6,6 +6,8 @@ import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
 import { isAdmin, isUnderboss } from '../middleware/auth.js';
 import { getAutoCoHostPartners, addPartnerToParty } from '../helpers/partnerSync.js';
+import { geocodeCity } from '../lib/geocode.js';
+import { haversineKm } from '../lib/distance.js';
 
 const router = Router();
 
@@ -312,6 +314,93 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
       );
     }
 
+    // --- Proximity check: reject if within 80 km of an approved GPP city ---
+    // Resolve coordinates: prefer submitted values, fall back to geocoding.
+    let resolvedLat: number | null = null;
+    let resolvedLng: number | null = null;
+
+    const submittedLat = typeof cityLat === 'number' ? cityLat : null;
+    const submittedLng = typeof cityLng === 'number' ? cityLng : null;
+
+    if (
+      submittedLat !== null && submittedLng !== null &&
+      submittedLat >= -90 && submittedLat <= 90 &&
+      submittedLng >= -180 && submittedLng <= 180
+    ) {
+      resolvedLat = submittedLat;
+      resolvedLng = submittedLng;
+    } else {
+      try {
+        const geocoded = await geocodeCity(normalizedCity, country);
+        if (geocoded) {
+          resolvedLat = geocoded.lat;
+          resolvedLng = geocoded.lng;
+        }
+      } catch (geocodeErr) {
+        // Fail-open: geocoder error → skip proximity check
+        console.warn('[gpp/nearby-check] geocodeCity threw unexpectedly:', geocodeErr);
+      }
+    }
+
+    if (resolvedLat !== null && resolvedLng !== null) {
+      // Query all approved GPP cities that have coordinates
+      const approvedCities = await prisma.$queryRaw<Array<{
+        id: string;
+        name: string;
+        custom_url: string | null;
+        invite_code: string;
+        latitude: number;
+        longitude: number;
+      }>>`
+        SELECT id, name, custom_url, invite_code, latitude, longitude
+        FROM parties
+        WHERE event_type = 'gpp'
+          AND underboss_status = 'approved'
+          AND latitude IS NOT NULL
+          AND longitude IS NOT NULL
+      `;
+
+      let nearestKm = Infinity;
+      let nearestCity: typeof approvedCities[number] | null = null;
+
+      for (const ac of approvedCities) {
+        const km = haversineKm(
+          { lat: resolvedLat, lng: resolvedLng },
+          { lat: ac.latitude, lng: ac.longitude }
+        );
+        if (km < nearestKm) {
+          nearestKm = km;
+          nearestCity = ac;
+        }
+      }
+
+      console.info('[gpp/nearby-check]', {
+        city: normalizedCity,
+        lat: resolvedLat,
+        lng: resolvedLng,
+        nearestKm: nearestCity ? Math.round(nearestKm) : null,
+        nearestId: nearestCity?.id ?? null,
+      });
+
+      if (nearestCity && nearestKm <= 80) {
+        const eventUrl = nearestCity.custom_url
+          ? `https://rsv.pizza/${nearestCity.custom_url}`
+          : `https://rsv.pizza/${nearestCity.invite_code}`;
+
+        // Strip 'Global Pizza Party ' prefix to get a friendly city name
+        const nearbyDisplayName = nearestCity.name.startsWith('Global Pizza Party ')
+          ? nearestCity.name.slice('Global Pizza Party '.length)
+          : nearestCity.name;
+
+        throw new AppError(
+          `There's already an approved Global Pizza Party near you in ${nearbyDisplayName} — it's about ${Math.round(nearestKm)} km away. Join them here: ${eventUrl}`,
+          409,
+          'NEARBY_CITY'
+        );
+      }
+    }
+    // --- End proximity check ---
+
     // Find or create user
     let user = await prisma.user.findUnique({
       where: { email: normalizedEmail },
@@ -411,8 +500,8 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
         country: country || null,
         address: cityAddress,
         addressIsCityDefault: true,
-        latitude: typeof cityLat === 'number' ? cityLat : null,
-        longitude: typeof cityLng === 'number' ? cityLng : null,
+        latitude: resolvedLat,
+        longitude: resolvedLng,
         placeId: null,
         availableBeverages: [],
         availableToppings: [],


### PR DESCRIPTION
## Summary
- Adds Haversine proximity check (80 km ≈ 1hr drive) to `POST /api/gpp/events`
- Rejects new GPP signups within 80 km of an existing `underboss_status='approved'` GPP city with `409 NEARBY_CITY` and a link to that city
- Resolves coords from submitted `cityLat`/`cityLng` or geocodes server-side via Nominatim → optional Google
- Fail-open on geocoder errors (signup still goes through; existing name dup-check still applies)
- Side fix: persists resolved `lat`/`lng` on created party (previously dropped)

## Files
- `backend/src/lib/geocode.ts` (new)
- `backend/src/lib/distance.ts` (new)
- `backend/src/routes/gpp.routes.ts` (modified)

## Notes
- 383 of 385 approved GPP cities have lat/lng — Tokyo and Monterrey are the blindspot but acceptable
- `GOOGLE_GEOCODING_API_KEY` not set in backend Vercel prod → Nominatim-only fallback in prod (helper still calls Google if key present locally / future-proofing)
- Plan: `plans/sausage-32344-gpp-nearby-city-rejection.md` (on main session disk, not in this branch)

## Test plan
- [ ] `tsc` clean (pre-existing errors in other files, none in our changes)
- [ ] Manual smoke once merged: POST /api/gpp/events with city near an approved GPP → expect 409 + URL in message
- [ ] Manual smoke: POST without cityLat/cityLng for a city near an approved GPP → server-side geocode should still catch it
- [ ] No false-positive: POST for a city >80km from all approved GPPs → succeeds
- [ ] After a successful new signup, verify `latitude`/`longitude` are populated on the new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)