### PR TITLE
forno-63425: add event flyer image to top of guest emails

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -848,6 +848,7 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
             address: true,
             inviteCode: true,
             customUrl: true,
+            eventImageUrl: true,
           },
         });
 
@@ -860,6 +861,7 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
             partyDate: party.date,
             partyTimezone: party.timezone,
             partyAddress: party.address,
+            partyImageUrl: party.eventImageUrl,
             inviteCode: party.inviteCode,
             customUrl: party.customUrl,
           });
@@ -979,6 +981,7 @@ router.post('/:partyId/guests/:guestId/promote', async (req: AuthRequest, res: R
             address: true,
             inviteCode: true,
             customUrl: true,
+            eventImageUrl: true,
           },
         });
 
@@ -991,6 +994,7 @@ router.post('/:partyId/guests/:guestId/promote', async (req: AuthRequest, res: R
             partyDate: party.date,
             partyTimezone: party.timezone,
             partyAddress: party.address,
+            partyImageUrl: party.eventImageUrl,
             inviteCode: party.inviteCode,
             customUrl: party.customUrl,
           });

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -318,6 +318,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
         timezone: true,
         address: true,
         customUrl: true,
+        eventImageUrl: true,
         rsvpClosedAt: true,
         maxGuests: true,
         requireApproval: true,
@@ -338,6 +339,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
           timezone: true,
           address: true,
           customUrl: true,
+          eventImageUrl: true,
           rsvpClosedAt: true,
           maxGuests: true,
           requireApproval: true,
@@ -364,6 +366,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             timezone: true,
             address: true,
             customUrl: true,
+            eventImageUrl: true,
             rsvpClosedAt: true,
             maxGuests: true,
             requireApproval: true,
@@ -592,6 +595,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             partyDate: party.date,
             partyTimezone: party.timezone,
             partyAddress: party.address,
+            partyImageUrl: party.eventImageUrl,
             inviteCode,
             customUrl: party.customUrl,
             requireApproval: party.requireApproval,
@@ -649,6 +653,7 @@ router.post('/:inviteCode/send-confirmation', async (req: Request, res: Response
         timezone: true,
         address: true,
         customUrl: true,
+        eventImageUrl: true,
       },
     });
 
@@ -662,6 +667,7 @@ router.post('/:inviteCode/send-confirmation', async (req: Request, res: Response
           timezone: true,
           address: true,
           customUrl: true,
+          eventImageUrl: true,
         },
       });
     }
@@ -682,6 +688,7 @@ router.post('/:inviteCode/send-confirmation', async (req: Request, res: Response
             timezone: true,
             address: true,
             customUrl: true,
+            eventImageUrl: true,
           },
         });
       }
@@ -700,6 +707,7 @@ router.post('/:inviteCode/send-confirmation', async (req: Request, res: Response
       partyDate: party.date,
       partyTimezone: party.timezone,
       partyAddress: party.address,
+      partyImageUrl: party.eventImageUrl,
       inviteCode,
       customUrl: party.customUrl,
     });
@@ -719,6 +727,7 @@ async function sendRSVPConfirmationEmail(params: {
   partyDate: Date | null;
   partyTimezone: string | null;
   partyAddress: string | null;
+  partyImageUrl?: string | null;
   inviteCode: string;
   customUrl: string | null;
   requireApproval?: boolean;
@@ -783,6 +792,14 @@ async function sendRSVPConfirmationEmail(params: {
     ? `RSVP Submitted for ${params.partyName} - Pending Approval`
     : `You're going to ${params.partyName}! 🍕`;
 
+  const flyerBlock = params.partyImageUrl
+    ? `
+        <div style="text-align: center; margin-bottom: 20px;">
+          <img src="${params.partyImageUrl}" alt="${params.partyName}" style="max-width: 100%; border-radius: 12px;" />
+        </div>
+  `
+    : '';
+
   const emailHtml = `
     <!DOCTYPE html>
     <html>
@@ -792,6 +809,7 @@ async function sendRSVPConfirmationEmail(params: {
         <title>${isPendingApproval ? 'RSVP Pending' : 'RSVP Confirmed'}</title>
       </head>
       <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+        ${flyerBlock}
         <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
           <h1 style="color: #ffffff; font-size: 32px; margin: 0 0 10px 0;">${headerTitle}</h1>
           <p style="color: rgba(255,255,255,0.8); font-size: 18px; margin: 0;">${headerSubtitle}</p>
@@ -848,6 +866,7 @@ export async function sendApprovalEmail(params: {
   partyDate: Date | null;
   partyTimezone: string | null;
   partyAddress: string | null;
+  partyImageUrl?: string | null;
   inviteCode: string;
   customUrl: string | null;
 }) {
@@ -883,6 +902,14 @@ export async function sendApprovalEmail(params: {
 
   const addressText = params.partyAddress || 'Location TBD';
 
+  const flyerBlock = params.partyImageUrl
+    ? `
+        <div style="text-align: center; margin-bottom: 20px;">
+          <img src="${params.partyImageUrl}" alt="${params.partyName}" style="max-width: 100%; border-radius: 12px;" />
+        </div>
+  `
+    : '';
+
   const emailHtml = `
     <!DOCTYPE html>
     <html>
@@ -892,6 +919,7 @@ export async function sendApprovalEmail(params: {
         <title>RSVP Approved</title>
       </head>
       <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+        ${flyerBlock}
         <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
           <h1 style="color: #ffffff; font-size: 32px; margin: 0 0 10px 0;">🍕 You're Approved!</h1>
           <p style="color: rgba(255,255,255,0.8); font-size: 18px; margin: 0;">Your RSVP has been confirmed</p>
@@ -1059,6 +1087,7 @@ export async function sendPromotionEmail(params: {
   partyDate: Date | null;
   partyTimezone: string | null;
   partyAddress: string | null;
+  partyImageUrl?: string | null;
   inviteCode: string;
   customUrl: string | null;
 }) {
@@ -1094,6 +1123,14 @@ export async function sendPromotionEmail(params: {
 
   const addressText = params.partyAddress || 'Location TBD';
 
+  const flyerBlock = params.partyImageUrl
+    ? `
+        <div style="text-align: center; margin-bottom: 20px;">
+          <img src="${params.partyImageUrl}" alt="${params.partyName}" style="max-width: 100%; border-radius: 12px;" />
+        </div>
+  `
+    : '';
+
   const emailHtml = `
     <!DOCTYPE html>
     <html>
@@ -1103,6 +1140,7 @@ export async function sendPromotionEmail(params: {
         <title>You're In!</title>
       </head>
       <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+        ${flyerBlock}
         <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
           <h1 style="color: #ffffff; font-size: 32px; margin: 0 0 10px 0;">You're In!</h1>
           <p style="color: rgba(255,255,255,0.8); font-size: 18px; margin: 0;">A spot opened up just for you</p>


### PR DESCRIPTION
## Summary

Adds the party's `eventImageUrl` as a flyer image at the very top of three guest-facing Resend email templates:

- `sendRSVPConfirmationEmail` (initial RSVP — confirmed and pending-approval variants)
- `sendApprovalEmail` (host approves a pending guest)
- `sendPromotionEmail` (guest moves off waitlist)

The flyer renders above the existing gradient header. When the party has no `eventImageUrl`, the block is omitted entirely (no fallback markup). Matches the placement pattern already in `buildInviteEmail` at `backend/src/routes/v1/guests.ts:72`.

Out of scope: `sendWaitlistConfirmationEmail` (initial waitlist join) is intentionally not changed.

## Test plan

- [ ] TypeScript: `cd backend && npx tsc --noEmit` passes
- [ ] Existing tests: `cd backend && npm test -- rsvp.routes.test.ts party.routes.test.ts` still pass
- [ ] Manual: after backend deploys to prod from master, trigger an approval / RSVP / waitlist-promotion on an event WITH an `eventImageUrl` — verify the flyer renders at top of the email in Gmail/Apple Mail
- [ ] Manual: trigger same on an event WITHOUT `eventImageUrl` — verify no broken-image placeholder, just the existing template

## Deploy notes

Backend-only change. After merge, deploy backend from master:
\`cd backend && vercel --prod --scope pizza-dao\`

Frontend Vercel preview WILL NOT show this change because preview frontends use production backend.