### PR TITLE
onion-58617: partnerSync preserve fields on undefined

### DIFF
--- a/backend/src/helpers/partnerSync.ts
+++ b/backend/src/helpers/partnerSync.ts
@@ -98,8 +98,15 @@ export async function addPartnerToParty(
   let updatedCoHosts: any[];
   if (existingIdx >= 0) {
     const existing = existingCoHosts[existingIdx];
+    // Strip undefined-valued keys so we don't clobber existing fields
+    // (e.g., avatar_url) when the SponsorUser has no value to provide.
+    // Boolean fields (showOnEvent, canEdit, isPartner) are always defined
+    // by buildPartnerCoHost, so they continue to overwrite as before.
+    const defined = Object.fromEntries(
+      Object.entries(partnerEntry).filter(([_, v]) => v !== undefined)
+    );
     updatedCoHosts = [...existingCoHosts];
-    updatedCoHosts[existingIdx] = { ...partnerEntry, id: existing.id };
+    updatedCoHosts[existingIdx] = { ...existing, ...defined, id: existing.id };
   } else {
     updatedCoHosts = [...existingCoHosts, partnerEntry];
   }


### PR DESCRIPTION
## Summary
- partnerSync.addPartnerToParty upsert no longer wipes avatar_url / website / twitter / instagram when SponsorUser has no value
- Strip undefined keys before merging over existing entry; booleans still overwrite (always defined)
- Append path (new partner entry) unchanged

## Why
buildPartnerCoHost emits `avatar_url: undefined` when both coHostAvatarUrl and coHostLogoUrl are null. The previous destructive spread {...partnerEntry, id: existing.id} dropped the undefined key on JSON write and clobbered the prior value. Fires on every SponsorUser PATCH via Case-4 sync in sponsor-user.routes.ts.

## Test plan
- [x] tsc clean (no new errors; pre-existing sharp/auth errors unrelated)
- [ ] No partnerSync test harness exists; lacks automated coverage. Helper is tightly coupled to Prisma and existing tests are pure-function only. Plan instructed skipping test scaffold in this case.
- [ ] Manual: after deploy, edit a partner in /underboss without touching avatar field; confirm event-page avatars unchanged

Plan: plans/onion-58617-partnersync-destructive-replace.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)