### PR TITLE
fix(map): filter stats include countries + InfoWindow no pan-back + click-outside dismiss

### DIFF
--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -63,6 +63,7 @@ export default function GPPEventsMap({
   const infoWindowListenerRef = useRef<google.maps.MapsEventListener | null>(
     null
   );
+  const mapClickListenerRef = useRef<google.maps.MapsEventListener | null>(null);
   const [error, setError] = useState(false);
 
   // Filter out events with no valid coordinates
@@ -364,8 +365,11 @@ export default function GPPEventsMap({
         const eventId = event.id;
         marker.addListener('click', () => {
           const latest = eventByIdRef.current.get(eventId) ?? event;
+          // Close first so setContent() doesn't trigger auto-pan against the
+          // previous anchor (which causes the "zoom back to old card" jitter).
+          infoWindow.close();
           infoWindow.setContent(buildInfoContent(latest));
-          infoWindow.open(map, marker);
+          infoWindow.open({ map, anchor: marker });
         });
 
         markers.push(marker);
@@ -405,6 +409,14 @@ export default function GPPEventsMap({
             });
           },
         },
+      });
+
+      if (mapClickListenerRef.current) {
+        mapClickListenerRef.current.remove();
+        mapClickListenerRef.current = null;
+      }
+      mapClickListenerRef.current = map.addListener('click', () => {
+        infoWindow.close();
       });
 
       // Fit bounds to all markers, then cap zoom at 15 on idle

--- a/frontend/src/pages/EventsMapPage.tsx
+++ b/frontend/src/pages/EventsMapPage.tsx
@@ -236,6 +236,19 @@ export function EventsMapPage() {
       ).size,
     [events]
   );
+  const filteredCityCount = useMemo(
+    () => new Set(filteredEvents.map((e) => e.city)).size,
+    [filteredEvents]
+  );
+  const filteredCountryCount = useMemo(
+    () =>
+      new Set(
+        filteredEvents
+          .map((e) => e.country)
+          .filter((c): c is string => !!c && c.trim() !== '')
+      ).size,
+    [filteredEvents]
+  );
 
   return (
     <>
@@ -357,7 +370,14 @@ export function EventsMapPage() {
                   {canModerate && activeFilterCount > 0 ? (
                     <>
                       {filteredEvents.length.toLocaleString()} of{' '}
-                      {events.length.toLocaleString()} matching
+                      {events.length.toLocaleString()} events across{' '}
+                      {filteredCityCount} {filteredCityCount === 1 ? 'city' : 'cities'}
+                      {filteredCountryCount > 0 && (
+                        <>
+                          {' '}in {filteredCountryCount}{' '}
+                          {filteredCountryCount === 1 ? 'country' : 'countries'}
+                        </>
+                      )}
                     </>
                   ) : (
                     <>


### PR DESCRIPTION
## Summary
Two related fixes bundled for `/map`:

- **pepperoni-77821** — Stats badge: when moderator filters are active, the badge previously showed only `X of Y matching`. It now shows `X of Y events across N cities in M countries`, matching the unfiltered string. Adds `filteredCityCount` and `filteredCountryCount` memos derived from `filteredEvents`.
- **sicilian-43215** — InfoWindow pan-back jitter: clicking a different pin used to pan the map back toward the previously-anchored card before settling on the new one. Fixed by calling `infoWindow.close()` before `setContent()` + `open()`, and switching to the options-object form (`{ map, anchor: marker }`). Also adds a map-level `click` listener that dismisses the open card when the user clicks empty map (Google Maps' map `click` does not bubble from markers/clusters/InfoWindow chrome, so this is safe).

## Files changed
- `frontend/src/pages/EventsMapPage.tsx`
- `frontend/src/components/GPPEventsMap.tsx`

## Test plan
- [ ] On `/map` as a non-moderator, the stats badge still reads `N events across X cities in Y countries`.
- [ ] On `/map` as a moderator with no filters active, same as above.
- [ ] As a moderator, apply a filter (status include/exclude, search, tag, or country); badge now reads `X of Y events across N cities in M countries`.
- [ ] When the filtered set spans 0 countries (e.g. all geocoded but country missing), the `in 0 countries` suffix is hidden.
- [ ] Click a pin to open its card; click a different pin — the new card opens at its anchor with no pan-back jitter toward the prior card.
- [ ] Click empty map area — the open card dismisses.
- [ ] Click a cluster bubble — zooms in (does NOT dismiss the card just because of the click).
- [ ] As a moderator, approve/reject from inside the card; the inline action still updates the marker color and card contents.

Task IDs: pepperoni-77821, sicilian-43215