### PR TITLE
fix(margherita-48195): Find a Venue modal - controlled input + Save/Cancel

### DIFF
--- a/frontend/src/components/checklist/ChecklistTab.tsx
+++ b/frontend/src/components/checklist/ChecklistTab.tsx
@@ -100,7 +100,7 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
 
   const handleNavigate = (tab: string) => {
     if (tab === 'venue') {
-      if (inviteCode) navigate(`/host/${inviteCode}`);
+      setFindVenueOpen(true);
       return;
     }
     if (inviteCode) {

--- a/frontend/src/components/checklist/FindVenueModal.tsx
+++ b/frontend/src/components/checklist/FindVenueModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2, X } from 'lucide-react';
 import { LocationAutocomplete } from '../LocationAutocomplete';
@@ -14,29 +14,47 @@ interface FindVenueModalProps {
 export const FindVenueModal: React.FC<FindVenueModalProps> = ({ open, onClose, onSaved }) => {
   const { t } = useTranslation('host');
   const { party, loadParty } = usePizza();
+  const [address, setAddress] = useState('');
+  const [venueName, setVenueName] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pendingCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
+  const pendingPlaceIdRef = useRef<string | null>(null);
+
+  // Seed from current party when opening; reset when closing
+  useEffect(() => {
+    if (open && party) {
+      setAddress(party.address ?? '');
+      setVenueName(party.venueName ?? null);
+      setError(null);
+      pendingCoordsRef.current = null;
+      pendingPlaceIdRef.current = null;
+    }
+    if (!open) {
+      setAddress('');
+      setVenueName(null);
+      setError(null);
+      pendingCoordsRef.current = null;
+      pendingPlaceIdRef.current = null;
+    }
+  }, [open, party?.id, party?.address, party?.venueName]);
 
   if (!open || !party) return null;
 
-  const handlePlaceSelected = async (
-    address: string,
-    venueName: string | null,
-    placeId: string | null,
-  ) => {
-    if (!party || saving) return;
-    const coords = pendingCoordsRef.current;
-    pendingCoordsRef.current = null;
+  const handleSave = async () => {
+    if (!address.trim() || saving) return;
     setSaving(true);
     setError(null);
     try {
       const success = await updateParty(party.id, {
-        address: address.trim() || null,
+        address: address.trim(),
         venue_name: venueName || null,
-        latitude: coords?.lat ?? null,
-        longitude: coords?.lng ?? null,
-        ...(placeId ? { place_id: placeId } : {}),
+        // Only include coords if we actually got a fresh pick — don't null out existing coords on free-form text save
+        ...(pendingCoordsRef.current ? {
+          latitude: pendingCoordsRef.current.lat,
+          longitude: pendingCoordsRef.current.lng,
+        } : {}),
+        ...(pendingPlaceIdRef.current ? { place_id: pendingPlaceIdRef.current } : {}),
       });
       if (!success) {
         setError(t('venue.findVenueSaveError'));
@@ -82,32 +100,47 @@ export const FindVenueModal: React.FC<FindVenueModalProps> = ({ open, onClose, o
         </p>
 
         <LocationAutocomplete
-          value=""
-          onChange={() => { /* committed via onPlaceSelected */ }}
+          value={venueName ? `${venueName}, ${address}` : address}
+          onChange={(v) => {
+            setVenueName(null);
+            setAddress(v);
+            pendingCoordsRef.current = null;
+            pendingPlaceIdRef.current = null;
+          }}
+          onVenueNameChange={setVenueName}
           onLocationSelected={(loc) => {
             pendingCoordsRef.current = loc;
           }}
-          onPlaceSelected={(address, venueName, placeId) => {
-            handlePlaceSelected(address, venueName, placeId);
+          onPlaceSelected={(addr, vName, placeId) => {
+            pendingPlaceIdRef.current = placeId;
+            setAddress(addr);
+            setVenueName(vName);
           }}
           placeholder={t('venue.findVenueModalPlaceholder')}
           disabled={saving}
         />
 
-        {saving && (
-          <div className="flex items-center gap-2 text-sm text-theme-text-muted mt-4">
-            <Loader2 size={14} className="animate-spin" />
-            {t('venue.saving')}
-          </div>
-        )}
+        {error && <p className="text-sm text-red-400 mt-3">{error}</p>}
 
-        {error && (
-          <p className="text-sm text-red-400 mt-3">{error}</p>
-        )}
-
-        <p className="text-xs text-theme-text-muted mt-5">
-          {t('venue.findVenueModalCta')}
-        </p>
+        <div className="flex gap-3 mt-5">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="flex-1 btn-secondary"
+          >
+            {t('venue.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!address.trim() || saving}
+            className="flex-1 btn-primary inline-flex items-center justify-center gap-2"
+          >
+            {saving && <Loader2 size={14} className="animate-spin" />}
+            {t('venue.findVenueModalCta')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/checklist/FindVenueModal.tsx
+++ b/frontend/src/components/checklist/FindVenueModal.tsx
@@ -4,6 +4,7 @@ import { Loader2, X } from 'lucide-react';
 import { LocationAutocomplete } from '../LocationAutocomplete';
 import { usePizza } from '../../contexts/PizzaContext';
 import { updateParty } from '../../lib/supabase';
+import { triggerFlyerRegen } from '../flyer/autoRegenFlyer';
 
 interface FindVenueModalProps {
   open: boolean;
@@ -63,6 +64,7 @@ export const FindVenueModal: React.FC<FindVenueModalProps> = ({ open, onClose, o
       if (party.inviteCode) {
         await loadParty(party.inviteCode);
       }
+      triggerFlyerRegen(party, loadParty);
       if (onSaved) {
         await onSaved();
       }

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -96,7 +96,7 @@ export const GPPDashboardTab: React.FC = () => {
         tab: item.linkTab,
         onClick: item.name === 'Build a Team' ? () => setHostsExpanded(prev => !prev) :
                  item.name === 'Find Partners' ? () => goToTab('partners') :
-                 item.name === 'Find a Venue' ? () => goToTab('details') : undefined,
+                 item.name === 'Find a Venue' ? () => setFindVenueOpen(true) : undefined,
         icon: ICON_MAP[item.name] ?? ClipboardCheck,
         dueDate: item.dueDate ? item.dueDate.split('T')[0] : null,
       };

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -208,7 +208,7 @@
     "findVenueModalTitle": "Find a Venue",
     "findVenueModalSubtitle": "Search for an address or named venue. We'll save it to your event.",
     "findVenueModalPlaceholder": "Search for an address or venue...",
-    "findVenueModalCta": "Picking a result saves the venue and ticks this checklist item.",
+    "findVenueModalCta": "Save venue",
     "findVenueSaveError": "Could not save the venue. Please try again.",
     "venueOptions": "Venue Options",
     "addVenue": "Add Venue",


### PR DESCRIPTION
## Summary
- Rewires `FindVenueModal` with real controlled state for `address` / `venueName` / coords / place_id (mirrors `EventDetailsTab.tsx`).
- Adds explicit Save and Cancel buttons. Save is disabled until address has text or while saving.
- Reverts the forno-25476 hotfix (#415) so the checklist row opens the now-working modal instead of routing to Settings.

## Root cause
Master had `<LocationAutocomplete value="" onChange={() => {}}>` — a controlled input pinned to empty. Typing produced no visible text and the Google Places dropdown never received a query.

## Behaviour
- Open modal → input seeded with `party.address` (if set) for editing.
- Type → characters render; Places dropdown surfaces suggestions.
- Pick a suggestion → input fills with `Venue, Address`; coords + place_id captured in refs; no PATCH yet.
- Click Save → PATCH writes `address`, `venue_name`, plus `latitude`/`longitude`/`place_id` only when a fresh pick was made (avoids nulling existing coords on free-form-text saves).
- Cancel or backdrop click → no save; state resets on next open.

## Test plan
- [ ] Click "Find a Venue" from /host/<code> → modal opens
- [ ] Type in input → characters appear (regression test)
- [ ] Pick a Google Places suggestion → input populates
- [ ] Click Save → checklist row ticks, modal closes
- [ ] Free-form-text save (no dropdown pick) → address saves, existing coords preserved
- [ ] Cancel button + backdrop click both close without saving
- [ ] Same flow from /host/<code>/checklist standalone tab

Generated with [Claude Code](https://claude.com/claude-code)