### PR TITLE
mushroom-38004: PartnerManager passes cleared fields through to backend

### DIFF
--- a/frontend/src/components/underboss/PartnerManager.tsx
+++ b/frontend/src/components/underboss/PartnerManager.tsx
@@ -74,26 +74,26 @@ export function PartnerManager({ isAdmin, events, onSyncComplete, onFlyerRegenNe
       // Proxy external avatar to storage
       const proxiedAvatarUrl = data.coHostAvatarUrl
         ? await proxyAvatarToStorage(data.coHostAvatarUrl)
-        : undefined;
+        : '';
 
       const payload = {
         email: data.email,
         tag: data.tag,
-        name: data.contactPersonName || undefined,
-        notes: data.notes || undefined,
-        coHostName: data.name || undefined,
-        coHostWebsite: data.website || undefined,
-        coHostTwitter: data.brandTwitter || undefined,
-        coHostInstagram: data.brandInstagram || undefined,
+        name: data.contactPersonName ?? undefined,
+        notes: data.notes ?? undefined,
+        coHostName: data.name ?? undefined,
+        coHostWebsite: data.website ?? undefined,
+        coHostTwitter: data.brandTwitter ?? undefined,
+        coHostInstagram: data.brandInstagram ?? undefined,
         coHostAvatarUrl: proxiedAvatarUrl,
-        coHostLogoUrl: data.logoUrl || undefined,
+        coHostLogoUrl: data.logoUrl ?? undefined,
         autoCoHost: data.autoCoHost,
         autoSponsor: data.autoSponsor,
         coHostShowOnEvent: data.coHostShowOnEvent,
         coHostCanEdit: data.coHostCanEdit,
         coHostAllowedTabs: data.coHostAllowedTabs,
-        category: data.category || undefined,
-        brandDescription: data.brandDescription || undefined,
+        category: data.category ?? undefined,
+        brandDescription: data.brandDescription ?? undefined,
       };
 
       let newSyncMessage: string | null = null;


### PR DESCRIPTION
## Summary
- || undefined -> ?? undefined for partner payload string fields in handlePartnerSubmit
- Avatar conditional ': undefined' -> ': '' so cleared avatars reach the backend
- Empty string round-trips: UI clear -> '' sent -> backend trims, writes null -> partnerSync propagates null cleanly

## Why
Previously the Underboss UI couldn't actually clear logo/twitter/website/etc on a partner — the cleared value was dropped from the JSON payload, the backend skipped the field, and partnerSync re-stamped the stale value across every tagged event. Repro doc'd against Team1/Avalanche 2026-05-13.

## Test plan
- [ ] Open /underboss -> Partners -> edit an existing partner with a logo
- [ ] Clear the logo field, save
- [ ] Confirm SponsorUser.co_host_logo_url is null in DB
- [ ] Confirm tagged events' co_hosts entries no longer carry the old logo
- [ ] Repeat for coHostName, coHostWebsite, coHostTwitter, coHostInstagram, brandDescription, category, contactPersonName, notes
- [ ] Regression: editing a partner without touching a field leaves that field unchanged (the key isn't on the form's form data -> still undefined -> backend skips, correct)

Plan: plans/mushroom-38004-partner-manager-clear-fields.md

Generated with Claude Code