### PR TITLE
hotfix(forno-25476): Find a Venue checklist → Settings tab

### DIFF
--- a/frontend/src/components/checklist/ChecklistTab.tsx
+++ b/frontend/src/components/checklist/ChecklistTab.tsx
@@ -100,7 +100,7 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
 
   const handleNavigate = (tab: string) => {
     if (tab === 'venue') {
-      setFindVenueOpen(true);
+      if (inviteCode) navigate(`/host/${inviteCode}`);
       return;
     }
     if (inviteCode) {

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -96,7 +96,7 @@ export const GPPDashboardTab: React.FC = () => {
         tab: item.linkTab,
         onClick: item.name === 'Build a Team' ? () => setHostsExpanded(prev => !prev) :
                  item.name === 'Find Partners' ? () => goToTab('partners') :
-                 item.name === 'Find a Venue' ? () => setFindVenueOpen(true) : undefined,
+                 item.name === 'Find a Venue' ? () => goToTab('details') : undefined,
         icon: ICON_MAP[item.name] ?? ClipboardCheck,
         dueDate: item.dueDate ? item.dueDate.split('T')[0] : null,
       };


### PR DESCRIPTION
## Summary
- Hotfix: route "Find a Venue" checklist row to the Settings tab in both `GPPDashboardTab` and `ChecklistTab`.
- Bypasses the broken `FindVenueModal` input (typing produces no visible text). Real fix tracked as margherita-48195.

## Why
The modal's `LocationAutocomplete` was wired with `value=""` + a no-op `onChange`, so the controlled input stays blank as the user types and the Google Places dropdown never gets a query. Settings tab has a working location editor — route there until the modal is fixed.

## Test plan
- [ ] `/host/<inviteCode>` → click Find a Venue → lands on Settings tab (no modal)
- [ ] `/host/<inviteCode>/checklist` → click Find a Venue → lands on Settings tab
- [ ] Other checklist rows (Find Partners, Select Pizzeria) still go to their original tabs
- [ ] Save an address on Settings tab → checklist row ticks via existing auto-rule
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)