### PR TITLE
buffalo-14542: fix graphics admin scope leak on Graphics Dashboard

### DIFF
--- a/backend/src/middleware/underbossAuth.ts
+++ b/backend/src/middleware/underbossAuth.ts
@@ -31,6 +31,12 @@ export interface UnderbossAuthRequest extends AuthRequest {
  * Authorizes admins, graphics-admins, and any active underboss with at
  * least one region OR city. Replaces the duplicated copies that previously
  * lived in `underboss.routes.ts` and `telegram.routes.ts`.
+ *
+ * Precedence: admin → graphics-admin → underboss. Graphics-admin status
+ * promotes scope to admin-equivalent (`regions: ['__admin__']`) even when
+ * the same user also has an underboss row with a limited city/region
+ * scope, so the Graphics Dashboard (`/api/underboss/all`) returns all GPP
+ * events. Mirrors the graphics-admin short-circuit in `partyAccess.ts`.
  */
 export async function requireUnderbossAuth(
   req: UnderbossAuthRequest,
@@ -57,19 +63,40 @@ export async function requireUnderbossAuth(
       return next();
     }
 
-    // Look up underboss by email
-    const underboss = await prisma.underboss.findFirst({
-      where: { email: email.toLowerCase(), isActive: true },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        region: true,
-        regions: true,
-        cities: true,
+    // Look up both rows in parallel. Graphics-admin status overrides any
+    // underboss city/region scope so dual-role users see all GPP events on
+    // the Graphics Dashboard.
+    const [underboss, graphicsAdmin] = await Promise.all([
+      prisma.underboss.findFirst({
+        where: { email: email.toLowerCase(), isActive: true },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          region: true,
+          regions: true,
+          cities: true,
+          isActive: true,
+        },
+      }),
+      prisma.graphicsAdmin.findUnique({
+        where: { email: email.toLowerCase() },
+        select: { id: true, name: true },
+      }),
+    ]);
+
+    if (graphicsAdmin) {
+      req.underboss = {
+        id: underboss?.id ?? 'graphics-admin',
+        name: underboss?.name ?? graphicsAdmin.name ?? 'Graphics Admin',
+        email: underboss?.email ?? email,
+        region: '__admin__',
+        regions: ['__admin__'],
+        cities: [],
         isActive: true,
-      },
-    });
+      };
+      return next();
+    }
 
     if (underboss) {
       // Fall back to [region] if regions array is empty (legacy data)
@@ -87,23 +114,6 @@ export async function requireUnderbossAuth(
         regions,
         cities,
         isActive: underboss.isActive,
-      };
-      return next();
-    }
-
-    // Check if user is a graphics admin (preserve existing behavior)
-    const graphicsAdmin = await prisma.graphicsAdmin.findUnique({
-      where: { email: email.toLowerCase() },
-    });
-    if (graphicsAdmin) {
-      req.underboss = {
-        id: 'graphics-admin',
-        name: graphicsAdmin.name || 'Graphics Admin',
-        email,
-        region: '__admin__',
-        regions: ['__admin__'],
-        cities: [],
-        isActive: true,
       };
       return next();
     }

--- a/plans/buffalo-14542-graphics-admin-scope.md
+++ b/plans/buffalo-14542-graphics-admin-scope.md
@@ -1,0 +1,30 @@
+# buffalo-14542 — Graphics admin restricted to underboss city scope on Graphics Dashboard
+
+**Priority:** P1 (blocks a real user — graphics admin sees only 4 of ~760 events)
+
+## Problem
+
+A user who is BOTH a graphics admin AND an underboss with a limited city scope (e.g., 4 Sri Lankan cities) sees only those 4 cities' events on the Graphics Dashboard. Graphics admins are supposed to see all GPP events for flyer/graphics work.
+
+## Root cause
+
+`backend/src/middleware/underbossAuth.ts` checks the `underboss` table **before** the `graphicsAdmin` table. When the same email is in both, the underboss branch matches first and the graphics-admin fallback never fires — the user gets `req.underboss = { regions: [], cities: [4 SL cities] }`. The Graphics Dashboard calls `GET /api/underboss/all`, which uses `buildScopedWhereClause(scope)` to filter the Prisma `Party` query to only those 4 cities.
+
+`partyAccess.ts` (per-party edit / tab access) already short-circuits to allow for graphics admins. The listing scope check just needs to be made consistent.
+
+## Fix
+
+In `backend/src/middleware/underbossAuth.ts`, look up both the `underboss` row and the `graphicsAdmin` row in parallel. If the user is a graphics admin, set scope to admin-equivalent (`regions: ['__admin__']`) regardless of any underboss row.
+
+## Files to modify
+
+- `backend/src/middleware/underbossAuth.ts` (only file)
+
+No DB migration. No frontend changes. No Prisma changes.
+
+## Verification
+
+1. `cd backend && npm run build` passes.
+2. Backend Vercel preview deploys cleanly.
+3. Manual test post-deploy: graphics-admin-and-underboss user sees all GPP events on `/graphics`.
+4. Regression: underboss-only user still scoped; graphics-admin-only user still admin-scoped (unchanged).


### PR DESCRIPTION
## Summary

Graphics admins who are also underbosses with city scope were being restricted to their underboss cities on the Graphics Dashboard (saw 4 events instead of all GPP events). `requireUnderbossAuth` checked the underboss table before the graphics-admin table, so the graphics-admin fallback never fired when both records existed.

## Fix

`backend/src/middleware/underbossAuth.ts`: look up `underboss` and `graphicsAdmin` rows in parallel. If the user is a graphics admin, set scope to admin-equivalent (`regions: ['__admin__']`) regardless of any underboss row. Underboss identity fields are preserved on `req.underboss`. This matches the existing graphics-admin short-circuit in `partyAccess.ts`.

## Test plan

- [ ] Backend Vercel preview deploys cleanly
- [ ] Graphics-admin-AND-underboss user sees all GPP events on `/graphics`
- [ ] Underboss-only user still sees only their scoped cities/regions on `/underboss` (no regression)
- [ ] Graphics-admin-only user still sees all events on `/graphics` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)