### PR TITLE
pepperoni-91685: memoize GPPMap to stop keystroke flash

### DIFF
--- a/frontend/src/components/GPPMap.tsx
+++ b/frontend/src/components/GPPMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const KML_URL = 'https://www.google.com/maps/d/kml?mid=1ixyD2QbCZcz9IdK2gFKCNCz92hDDzEA';
 
@@ -9,7 +9,7 @@ interface GPPMapProps {
   initialZoom?: number;
 }
 
-export default function GPPMap({
+function GPPMap({
   height = 500,
   minZoom = 3,
   maxZoom = 12,
@@ -118,3 +118,5 @@ export default function GPPMap({
     />
   );
 }
+
+export default React.memo(GPPMap);


### PR DESCRIPTION
## Summary
Wrap `GPPMap` default export in `React.memo`. On the GPP landing page, typing in the form was causing the map's icons to flash on every keystroke because the parent re-render was cascading into the map component. All props passed to `GPPMap` are stable primitive literals, so memoization is a clean short-circuit.

## Test plan
- [ ] Visit preview /, type into the city/host/email/telegram fields — map icons stay stable, no flash
- [ ] Map still loads correctly on initial visit
- [ ] Map still loads correctly after a language switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)