### PR TITLE
fix(arugula-38633): audit actorKind 'superadmin' -> 'super_admin'

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -33,7 +33,7 @@ const router = Router();
 const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed'] as const;
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 
-type AdminActorKind = 'admin' | 'superadmin' | 'payment_admin';
+type AdminActorKind = 'admin' | 'super_admin' | 'payment_admin';
 
 /**
  * Loads the admin row + the currently-authenticated user's id (used for
@@ -62,7 +62,7 @@ async function loadActor(req: AuthRequest): Promise<{
   }
 
   const actorKind: AdminActorKind =
-    admin.role === 'super_admin' ? 'superadmin' :
+    admin.role === 'super_admin' ? 'super_admin' :
     admin.role === 'payment_admin' ? 'payment_admin' :
     'admin';
 
@@ -447,9 +447,9 @@ router.post(
           },
         });
 
-        // DB CHECK on payout_audit.actor_kind expects 'super_admin' (with
-        // underscore), but loadActor() returns 'superadmin'. Normalize here.
-        const auditActorKind = actor.actorKind === 'superadmin' ? 'super_admin' : actor.actorKind;
+        // loadActor() now returns 'super_admin' (matches DB CHECK on
+        // payout_audit.actor_kind) — no normalization needed.
+        const auditActorKind = actor.actorKind;
 
         await tx.payoutAudit.create({
           data: {

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -75,6 +75,18 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
     if (canAccess) loadPayouts();
   }, [loadPayouts, canAccess]);
 
+  // arugula-38633 v2 follow-up: sum already-paid payouts so the host can see
+  // their running reimbursement total. MUST be declared before any conditional
+  // returns below — moving it after would break rules-of-hooks (hook count
+  // changes when canAccess flips null/false → true). Was the source of a hard
+  // React crash that black-screened the page.
+  const totalPaidUsd = useMemo(
+    () => payouts
+      .filter(p => p.status === 'paid')
+      .reduce((s, p) => s + Number(p.finalAmountUsd || 0), 0),
+    [payouts]
+  );
+
   if (canAccess === null) {
     return (
       <div className="card p-8 flex items-center justify-center">
@@ -105,16 +117,6 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   const handleCancelled = (payoutId: string) => {
     setPayouts(prev => prev.filter(p => p.id !== payoutId));
   };
-
-  // arugula-38633 v2 follow-up: sum already-paid payouts so the host can see
-  // their running reimbursement total (and how it compares to the cap, if any).
-  // Computed client-side from the existing list — no backend change needed.
-  const totalPaidUsd = useMemo(
-    () => payouts
-      .filter(p => p.status === 'paid')
-      .reduce((s, p) => s + Number(p.finalAmountUsd || 0), 0),
-    [payouts]
-  );
 
   if (loading) {
     return (


### PR DESCRIPTION
loadActor() in admin-payout.routes.ts returned 'superadmin' (no underscore) for super_admin admins, but the DB CHECK constraint on payout_audit.actor_kind requires 'super_admin'. Every audit write by a super_admin (approve, reject, mark_paid, edit, etc.) would CHECK-violate.

PR #438 worked around this by normalizing inline at one new endpoint. This fix corrects loadActor() at the source — type updated, all existing call sites are now correct without per-site normalization. Workaround removed.

No DB or migration changes. Safe to merge anytime.