### PR TITLE
chore(arugula-38633): rename user-facing Payout → Reimbursement

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -213,7 +213,7 @@ async function isUnderbossOrAdmin(email?: string): Promise<boolean> {
 async function assertCanUsePayouts(req: AuthRequest): Promise<void> {
   if (!(await isUnderbossOrAdmin(req.userEmail))) {
     throw new AppError(
-      'The payouts feature is currently in soft launch for underbosses and admins only.',
+      'The reimbursements feature is currently in soft launch for underbosses and admins only.',
       403,
       'FORBIDDEN',
     );
@@ -453,7 +453,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
 
     if (finalUsd <= 0) {
       throw new AppError(
-        'Could not determine payout amount — OCR returned $0 for all receipts and no manual amount was provided',
+        'Could not determine reimbursement amount — OCR returned $0 for all receipts and no manual amount was provided',
         400,
         'INVALID_AMOUNT'
       );
@@ -572,7 +572,7 @@ router.get('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response
     });
 
     if (!payout) {
-      throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      throw new AppError('Reimbursement not found', 404, 'NOT_FOUND');
     }
 
     res.json({ payout: serializePayout(payout) });
@@ -604,11 +604,11 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       where: { id: payoutId, partyId },
     });
     if (!existing) {
-      throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      throw new AppError('Reimbursement not found', 404, 'NOT_FOUND');
     }
     if (existing.status !== 'pending') {
       throw new AppError(
-        'Payouts can only be edited while pending; this one is ' + existing.status,
+        'Reimbursements can only be edited while pending; this one is ' + existing.status,
         400,
         'PAYOUT_NOT_PENDING'
       );
@@ -684,11 +684,11 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
       where: { id: payoutId, partyId },
     });
     if (!existing) {
-      throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      throw new AppError('Reimbursement not found', 404, 'NOT_FOUND');
     }
     if (existing.status !== 'pending') {
       throw new AppError(
-        'Only pending payouts can be cancelled',
+        'Only pending reimbursements can be cancelled',
         400,
         'PAYOUT_NOT_PENDING'
       );

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -174,7 +174,7 @@ const apps: AppItem[] = [
   },
   {
     id: 'payouts',
-    name: 'Payouts',
+    name: 'Reimbursements',
     description: 'Submit receipts for host reimbursement',
     icon: Receipt,
     status: 'live',

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -173,7 +173,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
             <h2 className="text-lg font-semibold text-theme-text">Record External Payment</h2>
             <p className="text-xs text-theme-text-muted mt-0.5">
               Use this for payments made OUTSIDE rsv.pizza (Venmo, manual bank, etc.). Creates a paid
-              payout row immediately and writes an audit entry.
+              reimbursement row immediately and writes an audit entry.
             </p>
           </div>
           <button
@@ -198,7 +198,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
               required
             />
             <p className="text-xs text-theme-text-muted mt-1">
-              Paste the party's UUID — find it in the URL of the admin payouts table or in the party admin page.
+              Paste the party's UUID — find it in the URL of the admin reimbursements table or in the party admin page.
             </p>
           </div>
 

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -58,7 +58,7 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
       />
       <StatCard
         icon={<TrendingUp size={14} />}
-        label="Avg payout"
+        label="Avg reimbursement"
         value={formatUsd(totals.avgUsd)}
       />
       <StatCard

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -149,7 +149,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h2 className="text-lg font-semibold text-theme-text">
-                Payout {payout.id.slice(0, 8)}
+                Reimbursement {payout.id.slice(0, 8)}
               </h2>
               <PayoutStatusPill status={payout.status} size="md" />
               <PayoutMethodIcon method={payout.payoutMethod} showLabel />
@@ -180,7 +180,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         {selfPayoutBlocked && (
           <div className="mx-5 mt-3 px-3 py-2 rounded-lg bg-amber-50 border border-amber-300 text-sm text-amber-800 flex items-center gap-2">
             <AlertTriangle size={14} />
-            You are the host on this payout. Payment admins cannot approve/edit their own payouts.
+            You are the host on this reimbursement. Payment admins cannot approve/edit their own reimbursements.
           </div>
         )}
 
@@ -456,7 +456,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             {/* Reject form */}
             {showRejectForm && (
               <div className="rounded-xl border border-red-300 p-3 bg-red-50 text-sm">
-                <h3 className="font-semibold text-red-900 mb-2">Reject this payout</h3>
+                <h3 className="font-semibold text-red-900 mb-2">Reject this reimbursement</h3>
                 <IconInput
                   icon={X}
                   multiline
@@ -493,7 +493,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             {/* Execute payout form (PR 5) */}
             {showExecuteForm && (
               <div className="rounded-xl border border-emerald-300 p-3 bg-emerald-50 text-sm space-y-2">
-                <h3 className="font-semibold text-emerald-900 mb-1">Execute payout</h3>
+                <h3 className="font-semibold text-emerald-900 mb-1">Execute reimbursement</h3>
 
                 {payout.payoutMethod === 'usdc_base' && (
                   <div className="space-y-2">
@@ -597,7 +597,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
                   >
                     {busy && <Loader2 size={12} className="animate-spin" />}
-                    {payout.payoutMethod === 'usdc_base' ? 'Send Payout' :
+                    {payout.payoutMethod === 'usdc_base' ? 'Send Reimbursement' :
                       payout.payoutMethod === 'wire' ? 'Confirm wire sent' :
                       'Confirm card issued'}
                   </button>
@@ -719,7 +719,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
               >
                 <Send size={14} />
-                Execute Payout
+                Execute Reimbursement
               </button>
               <button
                 type="button"

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -96,7 +96,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
             value={filters.payoutMethod ?? 'all'}
             onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
             className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Filter by payout method"
+            aria-label="Filter by reimbursement method"
           >
             {METHOD_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -92,7 +92,7 @@ function ActionsCell({
             onClick={() => onExecute(payout)}
             disabled={busy}
             className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
-            title="Execute Payout"
+            title="Execute Reimbursement"
           >
             {busy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
           </button>
@@ -160,14 +160,14 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
               <tr>
                 <td colSpan={9} className="px-3 py-12 text-center text-theme-text-muted">
                   <Loader2 size={20} className="inline-block animate-spin mr-2" />
-                  Loading payouts…
+                  Loading reimbursements…
                 </td>
               </tr>
             )}
             {!loading && payouts.length === 0 && (
               <tr>
                 <td colSpan={9} className="px-3 py-12 text-center text-theme-text-faint">
-                  No payouts match these filters.
+                  No reimbursements match these filters.
                 </td>
               </tr>
             )}

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -58,7 +58,7 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
             checked={selected}
             onChange={() => onSelectToggle?.()}
             className="rounded border-theme-stroke-hover bg-theme-surface"
-            aria-label="Select payout"
+            aria-label="Select reimbursement"
           />
         </td>
       )}

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -164,7 +164,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       });
       onCreated(created);
     } catch (err: any) {
-      setSubmitError(err?.message || 'Failed to submit payout');
+      setSubmitError(err?.message || 'Failed to submit reimbursement');
     } finally {
       setSubmitting(false);
     }
@@ -349,7 +349,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             ? 'Waiting for uploads…'
             : submitting
             ? 'Submitting…'
-            : `Submit $${finalAmount.toFixed(2)} payout`}
+            : `Submit $${finalAmount.toFixed(2)} reimbursement`}
         </button>
       </div>
 

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -26,7 +26,7 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
   pending: 'Pending review',
-  approved: 'Approved — payout pending',
+  approved: 'Approved — reimbursement pending',
   rejected: 'Rejected',
   paid: 'Paid',
   failed: 'Failed',
@@ -50,7 +50,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     setError(null);
     getPayout(partyId, payoutId)
       .then(p => { if (!cancelled) setPayout(p); })
-      .catch(err => { if (!cancelled) setError(err?.message || 'Failed to load payout'); })
+      .catch(err => { if (!cancelled) setError(err?.message || 'Failed to load reimbursement'); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, [partyId, payoutId]);
@@ -66,7 +66,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
       >
         <div className="flex items-start justify-between p-5 border-b border-theme-stroke">
           <div>
-            <h2 className="text-lg font-semibold text-theme-text">Payout details</h2>
+            <h2 className="text-lg font-semibold text-theme-text">Reimbursement details</h2>
             {payout && (
               <p className="text-xs text-theme-text-muted mt-0.5">
                 Submitted {new Date(payout.createdAt).toLocaleString()}
@@ -118,7 +118,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
 
               {/* Payout method */}
               <div className="rounded-lg bg-theme-surface-hover p-3 text-sm">
-                <p className="text-xs text-theme-text-muted mb-1">Payout method</p>
+                <p className="text-xs text-theme-text-muted mb-1">Reimbursement method</p>
                 <p className="inline-flex items-center gap-2 text-theme-text font-medium">
                   {methodIcon(payout.payoutMethod)}
                   {METHOD_LABEL[payout.payoutMethod]}

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -54,7 +54,7 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
 
   const handleCancel = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!confirm('Cancel this payout request? This cannot be undone.')) return;
+    if (!confirm('Cancel this reimbursement request? This cannot be undone.')) return;
     setCancelling(true);
     try {
       const ok = await cancelPayout(partyId, payout.id);

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -86,7 +86,7 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           value="usdc_base"
           icon={<Coins size={18} />}
           title="USDC on Base"
-          description="On-chain payout to your wallet."
+          description="On-chain reimbursement to your wallet."
         />
         <Option
           value="mercury_card"

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -42,7 +42,7 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
         <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-theme-surface-hover flex items-center justify-center">
           <ReceiptIcon className="w-7 h-7 text-theme-text-muted" />
         </div>
-        <h3 className="text-base font-semibold text-theme-text mb-1">No payouts yet</h3>
+        <h3 className="text-base font-semibold text-theme-text mb-1">No reimbursements yet</h3>
         <p className="text-sm text-theme-text-muted mb-6">
           Submit your first reimbursement to get paid back for pizza or venue costs.
         </p>

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -151,7 +151,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
               <div>
                 <h2 className="text-lg font-semibold text-theme-text">Reimbursements</h2>
                 <p className="text-sm text-theme-text-secondary mt-1">
-                  Upload receipts for out-of-pocket expenses and choose how you want to get paid back.
+                  Upload receipts for expenses and choose how you want to get paid back.
                 </p>
               </div>
               <button

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -65,7 +65,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
       const data = await listPayouts(partyId);
       setPayouts(data);
     } catch (err: any) {
-      setError(err?.message || 'Failed to load payouts');
+      setError(err?.message || 'Failed to load reimbursements');
     } finally {
       setLoading(false);
     }
@@ -99,7 +99,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
     return (
       <div className="card p-8 text-center max-w-lg mx-auto">
         <Lock className="w-10 h-10 text-white/40 mx-auto mb-4" />
-        <h3 className="text-lg font-semibold mb-2">Payouts — Coming Soon</h3>
+        <h3 className="text-lg font-semibold mb-2">Reimbursements — Coming Soon</h3>
         <p className="text-sm text-white/60">
           Host reimbursements are currently in soft launch for underbosses and admins.
           We'll open it up to all hosts soon — stay tuned.
@@ -159,7 +159,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
                 className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 whitespace-nowrap"
               >
                 <Plus size={16} />
-                New payout
+                New reimbursement
               </button>
             </div>
           </div>
@@ -183,7 +183,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             className="inline-flex items-center gap-2 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
           >
             <ArrowLeft size={16} />
-            Back to payouts
+            Back to reimbursements
           </button>
           <NewPayoutForm
             partyId={partyId}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3874,7 +3874,7 @@ export async function exportAdminPayoutsCsv(filters?: AdminPayoutFilters): Promi
   const objectUrl = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = objectUrl;
-  a.download = `host-payouts-${new Date().toISOString().split('T')[0]}.csv`;
+  a.download = `host-reimbursements-${new Date().toISOString().split('T')[0]}.csv`;
   a.click();
   URL.revokeObjectURL(objectUrl);
 }

--- a/frontend/src/lib/appDefinitions.ts
+++ b/frontend/src/lib/appDefinitions.ts
@@ -41,5 +41,5 @@ export const PINNABLE_APPS: PinnableApp[] = [
   { id: 'marketing-promo', name: 'Promo', tab: 'promo', icon: Megaphone },
   { id: 'flyer', name: 'Flyer', tab: 'flyer', icon: FileImage },
   { id: 'print-nametags', name: 'Print', tab: 'print', icon: Printer },
-  { id: 'payouts', name: 'Payouts', tab: 'payouts', icon: Receipt },
+  { id: 'payouts', name: 'Reimbursements', tab: 'payouts', icon: Receipt },
 ];

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -643,7 +643,7 @@ export function AdminPage() {
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-50 text-emerald-800 text-sm font-medium hover:bg-emerald-100 border border-emerald-300"
             >
               <DollarSign size={16} />
-              Manage Host Payouts
+              Manage Host Reimbursements
               <ArrowRight size={14} />
             </a>
           </div>

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -97,7 +97,7 @@ export function PaymentsAdminPage() {
       setTotals(res.totals);
       setNextCursor(res.nextCursor);
     } catch (err: any) {
-      setErrorMsg(err.message || 'Failed to load payouts');
+      setErrorMsg(err.message || 'Failed to load reimbursements');
     } finally {
       if (append) setLoadingMore(false);
       else setLoading(false);
@@ -149,7 +149,7 @@ export function PaymentsAdminPage() {
       const d = await getAdminPayout(p.id);
       setDetail(d);
     } catch (err: any) {
-      setErrorMsg(err.message || 'Failed to load payout');
+      setErrorMsg(err.message || 'Failed to load reimbursement');
     } finally {
       setDetailLoading(false);
     }
@@ -198,7 +198,7 @@ export function PaymentsAdminPage() {
 
   async function handleBulkApprove() {
     if (selectedIds.size === 0) return;
-    if (!window.confirm(`Approve ${selectedIds.size} payouts?`)) return;
+    if (!window.confirm(`Approve ${selectedIds.size} reimbursements?`)) return;
     setBulkBusy(true);
     try {
       for (const id of Array.from(selectedIds)) {
@@ -229,7 +229,7 @@ export function PaymentsAdminPage() {
 
   async function handleBulkMarkPaid() {
     if (selectedIds.size === 0) return;
-    if (!window.confirm(`Mark ${selectedIds.size} payouts as paid (no transaction refs)?`)) return;
+    if (!window.confirm(`Mark ${selectedIds.size} reimbursements as paid (no transaction refs)?`)) return;
     setBulkBusy(true);
     try {
       for (const id of Array.from(selectedIds)) {


### PR DESCRIPTION
## Summary

Sweeping rename of all user-visible "Payout"/"payouts" strings to "Reimbursement"/"reimbursements" for consistent vocabulary across the rsv.pizza frontend (and a few host-facing backend error messages). Pure copy/UX change — no logic, schema, or routes touched.

### What changed
- AppsHub tile: `name: 'Payouts'` → `'Reimbursements'` (id `'payouts'` unchanged — used for tab routing)
- Host PayoutsTab: "New payout" button → "New reimbursement"; "Back to payouts" → "Back to reimbursements"; empty-state heading "No payouts yet" → "No reimbursements yet"
- PayoutDetailModal: "Payout details" → "Reimbursement details"; "Payout method" → "Reimbursement method"; status label "Approved — payout pending" → "Approved — reimbursement pending"
- NewPayoutForm: submit CTA "Submit \$X payout" → "Submit \$X reimbursement"; error toast updated
- Admin PaymentsAdminPage / PayoutsTable / PayoutReviewModal / PaymentsStatsCards: modal title, action button ("Execute Payout" → "Execute Reimbursement"), filter aria-label, table loading + empty states, "Avg payout" stat card, confirm() dialogs, error toasts
- CSV export filename: `host-payouts-…csv` → `host-reimbursements-…csv`
- AdminPage link label: "Manage Host Payouts" → "Manage Host Reimbursements"
- backend/src/routes/payout.routes.ts: host-facing AppError messages ("Payout not found", "Only pending payouts can be cancelled", soft-launch gate text, OCR amount-missing error)

### What was deliberately NOT renamed
- DB tables/columns: `payouts`, `payout_documents`, `payout_audit`, `payout_method`
- Prisma models: `Payout`, `PayoutDocument`, `PayoutAudit`
- Backend route paths: `/api/parties/:id/payouts`, `/api/admin/payouts`
- File names: `PayoutsTab.tsx`, `NewPayoutForm.tsx`, `payout.routes.ts`, etc.
- TS types/interfaces/props/vars: `Payout`, `PayoutMethod`, `createPayout`, `payoutTempId`, `selfPayoutBlocked`, etc.
- AppsHub tile `id: 'payouts'`, `tab: 'payouts'`, `TabType` union, `ALL_VALID_TABS` — internal routing
- Admin route `/payments` (already named "payments", not "payouts")
- admin-payout.routes.ts error strings (admin-only, technical audience — out of scope)
- CSS classnames + image storage paths under `payouts/<partyId>/…` (admin internal)

### Stats
18 files changed, 42 insertions(+), 42 deletions(-).

## Test plan

- [ ] Vercel preview builds cleanly
- [ ] Open HostPage → Reimbursements tab → confirm header, empty-state, "New reimbursement" button, "Back to reimbursements" link all read "reimbursement"
- [ ] Open AppsHub → confirm tile reads "Reimbursements" with description unchanged
- [ ] Open a reimbursement detail modal (host view) → confirm "Reimbursement details" title and "Reimbursement method" label
- [ ] Admin /payments page → confirm bulk-action confirm() dialogs and toasts use "reimbursement(s)"
- [ ] Admin opens a row → confirm "Reimbursement <id>" header, "Execute Reimbursement" button, "Reject this reimbursement" form heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)