### PR TITLE
feat(arugula-38633): paid-so-far + external payment recording

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1473,6 +1473,7 @@ model Payout {
 
   transactionHash     String?   @map("transaction_hash")
   wireReference       String?   @map("wire_reference")
+  externalProofUrl    String?   @map("external_proof_url")
 
   createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt           DateTime  @updatedAt @map("updated_at") @db.Timestamptz

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -198,6 +198,7 @@ function serializePayout(row: any): any {
     paidAt: row.paidAt ? row.paidAt.toISOString() : null,
     transactionHash: row.transactionHash,
     wireReference: row.wireReference,
+    externalProofUrl: row.externalProofUrl,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
     documents: (row.documents || []).map((d: any) => ({
@@ -320,6 +321,163 @@ router.get(
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader('Content-Disposition', 'attachment; filename=host-payouts-export.csv');
       res.send(csvRows.join('\n'));
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/external — record an OUT-OF-BAND payment
+//   - For payments that happened OUTSIDE the rsv.pizza flow (Venmo, manual
+//     bank transfer, etc.). Creates a payout row in `paid` status immediately
+//     so the host's "paid so far" reflects it and there's an audit trail.
+//   - Literal `/external` MUST be declared before `/:id` so the literal path wins.
+//   - Auth: admin / super_admin / payment_admin all allowed.
+//   - payment_admin actors are blocked from recording payouts to themselves.
+//   - The plan allows 'other' as a method intent but the DB CHECK only allows
+//     the 3 — we map 'other' → 'wire' and rely on admin_notes for the real
+//     method (e.g. "Other: Venmo").
+// ============================================
+router.post(
+  '/external',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const body = req.body || {};
+
+      const partyId = typeof body.partyId === 'string' ? body.partyId.trim() : '';
+      const hostUserId = typeof body.hostUserId === 'string' ? body.hostUserId.trim() : '';
+      const finalAmountUsd = Number(body.finalAmountUsd);
+      const rawMethod = typeof body.payoutMethod === 'string' ? body.payoutMethod : '';
+      const adminNotes = typeof body.adminNotes === 'string' ? body.adminNotes.trim() : '';
+
+      if (!partyId) {
+        throw new AppError('partyId is required', 400, 'VALIDATION_ERROR');
+      }
+      if (!hostUserId) {
+        throw new AppError('hostUserId is required', 400, 'VALIDATION_ERROR');
+      }
+      if (!Number.isFinite(finalAmountUsd) || finalAmountUsd <= 0) {
+        throw new AppError('finalAmountUsd must be > 0', 400, 'VALIDATION_ERROR');
+      }
+      // 'other' is accepted at the API boundary, but the DB CHECK only allows
+      // the 3 hard rails. We map 'other' → 'wire' and the admin clarifies the
+      // real method in admin_notes (e.g. "Other: Venmo").
+      const ALLOWED_INTENT_METHODS = ['mercury_card', 'wire', 'usdc_base', 'other'] as const;
+      if (!ALLOWED_INTENT_METHODS.includes(rawMethod as any)) {
+        throw new AppError(
+          `payoutMethod must be one of: ${ALLOWED_INTENT_METHODS.join(', ')}`,
+          400,
+          'VALIDATION_ERROR',
+        );
+      }
+      const storedMethod = rawMethod === 'other' ? 'wire' : rawMethod;
+      if (!adminNotes) {
+        throw new AppError(
+          'adminNotes is required — please explain why this is being recorded',
+          400,
+          'VALIDATION_ERROR',
+        );
+      }
+
+      // Block payment_admin from paying themselves (full admins exempt).
+      assertNotSelfPayout(actor, hostUserId);
+
+      // Verify referenced party + host exist (avoids opaque FK errors).
+      const party = await prisma.party.findUnique({ where: { id: partyId }, select: { id: true } });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+      const host = await prisma.user.findUnique({ where: { id: hostUserId }, select: { id: true } });
+      if (!host) {
+        throw new AppError('Host user not found', 404, 'HOST_NOT_FOUND');
+      }
+
+      const paidAt = body.paidAt ? new Date(body.paidAt) : new Date();
+      if (Number.isNaN(paidAt.getTime())) {
+        throw new AppError('paidAt must be a valid ISO date', 400, 'VALIDATION_ERROR');
+      }
+
+      const txHash = typeof body.transactionHash === 'string' && body.transactionHash.trim()
+        ? body.transactionHash.trim()
+        : null;
+      const wireRef = typeof body.wireReference === 'string' && body.wireReference.trim()
+        ? body.wireReference.trim()
+        : null;
+      const cardLast4 = typeof body.mercuryCardLast4 === 'string' && body.mercuryCardLast4.trim()
+        ? body.mercuryCardLast4.trim()
+        : null;
+      const extProof = typeof body.externalProofUrl === 'string' && body.externalProofUrl.trim()
+        ? body.externalProofUrl.trim()
+        : null;
+
+      const composedNote = `External payment recorded. ${adminNotes}`;
+
+      const created = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.create({
+          data: {
+            partyId,
+            hostUserId,
+            // Required non-null fields — for external payments we know the
+            // amount already; original currency/rate/extracted all collapse to USD/1.
+            originalAmount: finalAmountUsd as any,
+            originalCurrency: 'USD',
+            exchangeRate: 1.0 as any,
+            extractedAmountUsd: finalAmountUsd as any,
+            finalAmountUsd: finalAmountUsd as any,
+            status: 'paid',
+            payoutMethod: storedMethod,
+            paidAt,
+            transactionHash: txHash,
+            wireReference: wireRef,
+            mercuryCardLast4: cardLast4,
+            externalProofUrl: extProof,
+            adminNotes: composedNote,
+            reviewedBy: actor.email,
+            reviewedAt: paidAt,
+          },
+          include: {
+            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            host: { select: { id: true, name: true, email: true } },
+            documents: { orderBy: { sortOrder: 'asc' } },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        // DB CHECK on payout_audit.actor_kind expects 'super_admin' (with
+        // underscore), but loadActor() returns 'superadmin'. Normalize here.
+        const auditActorKind = actor.actorKind === 'superadmin' ? 'super_admin' : actor.actorKind;
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: row.id,
+            action: 'create',
+            newStatus: 'paid',
+            newAmount: finalAmountUsd as any,
+            actorEmail: actor.email,
+            actorKind: auditActorKind,
+            note: composedNote,
+          },
+        });
+
+        return row;
+      });
+
+      // Refetch with audits included (the create() above already has them empty).
+      const full = await prisma.payout.findUnique({
+        where: { id: created.id },
+        include: {
+          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          host: { select: { id: true, name: true, email: true } },
+          documents: { orderBy: { sortOrder: 'asc' } },
+          audits: { orderBy: { createdAt: 'desc' } },
+        },
+      });
+
+      res.status(201).json({ payout: serializePayout(full || created) });
     } catch (error) {
       next(error);
     }

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -88,6 +88,7 @@ function serializePayout(p: any) {
     paidAt: p.paidAt ? p.paidAt.toISOString() : null,
     transactionHash: p.transactionHash ?? null,
     wireReference: p.wireReference ?? null,
+    externalProofUrl: p.externalProofUrl ?? null,
     createdAt: p.createdAt.toISOString(),
     updatedAt: p.updatedAt.toISOString(),
     documents: Array.isArray(p.documents) ? p.documents.map(serializeDocument) : undefined,

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -1,0 +1,439 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  X,
+  DollarSign,
+  User as UserIcon,
+  Calendar,
+  Link as LinkIcon,
+  Pencil,
+  Hash,
+  Upload,
+  Loader2,
+  CreditCard,
+  Coins,
+  Banknote,
+  HelpCircle,
+} from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { recordExternalPayment } from '../../lib/api';
+import { uploadPayoutPhoto } from '../../lib/supabase';
+import type { ExternalPaymentInput, PayoutMethod } from '../../types';
+
+interface ExternalPaymentModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+type ExternalMethod = PayoutMethod | 'other';
+
+/**
+ * Admin modal for recording payments that happened OUTSIDE the rsv.pizza
+ * payouts flow (Venmo, manual bank transfer, etc.). Creates a new payout row
+ * in `paid` status immediately so the host's "paid so far" total reflects it
+ * and there's an audit trail.
+ *
+ * No party picker dropdown in v1 — admin pastes the partyId + hostUserId
+ * directly (per the plan's "fallback" guidance). Snax can iterate later.
+ *
+ * arugula-38633 v2 follow-up.
+ */
+export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
+  onClose,
+  onCreated,
+}) => {
+  // Form state
+  const [partyId, setPartyId] = useState('');
+  const [hostUserId, setHostUserId] = useState('');
+  const [amountStr, setAmountStr] = useState('');
+  const [method, setMethod] = useState<ExternalMethod>('usdc_base');
+  const [paidAt, setPaidAt] = useState(() => new Date().toISOString().split('T')[0]);
+
+  // Method-specific refs
+  const [wireReference, setWireReference] = useState('');
+  const [transactionHash, setTransactionHash] = useState('');
+  const [mercuryCardLast4, setMercuryCardLast4] = useState('');
+
+  // Proof: either a URL or an uploaded file. The uploaded URL wins if both set.
+  const [proofUrlInput, setProofUrlInput] = useState('');
+  const [uploadedProofUrl, setUploadedProofUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const [adminNotes, setAdminNotes] = useState('');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const amountNum = useMemo(() => Number(amountStr), [amountStr]);
+
+  const canSubmit = useMemo(() => {
+    if (!partyId.trim()) return false;
+    if (!hostUserId.trim()) return false;
+    if (!Number.isFinite(amountNum) || amountNum <= 0) return false;
+    if (!adminNotes.trim()) return false;
+    return !submitting && !uploading;
+  }, [partyId, hostUserId, amountNum, adminNotes, submitting, uploading]);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!partyId.trim()) {
+      setUploadError('Enter party id first so we can group the upload correctly.');
+      e.target.value = '';
+      return;
+    }
+    setUploadError(null);
+    setUploading(true);
+    try {
+      // Group under an `external/<timestamp>` pseudo-tempId so the path shape
+      // still matches `payouts/{partyId}/{group}/{kind}/...`.
+      const groupId = `external-${Date.now()}`;
+      const result = await uploadPayoutPhoto(file, partyId.trim(), groupId, 'receipt');
+      if (!result) {
+        setUploadError('Upload failed — check the file type (jpg/png/webp/heic) and size (<10MB).');
+        return;
+      }
+      setUploadedProofUrl(result.url);
+    } catch (err: any) {
+      setUploadError(err?.message || 'Upload failed');
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      // Uploaded file wins over the manually-typed URL (the plan says either,
+      // but if both are present the uploaded one is the canonical proof).
+      const externalProofUrl = uploadedProofUrl?.trim()
+        || (proofUrlInput.trim() || undefined);
+
+      // The free-form notes get "Other: <method>" prefixed when method='other'
+      // so the audit trail captures the real intent (DB CHECK only allows the 3).
+      const composedAdminNotes = method === 'other'
+        ? `Other method. ${adminNotes.trim()}`
+        : adminNotes.trim();
+
+      const body: ExternalPaymentInput = {
+        partyId: partyId.trim(),
+        hostUserId: hostUserId.trim(),
+        finalAmountUsd: amountNum,
+        payoutMethod: method,
+        paidAt: paidAt ? new Date(paidAt).toISOString() : undefined,
+        externalProofUrl,
+        adminNotes: composedAdminNotes,
+      };
+      if (method === 'wire' || method === 'other') {
+        if (wireReference.trim()) body.wireReference = wireReference.trim();
+      }
+      if (method === 'usdc_base' && transactionHash.trim()) {
+        body.transactionHash = transactionHash.trim();
+      }
+      if (method === 'mercury_card' && mercuryCardLast4.trim()) {
+        body.mercuryCardLast4 = mercuryCardLast4.trim();
+      }
+
+      await recordExternalPayment(body);
+      onCreated();
+      onClose();
+    } catch (err: any) {
+      setSubmitError(err?.message || 'Failed to record payment');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-2xl max-h-[95vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-semibold text-theme-text">Record External Payment</h2>
+            <p className="text-xs text-theme-text-muted mt-0.5">
+              Use this for payments made OUTSIDE rsv.pizza (Venmo, manual bank, etc.). Creates a paid
+              payout row immediately and writes an audit entry.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* Party id */}
+          <div>
+            <IconInput
+              icon={Hash}
+              placeholder="Party id (uuid) *"
+              value={partyId}
+              onChange={(e) => setPartyId(e.target.value)}
+              required
+            />
+            <p className="text-xs text-theme-text-muted mt-1">
+              Paste the party's UUID — find it in the URL of the admin payouts table or in the party admin page.
+            </p>
+          </div>
+
+          {/* Host user id */}
+          <div>
+            <IconInput
+              icon={UserIcon}
+              placeholder="Host user id (cuid) — who is being reimbursed *"
+              value={hostUserId}
+              onChange={(e) => setHostUserId(e.target.value)}
+              required
+            />
+            <p className="text-xs text-theme-text-muted mt-1">
+              The user id of the host receiving this payment. Admin's responsibility to get right.
+            </p>
+          </div>
+
+          {/* Amount */}
+          <IconInput
+            icon={DollarSign}
+            type="number"
+            step="0.01"
+            min="0"
+            placeholder="Amount USD *"
+            value={amountStr}
+            onChange={(e) => setAmountStr(e.target.value)}
+            required
+          />
+
+          {/* Method radios — USDC / Mercury / Wire / Other, matching reorder pref */}
+          <div>
+            <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">Method</div>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+              <MethodOption
+                value="usdc_base"
+                current={method}
+                onSelect={setMethod}
+                icon={<Coins size={16} />}
+                label="USDC on Base"
+              />
+              <MethodOption
+                value="mercury_card"
+                current={method}
+                onSelect={setMethod}
+                icon={<CreditCard size={16} />}
+                label="Mercury card"
+              />
+              <MethodOption
+                value="wire"
+                current={method}
+                onSelect={setMethod}
+                icon={<Banknote size={16} />}
+                label="Wire"
+              />
+              <MethodOption
+                value="other"
+                current={method}
+                onSelect={setMethod}
+                icon={<HelpCircle size={16} />}
+                label="Other"
+              />
+            </div>
+            {method === 'other' && (
+              <p className="text-xs text-theme-text-muted mt-2">
+                "Other" stores as <code>wire</code> in the DB (CHECK constraint), but the real method
+                will be captured in admin notes as <code>Other method.</code>
+              </p>
+            )}
+          </div>
+
+          {/* Method-specific reference */}
+          {method === 'usdc_base' && (
+            <IconInput
+              icon={Hash}
+              placeholder="Transaction hash (optional, 0x...)"
+              value={transactionHash}
+              onChange={(e) => setTransactionHash(e.target.value)}
+            />
+          )}
+          {method === 'mercury_card' && (
+            <IconInput
+              icon={Hash}
+              placeholder="Card last 4 digits (optional)"
+              value={mercuryCardLast4}
+              onChange={(e) =>
+                setMercuryCardLast4(e.target.value.replace(/\D/g, '').slice(0, 4))
+              }
+              inputMode="numeric"
+              maxLength={4}
+            />
+          )}
+          {(method === 'wire' || method === 'other') && (
+            <IconInput
+              icon={Hash}
+              placeholder={
+                method === 'other'
+                  ? 'Reference (optional — e.g. Venmo transaction id)'
+                  : 'Wire reference (optional)'
+              }
+              value={wireReference}
+              onChange={(e) => setWireReference(e.target.value)}
+            />
+          )}
+
+          {/* Date paid */}
+          <IconInput
+            icon={Calendar}
+            type="date"
+            placeholder="Date paid"
+            value={paidAt}
+            onChange={(e) => setPaidAt(e.target.value)}
+          />
+
+          {/* Proof — URL or upload */}
+          <div className="space-y-2">
+            <div className="text-xs uppercase tracking-wide text-theme-text-muted">
+              Proof (optional)
+            </div>
+            <IconInput
+              icon={LinkIcon}
+              type="url"
+              placeholder="Transaction URL (e.g. Basescan, Venmo receipt link)"
+              value={proofUrlInput}
+              onChange={(e) => setProofUrlInput(e.target.value)}
+              disabled={!!uploadedProofUrl}
+            />
+            <div className="text-xs text-theme-text-muted">— or —</div>
+            <label className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface-hover hover:bg-theme-stroke text-sm text-theme-text cursor-pointer w-fit">
+              {uploading ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Upload size={14} />
+              )}
+              {uploadedProofUrl ? 'Replace proof file' : 'Upload proof file'}
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleFileChange}
+                disabled={uploading}
+              />
+            </label>
+            {uploadError && (
+              <p className="text-xs text-red-400">{uploadError}</p>
+            )}
+            {uploadedProofUrl && (
+              <p className="text-xs text-emerald-500 break-all">
+                Uploaded:{' '}
+                <a
+                  href={uploadedProofUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  {uploadedProofUrl}
+                </a>
+                {' '}
+                <button
+                  type="button"
+                  className="ml-1 underline text-theme-text-muted"
+                  onClick={() => setUploadedProofUrl(null)}
+                >
+                  clear
+                </button>
+              </p>
+            )}
+          </div>
+
+          {/* Admin notes — required */}
+          <div>
+            <IconInput
+              icon={Pencil}
+              multiline
+              rows={3}
+              placeholder="Why is this being recorded? What was paid for? *"
+              value={adminNotes}
+              onChange={(e) => setAdminNotes(e.target.value)}
+              required
+              maxLength={500}
+            />
+            <p className="text-xs text-theme-text-muted mt-1">
+              Required. The backend prefixes "External payment recorded." automatically.
+            </p>
+          </div>
+
+          {submitError && (
+            <div className="px-3 py-2 rounded-lg bg-red-100 text-red-700 border border-red-300 text-sm">
+              {submitError}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-theme-stroke px-5 py-3 flex items-center justify-end gap-2 bg-theme-surface">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-theme-text-secondary hover:bg-theme-surface-hover text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
+          >
+            {submitting && <Loader2 size={14} className="animate-spin" />}
+            Record payment
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+const MethodOption: React.FC<{
+  value: ExternalMethod;
+  current: ExternalMethod;
+  onSelect: (v: ExternalMethod) => void;
+  icon: React.ReactNode;
+  label: string;
+}> = ({ value, current, onSelect, icon, label }) => {
+  const active = current === value;
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(value)}
+      className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+        active
+          ? 'border-emerald-500 bg-emerald-500/10 text-theme-text'
+          : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong text-theme-text-secondary'
+      }`}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -356,6 +356,23 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               </div>
             )}
 
+            {/* External proof (arugula-38633 v2 follow-up) — visible for any
+                payout that has an externalProofUrl set, regardless of status. */}
+            {payout.externalProofUrl && (
+              <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface text-sm">
+                <h3 className="font-semibold text-theme-text mb-1">External proof</h3>
+                <a
+                  href={payout.externalProofUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-theme-text-secondary hover:underline break-all"
+                >
+                  {payout.externalProofUrl}
+                  <ExternalLink size={12} />
+                </a>
+              </div>
+            )}
+
             {/* Admin notes (editable) */}
             <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
               <h3 className="font-semibold text-theme-text mb-2 text-sm">Admin notes</h3>
@@ -421,6 +438,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     Mercury card ••••{payout.mercuryCardLast4}
                     {payout.mercuryCardId && <span className="text-emerald-700/70 ml-2">id: {payout.mercuryCardId}</span>}
                   </div>
+                )}
+                {payout.externalProofUrl && (
+                  <a
+                    href={payout.externalProofUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-emerald-800 hover:underline break-all"
+                  >
+                    External proof: {payout.externalProofUrl}
+                    <ExternalLink size={12} />
+                  </a>
                 )}
               </div>
             )}

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -3,3 +3,4 @@ export { PayoutsTable } from './PayoutsTable';
 export { PayoutReviewModal } from './PayoutReviewModal';
 export { PaymentsStatsCards } from './PaymentsStatsCards';
 export { BulkActionsBar } from './BulkActionsBar';
+export { ExternalPaymentModal } from './ExternalPaymentModal';

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -21,6 +21,12 @@ interface NewPayoutFormProps {
   reimbursementCapAppealNote?: string | null;
   /** Previous appeal timestamp — non-null means host has already appealed. */
   reimbursementCapAppealedAt?: string | null;
+  /**
+   * Sum of finalAmountUsd for already-paid payouts on this party.
+   * Shown inside the cap banner (and standalone if there's no cap).
+   * arugula-38633 v2 follow-up.
+   */
+  totalPaidUsd?: number;
 }
 
 const EMPTY_BANK: BankDetails = {
@@ -47,6 +53,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   reimbursementCapUsd,
   reimbursementCapAppealNote,
   reimbursementCapAppealedAt,
+  totalPaidUsd = 0,
 }) => {
   const { user } = useAuth();
   // Stable id for this in-flight form, used as the storage-path grouping key.
@@ -146,6 +153,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   };
 
   const showCapBanner = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
+  const showPaidOnlyBanner = !showCapBanner && totalPaidUsd > 0;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -156,7 +164,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             <BadgeDollarSign size={22} className="text-[#ff393a] mt-0.5 flex-shrink-0" />
             <div>
               <p className="text-sm font-medium text-theme-text">
-                We'll reimburse you for up to ${reimbursementCapUsd!.toFixed(2)}.
+                We'll reimburse you up to ${reimbursementCapUsd!.toFixed(2)}.
+                {totalPaidUsd > 0 && (
+                  <> ${totalPaidUsd.toFixed(2)} paid so far.</>
+                )}
               </p>
               <p className="text-xs text-theme-text-muted mt-0.5">
                 {localAppealedAt
@@ -172,6 +183,20 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           >
             {localAppealedAt ? 'Update appeal' : 'Appeal cap →'}
           </button>
+        </div>
+      )}
+
+      {/* Paid-so-far standalone banner (no cap) — only when there's at least one
+          paid payout. Same visual treatment as the cap banner so the layout is
+          consistent. */}
+      {showPaidOnlyBanner && (
+        <div className="card p-4 sm:p-5 border-l-4 border-l-emerald-500 flex items-start gap-3">
+          <BadgeDollarSign size={22} className="text-emerald-500 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-theme-text">
+              ${totalPaidUsd.toFixed(2)} paid so far.
+            </p>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Plus, Receipt as ReceiptIcon } from 'lucide-react';
+import { Plus, Receipt as ReceiptIcon, BadgeDollarSign } from 'lucide-react';
 import { Payout } from '../../types';
 import { PayoutListRow } from './PayoutListRow';
 
@@ -9,6 +9,13 @@ interface PayoutsListProps {
   onOpenDetail: (payoutId: string) => void;
   onCancelled: (payoutId: string) => void;
   onStartNew: () => void;
+  /**
+   * Sum of finalAmountUsd for paid payouts on this party (arugula-38633 v2
+   * follow-up). Renders a stat header above the list.
+   */
+  totalPaidUsd?: number;
+  /** Reimbursement cap, if any. Combined with totalPaidUsd in the stat header. */
+  reimbursementCapUsd?: number | null;
 }
 
 /**
@@ -21,7 +28,14 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
   onOpenDetail,
   onCancelled,
   onStartNew,
+  totalPaidUsd = 0,
+  reimbursementCapUsd,
 }) => {
+  // Stat block: render whenever there's a paid total OR a cap is set. Empty
+  // state otherwise (matches v2 follow-up plan).
+  const hasCap = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
+  const showStatHeader = totalPaidUsd > 0 || hasCap;
+
   if (payouts.length === 0) {
     return (
       <div className="card p-10 text-center">
@@ -44,17 +58,31 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
   }
 
   return (
-    <div className="card p-4 sm:p-6">
-      <div className="space-y-2">
-        {payouts.map(p => (
-          <PayoutListRow
-            key={p.id}
-            payout={p}
-            partyId={partyId}
-            onOpen={() => onOpenDetail(p.id)}
-            onCancelled={onCancelled}
-          />
-        ))}
+    <div className="space-y-3">
+      {showStatHeader && (
+        <div className="card p-4 sm:p-5 flex items-center gap-3">
+          <BadgeDollarSign size={20} className="text-emerald-500 flex-shrink-0" />
+          <div className="text-sm font-medium text-theme-text">
+            Total paid to date: ${totalPaidUsd.toFixed(2)}
+            {hasCap && (
+              <span className="text-theme-text-muted"> / ${reimbursementCapUsd!.toFixed(2)}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="card p-4 sm:p-6">
+        <div className="space-y-2">
+          {payouts.map(p => (
+            <PayoutListRow
+              key={p.id}
+              payout={p}
+              partyId={partyId}
+              onOpen={() => onOpenDetail(p.id)}
+              onCancelled={onCancelled}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Lock } from 'lucide-react';
 import { Payout } from '../../types';
 import { listPayouts, fetchUnderbossMe, fetchAdminMe } from '../../lib/api';
@@ -103,6 +103,16 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
     setPayouts(prev => prev.filter(p => p.id !== payoutId));
   };
 
+  // arugula-38633 v2 follow-up: sum already-paid payouts so the host can see
+  // their running reimbursement total (and how it compares to the cap, if any).
+  // Computed client-side from the existing list — no backend change needed.
+  const totalPaidUsd = useMemo(
+    () => payouts
+      .filter(p => p.status === 'paid')
+      .reduce((s, p) => s + Number(p.finalAmountUsd || 0), 0),
+    [payouts]
+  );
+
   if (loading) {
     return (
       <div className="card p-8 flex items-center justify-center">
@@ -155,6 +165,8 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             onCancelled={handleCancelled}
             onStartNew={() => setView('new')}
             partyId={partyId}
+            totalPaidUsd={totalPaidUsd}
+            reimbursementCapUsd={reimbursementCapUsd ?? null}
           />
         </>
       )}
@@ -175,6 +187,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             reimbursementCapUsd={reimbursementCapUsd}
             reimbursementCapAppealNote={reimbursementCapAppealNote}
             reimbursementCapAppealedAt={reimbursementCapAppealedAt}
+            totalPaidUsd={totalPaidUsd}
           />
         </>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -3824,6 +3824,23 @@ export async function executeAdminPayout(
     method: 'POST',
     body,
   });
+  return res.payout;
+}
+
+/**
+ * Record an OUT-OF-BAND payment (Venmo, manual bank, etc.) — creates a new
+ * payout row in `paid` status immediately. arugula-38633 v2 follow-up.
+ *
+ * The backend maps 'other' → 'wire' for the DB CHECK; the real method intent
+ * is preserved in adminNotes (e.g. "Other: Venmo").
+ */
+export async function recordExternalPayment(
+  body: ExternalPaymentInput,
+): Promise<AdminPayoutDetail> {
+  const res = await apiRequest<{ payout: AdminPayoutDetail }>(
+    '/api/admin/payouts/external',
+    { method: 'POST', body },
+  );
   return res.payout;
 }
 

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { ShieldX, Loader2, DollarSign, Download } from 'lucide-react';
+import { ShieldX, Loader2, DollarSign, Download, Plus } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import {
   fetchAdminMe,
@@ -27,6 +27,7 @@ import {
   PayoutReviewModal,
   PaymentsStatsCards,
   BulkActionsBar,
+  ExternalPaymentModal,
 } from '../components/payments-admin';
 
 type RoleState =
@@ -62,6 +63,9 @@ export function PaymentsAdminPage() {
 
   // CSV export
   const [exporting, setExporting] = useState(false);
+
+  // External payment modal (arugula-38633 v2 follow-up)
+  const [showExternalModal, setShowExternalModal] = useState(false);
 
   // Role gate
   useEffect(() => {
@@ -303,6 +307,14 @@ export function PaymentsAdminPage() {
           )}
           <button
             type="button"
+            onClick={() => setShowExternalModal(true)}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium"
+          >
+            <Plus size={14} />
+            Record External Payment
+          </button>
+          <button
+            type="button"
             onClick={handleExportCsv}
             disabled={exporting}
             className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke hover:bg-theme-surface-hover text-sm text-theme-text disabled:opacity-50"
@@ -468,6 +480,13 @@ export function PaymentsAdminPage() {
             }}
           />
         )}
+        {showExternalModal && (
+          <ExternalPaymentModal
+            onClose={() => setShowExternalModal(false)}
+            onCreated={() => refresh()}
+          />
+        )}
+
         {/* meUserId placeholder to silence unused-warning while client-side comparison stays optional */}
         <input type="hidden" value={meUserId} />
       </main>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1464,9 +1464,30 @@ export interface Payout {
   paidAt: string | null;
   transactionHash: string | null;
   wireReference: string | null;
+  externalProofUrl: string | null;
   createdAt: string;
   updatedAt: string;
   documents: PayoutDocument[];
+}
+
+/**
+ * Input for "Record External Payment" — payments made OUTSIDE the system
+ * (Venmo, manual bank, etc.) recorded by an admin so the host's "paid so far"
+ * is accurate and there's an audit trail. See backend
+ * `POST /api/admin/payouts/external`.
+ */
+export interface ExternalPaymentInput {
+  partyId: string;
+  hostUserId: string;
+  finalAmountUsd: number;
+  /** 'other' is accepted client-side and mapped to 'wire' server-side (DB CHECK only allows the 3). */
+  payoutMethod: PayoutMethod | 'other';
+  paidAt?: string;            // ISO date — defaults to now if omitted
+  transactionHash?: string;   // for usdc_base
+  wireReference?: string;     // for wire / other
+  mercuryCardLast4?: string;  // for mercury_card
+  externalProofUrl?: string;
+  adminNotes: string;         // REQUIRED — must explain why this is being recorded
 }
 
 // Admin-list payout: includes embedded party + host info

--- a/supabase/migrations/20260519_add_external_proof_url.sql
+++ b/supabase/migrations/20260519_add_external_proof_url.sql
@@ -1,0 +1,17 @@
+-- ============================================
+-- External payment proof URL on payouts (arugula-38633 v2 follow-up)
+-- ============================================
+-- Adds a single nullable TEXT column for the "Record External Payment" admin
+-- flow. When an admin records a payment that happened OUTSIDE the system
+-- (Venmo, bank transfer, etc.), they can attach a transaction URL OR a link
+-- to an uploaded proof file.
+--
+-- Presence of `external_proof_url` + admin_notes starting with
+-- "External payment recorded." is the canonical signal that a payout row
+-- represents an out-of-band payment. No separate boolean flag.
+--
+-- No GRANTs needed: payouts is fully revoked from anon/authenticated per the
+-- Feb 2026 security audit; all access is backend-only via service_role.
+-- ============================================
+
+ALTER TABLE payouts ADD COLUMN external_proof_url TEXT;


### PR DESCRIPTION
arugula-38633 v2 follow-up to the original payouts ship. Two features in one PR.

## Feature 1 — "Paid so far" indicator

Hosts see their running reimbursement total in two places (both derived from the existing payouts list — no backend change for this feature):

- **NewPayoutForm cap banner**: when the underboss-validated cap is set, the banner now reads `"We'll reimburse you up to $300. $120 paid so far."` (the second sentence only when there's at least one paid payout).
- **Standalone paid-so-far banner**: when there's no cap but there IS at least one paid payout, a small emerald banner shows `"$X paid so far."`.
- **PayoutsList stat header**: above the list rows, when either paid > 0 OR cap is set — `Total paid to date: $120 / $300` (slash + cap only if cap is set).

## Feature 2 — Record External Payment

Admins (admin / super_admin / payment_admin — same gate as the rest of `/payments`) can now record payments that happened OUTSIDE the rsv.pizza payouts flow (Venmo, manual bank, etc.) so the host's "paid so far" reflects them and there's an audit trail.

- New button in the `/payments` header: **+ Record External Payment**.
- Opens a modal with form fields: party id, host user id, amount USD, method (USDC / Mercury / Wire / Other), date paid, method-specific reference (wire ref / tx hash / card last4), proof (transaction URL **or** uploaded image file via `uploadPayoutPhoto`), admin notes (REQUIRED).
- New `POST /api/admin/payouts/external` endpoint creates a payout row with `status='paid'`, writes a `payout_audit` row, wrapped in a Prisma transaction.
- payment_admin self-payout block is applied (admin can't record an external payment to themselves).
- "Other" method is accepted at the API boundary but mapped to `wire` in the DB CHECK; the real intent gets captured in the admin notes as `Other method.`.
- `external_proof_url` is displayed in `PayoutReviewModal` (both the dedicated section AND in the paid-row receipt area).

### Deployment ordering

**Migration must be applied to prod BEFORE merging.** Schema-drift CI will block until applied.

- Migration filename: `supabase/migrations/20260519_add_external_proof_url.sql`
- Adds one nullable TEXT column: `payouts.external_proof_url`
- No GRANTs needed — `payouts` is fully revoked from anon/authenticated; all access is backend-only via service_role
- Purely additive — safe to roll back via `DROP COLUMN`

## Files changed

**Migration**
- `supabase/migrations/20260519_add_external_proof_url.sql` (new)

**Backend**
- `backend/prisma/schema.prisma` — `externalProofUrl String? @map("external_proof_url")`
- `backend/src/routes/admin-payout.routes.ts` — new `POST /external` endpoint + `externalProofUrl` in serializer
- `backend/src/routes/payout.routes.ts` — `externalProofUrl` in host-side serializer

**Frontend**
- `frontend/src/types.ts` — `externalProofUrl` on `Payout`, new `ExternalPaymentInput` type
- `frontend/src/lib/api.ts` — `recordExternalPayment()` helper
- `frontend/src/components/payouts/PayoutsTab.tsx` — compute `totalPaidUsd`, pass down
- `frontend/src/components/payouts/PayoutsList.tsx` — stat header, new props
- `frontend/src/components/payouts/NewPayoutForm.tsx` — extended cap banner + standalone paid-so-far banner
- `frontend/src/components/payments-admin/ExternalPaymentModal.tsx` (new)
- `frontend/src/components/payments-admin/PayoutReviewModal.tsx` — render external proof
- `frontend/src/components/payments-admin/index.ts` — barrel export
- `frontend/src/pages/PaymentsAdminPage.tsx` — "+ Record External Payment" button + modal wiring

## Test plan

- [ ] Apply migration to prod via Supabase Management API
- [ ] Verify schema-drift CI turns green after migration applied
- [ ] Frontend preview: open a host's payouts tab — confirm the new stat header / banner copy matches the cap state
- [ ] Admin: open `/payments`, click "Record External Payment", record a test payment, confirm it appears in the list and in the host's paid-so-far total
- [ ] Confirm `payment_admin` cannot record an external payment to themselves (403)
- [ ] Confirm the External proof link renders in `PayoutReviewModal` (both detail row + paid-row receipt)