### PR TITLE
spinach-88885: partner dashboard filters to approved events only

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -539,6 +539,12 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       where.NOT = { eventTags: { equals: [] } };
     }
 
+    // Non-admin partners only see approved events.
+    // Admins (req.isAdminViewing) continue to see everything for debugging/tagging.
+    if (!req.isAdminViewing) {
+      where.underbossStatus = 'approved';
+    }
+
     // Find events
     const events = await prisma.party.findMany({
       where,


### PR DESCRIPTION
## Summary
- Partner dashboard (`GET /api/sponsor/events`) now filters out events with `underbossStatus !== 'approved'` for non-admin partner users.
- Admins viewing `/partner` continue to see all tagged events (no behavior change for admin path).

## Test plan
- [ ] As a non-admin partner: visit `/partner`, confirm only approved events appear (no pending/rejected).
- [ ] As an admin: visit `/partner`, confirm all tagged events still appear including pending/rejected.
- [ ] CSV download for a partner user contains only approved events.
- [ ] Stats tiles reflect only approved-event counts for partners.

## Notes
- **Backend-only change.** Backend deploys from master, so this won't reflect on Vercel frontend previews until merged + backend redeployed.

Plan: inlined in dispatch (no plan file on master)

Generated with [Claude Code](https://claude.com/claude-code)