### PR TITLE
fix(pancetta-91204): dedupe regional SWC checkbox in variant arm

### DIFF
--- a/frontend/src/components/RSVPFormStep1.tsx
+++ b/frontend/src/components/RSVPFormStep1.tsx
@@ -309,7 +309,7 @@ export function RSVPFormStep1({
       )}
 
       {/* SWC Canada checkbox + info modal */}
-      {form.isSwcCaEvent && (
+      {form.isSwcCaEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
         <>
           <div className="flex items-center gap-2">
             <button
@@ -378,7 +378,7 @@ export function RSVPFormStep1({
       )}
 
       {/* SWC Australia checkbox + info modal */}
-      {form.isSwcAuEvent && (
+      {form.isSwcAuEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
         <>
           <div className="flex items-center gap-2">
             <button
@@ -447,7 +447,7 @@ export function RSVPFormStep1({
       )}
 
       {/* SWC EU checkbox + info modal */}
-      {form.isSwcEuEvent && (
+      {form.isSwcEuEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
         <>
           <div className="flex items-center gap-2">
             <button
@@ -516,7 +516,7 @@ export function RSVPFormStep1({
       )}
 
       {/* SWC UK checkbox + info modal */}
-      {form.isSwcUkEvent && (
+      {form.isSwcUkEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
         <>
           <div className="flex items-center gap-2">
             <button
@@ -585,7 +585,7 @@ export function RSVPFormStep1({
       )}
 
       {/* SWC Brazil checkbox + info modal */}
-      {form.isSwcBrEvent && (
+      {form.isSwcBrEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
         <>
           <div className="flex items-center gap-2">
             <button


### PR DESCRIPTION
## Summary

Variant-arm users on non-US SWC regional events (`swccanada`/`swcau`/`swceu`/`swcuk`/`swcbr`) were rendering **two checkboxes that both write the same `swc_*_opt_in` column** — the combined "Hear from PizzaDAO + our partners" checkbox AND the standalone regional SWC checkbox. The 5 regional SWC blocks in `RSVPFormStep1.tsx` were guarded only by `isSwc*Event` and lived outside the variant/control ternary; only the US block lives inside the ternary's else branch.

Fix mirrors the existing ethconf guard pattern (line 657 on master):

```diff
- {form.isSwcCaEvent && (
+ {form.isSwcCaEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
```

…applied to CA / AU / EU / UK / BR.

## Production impact

**Zero today.** All 5 regional kill-switch flags (`optin_ab_pizzadao_partners_{ca,au,eu,uk,br}`) are currently `enabled=false`, so no regional event has bucketed any variant guest. This fix lands before any regional flip-on so the secondary SWC opt-in metric stays clean when expansion begins.

US (`swc` tag, currently the only enabled region) is unaffected — its `isSwcEvent` block is already correctly inside the ternary's else branch.

## Test plan

- [ ] **US control** on an `swc`+`optin-ab-test` event still renders PizzaDAO + standalone US SWC checkboxes (unchanged).
- [ ] **US variant** still renders only the combined checkbox (unchanged).
- [ ] Flip `optin_ab_pizzadao_partners_uk` ON in a preview, RSVP to a `swcuk`+`optin-ab-test` event:
  - control: PizzaDAO ML + standalone SWC UK checkboxes (2 visible).
  - variant: combined checkbox only (1 visible, no duplicate UK SWC).
- [ ] Repeat for CA / AU / EU / BR.
- [ ] Variant tick on regional event writes `mailing_list_opt_in=true` AND `swc_<region>_opt_in=true`.
- [ ] Non-SWC events unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)