### PR TITLE
feat(arugula-52469): rename Sponsorship->Partnership Details, add community type

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -918,7 +918,7 @@ model Sponsor {
 
   // Fundraising
   amount          Decimal? @db.Decimal(10, 2) // Contribution amount
-  sponsorshipType String?  @map("sponsorship_type") // cash, in-kind, venue, pizza, drinks, other
+  sponsorshipType String?  @map("sponsorship_type") // cash, in-kind, venue, pizza, drinks, community, other
   productService  String?  @map("product_service") // For non-monetary contributions
 
   // Assets (for confirmed sponsors)

--- a/backend/src/routes/partner-intake.routes.ts
+++ b/backend/src/routes/partner-intake.routes.ts
@@ -217,7 +217,7 @@ router.post('/:token', async (req: AuthRequest, res: Response, next: NextFunctio
       updateData.telegram = body.telegram?.trim() || null;
     }
     if (body.sponsorshipType !== undefined) {
-      const validTypes = ['cash', 'in-kind', 'venue', 'pizza', 'drinks', 'other'];
+      const validTypes = ['cash', 'in-kind', 'venue', 'pizza', 'drinks', 'community', 'other'];
       if (body.sponsorshipType && !validTypes.includes(body.sponsorshipType)) {
         throw new AppError(`Invalid sponsorship type. Must be one of: ${validTypes.join(', ')}`, 400, 'VALIDATION_ERROR');
       }

--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -382,7 +382,7 @@ router.post('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Res
     }
 
     // Validate sponsorship type if provided
-    const validTypes = ['cash', 'in-kind', 'venue', 'pizza', 'drinks', 'other'];
+    const validTypes = ['cash', 'in-kind', 'venue', 'pizza', 'drinks', 'community', 'other'];
     if (sponsorshipType && !validTypes.includes(sponsorshipType)) {
       throw new AppError(`Invalid sponsorship type. Must be one of: ${validTypes.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
@@ -594,7 +594,7 @@ router.patch('/:partyId/sponsors/:sponsorId', requireAuth, async (req: AuthReque
     }
 
     // Validate sponsorship type if provided
-    const validTypes = ['cash', 'in-kind', 'venue', 'pizza', 'drinks', 'other'];
+    const validTypes = ['cash', 'in-kind', 'venue', 'pizza', 'drinks', 'community', 'other'];
     if (sponsorshipType && !validTypes.includes(sponsorshipType)) {
       throw new AppError(`Invalid sponsorship type. Must be one of: ${validTypes.join(', ')}`, 400, 'VALIDATION_ERROR');
     }

--- a/frontend/src/components/sponsors/PartnerForm.test.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.test.tsx
@@ -56,7 +56,7 @@ describe('PartnerForm mode="intake"', () => {
     // Section headings
     expect(screen.getByText('Company Info')).toBeInTheDocument();
     expect(screen.getByText('Contact Info')).toBeInTheDocument();
-    expect(screen.getByText('Sponsorship Details')).toBeInTheDocument();
+    expect(screen.getByText('Partnership Details')).toBeInTheDocument();
     expect(screen.getByText('Logo')).toBeInTheDocument();
     expect(screen.getByText('Message to Host')).toBeInTheDocument();
 

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -105,6 +105,7 @@ const TYPE_OPTIONS: { value: SponsorshipType; labelKey: string }[] = [
   { value: 'venue', labelKey: 'sponsors.venueType' },
   { value: 'pizza', labelKey: 'sponsors.pizzaType' },
   { value: 'drinks', labelKey: 'sponsors.drinksType' },
+  { value: 'community', labelKey: 'sponsors.communityType' },
   { value: 'other', labelKey: 'sponsors.otherType' },
 ];
 
@@ -749,12 +750,12 @@ export function PartnerForm({
         </div>
       )}
 
-      {/* Sponsorship Details — Intake mode only (CRM has it under Fundraising) */}
+      {/* Partnership Details — Intake mode only (CRM has it under Fundraising) */}
       {!logoOnly && isIntake && (
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-theme-text flex items-center gap-2">
             <FileText size={16} />
-            {t('sponsors.sponsorshipDetails')}
+            {t('sponsors.partnershipDetails')}
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div className="relative">

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -299,7 +299,7 @@
     "pipeline": "Pipeline",
     "fundraisingSection": "Fundraising",
     "contributionType": "Beitragsart",
-    "sponsorshipDetails": "Sponsoring-Details",
+    "partnershipDetails": "Partnerschaftsdetails",
     "messageFromSponsor": "Nachricht vom Sponsor",
     "logo": "Logo",
     "uploadLogo": "Logo hochladen",
@@ -348,6 +348,7 @@
     "venueType": "Veranstaltungsort",
     "pizzaType": "Pizza",
     "drinksType": "Getränke",
+    "communityType": "Community",
     "otherType": "Sonstiges",
     "brandDescription": "1-2 Sätze Markenbeschreibung (wird auf der Eventseite angezeigt)",
     "productService": "Produkt/Dienstleistung (wenn nicht monetär)"

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -305,7 +305,7 @@
     "pipeline": "Pipeline",
     "fundraisingSection": "Fundraising",
     "contributionType": "Contribution Type",
-    "sponsorshipDetails": "Sponsorship Details",
+    "partnershipDetails": "Partnership Details",
     "messageFromSponsor": "Message from Sponsor",
     "logo": "Logo",
     "uploadLogo": "Upload Logo",
@@ -354,6 +354,7 @@
     "venueType": "Venue",
     "pizzaType": "Pizza",
     "drinksType": "Drinks",
+    "communityType": "Community",
     "otherType": "Other",
     "brandDescription": "1-2 sentence brand description (shown on event page)",
     "productService": "Product/Service (if non-monetary)"

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -299,7 +299,7 @@
     "pipeline": "Pipeline",
     "fundraisingSection": "Recaudación",
     "contributionType": "Tipo de Contribución",
-    "sponsorshipDetails": "Detalles del Patrocinio",
+    "partnershipDetails": "Detalles de la Asociación",
     "messageFromSponsor": "Mensaje del Patrocinador",
     "logo": "Logo",
     "uploadLogo": "Subir Logo",
@@ -348,6 +348,7 @@
     "venueType": "Lugar",
     "pizzaType": "Pizza",
     "drinksType": "Bebidas",
+    "communityType": "Comunidad",
     "otherType": "Otro",
     "brandDescription": "Descripción de marca de 1-2 oraciones (se muestra en la página del evento)",
     "productService": "Producto/Servicio (si no es monetario)"

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -299,7 +299,7 @@
     "pipeline": "Pipeline",
     "fundraisingSection": "Collecte de fonds",
     "contributionType": "Type de contribution",
-    "sponsorshipDetails": "Détails du parrainage",
+    "partnershipDetails": "Détails du partenariat",
     "messageFromSponsor": "Message du sponsor",
     "logo": "Logo",
     "uploadLogo": "Télécharger le logo",
@@ -348,6 +348,7 @@
     "venueType": "Lieu",
     "pizzaType": "Pizza",
     "drinksType": "Boissons",
+    "communityType": "Communauté",
     "otherType": "Autre",
     "brandDescription": "Description de la marque en 1-2 phrases (affichée sur la page de l'événement)",
     "productService": "Produit/Service (si non monétaire)"

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -299,7 +299,7 @@
     "pipeline": "パイプライン",
     "fundraisingSection": "資金調達",
     "contributionType": "貢献タイプ",
-    "sponsorshipDetails": "スポンサーシップ詳細",
+    "partnershipDetails": "パートナーシップ詳細",
     "messageFromSponsor": "スポンサーからのメッセージ",
     "logo": "ロゴ",
     "uploadLogo": "ロゴをアップロード",
@@ -348,6 +348,7 @@
     "venueType": "会場",
     "pizzaType": "ピザ",
     "drinksType": "ドリンク",
+    "communityType": "コミュニティ",
     "otherType": "その他",
     "brandDescription": "1〜2文のブランド説明（イベントページに表示）",
     "productService": "製品/サービス（非金銭の場合）"

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -299,7 +299,7 @@
     "pipeline": "파이프라인",
     "fundraisingSection": "모금",
     "contributionType": "기여 유형",
-    "sponsorshipDetails": "후원 세부 정보",
+    "partnershipDetails": "파트너십 세부 정보",
     "messageFromSponsor": "후원자 메시지",
     "logo": "로고",
     "uploadLogo": "로고 업로드",
@@ -348,6 +348,7 @@
     "venueType": "베뉴",
     "pizzaType": "피자",
     "drinksType": "음료",
+    "communityType": "커뮤니티",
     "otherType": "기타",
     "brandDescription": "1-2문장 브랜드 설명 (이벤트 페이지에 표시)",
     "productService": "제품/서비스 (비현금인 경우)"

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -299,7 +299,7 @@
     "pipeline": "Pipeline",
     "fundraisingSection": "Captação de Recursos",
     "contributionType": "Tipo de Contribuição",
-    "sponsorshipDetails": "Detalhes do Patrocínio",
+    "partnershipDetails": "Detalhes da Parceria",
     "messageFromSponsor": "Mensagem do Patrocinador",
     "logo": "Logo",
     "uploadLogo": "Enviar Logo",
@@ -348,6 +348,7 @@
     "venueType": "Local",
     "pizzaType": "Pizza",
     "drinksType": "Bebidas",
+    "communityType": "Comunidade",
     "otherType": "Outro",
     "brandDescription": "Descrição de 1-2 frases da marca (exibida na página do evento)",
     "productService": "Produto/Serviço (se não monetário)"

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -299,7 +299,7 @@
     "pipeline": "进度管道",
     "fundraisingSection": "筹资",
     "contributionType": "贡献类型",
-    "sponsorshipDetails": "赞助详情",
+    "partnershipDetails": "合作详情",
     "messageFromSponsor": "赞助商留言",
     "logo": "Logo",
     "uploadLogo": "上传 Logo",
@@ -348,6 +348,7 @@
     "venueType": "场地",
     "pizzaType": "披萨",
     "drinksType": "饮品",
+    "communityType": "社区",
     "otherType": "其他",
     "brandDescription": "1-2句品牌描述（显示在活动页面上）",
     "productService": "产品/服务（如为非资金赞助）"

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -721,6 +721,7 @@ export function AccountPage() {
                       venue: 'Venue',
                       pizza: 'Pizza',
                       drinks: 'Drinks',
+                      community: 'Community',
                       other: 'Other',
                     };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -453,7 +453,7 @@ export interface PhotoStats {
 
 // Sponsor CRM types
 export type SponsorStatus = 'todo' | 'asked' | 'yes' | 'billed' | 'paid' | 'stuck' | 'alum' | 'skip';
-export type SponsorshipType = 'cash' | 'in-kind' | 'venue' | 'pizza' | 'drinks' | 'other';
+export type SponsorshipType = 'cash' | 'in-kind' | 'venue' | 'pizza' | 'drinks' | 'community' | 'other';
 export type SponsorCategory = 'hardware_wallet' | 'software_wallet' | 'cex' | 'blockchain' | 'dex' | 'community' | 'custom';
 
 export const SPONSOR_CATEGORIES: { id: SponsorCategory; label: string }[] = [


### PR DESCRIPTION
## Summary
- Renames "Sponsorship Details" -> "Partnership Details" on partner-intake form (all 8 locales: en/zh/pt/ja/fr/es/de/ko). i18n key renamed: `sponsors.sponsorshipDetails` -> `sponsors.partnershipDetails`.
- Adds `community` as a new contribution type, visible in both partner-intake form and CRM type dropdown.
- Extends backend validation allowlist in 3 places.

## Coupling note
Backend allowlist + frontend ship together - merging as one PR. Risk window only exists if frontend deploys before backend; on a clean master merge both deploy concurrently. No migration (sponsorshipType is String?).

## Out of scope (intentional)
- `SponsorshipType` type name, `sponsorshipType` field, `sponsorship_type` DB column - all stable data identifiers, not user copy.
- "Your Sponsorships" section on AccountPage (different header) - separate decision.
- AppsHub "Manage event partners and sponsorships" description - different surface.

## Deviation from plan
- Plan called for 7 locales (en/zh/pt/ja/fr/es/de) but the repo also has a `ko` (Korean) locale that contained `sponsorshipDetails`. Updated it too so `grep sponsorshipDetails frontend/src` returns zero matches as required. Korean translations used: `partnershipDetails: 파트너십 세부 정보`, `communityType: 커뮤니티`.

## Test plan
- [ ] Open Vercel preview, navigate to a partner-intake link, confirm "Partnership Details" header renders.
- [ ] Contribution type dropdown shows "Community" between Drinks and Other.
- [ ] Submit with Community selected -> backend accepts.
- [ ] Switch language to each of zh/pt/ja/fr/es/de/ko - verify both new strings render in target language.
- [ ] CRM mode (host view) -> Fundraising -> Contribution Type dropdown includes "Community".
- [ ] `cd frontend && npm test -- PartnerForm.test` passes.
- [ ] No instances of `sponsorshipDetails` remain in frontend/src.

Generated with [Claude Code](https://claude.com/claude-code)