### PR TITLE
chore(arugula-38633): payouts UX tweaks

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -291,11 +291,27 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       mercuryCardLast4,
       finalAmountUsd,
       saveAsDefault,
+      estimatedAttendance,
     } = req.body || {};
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // Validate optional one-shot attendance setup. Only persisted to the party
+    // below if the party's current expectedGuests is null (see updateMany call).
+    let validatedAttendance: number | null = null;
+    if (estimatedAttendance !== undefined && estimatedAttendance !== null) {
+      const n = Number(estimatedAttendance);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new AppError(
+          'estimatedAttendance must be a positive integer',
+          400,
+          'INVALID_ATTENDANCE'
+        );
+      }
+      validatedAttendance = n;
     }
 
     if (!Array.isArray(receiptPhotos) || receiptPhotos.length === 0) {
@@ -472,6 +488,21 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       },
       include: { documents: { orderBy: { sortOrder: 'asc' } } },
     });
+
+    // One-shot: persist the host's attendance estimate to the party, but only
+    // if it hasn't already been set. updateMany no-ops gracefully when the row
+    // already has a non-null expectedGuests value, so we never overwrite.
+    if (validatedAttendance != null) {
+      try {
+        await prisma.party.updateMany({
+          where: { id: partyId, expectedGuests: null },
+          data: { expectedGuests: validatedAttendance },
+        });
+      } catch (err) {
+        // Non-fatal — the payout itself succeeded.
+        console.warn('[payouts] failed to persist expectedGuests:', err);
+      }
+    }
 
     // Optional: save host defaults
     if (saveAsDefault === true) {

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote, BadgeDollarSign } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
 import { IconInput } from '../IconInput';
-import { Checkbox } from '../Checkbox';
 import { useAuth } from '../../contexts/AuthContext';
 import { Payout, PayoutMethod, BankDetails } from '../../types';
 import { createPayout } from '../../lib/api';
@@ -21,6 +20,12 @@ interface NewPayoutFormProps {
   reimbursementCapAppealNote?: string | null;
   /** Previous appeal timestamp — non-null means host has already appealed. */
   reimbursementCapAppealedAt?: string | null;
+  /**
+   * Current value of `parties.expectedGuests`. When null, the form prompts the
+   * host for an attendance estimate (asked once per event); when set, the
+   * estimated-attendance section is hidden entirely.
+   */
+  expectedGuests?: number | null;
 }
 
 const EMPTY_BANK: BankDetails = {
@@ -32,13 +37,13 @@ const EMPTY_BANK: BankDetails = {
  * Single-page submission form (no multi-step wizard — matches pizza-faucet-v2).
  *
  * Sections:
+ *   0. Estimated attendance (only if `expectedGuests` is currently null)
  *   1. Receipts (multi-upload + per-receipt OCR preview)
  *   2. Pizza / event photos (multi-upload, no OCR)
  *   3. Notes
  *   4. Amount summary (auto-summed + manual override)
  *   5. Payout method picker
- *   6. Save-as-default
- *   7. Submit
+ *   6. Submit
  */
 export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   partyId,
@@ -47,6 +52,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   reimbursementCapUsd,
   reimbursementCapAppealNote,
   reimbursementCapAppealedAt,
+  expectedGuests,
 }) => {
   const { user } = useAuth();
   // Stable id for this in-flight form, used as the storage-path grouping key.
@@ -67,7 +73,13 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const [walletAddress, setWalletAddress] = useState('');
   const [bankDetails, setBankDetails] = useState<BankDetails>(EMPTY_BANK);
   const [mercuryCardLast4, setMercuryCardLast4] = useState('');
-  const [saveAsDefault, setSaveAsDefault] = useState(false);
+
+  // Estimated attendance: asked once per event. Pre-fills from the party's
+  // existing `expectedGuests` if set; otherwise the host is prompted.
+  const askForAttendance = expectedGuests == null;
+  const [estimatedAttendance, setEstimatedAttendance] = useState<number | null>(
+    expectedGuests ?? null
+  );
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -98,9 +110,14 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
     return true;
   }, [method, walletAddress, bankDetails]);
 
+  // When the attendance section is shown, require a positive integer before submit.
+  const attendanceValid = !askForAttendance
+    || (estimatedAttendance != null && estimatedAttendance > 0);
+
   const canSubmit = hasUploadedReceipt
     && finalAmount > 0
     && methodValid
+    && attendanceValid
     && !isProcessing
     && !submitting;
 
@@ -135,7 +152,8 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           ? { mercuryCardLast4 }
           : {}),
         ...(overrideAmount != null ? { finalAmountUsd: overrideAmount } : {}),
-        saveAsDefault,
+        ...(estimatedAttendance != null ? { estimatedAttendance } : {}),
+        saveAsDefault: true,
       });
       onCreated(created);
     } catch (err: any) {
@@ -175,12 +193,36 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         </div>
       )}
 
+      {/* 0. Estimated attendance — asked once per event */}
+      {askForAttendance && (
+        <div className="card p-6">
+          <div className="mb-3">
+            <h3 className="text-base font-semibold text-theme-text">Estimated attendance</h3>
+            <p className="text-xs text-theme-text-muted mt-0.5">
+              How many people are you expecting at your event? (You'll only be asked this once.)
+            </p>
+          </div>
+          <IconInput
+            icon={Users}
+            type="number"
+            placeholder="e.g. 50"
+            value={estimatedAttendance ?? ''}
+            onChange={e =>
+              setEstimatedAttendance(
+                e.target.value ? Math.max(0, parseInt(e.target.value, 10)) : null
+              )
+            }
+            min={1}
+          />
+        </div>
+      )}
+
       {/* 1. Receipts */}
       <div className="card p-6">
         <div className="mb-3">
           <h3 className="text-base font-semibold text-theme-text">Receipts</h3>
           <p className="text-xs text-theme-text-muted mt-0.5">
-            Upload one receipt per transaction. We'll read each total automatically.
+            Upload each of your receipts. We'll add up the total.
           </p>
         </div>
         <ReceiptUpload
@@ -251,15 +293,6 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           userEmail={user?.email}
           amountUsd={finalAmount}
         />
-
-        {/* 6. Save as default */}
-        <div className="mt-4">
-          <Checkbox
-            checked={saveAsDefault}
-            onChange={() => setSaveAsDefault(v => !v)}
-            label="Use this method for my future payouts too"
-          />
-        </div>
 
         {/* Hidden last4 field is intentionally omitted — Mercury card numbers come from admin, not host. */}
         {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -11,6 +11,8 @@ interface PayoutsTabProps {
   reimbursementCapUsd?: number | null;
   reimbursementCapAppealNote?: string | null;
   reimbursementCapAppealedAt?: string | null;
+  /** Threaded to NewPayoutForm — gates the "ask once" attendance prompt. */
+  expectedGuests?: number | null;
 }
 
 type View = 'list' | 'new';
@@ -29,6 +31,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   reimbursementCapUsd,
   reimbursementCapAppealNote,
   reimbursementCapAppealedAt,
+  expectedGuests,
 }) => {
   const [view, setView] = useState<View>('list');
   const [payouts, setPayouts] = useState<Payout[]>([]);
@@ -175,6 +178,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             reimbursementCapUsd={reimbursementCapUsd}
             reimbursementCapAppealNote={reimbursementCapAppealNote}
             reimbursementCapAppealedAt={reimbursementCapAppealedAt}
+            expectedGuests={expectedGuests}
           />
         </>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3901,6 +3901,11 @@ export interface CreatePayoutData {
   mercuryCardLast4?: string;
   finalAmountUsd?: number;
   saveAsDefault?: boolean;
+  /**
+   * One-shot setup: backend writes this to `parties.expectedGuests` only when
+   * the party's current value is null. Sent only on the host's first payout.
+   */
+  estimatedAttendance?: number;
 }
 
 export async function createPayout(

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -493,6 +493,7 @@ function HostPageContent() {
                   reimbursementCapUsd={party.reimbursementCapUsd}
                   reimbursementCapAppealNote={party.reimbursementCapAppealNote}
                   reimbursementCapAppealedAt={party.reimbursementCapAppealedAt}
+                  expectedGuests={party.expectedGuests}
                 />
               )}
 


### PR DESCRIPTION
Small v2 follow-up — three UX tweaks to the host-side payouts form.

## Changes
1. **Receipts copy** — "Upload one receipt per transaction. We'll read each total automatically." → "Upload each of your receipts. We'll add up the total." (less prescriptive, friendlier).
2. **Drop the "Use this method for future payouts too" checkbox** — that behavior is now the default. The form always sends `saveAsDefault: true`; backend logic was already correct for that case.
3. **Add "Estimated attendance" field to `NewPayoutForm`** — shown only on the host's first payout submission per event. Pre-fills from `parties.expectedGuests` if already set (in which case the section is hidden entirely). Backend persists via `prisma.party.updateMany({ where: { id, expectedGuests: null }, data: { expectedGuests: n } })`, so a previously-set value is never overwritten.

## Schema
No Prisma schema changes — `parties.expectedGuests` (Int?, `@map("expected_guests")`) already exists. Safe to merge without a prior migration; schema-drift CI should pass cleanly.

## Files
- `frontend/src/components/payouts/NewPayoutForm.tsx` — all three UX changes
- `frontend/src/components/payouts/PayoutsTab.tsx` — thread `expectedGuests` prop through
- `frontend/src/pages/HostPage.tsx` — pass `party.expectedGuests` to `PayoutsTab`
- `frontend/src/lib/api.ts` — add `estimatedAttendance?: number` to `CreatePayoutData`
- `backend/src/routes/payout.routes.ts` — validate + persist `estimatedAttendance` (one-shot)

## Test plan
- [ ] Open a party with `expectedGuests = null` → New payout form shows the attendance card at the top; submit disabled until a positive integer is entered.
- [ ] Submit the form → payout created AND `parties.expected_guests` updated.
- [ ] Open another (different) payout form for the same party → attendance section NO longer rendered.
- [ ] Open a party with `expectedGuests` already set → attendance section never appears.
- [ ] Verify the save-as-default checkbox is gone and the chosen payout method is automatically saved as the host's default after submit.
- [ ] Verify receipt-section copy reads "Upload each of your receipts. We'll add up the total."