### PR TITLE
sicilian-79707: Fix expected guests slider track disappearing on click+drag

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -156,7 +156,7 @@ select {
   transition: all 0.2s ease;
 }
 
-input:focus,
+input:not([type="range"]):focus,
 textarea:focus,
 select:focus {
   outline: none;
@@ -483,7 +483,7 @@ body.gpp-theme-active .card:hover {
   border: 1px solid rgba(0, 0, 0, 0.12) !important;
   color: #1a1a1a !important;
 }
-.gpp-theme input:focus, body.gpp-theme-active input:focus,
+.gpp-theme input:not([type="range"]):focus, body.gpp-theme-active input:not([type="range"]):focus,
 .gpp-theme textarea:focus, body.gpp-theme-active textarea:focus,
 .gpp-theme select:focus, body.gpp-theme-active select:focus {
   border-color: #E52828 !important;


### PR DESCRIPTION
## Summary

Fixes the expected guests range slider on the HostPage "pizza" tab where the track (rendered via inline `linear-gradient`) would appear to disappear while the user was clicking and dragging.

## Root cause

The global focus rule in `frontend/src/index.css` applies `background: rgba(255, 255, 255, 0.08)` to all focused inputs:

```css
input:focus,
textarea:focus,
select:focus {
  outline: none;
  border-color: var(--accent);
  background: rgba(255, 255, 255, 0.08);
}
```

`<input type="range">` is also an `input`, so during click+drag (when the slider has focus) this rule clobbered the inline `background: linear-gradient(...)` used to render the filled/unfilled portions of the track — making the track "disappear" until focus was lost.

A matching rule in the `.gpp-theme` block had the same bug.

## Fix

Exclude `input[type="range"]` from both focus rules using `:not([type="range"])`. Range inputs now keep their inline gradient background while focused.

Two-line diff in `frontend/src/index.css` only — nothing else touched.

## Test plan

- [ ] On HostPage pizza tab, click+drag the "expected guests" slider — the red filled track stays visible throughout the drag.
- [ ] Slider value still updates correctly.
- [ ] Other inputs (text, textarea, select) still show the focus background.
- [ ] Same behavior under `.gpp-theme`.