### PR TITLE
fix(prosciutto-31882): EventPage address link opens place card, not search results

### DIFF
--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -536,7 +536,7 @@ export function EventPage() {
   // alone, then to lat/lng if no address. Both place_id and address are required
   // for the place_id form per Google's docs.
   const googleMapsUrl = event.placeId && event.address
-    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}&query_place_id=${event.placeId}`
+    ? `https://www.google.com/maps/place/?api=1&query=${encodeURIComponent(event.address)}&query_place_id=${event.placeId}`
     : event.address
       ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`
       : event.latitude && event.longitude


### PR DESCRIPTION
## Summary
- `EventPage.tsx` builds the venue address link with `/maps/search/?api=1&query=<addr>&query_place_id=<id>`. Per Google's Maps URLs API, the **search action** can still land on a results list (especially on mobile) even with `query_place_id`.
- Swap to the documented **place action** form (`/maps/place/?api=1&query=<addr>&query_place_id=<id>`) which is designed to display a specific place card.
- Only the `place_id` branch changes — address-only and lat/lng fallbacks stay on `/maps/search/` since a search is the right behavior when we don't have an ID.

Repro / pepperoni-85854 + buffalo-73455 follow-up: events like `/chicago` and `/philadelphia` already have `place_id` stored but the link was still resolving to a search-results list.

## Test plan
- [ ] Vercel preview: visit `/chicago` and `/philadelphia`; click the address; confirm Google Maps opens directly to the venue's place card (name, hours, photos), not a list of results.
- [ ] Sanity-check an event with address but no `place_id` — link should still work via the `/maps/search/` address fallback.
- [ ] Sanity-check an event with only lat/lng — link should still work via the coordinate fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)