### PR TITLE
pineapple-26037: underboss reject-only (delete is admin-only)

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -810,9 +810,13 @@ router.patch('/events/bulk-status', requireAuth, requireUnderbossAuth, async (re
   }
 });
 
-// DELETE /api/underboss/events/bulk-delete - Bulk delete events
+// DELETE /api/underboss/events/bulk-delete - Bulk delete events (admin-only, pineapple-26037)
 router.delete('/events/bulk-delete', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
     const { partyIds } = req.body;
 
     if (!Array.isArray(partyIds) || partyIds.length === 0) {

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -18,6 +18,7 @@ interface EventTableProps {
   onTelegramBroadcast?: (cities: string[]) => void;
   partnerTags?: string[];
   onFilteredEventsChange?: (events: UnderbossEvent[]) => void;
+  isAdmin?: boolean;
 }
 
 type SortField = 'name' | 'date' | 'guestCount' | 'progress';
@@ -88,7 +89,7 @@ function FilterPill({
   );
 }
 
-export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, onTelegramBroadcast, partnerTags = [], onFilteredEventsChange }: EventTableProps) {
+export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, onTelegramBroadcast, partnerTags = [], onFilteredEventsChange, isAdmin }: EventTableProps) {
   const { t } = useTranslation('partner');
   const [search, setSearch] = useState('');
   const [sortField, setSortField] = useState<SortField>('date');
@@ -535,15 +536,17 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                   >
                     {t('eventTable.hide')}
                   </button>
-                  <button
-                    onClick={() => {
-                      setShowActionDropdown(false);
-                      setShowDeleteConfirm(true);
-                    }}
-                    className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-theme-surface transition-colors"
-                  >
-                    {t('eventTable.cancelEvent')}
-                  </button>
+                  {isAdmin && (
+                    <button
+                      onClick={() => {
+                        setShowActionDropdown(false);
+                        setShowDeleteConfirm(true);
+                      }}
+                      className="w-full text-left px-4 py-2 text-sm text-red-400 hover:bg-theme-surface transition-colors"
+                    >
+                      {t('eventTable.cancelEvent')}
+                    </button>
+                  )}
                   <button
                     onClick={() => {
                       setShowActionDropdown(false);

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -567,7 +567,7 @@ export function UnderbossDashboard() {
           </div>
 
           {activeTab === 'events' && (
-            <EventTable events={filteredData.events} showRegion={showRegionColumn} onEventUpdate={handleEventUpdate} onBulkAction={() => loadDashboard(true)} onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }} partnerTags={partnerTags} onFilteredEventsChange={setTableFilteredEvents} />
+            <EventTable events={filteredData.events} showRegion={showRegionColumn} onEventUpdate={handleEventUpdate} onBulkAction={() => loadDashboard(true)} onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }} partnerTags={partnerTags} onFilteredEventsChange={setTableFilteredEvents} isAdmin={isAdmin} />
           )}
 
           {activeTab === 'cities' && (


### PR DESCRIPTION
## Summary
- Backend: gate `DELETE /api/underboss/events/bulk-delete` behind `isAdmin` check (returns 403 for underbosses).
- Frontend: hide the "Cancel Event" bulk action from non-admin underbosses.
- Context: mc@buildwithmc.com hard-deleted 93 Africa events via this button over 2 weeks. Restored separately; this PR prevents recurrence.

## Test plan
- [ ] As non-admin underboss: "Cancel Event" bulk option not visible in dropdown.
- [ ] As non-admin underboss: direct DELETE to /api/underboss/events/bulk-delete returns 403.
- [ ] As admin: "Cancel Event" still visible and functional end-to-end.
- [ ] Approve/Reject/Hide still work for non-admin underbosses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)