### PR TITLE
fix(calzone-34218): underboss tag/status live update

### DIFF
--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -335,9 +335,8 @@ function PhotoLightbox({
 
 export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggleSelect, partnerTags = [] }: EventRowProps) {
   const { t } = useTranslation('partner');
-  // Local state for optimistic updates
-  const [hostStatus, setHostStatus] = useState<HostStatus | null>(event.hostStatus);
-  const [eventTags, setEventTags] = useState<string[]>(event.eventTags || []);
+  // Read tag/status directly from props — parent setAllData drives optimistic
+  // re-render, so local mirrors would just shadow bulk updates until reload.
   const [notesOpen, setNotesOpen] = useState(false);
   const [notesValue, setNotesValue] = useState(event.underbossNotes || '');
   const [notesSaving, setNotesSaving] = useState(false);
@@ -616,10 +615,9 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-theme-text-secondary">{event.host.name || t('eventRow.unknownHost')}</span>
             <HostStatusBadge
-              status={hostStatus}
+              status={event.hostStatus}
               eventId={event.id}
               onUpdate={(s) => {
-                setHostStatus(s);
                 onEventUpdate?.(event.id, { hostStatus: s });
               }}
             />
@@ -631,12 +629,11 @@ export function EventRow({ event, showRegion, onEventUpdate, isSelected, onToggl
             </div>
           )}
           <HostTagsPills
-            tags={eventTags}
+            tags={event.eventTags ?? []}
             eventId={event.id}
             event={event}
             partnerTags={partnerTags}
             onUpdate={(tags) => {
-              setEventTags(tags);
               onEventUpdate?.(event.id, { eventTags: tags });
             }}
           />


### PR DESCRIPTION
## Summary

- **Bug**: On `/underboss`, bulk Add Tag / Remove Tag / approve / reject actions don't visibly update the affected rows until a full page reload. Inline single-row edits appear to work.
- **Cause**: `EventRow.tsx` mirrored `event.eventTags` and `event.hostStatus` into local `useState` seeded once from props. The inline editors update both the local state and the parent via `onEventUpdate`, so they re-render. The bulk path in `EventTable.tsx` only calls `onEventUpdate`, which updates `allData` in `UnderbossDashboard` and pipes a new `event` prop into `EventRow` — but the never-synced `useState` shadows the prop.
- **Fix**: Delete the two `useState` mirrors and read directly from `event.hostStatus` / `event.eventTags ?? []`. The parent's `setAllData` is synchronous, so optimistic-update behavior is preserved with no flicker.

Only `frontend/src/components/underboss/EventRow.tsx` is touched. No backend / DB / type changes.

## Preview

https://rsvpizza-git-calzone-34218-tag-live-update-pizza-dao.vercel.app

## Test plan

- [ ] Inline `+` on a row's pills — pill appears instantly (regression check)
- [ ] Click an existing pill on a row — disappears instantly (regression check)
- [ ] Select 2-3 rows, bulk Add Tag `swc` — pills appear on all selected rows without reload
- [ ] Same set, bulk Remove Tag `swc` — pills disappear without reload
- [ ] Bulk custom tag input — same behavior
- [ ] Bulk approve / reject — host status badge changes on all selected rows without reload
- [ ] Refresh after each — DB state matches what was on screen