### PR TITLE
chore(arugula-38633): drop 'Optional —' from event photos copy

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -22,9 +22,9 @@ const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
 
 const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [
   { value: 'all', label: 'All methods' },
+  { value: 'usdc_base', label: PAYOUT_METHOD_LABELS.usdc_base },
   { value: 'mercury_card', label: PAYOUT_METHOD_LABELS.mercury_card },
   { value: 'wire', label: PAYOUT_METHOD_LABELS.wire },
-  { value: 'usdc_base', label: PAYOUT_METHOD_LABELS.usdc_base },
 ];
 
 /**

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -148,7 +148,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({ partyId, onCreated
         <div className="mb-3">
           <h3 className="text-base font-semibold text-theme-text">Pizza or event photos</h3>
           <p className="text-xs text-theme-text-muted mt-0.5">
-            Optional — proof-of-event photos help your reviewer.
+            Proof-of-event photos help your reviewer.
           </p>
         </div>
         <PizzaPhotoUpload

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -83,6 +83,12 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
     <div className="space-y-4">
       <div className="grid sm:grid-cols-3 gap-3">
         <Option
+          value="usdc_base"
+          icon={<Coins size={18} />}
+          title="USDC on Base"
+          description="On-chain payout to your wallet."
+        />
+        <Option
           value="mercury_card"
           icon={<CreditCard size={18} />}
           title="Mercury virtual card"
@@ -93,12 +99,6 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           icon={<Banknote size={18} />}
           title="Bank wire"
           description="We send a wire to your bank account."
-        />
-        <Option
-          value="usdc_base"
-          icon={<Coins size={18} />}
-          title="USDC on Base"
-          description="On-chain payout to your wallet."
         />
       </div>
 

--- a/frontend/src/components/payouts/PizzaPhotoUpload.tsx
+++ b/frontend/src/components/payouts/PizzaPhotoUpload.tsx
@@ -111,7 +111,7 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
             : 'Drop pizza / event photos here, or click to choose files'}
         </p>
         <p className="text-xs text-theme-text-muted mt-1">
-          {remaining > 0 && `Optional — up to ${remaining} more.`}
+          {remaining > 0 && `Up to ${remaining} more.`}
         </p>
       </div>
 


### PR DESCRIPTION
Removes 'Optional — ' prefix from two strings in the Payouts form: the section description in NewPayoutForm and the upload hint in PizzaPhotoUpload.