### PR TITLE
gorgonzola-71284: show party Telegram group on public EventPage

### DIFF
--- a/frontend/src/i18n/locales/de/event.json
+++ b/frontend/src/i18n/locales/de/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Telegram-Gruppe",
   "notFound": {
     "title": "Event nicht gefunden",
     "goHome": "Zur Startseite"

--- a/frontend/src/i18n/locales/en/event.json
+++ b/frontend/src/i18n/locales/en/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Telegram group",
   "notFound": {
     "title": "Event Not Found",
     "goHome": "Go to Home"

--- a/frontend/src/i18n/locales/es/event.json
+++ b/frontend/src/i18n/locales/es/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Grupo de Telegram",
   "notFound": {
     "title": "Evento No Encontrado",
     "goHome": "Ir al Inicio"

--- a/frontend/src/i18n/locales/fr/event.json
+++ b/frontend/src/i18n/locales/fr/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Groupe Telegram",
   "notFound": {
     "title": "Événement introuvable",
     "goHome": "Retour à l'accueil"

--- a/frontend/src/i18n/locales/ja/event.json
+++ b/frontend/src/i18n/locales/ja/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Telegram グループ",
   "notFound": {
     "title": "イベントが見つかりません",
     "goHome": "ホームに戻る"

--- a/frontend/src/i18n/locales/ko/event.json
+++ b/frontend/src/i18n/locales/ko/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "텔레그램 그룹",
   "notFound": {
     "title": "이벤트를 찾을 수 없습니다",
     "goHome": "홈으로 이동"

--- a/frontend/src/i18n/locales/pt/event.json
+++ b/frontend/src/i18n/locales/pt/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Grupo do Telegram",
   "notFound": {
     "title": "Evento Não Encontrado",
     "goHome": "Ir para Início"

--- a/frontend/src/i18n/locales/zh/event.json
+++ b/frontend/src/i18n/locales/zh/event.json
@@ -1,4 +1,5 @@
 {
+  "telegramGroup": "Telegram 群组",
   "notFound": {
     "title": "未找到活动",
     "goHome": "返回首页"

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -36,7 +36,7 @@ import VenueMap from '../components/VenueMap';
 import { CheckInButton } from '../components/CheckInButton';
 import { GuestScorecard } from '../components/scorecard';
 
-function normalizeTelegramUrl(raw: string | null | undefined): { href: string; display: string } | null {
+function normalizeTelegramUrl(raw: string | null | undefined): string | null {
   if (!raw) return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
@@ -45,8 +45,7 @@ function normalizeTelegramUrl(raw: string | null | undefined): { href: string; d
     try {
       const u = new URL(trimmed);
       if (!/(^|\.)t\.me$/i.test(u.hostname) && !/(^|\.)telegram\.me$/i.test(u.hostname)) return null;
-      const path = u.pathname.replace(/^\/+/, '');
-      return { href: u.toString(), display: path ? `t.me/${path}` : 't.me' };
+      return u.toString();
     } catch {
       return null;
     }
@@ -54,13 +53,12 @@ function normalizeTelegramUrl(raw: string | null | undefined): { href: string; d
 
   const noScheme = trimmed.match(/^(?:t\.me|telegram\.me)\/(.+)$/i);
   if (noScheme) {
-    const path = noScheme[1].replace(/^\/+/, '');
-    return { href: `https://t.me/${path}`, display: `t.me/${path}` };
+    return `https://t.me/${noScheme[1].replace(/^\/+/, '')}`;
   }
 
   const bare = trimmed.replace(/^@/, '');
   if (/^[A-Za-z0-9_+\-]{3,}$/.test(bare)) {
-    return { href: `https://t.me/${bare}`, display: `t.me/${bare}` };
+    return `https://t.me/${bare}`;
   }
 
   return null;
@@ -941,10 +939,10 @@ export function EventPage() {
                     {/* Telegram group */}
                     {telegramLink && (
                       <a
-                        href={telegramLink.href}
+                        href={telegramLink}
                         target="_blank"
                         rel="noopener noreferrer"
-                        onClick={() => slug && trackLinkClick(slug, telegramLink.href, 'telegram')}
+                        onClick={() => slug && trackLinkClick(slug, telegramLink, 'telegram')}
                         className="flex items-start gap-3 group"
                         data-testid="event-telegram"
                       >
@@ -955,7 +953,6 @@ export function EventPage() {
                           <p className="text-lg font-medium text-theme-text group-hover:text-[#ff393a] transition-colors">
                             {t('telegramGroup')}
                           </p>
-                          <p className="text-base text-theme-text-secondary">{telegramLink.display}</p>
                         </div>
                       </a>
                     )}
@@ -1074,10 +1071,10 @@ export function EventPage() {
                 {/* Mobile: Telegram group */}
                 {telegramLink && (
                   <a
-                    href={telegramLink.href}
+                    href={telegramLink}
                     target="_blank"
                     rel="noopener noreferrer"
-                    onClick={() => slug && trackLinkClick(slug, telegramLink.href, 'telegram')}
+                    onClick={() => slug && trackLinkClick(slug, telegramLink, 'telegram')}
                     className="md:hidden flex items-start gap-3 group"
                   >
                     <div className="flex-shrink-0 w-11 h-12 rounded-lg border border-theme-stroke bg-theme-surface flex items-center justify-center mt-0.5 group-hover:border-[#ff393a] transition-colors">
@@ -1087,7 +1084,6 @@ export function EventPage() {
                       <p className="text-lg font-medium text-theme-text group-hover:text-[#ff393a] transition-colors">
                         {t('telegramGroup')}
                       </p>
-                      <p className="text-base text-theme-text-secondary">{telegramLink.display}</p>
                     </div>
                   </a>
                 )}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet-async';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
-import { MapPin, Users, Pizza, Loader2, Lock, AlertCircle, Settings, Heart, Camera, Link2, LogIn } from 'lucide-react';
+import { MapPin, Users, Pizza, Loader2, Lock, AlertCircle, Settings, Heart, Camera, Link2, LogIn, Send } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { verifyPartyPassword, isUserGuestAtParty, getExistingGuest, ExistingGuestData } from '../lib/supabase';
 import { getEventBySlug, PublicEvent, getPhotoStats, verifyTweet, trackLinkClick } from '../lib/api';
@@ -35,6 +35,36 @@ import { LastYearPhotos } from '../components/LastYearPhotos';
 import VenueMap from '../components/VenueMap';
 import { CheckInButton } from '../components/CheckInButton';
 import { GuestScorecard } from '../components/scorecard';
+
+function normalizeTelegramUrl(raw: string | null | undefined): { href: string; display: string } | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const u = new URL(trimmed);
+      if (!/(^|\.)t\.me$/i.test(u.hostname) && !/(^|\.)telegram\.me$/i.test(u.hostname)) return null;
+      const path = u.pathname.replace(/^\/+/, '');
+      return { href: u.toString(), display: path ? `t.me/${path}` : 't.me' };
+    } catch {
+      return null;
+    }
+  }
+
+  const noScheme = trimmed.match(/^(?:t\.me|telegram\.me)\/(.+)$/i);
+  if (noScheme) {
+    const path = noScheme[1].replace(/^\/+/, '');
+    return { href: `https://t.me/${path}`, display: `t.me/${path}` };
+  }
+
+  const bare = trimmed.replace(/^@/, '');
+  if (/^[A-Za-z0-9_+\-]{3,}$/.test(bare)) {
+    return { href: `https://t.me/${bare}`, display: `t.me/${bare}` };
+  }
+
+  return null;
+}
 
 export function EventPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -515,6 +545,8 @@ export function EventPage() {
         ? `https://www.google.com/maps/search/?api=1&query=${event.latitude},${event.longitude}`
         : null;
 
+  const telegramLink = normalizeTelegramUrl(event.telegramGroup);
+
   const metaTitle = event.name;
 
   // Construct description: Host * Date @ Time * Location. Description
@@ -906,6 +938,28 @@ export function EventPage() {
                       </a>
                     )}
 
+                    {/* Telegram group */}
+                    {telegramLink && (
+                      <a
+                        href={telegramLink.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => slug && trackLinkClick(slug, telegramLink.href, 'telegram')}
+                        className="flex items-start gap-3 group"
+                        data-testid="event-telegram"
+                      >
+                        <div className="flex-shrink-0 w-11 h-12 rounded-lg border border-theme-stroke bg-theme-surface flex items-center justify-center mt-0.5 group-hover:border-[#ff393a] transition-colors">
+                          <Send className="w-5 h-5 text-theme-text" />
+                        </div>
+                        <div>
+                          <p className="text-lg font-medium text-theme-text group-hover:text-[#ff393a] transition-colors">
+                            {t('telegramGroup')}
+                          </p>
+                          <p className="text-base text-theme-text-secondary">{telegramLink.display}</p>
+                        </div>
+                      </a>
+                    )}
+
                     {/* RSVP Button (+ Check In) - Desktop */}
                     <div className="pt-1">
                       {showCheckIn ? (
@@ -1013,6 +1067,27 @@ export function EventPage() {
                         <p className="text-lg font-medium text-theme-text group-hover:text-[#ff393a] transition-colors">{event.venueName}</p>
                       )}
                       <p className={`${event.venueName ? 'text-base text-theme-text-secondary' : 'text-lg font-medium text-theme-text group-hover:text-[#ff393a] transition-colors'}`}>{event.address}</p>
+                    </div>
+                  </a>
+                )}
+
+                {/* Mobile: Telegram group */}
+                {telegramLink && (
+                  <a
+                    href={telegramLink.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => slug && trackLinkClick(slug, telegramLink.href, 'telegram')}
+                    className="md:hidden flex items-start gap-3 group"
+                  >
+                    <div className="flex-shrink-0 w-11 h-12 rounded-lg border border-theme-stroke bg-theme-surface flex items-center justify-center mt-0.5 group-hover:border-[#ff393a] transition-colors">
+                      <Send className="w-5 h-5 text-theme-text" />
+                    </div>
+                    <div>
+                      <p className="text-lg font-medium text-theme-text group-hover:text-[#ff393a] transition-colors">
+                        {t('telegramGroup')}
+                      </p>
+                      <p className="text-base text-theme-text-secondary">{telegramLink.display}</p>
                     </div>
                   </a>
                 )}


### PR DESCRIPTION
## Summary
- Renders a Telegram-group card under the address block on the public EventPage (desktop + mobile layouts).
- Public visibility (no RSVP gate); uses `lucide-react` `Send` icon; clicks tracked via `trackLinkClick(slug, url, 'telegram')`.
- Accepts `@handle`, `t.me/handle`, `https://t.me/+invite`, or bare-handle inputs via a local `normalizeTelegramUrl` helper; unparseable values render nothing.
- i18n keys added in all 8 locales (en, de, es, fr, ja, ko, pt, zh).

## Backend
None. The `parties.telegram_group` column + anon SELECT grant + public `/api/events/:slug` payload + `PublicEvent.telegramGroup` were already in place. This PR is the FE render only.

## Test plan
- [ ] Vercel preview builds.
- [ ] On a party with `telegram_group` set, the card renders under the address on desktop and mobile widths.
- [ ] Clicking the card opens `https://t.me/...` in a new tab and POSTs to `/api/events/:slug/click`.
- [ ] Setting `telegram_group` to `@handle`, `t.me/handle`, and `https://t.me/+invite` all render and link correctly.
- [ ] Setting `telegram_group` to garbage (e.g. `not a url`) does NOT render the card.
- [ ] Card hidden when `telegram_group` is null/empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)