### PR TITLE
romana-30802: visitor session cookie for fake detection

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -286,6 +286,9 @@ model Guest {
   privyUserId  String? @map("privy_user_id") @db.VarChar
   walletSource String? @map("wallet_source") @db.VarChar
 
+  // romana-30802: cookie-based visitor session ID for duplicate-RSVP detection
+  visitorSessionId String? @map("visitor_session_id")
+
   // Check-in fields
   checkedInAt       DateTime? @map("checked_in_at") @db.Timestamptz
   checkedInBy       String?   @map("checked_in_by")

--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -29,6 +29,7 @@ import {
   checkLshFieldSigCluster,
   checkEmailDigitBenford,
   checkCoHostTwitterHandlesMissing,
+  checkRepeatSessionRsvpCount,
   scoreEvent,
   buildSybilWalletSet,
   tierFromScore,
@@ -62,6 +63,7 @@ function makeGuest(overrides: Partial<FakeDetectionGuest> = {}): FakeDetectionGu
     pizzeriaRankings: ['da Michele', 'Sorbillo'],
     suggestedPizzerias: [{ name: 'da Michele' }],
     mailingListOptIn: false,
+    visitorSessionId: null,
     ...overrides,
   };
 }
@@ -917,6 +919,56 @@ describe('checkCoHostTwitterHandlesMissing', () => {
     expect(result.fired).toBe(false);
     expect(result.evidence?.filteredTotal).toBe(2);
     expect(result.evidence?.missingCount).toBe(0);
+  });
+});
+
+describe('checkRepeatSessionRsvpCount', () => {
+  // romana-30802: cookie-based padding detector. Min-n=20 non-null sessions;
+  // fires when max session repeat ≥ 5.
+
+  it('does not fire below min-n (only 10 guests with session_id)', () => {
+    const guests = Array.from({ length: 10 }, (_, i) =>
+      makeGuest({ visitorSessionId: `sess-${i}` }),
+    );
+    const result = checkRepeatSessionRsvpCount(guests);
+    expect(result.fired).toBe(false);
+    expect(result.detail).toMatch(/need ≥20/);
+  });
+
+  it('does not fire when all session IDs are distinct (no repeats)', () => {
+    const guests = Array.from({ length: 30 }, (_, i) =>
+      makeGuest({ visitorSessionId: `unique-sess-${i}` }),
+    );
+    const result = checkRepeatSessionRsvpCount(guests);
+    expect(result.fired).toBe(false);
+    expect(result.evidence?.maxRepeats).toBe(1);
+  });
+
+  it('fires when one session_id repeats 5+ times', () => {
+    // 5 guests share "padder-session"; 20 others are distinct → maxRepeats=5
+    const padder = Array.from({ length: 5 }, () =>
+      makeGuest({ visitorSessionId: 'padder-session-aaaa-bbbb-cccc' }),
+    );
+    const others = Array.from({ length: 20 }, (_, i) =>
+      makeGuest({ visitorSessionId: `legit-${i}` }),
+    );
+    const result = checkRepeatSessionRsvpCount([...padder, ...others]);
+    expect(result.fired).toBe(true);
+    expect(result.evidence?.maxRepeats).toBe(5);
+    expect(result.evidence?.sessionsWithData).toBe(25);
+  });
+
+  it('ignores null session IDs in the count', () => {
+    // 30 guests total, but only 10 have a session_id → below min-n, no fire
+    const withSession = Array.from({ length: 10 }, (_, i) =>
+      makeGuest({ visitorSessionId: `s-${i}` }),
+    );
+    const withoutSession = Array.from({ length: 20 }, () =>
+      makeGuest({ visitorSessionId: null }),
+    );
+    const result = checkRepeatSessionRsvpCount([...withSession, ...withoutSession]);
+    expect(result.fired).toBe(false);
+    expect(result.detail).toMatch(/10\/30/);
   });
 });
 

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -29,6 +29,9 @@ export interface FakeDetectionGuest {
   pizzeriaRankings: string[];
   suggestedPizzerias: unknown; // jsonb
   mailingListOptIn: boolean;
+  // romana-30802: cookie-based per-browser session ID; null for legacy rows
+  // (pre-2026-05) and for browsers that block cookies.
+  visitorSessionId?: string | null;
 }
 
 export interface FakeDetectionCoHost {
@@ -115,6 +118,7 @@ export const WEIGHTS = {
   lsh_field_sig_cluster: 10,
   email_digit_benford: 5,
   co_host_twitter_handles_missing: 12,
+  repeat_session_rsvp_count: 20,
 } as const;
 
 // ============================================
@@ -922,6 +926,53 @@ export function checkCoHostTwitterHandlesMissing(party: FakeDetectionParty): Fla
   );
 }
 
+/**
+ * romana-30802: `repeat_session_rsvp_count` — cookie-based padding detector.
+ *
+ * Each RSVP page mount stamps `_rsvp_sid` (a per-browser UUID) into the guest
+ * row's `visitor_session_id`. If the same session ID repeats 5+ times on one
+ * event, that's near-certain same-browser padding.
+ *
+ * Supplements (does not replace) `high_per_visitor_rsvp_saturation`, which uses
+ * a SHA-256(IP+UA) proxy joined temporally.
+ *
+ * - Min-n: need ≥20 guests with non-null session_id to skip legacy events.
+ * - Threshold: max repeats ≥ 5 (couples may share a device for 2; 3-4 is rare
+ *   but possible; 5+ is padding).
+ * - Nulls are ignored — they represent legacy rows and cookie-blocked browsers.
+ */
+export function checkRepeatSessionRsvpCount(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'repeat_session_rsvp_count';
+  const withSession = guests.filter(g => typeof g.visitorSessionId === 'string' && g.visitorSessionId);
+  if (withSession.length < 20) {
+    return flag(
+      id,
+      false,
+      `only ${withSession.length}/${guests.length} have session_id (need ≥20)`,
+    );
+  }
+  const counts = new Map<string, number>();
+  for (const g of withSession) {
+    const sid = g.visitorSessionId as string;
+    counts.set(sid, (counts.get(sid) ?? 0) + 1);
+  }
+  let max = 0;
+  let worst = '';
+  for (const [sid, n] of counts) {
+    if (n > max) {
+      max = n;
+      worst = sid;
+    }
+  }
+  const fired = max >= 5;
+  return flag(
+    id,
+    fired,
+    `max repeats=${max} (n_with_session=${withSession.length})`,
+    { maxRepeats: max, sessionsWithData: withSession.length, sessionPrefix: worst.slice(0, 8) },
+  );
+}
+
 // ============================================
 // Aggregator
 // ============================================
@@ -965,6 +1016,7 @@ export function scoreEvent(
     checkLshFieldSigCluster(guests),
     checkEmailDigitBenford(guests),
     checkCoHostTwitterHandlesMissing(party),
+    checkRepeatSessionRsvpCount(guests),
   ];
 
   const score = Math.min(

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -271,11 +271,19 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       likedBeverages,
       dislikedBeverages,
       pizzeriaRankings,
-      suggestedPizzerias
+      suggestedPizzerias,
+      visitorSessionId,
     } = req.body;
 
     const safeOptinAbVariant: 'control' | 'variant' | null =
       optinAbVariant === 'control' || optinAbVariant === 'variant' ? optinAbVariant : null;
+
+    // romana-30802: accept only string-shaped UUID-ish values (loose hex+dash
+    // check). Anything else (numbers, objects, tampered junk) → null.
+    const safeVisitorSessionId: string | null =
+      typeof visitorSessionId === 'string' && /^[a-f0-9-]{20,128}$/i.test(visitorSessionId)
+        ? visitorSessionId
+        : null;
 
     // Validate required fields
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -457,6 +465,9 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             status: newStatus,
             ...(newWaitlistPosition !== null ? { waitlistPosition: newWaitlistPosition } : {}),
             submittedVia: existingGuest.status === 'INVITED' ? 'rsvp' : existingGuest.submittedVia,
+            // romana-30802: only overwrite session ID if the current request
+            // carries one — otherwise preserve whatever's already on the row.
+            ...(safeVisitorSessionId ? { visitorSessionId: safeVisitorSessionId } : {}),
           },
         });
 
@@ -525,6 +536,8 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
         partyId: party.id,
         status: guestStatus,
         waitlistPosition: waitlistPosition,
+        // romana-30802: cookie-based per-browser ID; null for legacy/blocked browsers
+        visitorSessionId: safeVisitorSessionId,
       },
     });
 

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -404,6 +404,7 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
             pizzeriaRankings: true,
             suggestedPizzerias: true,
             mailingListOptIn: true,
+            visitorSessionId: true,
           },
         },
         linkClicks: {
@@ -450,6 +451,7 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
           pizzeriaRankings: g.pizzeriaRankings,
           suggestedPizzerias: g.suggestedPizzerias,
           mailingListOptIn: g.mailingListOptIn,
+          visitorSessionId: g.visitorSessionId,
         })),
         p.linkClicks.map(c => ({ clickedAt: c.clickedAt })),
         sybilWallets,

--- a/frontend/src/components/RSVPFormStep1.tsx
+++ b/frontend/src/components/RSVPFormStep1.tsx
@@ -687,6 +687,11 @@ export function RSVPFormStep1({
         {t('step1.next')}
         <ChevronRight size={18} />
       </button>
+
+      {/* romana-30802: cookie disclosure */}
+      <p className="text-xs text-white/40 text-center">
+        We use a cookie to detect duplicate RSVPs. Expires in 90 days.
+      </p>
     </form>
   );
 }

--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -7,6 +7,7 @@ import { PublicEvent, trackRsvpFunnel } from '../lib/api';
 import { DbParty } from '../lib/supabase';
 import { uuid } from '../lib/utils';
 import { findActiveRegion } from '../lib/optinAbRegions';
+import { getOrCreateVisitorSessionId } from '../lib/visitorSession';
 
 // ---- Types ----
 
@@ -451,6 +452,18 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     setSubmitting(true);
     setError(null);
 
+    // romana-30802: stamp the visitor session cookie ID on every submission.
+    // Cookie was already set on first RSVPPage mount but we read it again here
+    // to handle the modal entry point (RSVPModal) which doesn't trigger that
+    // useEffect.
+    let visitorSessionId: string | undefined;
+    try {
+      visitorSessionId = getOrCreateVisitorSessionId();
+    } catch (e) {
+      // Cookie failures (private mode, blocked) are non-fatal.
+      console.warn('visitor session cookie unavailable:', e);
+    }
+
     try {
       const result = await addGuestToParty(
         eventData.id,
@@ -475,6 +488,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
         swcBrOptIn || undefined,
         ethconfOptIn || undefined,
         optinAbVariant ?? undefined,
+        visitorSessionId,
       );
 
       if (result) {

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1292,7 +1292,8 @@ export async function addGuestToParty(
   swcUkOptIn?: boolean,
   swcBrOptIn?: boolean,
   ethconfOptIn?: boolean,
-  optinAbVariant?: 'control' | 'variant' | null
+  optinAbVariant?: 'control' | 'variant' | null,
+  visitorSessionId?: string,
 ): Promise<{ guest: DbGuest; alreadyRegistered: boolean; requireApproval: boolean; updated: boolean; waitlisted: boolean; waitlistPosition: number | null }> {
   if (!inviteCode) {
     console.error('Invite code is required to add guest');
@@ -1324,6 +1325,7 @@ export async function addGuestToParty(
         swcBrOptIn: swcBrOptIn || false,
         ethconfOptIn: ethconfOptIn || false,
         optinAbVariant: optinAbVariant ?? null,
+        visitorSessionId: visitorSessionId ?? null,
       }),
     });
 

--- a/frontend/src/lib/visitorSession.ts
+++ b/frontend/src/lib/visitorSession.ts
@@ -1,0 +1,45 @@
+/**
+ * romana-30802: First-party cookie that stamps each RSVP with a stable
+ * per-browser UUID. Supplements (does not replace) the existing temporal-join
+ * fake-detection heuristic. Same cookie value repeating across many RSVPs on
+ * one event ≈ same browser padding the guest list.
+ *
+ * Cookie spec:
+ *   name:     `_rsvp_sid`
+ *   value:    crypto.randomUUID() (via existing `uuid()` helper)
+ *   max-age:  90 days
+ *   path:     `/`
+ *   SameSite: Lax
+ *   Secure:   on https only
+ *   HttpOnly: NO (JS reads it)
+ *   Domain:   unset (host-only)
+ */
+
+import { uuid } from './utils';
+
+const COOKIE_NAME = '_rsvp_sid';
+const NINETY_DAYS_SECONDS = 60 * 60 * 24 * 90;
+
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function writeCookie(name: string, value: string, maxAgeSec: number): void {
+  if (typeof document === 'undefined') return;
+  const secure = typeof window !== 'undefined' && window.location.protocol === 'https:';
+  document.cookie =
+    `${name}=${encodeURIComponent(value)}; Max-Age=${maxAgeSec}; Path=/; SameSite=Lax` +
+    (secure ? '; Secure' : '');
+}
+
+/** Returns the existing visitor session ID, or creates and persists a new one. */
+export function getOrCreateVisitorSessionId(): string {
+  const existing = readCookie(COOKIE_NAME);
+  // Loose hex+dash sanity check — guards against tampering/garbage values.
+  if (existing && /^[a-f0-9-]{20,}$/i.test(existing)) return existing;
+  const fresh = uuid();
+  writeCookie(COOKIE_NAME, fresh, NINETY_DAYS_SECONDS);
+  return fresh;
+}

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -12,6 +12,7 @@ import { GPPClouds } from '../components/GPPClouds';
 import { useConfetti } from '../hooks/useConfetti';
 import { useTranslation } from 'react-i18next';
 import { RSVPFlowContent } from '../components/RSVPFlowContent';
+import { getOrCreateVisitorSessionId } from '../lib/visitorSession';
 
 /** Map DbParty (snake_case) to a partial PublicEvent for RSVPFlowContent */
 function dbPartyToPublicEvent(party: DbParty, inviteCode: string): PublicEvent {
@@ -146,10 +147,17 @@ export function RSVPPage() {
     loadParty();
   }, [inviteCode, user?.email]);
 
-  // Track RSVP funnel: opened
+  // Track RSVP funnel: opened, and stamp the visitor session cookie on first
+  // mount so it's already present by the time `addGuestToParty` runs.
   useEffect(() => {
     if (party && inviteCode) {
       trackRsvpFunnel(inviteCode, 'rsvp_opened');
+      try {
+        getOrCreateVisitorSessionId();
+      } catch (e) {
+        // Cookie failures (private mode, blocked) are non-fatal — RSVP still works.
+        console.warn('visitor session cookie unavailable:', e);
+      }
     }
   }, [party, inviteCode]);
 

--- a/supabase/migrations/20260518_add_visitor_session_id.sql
+++ b/supabase/migrations/20260518_add_visitor_session_id.sql
@@ -1,0 +1,15 @@
+-- romana-30802: Add visitor_session_id column to guests for cookie-based
+-- duplicate-RSVP detection. Cookie is set on RSVP page first mount and
+-- repeats indicate same-browser padding.
+--
+-- Column is nullable — legacy rows stay NULL (intentional, no backfill).
+-- Partial index excludes nulls to keep it small.
+--
+-- No anon/authenticated SELECT grant — admin/scorer only.
+
+ALTER TABLE guests
+  ADD COLUMN IF NOT EXISTS visitor_session_id TEXT;
+
+CREATE INDEX IF NOT EXISTS guests_visitor_session_id_idx
+  ON guests(visitor_session_id)
+  WHERE visitor_session_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Adds a first-party cookie (`_rsvp_sid`) that stamps each RSVP with a per-browser UUID, and a new fake-detection heuristic `repeat_session_rsvp_count` (weight 20) that fires when 5+ guests on one event share the same session ID. Supplements (does not replace) the existing temporal-join `high_per_visitor_rsvp_saturation` check, which relies on a SHA-256(IP+UA) proxy.

**Migration applied to prod Supabase BEFORE this push** via Management API (per the "apply migration before merging Prisma changes" rule). Column verified:
```
SELECT column_name, data_type, is_nullable FROM information_schema.columns
WHERE table_name='guests' AND column_name='visitor_session_id';
-- {"column_name":"visitor_session_id","data_type":"text","is_nullable":"YES"}
```

## Cookie spec

| Setting | Value |
|---|---|
| Name | `_rsvp_sid` |
| Value | `crypto.randomUUID()` |
| Max-Age | 90 days (`60*60*24*90`) |
| Path | `/` |
| SameSite | `Lax` |
| Secure | on https only |
| HttpOnly | off (JS reads it) |
| Domain | unset (host-only, `rsv.pizza` exact) |

Set on first `RSVPPage` mount, also re-checked in `useRSVPForm.handleSubmit` so the modal entry point stamps it too.

## Heuristic

- Min-n 20 guests with non-null `visitor_session_id` (skips legacy events)
- Fires when max session repeats >= 5
- Null IDs (legacy rows + cookie-blocked browsers) ignored

## Inline disclosure

Under Step 1 submit button, `text-xs text-white/40`:
> We use a cookie to detect duplicate RSVPs. Expires in 90 days.

## Snax's decisions baked in

1. 9-word inline disclosure (no popover)
2. Cookie expiry 90 days (not 1 year)
3. Legacy null rows left as NULL (no backfill)
4. Threshold 5 (not 3)

## Files (11)

**Frontend**:
- NEW `frontend/src/lib/visitorSession.ts` — cookie helper with 90-day expiry
- `frontend/src/pages/RSVPPage.tsx` — set cookie on rsvp_opened
- `frontend/src/hooks/useRSVPForm.ts` — pass session ID into `addGuestToParty`
- `frontend/src/lib/supabase.ts` — `addGuestToParty` accepts + sends `visitorSessionId`
- `frontend/src/components/RSVPFormStep1.tsx` — disclosure under submit

**Backend**:
- `backend/prisma/schema.prisma` — `visitorSessionId String? @map("visitor_session_id")` on Guest
- `backend/src/routes/rsvp.routes.ts` — destructure + validate + persist on create and update
- `backend/src/lib/fakeDetection.ts` — type field, WEIGHTS entry, `checkRepeatSessionRsvpCount`, wired into `scoreEvent`
- `backend/src/lib/fakeDetection.test.ts` — 4 fixtures (below-min-n / distinct / 5x repeat fires / null ignored)
- `backend/src/routes/underboss.routes.ts` — `visitorSessionId: true` in guests select + per-guest map

**Migration**:
- `supabase/migrations/20260518_add_visitor_session_id.sql` (record-keeping copy; applied to prod 2026-05-18 before push)

## Test plan

- [x] `npm test -- --run fakeDetection` (backend) — 101 passed, including 4 new tests with threshold 5
- [x] `tsc --noEmit` in `backend/` — only 1 pre-existing unrelated error in `auth.test.ts`
- [x] `tsc --noEmit` in `frontend/` — 0 errors
- [ ] Preview deploy: DevTools → Cookies → `_rsvp_sid` set with Max-Age=7776000, SameSite=Lax, Secure on https
- [ ] Submit RSVP. Verify `visitor_session_id` matches cookie via SQL
- [ ] Submit second RSVP with different email same browser — same `visitor_session_id`
- [ ] Open `/underboss/fake-detection`; if a test event has 5+ rows sharing session_id and ≥20 non-null, `repeat_session_rsvp_count` fires with +20 score

## Notes

- Frontend ships immediately to preview; backend ships from master after merge. Frontend can land first — backend silently ignores unknown body fields. Either order is safe.
- Column is nullable and unindexed-when-null — no impact on legacy rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)