### PR TITLE
fake-detection: hide rejected events by default

### DIFF
--- a/frontend/src/components/underboss/FakeDetectionTable.tsx
+++ b/frontend/src/components/underboss/FakeDetectionTable.tsx
@@ -86,6 +86,7 @@ export function FakeDetectionTable() {
   });
   const [countryFilter, setCountryFilter] = useState<string>('all');
   const [onlyFlagged, setOnlyFlagged] = useState(false);
+  const [hideRejected, setHideRejected] = useState(true);  // default ON — rejected events clutter the queue
 
   // Per-row action state (keyed by party id)
   const [actionPending, setActionPending] = useState<Record<string, boolean>>({});
@@ -231,6 +232,10 @@ export function FakeDetectionTable() {
       rows = rows.filter((r) => r.flags.some((f) => f.fired));
     }
 
+    if (hideRejected) {
+      rows = rows.filter((r) => effectiveStatus(r) !== 'rejected');
+    }
+
     rows = [...rows].sort((a, b) => {
       let cmp = 0;
       switch (sortField) {
@@ -251,7 +256,7 @@ export function FakeDetectionTable() {
     });
 
     return rows;
-  }, [data, search, sortField, sortDir, tierFilters, countryFilter, onlyFlagged]);
+  }, [data, search, sortField, sortDir, tierFilters, countryFilter, onlyFlagged, hideRejected, statusOverride]);
 
   function toggleSort(field: SortField) {
     if (sortField === field) {
@@ -360,6 +365,13 @@ export function FakeDetectionTable() {
           checked={onlyFlagged}
           onChange={() => setOnlyFlagged((v) => !v)}
           label={t('fakeDetection.onlyFlagged', 'Only flagged')}
+          size={14}
+          labelClassName="text-xs text-theme-text"
+        />
+        <Checkbox
+          checked={hideRejected}
+          onChange={() => setHideRejected((v) => !v)}
+          label={t('fakeDetection.hideRejected', 'Hide rejected')}
           size={14}
           labelClassName="text-xs text-theme-text"
         />

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -155,6 +155,7 @@
     "country": "Country",
     "allCountries": "All",
     "onlyFlagged": "Only flagged",
+    "hideRejected": "Hide rejected",
     "noResults": "No events match the current filters.",
     "openEvent": "Open event page",
     "columns": {


### PR DESCRIPTION
## Why

Post-rejection cleanup left the fake-detection queue cluttered with already-actioned events. Mods asked for a quick way to focus on what still needs review.

## What

- New "Hide rejected" checkbox in the FakeDetectionTable filter row, alongside "Only flagged"
- Default ON (rejected events hidden by default)
- Uses `effectiveStatus(row)` so optimistic rejects (post-click, pre-server-confirm) also disappear from view immediately
- Pure client-side filter — no backend changes, no refetch
- Added `fakeDetection.hideRejected` to `en/admin.json` only; other 7 locales fall back to the English default

## Test plan

- [ ] Verify checkbox appears alongside "Only flagged" in the filter row
- [ ] Defaults to checked (rejected hidden)
- [ ] Toggle off → rejected events appear live without refetch
- [ ] Click Reject on a row → it disappears immediately while toggle is on