### PR TITLE
capricciosa-58661: drop 'approved' from NEARBY_CITY error

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -393,7 +393,7 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
           : nearestCity.name;
 
         throw new AppError(
-          `There's already an approved Global Pizza Party near you in ${nearbyDisplayName} — it's about ${Math.round(nearestKm)} km away. Join them here: ${eventUrl}`,
+          `There's already a Global Pizza Party near you in ${nearbyDisplayName} — it's about ${Math.round(nearestKm)} km away. Join them here: ${eventUrl}`,
           409,
           'NEARBY_CITY'
         );


### PR DESCRIPTION
## Summary
One-line copy tweak to the NEARBY_CITY error from #393 — drops "an approved" so the message reads "There's already a Global Pizza Party near you in..." instead of "There's already an approved Global Pizza Party near you in...".

## Test plan
- [ ] After merge + backend deploy, POST /api/gpp/events with coords near an existing approved GPP → error message starts with "There's already a Global Pizza Party near you in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)