### PR TITLE
feat(arugula-38633): reimbursement cap + appeal

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -195,6 +195,12 @@ model Party {
   // Turtle role selection on RSVP form
   turtleRolesEnabled Boolean @default(false) @map("turtle_roles_enabled")
 
+  // Reimbursement cap (arugula-38633 v2) — set by underboss after validating
+  // the city-tier × RSVP heuristic. NULL = not yet validated (banner hidden).
+  reimbursementCapUsd        Decimal?  @map("reimbursement_cap_usd") @db.Decimal(10, 2)
+  reimbursementCapAppealNote String?   @map("reimbursement_cap_appeal_note")
+  reimbursementCapAppealedAt DateTime? @map("reimbursement_cap_appealed_at") @db.Timestamptz
+
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -64,6 +64,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         telegramGroup: true,
         turtleRolesEnabled: true,
         underbossStatus: true,
+        reimbursementCapUsd: true,
         password: true, // Just to check if it exists
         userId: true,
         user: {
@@ -137,6 +138,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
           telegramGroup: true,
           turtleRolesEnabled: true,
           underbossStatus: true,
+          reimbursementCapUsd: true,
           password: true,
           userId: true,
           user: {
@@ -320,6 +322,7 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         userId: party.userId,
         sponsors,
         pageViewStats,
+        reimbursementCapUsd: party.reimbursementCapUsd != null ? Number(party.reimbursementCapUsd) : null,
       },
     });
   } catch (error) {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -1,6 +1,6 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest, isSuperAdmin } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isSuperAdmin, isAdmin, isUnderboss } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
@@ -433,7 +433,12 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       // the chat_id is webhook-only (set by /api/telegram/webhook when the host
       // sends /start <token> to the bot). Allowing PATCH writes would let a host
       // spoof another user's chat_id.
-      turtleRolesEnabled
+      turtleRolesEnabled,
+      reimbursementCapUsd,
+      // NOTE: reimbursementCapAppealNote + reimbursementCapAppealedAt are NOT
+      // destructured here — appeals flow through the dedicated
+      // POST /:partyId/reimbursement-cap/appeal endpoint so we can timestamp
+      // the appeal and avoid leaking it through the generic PATCH whitelist.
     } = req.body;
 
     // Verify ownership or super admin
@@ -513,6 +518,31 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       mergedCoHosts = ordered;
     }
 
+    // reimbursementCapUsd is settable by underbosses + admins only (arugula-38633 v2).
+    // Hosts who try to set it via this generic PATCH get silently dropped from
+    // the update (rather than 403'd) so the rest of their save still succeeds.
+    let reimbursementCapUsdToWrite: number | null | undefined = undefined;
+    if (reimbursementCapUsd !== undefined) {
+      const allowed = (await isSuperAdmin(req.userEmail))
+        || (await isAdmin(req.userEmail))
+        || (await isUnderboss(req.userEmail));
+      if (allowed) {
+        if (reimbursementCapUsd === null || reimbursementCapUsd === '') {
+          reimbursementCapUsdToWrite = null;
+        } else {
+          const n = Number(reimbursementCapUsd);
+          if (!Number.isFinite(n) || n < 0 || n > 100000) {
+            throw new AppError(
+              'reimbursementCapUsd must be a non-negative number ≤ 100000',
+              400,
+              'VALIDATION_ERROR'
+            );
+          }
+          reimbursementCapUsdToWrite = n;
+        }
+      }
+    }
+
     const party = await prisma.party.update({
       where: { id },
       data: {
@@ -577,6 +607,7 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(telegramGroup !== undefined && { telegramGroup: telegramGroup || null }),
         ...(hostTelegramLinkToken !== undefined && { hostTelegramLinkToken: hostTelegramLinkToken || null }),
         ...(turtleRolesEnabled !== undefined && { turtleRolesEnabled }),
+        ...(reimbursementCapUsdToWrite !== undefined && { reimbursementCapUsd: reimbursementCapUsdToWrite }),
       },
       include: {
         user: { select: { name: true } },
@@ -698,6 +729,56 @@ router.post('/:id/open-rsvp', async (req: AuthRequest, res: Response, next: Next
     await triggerWebhook('party.rsvp_opened', party, req.userId!);
 
     res.json({ success: true, message: 'RSVPs reopened' });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/reimbursement-cap/appeal - Host appeal of the
+// reimbursement cap (arugula-38633 v2).
+//
+// Intentionally lives in party.routes.ts (NOT payout.routes.ts) so the
+// payouts soft-launch gate does not block hosts — even hosts who can't yet
+// submit a payout may want to register that they think their cap is too low.
+router.post('/:partyId/reimbursement-cap/appeal', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { note } = req.body || {};
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    if (typeof note !== 'string' || note.trim().length === 0) {
+      throw new AppError('Appeal note is required', 400, 'VALIDATION_ERROR');
+    }
+    const trimmed = note.trim();
+    if (trimmed.length > 2000) {
+      throw new AppError('Appeal note must be 2000 characters or fewer', 400, 'VALIDATION_ERROR');
+    }
+
+    const now = new Date();
+    const updated = await prisma.party.update({
+      where: { id: partyId },
+      data: {
+        reimbursementCapAppealNote: trimmed,
+        reimbursementCapAppealedAt: now,
+      },
+      select: {
+        id: true,
+        reimbursementCapUsd: true,
+        reimbursementCapAppealNote: true,
+        reimbursementCapAppealedAt: true,
+      },
+    });
+
+    res.json({
+      partyId: updated.id,
+      reimbursementCapUsd: updated.reimbursementCapUsd != null ? Number(updated.reimbursementCapUsd) : null,
+      reimbursementCapAppealNote: updated.reimbursementCapAppealNote,
+      reimbursementCapAppealedAt: updated.reimbursementCapAppealedAt ? updated.reimbursementCapAppealedAt.toISOString() : null,
+    });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -174,6 +174,14 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
     flyerConfig: party.flyerConfig || null,
     latestSponsorAt: latestSponsorAtStr,
     flyerStale,
+    // Reimbursement cap (arugula-38633 v2) — exposed so the underboss
+    // dashboard can render Validate/Override controls + appeal indicator.
+    city: party.city || null,
+    reimbursementCapUsd: party.reimbursementCapUsd != null ? Number(party.reimbursementCapUsd) : null,
+    reimbursementCapAppealNote: party.reimbursementCapAppealNote || null,
+    reimbursementCapAppealedAt: party.reimbursementCapAppealedAt
+      ? new Date(party.reimbursementCapAppealedAt).toISOString()
+      : null,
   };
 }
 

--- a/frontend/src/components/payouts/AppealCapModal.tsx
+++ b/frontend/src/components/payouts/AppealCapModal.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Loader2, X, MessageSquare } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { appealReimbursementCap } from '../../lib/api';
+
+interface AppealCapModalProps {
+  partyId: string;
+  capUsd: number;
+  /** ISO string — null if the host hasn't appealed yet. */
+  previousAppealedAt: string | null;
+  /** Previous note, if any — shown when the user is re-appealing. */
+  previousNote: string | null;
+  onClose: () => void;
+  onSubmitted: (result: { note: string; appealedAt: string }) => void;
+}
+
+const MAX_NOTE_LEN = 2000;
+
+/**
+ * Modal for hosts to appeal their reimbursement cap (arugula-38633 v2).
+ *
+ * Submits to POST /api/parties/:id/reimbursement-cap/appeal which lives
+ * outside the payouts soft-launch gate, so hosts can still register an
+ * appeal even before they can submit payouts.
+ */
+export const AppealCapModal: React.FC<AppealCapModalProps> = ({
+  partyId,
+  capUsd,
+  previousAppealedAt,
+  previousNote,
+  onClose,
+  onSubmitted,
+}) => {
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const isReappeal = !!previousAppealedAt;
+  const trimmed = note.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_NOTE_LEN && !submitting;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await appealReimbursementCap(partyId, trimmed);
+      setSuccess(true);
+      if (res.reimbursementCapAppealedAt) {
+        onSubmitted({
+          note: res.reimbursementCapAppealNote ?? trimmed,
+          appealedAt: res.reimbursementCapAppealedAt,
+        });
+      }
+    } catch (err: any) {
+      setError(err?.message || 'Failed to submit appeal');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="card p-6 sm:p-8 max-w-lg w-full relative"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-theme-text-muted hover:text-theme-text transition-colors"
+          aria-label="Close"
+        >
+          <X size={24} />
+        </button>
+
+        <div className="mb-4">
+          <h2 className="text-xl font-bold text-theme-text mb-1">Appeal reimbursement cap</h2>
+          <p className="text-sm text-theme-text-muted">
+            Your cap is currently <span className="font-medium text-theme-text">${capUsd.toFixed(2)}</span>.
+            Tell us why it should be higher and an underboss will review.
+          </p>
+        </div>
+
+        {success ? (
+          <div className="space-y-4">
+            <div className="bg-green-500/10 border border-green-500/30 text-green-300 p-4 rounded-xl text-sm">
+              Thanks — your appeal has been recorded. An underboss will review it
+              and follow up if they need more info.
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-full btn-secondary"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {isReappeal && (
+              <div className="bg-theme-surface border border-theme-stroke p-3 rounded-xl text-xs text-theme-text-muted">
+                You've already appealed this cap. Submitting again replaces your
+                previous note{previousNote ? `: "${previousNote.slice(0, 120)}${previousNote.length > 120 ? '…' : ''}"` : '.'}
+              </div>
+            )}
+
+            <div>
+              <IconInput
+                icon={MessageSquare}
+                multiline
+                rows={5}
+                placeholder="Why should the cap be higher? (e.g. expensive venue, larger crowd than usual, sponsor commitments…)"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                maxLength={MAX_NOTE_LEN}
+                autoFocus
+              />
+              <p className="text-xs text-white/40 mt-1">
+                {trimmed.length}/{MAX_NOTE_LEN}
+              </p>
+            </div>
+
+            {error && (
+              <div className="bg-[#ff393a]/10 border border-[#ff393a]/30 text-[#ff393a] p-3 rounded-xl text-sm">
+                {error}
+              </div>
+            )}
+
+            <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="btn-secondary"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className="btn-primary inline-flex items-center justify-center gap-2"
+              >
+                {submitting && <Loader2 size={16} className="animate-spin" />}
+                {submitting ? 'Submitting…' : 'Submit appeal'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { useAuth } from '../../contexts/AuthContext';
@@ -9,11 +9,18 @@ import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
 import { PayoutAmountSummary } from './PayoutAmountSummary';
+import { AppealCapModal } from './AppealCapModal';
 
 interface NewPayoutFormProps {
   partyId: string;
   onCreated: (payout: Payout) => void;
   onCancel: () => void;
+  /** Reimbursement cap (arugula-38633 v2) — banner only renders if non-null. */
+  reimbursementCapUsd?: number | null;
+  /** Previous appeal note (if any) — shown in re-appeal flow. */
+  reimbursementCapAppealNote?: string | null;
+  /** Previous appeal timestamp — non-null means host has already appealed. */
+  reimbursementCapAppealedAt?: string | null;
 }
 
 const EMPTY_BANK: BankDetails = {
@@ -33,10 +40,23 @@ const EMPTY_BANK: BankDetails = {
  *   6. Save-as-default
  *   7. Submit
  */
-export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({ partyId, onCreated, onCancel }) => {
+export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
+  partyId,
+  onCreated,
+  onCancel,
+  reimbursementCapUsd,
+  reimbursementCapAppealNote,
+  reimbursementCapAppealedAt,
+}) => {
   const { user } = useAuth();
   // Stable id for this in-flight form, used as the storage-path grouping key.
   const [payoutTempId] = useState(() => `tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+
+  // Cap appeal modal + local mirror of appeal state so submissions update the
+  // banner without requiring the parent to reload the Party context.
+  const [showAppealModal, setShowAppealModal] = useState(false);
+  const [localAppealNote, setLocalAppealNote] = useState<string | null>(reimbursementCapAppealNote ?? null);
+  const [localAppealedAt, setLocalAppealedAt] = useState<string | null>(reimbursementCapAppealedAt ?? null);
 
   const [receipts, setReceipts] = useState<ReceiptItem[]>([]);
   const [pizzaPhotos, setPizzaPhotos] = useState<PizzaPhotoItem[]>([]);
@@ -125,8 +145,36 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({ partyId, onCreated
     }
   };
 
+  const showCapBanner = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* 0. Reimbursement cap banner (arugula-38633 v2) — only when underboss-validated */}
+      {showCapBanner && (
+        <div className="card p-4 sm:p-5 border-l-4 border-l-[#ff393a] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <BadgeDollarSign size={22} className="text-[#ff393a] mt-0.5 flex-shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-theme-text">
+                We'll reimburse you for up to ${reimbursementCapUsd!.toFixed(2)}.
+              </p>
+              <p className="text-xs text-theme-text-muted mt-0.5">
+                {localAppealedAt
+                  ? 'Appeal submitted — an underboss will review.'
+                  : 'Submissions above this amount may not be fully reimbursed.'}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowAppealModal(true)}
+            className="text-xs text-theme-text-secondary hover:text-theme-text underline underline-offset-2 whitespace-nowrap"
+          >
+            {localAppealedAt ? 'Update appeal' : 'Appeal cap →'}
+          </button>
+        </div>
+      )}
+
       {/* 1. Receipts */}
       <div className="card p-6">
         <div className="mb-3">
@@ -246,6 +294,20 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({ partyId, onCreated
             : `Submit $${finalAmount.toFixed(2)} payout`}
         </button>
       </div>
+
+      {showAppealModal && showCapBanner && (
+        <AppealCapModal
+          partyId={partyId}
+          capUsd={reimbursementCapUsd!}
+          previousAppealedAt={localAppealedAt}
+          previousNote={localAppealNote}
+          onClose={() => setShowAppealModal(false)}
+          onSubmitted={({ note, appealedAt }) => {
+            setLocalAppealNote(note);
+            setLocalAppealedAt(appealedAt);
+          }}
+        />
+      )}
     </form>
   );
 };

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -8,6 +8,9 @@ import { PayoutDetailModal } from './PayoutDetailModal';
 
 interface PayoutsTabProps {
   partyId: string;
+  reimbursementCapUsd?: number | null;
+  reimbursementCapAppealNote?: string | null;
+  reimbursementCapAppealedAt?: string | null;
 }
 
 type View = 'list' | 'new';
@@ -21,7 +24,12 @@ type View = 'list' | 'new';
  * full UI; everyone else sees a "coming soon" placeholder. Backend enforces
  * the same restriction. Remove `canAccess` checks here when opening up.
  */
-export const PayoutsTab: React.FC<PayoutsTabProps> = ({ partyId }) => {
+export const PayoutsTab: React.FC<PayoutsTabProps> = ({
+  partyId,
+  reimbursementCapUsd,
+  reimbursementCapAppealNote,
+  reimbursementCapAppealedAt,
+}) => {
   const [view, setView] = useState<View>('list');
   const [payouts, setPayouts] = useState<Payout[]>([]);
   const [loading, setLoading] = useState(true);
@@ -164,6 +172,9 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({ partyId }) => {
             partyId={partyId}
             onCreated={handleCreated}
             onCancel={() => setView('list')}
+            reimbursementCapUsd={reimbursementCapUsd}
+            reimbursementCapAppealNote={reimbursementCapAppealNote}
+            reimbursementCapAppealedAt={reimbursementCapAppealedAt}
           />
         </>
       )}

--- a/frontend/src/components/payouts/index.ts
+++ b/frontend/src/components/payouts/index.ts
@@ -7,3 +7,4 @@ export { PizzaPhotoUpload } from './PizzaPhotoUpload';
 export { PayoutMethodPicker } from './PayoutMethodPicker';
 export { PayoutAmountSummary } from './PayoutAmountSummary';
 export { PayoutDetailModal } from './PayoutDetailModal';
+export { AppealCapModal } from './AppealCapModal';

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, Handshake, StickyNote, ChevronLeft, ChevronRight, MessageCircle, Send } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
+import { ReimbursementCapCell } from './ReimbursementCapCell';
 import { IconInput } from '../IconInput';
 import { CopyEmailButton } from '../CopyEmailButton';
 import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, updateExpectedGuests, getPartyPhotos } from '../../lib/api';
@@ -566,6 +567,8 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
                 </span>
                 <span className="text-xs font-medium text-green-400 ml-1">&middot; ${price.toLocaleString()}</span>
               </div>
+              {/* Reimbursement cap controls (arugula-38633 v2) */}
+              <ReimbursementCapCell event={event} onUpdate={onEventUpdate} />
               {/* Inline notes editor */}
               {notesOpen && (
                 <div className="mt-1.5">

--- a/frontend/src/components/underboss/ReimbursementCapCell.tsx
+++ b/frontend/src/components/underboss/ReimbursementCapCell.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import { Check, Edit2, AlertCircle, X, Loader2 } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { computeSuggestedReimbursementCap } from '../../utils/reimbursementCap';
+import { updatePartyApi } from '../../lib/api';
+import type { UnderbossEvent } from '../../types';
+
+interface ReimbursementCapCellProps {
+  event: UnderbossEvent;
+  onUpdate?: (eventId: string, updates: Partial<UnderbossEvent>) => void;
+}
+
+/**
+ * Underboss-side control for the per-event reimbursement cap (arugula-38633 v2).
+ *
+ * States:
+ *   * Unvalidated (capUsd == null) — show "Suggested: $X" + [Validate] +
+ *     [Override] buttons.
+ *   * Validated  (capUsd != null)  — show "$X" + [Edit] button.
+ *   * If host has appealed: amber badge with hover-to-see-note.
+ *
+ * Falls back to deriving the city from the event name (strips "Global Pizza
+ * Party " prefix) when the underboss API hasn't populated `event.city` yet.
+ */
+export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ event, onUpdate }) => {
+  const cityName = event.city
+    || event.name.replace(/^Global Pizza Party\s*/i, '').trim()
+    || null;
+  const confirmedRsvps = event.guestCount ?? 0;
+  const { suggestedUsd, formula } = computeSuggestedReimbursementCap({
+    city: cityName,
+    confirmedRsvpCount: confirmedRsvps,
+  });
+
+  const currentCap = event.reimbursementCapUsd;
+  const hasAppeal = !!event.reimbursementCapAppealedAt;
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(
+    currentCap != null ? String(currentCap) : String(suggestedUsd)
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(value: number | null) {
+    setSaving(true);
+    setError(null);
+    try {
+      await updatePartyApi(event.id, { reimbursementCapUsd: value });
+      onUpdate?.(event.id, { reimbursementCapUsd: value });
+      setEditing(false);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleValidate() {
+    await save(suggestedUsd);
+  }
+
+  async function handleOverrideSubmit() {
+    const trimmed = draft.trim();
+    if (trimmed === '') {
+      // Empty = clear the cap
+      await save(null);
+      return;
+    }
+    const n = Number(trimmed);
+    if (!Number.isFinite(n) || n < 0 || n > 100000) {
+      setError('Enter a non-negative number ≤ 100000');
+      return;
+    }
+    await save(n);
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-1 mt-0.5" onClick={(e) => e.stopPropagation()}>
+        <span className="text-[10px] text-theme-text-faint">$</span>
+        <IconInput
+          icon={Edit2}
+          iconSize={10}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') { e.preventDefault(); handleOverrideSubmit(); }
+            if (e.key === 'Escape') { setEditing(false); setError(null); }
+          }}
+          placeholder={String(suggestedUsd)}
+          className="!pl-6 py-0.5 text-[10px] w-16 bg-theme-surface border border-theme-stroke rounded text-theme-text"
+          autoFocus
+        />
+        <button
+          type="button"
+          onClick={handleOverrideSubmit}
+          disabled={saving}
+          className="text-[#39d98a] hover:opacity-80 disabled:opacity-40"
+          title="Save"
+        >
+          {saving ? <Loader2 size={10} className="animate-spin" /> : <Check size={10} />}
+        </button>
+        <button
+          type="button"
+          onClick={() => { setEditing(false); setError(null); }}
+          disabled={saving}
+          className="text-theme-text-faint hover:text-theme-text-muted disabled:opacity-40"
+          title="Cancel"
+        >
+          <X size={10} />
+        </button>
+        {error && (
+          <span className="text-[9px] text-red-400 ml-1" title={error}>!</span>
+        )}
+      </div>
+    );
+  }
+
+  if (currentCap == null) {
+    return (
+      <div className="flex items-center gap-1 mt-0.5" title={formula}>
+        <span className="text-[10px] text-theme-text-faint">
+          Cap: <span className="text-theme-text-muted">${suggestedUsd}</span>?
+        </span>
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={saving}
+          className="text-[9px] px-1 py-0.5 rounded border border-[#39d98a]/40 text-[#39d98a] hover:bg-[#39d98a]/10 transition-colors disabled:opacity-40"
+          title={`Validate suggestion (${formula})`}
+        >
+          {saving ? '…' : 'Validate'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="text-[9px] px-1 py-0.5 rounded border border-theme-stroke text-theme-text-muted hover:text-theme-text transition-colors"
+          title="Override with a custom value"
+        >
+          Override
+        </button>
+        {hasAppeal && (
+          <span title={event.reimbursementCapAppealNote || 'Host has appealed'}>
+            <AlertCircle size={10} className="text-amber-400" />
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1 mt-0.5" title={formula}>
+      <span className="text-[10px] text-theme-text-muted">
+        Cap: <span className="text-theme-text font-medium">${Number(currentCap).toLocaleString()}</span>
+      </span>
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="text-theme-text-faint hover:text-theme-text-muted transition-colors"
+        title="Edit cap"
+      >
+        <Edit2 size={9} />
+      </button>
+      {hasAppeal && (
+        <span title={event.reimbursementCapAppealNote || 'Host has appealed'}>
+          <AlertCircle size={10} className="text-amber-400" />
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -9,3 +9,4 @@ export { FunnelTab } from './FunnelTab';
 export { CityScopePicker } from './CityScopePicker';
 export { FakeDetectionTable } from './FakeDetectionTable';
 export { OutreachTab } from './OutreachTab';
+export { ReimbursementCapCell } from './ReimbursementCapCell';

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -154,6 +154,9 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     hostTelegramLinkToken: dbParty.host_telegram_link_token || null,
     underbossStatus: (dbParty.underboss_status as any) || null,
     turtleRolesEnabled: dbParty.turtle_roles_enabled || false,
+    reimbursementCapUsd: dbParty.reimbursement_cap_usd != null ? Number(dbParty.reimbursement_cap_usd) : null,
+    reimbursementCapAppealNote: dbParty.reimbursement_cap_appeal_note ?? null,
+    reimbursementCapAppealedAt: dbParty.reimbursement_cap_appealed_at ?? null,
     guests,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -198,6 +198,7 @@ export interface UpdatePartyData {
   telegramGroup?: string | null;
   hostTelegramLinkToken?: string | null;
   turtleRolesEnabled?: boolean;
+  reimbursementCapUsd?: number | null;
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -306,6 +307,7 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       telegramGroup: data.telegramGroup,
       hostTelegramLinkToken: data.hostTelegramLinkToken,
       turtleRolesEnabled: data.turtleRolesEnabled,
+      reimbursementCapUsd: data.reimbursementCapUsd,
     },
   });
 }
@@ -478,6 +480,10 @@ export interface PublicEvent {
   turtleRolesEnabled?: boolean;
   sponsors?: PublicEventSponsor[];
   pageViewStats?: { totalViews: number; uniqueVisitors: number };
+  // Reimbursement cap (arugula-38633 v2) — public so the host-facing payout
+  // banner can render before re-loading the Party context. NULL when an
+  // underboss has not validated yet.
+  reimbursementCapUsd?: number | null;
 }
 
 // Public Event API (no auth required)
@@ -3951,6 +3957,32 @@ export async function cancelPayout(partyId: string, payoutId: string): Promise<b
     { method: 'DELETE', requireAuth: true }
   );
   return true;
+}
+
+// ============================================================
+// Reimbursement cap appeal (arugula-38633 v2)
+// ============================================================
+
+export interface ReimbursementCapAppealResponse {
+  partyId: string;
+  reimbursementCapUsd: number | null;
+  reimbursementCapAppealNote: string | null;
+  reimbursementCapAppealedAt: string | null;
+}
+
+/**
+ * Host appeals the reimbursement cap. Endpoint lives outside the payouts
+ * soft-launch gate so hosts can still register their objection even if they
+ * can't yet submit payouts.
+ */
+export async function appealReimbursementCap(
+  partyId: string,
+  note: string
+): Promise<ReimbursementCapAppealResponse> {
+  return apiRequest<ReimbursementCapAppealResponse>(
+    `/api/parties/${partyId}/reimbursement-cap/appeal`,
+    { method: 'POST', body: { note }, requireAuth: true }
+  );
 }
 
 export async function previewReceiptOCR(

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -774,6 +774,10 @@ export interface DbParty {
   underboss_status?: string | null;
   // Turtle role selection toggle
   turtle_roles_enabled?: boolean;
+  // Reimbursement cap (arugula-38633 v2)
+  reimbursement_cap_usd?: number | null;
+  reimbursement_cap_appeal_note?: string | null;
+  reimbursement_cap_appealed_at?: string | null;
 }
 
 export type DbGuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
@@ -842,7 +846,8 @@ export const SAFE_PARTY_COLUMNS = `
   underboss_status,
   flyer_config,
   poster_image_url, poster_generated_at,
-  rollup_image_url, rollup_generated_at
+  rollup_image_url, rollup_generated_at,
+  reimbursement_cap_usd, reimbursement_cap_appeal_note, reimbursement_cap_appealed_at
 `;
 
 /**
@@ -1824,6 +1829,7 @@ export async function updateParty(
     telegram_group?: string | null;
     host_telegram_link_token?: string | null;
     turtle_roles_enabled?: boolean;
+    reimbursement_cap_usd?: number | null;
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -1898,6 +1904,7 @@ export async function updateParty(
         telegramGroup: updates.telegram_group,
         hostTelegramLinkToken: updates.host_telegram_link_token,
         turtleRolesEnabled: updates.turtle_roles_enabled,
+        reimbursementCapUsd: updates.reimbursement_cap_usd,
       });
       return true;
     } catch (error) {

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -488,7 +488,12 @@ function HostPageContent() {
               )}
 
               {activeTab === 'payouts' && party && (
-                <PayoutsTab partyId={party.id} />
+                <PayoutsTab
+                  partyId={party.id}
+                  reimbursementCapUsd={party.reimbursementCapUsd}
+                  reimbursementCapAppealNote={party.reimbursementCapAppealNote}
+                  reimbursementCapAppealedAt={party.reimbursementCapAppealedAt}
+                />
               )}
 
               {activeTab === 'gpp' && party && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -296,6 +296,11 @@ export interface Party {
   hostTelegramLinkToken?: string | null;
   underbossStatus?: UnderbossStatus | null;
   turtleRolesEnabled?: boolean;
+  // Reimbursement cap (arugula-38633 v2) — populated by underboss validation.
+  // Banner on payout form only renders when reimbursementCapUsd != null.
+  reimbursementCapUsd?: number | null;
+  reimbursementCapAppealNote?: string | null;
+  reimbursementCapAppealedAt?: string | null;
 }
 
 export interface Donation {
@@ -1029,6 +1034,7 @@ export interface UnderbossEvent {
   timezone: string | null;
   duration: number | null;
   country?: string | null;
+  city?: string | null;
   host: { name: string | null; email: string | null };
   hostTelegram?: string | null;
   hostTelegramConnected?: boolean;
@@ -1054,6 +1060,11 @@ export interface UnderbossEvent {
   flyerConfig?: Record<string, any> | null;
   latestSponsorAt: string | null;
   flyerStale: boolean;
+  // Reimbursement cap (arugula-38633 v2) — set by underboss after validating
+  // the heuristic. NULL means "not yet validated".
+  reimbursementCapUsd?: number | null;
+  reimbursementCapAppealNote?: string | null;
+  reimbursementCapAppealedAt?: string | null;
 }
 
 export interface UnderbossStats {

--- a/frontend/src/utils/reimbursementCap.ts
+++ b/frontend/src/utils/reimbursementCap.ts
@@ -1,0 +1,78 @@
+/**
+ * Reimbursement cap heuristic (arugula-38633 v2).
+ *
+ * Suggests a per-event reimbursement cap from the city tier (reused from
+ * sponsorshipPricing.ts) plus the confirmed RSVP count. The result is a
+ * starting point — underbosses validate or override before the cap takes
+ * effect on the host-facing payout form.
+ *
+ * Country-tier logic is intentionally out of scope for v1 (city tier only).
+ */
+
+import { getCityTier } from './sponsorshipPricing';
+
+export interface ReimbursementCapInput {
+  city?: string | null;
+  /** Reserved for v2 country-tier support — accepted but currently unused. */
+  country?: string | null;
+  confirmedRsvpCount: number;
+}
+
+export interface ReimbursementCapResult {
+  suggestedUsd: number;
+  tier: 1 | 2 | 3;
+  /** Human-readable explanation, e.g. "Tier 2, 67 RSVPs → $300". */
+  formula: string;
+}
+
+interface TierConfig {
+  /** Floor RSVP count — anything ≤ this gets the floor amount. */
+  rsvpFloor: number;
+  /** Ceiling RSVP count — anything ≥ this gets the max amount. */
+  rsvpCeiling: number;
+  /** Minimum suggested cap (at or below rsvpFloor). */
+  minUsd: number;
+  /** Maximum suggested cap (at or above rsvpCeiling). */
+  maxUsd: number;
+}
+
+const TIER_CONFIG: Record<1 | 2 | 3, TierConfig> = {
+  1: { rsvpFloor: 25, rsvpCeiling: 150, minUsd: 100, maxUsd: 625 },
+  2: { rsvpFloor: 25, rsvpCeiling: 100, minUsd: 75,  maxUsd: 400 },
+  3: { rsvpFloor: 35, rsvpCeiling: 150, minUsd: 50,  maxUsd: 300 },
+};
+
+const ROUNDING_INCREMENT_USD = 25;
+
+function resolveTier(city?: string | null): 1 | 2 | 3 {
+  if (!city) return 3;
+  const trimmed = city.trim();
+  if (!trimmed) return 3;
+  // getCityTier already does case-insensitive matching against the same lists
+  // we use for sponsorship pricing — single source of truth for tier
+  // classification.
+  return getCityTier(trimmed);
+}
+
+function roundToIncrement(value: number, increment: number): number {
+  return Math.round(value / increment) * increment;
+}
+
+export function computeSuggestedReimbursementCap(
+  input: ReimbursementCapInput
+): ReimbursementCapResult {
+  const tier = resolveTier(input.city);
+  const { rsvpFloor, rsvpCeiling, minUsd, maxUsd } = TIER_CONFIG[tier];
+
+  const rsvps = Math.max(0, Math.floor(input.confirmedRsvpCount ?? 0));
+  const clamped = Math.max(rsvpFloor, Math.min(rsvpCeiling, rsvps));
+  const ratio = (clamped - rsvpFloor) / (rsvpCeiling - rsvpFloor);
+  const raw = minUsd + ratio * (maxUsd - minUsd);
+  const suggestedUsd = roundToIncrement(raw, ROUNDING_INCREMENT_USD);
+
+  return {
+    suggestedUsd,
+    tier,
+    formula: `Tier ${tier}, ${rsvps} RSVPs → $${suggestedUsd}`,
+  };
+}

--- a/supabase/migrations/20260519_add_reimbursement_cap.sql
+++ b/supabase/migrations/20260519_add_reimbursement_cap.sql
@@ -1,0 +1,21 @@
+-- ============================================
+-- Reimbursement cap + appeal (arugula-38633 v2)
+-- ============================================
+-- Adds three columns to `parties` for the per-event reimbursement cap feature:
+--   * reimbursement_cap_usd          — underboss-validated cap shown to hosts
+--   * reimbursement_cap_appeal_note  — free-text appeal from the host
+--   * reimbursement_cap_appealed_at  — timestamp the appeal was submitted
+--
+-- Until an underboss validates or overrides, reimbursement_cap_usd stays NULL
+-- and the host-side banner does not render.
+-- ============================================
+
+ALTER TABLE parties ADD COLUMN reimbursement_cap_usd NUMERIC(10, 2);
+ALTER TABLE parties ADD COLUMN reimbursement_cap_appeal_note TEXT;
+ALTER TABLE parties ADD COLUMN reimbursement_cap_appealed_at TIMESTAMPTZ;
+
+-- Column-level SELECT grants — the Feb 2026 security audit revoked table-level
+-- SELECT on `parties`; new columns require explicit grants or anon/authenticated
+-- frontend queries return 42501 (permission denied for table parties).
+GRANT SELECT (reimbursement_cap_usd, reimbursement_cap_appeal_note, reimbursement_cap_appealed_at)
+  ON parties TO anon, authenticated;


### PR DESCRIPTION
## Summary

Per-event reimbursement caps with a city-tier × RSVP heuristic, underboss validate/override flow, and host appeal mechanism. v2 follow-up to the 5-PR payments ship (arugula-38633).

**Migration must be applied to prod BEFORE merging.** The schema-drift CI (PR #371) will block this PR until the new columns exist in prod — that's the desired safety net to prevent prod 500s on `prisma.party.findUnique()`.

**Migration file:** `supabase/migrations/20260519_add_reimbursement_cap.sql`

## What's in here

### DB migration
Adds 3 nullable columns to `parties`:
- `reimbursement_cap_usd` — NUMERIC(10, 2)
- `reimbursement_cap_appeal_note` — TEXT
- `reimbursement_cap_appealed_at` — TIMESTAMPTZ

Includes column-level `GRANT SELECT` to anon/authenticated per the Feb 2026 security audit (table-level SELECT was revoked).

### Heuristic
`frontend/src/utils/reimbursementCap.ts` — pure function, reuses `getCityTier` from `sponsorshipPricing.ts` as single source of truth:

| Tier | RSVP floor → ceiling | $ floor → $ max |
|------|----------------------|------------------|
| 1    | 25 → 150             | $100 → $625      |
| 2    | 25 → 100             | $75 → $400       |
| 3    | 35 → 150             | $50 → $300       |

Linear interpolation, rounded to nearest $25. Country tier is intentionally out of scope for v1.

### Backend
- `backend/prisma/schema.prisma` — 3 new Party fields
- `backend/src/routes/party.routes.ts` — PATCH whitelist accepts `reimbursementCapUsd` only from underbosses/admins (host edits silently dropped, not 403'd, so the rest of their save still succeeds). New endpoint `POST /:partyId/reimbursement-cap/appeal` lives here (NOT in `payout.routes.ts`) so the payouts soft-launch gate doesn't block hosts.
- `backend/src/routes/event.routes.ts` — exposes `reimbursementCapUsd` on `PublicEvent` (both findUnique branches) so the host banner can render pre-Party-load
- `backend/src/routes/underboss.routes.ts` — `formatEvent` returns the cap fields + `city` so the dashboard heuristic uses the actual city, not a regex-parsed event name

### Frontend
- `frontend/src/types.ts` — adds cap fields to `Party` + `UnderbossEvent` (with `city`)
- `frontend/src/lib/api.ts` — adds `PublicEvent.reimbursementCapUsd`, extends `UpdatePartyData`, adds `appealReimbursementCap(partyId, note)`
- `frontend/src/lib/supabase.ts` — `DbParty`, `SAFE_PARTY_COLUMNS`, `updateParty` whitelist updated
- `frontend/src/contexts/PizzaContext.tsx` — `dbPartyToParty` maps snake_case → camelCase
- `frontend/src/components/underboss/ReimbursementCapCell.tsx` (NEW) — inline cell with Validate / Override / Edit controls + amber appeal-pending indicator with hover-to-see-note. Rendered in `EventRow` next to the existing per-row sponsorship suggestion.
- `frontend/src/components/payouts/NewPayoutForm.tsx` — \"We'll reimburse you for up to \$X\" banner on top of the form when cap is non-null + an "Appeal cap →" button that opens the modal
- `frontend/src/components/payouts/AppealCapModal.tsx` (NEW) — modal with `IconInput` multiline (max 2000 chars), confirmation state, re-appeal hint when a prior note exists
- `frontend/src/pages/HostPage.tsx` — threads cap props from `party` through to `PayoutsTab` → `NewPayoutForm`

## Design decisions worth flagging

1. **Appeal endpoint lives in `party.routes.ts`, not `payout.routes.ts`** — so hosts behind the payouts soft-launch gate can still register an appeal. They can't submit payouts yet, but recording "this cap is too low" is still valuable data for underbosses.
2. **Host PATCH attempts to set `reimbursementCapUsd` are silently dropped** rather than 403'd. This matches the existing party-PATCH pattern where unauthorized fields just don't write. Keeps the host's other edits saving cleanly.
3. **Underboss UI is inline in the existing EventRow** instead of a new column. Adding a column to the 908-line `EventTable.tsx` would have touched a lot of unrelated layout code; the inline cell is far lower-risk.
4. **The appeal fields (`reimbursementCapAppealNote`, `reimbursementCapAppealedAt`)** are NOT in `PublicEvent` — they're admin-only data. Hosts see their own appeal state through the `Party` context (`/api/parties/:id`).

## Deployment ordering (CRITICAL)

1. Apply migration via Supabase MCP: `supabase/migrations/20260519_add_reimbursement_cap.sql`
2. Merge this PR
3. Backend auto-deploys from master

If the migration is not applied first, every `prisma.party.findUnique()` will 500 because Prisma SELECTs all schema fields by default and the columns won't exist. The schema-drift CI will fail this PR until the migration is applied — please don't bypass it.

## Test plan

- [ ] Apply migration via Supabase MCP and confirm CI turns green
- [ ] On the preview deploy, visit `/underboss` — confirm each event row shows "Cap: \$X?" + Validate/Override buttons (admin/UB only sees them)
- [ ] Click Validate on a Tier-2 city with ~50 RSVPs — confirm it saves and reloads as "Cap: \$X" with an Edit pencil
- [ ] On a host page, click into Payouts → New payout — confirm the banner appears with the validated amount and the Appeal cap button opens the modal
- [ ] Submit an appeal — confirm the amber bell appears in the underboss row with hover-to-read-note
- [ ] Confirm a host's generic PATCH to `/api/parties/:id` with `reimbursementCapUsd: 999` is silently dropped (the rest of their save still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)