### PR TITLE
fix(gpp): redirect unapproved party URLs to approved alt or globalpizza.party

### DIFF
--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1019,6 +1019,32 @@ export async function getPartyByInviteCode(inviteCode: string): Promise<DbParty 
   return data;
 }
 
+/**
+ * For a GPP party that is NOT approved, find another GPP party in the same
+ * city that IS approved. Returns null if no replacement exists. Used to
+ * redirect old-email-link visitors to a sanctioned party.
+ */
+export async function findApprovedGppPartyInCity(
+  city: string,
+  excludeId: string,
+): Promise<DbParty | null> {
+  const { data, error } = await supabase
+    .from('parties')
+    .select(SAFE_PARTY_COLUMNS)
+    .eq('event_type', 'gpp')
+    .eq('city', city)
+    .eq('underboss_status', 'approved')
+    .neq('id', excludeId)
+    .limit(1)
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('Error finding approved GPP party in city:', error);
+    return null;
+  }
+  return (data as DbParty | null) ?? null;
+}
+
 export async function getPartyByCustomUrl(customUrl: string): Promise<DbParty | null> {
   const { data, error } = await supabase
     .from('parties')

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { AlertCircle, Loader2, Lock, ChevronRight, Heart } from 'lucide-react';
-import { getPartyByInviteCodeOrCustomUrl, verifyPartyPassword, isUserGuestAtParty, DbParty } from '../lib/supabase';
+import { getPartyByInviteCodeOrCustomUrl, verifyPartyPassword, isUserGuestAtParty, findApprovedGppPartyInCity, DbParty } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import { DonationForm } from '../components/DonationForm';
 import { PublicEvent, getDonationStats, trackRsvpFunnel } from '../lib/api';
@@ -95,6 +95,22 @@ export function RSVPPage() {
       if (inviteCode) {
         const foundParty = await getPartyByInviteCodeOrCustomUrl(inviteCode);
         if (foundParty) {
+          // GPP parties must be underboss-approved. If not, redirect to an
+          // approved party in the same city, or fall back to globalpizza.party.
+          if (
+            foundParty.event_type === 'gpp' &&
+            foundParty.underboss_status !== 'approved'
+          ) {
+            const altParty = foundParty.city
+              ? await findApprovedGppPartyInCity(foundParty.city, foundParty.id)
+              : null;
+            if (altParty?.custom_url) {
+              navigate(`/${altParty.custom_url}`, { replace: true });
+            } else {
+              window.location.replace('https://globalpizza.party');
+            }
+            return;
+          }
           setParty(foundParty);
 
           // Check if donations are enabled


### PR DESCRIPTION
## Summary
- When a GPP party page loads with `underboss_status !== 'approved'`, redirect the visitor to another approved GPP party in the same city, or to https://globalpizza.party as a fallback.
- Adds `findApprovedGppPartyInCity(city, excludeId)` helper in `supabase.ts`.
- Wires the check into `RSVPPage.tsx` before rendering.

## Why
The email campaign that fired today (2026-05-19) sent personalized `rsv.pizza/{slug}` URLs to ~12k subscribers based on a city-rsvp-map built without filtering on approval status. ~4k of those recipients now have links to **rejected** or **pending** parties (NY 830, Ciudad de Guatemala 133, Calabar 115, Owerri 71, Guadalajara 61, Akwa Ibom 50, others). This redirect bails them out cleanly when they click.

## Behavior
- Non-GPP parties: unchanged (only `event_type === 'gpp'` triggers the check).
- GPP party with `underboss_status === 'approved'`: renders normally.
- GPP party not approved + another approved party exists in the same `city`: navigate (replace) to that party.
- GPP party not approved + no approved alternative in city: external redirect to `globalpizza.party`.

## Test plan
- [ ] Visit `https://rsv-pizza-git-gpp-redirect-unapproved-pizza-dao.vercel.app/newyork` on the Vercel preview — should redirect to globalpizza.party (NY is rejected, no approved NY alt).
- [ ] Visit a known-approved party slug on the preview — should render normally.
- [ ] Visit a non-GPP party slug on the preview — should render normally (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)