### PR TITLE
feat(dough-91206): shipping dashboard rsvp count + inline no-kit rows

### DIFF
--- a/backend/src/routes/shipping.routes.ts
+++ b/backend/src/routes/shipping.routes.ts
@@ -122,6 +122,19 @@ router.get('/stats', requireAuth, requireShippingAuth, async (req: ShippingReque
       },
     });
 
+    // Count GPP-approved events in scope that have NOT submitted a kit request.
+    const partyRegionFilter = req.shippingRegions!.includes('__admin__')
+      ? {}
+      : { region: { in: req.shippingRegions! } };
+    const noRequest = await prisma.party.count({
+      where: {
+        ...partyRegionFilter,
+        region: { not: null },
+        underbossStatus: 'approved',
+        partyKit: { is: null },
+      },
+    });
+
     const stats = {
       total: kits.length,
       pending: kits.filter(k => k.status === 'pending').length,
@@ -129,6 +142,7 @@ router.get('/stats', requireAuth, requireShippingAuth, async (req: ShippingReque
       shipped: kits.filter(k => k.status === 'shipped').length,
       delivered: kits.filter(k => k.status === 'delivered').length,
       declined: kits.filter(k => k.status === 'declined').length,
+      noRequest,
       byCountry: {} as Record<string, number>,
       byTier: {} as Record<string, number>,
     };
@@ -185,6 +199,13 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
             venueName: true,
             underbossStatus: true,
             user: { select: { name: true, email: true } },
+            _count: {
+              select: {
+                guests: {
+                  where: { status: { notIn: ['DECLINED', 'INVITED'] } },
+                },
+              },
+            },
           },
         },
       },
@@ -203,14 +224,72 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
       );
     }
 
+    // Include placeholder rows (GPP-approved events with no kit request) when
+    // none of status / tier / country are filtered — they have no shipping
+    // fields to match against.
+    const includePlaceholders = !status && !tier && !country;
+    let placeholderParties: Array<{
+      id: string;
+      name: string;
+      region: string | null;
+      date: Date | null;
+      address: string | null;
+      venueName: string | null;
+      underbossStatus: string | null;
+      user: { name: string | null; email: string | null } | null;
+      _count: { guests: number };
+    }> = [];
+    if (includePlaceholders) {
+      const partyRegionFilter = req.shippingRegions!.includes('__admin__')
+        ? {}
+        : { region: { in: req.shippingRegions! } };
+      const explicitRegion = region && typeof region === 'string' ? { region } : {};
+      placeholderParties = await prisma.party.findMany({
+        where: {
+          ...partyRegionFilter,
+          ...explicitRegion,
+          region: { not: null },
+          underbossStatus: 'approved',
+          partyKit: { is: null },
+        },
+        select: {
+          id: true,
+          name: true,
+          region: true,
+          date: true,
+          address: true,
+          venueName: true,
+          underbossStatus: true,
+          user: { select: { name: true, email: true } },
+          _count: {
+            select: {
+              guests: {
+                where: { status: { notIn: ['DECLINED', 'INVITED'] } },
+              },
+            },
+          },
+        },
+        orderBy: { date: 'desc' },
+      });
+      if (search && typeof search === 'string') {
+        const term = search.toLowerCase();
+        placeholderParties = placeholderParties.filter(p =>
+          p.name.toLowerCase().includes(term) ||
+          (p.user?.name || '').toLowerCase().includes(term) ||
+          (p.user?.email || '').toLowerCase().includes(term)
+        );
+      }
+    }
+
     // Build CSV
-    const headers = ['Kit ID', 'Event Name', 'Region', 'Host Name', 'Host Email', 'Event Venue', 'Event Address', 'Event Approved', 'Recipient', 'Address 1', 'Address 2', 'City', 'State', 'Postal Code', 'Country', 'Phone', 'Requested Tier', 'Allocated Tier', 'Status', 'Notes', 'Tracking Number', 'Tracking URL'];
+    const headers = ['Kit ID', 'Event Name', 'RSVPs', 'Region', 'Host Name', 'Host Email', 'Event Venue', 'Event Address', 'Event Approved', 'Recipient', 'Address 1', 'Address 2', 'City', 'State', 'Postal Code', 'Country', 'Phone', 'Requested Tier', 'Allocated Tier', 'Status', 'Notes', 'Tracking Number', 'Tracking URL'];
     const csvRows = [headers.join(',')];
 
     for (const kit of filtered) {
       const row = [
         escapeCSV(kit.id),
         escapeCSV(kit.party.name),
+        escapeCSV(String(kit.party._count.guests)),
         escapeCSV(kit.party.region || ''),
         escapeCSV(kit.party.user?.name || ''),
         escapeCSV(kit.party.user?.email || ''),
@@ -231,6 +310,35 @@ router.get('/kits/export', requireAuth, requireShippingAuth, async (req: Shippin
         escapeCSV(kit.notes || ''),
         escapeCSV(kit.trackingNumber || ''),
         escapeCSV(kit.trackingUrl || ''),
+      ];
+      csvRows.push(row.join(','));
+    }
+
+    for (const p of placeholderParties) {
+      const row = [
+        escapeCSV(`placeholder:${p.id}`),
+        escapeCSV(p.name),
+        escapeCSV(String(p._count.guests)),
+        escapeCSV(p.region || ''),
+        escapeCSV(p.user?.name || ''),
+        escapeCSV(p.user?.email || ''),
+        escapeCSV(p.venueName || ''),
+        escapeCSV(p.address || ''),
+        escapeCSV('Approved'),
+        escapeCSV(''),  // Recipient
+        escapeCSV(''),  // Address 1
+        escapeCSV(''),  // Address 2
+        escapeCSV(''),  // City
+        escapeCSV(''),  // State
+        escapeCSV(''),  // Postal Code
+        escapeCSV(''),  // Country
+        escapeCSV(''),  // Phone
+        escapeCSV(''),  // Requested Tier
+        escapeCSV(''),  // Allocated Tier
+        escapeCSV('No request'),
+        escapeCSV(''),  // Notes
+        escapeCSV(''),  // Tracking Number
+        escapeCSV(''),  // Tracking URL
       ];
       csvRows.push(row.join(','));
     }
@@ -376,9 +484,12 @@ router.get('/kits', requireAuth, requireShippingAuth, async (req: ShippingReques
     const { status, tier, country, region, search, sort } = req.query;
     const regionFilter = buildRegionFilter(req.shippingRegions!);
 
+    // status === 'no_request' is a pseudo-status: return placeholders only.
+    const placeholdersOnly = status === 'no_request';
+
     const where: any = { ...regionFilter };
 
-    if (status && typeof status === 'string') {
+    if (status && typeof status === 'string' && !placeholdersOnly) {
       where.status = status;
     }
     if (tier && typeof tier === 'string') {
@@ -409,24 +520,35 @@ router.get('/kits', requireAuth, requireShippingAuth, async (req: ShippingReques
       }
     }
 
-    const kits = await prisma.partyKit.findMany({
-      where,
-      include: {
-        party: {
-          select: {
-            id: true,
-            name: true,
-            region: true,
-            date: true,
-            address: true,
-            venueName: true,
-            underbossStatus: true,
-            user: { select: { name: true, email: true } },
+    // Skip the real-kits query entirely when in placeholders-only mode.
+    let kits: any[] = [];
+    if (!placeholdersOnly) {
+      kits = await prisma.partyKit.findMany({
+        where,
+        include: {
+          party: {
+            select: {
+              id: true,
+              name: true,
+              region: true,
+              date: true,
+              address: true,
+              venueName: true,
+              underbossStatus: true,
+              user: { select: { name: true, email: true } },
+              _count: {
+                select: {
+                  guests: {
+                    where: { status: { notIn: ['DECLINED', 'INVITED'] } },
+                  },
+                },
+              },
+            },
           },
         },
-      },
-      orderBy,
-    });
+        orderBy,
+      });
+    }
 
     // Apply search filter in memory
     let filtered = kits;
@@ -441,7 +563,7 @@ router.get('/kits', requireAuth, requireShippingAuth, async (req: ShippingReques
       );
     }
 
-    // Format response
+    // Format real kits
     const formattedKits = filtered.map(kit => ({
       id: kit.id,
       partyId: kit.partyId,
@@ -472,9 +594,96 @@ router.get('/kits', requireAuth, requireShippingAuth, async (req: ShippingReques
       approvedAt: kit.approvedAt?.toISOString() || null,
       shippedAt: kit.shippedAt?.toISOString() || null,
       deliveredAt: kit.deliveredAt?.toISOString() || null,
+      rsvpCount: kit.party._count.guests,
+      isPlaceholder: false,
     }));
 
-    res.json({ kits: formattedKits });
+    // Placeholder rows: GPP-approved events with no PartyKit row.
+    // Included when (placeholdersOnly OR no status filter) and tier/country are
+    // empty (placeholders have no tier/country to match).
+    const shouldIncludePlaceholders =
+      (placeholdersOnly || !status) && !tier && !country;
+
+    let placeholders: any[] = [];
+    if (shouldIncludePlaceholders) {
+      const partyRegionFilter = req.shippingRegions!.includes('__admin__')
+        ? {}
+        : { region: { in: req.shippingRegions! } };
+      const explicitRegion = region && typeof region === 'string' ? { region } : {};
+
+      let placeholderParties = await prisma.party.findMany({
+        where: {
+          ...partyRegionFilter,
+          ...explicitRegion,
+          region: { not: null },
+          underbossStatus: 'approved',
+          partyKit: { is: null },
+        },
+        select: {
+          id: true,
+          name: true,
+          region: true,
+          date: true,
+          address: true,
+          venueName: true,
+          underbossStatus: true,
+          user: { select: { name: true, email: true } },
+          _count: {
+            select: {
+              guests: {
+                where: { status: { notIn: ['DECLINED', 'INVITED'] } },
+              },
+            },
+          },
+        },
+        orderBy: { date: 'desc' },
+      });
+
+      if (search && typeof search === 'string') {
+        const term = search.toLowerCase();
+        placeholderParties = placeholderParties.filter(p =>
+          p.name.toLowerCase().includes(term) ||
+          (p.user?.name || '').toLowerCase().includes(term) ||
+          (p.user?.email || '').toLowerCase().includes(term)
+        );
+      }
+
+      placeholders = placeholderParties.map(p => ({
+        id: `placeholder:${p.id}`,
+        partyId: p.id,
+        partyName: p.name,
+        eventDate: p.date?.toISOString() || null,
+        region: p.region || null,
+        hostName: p.user?.name || null,
+        hostEmail: p.user?.email || null,
+        eventAddress: p.address || null,
+        eventVenue: p.venueName || null,
+        underbossStatus: p.underbossStatus || 'pending',
+        requestedTier: '',
+        allocatedTier: null,
+        recipientName: '',
+        addressLine1: '',
+        addressLine2: null,
+        city: '',
+        state: null,
+        postalCode: '',
+        country: '',
+        phone: null,
+        status: 'no_request',
+        trackingNumber: null,
+        trackingUrl: null,
+        notes: null,
+        adminNotes: null,
+        requestedAt: p.date?.toISOString() || new Date(0).toISOString(),
+        approvedAt: null,
+        shippedAt: null,
+        deliveredAt: null,
+        rsvpCount: p._count.guests,
+        isPlaceholder: true,
+      }));
+    }
+
+    res.json({ kits: [...formattedKits, ...placeholders] });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/shipping/KitFilters.tsx
+++ b/frontend/src/components/shipping/KitFilters.tsx
@@ -3,13 +3,14 @@ import { Search, Download, Upload, Package } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type { KitStatus } from '../../types';
 
-const STATUS_OPTIONS: { value: KitStatus | ''; label: string }[] = [
+const STATUS_OPTIONS: { value: KitStatus | 'no_request' | ''; label: string }[] = [
   { value: '', label: 'All Statuses' },
   { value: 'pending', label: 'Pending' },
   { value: 'approved', label: 'Approved' },
   { value: 'shipped', label: 'Shipped' },
   { value: 'delivered', label: 'Delivered' },
   { value: 'declined', label: 'Declined' },
+  { value: 'no_request', label: 'No request' },
 ];
 
 const STATUS_COLORS: Record<string, string> = {
@@ -18,6 +19,7 @@ const STATUS_COLORS: Record<string, string> = {
   shipped: 'bg-purple-500/20 text-purple-600 border-purple-500/30',
   delivered: 'bg-green-500/20 text-green-600 border-green-500/30',
   declined: 'bg-red-500/20 text-red-600 border-red-500/30',
+  no_request: 'bg-orange-500/20 text-orange-600 border-orange-500/30',
 };
 
 interface KitFiltersProps {

--- a/frontend/src/components/shipping/KitRow.tsx
+++ b/frontend/src/components/shipping/KitRow.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ExternalLink, Eye, Info } from 'lucide-react';
 import { KitContentsModal } from './KitContentsModal';
 import type { ShippingKit, KitStatus, KitTier } from '../../types';
@@ -11,6 +12,7 @@ const STATUS_COLORS: Record<string, string> = {
   shipped: 'bg-purple-500/20 text-purple-700',
   delivered: 'bg-green-500/20 text-green-700',
   declined: 'bg-red-500/20 text-red-700',
+  no_request: 'bg-orange-500/20 text-orange-700',
 };
 
 const STATUS_OPTIONS: KitStatus[] = ['pending', 'approved', 'shipped', 'delivered', 'declined'];
@@ -37,10 +39,13 @@ export function KitRow({
   onViewDetail,
   showRegion,
 }: KitRowProps) {
+  const { t } = useTranslation('admin');
   const [showTracking, setShowTracking] = useState(false);
   const [showContents, setShowContents] = useState(false);
   const [trackingNum, setTrackingNum] = useState(kit.trackingNumber || '');
   const [trackingLink, setTrackingLink] = useState(kit.trackingUrl || '');
+
+  const isPlaceholder = !!kit.isPlaceholder;
 
   const regionLabel = kit.region
     ? GPP_REGIONS.find((r) => r.id === kit.region)?.label || kit.region
@@ -50,7 +55,9 @@ export function KitRow({
     ? new Date(kit.eventDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     : '--';
 
-  const requestedDate = new Date(kit.requestedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const requestedDate = !isPlaceholder
+    ? new Date(kit.requestedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    : '--';
 
   const handleTrackingBlur = () => {
     // Auto-fill tracking URL if the tracking number changed and URL is empty
@@ -69,15 +76,19 @@ export function KitRow({
 
   return (
     <tr className="border-b border-theme-stroke hover:bg-theme-surface/50 transition-colors">
-      {/* Checkbox */}
-      <td className="px-3 py-3">
-        <input
-          type="checkbox"
-          checked={selected}
-          onChange={() => onSelect(kit.id)}
-          className="rounded border-theme-stroke-hover"
-        />
-      </td>
+      {/* Checkbox — placeholders cannot be bulk-acted on */}
+      {isPlaceholder ? (
+        <td className="px-3 py-3" />
+      ) : (
+        <td className="px-3 py-3">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onSelect(kit.id)}
+            className="rounded border-theme-stroke-hover"
+          />
+        </td>
+      )}
 
       {/* Event */}
       <td className="px-3 py-3">
@@ -91,6 +102,11 @@ export function KitRow({
           </span>
         </div>
         <div className="text-xs text-theme-text-muted ml-3.5">{eventDate}</div>
+      </td>
+
+      {/* RSVPs */}
+      <td className="px-3 py-3" title={t('shipping.rsvpsTooltip')}>
+        <span className="text-sm text-theme-text">{kit.rsvpCount ?? '--'}</span>
       </td>
 
       {/* Region */}
@@ -109,55 +125,75 @@ export function KitRow({
 
       {/* Recipient + Location */}
       <td className="px-3 py-3">
-        <div className="text-sm text-theme-text">{kit.recipientName}</div>
-        <div className="text-xs text-theme-text-muted truncate max-w-[160px]">
-          {kit.city}{kit.state ? `, ${kit.state}` : ''}, {kit.country}
-        </div>
+        {isPlaceholder ? (
+          <span className="text-sm text-theme-text-muted">--</span>
+        ) : (
+          <>
+            <div className="text-sm text-theme-text">{kit.recipientName}</div>
+            <div className="text-xs text-theme-text-muted truncate max-w-[160px]">
+              {kit.city}{kit.state ? `, ${kit.state}` : ''}, {kit.country}
+            </div>
+          </>
+        )}
       </td>
 
       {/* Tier */}
       <td className="px-3 py-3 hidden lg:table-cell">
-        <div className="flex items-center gap-1">
-          <select
-            value={kit.allocatedTier || kit.requestedTier}
-            onChange={(e) => onTierChange(kit.id, e.target.value)}
-            className="appearance-none bg-theme-surface border border-theme-stroke rounded px-2 py-1 pr-6 text-xs text-theme-text focus:outline-none focus:border-theme-stroke-hover capitalize"
-          >
-            {TIER_OPTIONS.map((t) => (
-              <option key={t} value={t}>{t}</option>
-            ))}
-          </select>
-          <button
-            onClick={() => setShowContents(true)}
-            className="p-1 rounded hover:bg-theme-surface transition-colors text-theme-text-faint hover:text-theme-text-muted"
-            title="View tier contents"
-          >
-            <Info size={14} />
-          </button>
-        </div>
-        {kit.allocatedTier && kit.allocatedTier !== kit.requestedTier && (
-          <div className="text-xs text-theme-text-faint mt-0.5">req: {kit.requestedTier}</div>
+        {isPlaceholder ? (
+          <span className="text-sm text-theme-text-muted">--</span>
+        ) : (
+          <>
+            <div className="flex items-center gap-1">
+              <select
+                value={kit.allocatedTier || (kit.requestedTier as KitTier)}
+                onChange={(e) => onTierChange(kit.id, e.target.value)}
+                className="appearance-none bg-theme-surface border border-theme-stroke rounded px-2 py-1 pr-6 text-xs text-theme-text focus:outline-none focus:border-theme-stroke-hover capitalize"
+              >
+                {TIER_OPTIONS.map((tierOption) => (
+                  <option key={tierOption} value={tierOption}>{tierOption}</option>
+                ))}
+              </select>
+              <button
+                onClick={() => setShowContents(true)}
+                className="p-1 rounded hover:bg-theme-surface transition-colors text-theme-text-faint hover:text-theme-text-muted"
+                title="View tier contents"
+              >
+                <Info size={14} />
+              </button>
+            </div>
+            {kit.allocatedTier && kit.allocatedTier !== kit.requestedTier && (
+              <div className="text-xs text-theme-text-faint mt-0.5">req: {kit.requestedTier}</div>
+            )}
+          </>
         )}
       </td>
 
       {/* Status */}
       <td className="px-3 py-3">
-        <div className="relative">
-          <select
-            value={kit.status}
-            onChange={(e) => onStatusChange(kit.id, e.target.value)}
-            className={`appearance-none rounded-full px-3 py-1 pr-7 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-red-500 cursor-pointer ${STATUS_COLORS[kit.status] || 'bg-gray-100 text-gray-700'}`}
-          >
-            {STATUS_OPTIONS.map((s) => (
-              <option key={s} value={s} className="bg-white text-gray-900 capitalize">{s}</option>
-            ))}
-          </select>
-        </div>
+        {isPlaceholder ? (
+          <span className={`inline-block rounded-full px-3 py-1 text-xs font-medium ${STATUS_COLORS.no_request}`}>
+            {t('shipping.noKitRequest')}
+          </span>
+        ) : (
+          <div className="relative">
+            <select
+              value={kit.status}
+              onChange={(e) => onStatusChange(kit.id, e.target.value)}
+              className={`appearance-none rounded-full px-3 py-1 pr-7 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-red-500 cursor-pointer ${STATUS_COLORS[kit.status] || 'bg-gray-100 text-gray-700'}`}
+            >
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s} className="bg-white text-gray-900 capitalize">{s}</option>
+              ))}
+            </select>
+          </div>
+        )}
       </td>
 
       {/* Tracking */}
       <td className="px-3 py-3 hidden xl:table-cell">
-        {showTracking ? (
+        {isPlaceholder ? (
+          <span className="text-xs text-theme-text-muted">--</span>
+        ) : showTracking ? (
           <div className="space-y-1">
             <input
               type="text"
@@ -200,18 +236,20 @@ export function KitRow({
 
       {/* Actions */}
       <td className="px-3 py-3">
-        <button
-          onClick={() => onViewDetail(kit)}
-          className="p-1.5 rounded-lg hover:bg-theme-surface transition-colors text-theme-text-muted hover:text-theme-text"
-          title="View details"
-        >
-          <Eye size={16} />
-        </button>
+        {!isPlaceholder && (
+          <button
+            onClick={() => onViewDetail(kit)}
+            className="p-1.5 rounded-lg hover:bg-theme-surface transition-colors text-theme-text-muted hover:text-theme-text"
+            title="View details"
+          >
+            <Eye size={16} />
+          </button>
+        )}
       </td>
 
       {showContents && (
         <KitContentsModal
-          tier={kit.allocatedTier || kit.requestedTier}
+          tier={kit.allocatedTier || (kit.requestedTier as KitTier | undefined) || undefined}
           onClose={() => setShowContents(false)}
         />
       )}

--- a/frontend/src/components/shipping/KitStats.tsx
+++ b/frontend/src/components/shipping/KitStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Package, CheckCircle, Truck, MapPin, XCircle, BarChart3 } from 'lucide-react';
+import { Package, CheckCircle, Truck, MapPin, XCircle, AlertCircle, BarChart3 } from 'lucide-react';
 import type { ShippingKitStats } from '../../types';
 
 interface KitStatsProps {
@@ -14,19 +14,30 @@ const STAT_CARDS = [
   { key: 'shipped', label: 'Shipped', icon: Truck, color: 'text-purple-500', bg: 'bg-purple-500/10' },
   { key: 'delivered', label: 'Delivered', icon: MapPin, color: 'text-green-500', bg: 'bg-green-500/10' },
   { key: 'declined', label: 'Declined', icon: XCircle, color: 'text-red-500', bg: 'bg-red-500/10' },
+  { key: 'noRequest', label: 'No request', icon: AlertCircle, color: 'text-orange-500', bg: 'bg-orange-500/10' },
   { key: 'total', label: 'Total', icon: BarChart3, color: 'text-theme-text-secondary', bg: 'bg-theme-surface' },
 ] as const;
 
+// Map STAT_CARDS `key` to the corresponding status filter value.
+// Most keys match the filter value 1:1; `noRequest` maps to the pseudo-status
+// `no_request`, and `total` clears the filter (null).
+function keyToStatus(key: typeof STAT_CARDS[number]['key']): string | null {
+  if (key === 'total') return null;
+  if (key === 'noRequest') return 'no_request';
+  return key;
+}
+
 export function KitStats({ stats, onStatusFilter, activeStatus }: KitStatsProps) {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3">
       {STAT_CARDS.map(({ key, label, icon: Icon, color, bg }) => {
-        const count = stats[key as keyof ShippingKitStats] as number;
-        const isActive = activeStatus === (key === 'total' ? null : key);
+        const count = (stats[key as keyof ShippingKitStats] as number | undefined) ?? 0;
+        const statusValue = keyToStatus(key);
+        const isActive = activeStatus === statusValue;
         return (
           <button
             key={key}
-            onClick={() => onStatusFilter?.(key === 'total' ? null : key)}
+            onClick={() => onStatusFilter?.(statusValue)}
             className={`rounded-xl p-4 text-left transition-all ${bg} ${
               isActive ? 'ring-2 ring-red-500 shadow-lg' : 'hover:shadow-md'
             }`}

--- a/frontend/src/components/shipping/KitTable.tsx
+++ b/frontend/src/components/shipping/KitTable.tsx
@@ -31,7 +31,9 @@ export function KitTable({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState('');
 
-  const allSelected = kits.length > 0 && selectedIds.size === kits.length;
+  // Placeholder rows have no kit to update, so bulk actions skip them.
+  const realKits = useMemo(() => kits.filter((k) => !k.isPlaceholder), [kits]);
+  const allSelected = realKits.length > 0 && selectedIds.size === realKits.length;
 
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) => {
@@ -49,7 +51,7 @@ export function KitTable({
     if (allSelected) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(kits.map((k) => k.id)));
+      setSelectedIds(new Set(realKits.map((k) => k.id)));
     }
   };
 
@@ -140,6 +142,7 @@ export function KitTable({
                 />
               </th>
               <SortHeader field="eventDate">Event</SortHeader>
+              <SortHeader field="rsvpCount">RSVPs</SortHeader>
               {showRegion && <SortHeader field="region">Region</SortHeader>}
               <th className="px-3 py-3 text-left text-xs font-medium text-theme-text-muted hidden md:table-cell">Host</th>
               <th className="px-3 py-3 text-left text-xs font-medium text-theme-text-muted">Recipient</th>
@@ -153,7 +156,7 @@ export function KitTable({
           <tbody>
             {kits.length === 0 ? (
               <tr>
-                <td colSpan={showRegion ? 10 : 9} className="px-6 py-12 text-center text-theme-text-muted text-sm">
+                <td colSpan={showRegion ? 11 : 10} className="px-6 py-12 text-center text-theme-text-muted text-sm">
                   No kit requests found matching your filters.
                 </td>
               </tr>

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "Global Pizza Party · Versand-Dashboard",
     "signedInAdmin": "Angemeldet als Admin ({{email}})",
     "signedInAs": "Angemeldet als {{name}}",
-    "kitRequests": "Kit-Anfragen ({{count}})"
+    "kitRequests": "Kit-Anfragen ({{count}})",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -211,6 +211,10 @@
     "subtitle": "Global Pizza Party · Shipping Dashboard",
     "signedInAdmin": "Signed in as Admin ({{email}})",
     "signedInAs": "Signed in as {{name}}",
-    "kitRequests": "Kit Requests ({{count}})"
+    "kitRequests": "Kit Requests ({{count}})",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   }
 }

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "Global Pizza Party · Panel de Envíos",
     "signedInAdmin": "Conectado como Admin ({{email}})",
     "signedInAs": "Conectado como {{name}}",
-    "kitRequests": "Solicitudes de Kit ({{count}})"
+    "kitRequests": "Solicitudes de Kit ({{count}})",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "Global Pizza Party · Tableau de bord expédition",
     "signedInAdmin": "Connecté en tant qu'administrateur ({{email}})",
     "signedInAs": "Connecté en tant que {{name}}",
-    "kitRequests": "Demandes de kit ({{count}})"
+    "kitRequests": "Demandes de kit ({{count}})",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/i18n/locales/ja/admin.json
+++ b/frontend/src/i18n/locales/ja/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "グローバルピザパーティー · 配送ダッシュボード",
     "signedInAdmin": "管理者としてログイン中（{{email}}）",
     "signedInAs": "{{name}}としてログイン中",
-    "kitRequests": "キットリクエスト（{{count}}）"
+    "kitRequests": "キットリクエスト（{{count}}）",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/i18n/locales/ko/admin.json
+++ b/frontend/src/i18n/locales/ko/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "Global Pizza Party · 배송 대시보드",
     "signedInAdmin": "관리자로 로그인됨 ({{email}})",
     "signedInAs": "{{name}}(으)로 로그인됨",
-    "kitRequests": "키트 요청 ({{count}})"
+    "kitRequests": "키트 요청 ({{count}})",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/i18n/locales/pt/admin.json
+++ b/frontend/src/i18n/locales/pt/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "Global Pizza Party · Painel de Envios",
     "signedInAdmin": "Conectado como Admin ({{email}})",
     "signedInAs": "Conectado como {{name}}",
-    "kitRequests": "Solicitações de Kit ({{count}})"
+    "kitRequests": "Solicitações de Kit ({{count}})",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/i18n/locales/zh/admin.json
+++ b/frontend/src/i18n/locales/zh/admin.json
@@ -167,7 +167,11 @@
     "subtitle": "Global Pizza Party · 物流仪表盘",
     "signedInAdmin": "以管理员身份登录（{{email}}）",
     "signedInAs": "以 {{name}} 身份登录",
-    "kitRequests": "套装申请（{{count}}）"
+    "kitRequests": "套装申请（{{count}}）",
+    "rsvpsColumn": "RSVPs",
+    "noKitRequest": "No kit request",
+    "noRequest": "No request",
+    "rsvpsTooltip": "Non-declined guests for this event"
   },
   "fakeDetection": {
     "actions": {

--- a/frontend/src/pages/ShippingDashboard.tsx
+++ b/frontend/src/pages/ShippingDashboard.tsx
@@ -156,9 +156,10 @@ export function ShippingDashboard() {
     });
   }, [meData, loadData]);
 
-  // Unique countries from kit data
+  // Unique countries from kit data. Filter out empty strings so placeholder
+  // rows (which have no shipping country) don't add a blank entry.
   const countries = useMemo(() => {
-    const set = new Set(kits.map((k) => k.country));
+    const set = new Set(kits.map((k) => k.country).filter(Boolean));
     return Array.from(set).sort();
   }, [kits]);
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1163,7 +1163,11 @@ export interface ShippingKit {
   eventAddress: string | null;
   eventVenue: string | null;
   underbossStatus: UnderbossStatus;
-  requestedTier: KitTier;
+  /**
+   * Placeholder rows (events with no kit request) send an empty string here;
+   * widened from `KitTier` to allow that.
+   */
+  requestedTier: KitTier | '';
   allocatedTier: KitTier | null;
   recipientName: string;
   addressLine1: string;
@@ -1173,7 +1177,11 @@ export interface ShippingKit {
   postalCode: string;
   country: string;
   phone: string | null;
-  status: KitStatus;
+  /**
+   * Real kits use the `KitStatus` enum. Placeholder rows (events with no
+   * `party_kits` row) send the sentinel `'no_request'`.
+   */
+  status: KitStatus | 'no_request';
   trackingNumber: string | null;
   trackingUrl: string | null;
   notes: string | null;
@@ -1182,6 +1190,10 @@ export interface ShippingKit {
   approvedAt: string | null;
   shippedAt: string | null;
   deliveredAt: string | null;
+  /** Non-declined, non-invited guest count for this kit's event. */
+  rsvpCount: number;
+  /** True when this row is a placeholder for an event with no kit request. */
+  isPlaceholder?: boolean;
 }
 
 export interface ShippingKitStats {
@@ -1191,6 +1203,8 @@ export interface ShippingKitStats {
   shipped: number;
   delivered: number;
   declined: number;
+  /** GPP-approved events in scope that have not submitted a kit request. */
+  noRequest: number;
   byCountry: Record<string, number>;
   byTier: Record<string, number>;
 }

--- a/plans/dough-91206-shipping-rsvp-count.md
+++ b/plans/dough-91206-shipping-rsvp-count.md
@@ -1,0 +1,288 @@
+# dough-91206 — Shipping dashboard: per-kit RSVP count + inline no-kit events
+
+**Priority**: P2
+**Branch**: dough-91206-shipping-rsvp-count
+
+## Summary
+
+Two related additions to `/shipping`:
+
+1. New **sortable** `RSVPs` column in `KitTable` showing the count of non-declined guests for each kit's event.
+2. Inline placeholder rows in `KitTable` for GPP-approved events that have NOT submitted a kit request, scoped to the coordinator's regions.
+3. New **"No request" stat card** on the dashboard counting placeholder events in the current region scope.
+4. New **"No request" pseudo-status** in the status filter dropdown that swaps the table to placeholder-only.
+
+No DB schema changes. Pure read-side feature: extends `GET /api/shipping/kits`, `GET /api/shipping/stats`, and the CSV export with new fields, then updates the `ShippingKit` type, `KitStats`, `KitFilters`, `KitTable`, and `KitRow` on the frontend.
+
+## Decisions locked in (from Snax 2026-05-18)
+
+- **Non-declined RSVP filter**: `Guest.status NOT IN ('DECLINED', 'INVITED')` — counts `CONFIRMED + PENDING + WAITLISTED`.
+- **Add "No request" stat card** to the dashboard (open question #2 → YES).
+- **Add `no_request` pseudo-status** to the status filter dropdown (open question #3 → YES).
+- **RSVPs column is sortable** in phase 1.
+- Placeholder row ID convention: `placeholder:<partyId>` (open question #4 → YES).
+- Placeholder sort behavior: when sorting by RSVPs, placeholders sort by their RSVP count alongside real kits. For other columns (`requestedAt`, `status`), placeholders sort to the bottom (acceptable, open question #5 → YES).
+
+## Behavior
+
+### Per-kit RSVP count
+- New `rsvpCount: number` field on each kit returned by `GET /api/shipping/kits`.
+- Column rendered between **Event** and **Region** (visually compact: e.g. `12` in muted text, optionally with a small users icon).
+- **Sortable** — wrap in `SortHeader` with `field="rsvpCount"`. Sort happens client-side in `sortedKits` memo (no backend orderBy change needed).
+
+### Inline "no kit request" placeholder rows
+- Same endpoint (`GET /api/shipping/kits`) returns BOTH real kits and placeholder rows for eligible parties with no `party_kits` row.
+- Eligibility for a placeholder row:
+  - `parties.region IS NOT NULL`
+  - `parties.underbossStatus = 'approved'`
+  - No related `PartyKit` row (Prisma: `partyKit: { is: null }` — `PartyKit.partyId` is `@unique`, so the relation field on `Party` is the singular scalar `partyKit`, not `kits`. **This contradicts the spec hint `kits: { none: {} }` — use the actual relation name from the schema.**)
+- Placeholder rows are region-scoped exactly like real kits (admin sees all; coordinator sees only their `regions[]`).
+- In the Status column we render a distinct "No kit request" badge (gray/orange) instead of a status `<select>`.
+- Tier dropdown, Tracking inputs, the row checkbox, and the bulk-action select are SUPPRESSED for placeholder rows (nothing to update server-side).
+- Recipient / address / country fields are empty (rendered as "—").
+- `rsvpCount` is still populated for placeholder rows (the event still has guests).
+- Search filter (`search` query param) applies to placeholders too: party name and host name/email. Tier and Country filters never match placeholders (they have no kit tier / shipping country). Status filter behavior:
+  - `status=""` (empty / "All"): placeholders included alongside real kits.
+  - `status="no_request"` (new): table shows placeholders ONLY (no real kits).
+  - `status="pending"` / `approved` / `shipped` / `delivered` / `declined`: placeholders excluded.
+
+## Open questions
+
+All resolved — see "Decisions locked in" above.
+
+## Backend changes
+
+### Files
+- `backend/src/routes/shipping.routes.ts` — extend `GET /kits` (~line 374), `GET /kits/export` (~line 153), and `GET /stats` (~line 111).
+- No Prisma schema change. No migration. No GRANT. (Confirm: feature is read-only on existing tables — `Party`, `Guest`, `PartyKit`.)
+
+### `GET /api/shipping/kits` — merged query pseudocode
+
+```ts
+// Treat status=='no_request' as a special placeholders-only mode.
+const placeholdersOnly = status === 'no_request';
+const realKitsStatusFilter = placeholdersOnly ? null : status;
+
+// 1. Real kits (existing query, unchanged) — now include guest count.
+//    Skip entirely when placeholdersOnly=true.
+let kits: any[] = [];
+if (!placeholdersOnly) {
+  const realWhere = { ...where };
+  if (realKitsStatusFilter && typeof realKitsStatusFilter === 'string') {
+    realWhere.status = realKitsStatusFilter;
+  }
+  kits = await prisma.partyKit.findMany({
+    where: realWhere,
+    include: {
+      party: { select: { /* existing fields */
+        _count: {
+          select: {
+            guests: {
+              where: { status: { notIn: ['DECLINED', 'INVITED'] } }
+            }
+          }
+        }
+      } },
+    },
+    orderBy,
+  });
+}
+
+// 2. Placeholder parties — include when status is empty OR status === 'no_request'.
+//    Tier/Country filters never match placeholders, so skip when those are set.
+const shouldIncludePlaceholders =
+  (placeholdersOnly || !status) && !tier && !country;
+
+let placeholderParties: any[] = [];
+if (shouldIncludePlaceholders) {
+  const partyRegionFilter = regions.includes('__admin__')
+    ? {}
+    : { region: { in: regions } };
+  const explicitRegion = region && typeof region === 'string' ? { region } : {};
+
+  placeholderParties = await prisma.party.findMany({
+    where: {
+      ...partyRegionFilter,
+      ...explicitRegion,
+      region: { not: null },
+      underbossStatus: 'approved',
+      partyKit: { is: null }, // verify relation name vs schema.prisma
+    },
+    select: {
+      id: true, name: true, region: true, date: true,
+      address: true, venueName: true, underbossStatus: true,
+      user: { select: { name: true, email: true } },
+      _count: {
+        select: {
+          guests: {
+            where: { status: { notIn: ['DECLINED', 'INVITED'] } }
+          }
+        }
+      }
+    },
+    orderBy: { date: 'desc' },
+  });
+}
+
+// 3. Apply search filter to BOTH lists in memory.
+//    For placeholders, search matches party.name, user.name, user.email.
+
+// 4. Format real kits, appending `rsvpCount: kit.party._count.guests` and `isPlaceholder: false`.
+
+// 5. Format placeholder rows:
+const placeholders = filteredPlaceholders.map(p => ({
+  id: `placeholder:${p.id}`,
+  partyId: p.id,
+  partyName: p.name,
+  eventDate: p.date?.toISOString() || null,
+  region: p.region,
+  hostName: p.user?.name || null,
+  hostEmail: p.user?.email || null,
+  eventAddress: p.address || null,
+  eventVenue: p.venueName || null,
+  underbossStatus: p.underbossStatus || 'pending',
+  requestedTier: '',
+  allocatedTier: null,
+  recipientName: '',
+  addressLine1: '',
+  addressLine2: null,
+  city: '',
+  state: null,
+  postalCode: '',
+  country: '',
+  phone: null,
+  status: 'no_request',     // sentinel — frontend treats as placeholder badge
+  trackingNumber: null,
+  trackingUrl: null,
+  notes: null,
+  adminNotes: null,
+  requestedAt: p.date?.toISOString() || new Date(0).toISOString(),
+  approvedAt: null,
+  shippedAt: null,
+  deliveredAt: null,
+  rsvpCount: p._count.guests,
+  isPlaceholder: true,
+}));
+
+res.json({ kits: [...formattedKits, ...placeholders] });
+```
+
+### CSV export updates (`GET /kits/export`)
+- Add header column `RSVPs` immediately after `Event Name`.
+- Add `RSVPs` value (the integer) per row.
+- Include placeholder rows in the export when `status` / `tier` / `country` filters are empty. For placeholders, leave shipping fields blank but populate `Event Name`, `Region`, `Host Name`, `Host Email`, `Event Venue`, `Event Address`, `Event Approved=Approved`, `RSVPs=N`, `Status=No request`.
+
+### Stats endpoint (`GET /api/shipping/stats`)
+- **Do NOT add an aggregate RSVP stat card** (user explicitly chose per-row only).
+- **DO add `noRequest: number`** to the stats response. Compute it with a single Prisma count:
+  ```ts
+  const partyRegionFilter = req.shippingRegions!.includes('__admin__')
+    ? {}
+    : { region: { in: req.shippingRegions! } };
+  const noRequest = await prisma.party.count({
+    where: {
+      ...partyRegionFilter,
+      region: { not: null },
+      underbossStatus: 'approved',
+      partyKit: { is: null }, // verify relation name in schema.prisma
+    },
+  });
+  stats.noRequest = noRequest;
+  ```
+- Update the `ShippingKitStats` TS type accordingly.
+
+### Status validation
+- Add `'no_request'` to `VALID_STATUSES` ONLY for query filtering — DO NOT accept it on PATCH/bulk-update. Easiest: keep `VALID_STATUSES` as-is for write paths and define a separate `VALID_LIST_STATUSES = [...VALID_STATUSES, 'no_request']` for the list endpoint, OR just special-case `status === 'no_request'` early in the list handler. Recommend the latter — simpler.
+
+## Frontend changes
+
+### `frontend/src/types.ts`
+- Add to `ShippingKit`:
+  ```ts
+  rsvpCount: number;
+  isPlaceholder?: boolean;
+  ```
+- Keep `recipientName`, `addressLine1`, `city`, `postalCode`, `country` as `string` (already are). Placeholder rows send empty strings — no type change needed. `requestedTier` is currently `KitTier` (`'basic' | 'large' | 'deluxe'`); placeholders need to send `''`. Two options:
+  - **(A) [recommended]** Widen `requestedTier` to `KitTier | ''` (or `KitTier | null`) and let `KitRow` short-circuit on `isPlaceholder` before reading it. Lowest churn.
+  - (B) Introduce `ShippingKitOrPlaceholder = ShippingKit | ShippingKitPlaceholder` discriminated union. Cleaner type but ripples through every consumer (`KitTable`, `KitRow`, `KitDetailModal`, the optimistic update lambdas in `ShippingDashboard.tsx`).
+- Recommend (A): widen `requestedTier`/`allocatedTier`/`status` to allow the empty/no_request sentinel and gate every consumer on `isPlaceholder`.
+
+### `frontend/src/components/shipping/KitTable.tsx`
+- Add new `<SortHeader field="rsvpCount">RSVPs</SortHeader>` between Event and (showRegion?) Region — sortable.
+- Bump the empty-state `colSpan` (currently `showRegion ? 10 : 9`) by +1.
+- Toggle-all checkbox should select real kits only (filter out `isPlaceholder` before `new Set(kits.map(k => k.id))`).
+- `selectedIds.size` display should reflect real kits selected.
+
+### `frontend/src/components/shipping/KitRow.tsx`
+- New `<td>` rendering `kit.rsvpCount` (e.g. `<span className="text-sm text-theme-text">{kit.rsvpCount}</span>`).
+- If `kit.isPlaceholder`:
+  - Render the checkbox cell as empty (`<td />`).
+  - Render Recipient cell as `—`.
+  - Render Tier cell as `—` (skip the `<select>` and Info button).
+  - Render Status cell as a badge (e.g. `bg-gray-500/20 text-gray-700` or orange): `t('shipping.noKitRequest')`.
+  - Render Tracking cell as `—` and Requested cell as `—`.
+  - Eye/View button can still link to the event — or hide it. Recommend hide for phase 1.
+- For real kits: render the existing controls plus the new RSVPs cell.
+
+### `frontend/src/pages/ShippingDashboard.tsx`
+- `handleStatusChange`, `handleTierChange`, `handleTrackingChange`, `handleDetailUpdate`, `handleBulkUpdate` — all should early-return / be unreachable for placeholder rows (because `KitRow` won't render the controls). No structural changes required.
+- `sortedKits` memo: placeholders sort to the bottom for `requestedAt` / `status`. For `rsvpCount` they sort naturally by their count. Acceptable.
+- `countries` memo: filter out empty strings so placeholders don't add a blank country entry to the country filter dropdown:
+  ```ts
+  const countries = useMemo(() => {
+    const set = new Set(kits.map(k => k.country).filter(Boolean));
+    return Array.from(set).sort();
+  }, [kits]);
+  ```
+
+### `frontend/src/components/shipping/KitStats.tsx`
+- Add a new `STAT_CARDS` entry between `declined` and `total`:
+  ```ts
+  { key: 'noRequest', label: 'No request', icon: AlertCircle, color: 'text-orange-500', bg: 'bg-orange-500/10' }
+  ```
+- Bump the grid from `lg:grid-cols-6` to `lg:grid-cols-7` (or wrap to two rows on smaller screens — confirm what looks best).
+- When this card is clicked, call `onStatusFilter('no_request')` (the existing handler already swaps to `setStatusFilter`).
+- `activeStatus === 'no_request'` should highlight the card.
+
+### `frontend/src/components/shipping/KitFilters.tsx`
+- Add a `<option value="no_request">No request</option>` to the status dropdown (verify component exists — search for the existing pending/approved/shipped options).
+
+### i18n keys (add to all 7 locale files: `en/admin.json`, plus `de`, `es`, `fr`, `ja`, `pt`, `zh`)
+Add inside the `"shipping"` block:
+```json
+"rsvpsColumn": "RSVPs",
+"noKitRequest": "No kit request",
+"noRequest": "No request",
+"rsvpsTooltip": "Non-declined guests for this event"
+```
+Provide English copy in `en/admin.json`. For other locales, COPY the English strings as a placeholder so the keys exist and the UI doesn't show `shipping.rsvpsColumn` — call this out in the PR description so Snax can translate later.
+
+## Verification steps
+
+### Local
+1. Backend: from `backend/`, run `npm test` (or whichever exists) and ensure `shipping.routes.ts` still compiles (`tsc --noEmit`).
+2. Manually hit `GET /api/shipping/kits` as an admin (use auth cookie/JWT): confirm each kit has `rsvpCount: number` and `isPlaceholder: false`, and placeholder rows appear with `isPlaceholder: true` and synthesized `id`.
+3. Hit `GET /api/shipping/kits?status=pending`: placeholders should be excluded.
+4. Hit `GET /api/shipping/kits?region=usa` as admin and as a single-region coordinator scoped to `usa`: placeholders should appear only for US parties.
+5. CSV export: hit `GET /api/shipping/kits/export` and confirm header has `RSVPs` and placeholder rows are present.
+6. Frontend: `npm run dev`, log in as shipping admin, confirm new column renders, placeholders render with the gray "No kit request" badge, search by event name surfaces both real and placeholder, country filter hides placeholders.
+
+### Vercel preview (after backend deploys to prod)
+1. Visit the frontend preview URL for the PR branch — RSVPs column and placeholders should populate (backend is shared from prod).
+2. Test on the admin account AND a single-region coordinator to confirm region scoping.
+
+## Deploy order (CRITICAL)
+
+Per project memory: **the backend only deploys from master**, and frontend Vercel previews share the production backend.
+
+1. Open backend PR with the `shipping.routes.ts` changes — get review + merge to master.
+2. After master merge, run `cd backend && vercel --prod --scope pizza-dao` to push the backend.
+3. Only AFTER step 2, frontend Vercel preview URLs for this branch will return the new `rsvpCount` / placeholder fields. Before that, the preview will silently fall back to old data (and `rsvpCount` will be `undefined` — render defensively in `KitRow`: `{kit.rsvpCount ?? '—'}`).
+4. Frontend PR can be opened in parallel but mark it "DO NOT MERGE until backend deployed".
+
+## Out of scope / explicitly not doing
+
+- No database migration; no new columns, no new tables, no GRANT.
+- No bulk-action support targeting placeholder rows (they have no kit to update).
+- No edit/create-kit-from-placeholder shortcut (could be a follow-up — e.g. an "Invite host to request a kit" email button).
+- No aggregate RSVP stat card (per-row only).


### PR DESCRIPTION
## Summary

Two related additions to `/shipping`:

1. **Per-kit RSVP count column** — new sortable `RSVPs` column in `KitTable` showing the count of non-declined, non-invited guests (i.e. `CONFIRMED + PENDING + WAITLISTED`) for each kit's event.
2. **Inline no-kit-request placeholder rows** — events that are GPP-approved but have not yet submitted a kit request now appear directly in the kit table with a muted `No kit request` badge. Status filter has a new `No request` chip; KitStats has a new orange `No request` card.

No DB migration. Pure read-side feature on `parties`, `guests`, and `party_kits`.

## Vercel preview

`https://rsvpizza-git-dough-91206-shipping-rsvp-count-pizza-dao.vercel.app/shipping`

## CRITICAL deploy order

Per project memory, **the backend only deploys from `master`**, and Vercel frontend previews share the production backend. So:

1. Merge this PR to `master`.
2. Deploy the backend: `cd backend && vercel --prod --scope pizza-dao` (from `rsvpizza-master-deploy` worktree).
3. **Only after step 2** will the frontend preview return the new `rsvpCount`, placeholder rows, and `noRequest` stat. Until then, RSVPs will render as `--` and the No request card will show 0.

Do **NOT** merge this PR until the backend deploy is queued.

## Notes

- Relation `Party.partyKit` (singular — `PartyKit.partyId` is `@unique`) confirmed in `backend/prisma/schema.prisma:203`. Used `partyKit: { is: null }` for placeholder eligibility.
- `'no_request'` is treated as a sentinel/pseudo-status on the **list** endpoint only. It is NOT added to `VALID_STATUSES` for PATCH/bulk-update — those paths still reject it.
- i18n: English copy added to all 8 locales (`en/de/es/fr/ja/ko/pt/zh`). Non-English locales currently use the English strings as placeholders so the keys exist; needs translation later.
- Placeholder rows hide checkbox, tier `<select>`, status `<select>`, tracking input, and view-detail button. Bulk-action "select all" only selects real kits.

## Test plan

- [x] Backend `tsc --noEmit` — passes (pre-existing sharp + auth.test errors unrelated to this PR)
- [x] Frontend `tsc --noEmit` — passes clean
- [ ] As admin: RSVPs column populates, sort by RSVPs works asc/desc
- [ ] As admin: `No request` stat card shows a count; clicking it filters to placeholder-only view
- [ ] As single-region coordinator: placeholders are region-scoped correctly
- [ ] As coordinator: search by event name / host name surfaces both real kits and placeholder rows
- [ ] Country filter dropdown does NOT show a blank entry (placeholders filtered out)
- [ ] CSV export: contains `RSVPs` column and placeholder rows (`Status=No request`, shipping fields blank)
- [ ] `status=pending` (or any real status): placeholders excluded from list + CSV
- [ ] `tier=` or `country=` filters: placeholders excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)