### PR TITLE
deep-dish-73639: country count on /map stats badge

### DIFF
--- a/frontend/src/pages/EventsMapPage.tsx
+++ b/frontend/src/pages/EventsMapPage.tsx
@@ -227,6 +227,15 @@ export function EventsMapPage() {
   // Count unique cities (use full events count for the non-moderator pill,
   // filteredEvents for the moderator "X of Y" pill).
   const cityCount = useMemo(() => new Set(events.map((e) => e.city)).size, [events]);
+  const countryCount = useMemo(
+    () =>
+      new Set(
+        events
+          .map((e) => e.country)
+          .filter((c): c is string => !!c && c.trim() !== '')
+      ).size,
+    [events]
+  );
 
   return (
     <>
@@ -354,6 +363,12 @@ export function EventsMapPage() {
                     <>
                       {events.length.toLocaleString()} events across{' '}
                       {cityCount} {cityCount === 1 ? 'city' : 'cities'}
+                      {countryCount > 0 && (
+                        <>
+                          {' '}in {countryCount}{' '}
+                          {countryCount === 1 ? 'country' : 'countries'}
+                        </>
+                      )}
                     </>
                   )}
                 </span>

--- a/plans/deep-dish-73639-map-country-count.md
+++ b/plans/deep-dish-73639-map-country-count.md
@@ -1,0 +1,43 @@
+# deep-dish-73639 — Add country count to /map stats badge
+
+**Priority**: P3 (small UX polish)
+
+## Feature
+
+The `/map` page (underboss-only `EventsMapPage`) shows a floating stats badge above the map:
+
+> "{N} events across {M} cities"
+
+Add a unique country count to the badge so it reads:
+
+> "{N} events across {M} cities in {K} countries"
+
+(Pluralization handled the same way as cities: "1 country" / "K countries".)
+
+## Why it's safe
+
+- `country` is already on `GPPEventMapItem` (`frontend/src/lib/api.ts:3266`) — populated by `fetchGppEventsForMap` from the backend `GET /api/gpp/events` payload. No backend or DB change needed.
+- Counting is done client-side on already-fetched data — no extra request.
+- Page is gated to admin/underboss; risk of regressing public surface is zero.
+
+## Files to modify
+
+Only one file:
+
+- `frontend/src/pages/EventsMapPage.tsx`
+
+## Implementation
+
+1. Just after the existing `cityCount` line (around line 64), add a `countryCount` const derived from `events.map(e => e.country)`, filtering out null/empty strings before passing through `new Set(...).size`.
+
+2. In the floating stats badge (around line 159-162), extend the span to append `" in {countryCount} country/countries"` when `countryCount > 0`.
+
+## Out of scope
+
+- No layout/restyle of the badge — single-line text, same pill shape.
+- No backend/API changes — `country` already returned.
+- No translation strings — page is admin-only and the badge is English-only today.
+
+## Branch
+
+`deep-dish-73639-map-country-count`


### PR DESCRIPTION
## Summary
- Adds unique country count to the floating stats badge on `/map` (admin/underboss-only page).
- Reads as e.g. "534 events across 217 cities in 73 countries". Uses existing `country` field on `GPPEventMapItem` — no backend or DB change.
- Filters out null/empty countries before counting; degrades to prior wording if no countries are set.

## Test plan
- [ ] Open Vercel preview `/map`, sign in as underboss
- [ ] Badge shows event/city/country counts with correct pluralization
- [ ] Numbers match reality (spot-check: e.g. country count <= city count)

Plan: `plans/deep-dish-73639-map-country-count.md`