### PR TITLE
feta-64218: surface Supabase upload errors to host

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -344,11 +344,10 @@ export const EventDetailsTab: React.FC = () => {
       // Upload image if file is selected
       let imageUrl = eventImageUrl.trim() || undefined;
       if (eventImageFile) {
-        const uploadedUrl = await uploadEventImage(eventImageFile);
-        if (uploadedUrl) {
-          imageUrl = uploadedUrl;
-        } else {
-          throw new Error('Failed to upload image. Please ensure the storage bucket is configured or use an image URL instead.');
+        try {
+          imageUrl = await uploadEventImage(eventImageFile);
+        } catch (err) {
+          throw new Error(err instanceof Error ? err.message : 'Failed to upload image. Please ensure the storage bucket is configured or use an image URL instead.');
         }
       }
 
@@ -585,11 +584,10 @@ export const EventDetailsTab: React.FC = () => {
   const saveImage = async () => {
     let imageUrl = eventImageUrl.trim() || undefined;
     if (eventImageFile) {
-      const uploadedUrl = await uploadEventImage(eventImageFile);
-      if (uploadedUrl) {
-        imageUrl = uploadedUrl;
-      } else {
-        setMessage({ type: 'error', text: 'Failed to upload image' });
+      try {
+        imageUrl = await uploadEventImage(eventImageFile);
+      } catch (err) {
+        setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Failed to upload image' });
         return;
       }
     }

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -237,11 +237,10 @@ export function EventForm() {
 
       let imageUrl = eventImageUrl.trim() || undefined;
       if (eventImageFile) {
-        const uploadedUrl = await uploadEventImage(eventImageFile);
-        if (uploadedUrl) {
-          imageUrl = uploadedUrl;
-        } else {
-          setImageError(t('eventForm.imageUploadFailed'));
+        try {
+          imageUrl = await uploadEventImage(eventImageFile);
+        } catch (err) {
+          setImageError(err instanceof Error ? err.message : t('eventForm.imageUploadFailed'));
           setCreating(false);
           return;
         }

--- a/frontend/src/components/PartyHeader.tsx
+++ b/frontend/src/components/PartyHeader.tsx
@@ -100,11 +100,10 @@ export const PartyHeader: React.FC = () => {
       // Upload image if file is selected
       let imageUrl = eventImageUrl.trim() || undefined;
       if (eventImageFile) {
-        const uploadedUrl = await uploadEventImage(eventImageFile);
-        if (uploadedUrl) {
-          imageUrl = uploadedUrl;
-        } else {
-          setImageError('Failed to upload image. Please try again.');
+        try {
+          imageUrl = await uploadEventImage(eventImageFile);
+        } catch (err) {
+          setImageError(err instanceof Error ? err.message : 'Failed to upload image. Please try again.');
           setCreating(false);
           return;
         }

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -37,6 +37,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
   const canvasRef = useRef<HTMLDivElement>(null);
   const [downloading, setDownloading] = useState(false);
   const [setImageState, setSetImageState] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle');
+  const [setImageError, setSetImageError] = useState<string | null>(null);
   const [sponsors, setSponsors] = useState<Sponsor[]>([]);
   const [containerWidth, setContainerWidth] = useState(500);
   const [hoveredElement, setHoveredElement] = useState<keyof FlyerPositions | null>(null);
@@ -703,6 +704,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
   const handleUseAsEventImage = async () => {
     if (!party) return;
     setSetImageState('uploading');
+    setSetImageError(null);
     try {
       const canvas = await renderFlyerToCanvas();
       const blob: Blob | null = await new Promise(resolve =>
@@ -717,7 +719,6 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
       );
 
       const uploadedUrl = await uploadEventImage(file);
-      if (!uploadedUrl) throw new Error('Upload failed');
 
       // Build flyerConfig from current customization state (only save non-default values)
       const hasCustomizations =
@@ -767,8 +768,12 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
       setTimeout(() => setSetImageState('idle'), 2000);
     } catch (err) {
       console.error('Failed to set flyer as event image:', err);
+      setSetImageError(err instanceof Error ? err.message : 'Upload failed');
       setSetImageState('error');
-      setTimeout(() => setSetImageState('idle'), 2500);
+      setTimeout(() => {
+        setSetImageState('idle');
+        setSetImageError(null);
+      }, 2500);
     }
   };
 
@@ -1700,6 +1705,12 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
           </button>
         )}
       </div>
+
+      {setImageError && (
+        <div className="text-xs text-red-400 text-center mt-2 px-4 break-words">
+          {setImageError}
+        </div>
+      )}
 
       {showAddSponsor && (
         <PartnerForm

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -357,11 +357,10 @@ export function PartnerForm({
       // Upload logo if a new file was selected (CRM, intake, and partner modes)
       if ((isCrm || isIntake || isPartner) && logoFile) {
         setUploadingLogo(true);
-        const uploadedUrl = await uploadSponsorLogo(logoFile);
-        if (uploadedUrl) {
-          logoUrl = uploadedUrl;
-        } else {
-          setError('Failed to upload logo. Please try again.');
+        try {
+          logoUrl = await uploadSponsorLogo(logoFile);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Failed to upload logo. Please try again.');
           setUploadingLogo(false);
           return;
         }
@@ -372,11 +371,10 @@ export function PartnerForm({
       let avatarUrl = formData.coHostAvatarUrl.trim() || undefined;
       if (avatarFile) {
         setUploadingAvatar(true);
-        const uploadedAvatar = await uploadSponsorLogo(avatarFile);
-        if (uploadedAvatar) {
-          avatarUrl = uploadedAvatar;
-        } else {
-          setError('Failed to upload avatar. Please try again.');
+        try {
+          avatarUrl = await uploadSponsorLogo(avatarFile);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Failed to upload avatar. Please try again.');
           setUploadingAvatar(false);
           return;
         }

--- a/frontend/src/hooks/useImageUpload.ts
+++ b/frontend/src/hooks/useImageUpload.ts
@@ -82,21 +82,16 @@ export function useImageUpload(options: UseImageUploadOptions = {}): UseImageUpl
 
     try {
       const uploadedUrl = await uploadEventImage(file, bucket);
-      if (uploadedUrl) {
-        // Clean up object URL after successful upload
-        if (objectUrl) {
-          URL.revokeObjectURL(objectUrl);
-          setObjectUrl(null);
-        }
-        setPreviewUrl(uploadedUrl);
-        setFile(null);
-        return uploadedUrl;
-      } else {
-        setError('Failed to upload image. Please try again.');
-        return null;
+      // Clean up object URL after successful upload
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        setObjectUrl(null);
       }
+      setPreviewUrl(uploadedUrl);
+      setFile(null);
+      return uploadedUrl;
     } catch (err) {
-      setError('Failed to upload image. Please try again.');
+      setError(err instanceof Error ? err.message : 'Failed to upload image. Please try again.');
       return null;
     } finally {
       setUploading(false);

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -83,7 +83,7 @@ export async function uploadProfilePicture(file: File, userId: string): Promise<
  * @param bucket The storage bucket name (default: 'event-images')
  * @returns The public URL of the uploaded image, or null if upload failed
  */
-export async function uploadEventImage(file: File, bucket: string = 'event-images'): Promise<string | null> {
+export async function uploadEventImage(file: File, bucket: string = 'event-images'): Promise<string> {
   try {
     // Generate unique filename
     const fileExt = file.name.split('.').pop();
@@ -100,7 +100,7 @@ export async function uploadEventImage(file: File, bucket: string = 'event-image
 
     if (error) {
       console.error('Error uploading image:', error);
-      return null;
+      throw new Error(error.message);
     }
 
     // Get public URL
@@ -111,7 +111,7 @@ export async function uploadEventImage(file: File, bucket: string = 'event-image
     return urlData.publicUrl;
   } catch (error) {
     console.error('Error uploading image:', error);
-    return null;
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }
 
@@ -120,7 +120,7 @@ export async function uploadEventImage(file: File, bucket: string = 'event-image
  * @param file The image file to upload
  * @returns The public URL of the uploaded logo, or null if upload failed
  */
-export async function uploadSponsorLogo(file: File): Promise<string | null> {
+export async function uploadSponsorLogo(file: File): Promise<string> {
   try {
     // Generate unique filename
     const fileExt = file.name.split('.').pop();
@@ -136,7 +136,7 @@ export async function uploadSponsorLogo(file: File): Promise<string | null> {
 
     if (error) {
       console.error('Error uploading sponsor logo:', error);
-      return null;
+      throw new Error(error.message);
     }
 
     // Get public URL
@@ -147,7 +147,7 @@ export async function uploadSponsorLogo(file: File): Promise<string | null> {
     return urlData.publicUrl;
   } catch (error) {
     console.error('Error uploading sponsor logo:', error);
-    return null;
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }
 


### PR DESCRIPTION
## Summary
- Switch `uploadEventImage` / `uploadSponsorLogo` from `Promise<string|null>` (swallowing the Supabase error) to `Promise<string>` (throwing it).
- Surface the thrown message in `FlyerGenerator`, `EventDetailsTab`, `PartnerForm`, and `useImageUpload` instead of the generic "Upload failed" string.

## Why
Craiova GPP host (2026-05-18) couldn't update their event flyer; the UI gave no diagnostic. Bucket size limit was raised 5MB->10MB during the incident, but the root cause was unverifiable because the error was swallowed. This makes every future upload failure self-explanatory.

## Test plan
- [ ] Normal "Use as Event Image" still succeeds and saves
- [ ] With auth cookie wiped, click triggers a real RLS message, not "Upload failed"
- [ ] Uploading an HEIC via Event Details shows MIME-rejection message
- [ ] Uploading >10MB sponsor logo shows size-limit message
- [ ] No regression in npm run typecheck

Generated with Claude Code