### PR TITLE
fix(marinara-31247): public /map shows approved events only

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3460,7 +3460,7 @@ export async function fetchGppEventsForMap(force?: boolean, curated?: boolean, i
     coHostTelegrams: e.coHostTelegrams ?? [],
   }));
   if (curated) {
-    events = events.filter((e) => e.underbossStatus === 'approved' || e.underbossStatus === 'listed');
+    events = events.filter((e) => e.underbossStatus === 'approved');
   }
   return events;
 }


### PR DESCRIPTION
## Task
marinara-31247 — public `/map` should only show `approved` events, not `listed`.

## Summary
On rsv.pizza/map for logged-out / non-moderator visitors, the curated event set previously included both `underbossStatus === 'approved'` AND `'listed'` (community tier). This PR drops the `listed` filter from `fetchGppEventsForMap`'s curated branch so the public map renders approved events only. Moderator code paths and the `statuses=all` flow are untouched, so underbosses still see everything via existing toggles. The backend `/api/gpp/events` route is also unchanged because other callers (e.g. `/gpp` landing page community tiles) depend on listed events.

## Test plan
- [ ] Log out (or open incognito), visit `/map`, confirm no `listed` events appear (compare counts before/after).
- [ ] Sign in as underboss, verify listed events still appear and toggles still work.
- [ ] `/gpp` landing page community tiles still show listed events (no regression).