### PR TITLE
mushroom-31723: move Invited modal trigger from dashboard to GuestList

### DIFF
--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -7,6 +7,7 @@ import { UserRoundX, Users, Clock, Search, CheckCircle2, Download, Mail, Check, 
 import { IconInput } from './IconInput';
 import { Checkbox } from './Checkbox';
 import { RejectedGuestsModal } from './RejectedGuestsModal';
+import { InvitedGuestsModal } from './InvitedGuestsModal';
 import { checkInGuest, getNotableGuestIds, addNotableAttendee, deleteNotableAttendeeByGuestId } from '../lib/api';
 
 export const GuestList: React.FC = () => {
@@ -17,6 +18,7 @@ export const GuestList: React.FC = () => {
   const [notableGuestIds, setNotableGuestIds] = useState<Set<string>>(new Set());
   const [togglingNotableId, setTogglingNotableId] = useState<string | null>(null);
   const [showRejectedModal, setShowRejectedModal] = useState(false);
+  const [showInvitedModal, setShowInvitedModal] = useState(false);
 
   // Bulk selection state
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -427,13 +429,18 @@ export const GuestList: React.FC = () => {
       {invitedGuests.length > 0 && (
         <div className="card p-6">
           <div className="flex justify-between items-center mb-4">
-            <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setShowInvitedModal(true)}
+              className="flex items-center gap-3 rounded-lg -mx-2 px-2 py-1 hover:bg-theme-surface-hover transition-colors"
+              aria-label={`View ${invitedGuests.length} invited guests`}
+            >
               <Mail size={20} className="text-theme-text-secondary" />
               <h2 className="text-xl font-bold text-theme-text">Invited</h2>
               <span className="bg-blue-500/20 text-blue-400 text-sm font-medium px-3 py-1 rounded-full border border-blue-500/30">
                 {invitedGuests.length}
               </span>
-            </div>
+            </button>
           </div>
           <div className="flex items-center py-2 -mx-2 px-2">
             <Checkbox
@@ -568,6 +575,13 @@ export const GuestList: React.FC = () => {
         rejectedGuests={rejectedGuests}
         onRestore={restoreGuest}
         party={party}
+      />
+
+      {/* Invited Guests modal — opened from the Invited section header. */}
+      <InvitedGuestsModal
+        isOpen={showInvitedModal}
+        onClose={() => setShowInvitedModal(false)}
+        invitedGuests={invitedGuests}
       />
     </>
   );

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -7,7 +7,6 @@ import { AutoCompleteStates, ChecklistItem } from '../../types';
 import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
 import { FindVenueModal } from '../checklist/FindVenueModal';
-import { InvitedGuestsModal } from '../InvitedGuestsModal';
 
 export const GPPDashboardTab: React.FC = () => {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -22,12 +21,6 @@ export const GPPDashboardTab: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [findVenueOpen, setFindVenueOpen] = useState(false);
-  const [invitedModalOpen, setInvitedModalOpen] = useState(false);
-
-  const invitedGuests = useMemo(
-    () => guests.filter(g => g.approved !== false && g.status === 'INVITED'),
-    [guests]
-  );
 
   const loadChecklist = useCallback(async () => {
     if (!party?.id) return;
@@ -136,18 +129,12 @@ export const GPPDashboardTab: React.FC = () => {
     <div className="space-y-6">
       {/* Quick stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <button
-          type="button"
-          onClick={() => invitedGuests.length > 0 && setInvitedModalOpen(true)}
-          disabled={invitedGuests.length === 0}
-          className="card p-4 text-center transition-colors enabled:hover:bg-theme-surface-hover enabled:cursor-pointer disabled:cursor-default"
-          aria-label={invitedGuests.length > 0 ? `View ${invitedGuests.length} invited guests` : 'No invited guests'}
-        >
+        <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-theme-text">
-            {invitedGuests.length}
+            {guests.filter(g => g.approved !== false && g.status === 'INVITED').length}
           </div>
           <div className="text-xs text-theme-text-muted">Invited</div>
-        </button>
+        </div>
         <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-theme-text">
             {guests.filter(g => g.approved !== false && g.status !== 'INVITED').length}
@@ -373,12 +360,6 @@ export const GPPDashboardTab: React.FC = () => {
         open={findVenueOpen}
         onClose={() => setFindVenueOpen(false)}
         onSaved={loadChecklist}
-      />
-
-      <InvitedGuestsModal
-        isOpen={invitedModalOpen}
-        onClose={() => setInvitedModalOpen(false)}
-        invitedGuests={invitedGuests}
       />
 
       {/* Host Resources */}


### PR DESCRIPTION
## Summary

Tiny follow-up to #383. I originally wired InvitedGuestsModal to the Invited stat card on the GPP dashboard, but that surface is GPP-only and most hosts never see it. The natural click target was the **Invited section header in GuestList** (the regular guests tab).

- Reverts the GPPDashboardTab change (Invited stat card is a plain div again).
- Wraps the Invited section header in GuestList.tsx (Mail icon + "Invited" + count pill) in a button that opens the existing InvitedGuestsModal.

## Test plan

- [ ] Regular event with invited guests: the "Invited" header in GuestList is clickable and opens the modal with name/email rows.
- [ ] GPP event: dashboard Invited stat card is no longer clickable.