### PR TITLE
tomato-37465: host telegram icons on /map InfoWindow for mods

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -648,23 +648,40 @@ const gppEventSelect = {
   underbossStatus: true,
   rsvpClosedAt: true,
   createdAt: true,
+  coHosts: true,
   _count: {
     select: { guests: true },
   },
   user: {
-    select: { name: true },
+    select: { name: true, telegram: true },
   },
 } as const;
 
+async function resolveCallerIsModerator(req: Request): Promise<boolean> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) return false;
+  const token = authHeader.slice(7);
+  const secret = process.env.JWT_SECRET;
+  if (!secret) return false;
+  try {
+    const decoded = jwt.verify(token, secret) as { userId: string; email: string };
+    const email = decoded.email;
+    if (!email) return false;
+    return (await isAdmin(email)) || (await isUnderboss(email));
+  } catch {
+    return false;
+  }
+}
+
 // Format a Party record into the public GPP API response
-function formatGppEvent(event: any) {
+function formatGppEvent(event: any, callerIsModerator = false) {
   const baseUrl = 'https://rsv.pizza';
   const url = event.customUrl
     ? `${baseUrl}/${event.customUrl}`
     : `${baseUrl}/${event.inviteCode}`;
   const city = event.name?.replace(/^Global Pizza Party\s*/i, '').trim() || event.name;
 
-  return {
+  const base = {
     id: event.id,
     name: event.name,
     city,
@@ -691,6 +708,20 @@ function formatGppEvent(event: any) {
     approved: event.underbossStatus === 'approved',
     community: event.underbossStatus === 'listed',
     rsvpOpen: !event.rsvpClosedAt,
+  };
+
+  if (!callerIsModerator) return base;
+
+  const cohostArr: any[] = Array.isArray(event.coHosts) ? event.coHosts : [];
+  const firstCohostTelegram = cohostArr
+    .map((c) => (c && typeof c.telegram === 'string' ? c.telegram.trim() : ''))
+    .find((t) => t.length > 0) || null;
+  const hostTelegram = event.user?.telegram?.trim() || null;
+
+  return {
+    ...base,
+    hostTelegram: hostTelegram || null,
+    coHostTelegrams: firstCohostTelegram ? [firstCohostTelegram] : [],
   };
 }
 
@@ -728,8 +759,12 @@ router.get('/events/by-city/:citySlug', async (req: Request, res: Response, next
       return res.status(404).json({ error: 'GPP event not found for this city' });
     }
 
-    res.set('Cache-Control', 'public, max-age=300');
-    res.json({ event: formatGppEvent(event) });
+    const callerIsModerator = await resolveCallerIsModerator(req);
+    res.set(
+      'Cache-Control',
+      callerIsModerator ? 'private, no-store' : 'public, max-age=300'
+    );
+    res.json({ event: formatGppEvent(event, callerIsModerator) });
   } catch (error) {
     next(error);
   }
@@ -746,24 +781,10 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
     // underboss/admin. Unauthenticated callers silently fall back to the
     // filtered (non-rejected, non-hidden) view — no 401, preserving backwards compat.
     const requestedAllStatuses = statuses === 'all' || req.query.includeAll === '1';
+    const callerIsModerator = await resolveCallerIsModerator(req);
     let includeAllStatuses = false;
-    if (requestedAllStatuses) {
-      const authHeader = req.headers.authorization;
-      if (authHeader && authHeader.startsWith('Bearer ')) {
-        const token = authHeader.slice(7);
-        const secret = process.env.JWT_SECRET;
-        if (secret) {
-          try {
-            const decoded = jwt.verify(token, secret) as { userId: string; email: string };
-            const email = decoded.email;
-            if (email && (await isAdmin(email) || await isUnderboss(email))) {
-              includeAllStatuses = true;
-            }
-          } catch {
-            // Bad/expired token — silently fall back to the filtered view
-          }
-        }
-      }
+    if (requestedAllStatuses && callerIsModerator) {
+      includeAllStatuses = true;
     }
 
     const where: any = { eventType: 'gpp' };
@@ -798,9 +819,12 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
       prisma.party.count({ where }),
     ]);
 
-    res.set('Cache-Control', 'public, max-age=300');
+    res.set(
+      'Cache-Control',
+      callerIsModerator ? 'private, no-store' : 'public, max-age=300'
+    );
     res.json({
-      events: events.map(formatGppEvent),
+      events: events.map((e) => formatGppEvent(e, callerIsModerator)),
       total,
       limit: parsedLimit,
       offset: parsedOffset,

--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { MarkerClusterer } from '@googlemaps/markerclusterer';
 import { GPPEventMapItem, updateUnderbossStatus } from '../lib/api';
 
+// Lucide "send" icon SVG, inlined for use inside the InfoWindow HTML string.
+const SEND_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>`;
+
 interface GPPEventsMapProps {
   events: GPPEventMapItem[];
   cityChats?: Map<string, string>;
@@ -187,6 +190,31 @@ export default function GPPEventsMap({
           ? `<a href="${telegramUrl}" target="_blank" rel="noopener noreferrer" style="color:#29B6F6;font-size:12px;text-decoration:none;font-weight:500">Telegram &rarr;</a>`
           : '';
 
+        const sanitizeHandle = (raw: string | null | undefined): string | null => {
+          if (!raw) return null;
+          const stripped = raw.trim().replace(/^@/, '');
+          if (!/^[A-Za-z0-9_]{3,40}$/.test(stripped)) return null;
+          return stripped;
+        };
+
+        const hostTgHandles: string[] = [];
+        if (canModerate) {
+          const primary = sanitizeHandle(event.hostTelegram);
+          if (primary) hostTgHandles.push(primary);
+          for (const raw of event.coHostTelegrams || []) {
+            if (hostTgHandles.length >= 2) break;
+            const h = sanitizeHandle(raw);
+            if (h && !hostTgHandles.includes(h)) hostTgHandles.push(h);
+          }
+        }
+
+        const hostTgIconsHtml = hostTgHandles
+          .map(
+            (h) =>
+              `<a href="https://t.me/${h}" target="_blank" rel="noopener noreferrer" title="DM @${h} on Telegram" style="color:#29B6F6;display:inline-flex;align-items:center;text-decoration:none">${SEND_ICON_SVG}</a>`
+          )
+          .join('');
+
         let actionsHtml = '';
         if (canModerate) {
           // Status pill — shown for every moderator-visible event so the
@@ -198,18 +226,21 @@ export default function GPPEventsMap({
           if (statusKey === 'approved') {
             actionsHtml = `
               ${statusPillHtml}
+              ${hostTgIconsHtml}
               ${rsvpPillHtml}
               <button data-action="reject" data-event-id="${event.id}" style="background:none;border:none;color:#dc2626;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark rejected</button>
             `;
           } else if (statusKey === 'rejected') {
             actionsHtml = `
               ${statusPillHtml}
+              ${hostTgIconsHtml}
               ${rsvpPillHtml}
               <button data-action="approve" data-event-id="${event.id}" style="background:none;border:none;color:#16a34a;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark approved</button>
             `;
           } else {
             actionsHtml = `
               ${statusPillHtml}
+              ${hostTgIconsHtml}
               ${rsvpPillHtml}
               <button data-action="approve" data-event-id="${event.id}" style="background:#16a34a;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Approve</button>
               <button data-action="reject" data-event-id="${event.id}" style="background:#dc2626;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Reject</button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3373,6 +3373,8 @@ export interface GPPEventMapItem {
   underbossStatus?: string | null;
   eventTags?: string[];
   telegramGroup: string | null;
+  hostTelegram?: string | null;
+  coHostTelegrams?: string[];
 }
 
 interface GPPEventApiResponse {
@@ -3391,6 +3393,8 @@ interface GPPEventApiResponse {
   underbossStatus?: string | null;
   eventTags?: string[];
   telegramGroup: string | null;
+  hostTelegram?: string | null;
+  coHostTelegrams?: string[];
 }
 
 interface GPPEventsApiPayload {
@@ -3427,6 +3431,8 @@ export async function fetchGppEventsForMap(force?: boolean, curated?: boolean, i
     underbossStatus: e.underbossStatus,
     eventTags: e.eventTags ?? [],
     telegramGroup: e.telegramGroup ?? null,
+    hostTelegram: e.hostTelegram ?? null,
+    coHostTelegrams: e.coHostTelegrams ?? [],
   }));
   if (curated) {
     events = events.filter((e) => e.underbossStatus === 'approved' || e.underbossStatus === 'listed');


### PR DESCRIPTION
## Summary
- Backend `/api/gpp/events*` now returns `hostTelegram` + `coHostTelegrams` ONLY when caller is admin/underboss (JWT-gated). CDN cache flipped to `private, no-store` on the moderator branch to prevent edge leakage.
- `/map` InfoWindow renders up to 2 lucide-Send DM icons in the moderator action row (primary host + first cohost). Public view unchanged.

## Test plan
- [ ] Open `/map` logged out: no host-telegram icons appear in any InfoWindow.
- [ ] Open `/map` as admin/underboss: icons appear next to the status pill on events where the host or first cohost has a `telegram` set.
- [ ] Clicking an icon opens `https://t.me/<handle>` in a new tab.
- [ ] Network tab: anonymous `/api/gpp/events` response has NO `hostTelegram` field; moderator request (with bearer) DOES include it.
- [ ] Cache-Control: anonymous response = `public, max-age=300`; moderator response = `private, no-store`.

Generated with [Claude Code](https://claude.com/claude-code)