### PR TITLE
marinara-67583: /underboss/outreach admin tab

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -223,6 +223,7 @@ model Party {
   slugAliases           SlugAlias[]
   scorecardItems        GuestScorecardItem[]
   payouts               Payout[]
+  outreachAttempts      OutreachAttempt[]
 
   @@map("parties")
 }
@@ -1518,4 +1519,54 @@ model PayoutAudit {
   @@index([payoutId])
   @@index([createdAt(sort: Desc)])
   @@map("payout_audit")
+}
+
+// marinara-67583 + stagioni-29104: Outreach to candidate blockchain communities
+// for GPP 2026 in uncovered cities.
+//
+// NOTE: OutreachCommunity is duplicated from PR #428 (stagioni-29104) to allow
+// `prisma generate` to succeed independently on this branch. Whichever PR
+// merges first wins; the other resolves the dup by removing this model block.
+model OutreachCommunity {
+  id             String    @id @default(cuid())
+  city           String
+  country        String?
+  communityName  String    @map("community_name")
+  source         String
+  contactHandle  String?   @map("contact_handle")
+  contactUrl     String    @map("contact_url")
+  contactEmail   String?   @map("contact_email")
+  followerCount  Int?      @map("follower_count")
+  activityScore  Decimal?  @map("activity_score") @db.Decimal(10, 4)
+  priority       String?
+  notes          String?
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+  attempts       OutreachAttempt[]
+
+  @@unique([source, contactUrl])
+  @@index([city])
+  @@index([priority])
+  @@map("outreach_communities")
+}
+
+model OutreachAttempt {
+  id                String   @id @default(cuid())
+  communityId       String   @map("community_id")
+  community         OutreachCommunity @relation(fields: [communityId], references: [id], onDelete: Cascade)
+  channel           String   // 'twitter_dm' | 'email' | 'telegram'
+  templateId        String   @map("template_id") // 'v1_twitter' | 'v1_email' | 'v1_telegram'
+  sentAt            DateTime @default(now()) @map("sent_at") @db.Timestamptz
+  sentBy            String   @map("sent_by") // admin email from req.userEmail
+  status            String   @default("sent") // 'sent' | 'replied' | 'declined' | 'converted' | 'bounced'
+  convertedPartyId  String?  @map("converted_party_id") @db.Uuid
+  convertedParty    Party?   @relation(fields: [convertedPartyId], references: [id], onDelete: SetNull)
+  notes             String?
+  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([communityId])
+  @@index([status])
+  @@index([sentAt(sort: Desc)])
+  @@map("outreach_attempts")
 }

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -482,6 +482,252 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
   }
 });
 
+// ============================================
+// Outreach (marinara-67583)
+// Admin/underboss tool for tracking outreach to candidate blockchain
+// communities in uncovered cities. Per-route middleware ONLY — no
+// `router.use('/outreach', ...)` (see memory: arugula-38633).
+// NOTE: Must be registered BEFORE /:region catch-all.
+// ============================================
+
+const OUTREACH_CHANNELS = ['twitter_dm', 'email', 'telegram'] as const;
+const OUTREACH_TEMPLATE_IDS = ['v1_twitter', 'v1_email', 'v1_telegram'] as const;
+const OUTREACH_STATUSES = ['sent', 'replied', 'declined', 'converted', 'bounced'] as const;
+
+function formatOutreachCommunity(community: any) {
+  const attempts: any[] = Array.isArray(community.attempts) ? community.attempts : [];
+  const last = attempts.length > 0 ? attempts[0] : null;
+  return {
+    id: community.id,
+    city: community.city,
+    country: community.country ?? null,
+    name: community.communityName,
+    source: community.source,
+    contactHandle: community.contactHandle ?? null,
+    contactUrl: community.contactUrl,
+    contactEmail: community.contactEmail ?? null,
+    twitterHandle:
+      community.source && community.source.toLowerCase().includes('twitter')
+        ? community.contactHandle ?? null
+        : null,
+    telegramHandle:
+      community.source && community.source.toLowerCase().includes('telegram')
+        ? community.contactHandle ?? null
+        : null,
+    email: community.contactEmail ?? null,
+    followerCount: community.followerCount ?? null,
+    priority: community.priority ?? null,
+    notes: community.notes ?? null,
+    lastAttempt: last
+      ? {
+          id: last.id,
+          channel: last.channel,
+          templateId: last.templateId,
+          sentAt: last.sentAt instanceof Date ? last.sentAt.toISOString() : last.sentAt,
+          sentBy: last.sentBy,
+          status: last.status,
+          convertedPartyId: last.convertedPartyId ?? null,
+          notes: last.notes ?? null,
+        }
+      : null,
+    attemptCount: community._count?.attempts ?? attempts.length,
+    createdAt: community.createdAt instanceof Date ? community.createdAt.toISOString() : community.createdAt,
+    updatedAt: community.updatedAt instanceof Date ? community.updatedAt.toISOString() : community.updatedAt,
+  };
+}
+
+// GET /api/underboss/outreach/communities - List outreach candidates with latest attempt
+router.get('/outreach/communities', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const cityFilter = typeof req.query.city === 'string' ? req.query.city.trim() : '';
+    const priorityFilter = typeof req.query.priority === 'string' ? req.query.priority.trim() : '';
+    const sourceFilter = typeof req.query.source === 'string' ? req.query.source.trim() : '';
+    const statusFilter = typeof req.query.status === 'string' ? req.query.status.trim() : '';
+
+    const where: any = {};
+    if (cityFilter) where.city = { contains: cityFilter, mode: 'insensitive' };
+    if (priorityFilter) where.priority = priorityFilter;
+    if (sourceFilter) where.source = sourceFilter;
+    if (statusFilter === 'none') where.attempts = { none: {} };
+
+    const rows = await prisma.outreachCommunity.findMany({
+      where,
+      include: {
+        attempts: {
+          orderBy: { sentAt: 'desc' },
+          take: 1,
+        },
+        _count: { select: { attempts: true } },
+      },
+      orderBy: [
+        { priority: 'asc' },
+        { followerCount: 'desc' },
+        { city: 'asc' },
+      ],
+    });
+
+    let formatted = rows.map(formatOutreachCommunity);
+
+    // For status filters other than 'none' / '', post-filter on latest attempt status.
+    if (statusFilter && statusFilter !== 'none') {
+      if (!(OUTREACH_STATUSES as readonly string[]).includes(statusFilter)) {
+        throw new AppError(
+          `status must be one of: ${OUTREACH_STATUSES.join(', ')}, none`,
+          400,
+          'VALIDATION_ERROR'
+        );
+      }
+      formatted = formatted.filter((c) => c.lastAttempt?.status === statusFilter);
+    }
+
+    res.json({ communities: formatted });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/underboss/outreach/attempts - Log a new outreach attempt
+router.post('/outreach/attempts', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const { communityId, channel, templateId, notes } = req.body ?? {};
+
+    if (!communityId || typeof communityId !== 'string') {
+      throw new AppError('communityId is required', 400, 'VALIDATION_ERROR');
+    }
+    if (!channel || !(OUTREACH_CHANNELS as readonly string[]).includes(channel)) {
+      throw new AppError(`channel must be one of: ${OUTREACH_CHANNELS.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+    if (!templateId || !(OUTREACH_TEMPLATE_IDS as readonly string[]).includes(templateId)) {
+      throw new AppError(`templateId must be one of: ${OUTREACH_TEMPLATE_IDS.join(', ')}`, 400, 'VALIDATION_ERROR');
+    }
+    if (notes !== undefined && notes !== null && typeof notes !== 'string') {
+      throw new AppError('notes must be a string', 400, 'VALIDATION_ERROR');
+    }
+
+    const community = await prisma.outreachCommunity.findUnique({
+      where: { id: communityId },
+      select: { id: true },
+    });
+    if (!community) {
+      throw new AppError('community not found', 404, 'NOT_FOUND');
+    }
+
+    const sentBy = req.underboss?.email || req.userEmail || '';
+    if (!sentBy) {
+      throw new AppError('authenticated email missing', 401, 'UNAUTHORIZED');
+    }
+
+    const attempt = await prisma.outreachAttempt.create({
+      data: {
+        communityId,
+        channel,
+        templateId,
+        sentBy,
+        notes: notes ?? null,
+        // status defaults to 'sent' per schema
+      },
+    });
+
+    res.status(201).json({ attempt });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/underboss/outreach/attempts/:id - Update status / link converted party / notes
+router.patch('/outreach/attempts/:id', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+    const { status, convertedPartyId, notes } = req.body ?? {};
+
+    if (status === undefined && convertedPartyId === undefined && notes === undefined) {
+      throw new AppError('nothing to update', 400, 'VALIDATION_ERROR');
+    }
+
+    const updateData: any = {};
+
+    if (status !== undefined) {
+      if (!(OUTREACH_STATUSES as readonly string[]).includes(status)) {
+        throw new AppError(
+          `status must be one of: ${OUTREACH_STATUSES.join(', ')}`,
+          400,
+          'VALIDATION_ERROR'
+        );
+      }
+      updateData.status = status;
+    }
+
+    if (convertedPartyId !== undefined) {
+      if (convertedPartyId === null) {
+        updateData.convertedPartyId = null;
+      } else if (typeof convertedPartyId === 'string') {
+        const party = await prisma.party.findUnique({
+          where: { id: convertedPartyId },
+          select: { id: true },
+        });
+        if (!party) {
+          throw new AppError('party not found', 404, 'NOT_FOUND');
+        }
+        updateData.convertedPartyId = convertedPartyId;
+      } else {
+        throw new AppError('convertedPartyId must be a string or null', 400, 'VALIDATION_ERROR');
+      }
+    }
+
+    if (notes !== undefined) {
+      if (notes !== null && typeof notes !== 'string') {
+        throw new AppError('notes must be a string or null', 400, 'VALIDATION_ERROR');
+      }
+      updateData.notes = notes;
+    }
+
+    const existing = await prisma.outreachAttempt.findUnique({ where: { id }, select: { id: true } });
+    if (!existing) {
+      throw new AppError('attempt not found', 404, 'NOT_FOUND');
+    }
+
+    const attempt = await prisma.outreachAttempt.update({
+      where: { id },
+      data: updateData,
+    });
+
+    res.json({ attempt });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/underboss/outreach/parties-search?q=<query> - Search parties for "Link to converted party"
+router.get('/outreach/parties-search', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!q || q.length < 2) {
+      return res.json({ parties: [] });
+    }
+
+    const parties = await prisma.party.findMany({
+      where: {
+        OR: [
+          { name: { contains: q, mode: 'insensitive' } },
+          { customUrl: { contains: q, mode: 'insensitive' } },
+        ],
+      },
+      select: {
+        id: true,
+        name: true,
+        customUrl: true,
+        city: true,
+      },
+      take: 10,
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({ parties });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // GET /api/underboss/:region - Main dashboard data
 router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {

--- a/frontend/src/components/underboss/OutreachLinkPartyModal.tsx
+++ b/frontend/src/components/underboss/OutreachLinkPartyModal.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Loader2, Search, X } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import {
+  searchPartiesForOutreach,
+  updateOutreachAttempt,
+  type OutreachPartySearchResult,
+} from '../../lib/api';
+
+interface OutreachLinkPartyModalProps {
+  attemptId: string;
+  communityName: string;
+  onClose: () => void;
+  onLinked: () => void;
+}
+
+export function OutreachLinkPartyModal({
+  attemptId,
+  communityName,
+  onClose,
+  onLinked,
+}: OutreachLinkPartyModalProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<OutreachPartySearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [linking, setLinking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!query.trim() || query.trim().length < 2) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const rows = await searchPartiesForOutreach(query.trim());
+        setResults(rows);
+      } catch (e: any) {
+        setError(e?.message || 'Search failed');
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
+
+  const handlePick = async (party: OutreachPartySearchResult) => {
+    setLinking(true);
+    setError(null);
+    try {
+      await updateOutreachAttempt(attemptId, { convertedPartyId: party.id });
+      onLinked();
+      onClose();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to link party');
+      setLinking(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-card border border-theme-stroke rounded-2xl p-6 w-full max-w-xl mx-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-theme-text">Link converted party</h3>
+            <p className="text-sm text-theme-text-muted mt-1">
+              Outreach to <span className="text-theme-text">{communityName}</span>
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-theme-text-faint hover:text-theme-text-secondary"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <IconInput
+          icon={Search}
+          placeholder="Search by event name or custom URL..."
+          value={query}
+          onChange={(e: any) => setQuery(e.target.value)}
+          autoFocus
+        />
+
+        <div className="mt-4 min-h-[120px]">
+          {searching && (
+            <div className="flex items-center justify-center py-6 text-theme-text-muted">
+              <Loader2 size={18} className="animate-spin" />
+            </div>
+          )}
+          {!searching && query.trim().length >= 2 && results.length === 0 && (
+            <div className="text-center py-6 text-sm text-theme-text-muted">
+              No matching events. Try a different search.
+            </div>
+          )}
+          {!searching && query.trim().length < 2 && (
+            <div className="text-center py-6 text-sm text-theme-text-muted">
+              Type at least 2 characters to search.
+            </div>
+          )}
+          {results.length > 0 && (
+            <ul className="divide-y divide-theme-stroke">
+              {results.map((party) => (
+                <li key={party.id}>
+                  <button
+                    type="button"
+                    disabled={linking}
+                    onClick={() => handlePick(party)}
+                    className="w-full text-left px-3 py-3 hover:bg-theme-surface rounded-lg disabled:opacity-50"
+                  >
+                    <div className="font-medium text-theme-text">{party.name}</div>
+                    <div className="text-xs text-theme-text-muted mt-0.5 flex items-center gap-2">
+                      {party.city && <span>{party.city}</span>}
+                      {party.customUrl && (
+                        <span className="text-theme-text-faint">rsv.pizza/{party.customUrl}</span>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {error && (
+          <div className="mt-3 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-sm text-red-500">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/underboss/OutreachTab.tsx
+++ b/frontend/src/components/underboss/OutreachTab.tsx
@@ -1,0 +1,497 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowUpDown, ExternalLink, Loader2, Mail, MapPin, MessageCircle, Search, Send, Twitter, Users } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import {
+  fetchOutreachCommunities,
+  fetchUnderbossMe,
+  updateOutreachAttempt,
+  type OutreachChannel,
+  type OutreachCommunityRow,
+  type OutreachStatus,
+} from '../../lib/api';
+import { OUTREACH_CHANNEL_LABELS } from '../../lib/outreachTemplates';
+import { OutreachTemplateModal } from './OutreachTemplateModal';
+import { OutreachLinkPartyModal } from './OutreachLinkPartyModal';
+
+interface OutreachTabProps {
+  isAdmin: boolean;
+}
+
+type StatusFilter = '' | 'none' | OutreachStatus;
+type SortField = 'city' | 'followers' | 'priority' | 'lastAttempt';
+type SortDir = 'asc' | 'desc';
+
+const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: '', label: 'All statuses' },
+  { value: 'none', label: 'Not contacted' },
+  { value: 'sent', label: 'Sent' },
+  { value: 'replied', label: 'Replied' },
+  { value: 'declined', label: 'Declined' },
+  { value: 'converted', label: 'Converted' },
+  { value: 'bounced', label: 'Bounced' },
+];
+
+const PRIORITY_BADGE: Record<string, string> = {
+  high: 'bg-red-500/15 text-red-500 border-red-500/30',
+  medium: 'bg-amber-500/15 text-amber-500 border-amber-500/30',
+  low: 'bg-theme-surface text-theme-text-muted border-theme-stroke',
+};
+
+const STATUS_BADGE: Record<OutreachStatus, string> = {
+  sent: 'bg-blue-500/15 text-blue-500 border-blue-500/30',
+  replied: 'bg-cyan-500/15 text-cyan-500 border-cyan-500/30',
+  declined: 'bg-theme-surface text-theme-text-muted border-theme-stroke',
+  converted: 'bg-green-500/15 text-green-500 border-green-500/30',
+  bounced: 'bg-orange-500/15 text-orange-500 border-orange-500/30',
+};
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diff = Date.now() - then;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  const yr = Math.floor(mo / 12);
+  return `${yr}y ago`;
+}
+
+function channelEnabled(community: OutreachCommunityRow, channel: OutreachChannel): boolean {
+  if (channel === 'twitter_dm') {
+    return Boolean(community.twitterHandle || (community.source && community.source.toLowerCase().includes('twitter')));
+  }
+  if (channel === 'email') {
+    return Boolean(community.email);
+  }
+  if (channel === 'telegram') {
+    return Boolean(community.telegramHandle || (community.source && community.source.toLowerCase().includes('telegram')));
+  }
+  return false;
+}
+
+export function OutreachTab(_props: OutreachTabProps) {
+  const [communities, setCommunities] = useState<OutreachCommunityRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [cityFilter, setCityFilter] = useState('');
+  const [debouncedCity, setDebouncedCity] = useState('');
+  const [priorityFilter, setPriorityFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('');
+  const [sourceFilter, setSourceFilter] = useState('');
+
+  const [sortField, setSortField] = useState<SortField>('priority');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const [templateModal, setTemplateModal] = useState<{ community: OutreachCommunityRow; channel: OutreachChannel } | null>(null);
+  const [linkPartyModal, setLinkPartyModal] = useState<{ attemptId: string; communityName: string } | null>(null);
+
+  const [senderName, setSenderName] = useState<string | null>(null);
+
+  const cityDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load sender display name for template interpolation
+  useEffect(() => {
+    let mounted = true;
+    fetchUnderbossMe()
+      .then((me) => {
+        if (!mounted) return;
+        const name = me?.name || me?.email || null;
+        setSenderName(name);
+      })
+      .catch(() => {});
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // Debounce city filter
+  useEffect(() => {
+    if (cityDebounceRef.current) clearTimeout(cityDebounceRef.current);
+    cityDebounceRef.current = setTimeout(() => setDebouncedCity(cityFilter.trim()), 300);
+    return () => {
+      if (cityDebounceRef.current) clearTimeout(cityDebounceRef.current);
+    };
+  }, [cityFilter]);
+
+  const loadCommunities = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await fetchOutreachCommunities({
+        city: debouncedCity,
+        priority: priorityFilter,
+        source: sourceFilter,
+        status: statusFilter,
+      });
+      setCommunities(rows);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load communities');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCommunities();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedCity, priorityFilter, sourceFilter, statusFilter]);
+
+  const sources = useMemo(() => {
+    const set = new Set<string>();
+    communities.forEach((c) => {
+      if (c.source) set.add(c.source);
+    });
+    return Array.from(set).sort();
+  }, [communities]);
+
+  const sorted = useMemo(() => {
+    const list = [...communities];
+    const dir = sortDir === 'asc' ? 1 : -1;
+    list.sort((a, b) => {
+      if (sortField === 'city') return a.city.localeCompare(b.city) * dir;
+      if (sortField === 'followers') {
+        const av = a.followerCount ?? -1;
+        const bv = b.followerCount ?? -1;
+        return (av - bv) * dir;
+      }
+      if (sortField === 'priority') {
+        const order: Record<string, number> = { high: 0, medium: 1, low: 2 };
+        const av = order[a.priority || ''] ?? 99;
+        const bv = order[b.priority || ''] ?? 99;
+        return (av - bv) * dir;
+      }
+      if (sortField === 'lastAttempt') {
+        const av = a.lastAttempt ? new Date(a.lastAttempt.sentAt).getTime() : 0;
+        const bv = b.lastAttempt ? new Date(b.lastAttempt.sentAt).getTime() : 0;
+        return (av - bv) * dir;
+      }
+      return 0;
+    });
+    return list;
+  }, [communities, sortField, sortDir]);
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDir(field === 'followers' || field === 'lastAttempt' ? 'desc' : 'asc');
+    }
+  };
+
+  const clearFilters = () => {
+    setCityFilter('');
+    setPriorityFilter('');
+    setStatusFilter('');
+    setSourceFilter('');
+  };
+
+  const handleStatusChange = async (attemptId: string, status: OutreachStatus) => {
+    // Optimistic update
+    setCommunities((prev) =>
+      prev.map((c) => {
+        if (c.lastAttempt?.id !== attemptId) return c;
+        return { ...c, lastAttempt: { ...c.lastAttempt, status } };
+      })
+    );
+    try {
+      await updateOutreachAttempt(attemptId, { status });
+    } catch (e) {
+      // Reload on failure to revert
+      loadCommunities();
+    }
+  };
+
+  const handleAttemptLogged = () => {
+    loadCommunities();
+  };
+
+  return (
+    <div>
+      {/* Filter bar */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="w-64">
+          <IconInput
+            icon={MapPin}
+            placeholder="Search city..."
+            value={cityFilter}
+            onChange={(e: any) => setCityFilter(e.target.value)}
+          />
+        </div>
+
+        <select
+          value={priorityFilter}
+          onChange={(e) => setPriorityFilter(e.target.value)}
+          className="px-3 py-2 rounded-lg bg-theme-card border border-theme-stroke text-sm text-theme-text"
+        >
+          <option value="">All priorities</option>
+          <option value="high">High</option>
+          <option value="medium">Medium</option>
+          <option value="low">Low</option>
+        </select>
+
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+          className="px-3 py-2 rounded-lg bg-theme-card border border-theme-stroke text-sm text-theme-text"
+        >
+          {STATUS_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={sourceFilter}
+          onChange={(e) => setSourceFilter(e.target.value)}
+          className="px-3 py-2 rounded-lg bg-theme-card border border-theme-stroke text-sm text-theme-text"
+        >
+          <option value="">All sources</option>
+          {sources.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+
+        {(cityFilter || priorityFilter || statusFilter || sourceFilter) && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="px-3 py-2 rounded-lg text-sm text-theme-text-secondary hover:text-theme-text"
+          >
+            Clear filters
+          </button>
+        )}
+
+        <div className="ml-auto text-sm text-theme-text-muted">
+          {communities.length} communit{communities.length === 1 ? 'y' : 'ies'}
+        </div>
+      </div>
+
+      {/* Table */}
+      {loading && (
+        <div className="flex items-center justify-center py-12 text-theme-text-muted">
+          <Loader2 size={20} className="animate-spin" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/30 text-sm text-red-500">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && sorted.length === 0 && (
+        <div className="text-center py-12 text-theme-text-muted">
+          <Search size={28} className="mx-auto mb-2 opacity-50" />
+          <p>No communities match your filters. Try clearing them.</p>
+        </div>
+      )}
+
+      {!loading && !error && sorted.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-theme-stroke">
+          <table className="w-full text-sm">
+            <thead className="bg-theme-surface text-theme-text-muted text-xs uppercase tracking-wide">
+              <tr>
+                <th className="px-3 py-2 text-left">
+                  <button
+                    type="button"
+                    onClick={() => toggleSort('city')}
+                    className="inline-flex items-center gap-1 hover:text-theme-text"
+                  >
+                    City <ArrowUpDown size={12} />
+                  </button>
+                </th>
+                <th className="px-3 py-2 text-left">Community</th>
+                <th className="px-3 py-2 text-left">Source</th>
+                <th className="px-3 py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => toggleSort('followers')}
+                    className="inline-flex items-center gap-1 hover:text-theme-text"
+                  >
+                    Followers <ArrowUpDown size={12} />
+                  </button>
+                </th>
+                <th className="px-3 py-2 text-left">
+                  <button
+                    type="button"
+                    onClick={() => toggleSort('priority')}
+                    className="inline-flex items-center gap-1 hover:text-theme-text"
+                  >
+                    Priority <ArrowUpDown size={12} />
+                  </button>
+                </th>
+                <th className="px-3 py-2 text-left">
+                  <button
+                    type="button"
+                    onClick={() => toggleSort('lastAttempt')}
+                    className="inline-flex items-center gap-1 hover:text-theme-text"
+                  >
+                    Last attempt <ArrowUpDown size={12} />
+                  </button>
+                </th>
+                <th className="px-3 py-2 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-theme-stroke">
+              {sorted.map((community) => {
+                const last = community.lastAttempt;
+                const priorityKey = (community.priority || '').toLowerCase();
+                return (
+                  <tr key={community.id} className="hover:bg-theme-surface/50">
+                    <td className="px-3 py-2 text-theme-text whitespace-nowrap">{community.city}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-theme-text">{community.name}</span>
+                        {community.contactUrl && (
+                          <a
+                            href={community.contactUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-theme-text-muted hover:text-theme-text"
+                            title={community.contactUrl}
+                          >
+                            <ExternalLink size={14} />
+                          </a>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-theme-text-muted whitespace-nowrap">
+                      <span className="px-2 py-0.5 rounded text-xs bg-theme-surface border border-theme-stroke">
+                        {community.source}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right text-theme-text-muted tabular-nums">
+                      {community.followerCount != null ? community.followerCount.toLocaleString() : '—'}
+                    </td>
+                    <td className="px-3 py-2">
+                      {community.priority ? (
+                        <span
+                          className={`px-2 py-0.5 rounded text-xs border ${
+                            PRIORITY_BADGE[priorityKey] || PRIORITY_BADGE.low
+                          }`}
+                        >
+                          {community.priority}
+                        </span>
+                      ) : (
+                        <span className="text-theme-text-faint">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap">
+                      {last ? (
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`px-2 py-0.5 rounded text-xs border ${STATUS_BADGE[last.status]}`}
+                          >
+                            {last.status}
+                          </span>
+                          <span className="text-xs text-theme-text-muted">
+                            {formatRelative(last.sentAt)}
+                          </span>
+                        </div>
+                      ) : (
+                        <span className="text-theme-text-faint text-xs">Not contacted</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        {/* Channel buttons */}
+                        {(['twitter_dm', 'email', 'telegram'] as OutreachChannel[]).map((ch) => {
+                          const enabled = channelEnabled(community, ch);
+                          const Icon = ch === 'twitter_dm' ? Twitter : ch === 'email' ? Mail : MessageCircle;
+                          return (
+                            <button
+                              key={ch}
+                              type="button"
+                              disabled={!enabled}
+                              onClick={() => setTemplateModal({ community, channel: ch })}
+                              title={enabled ? `Compose ${OUTREACH_CHANNEL_LABELS[ch]}` : `No ${OUTREACH_CHANNEL_LABELS[ch]} contact`}
+                              className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs border ${
+                                enabled
+                                  ? 'border-theme-stroke text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface'
+                                  : 'border-theme-stroke text-theme-text-faint opacity-50 cursor-not-allowed'
+                              }`}
+                            >
+                              <Icon size={12} />
+                              {OUTREACH_CHANNEL_LABELS[ch]}
+                            </button>
+                          );
+                        })}
+
+                        {/* Status change select (only if there's a last attempt) */}
+                        {last && (
+                          <select
+                            value={last.status}
+                            onChange={(e) => handleStatusChange(last.id, e.target.value as OutreachStatus)}
+                            className="px-2 py-1 rounded text-xs bg-theme-card border border-theme-stroke text-theme-text"
+                            title="Update status"
+                          >
+                            <option value="sent">Sent</option>
+                            <option value="replied">Replied</option>
+                            <option value="declined">Declined</option>
+                            <option value="converted">Converted</option>
+                            <option value="bounced">Bounced</option>
+                          </select>
+                        )}
+
+                        {/* Link party (only if converted + not yet linked) */}
+                        {last && last.status === 'converted' && !last.convertedPartyId && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setLinkPartyModal({ attemptId: last.id, communityName: community.name })
+                            }
+                            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs border border-green-500/30 bg-green-500/10 text-green-500 hover:bg-green-500/20"
+                          >
+                            <Users size={12} />
+                            Link party
+                          </button>
+                        )}
+
+                        {last && last.convertedPartyId && (
+                          <span className="inline-flex items-center gap-1 text-xs text-green-500" title={last.convertedPartyId}>
+                            <Send size={12} /> linked
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {templateModal && (
+        <OutreachTemplateModal
+          community={templateModal.community}
+          channel={templateModal.channel}
+          senderName={senderName}
+          onClose={() => setTemplateModal(null)}
+          onLogged={handleAttemptLogged}
+        />
+      )}
+
+      {linkPartyModal && (
+        <OutreachLinkPartyModal
+          attemptId={linkPartyModal.attemptId}
+          communityName={linkPartyModal.communityName}
+          onClose={() => setLinkPartyModal(null)}
+          onLinked={handleAttemptLogged}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/underboss/OutreachTemplateModal.tsx
+++ b/frontend/src/components/underboss/OutreachTemplateModal.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, Copy, Loader2, X, MessageSquare } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import {
+  OUTREACH_CHANNEL_LABELS,
+  getTemplate,
+  renderTemplate,
+  type OutreachChannel,
+} from '../../lib/outreachTemplates';
+import { logOutreachAttempt, type OutreachCommunityRow } from '../../lib/api';
+
+interface OutreachTemplateModalProps {
+  community: OutreachCommunityRow;
+  channel: OutreachChannel;
+  senderName?: string | null;
+  onClose: () => void;
+  onLogged: () => void;
+}
+
+export function OutreachTemplateModal({
+  community,
+  channel,
+  senderName,
+  onClose,
+  onLogged,
+}: OutreachTemplateModalProps) {
+  const template = useMemo(() => getTemplate(channel), [channel]);
+
+  const rendered = useMemo(() => {
+    if (!template) return { body: '', subject: undefined as string | undefined };
+    return renderTemplate(template, {
+      community_name: community.name,
+      city: community.city,
+      sender_name: senderName || undefined,
+    });
+  }, [template, community, senderName]);
+
+  const [notes, setNotes] = useState('');
+  const [copyState, setCopyState] = useState<'idle' | 'body' | 'subject'>('idle');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (copyState === 'idle') return;
+    const t = setTimeout(() => setCopyState('idle'), 2000);
+    return () => clearTimeout(t);
+  }, [copyState]);
+
+  if (!template) return null;
+
+  const handleCopyBody = async () => {
+    try {
+      await navigator.clipboard.writeText(rendered.body);
+      setCopyState('body');
+    } catch {
+      // ignore — user can manually select
+    }
+  };
+
+  const handleCopySubject = async () => {
+    if (!rendered.subject) return;
+    try {
+      await navigator.clipboard.writeText(rendered.subject);
+      setCopyState('subject');
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleMarkSent = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await logOutreachAttempt({
+        communityId: community.id,
+        channel,
+        templateId: template.id,
+        notes: notes.trim() || undefined,
+      });
+      onLogged();
+      onClose();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to log attempt');
+      setSaving(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-card border border-theme-stroke rounded-2xl p-6 w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-theme-text flex items-center gap-2">
+              <MessageSquare size={18} />
+              Outreach template — {OUTREACH_CHANNEL_LABELS[channel]}
+            </h3>
+            <p className="text-sm text-theme-text-muted mt-1">
+              {community.name} · {community.city}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-theme-text-faint hover:text-theme-text-secondary"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {rendered.subject && (
+          <div className="mb-4">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-xs uppercase tracking-wide text-theme-text-muted">Subject</span>
+              <button
+                type="button"
+                onClick={handleCopySubject}
+                className="inline-flex items-center gap-1 text-xs text-theme-text-secondary hover:text-theme-text"
+              >
+                {copyState === 'subject' ? <Check size={14} /> : <Copy size={14} />}
+                {copyState === 'subject' ? 'Copied' : 'Copy subject'}
+              </button>
+            </div>
+            <div className="px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke text-sm text-theme-text font-mono">
+              {rendered.subject}
+            </div>
+          </div>
+        )}
+
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs uppercase tracking-wide text-theme-text-muted">Message</span>
+            <button
+              type="button"
+              onClick={handleCopyBody}
+              className="inline-flex items-center gap-1 text-xs text-theme-text-secondary hover:text-theme-text"
+            >
+              {copyState === 'body' ? <Check size={14} /> : <Copy size={14} />}
+              {copyState === 'body' ? 'Copied' : 'Copy to clipboard'}
+            </button>
+          </div>
+          <textarea
+            readOnly
+            value={rendered.body}
+            rows={Math.max(6, rendered.body.split('\n').length + 1)}
+            className="w-full px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke text-sm text-theme-text font-mono resize-y"
+          />
+        </div>
+
+        <div className="mb-4">
+          <IconInput
+            multiline
+            rows={2}
+            placeholder="Notes (optional, internal only)..."
+            value={notes}
+            onChange={(e: any) => setNotes(e.target.value)}
+          />
+        </div>
+
+        {error && (
+          <div className="mb-3 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-sm text-red-500">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 rounded-lg text-theme-text-secondary hover:text-theme-text disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleMarkSent}
+            disabled={saving}
+            className="px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white font-semibold inline-flex items-center gap-2 disabled:opacity-60"
+          >
+            {saving ? <Loader2 size={16} className="animate-spin" /> : null}
+            Mark as sent
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -8,3 +8,4 @@ export { PartnerManager } from './PartnerManager';
 export { FunnelTab } from './FunnelTab';
 export { CityScopePicker } from './CityScopePicker';
 export { FakeDetectionTable } from './FakeDetectionTable';
+export { OutreachTab } from './OutreachTab';

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -143,7 +143,8 @@
       "events": "Events",
       "cities": "Cities",
       "partners": "Partners",
-      "fakeDetection": "Fake Detection"
+      "fakeDetection": "Fake Detection",
+      "outreach": "Outreach"
     }
   },
   "fakeDetection": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3963,3 +3963,103 @@ export async function previewReceiptOCR(
   );
 }
 
+// ============================================================
+// Outreach (marinara-67583) — admin-only outreach tracker
+// ============================================================
+
+export type OutreachChannel = 'twitter_dm' | 'email' | 'telegram';
+export type OutreachStatus = 'sent' | 'replied' | 'declined' | 'converted' | 'bounced';
+
+export interface OutreachAttemptRow {
+  id: string;
+  channel: OutreachChannel;
+  templateId: string;
+  sentAt: string;
+  sentBy: string;
+  status: OutreachStatus;
+  convertedPartyId: string | null;
+  notes: string | null;
+}
+
+export interface OutreachCommunityRow {
+  id: string;
+  city: string;
+  country: string | null;
+  name: string;
+  source: string;
+  contactHandle: string | null;
+  contactUrl: string;
+  contactEmail: string | null;
+  twitterHandle: string | null;
+  telegramHandle: string | null;
+  email: string | null;
+  followerCount: number | null;
+  priority: string | null;
+  notes: string | null;
+  lastAttempt: OutreachAttemptRow | null;
+  attemptCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OutreachFilters {
+  city?: string;
+  priority?: string;
+  source?: string;
+  status?: string; // 'none' | OutreachStatus | ''
+}
+
+export async function fetchOutreachCommunities(
+  filters: OutreachFilters = {}
+): Promise<OutreachCommunityRow[]> {
+  const params = new URLSearchParams();
+  if (filters.city) params.set('city', filters.city);
+  if (filters.priority) params.set('priority', filters.priority);
+  if (filters.source) params.set('source', filters.source);
+  if (filters.status) params.set('status', filters.status);
+  const qs = params.toString();
+  const res = await apiRequest<{ communities: OutreachCommunityRow[] }>(
+    `/api/underboss/outreach/communities${qs ? `?${qs}` : ''}`
+  );
+  return res.communities;
+}
+
+export async function logOutreachAttempt(body: {
+  communityId: string;
+  channel: OutreachChannel;
+  templateId: string;
+  notes?: string;
+}): Promise<OutreachAttemptRow> {
+  const res = await apiRequest<{ attempt: any }>(
+    '/api/underboss/outreach/attempts',
+    { method: 'POST', body }
+  );
+  return res.attempt;
+}
+
+export async function updateOutreachAttempt(
+  id: string,
+  body: { status?: OutreachStatus; convertedPartyId?: string | null; notes?: string | null }
+): Promise<OutreachAttemptRow> {
+  const res = await apiRequest<{ attempt: any }>(
+    `/api/underboss/outreach/attempts/${id}`,
+    { method: 'PATCH', body }
+  );
+  return res.attempt;
+}
+
+export interface OutreachPartySearchResult {
+  id: string;
+  name: string;
+  customUrl: string | null;
+  city: string | null;
+}
+
+export async function searchPartiesForOutreach(q: string): Promise<OutreachPartySearchResult[]> {
+  const params = new URLSearchParams({ q });
+  const res = await apiRequest<{ parties: OutreachPartySearchResult[] }>(
+    `/api/underboss/outreach/parties-search?${params.toString()}`
+  );
+  return res.parties;
+}
+

--- a/frontend/src/lib/outreachTemplates.ts
+++ b/frontend/src/lib/outreachTemplates.ts
@@ -1,0 +1,72 @@
+// marinara-67583: Outreach message templates for /underboss/outreach tab.
+//
+// Templates are stored inline (no DB table for v1). To tweak copy, edit this
+// file and redeploy. The `id` field MUST stay stable across edits — old
+// outreach_attempts rows reference these ids. If you make a material change,
+// bump to `v2_<channel>` instead so historical rows still resolve.
+
+export const OUTREACH_CALENDAR_LINK = 'https://cal.com/pizzadao/gpp-host';
+
+export type OutreachChannel = 'twitter_dm' | 'email' | 'telegram';
+
+export interface OutreachTemplate {
+  id: string;
+  channel: OutreachChannel;
+  subject?: string;
+  body: string;
+}
+
+export const OUTREACH_TEMPLATES: OutreachTemplate[] = [
+  {
+    id: 'v1_twitter',
+    channel: 'twitter_dm',
+    body: `hey {{community_name}} — we're running Global Pizza Party 2026 on Sept 20, a worldwide simultaneous pizza meetup. {{city}} doesn't have a host yet. would love to chat about you running one — free pizza budget, no upfront cost. 15 min call? {{calendar_link}}`,
+  },
+  {
+    id: 'v1_email',
+    channel: 'email',
+    subject: 'Host the {{city}} Global Pizza Party 2026?',
+    body: `Hi {{community_name}},
+
+We're organizing Global Pizza Party 2026 — a global, simultaneous pizza meetup on Sept 20 across hundreds of cities. We don't have a host in {{city}} yet and your community seemed like a strong fit.
+
+PizzaDAO covers the pizza budget; you bring the venue and the people. 200+ cities ran their own party last year.
+
+15-minute intro call? {{calendar_link}}
+
+— {{sender_name}}, PizzaDAO`,
+  },
+  {
+    id: 'v1_telegram',
+    channel: 'telegram',
+    body: `hi {{community_name}} 👋 we're running Global Pizza Party 2026 (sept 20, simultaneous worldwide). {{city}} is uncovered. interested in hosting? we pay for the pizza. {{calendar_link}}`,
+  },
+];
+
+export function renderTemplate(
+  tpl: OutreachTemplate,
+  vars: { community_name: string; city: string; calendar_link?: string; sender_name?: string }
+): { subject?: string; body: string } {
+  const calendar = vars.calendar_link ?? OUTREACH_CALENDAR_LINK;
+  const sender = vars.sender_name ?? 'PizzaDAO';
+  const replace = (s: string) =>
+    s
+      .replaceAll('{{community_name}}', vars.community_name)
+      .replaceAll('{{city}}', vars.city)
+      .replaceAll('{{calendar_link}}', calendar)
+      .replaceAll('{{sender_name}}', sender);
+  return {
+    subject: tpl.subject ? replace(tpl.subject) : undefined,
+    body: replace(tpl.body),
+  };
+}
+
+export function getTemplate(channel: OutreachChannel): OutreachTemplate | undefined {
+  return OUTREACH_TEMPLATES.find((t) => t.channel === channel);
+}
+
+export const OUTREACH_CHANNEL_LABELS: Record<OutreachChannel, string> = {
+  twitter_dm: 'Twitter DM',
+  email: 'Email',
+  telegram: 'Telegram',
+};

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -6,7 +6,7 @@ import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, C
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable } from '../components/underboss';
+import { RegionStats, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, OutreachTab } from '../components/underboss';
 import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
@@ -69,7 +69,7 @@ export function UnderbossDashboard() {
   const [availableRegions, setAvailableRegions] = useState<string[]>([]);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection'>('events');
+  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection' | 'outreach'>('events');
 
   const [tableFilteredEvents, setTableFilteredEvents] = useState<UnderbossEvent[] | null>(null);
 
@@ -564,6 +564,19 @@ export function UnderbossDashboard() {
                 )}
               </button>
             )}
+            <button
+              onClick={() => setActiveTab('outreach')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'outreach'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              {t('underbossDashboard.tabs.outreach')}
+              {activeTab === 'outreach' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
           </div>
 
           {activeTab === 'events' && (
@@ -580,6 +593,10 @@ export function UnderbossDashboard() {
 
           {isAdmin && activeTab === 'fake-detection' && (
             <FakeDetectionTable />
+          )}
+
+          {activeTab === 'outreach' && (
+            <OutreachTab isAdmin={isAdmin} />
           )}
 
         </section>

--- a/plans/marinara-67583-underboss-outreach-tab.md
+++ b/plans/marinara-67583-underboss-outreach-tab.md
@@ -1,0 +1,465 @@
+# marinara-67583: /underboss/outreach admin tab
+
+**Priority**: P2
+**Type**: Full feature (worktree + draft PR + Vercel preview)
+**Depends on**: `stagioni-29104` — the `outreach_communities` table must exist in production before this tab works on any preview deploy. The migration in `stagioni-29104` MUST land (and be applied to prod via `mcp__supabase-pizzadao__apply_migration`) before this branch ships.
+
+## Problem
+
+GPP 2026 outreach (run from `supreme-43217` gap analysis + `stagioni-29104` scrapers) currently has nowhere for an admin to do the actual recruitment work. Snax + underbosses need a single screen that:
+
+1. Lists candidate blockchain communities in uncovered cities (joined from `outreach_communities`).
+2. Provides one-click "copy template" actions for Twitter DM / Email / Telegram (the three channels Snax confirmed).
+3. Logs every outreach attempt (channel, template, who sent it, when) so we don't double-message a community.
+4. Tracks each community's lifecycle: sent → replied → declined → converted → bounced, and when converted, links to the actual `parties` row that the community produced.
+
+Without this, the scraped data from `stagioni-29104` sits in a table no one looks at.
+
+## Approach
+
+A standard rsvpizza feature: backend migration + backend endpoints + frontend tab. No new infrastructure. Reuse:
+
+- `requireAuth` + `requireUnderbossAuth` middleware (proven pattern; see `backend/src/routes/underboss.routes.ts` lines 27-99).
+- The existing `UnderbossDashboard.tsx` tab list (events / cities / partners / fake-detection on origin/master) — add an `'outreach'` tab string and a 5th button + 5th render branch.
+- `IconInput`, `Checkbox`, and the established `fixed inset-0 bg-black/60 backdrop-blur-sm z-50` modal pattern.
+- `apiRequest<T>()` from `frontend/src/lib/api.ts` for all calls.
+
+Message templates are stored **inline** in `frontend/src/lib/outreachTemplates.ts` for v1 (per task spec). No DB table for templates yet — keeps the feature scope tight and lets Snax iterate copy by editing one file.
+
+**Per memory `architecture_router_use_at_shared_prefix.md`**: the existing `underboss.routes.ts` already uses per-route middleware (every route has `requireAuth, requireUnderbossAuth` inline; no path-less `router.use(gate)`). The new outreach endpoints will follow this exact same per-route pattern. They live inside the existing `underboss.routes.ts` router (mounted at `app.use('/api/underboss', underbossRoutes)` in `backend/src/index.ts:107`), so no new top-level mount is added and no path-less middleware is introduced.
+
+**Per memory `feedback_reversible_actions_no_confirm.md`**: logging an outreach attempt is fully reversible (delete the row, or PATCH the status). No confirm modals on "Mark as sent", "Mark status", or "Link to converted party".
+
+## Database changes
+
+### Migration: `outreach_attempts`
+
+File: `supabase/migrations/20260520_create_outreach_attempts.sql` (using Supabase migration path per stagioni-29104 precedent — not `backend/prisma/migrations/`).
+
+```sql
+-- marinara-67583: Outreach attempts log
+-- Admin-only — no anon/authenticated GRANTs (mirrors outreach_communities).
+-- Backend reads/writes via service_role.
+
+CREATE TABLE outreach_attempts (
+  id                  TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  community_id        TEXT NOT NULL REFERENCES outreach_communities(id) ON DELETE CASCADE,
+  channel             TEXT NOT NULL,                              -- 'twitter_dm' | 'email' | 'telegram'
+  template_id         TEXT NOT NULL,                              -- 'v1_twitter' | 'v1_email' | 'v1_telegram'
+  sent_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  sent_by             TEXT NOT NULL,                              -- admin email from req.userEmail
+  status              TEXT NOT NULL DEFAULT 'sent',               -- 'sent' | 'replied' | 'declined' | 'converted' | 'bounced'
+  converted_party_id  UUID REFERENCES parties(id) ON DELETE SET NULL,
+  notes               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT outreach_attempts_channel_check
+    CHECK (channel IN ('twitter_dm', 'email', 'telegram')),
+  CONSTRAINT outreach_attempts_status_check
+    CHECK (status IN ('sent', 'replied', 'declined', 'converted', 'bounced'))
+);
+
+CREATE INDEX idx_outreach_attempts_community ON outreach_attempts(community_id);
+CREATE INDEX idx_outreach_attempts_status ON outreach_attempts(status);
+CREATE INDEX idx_outreach_attempts_sent_at ON outreach_attempts(sent_at DESC);
+
+ALTER TABLE outreach_attempts ENABLE ROW LEVEL SECURITY;
+
+CREATE TRIGGER trg_outreach_attempts_updated_at
+  BEFORE UPDATE ON outreach_attempts
+  FOR EACH ROW
+  EXECUTE FUNCTION set_outreach_communities_updated_at();  -- reuse the function from stagioni-29104
+```
+
+**Verified against origin/master `backend/prisma/schema.prisma`:**
+- `Party.id` is `String @id @default(uuid()) @db.Uuid` and maps to `@@map("parties")` (line 227). So the FK column type must be `UUID`, and the referenced table is `"parties"` (lowercase, plural).
+- `User` has NO `@@map` (line 10), confirming the memory note that "User is capital singular, no @@map." Not directly relevant here but reinforces the pattern.
+- `outreach_communities.id` is `TEXT` per stagioni-29104. So `community_id` is `TEXT`.
+
+### Prisma schema additions
+
+Add to `backend/prisma/schema.prisma` (after the `OutreachCommunity` model that `stagioni-29104` will introduce):
+
+```prisma
+model OutreachAttempt {
+  id                String   @id @default(cuid())
+  communityId       String   @map("community_id")
+  community         OutreachCommunity @relation(fields: [communityId], references: [id], onDelete: Cascade)
+  channel           String   // 'twitter_dm' | 'email' | 'telegram'
+  templateId        String   @map("template_id") // 'v1_twitter' | 'v1_email' | 'v1_telegram'
+  sentAt            DateTime @default(now()) @map("sent_at") @db.Timestamptz
+  sentBy            String   @map("sent_by")  // admin email from req.userEmail
+  status            String   @default("sent") // 'sent' | 'replied' | 'declined' | 'converted' | 'bounced'
+  convertedPartyId  String?  @map("converted_party_id") @db.Uuid
+  convertedParty    Party?   @relation(fields: [convertedPartyId], references: [id], onDelete: SetNull)
+  notes             String?
+  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([communityId])
+  @@index([status])
+  @@index([sentAt(sort: Desc)])
+  @@map("outreach_attempts")
+}
+```
+
+Add the back-relations:
+- On `OutreachCommunity` (created by stagioni-29104): `attempts OutreachAttempt[]`
+- On `Party`: `outreachAttempts OutreachAttempt[]` (add inside the `Party` block near the other relations around line 220).
+
+### Order of operations
+
+1. `stagioni-29104` ships and its migration is applied to production via `mcp__supabase-pizzadao__apply_migration` — confirms `outreach_communities` exists.
+2. This branch applies `20260520_create_outreach_attempts` via `mcp__supabase-pizzadao__apply_migration` to prod **before** opening the PR for review (per the CLAUDE.md note: "New DB columns and backend endpoints must be applied to production before they'll work on preview branches").
+3. Run `npx prisma generate` locally + in CI so the Prisma client knows the new model.
+4. Backend deploy from `master` picks up the new Prisma client + new endpoints automatically once merged.
+5. Frontend Vercel preview talks to production backend; once steps 2-4 are done the preview works.
+
+## Backend API
+
+All endpoints live in `backend/src/routes/underboss.routes.ts`, added before `export default router;`. They follow the **exact same per-route auth pattern** the rest of the file uses (`requireAuth, requireUnderbossAuth`) — no shared `router.use()` at any prefix.
+
+### Endpoints
+
+**`GET /api/underboss/outreach/communities`**
+- Query params: `?city=<string>`, `?priority=<string>`, `?status=<sent|replied|declined|converted|bounced|none>`, `?source=<string>`
+- Returns `{ communities: Array<{ id, city, name, source, followerCount, priority, twitterHandle, email, telegramHandle, lastAttempt: { id, channel, templateId, sentAt, sentBy, status, convertedPartyId, notes } | null, attemptCount: number }> }`.
+- Implementation: `prisma.outreachCommunity.findMany({ where: <filters>, include: { attempts: { orderBy: { sentAt: 'desc' }, take: 1 } } })`. Then compute `lastAttempt` from the first element and `attemptCount` from a separate `_count` aggregation in the same query.
+- Filter logic:
+  - `city` → `where.city = { contains: <city>, mode: 'insensitive' }`
+  - `priority` → `where.priority = <priority>`
+  - `source` → `where.source = <source>`
+  - `status === 'none'` → `where.attempts = { none: {} }` (communities never contacted)
+  - `status === 'sent' | 'replied' | ...` → filter on `attempts.some.status = <status>` AND ensure it's the latest by sorting in JS after fetch (Prisma can't trivially filter "latest attempt has status X"; simpler to fetch and post-filter, given dataset size will be ~hundreds, not thousands).
+
+**`POST /api/underboss/outreach/attempts`**
+- Body: `{ communityId: string, channel: 'twitter_dm' | 'email' | 'telegram', templateId: string, notes?: string }`
+- `sentBy` is set from `req.userEmail` (the authenticated admin email) — NOT from the body.
+- `status` defaults to `'sent'`.
+- Validate `channel` is one of the 3 allowed values; validate `templateId` is one of `['v1_twitter', 'v1_email', 'v1_telegram']`; validate `communityId` exists.
+- Returns `{ attempt: <full row> }`.
+
+**`PATCH /api/underboss/outreach/attempts/:id`**
+- Body: `{ status?: string, convertedPartyId?: string | null, notes?: string }`
+- Validate `status` is one of `['sent', 'replied', 'declined', 'converted', 'bounced']`.
+- If `convertedPartyId` is provided, validate the party exists via `prisma.party.findUnique({ where: { id }, select: { id: true } })`. If status is set to `'converted'`, `convertedPartyId` SHOULD be set (warn in response but don't block — admin may link later).
+- Returns `{ attempt: <full row> }`.
+
+**`GET /api/underboss/outreach/parties-search?q=<query>`**
+- Helper for the "Link to converted party" action. Searches `parties` by `name` ILIKE `%<q>%` OR `customUrl` ILIKE — limit 10.
+- Returns `{ parties: Array<{ id, name, customUrl, city }> }`.
+- Same `requireAuth, requireUnderbossAuth` gate.
+
+### Routing pattern (PATH-SCOPED MIDDLEWARE)
+
+The new endpoints live INSIDE the existing `underboss.routes.ts` router. They use per-route middleware exactly like every other route in the file:
+
+```ts
+// Add near line 1450, before `export default router;`
+router.get(
+  '/outreach/communities',
+  requireAuth,
+  requireUnderbossAuth,
+  async (req: UnderbossRequest, res: Response, next: NextFunction) => { ... }
+);
+
+router.post(
+  '/outreach/attempts',
+  requireAuth,
+  requireUnderbossAuth,
+  async (req: UnderbossRequest, res: Response, next: NextFunction) => { ... }
+);
+
+router.patch(
+  '/outreach/attempts/:id',
+  requireAuth,
+  requireUnderbossAuth,
+  async (req: UnderbossRequest, res: Response, next: NextFunction) => { ... }
+);
+
+router.get(
+  '/outreach/parties-search',
+  requireAuth,
+  requireUnderbossAuth,
+  async (req: UnderbossRequest, res: Response, next: NextFunction) => { ... }
+);
+```
+
+**No `router.use('/outreach', ...)`** anywhere. The shared underboss router is already mounted at `/api/underboss` in `backend/src/index.ts:107` via `app.use('/api/underboss', underbossRoutes)`. Adding more `router.METHOD()` calls to that same router file is the proven pattern — every existing route there does the same thing. No risk of leaking auth across sibling routers.
+
+### Auth gate
+
+Reuse `requireUnderbossAuth` (defined at `underboss.routes.ts:27-99`). It already handles:
+- Admin emails (granted via `isAdmin(email)` check)
+- Active underbosses (looked up in `underbosses` table)
+- Graphics admins (looked up in `graphics_admins` table)
+
+All three of these populate `req.underboss` and are eligible to use the outreach tab. **Non-admins / non-underbosses get 403** — same as every other underboss route. No new middleware needed.
+
+## Frontend
+
+### New tab in UnderbossDashboard
+
+File: `frontend/src/pages/UnderbossDashboard.tsx`
+
+The origin/master version has the tab state at line ~72:
+```ts
+const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection'>('events');
+```
+
+Changes:
+
+1. Extend the `activeTab` type to include `'outreach'`.
+2. Add a 5th tab button after the `partners` button (~line 540), gated to admin OR underboss (i.e. anyone reaching this page already passes the gate).
+3. Add a 5th render branch after the `partners` branch (~line 580): `{activeTab === 'outreach' && <OutreachTab isAdmin={isAdmin} />}`.
+4. Add `OutreachTab` to the `underboss` index (`frontend/src/components/underboss/index.ts`) and import it at the top of `UnderbossDashboard.tsx`.
+
+### New component: `OutreachTab.tsx`
+
+Location: `frontend/src/components/underboss/OutreachTab.tsx`
+
+Top-level structure:
+```tsx
+export function OutreachTab({ isAdmin }: { isAdmin: boolean }) {
+  const [communities, setCommunities] = useState<OutreachCommunity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filters, setFilters] = useState({ city: '', priority: '', status: '', source: '' });
+  const [selected, setSelected] = useState<OutreachCommunity | null>(null);
+  const [templateModal, setTemplateModal] = useState<{ community: OutreachCommunity; channel: Channel } | null>(null);
+  const [linkPartyModal, setLinkPartyModal] = useState<{ attemptId: string } | null>(null);
+  // ... fetch + filter logic
+}
+```
+
+### Filter bar
+
+A horizontal row of `IconInput` + 3 select dropdowns (the select pattern is similar to the regionDropdown in `UnderbossDashboard.tsx` ~line 380-410):
+
+- City search: `<IconInput icon={MapPin} placeholder="Search city..." value={filters.city} onChange={...} />` (debounced 300ms).
+- Priority select: dropdown with `All / High / Medium / Low`.
+- Status select: dropdown with `All / Not contacted / Sent / Replied / Declined / Converted / Bounced`. "Not contacted" maps to `status=none` query param.
+- Source select: dropdown with `All / Lu.ma / Meetup / Curated / Twitter`.
+- "Clear filters" button (resets all four to empty string).
+
+### Communities table
+
+Columns (left to right):
+
+| Column | Source |
+|--------|--------|
+| City | `community.city` |
+| Community | `community.name` (with `community.twitterHandle` / `telegramHandle` icon link if present) |
+| Source | `community.source` (small badge) |
+| Followers | `community.followerCount.toLocaleString()` |
+| Priority | `community.priority` (colored badge: high=red, medium=yellow, low=gray) |
+| Last attempt | If `lastAttempt`: status badge + relative time ("2 days ago"). If null: "—" + "Not contacted" muted text. |
+| Actions | 3 inline buttons (see below) |
+
+Sort: default by `priority desc, followerCount desc`. Allow column sort on City, Followers, Priority, Last attempt by clicking the header (use the same `ArrowUpDown` icon + sort-toggle pattern as `EventTable.tsx:90-100`).
+
+Empty state: "No communities match your filters. Try clearing them." with a centered icon.
+
+Loading state: existing `Loader2 className="animate-spin"` pattern.
+
+### Inline actions per row
+
+#### 1. "Copy template" dropdown
+A dropdown button (Twitter / Email / Telegram). Clicking a channel opens the `<TemplateModal>` (see below).
+
+Disabled state: gray out if no contact info for that channel (e.g. disable "Twitter" if `community.twitterHandle == null`; disable "Email" if `community.email == null`).
+
+#### 2. "Mark status" (only shown if `lastAttempt != null`)
+A small select inline in the row: changes the `lastAttempt.status` via `PATCH /api/underboss/outreach/attempts/:id`. Options: Sent / Replied / Declined / Converted / Bounced. Optimistic update. No confirm modal (reversible).
+
+#### 3. "Link party" (only shown if `lastAttempt.status === 'converted'` AND `convertedPartyId == null`)
+Opens the `<LinkPartyModal>` (see below).
+
+### TemplateModal
+
+```tsx
+<TemplateModal
+  community={selected}
+  channel={'twitter_dm' | 'email' | 'telegram'}
+  onClose={...}
+  onMarkSent={(notes) => POST /api/underboss/outreach/attempts}
+/>
+```
+
+Layout (uses the project modal pattern from CLAUDE.md: `fixed inset-0 bg-black/60 backdrop-blur-sm z-50`):
+
+- Modal card: `max-w-2xl` centered, white bg, rounded.
+- Title: "Outreach template — {channel label}"
+- Subject line (email only): rendered above body, with a "Copy subject" button.
+- Body textarea (read-only, monospace, `IconInput multiline`): rendered template with placeholders interpolated against:
+  - `{{community_name}}` → `community.name`
+  - `{{city}}` → `community.city`
+  - `{{calendar_link}}` → `https://cal.com/pizzadao/gpp-host` (constant in `outreachTemplates.ts`, can be tweaked)
+  - `{{sender_name}}` → admin's display name from `fetchUnderbossMe()` — or fall back to "PizzaDAO"
+- "Copy to clipboard" button (uses `navigator.clipboard.writeText`) — shows a checkmark for 2s after click.
+- Optional notes field: `<IconInput multiline placeholder="Notes (optional, internal only)..." />` for any context the admin wants to attach to the attempt log.
+- "Mark as sent" button (primary, red): POSTs the attempt and closes the modal. **No confirm step** per `feedback_reversible_actions_no_confirm.md`.
+- "Cancel" button (secondary): closes modal without logging.
+
+### LinkPartyModal
+
+```tsx
+<LinkPartyModal attemptId={...} onClose={...} onLink={(partyId) => PATCH /api/underboss/outreach/attempts/:id} />
+```
+
+- `IconInput` with debounced search (300ms), hits `GET /api/underboss/outreach/parties-search?q=<query>`.
+- Results list (up to 10): each row shows `party.name` + `party.city` + `rsv.pizza/{customUrl}` muted.
+- Clicking a result: PATCHes the attempt with `convertedPartyId`, closes modal, refreshes the row.
+
+## Message templates
+
+File: `frontend/src/lib/outreachTemplates.ts`
+
+```ts
+export const OUTREACH_CALENDAR_LINK = 'https://cal.com/pizzadao/gpp-host';
+
+export type OutreachChannel = 'twitter_dm' | 'email' | 'telegram';
+
+export interface OutreachTemplate {
+  id: string;
+  channel: OutreachChannel;
+  subject?: string;
+  body: string;
+}
+
+export const OUTREACH_TEMPLATES: OutreachTemplate[] = [
+  {
+    id: 'v1_twitter',
+    channel: 'twitter_dm',
+    body: `hey {{community_name}} — we're running Global Pizza Party 2026 on Sept 20, a worldwide simultaneous pizza meetup. {{city}} doesn't have a host yet. would love to chat about you running one — free pizza budget, no upfront cost. 15 min call? {{calendar_link}}`,
+  },
+  {
+    id: 'v1_email',
+    channel: 'email',
+    subject: 'Host the {{city}} Global Pizza Party 2026?',
+    body: `Hi {{community_name}},
+
+We're organizing Global Pizza Party 2026 — a global, simultaneous pizza meetup on Sept 20 across hundreds of cities. We don't have a host in {{city}} yet and your community seemed like a strong fit.
+
+PizzaDAO covers the pizza budget; you bring the venue and the people. 200+ cities ran their own party last year.
+
+15-minute intro call? {{calendar_link}}
+
+— {{sender_name}}, PizzaDAO`,
+  },
+  {
+    id: 'v1_telegram',
+    channel: 'telegram',
+    body: `hi {{community_name}} 👋 we're running Global Pizza Party 2026 (sept 20, simultaneous worldwide). {{city}} is uncovered. interested in hosting? we pay for the pizza. {{calendar_link}}`,
+  },
+];
+
+export function renderTemplate(
+  tpl: OutreachTemplate,
+  vars: { community_name: string; city: string; calendar_link?: string; sender_name?: string }
+): { subject?: string; body: string } {
+  const calendar = vars.calendar_link ?? OUTREACH_CALENDAR_LINK;
+  const sender = vars.sender_name ?? 'PizzaDAO';
+  const replace = (s: string) =>
+    s
+      .replaceAll('{{community_name}}', vars.community_name)
+      .replaceAll('{{city}}', vars.city)
+      .replaceAll('{{calendar_link}}', calendar)
+      .replaceAll('{{sender_name}}', sender);
+  return {
+    subject: tpl.subject ? replace(tpl.subject) : undefined,
+    body: replace(tpl.body),
+  };
+}
+
+export function getTemplate(channel: OutreachChannel): OutreachTemplate | undefined {
+  return OUTREACH_TEMPLATES.find((t) => t.channel === channel);
+}
+```
+
+**Placeholder resolution**: Done client-side at modal render time. The `templateId` stored in `outreach_attempts` is just the identifier (`v1_twitter` etc.) — we don't store the rendered text. This means:
+- Tweaks to template copy don't require a migration.
+- We can compute "which version was sent" historically by joining `templateId` against the in-code template list.
+
+**Review checkpoint**: Snax may want to refine copy. Surface this in the PR description: "Templates are at `frontend/src/lib/outreachTemplates.ts` — edit there and redeploy. The `id` field (e.g. `v1_email`) MUST stay stable across edits, or bump to `v2_email` if making a material change so old `outreach_attempts` rows still reference a valid template id (or migrate them)."
+
+## Approval gate
+
+The entire `/underboss` route is gated. The new outreach tab is inside the existing `UnderbossDashboard` page, which already does access checks via `fetchUnderbossMe()` (`UnderbossDashboard.tsx:149-181`) and only renders the dashboard if `me.isAdmin` or `me.isUnderboss`. Non-admins see "You are not authorized."
+
+The backend endpoints are independently gated via `requireAuth, requireUnderbossAuth` (defense in depth — if a non-admin somehow guesses the URL, the API still refuses).
+
+## Files to create
+
+- `supabase/migrations/20260520_create_outreach_attempts.sql`
+- `frontend/src/components/underboss/OutreachTab.tsx`
+- `frontend/src/components/underboss/OutreachTemplateModal.tsx`
+- `frontend/src/components/underboss/OutreachLinkPartyModal.tsx`
+- `frontend/src/lib/outreachTemplates.ts`
+
+## Files to modify
+
+- `backend/prisma/schema.prisma` — add `OutreachAttempt` model + back-relations on `OutreachCommunity` (already added by stagioni-29104) and `Party`.
+- `backend/src/routes/underboss.routes.ts` — add 4 new routes (`GET /outreach/communities`, `POST /outreach/attempts`, `PATCH /outreach/attempts/:id`, `GET /outreach/parties-search`) before `export default router;`.
+- `frontend/src/pages/UnderbossDashboard.tsx` — extend `activeTab` union, add tab button (~line 540), add render branch (~line 580), import `OutreachTab`.
+- `frontend/src/components/underboss/index.ts` — export `OutreachTab`.
+- `frontend/src/lib/api.ts` — add 4 API client functions: `fetchOutreachCommunities(filters)`, `logOutreachAttempt(body)`, `updateOutreachAttempt(id, body)`, `searchPartiesForOutreach(q)`. Add corresponding TS types.
+- `frontend/src/types/index.ts` (or wherever Underboss types live) — add `OutreachCommunity`, `OutreachAttempt`, `OutreachChannel`, `OutreachStatus` types.
+- `frontend/src/locales/en/admin.json` (or wherever `underbossDashboard.tabs.*` lives) — add `tabs.outreach: "Outreach"` key. Default English-only; other locales fall back per i18n config. (Korean is in the locale list per memory note, but admin tabs aren't translated.)
+
+## Step-by-step implementation
+
+1. **Block until `stagioni-29104` is merged.** Verify `outreach_communities` exists in prod Supabase via `mcp__supabase-pizzadao__list_tables`.
+2. Create worktree branch `marinara-67583-underboss-outreach-tab` off `origin/master`.
+3. Add the `OutreachAttempt` Prisma model + back-relations on `Party`.
+4. Write the migration SQL file. Apply to prod via `mcp__supabase-pizzadao__apply_migration` first (per CLAUDE.md preview/prod-backend note).
+5. Run `npx prisma generate` to refresh the client.
+6. Implement the 4 backend routes in `underboss.routes.ts` — copy the per-route auth pattern from existing routes (e.g. lines 326-378). Each handler wraps in `try/catch` and calls `next(error)`.
+7. Wire `index.ts` — no change needed; routes auto-mount under `/api/underboss`.
+8. Add the 4 frontend API client functions + TS types.
+9. Create `frontend/src/lib/outreachTemplates.ts` (copy from the spec above).
+10. Create `OutreachTemplateModal.tsx` (renders one template, interpolates, copy + mark-sent buttons).
+11. Create `OutreachLinkPartyModal.tsx` (search + select + PATCH).
+12. Create `OutreachTab.tsx` (filter bar + table + inline actions + state for both modals).
+13. Wire `OutreachTab` into `UnderbossDashboard.tsx` as the 5th tab.
+14. Add `tabs.outreach: "Outreach"` translation key to `en/admin.json`.
+15. Local smoke test: `npm run dev` in `frontend/`, run `backend/` against staging DB. Verify all 4 endpoints + tab UI.
+16. Open draft PR. Tag Snax for template-copy review.
+17. Verify Vercel preview loads `/underboss` → Outreach tab → all 3 templates render with correct interpolation → mark-as-sent persists → status PATCH persists → link-party search returns parties.
+18. Lift to ready-for-review once Snax signs off on copy.
+
+## Verification
+
+- `outreach_attempts` table exists in prod Supabase (`mcp__supabase-pizzadao__list_tables`).
+- `prisma generate` succeeds locally; `npx tsc --noEmit` passes in both `backend/` and `frontend/`.
+- Vercel preview `https://rsvpizza-git-marinara-67583-underboss-outreach-tab-pizza-dao.vercel.app/underboss` loads.
+- "Outreach" tab is visible and clickable.
+- Tab loads communities from the prod `outreach_communities` table (assuming stagioni-29104 has populated it).
+- Filter bar: typing in city box, changing priority/status/source filters, all narrow the list.
+- "Copy template" → Twitter / Email / Telegram each open a modal with the correct interpolated text. Copy-to-clipboard works (paste into a text field to verify).
+- "Mark as sent" creates an `outreach_attempts` row visible in Supabase Table Editor. Row has correct `community_id`, `channel`, `template_id`, `sent_by` (= admin email), `status='sent'`.
+- After marking sent, the row in the table updates to show the new last-attempt status without a full page reload.
+- "Mark status" → changing status to "replied" persists; row reflects new status.
+- "Link party" appears only when status is "converted". Search returns matching parties; selecting one updates `converted_party_id`.
+- Non-underboss user (logged in as a regular host) hits `/api/underboss/outreach/communities` directly → gets 403.
+- No console errors. No 401/500s.
+- Confirm no `router.use(<gate>)` was introduced (`grep -nE "^router\.use\(" backend/src/routes/underboss.routes.ts` should still show zero results).
+- Confirm no confirm-modal anti-pattern on Mark-as-sent / Mark-status / Link-party.
+
+## Out of scope (handed off to supreme-43217 / stagioni-29104)
+
+- The `outreach_communities` staging table (stagioni-29104 owns the migration + scrapers).
+- The four scrapers (Twitter / Telegram / Meetup / Eventbrite) — stagioni-29104.
+- Cross-reference logic that flags which scraped communities are in "uncovered" cities — stagioni-29104.
+- The GPP 2026 coverage-gap Google Sheet — supreme-43217.
+- Template versioning beyond `v1` (no `v2_*` planned for this task).
+- Outbound automated sending (e.g. auto-DM via Twitter API). v1 is **manual copy-paste only** — admin sends the message themselves and logs the attempt. Automation can come in a follow-up task once we know which templates convert.
+- Per-locale template translation. Templates are English-only for v1.
+
+### Critical files for implementation
+
+- `backend/src/routes/underboss.routes.ts`
+- `backend/prisma/schema.prisma`
+- `frontend/src/pages/UnderbossDashboard.tsx`
+- `frontend/src/lib/api.ts`
+- `frontend/src/components/underboss/index.ts`

--- a/supabase/migrations/20260520_create_outreach_attempts.sql
+++ b/supabase/migrations/20260520_create_outreach_attempts.sql
@@ -1,0 +1,37 @@
+-- marinara-67583: Outreach attempts log
+-- Admin-only — explicitly revoke from anon/authenticated.
+-- Backend reads/writes via service_role.
+
+CREATE TABLE IF NOT EXISTS outreach_attempts (
+  id                  TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  community_id        TEXT NOT NULL REFERENCES outreach_communities(id) ON DELETE CASCADE,
+  channel             TEXT NOT NULL,                              -- 'twitter_dm' | 'email' | 'telegram'
+  template_id         TEXT NOT NULL,                              -- 'v1_twitter' | 'v1_email' | 'v1_telegram'
+  sent_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  sent_by             TEXT NOT NULL,                              -- admin email from req.userEmail
+  status              TEXT NOT NULL DEFAULT 'sent',               -- 'sent' | 'replied' | 'declined' | 'converted' | 'bounced'
+  converted_party_id  UUID REFERENCES parties(id) ON DELETE SET NULL,
+  notes               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT outreach_attempts_channel_check
+    CHECK (channel IN ('twitter_dm', 'email', 'telegram')),
+  CONSTRAINT outreach_attempts_status_check
+    CHECK (status IN ('sent', 'replied', 'declined', 'converted', 'bounced'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_outreach_attempts_community ON outreach_attempts(community_id);
+CREATE INDEX IF NOT EXISTS idx_outreach_attempts_status    ON outreach_attempts(status);
+CREATE INDEX IF NOT EXISTS idx_outreach_attempts_sent_at   ON outreach_attempts(sent_at DESC);
+
+ALTER TABLE outreach_attempts ENABLE ROW LEVEL SECURITY;
+
+DROP TRIGGER IF EXISTS trg_outreach_attempts_updated_at ON outreach_attempts;
+CREATE TRIGGER trg_outreach_attempts_updated_at
+  BEFORE UPDATE ON outreach_attempts
+  FOR EACH ROW
+  EXECUTE FUNCTION set_outreach_communities_updated_at();
+
+-- Admin-only — Supabase auto-grants on new public tables; revoke explicitly.
+REVOKE ALL ON outreach_attempts FROM anon, authenticated;


### PR DESCRIPTION
## Summary

Adds the `/underboss` **Outreach** tab — Task C of the GPP 2026 outreach initiative (supreme-43217 → stagioni-29104 → marinara-67583). Snax and underbosses can now actually do recruitment work against the `outreach_communities` table that #428 populates:

- Filter candidate communities by city, priority, source, and contact status
- One-click **copy template** for Twitter DM / Email / Telegram (templates inline in `frontend/src/lib/outreachTemplates.ts`)
- Log every outreach attempt to a new `outreach_attempts` table with channel + template_id + admin email
- Lifecycle tracking: `sent → replied → declined → converted → bounced`
- When converted, search and link the actual `parties` row it produced

## Migration status

The `outreach_attempts` migration is **already applied to production** (via `pg` + `DATABASE_URL`, per project memory `reference_db_backfill_fallback.md`). 11 columns, REVOKEd from anon/authenticated, no Supabase auto-grants leaked. Verified `to_regclass('public.outreach_attempts')` returns non-null and zero `anon`/`authenticated` grants.

`outreach_communities` (the dependency from #428) was already applied to prod before this PR was opened, so the frontend can be exercised against the production backend straight from the preview URL.

## Notable details to review

1. **Calendar link**: hard-coded to `https://cal.com/pizzadao/gpp-host` in `frontend/src/lib/outreachTemplates.ts`. Confirm this is the right URL or swap it in that file.
2. **Templates**: three v1 templates inline at the same path. The `id` field (e.g. `v1_email`) MUST stay stable across edits, or bump to `v2_*` for material changes so old `outreach_attempts` rows still resolve.
3. **Duplicate Prisma model**: this branch adds `OutreachCommunity` to `backend/prisma/schema.prisma` so `prisma generate` succeeds independently of #428. Whichever PR merges first wins; the other resolves the conflict by deleting its duplicate block. Snippet copied verbatim from the stagioni-29104 plan to keep the diff trivial.
4. **No confirm modals** on Mark-as-sent, status changes, or Link party — all reversible, per project convention (`feedback_reversible_actions_no_confirm.md`).
5. **Per-route middleware only** — no `router.use('/outreach', ...)`. Each route registers `requireAuth, requireUnderbossAuth` inline. Verified via `grep -nE "^router\.use\(" backend/src/routes/underboss.routes.ts` → zero hits.
6. **English-only UI**. Only `tabs.outreach: "Outreach"` was added to `en/admin.json`. Other locales fall back per i18n config.

## Test plan

Vercel preview: `https://rsvpizza-git-marinara-67583-outreach-tab-pizza-dao.vercel.app/underboss`

- [ ] Outreach tab appears in the underboss dashboard tab bar (5th tab, last)
- [ ] Tab loads communities from prod `outreach_communities` with their latest attempt status (if any)
- [ ] Filter bar narrows the list: city search (debounced), priority, status, source dropdowns
- [ ] "Not contacted" status filter returns only communities with zero attempts
- [ ] Status filter for sent/replied/declined/converted/bounced filters by latest-attempt status
- [ ] Clicking Twitter/Email/Telegram button opens the modal with correct interpolation
- [ ] Disabled channel buttons (no contact info) cannot open the modal
- [ ] "Copy to clipboard" puts the rendered body on the clipboard, checkmark for 2s
- [ ] "Mark as sent" creates an `outreach_attempts` row visible in Supabase; row appears in table immediately
- [ ] Inline status select updates the attempt status (PATCH) optimistically
- [ ] When status flipped to "converted", "Link party" button appears
- [ ] Link party modal: search by event name / customUrl returns up to 10 matches; selecting one PATCHes `converted_party_id`
- [ ] Non-underboss user hitting `/api/underboss/outreach/*` directly → 403
- [ ] No console errors, no 401/500s

## Files

- New: `supabase/migrations/20260520_create_outreach_attempts.sql`, `frontend/src/components/underboss/OutreachTab.tsx`, `OutreachTemplateModal.tsx`, `OutreachLinkPartyModal.tsx`, `frontend/src/lib/outreachTemplates.ts`, `plans/marinara-67583-underboss-outreach-tab.md`
- Modified: `backend/prisma/schema.prisma`, `backend/src/routes/underboss.routes.ts`, `frontend/src/lib/api.ts`, `frontend/src/pages/UnderbossDashboard.tsx`, `frontend/src/components/underboss/index.ts`, `frontend/src/i18n/locales/en/admin.json`

Plan: `plans/marinara-67583-underboss-outreach-tab.md`
Depends on: #428 (stagioni-29104) — `outreach_communities` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)