### PR TITLE
feat(pizzaiolo-63884): gate opt-in A/B on 'optin-ab-test' event tag

### DIFF
--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -182,6 +182,12 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
   useEffect(() => {
     if (optinAbVariant !== null) return; // preservation path already set
     if (!activeRegionConfig) return;     // not an SWC event
+    // pizzaiolo-63884: pilot mode — only events explicitly tagged 'optin-ab-test'
+    // participate in the experiment, even when the region's kill-switch flag is ON.
+    // Remove this gate (or remove the tag from each pilot event) to fan out to all
+    // region-tagged events.
+    const tags = eventData.eventTags || [];
+    if (!tags.includes('optin-ab-test')) return;
     let cancelled = false;
     (async () => {
       const enabled = await getExperimentFlag(activeRegionConfig.flagKey);


### PR DESCRIPTION
## Summary
Adds a one-line gate to `useRSVPForm.ts`: variant roll requires the event to be tagged `optin-ab-test`, on top of the existing region-tag + flag-enabled checks. Pilots the opt-in A/B experiment on a single tagged event.

## How to use
1. In `/underboss` (or wherever you edit event tags), add `optin-ab-test` to the one event you want to pilot on.
2. Flip the region's flag ON in `/admin` -> Experiments (e.g. US `swc` flag).
3. Only that tagged event will bucket RSVPs into control/variant. Other US `swc` events stay on the two-checkbox baseline.

## How to fan out (when ready)
Two options:
- **Add the tag to every event you want in the experiment** (no code change; chore).
- **Remove the gate from `useRSVPForm.ts`** (small follow-up PR, ~3 lines removed).

## Test plan
- [ ] Open a US `swc` event with no `optin-ab-test` tag while the US flag is ON -> form shows today's two-checkbox baseline in 100% of sessions.
- [ ] Add `optin-ab-test` tag to one event -> ~50% of incognito sessions show the combined checkbox; ~50% control.
- [ ] Remove the tag -> next RSVPs revert to baseline. (Existing variant-bucketed guests keep their assignment on edit-RSVP per the preservation path.)