### PR TITLE
refactor(brick-oven-79150): shared HostFormModal for add+edit host

### DIFF
--- a/frontend/src/components/HostFormModal.tsx
+++ b/frontend/src/components/HostFormModal.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { User, Mail, Globe, Instagram, Send, Upload, UserPlus, Loader2 } from 'lucide-react';
+import { Checkbox } from './Checkbox';
+import { IconInput } from './IconInput';
+
+// X (Twitter) icon component
+const XIcon: React.FC<{ size?: number; className?: string }> = ({ size = 20, className }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+export interface HostFormModalProps {
+  open: boolean;
+  mode: 'add' | 'edit';
+  name: string;
+  email: string;
+  website: string;
+  twitter: string;
+  instagram: string;
+  telegram: string;
+  avatarUrl: string;
+  avatarFilePreview: string | null;
+  showOnEvent: boolean;
+  canEdit: boolean;
+  xAvatarFetching: boolean;
+  onNameChange: (v: string) => void;
+  onEmailChange: (v: string) => void;
+  onWebsiteChange: (v: string) => void;
+  onWebsiteBlur: () => void;
+  onTwitterChange: (v: string) => void;
+  onTwitterBlur: () => void | Promise<void>;
+  onInstagramChange: (v: string) => void;
+  onInstagramBlur: () => void;
+  onTelegramChange: (v: string) => void;
+  onTelegramBlur: () => void;
+  onShowOnEventChange: () => void;
+  onCanEditChange: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  onAvatarFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAvatarClear: () => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}
+
+const HostFormModal: React.FC<HostFormModalProps> = ({
+  open,
+  mode,
+  name,
+  email,
+  website,
+  twitter,
+  instagram,
+  telegram,
+  avatarUrl,
+  avatarFilePreview,
+  showOnEvent,
+  canEdit,
+  xAvatarFetching,
+  onNameChange,
+  onEmailChange,
+  onWebsiteChange,
+  onWebsiteBlur,
+  onTwitterChange,
+  onTwitterBlur,
+  onInstagramChange,
+  onInstagramBlur,
+  onTelegramChange,
+  onTelegramBlur,
+  onShowOnEventChange,
+  onCanEditChange,
+  fileInputRef,
+  onAvatarFileChange,
+  onAvatarClear,
+  onCancel,
+  onSubmit,
+  submitting,
+}) => {
+  if (!open) return null;
+
+  const title = mode === 'add' ? 'Add Host' : 'Edit Host';
+  const submitLabel = submitting
+    ? mode === 'add' ? 'Adding...' : 'Saving...'
+    : mode === 'add' ? 'Add Host' : 'Save';
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl max-w-md w-full p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold text-theme-text mb-4">{title}</h2>
+
+        <div className="space-y-3">
+          {/* Avatar upload */}
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={onAvatarFileChange}
+              className="hidden"
+            />
+            <div className="flex items-center gap-3">
+              {(avatarFilePreview || avatarUrl) ? (
+                <img
+                  src={avatarFilePreview || avatarUrl}
+                  alt=""
+                  className="w-10 h-10 rounded-full object-cover border border-white/20 shrink-0"
+                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                />
+              ) : (
+                <div className="w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke shrink-0" />
+              )}
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
+              >
+                <Upload size={16} />
+                Upload avatar
+              </button>
+              {(avatarFilePreview || avatarUrl) && (
+                <button
+                  type="button"
+                  onClick={onAvatarClear}
+                  className="text-xs text-red-400 hover:text-red-300"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
+
+          <IconInput
+            icon={User}
+            type="text"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder="Name"
+            required
+          />
+
+          <IconInput
+            icon={Mail}
+            type="email"
+            value={email}
+            onChange={(e) => onEmailChange(e.target.value)}
+            placeholder="Email (required to edit event)"
+          />
+
+          <IconInput
+            icon={Globe}
+            type="url"
+            value={website}
+            onChange={(e) => onWebsiteChange(e.target.value)}
+            onBlur={onWebsiteBlur}
+            placeholder="Website"
+          />
+
+          <div className="relative">
+            <IconInput
+              customIcon={<XIcon size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />}
+              type="text"
+              value={twitter}
+              onChange={(e) => onTwitterChange(e.target.value)}
+              onBlur={onTwitterBlur}
+              disabled={xAvatarFetching}
+              placeholder="Twitter (no @)"
+            />
+            {xAvatarFetching && (
+              <Loader2
+                size={14}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-muted animate-spin pointer-events-none"
+              />
+            )}
+          </div>
+
+          <IconInput
+            icon={Instagram}
+            type="text"
+            value={instagram}
+            onChange={(e) => onInstagramChange(e.target.value)}
+            onBlur={onInstagramBlur}
+            placeholder="Instagram (no @)"
+          />
+
+          <IconInput
+            icon={Send}
+            type="text"
+            value={telegram}
+            onChange={(e) => onTelegramChange(e.target.value)}
+            onBlur={onTelegramBlur}
+            placeholder="Telegram (no @)"
+          />
+        </div>
+
+        <div className="flex items-center gap-4 mt-3">
+          <Checkbox
+            checked={showOnEvent}
+            onChange={onShowOnEventChange}
+            label="Show on event"
+            size={16}
+            labelClassName="text-xs font-medium text-white/60"
+          />
+          <Checkbox
+            checked={canEdit}
+            onChange={onCanEditChange}
+            label="Editor"
+            size={16}
+            labelClassName="text-xs font-medium text-white/60"
+          />
+        </div>
+
+        <div className="flex gap-3 mt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-theme-surface-hover hover:bg-theme-surface-hover text-theme-text font-medium py-2.5 rounded-lg transition-colors text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={!name.trim() || submitting}
+            className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
+          >
+            <UserPlus size={16} />
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default HostFormModal;

--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -1,20 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
-import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp, Upload, Loader2, Send, Mail } from 'lucide-react';
+import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp, Send } from 'lucide-react';
 import { CoHost } from '../types';
 import { Checkbox } from './Checkbox';
-import { IconInput } from './IconInput';
+import HostFormModal from './HostFormModal';
 import { updateParty, addGuestByHost, proxyAvatarToStorage, uploadCoHostAvatar } from '../lib/supabase';
 import { fetchXAvatarToSupabase, isAutoFilledXAvatar } from '../utils/avatarUtils';
 import { uuid, normalizeUrl, stripToHandle } from '../lib/utils';
 import { ALL_HOST_TABS } from '../lib/tabPermissions';
-
-// X (Twitter) icon component
-const XIcon: React.FC<{ size?: number; className?: string }> = ({ size = 20, className }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>
-    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-  </svg>
-);
 
 interface HostsManagerProps {
   partyId: string;
@@ -543,331 +535,128 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
       </button>
 
       {/* Host Edit Modal */}
-      {editingHostId && createPortal(
-        <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70" onClick={cancelEditingHost}>
-          <div className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl max-w-md w-full p-5" onClick={(e) => e.stopPropagation()}>
-            <h2 className="text-lg font-semibold text-theme-text mb-4">Edit Host</h2>
-
-            <div className="space-y-3">
-              {/* Avatar upload */}
-              <div>
-                <input
-                  ref={editAvatarInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleEditAvatarFileChange}
-                  className="hidden"
-                />
-                <div className="flex items-center gap-3">
-                  {(editAvatarFilePreview || editHostAvatarUrl) ? (
-                    <img
-                      src={editAvatarFilePreview || editHostAvatarUrl}
-                      alt=""
-                      className="w-10 h-10 rounded-full object-cover border border-white/20 shrink-0"
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                    />
-                  ) : (
-                    <div className="w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke shrink-0" />
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => editAvatarInputRef.current?.click()}
-                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
-                  >
-                    <Upload size={16} />
-                    Upload avatar
-                  </button>
-                  {(editAvatarFilePreview || editHostAvatarUrl) && (
-                    <button
-                      type="button"
-                      onClick={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); setEditHostAvatarFromX(null); }}
-                      className="text-xs text-red-400 hover:text-red-300"
-                    >
-                      Clear
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              <IconInput
-                icon={User}
-                type="text"
-                value={editHostName}
-                onChange={(e) => setEditHostName(e.target.value)}
-                placeholder="Name"
-                required
-              />
-
-              <IconInput
-                icon={Mail}
-                type="email"
-                value={editHostEmail}
-                onChange={(e) => setEditHostEmail(e.target.value)}
-                placeholder="Email (required to edit event)"
-              />
-
-              <IconInput
-                icon={Globe}
-                type="url"
-                value={editHostWebsite}
-                onChange={(e) => setEditHostWebsite(e.target.value)}
-                onBlur={() => setEditHostWebsite(normalizeUrl(editHostWebsite))}
-                placeholder="Website"
-              />
-
-              <div className="relative">
-                <IconInput
-                  customIcon={<XIcon size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none" />}
-                  type="text"
-                  value={editHostTwitter}
-                  onChange={(e) => setEditHostTwitter(e.target.value)}
-                  onBlur={async () => {
-                    const handle = stripToHandle(editHostTwitter);
-                    setEditHostTwitter(handle);
-                    if (!handle) return;
-                    // Skip partial-handle lookups that resolve to wrong users
-                    if (handle.length < 4) return;
-                    if (editHostAvatarFile) return;
-                    // Already current for this handle — no-op
-                    if (editHostAvatarFromX === handle) return;
-                    // First-time fetch: only auto-fill empty slot or legacy unavatar URL
-                    if (editHostAvatarFromX == null) {
-                      if (editHostAvatarUrl.trim() && !isAutoFilledXAvatar(editHostAvatarUrl)) return;
-                    }
-                    setEditXAvatarFetching(true);
-                    try {
-                      const fetched = await fetchXAvatarToSupabase(handle);
-                      if (fetched) {
-                        setEditHostAvatarUrl(fetched);
-                        setEditHostAvatarFromX(handle);
-                      }
-                    } finally {
-                      setEditXAvatarFetching(false);
-                    }
-                  }}
-                  disabled={editXAvatarFetching}
-                  placeholder="Twitter (no @)"
-                />
-                {editXAvatarFetching && (
-                  <Loader2
-                    size={14}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-muted animate-spin pointer-events-none"
-                  />
-                )}
-              </div>
-
-              <IconInput
-                icon={Instagram}
-                type="text"
-                value={editHostInstagram}
-                onChange={(e) => setEditHostInstagram(e.target.value)}
-                onBlur={() => setEditHostInstagram(stripToHandle(editHostInstagram))}
-                placeholder="Instagram (no @)"
-              />
-
-              <IconInput
-                icon={Send}
-                type="text"
-                value={editHostTelegram}
-                onChange={(e) => setEditHostTelegram(e.target.value)}
-                onBlur={() => setEditHostTelegram(stripToHandle(editHostTelegram))}
-                placeholder="Telegram (no @)"
-              />
-            </div>
-
-            <div className="flex gap-3 mt-4">
-              <button
-                type="button"
-                onClick={cancelEditingHost}
-                className="flex-1 bg-theme-surface-hover hover:bg-theme-surface-hover text-theme-text font-medium py-2.5 rounded-lg transition-colors text-sm"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={saveHostEdit}
-                disabled={!editHostName.trim() || savingHost}
-                className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm"
-              >
-                {savingHost ? 'Saving...' : 'Save'}
-              </button>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
+      <HostFormModal
+        open={editingHostId !== null}
+        mode="edit"
+        name={editHostName}
+        email={editHostEmail}
+        website={editHostWebsite}
+        twitter={editHostTwitter}
+        instagram={editHostInstagram}
+        telegram={editHostTelegram}
+        avatarUrl={editHostAvatarUrl}
+        avatarFilePreview={editAvatarFilePreview}
+        showOnEvent={
+          editingHostId
+            ? (coHosts.find(h => h.id === editingHostId)?.showOnEvent !== false)
+            : true
+        }
+        canEdit={
+          editingHostId
+            ? (coHosts.find(h => h.id === editingHostId)?.canEdit === true)
+            : false
+        }
+        xAvatarFetching={editXAvatarFetching}
+        onNameChange={setEditHostName}
+        onEmailChange={setEditHostEmail}
+        onWebsiteChange={setEditHostWebsite}
+        onWebsiteBlur={() => setEditHostWebsite(normalizeUrl(editHostWebsite))}
+        onTwitterChange={setEditHostTwitter}
+        onTwitterBlur={async () => {
+          const handle = stripToHandle(editHostTwitter);
+          setEditHostTwitter(handle);
+          if (!handle) return;
+          // Skip partial-handle lookups that resolve to wrong users
+          if (handle.length < 4) return;
+          if (editHostAvatarFile) return;
+          // Already current for this handle — no-op
+          if (editHostAvatarFromX === handle) return;
+          // First-time fetch: only auto-fill empty slot or legacy unavatar URL
+          if (editHostAvatarFromX == null) {
+            if (editHostAvatarUrl.trim() && !isAutoFilledXAvatar(editHostAvatarUrl)) return;
+          }
+          setEditXAvatarFetching(true);
+          try {
+            const fetched = await fetchXAvatarToSupabase(handle);
+            if (fetched) {
+              setEditHostAvatarUrl(fetched);
+              setEditHostAvatarFromX(handle);
+            }
+          } finally {
+            setEditXAvatarFetching(false);
+          }
+        }}
+        onInstagramChange={setEditHostInstagram}
+        onInstagramBlur={() => setEditHostInstagram(stripToHandle(editHostInstagram))}
+        onTelegramChange={setEditHostTelegram}
+        onTelegramBlur={() => setEditHostTelegram(stripToHandle(editHostTelegram))}
+        onShowOnEventChange={() => { if (editingHostId) toggleCoHostShowOnEvent(editingHostId); }}
+        onCanEditChange={() => { if (editingHostId) toggleCoHostCanEdit(editingHostId); }}
+        fileInputRef={editAvatarInputRef}
+        onAvatarFileChange={handleEditAvatarFileChange}
+        onAvatarClear={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); setEditHostAvatarFromX(null); }}
+        onCancel={cancelEditingHost}
+        onSubmit={saveHostEdit}
+        submitting={savingHost}
+      />
 
       {/* Add Host Modal */}
-      {showAddHostModal && createPortal(
-        <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70" onClick={() => setShowAddHostModal(false)}>
-          <div className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl max-w-md w-full p-5" onClick={(e) => e.stopPropagation()}>
-            <h2 className="text-lg font-semibold text-theme-text mb-4">Add Host</h2>
-
-            <div className="space-y-3">
-              {/* Avatar upload */}
-              <div>
-                <input
-                  ref={newAvatarInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={handleNewAvatarFileChange}
-                  className="hidden"
-                />
-                <div className="flex items-center gap-3">
-                  {(newAvatarFilePreview || newCoHostAvatarUrl) ? (
-                    <img
-                      src={newAvatarFilePreview || newCoHostAvatarUrl}
-                      alt=""
-                      className="w-10 h-10 rounded-full object-cover border border-white/20 shrink-0"
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                    />
-                  ) : (
-                    <div className="w-10 h-10 rounded-full bg-theme-surface border border-theme-stroke shrink-0" />
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => newAvatarInputRef.current?.click()}
-                    className="flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-stroke rounded-lg text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors text-sm"
-                  >
-                    <Upload size={16} />
-                    Upload avatar
-                  </button>
-                  {(newAvatarFilePreview || newCoHostAvatarUrl) && (
-                    <button
-                      type="button"
-                      onClick={() => { setNewCoHostAvatarFile(null); setNewCoHostAvatarUrl(''); setNewCoHostAvatarFromX(null); }}
-                      className="text-xs text-red-400 hover:text-red-300"
-                    >
-                      Clear
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              <input
-                type="text"
-                value={newCoHostName}
-                onChange={(e) => setNewCoHostName(e.target.value)}
-                placeholder="Name *"
-                className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-              />
-
-              <input
-                type="email"
-                value={newCoHostEmail}
-                onChange={(e) => setNewCoHostEmail(e.target.value)}
-                placeholder="Email (required to edit event)"
-                className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-              />
-
-              <input
-                type="url"
-                value={newCoHostWebsite}
-                onChange={(e) => setNewCoHostWebsite(e.target.value)}
-                onBlur={() => setNewCoHostWebsite(normalizeUrl(newCoHostWebsite))}
-                placeholder="Website"
-                className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-              />
-
-              <div className="grid grid-cols-3 gap-3">
-                <div className="relative">
-                  <input
-                    type="text"
-                    value={newCoHostTwitter}
-                    onChange={(e) => setNewCoHostTwitter(e.target.value)}
-                    onBlur={async () => {
-                      const handle = stripToHandle(newCoHostTwitter);
-                      setNewCoHostTwitter(handle);
-                      if (!handle) return;
-                      // Skip partial-handle lookups that resolve to wrong users
-                      if (handle.length < 4) return;
-                      if (newCoHostAvatarFile) return;
-                      // Already current for this handle — no-op
-                      if (newCoHostAvatarFromX === handle) return;
-                      // First-time fetch: only auto-fill empty slot or legacy unavatar URL
-                      if (newCoHostAvatarFromX == null) {
-                        if (newCoHostAvatarUrl.trim() && !isAutoFilledXAvatar(newCoHostAvatarUrl)) return;
-                      }
-                      setNewXAvatarFetching(true);
-                      try {
-                        const fetched = await fetchXAvatarToSupabase(handle);
-                        if (fetched) {
-                          setNewCoHostAvatarUrl(fetched);
-                          setNewCoHostAvatarFromX(handle);
-                        }
-                      } finally {
-                        setNewXAvatarFetching(false);
-                      }
-                    }}
-                    disabled={newXAvatarFetching}
-                    placeholder="Twitter (no @)"
-                    className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a] disabled:opacity-60"
-                  />
-                  {newXAvatarFetching && (
-                    <Loader2
-                      size={14}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-muted animate-spin pointer-events-none"
-                    />
-                  )}
-                </div>
-                <input
-                  type="text"
-                  value={newCoHostInstagram}
-                  onChange={(e) => setNewCoHostInstagram(e.target.value)}
-                  onBlur={() => setNewCoHostInstagram(stripToHandle(newCoHostInstagram))}
-                  placeholder="Instagram (no @)"
-                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-                />
-                <input
-                  type="text"
-                  value={newCoHostTelegram}
-                  onChange={(e) => setNewCoHostTelegram(e.target.value)}
-                  onBlur={() => setNewCoHostTelegram(stripToHandle(newCoHostTelegram))}
-                  placeholder="Telegram (no @)"
-                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center gap-4 mt-3">
-              <Checkbox
-                checked={newCoHostShowOnEvent}
-                onChange={() => setNewCoHostShowOnEvent(!newCoHostShowOnEvent)}
-                label="Show on event"
-                size={16}
-                labelClassName="text-xs font-medium text-white/60"
-              />
-              <Checkbox
-                checked={newCoHostCanEdit}
-                onChange={() => setNewCoHostCanEdit(!newCoHostCanEdit)}
-                label="Editor"
-                size={16}
-                labelClassName="text-xs font-medium text-white/60"
-              />
-            </div>
-
-            <div className="flex gap-3 mt-4">
-              <button
-                type="button"
-                onClick={() => setShowAddHostModal(false)}
-                className="flex-1 bg-theme-surface-hover hover:bg-theme-surface-hover text-theme-text font-medium py-2.5 rounded-lg transition-colors text-sm"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={addCoHost}
-                disabled={!newCoHostName.trim() || savingHost}
-                className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
-              >
-                <UserPlus size={16} />
-                {savingHost ? 'Adding...' : 'Add Host'}
-              </button>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
+      <HostFormModal
+        open={showAddHostModal}
+        mode="add"
+        name={newCoHostName}
+        email={newCoHostEmail}
+        website={newCoHostWebsite}
+        twitter={newCoHostTwitter}
+        instagram={newCoHostInstagram}
+        telegram={newCoHostTelegram}
+        avatarUrl={newCoHostAvatarUrl}
+        avatarFilePreview={newAvatarFilePreview}
+        showOnEvent={newCoHostShowOnEvent}
+        canEdit={newCoHostCanEdit}
+        xAvatarFetching={newXAvatarFetching}
+        onNameChange={setNewCoHostName}
+        onEmailChange={setNewCoHostEmail}
+        onWebsiteChange={setNewCoHostWebsite}
+        onWebsiteBlur={() => setNewCoHostWebsite(normalizeUrl(newCoHostWebsite))}
+        onTwitterChange={setNewCoHostTwitter}
+        onTwitterBlur={async () => {
+          const handle = stripToHandle(newCoHostTwitter);
+          setNewCoHostTwitter(handle);
+          if (!handle) return;
+          // Skip partial-handle lookups that resolve to wrong users
+          if (handle.length < 4) return;
+          if (newCoHostAvatarFile) return;
+          // Already current for this handle — no-op
+          if (newCoHostAvatarFromX === handle) return;
+          // First-time fetch: only auto-fill empty slot or legacy unavatar URL
+          if (newCoHostAvatarFromX == null) {
+            if (newCoHostAvatarUrl.trim() && !isAutoFilledXAvatar(newCoHostAvatarUrl)) return;
+          }
+          setNewXAvatarFetching(true);
+          try {
+            const fetched = await fetchXAvatarToSupabase(handle);
+            if (fetched) {
+              setNewCoHostAvatarUrl(fetched);
+              setNewCoHostAvatarFromX(handle);
+            }
+          } finally {
+            setNewXAvatarFetching(false);
+          }
+        }}
+        onInstagramChange={setNewCoHostInstagram}
+        onInstagramBlur={() => setNewCoHostInstagram(stripToHandle(newCoHostInstagram))}
+        onTelegramChange={setNewCoHostTelegram}
+        onTelegramBlur={() => setNewCoHostTelegram(stripToHandle(newCoHostTelegram))}
+        onShowOnEventChange={() => setNewCoHostShowOnEvent(!newCoHostShowOnEvent)}
+        onCanEditChange={() => setNewCoHostCanEdit(!newCoHostCanEdit)}
+        fileInputRef={newAvatarInputRef}
+        onAvatarFileChange={handleNewAvatarFileChange}
+        onAvatarClear={() => { setNewCoHostAvatarFile(null); setNewCoHostAvatarUrl(''); setNewCoHostAvatarFromX(null); }}
+        onCancel={() => setShowAddHostModal(false)}
+        onSubmit={addCoHost}
+        submitting={savingHost}
+      />
     </div>
   );
 };

--- a/plans/brick-oven-79150-host-modal-refactor.md
+++ b/plans/brick-oven-79150-host-modal-refactor.md
@@ -1,0 +1,108 @@
+# brick-oven-79150 — Refactor add/edit host modals to share a single component
+
+## Problem
+`frontend/src/components/HostsManager.tsx` has two near-identical inline modals (~140 lines duplicated):
+- **Edit Host modal** (currently lines 510–631) — no permission checkboxes.
+- **Add Host modal** (currently lines 633–771) — adds "Show on event" + "Editor" checkboxes and a `UserPlus` icon on the submit button.
+
+Visual structure is otherwise identical.
+
+Per product decision: **both** modals will show the "Show on event" + "Editor" checkboxes. For Edit mode, they wire to `toggleCoHostShowOnEvent` / `toggleCoHostCanEdit` (the existing inline-row handlers).
+
+## Scope
+- Single component to extract; only `frontend/src/components/HostsManager.tsx` is modified, and one new file is added.
+- No backend, API, DB, or call-site changes (`EventDetailsTab.tsx` imports `HostsManager` and is untouched).
+
+## Approach
+
+### 1. New file: `frontend/src/components/HostFormModal.tsx`
+
+Presentational component. Owns modal chrome + form JSX; all state via props.
+
+```ts
+interface HostFormModalProps {
+  open: boolean;
+  mode: 'add' | 'edit';
+  name: string;
+  email: string;
+  website: string;
+  twitter: string;
+  instagram: string;
+  telegram: string;
+  avatarUrl: string;
+  avatarFilePreview: string | null;
+  showOnEvent: boolean;
+  canEdit: boolean;
+  xAvatarFetching: boolean;
+  onNameChange: (v: string) => void;
+  onEmailChange: (v: string) => void;
+  onWebsiteChange: (v: string) => void;
+  onWebsiteBlur: () => void;
+  onTwitterChange: (v: string) => void;
+  onTwitterBlur: () => void | Promise<void>;
+  onInstagramChange: (v: string) => void;
+  onInstagramBlur: () => void;
+  onTelegramChange: (v: string) => void;
+  onTelegramBlur: () => void;
+  onShowOnEventChange: () => void;
+  onCanEditChange: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  onAvatarFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAvatarClear: () => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}
+```
+
+JSX template — use the **edit modal version** as the base (current lines 511–630) and adapt:
+- Title: `mode === 'add' ? 'Add Host' : 'Edit Host'`
+- Submit button: `submitting ? (mode === 'add' ? 'Adding...' : 'Saving...') : (mode === 'add' ? 'Add Host' : 'Save')`
+- Submit button keeps `<UserPlus size={16} />` icon in both modes (use `flex items-center justify-center gap-2` classes from the current Add button).
+- Render the two `Checkbox`es (Show on event + Editor) in **both** modes, with the existing wrapper `<div className="flex items-center gap-4 mt-3">`, positioned after the input grid and before the button row (same position the Add modal uses today).
+- `createPortal(..., document.body)` exactly as today.
+- Guard with `if (!open) return null;` at top.
+
+Imports needed: `React`, `createPortal` from `react-dom`, `User, Mail, Globe, Instagram, Send, Upload, UserPlus, Loader2` from `lucide-react`, `Checkbox` from `./Checkbox`, `IconInput` from `./IconInput`.
+
+### 2. Modify `frontend/src/components/HostsManager.tsx`
+
+Replace the two inline modal JSX blocks (current lines 510–771) with two `<HostFormModal>` invocations.
+
+**Edit invocation:**
+- `open={editingHostId !== null}`
+- `mode="edit"`
+- All field props bound to existing `editHost*` state and setters
+- `avatarUrl={editHostAvatarUrl}`, `avatarFilePreview={editAvatarFilePreview}`
+- `fileInputRef={editAvatarInputRef}`, `onAvatarFileChange={handleEditAvatarFileChange}`
+- `onAvatarClear={() => { setEditHostAvatarFile(null); setEditHostAvatarUrl(''); setEditHostAvatarFromX(null); }}`
+- `showOnEvent` / `canEdit`: look up via `coHosts.find(h => h.id === editingHostId)`; default to safe fallbacks (`true`/`false`) if not found
+- `onShowOnEventChange={() => editingHostId && toggleCoHostShowOnEvent(editingHostId)}`
+- `onCanEditChange={() => editingHostId && toggleCoHostCanEdit(editingHostId)}`
+- `onWebsiteBlur={() => setEditHostWebsite(normalizeUrl(editHostWebsite))}`
+- `onTwitterBlur`: keep the existing async logic (strip handle → maybe fetch avatar). Encapsulate as an inline arrow that does what current lines 587–596 do.
+- `onInstagramBlur={() => setEditHostInstagram(stripToHandle(editHostInstagram))}`
+- `onTelegramBlur={() => setEditHostTelegram(stripToHandle(editHostTelegram))}`
+- `onSubmit={saveHostEdit}`, `onCancel={cancelEditingHost}`, `submitting={savingHost}`
+
+**Add invocation:** symmetric — bind to `newCoHost*` state, `newAvatarInputRef`, `handleNewAvatarFileChange`; `onSubmit={addCoHost}`, `onCancel={() => setShowAddHostModal(false)}`; `showOnEvent={newCoHostShowOnEvent}` with `onShowOnEventChange={() => setNewCoHostShowOnEvent(!newCoHostShowOnEvent)}`; same for `canEdit`.
+
+Add import: `import HostFormModal from './HostFormModal';` near the top.
+
+Leave the Add Host trigger button at line 500–508 unchanged (it keeps its own `UserPlus` icon).
+
+### 3. No call-site changes
+`EventDetailsTab.tsx` keeps importing `HostsManager` — public surface unchanged.
+
+## Test Plan
+- Open Edit Host modal — fields prefill from current host, checkboxes reflect current state, toggling them mutates the host record (same as inline row), Save persists, modal closes.
+- Open Add Host modal — empty fields, defaults Show=true, Editor=false, Add creates the host.
+- X handle blur in both modes auto-fetches avatar if avatar slot empty.
+- Website blur in both modes normalizes URL.
+- Cancel button + click-backdrop close both modals.
+- TypeScript build passes with zero errors.
+
+## Out of Scope
+- Permission tabs expander (current lines 452+) stays inline on the host row.
+- HostsList component (read-only host display) — separate UI surface, untouched.
+- Backend changes.


### PR DESCRIPTION
## Summary
- Extracts a new `frontend/src/components/HostFormModal.tsx` (~244 lines) and replaces both inline modals in `HostsManager.tsx` (-455+122 = ~333 lines removed, 122 added back as two invocations)
- Both Add and Edit now render the same component with `mode='add'|'edit'` switching title + submit label
- Per product decision, the "Show on event" + "Editor" checkboxes now appear in **both** modes. In Edit mode they're wired to the existing inline-row toggle handlers (`toggleCoHostShowOnEvent` / `toggleCoHostCanEdit`), so they mirror the row checkbox state
- Plan: `plans/brick-oven-79150-host-modal-refactor.md`

## Visual changes worth eyeballing on preview
- **Add modal previously stacked Twitter/Instagram/Telegram in a 3-column grid; Edit used single-column.** The shared component uses the Edit (single-column) layout per the plan, since the Edit JSX was used as the template. Snax — confirm this is the look you want, or we flip back to 3-column.
- **Add modal now uses `IconInput` for all fields** (matching project convention + Edit modal). Previously used raw `<input>` elements.
- **Edit modal now has the two checkboxes** ("Show on event" + "Editor") that the Add modal had. They toggle the same state as the inline row checkboxes.

## Test plan
- [ ] Open Add Host modal — empty fields, defaults Show=true Editor=false, Add creates host
- [ ] Open Edit Host modal — fields prefill, checkboxes reflect current state, toggling them mirrors the inline row toggle
- [ ] X/Twitter handle blur auto-fetches avatar in both modes (loading spinner visible)
- [ ] Website blur normalizes URL in both modes
- [ ] Cancel button + backdrop-click close both modals
- [ ] Telegram input present in both modes (regression check — agent caught this; my original plan omitted it)
- [ ] No console errors, no TS errors (`npx tsc --noEmit` passed locally)

Preview: https://rsvpizza-git-brick-oven-79150-host-modal-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)