### PR TITLE
anchovy-59118: fix waitlist gate, approved=null counted toward capacity

### DIFF
--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -81,7 +81,8 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         },
         _count: {
           // mushroom-31723: exclude rejected guests (approved=false) from the public count.
-          select: { guests: { where: { approved: { not: false } } } },
+          // anchovy-59118: see rsvp.routes.ts capacity-gate comment for why we use OR/null.
+          select: { guests: { where: { OR: [{ approved: true }, { approved: null }] } } },
         },
       },
     });

--- a/backend/src/routes/raffle.routes.ts
+++ b/backend/src/routes/raffle.routes.ts
@@ -365,7 +365,7 @@ router.post('/:partyId/raffles/:raffleId/enter', async (req: AuthRequest, res: R
     // Verify guest belongs to this party. mushroom-31723: rejected guests
     // (approved=false) cannot enter raffles.
     const guest = await prisma.guest.findFirst({
-      where: { id: guestId, partyId, approved: { not: false } },
+      where: { id: guestId, partyId, OR: [{ approved: true }, { approved: null }] },
     });
 
     if (!guest) {

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -418,11 +418,16 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
 
     // Count confirmed guests to check capacity. Rejected guests
     // (approved === false, see mushroom-31723) do not count toward capacity.
+    // anchovy-59118: use `OR: [{approved:true},{approved:null}]` instead of
+    // `{ not: false }` — Prisma compiles `{ not: false }` to SQL `<>`, and
+    // under Postgres three-valued logic `NULL <> false` is NULL (falsy in
+    // WHERE), so unreviewed RSVPs (approved=null by default) were silently
+    // excluded from the capacity gate.
     const confirmedGuestCount = await prisma.guest.count({
       where: {
         partyId: party.id,
         status: { in: ['CONFIRMED', 'PENDING'] },
-        approved: { not: false },
+        OR: [{ approved: true }, { approved: null }],
       },
     });
 
@@ -461,7 +466,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
           if (isAtCapacity) {
             newStatus = 'WAITLISTED';
             const maxPos = await prisma.guest.aggregate({
-              where: { partyId: party.id, status: 'WAITLISTED', approved: { not: false } },
+              where: { partyId: party.id, status: 'WAITLISTED', OR: [{ approved: true }, { approved: null }] },
               _max: { waitlistPosition: true },
             });
             newWaitlistPosition = (maxPos._max.waitlistPosition || 0) + 1;
@@ -525,7 +530,7 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
         where: {
           partyId: party.id,
           status: 'WAITLISTED',
-          approved: { not: false },
+          OR: [{ approved: true }, { approved: null }],
         },
         _max: { waitlistPosition: true },
       });

--- a/backend/src/routes/scorecard.routes.ts
+++ b/backend/src/routes/scorecard.routes.ts
@@ -59,7 +59,7 @@ async function findGuestForUser(partyId: string, userEmail?: string) {
     where: {
       partyId,
       email: userEmail.toLowerCase(),
-      approved: { not: false },
+      OR: [{ approved: true }, { approved: null }],
     },
     select: { id: true, checkedInAt: true },
   });

--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -155,7 +155,10 @@ router.get('/', requireApiKey(SCOPES.GUESTS_READ), async (req: ApiKeyRequest, re
     } else {
       // mushroom-31723: by default, exclude rejected guests (approved=false)
       // so they don't leak into integrations that aren't aware of soft-reject.
-      whereClause.approved = { not: false };
+      // anchovy-59118: `{ not: false }` translates to SQL `<>`, which excludes
+      // approved=NULL via three-valued logic. Use an explicit OR so new RSVPs
+      // (approved=null by default) aren't silently filtered out.
+      whereClause.OR = [{ approved: true }, { approved: null }];
     }
 
     const [guests, total] = await Promise.all([


### PR DESCRIPTION
## Summary

Fixes a P0 silent-data-correctness bug: events at capacity stopped
waitlisting new RSVPs.

## Root cause

`mushroom-31723` added `approved: { not: false }` to several Prisma
queries. Prisma emits SQL `<>`, and Postgres `NULL <> false` is NULL
(falsy in WHERE), so rows with `approved IS NULL` are silently excluded.
New RSVPs default to `approved=null` (the create site never sets it).

The capacity gate at POST `/api/rsvp/:slug/guest` ran a count that
returned 4 instead of 35 for cannes, so `isAtCapacity` was false and
new guests landed as CONFIRMED instead of WAITLISTED.

## Fix

Swap all 7 occurrences of `approved: { not: false }` to:

```ts
OR: [{ approved: true }, { approved: null }]
```

which compiles to `(approved = \$N OR approved IS NULL)`.

## Test plan

- [ ] CI typecheck passes
- [ ] Existing rsvp/raffle/scorecard tests pass
- [ ] After merge + backend deploy, a fresh RSVP to an over-cap event
  returns `waitlisted: true` and creates a row with `status='WAITLISTED'`
- [ ] Backfill of existing over-cap CONFIRMEDs is a separate follow-up

## Affected files

- backend/src/routes/rsvp.routes.ts (3 sites)
- backend/src/routes/event.routes.ts (1)
- backend/src/routes/raffle.routes.ts (1)
- backend/src/routes/scorecard.routes.ts (1)
- backend/src/routes/v1/guests.ts (1)

Generated with [Claude Code](https://claude.com/claude-code)