### PR TITLE
figma-71823: Add Figma link to Print tab

### DIFF
--- a/frontend/src/components/print/PrintTab.tsx
+++ b/frontend/src/components/print/PrintTab.tsx
@@ -140,6 +140,17 @@ function PrintContent({ eventTags = [], showAllSwc = false }: { eventTags?: stri
         <p className="text-sm text-theme-text-secondary mt-1">
           Download print-ready materials for your event
         </p>
+        <p className="text-sm text-theme-text-secondary mt-1">
+          Need something custom?{' '}
+          <a
+            href="https://www.figma.com/design/itTDjW8plqdUiEGIXlwBP8/PizzaDAO---Marketing?node-id=588-1909&t=gkFsmruefaXmimZs-1"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#ff393a] hover:underline font-medium"
+          >
+            Browse the PizzaDAO Figma →
+          </a>
+        </p>
       </div>
 
       {/* Stickers Section */}


### PR DESCRIPTION
## Summary
- Adds a one-line link to the PizzaDAO Marketing Figma file at the top of the Print tab
- Visible on both `/shipping` (PrintMaterials) and the in-event host Print tab (PrintTab)
- Opens in a new tab; styled with the existing red accent

## Test plan
- [ ] Visit any host event's Print tab on the Vercel preview — link is visible under the subtitle and opens Figma in a new tab
- [ ] Visit `/shipping` on the preview — same link is visible
- [ ] No console errors

Generated with [Claude Code](https://claude.com/claude-code)