### PR TITLE
chore(arugula-38633): rename user-facing Reimbursement -> Payment

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -213,7 +213,7 @@ async function isUnderbossOrAdmin(email?: string): Promise<boolean> {
 async function assertCanUsePayouts(req: AuthRequest): Promise<void> {
   if (!(await isUnderbossOrAdmin(req.userEmail))) {
     throw new AppError(
-      'The reimbursements feature is currently in soft launch for underbosses and admins only.',
+      'The payments feature is currently in soft launch for underbosses and admins only.',
       403,
       'FORBIDDEN',
     );
@@ -453,7 +453,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
 
     if (finalUsd <= 0) {
       throw new AppError(
-        'Could not determine reimbursement amount — OCR returned $0 for all receipts and no manual amount was provided',
+        'Could not determine payment amount — OCR returned $0 for all receipts and no manual amount was provided',
         400,
         'INVALID_AMOUNT'
       );
@@ -572,7 +572,7 @@ router.get('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response
     });
 
     if (!payout) {
-      throw new AppError('Reimbursement not found', 404, 'NOT_FOUND');
+      throw new AppError('Payment not found', 404, 'NOT_FOUND');
     }
 
     res.json({ payout: serializePayout(payout) });
@@ -604,11 +604,11 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       where: { id: payoutId, partyId },
     });
     if (!existing) {
-      throw new AppError('Reimbursement not found', 404, 'NOT_FOUND');
+      throw new AppError('Payment not found', 404, 'NOT_FOUND');
     }
     if (existing.status !== 'pending') {
       throw new AppError(
-        'Reimbursements can only be edited while pending; this one is ' + existing.status,
+        'Payments can only be edited while pending; this one is ' + existing.status,
         400,
         'PAYOUT_NOT_PENDING'
       );
@@ -684,11 +684,11 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
       where: { id: payoutId, partyId },
     });
     if (!existing) {
-      throw new AppError('Reimbursement not found', 404, 'NOT_FOUND');
+      throw new AppError('Payment not found', 404, 'NOT_FOUND');
     }
     if (existing.status !== 'pending') {
       throw new AppError(
-        'Only pending reimbursements can be cancelled',
+        'Only pending payments can be cancelled',
         400,
         'PAYOUT_NOT_PENDING'
       );

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -174,8 +174,8 @@ const apps: AppItem[] = [
   },
   {
     id: 'payouts',
-    name: 'Reimbursements',
-    description: 'Submit receipts for host reimbursement',
+    name: 'Payments',
+    description: 'Submit receipts for host payment',
     icon: Receipt,
     status: 'live',
     category: 'after-party',

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -173,7 +173,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
             <h2 className="text-lg font-semibold text-theme-text">Record External Payment</h2>
             <p className="text-xs text-theme-text-muted mt-0.5">
               Use this for payments made OUTSIDE rsv.pizza (Venmo, manual bank, etc.). Creates a paid
-              reimbursement row immediately and writes an audit entry.
+              payment row immediately and writes an audit entry.
             </p>
           </div>
           <button
@@ -198,7 +198,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
               required
             />
             <p className="text-xs text-theme-text-muted mt-1">
-              Paste the party's UUID — find it in the URL of the admin reimbursements table or in the party admin page.
+              Paste the party's UUID — find it in the URL of the admin payments table or in the party admin page.
             </p>
           </div>
 
@@ -206,7 +206,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
           <div>
             <IconInput
               icon={UserIcon}
-              placeholder="Host user id (cuid) — who is being reimbursed *"
+              placeholder="Host user id (cuid) — who is being paid *"
               value={hostUserId}
               onChange={(e) => setHostUserId(e.target.value)}
               required

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -58,7 +58,7 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
       />
       <StatCard
         icon={<TrendingUp size={14} />}
-        label="Avg reimbursement"
+        label="Avg payment"
         value={formatUsd(totals.avgUsd)}
       />
       <StatCard

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -149,7 +149,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h2 className="text-lg font-semibold text-theme-text">
-                Reimbursement {payout.id.slice(0, 8)}
+                Payment {payout.id.slice(0, 8)}
               </h2>
               <PayoutStatusPill status={payout.status} size="md" />
               <PayoutMethodIcon method={payout.payoutMethod} showLabel />
@@ -180,7 +180,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         {selfPayoutBlocked && (
           <div className="mx-5 mt-3 px-3 py-2 rounded-lg bg-amber-50 border border-amber-300 text-sm text-amber-800 flex items-center gap-2">
             <AlertTriangle size={14} />
-            You are the host on this reimbursement. Payment admins cannot approve/edit their own reimbursements.
+            You are the host on this payment. Payment admins cannot approve/edit their own payments.
           </div>
         )}
 
@@ -456,7 +456,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             {/* Reject form */}
             {showRejectForm && (
               <div className="rounded-xl border border-red-300 p-3 bg-red-50 text-sm">
-                <h3 className="font-semibold text-red-900 mb-2">Reject this reimbursement</h3>
+                <h3 className="font-semibold text-red-900 mb-2">Reject this payment</h3>
                 <IconInput
                   icon={X}
                   multiline
@@ -493,7 +493,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             {/* Execute payout form (PR 5) */}
             {showExecuteForm && (
               <div className="rounded-xl border border-emerald-300 p-3 bg-emerald-50 text-sm space-y-2">
-                <h3 className="font-semibold text-emerald-900 mb-1">Execute reimbursement</h3>
+                <h3 className="font-semibold text-emerald-900 mb-1">Execute payment</h3>
 
                 {payout.payoutMethod === 'usdc_base' && (
                   <div className="space-y-2">
@@ -597,7 +597,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
                   >
                     {busy && <Loader2 size={12} className="animate-spin" />}
-                    {payout.payoutMethod === 'usdc_base' ? 'Send Reimbursement' :
+                    {payout.payoutMethod === 'usdc_base' ? 'Send Payment' :
                       payout.payoutMethod === 'wire' ? 'Confirm wire sent' :
                       'Confirm card issued'}
                   </button>
@@ -719,7 +719,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
               >
                 <Send size={14} />
-                Execute Reimbursement
+                Execute Payment
               </button>
               <button
                 type="button"

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -96,7 +96,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
             value={filters.payoutMethod ?? 'all'}
             onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
             className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Filter by reimbursement method"
+            aria-label="Filter by payment method"
           >
             {METHOD_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -92,7 +92,7 @@ function ActionsCell({
             onClick={() => onExecute(payout)}
             disabled={busy}
             className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
-            title="Execute Reimbursement"
+            title="Execute Payment"
           >
             {busy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
           </button>
@@ -160,14 +160,14 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
               <tr>
                 <td colSpan={9} className="px-3 py-12 text-center text-theme-text-muted">
                   <Loader2 size={20} className="inline-block animate-spin mr-2" />
-                  Loading reimbursements…
+                  Loading payments…
                 </td>
               </tr>
             )}
             {!loading && payouts.length === 0 && (
               <tr>
                 <td colSpan={9} className="px-3 py-12 text-center text-theme-text-faint">
-                  No reimbursements match these filters.
+                  No payments match these filters.
                 </td>
               </tr>
             )}

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -58,7 +58,7 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
             checked={selected}
             onChange={() => onSelectToggle?.()}
             className="rounded border-theme-stroke-hover bg-theme-surface"
-            aria-label="Select reimbursement"
+            aria-label="Select payment"
           />
         </td>
       )}

--- a/frontend/src/components/payouts/AppealCapModal.tsx
+++ b/frontend/src/components/payouts/AppealCapModal.tsx
@@ -80,7 +80,7 @@ export const AppealCapModal: React.FC<AppealCapModalProps> = ({
         </button>
 
         <div className="mb-4">
-          <h2 className="text-xl font-bold text-theme-text mb-1">Appeal reimbursement cap</h2>
+          <h2 className="text-xl font-bold text-theme-text mb-1">Appeal payment cap</h2>
           <p className="text-sm text-theme-text-muted">
             Your cap is currently <span className="font-medium text-theme-text">${capUsd.toFixed(2)}</span>.
             Tell us why it should be higher and an underboss will review.

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -182,7 +182,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             <BadgeDollarSign size={22} className="text-[#ff393a] mt-0.5 flex-shrink-0" />
             <div>
               <p className="text-sm font-medium text-theme-text">
-                We'll pay you up to ${reimbursementCapUsd!.toFixed(2)}.
+                We'll reimburse you for up to ${reimbursementCapUsd!.toFixed(2)}.
                 {totalPaidUsd > 0 && (
                   <> ${totalPaidUsd.toFixed(2)} paid so far.</>
                 )}
@@ -190,7 +190,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
               <p className="text-xs text-theme-text-muted mt-0.5">
                 {localAppealedAt
                   ? 'Appeal submitted — an underboss will review.'
-                  : 'Submissions above this amount may not be fully paid.'}
+                  : 'Submissions above this amount may not be fully reimbursed.'}
               </p>
             </div>
           </div>

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -164,7 +164,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       });
       onCreated(created);
     } catch (err: any) {
-      setSubmitError(err?.message || 'Failed to submit reimbursement');
+      setSubmitError(err?.message || 'Failed to submit payment');
     } finally {
       setSubmitting(false);
     }
@@ -182,7 +182,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             <BadgeDollarSign size={22} className="text-[#ff393a] mt-0.5 flex-shrink-0" />
             <div>
               <p className="text-sm font-medium text-theme-text">
-                We'll reimburse you up to ${reimbursementCapUsd!.toFixed(2)}.
+                We'll pay you up to ${reimbursementCapUsd!.toFixed(2)}.
                 {totalPaidUsd > 0 && (
                   <> ${totalPaidUsd.toFixed(2)} paid so far.</>
                 )}
@@ -190,7 +190,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
               <p className="text-xs text-theme-text-muted mt-0.5">
                 {localAppealedAt
                   ? 'Appeal submitted — an underboss will review.'
-                  : 'Submissions above this amount may not be fully reimbursed.'}
+                  : 'Submissions above this amount may not be fully paid.'}
               </p>
             </div>
           </div>
@@ -349,7 +349,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             ? 'Waiting for uploads…'
             : submitting
             ? 'Submitting…'
-            : `Submit $${finalAmount.toFixed(2)} reimbursement`}
+            : `Submit $${finalAmount.toFixed(2)} payment`}
         </button>
       </div>
 

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -26,7 +26,7 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
   pending: 'Pending review',
-  approved: 'Approved — reimbursement pending',
+  approved: 'Approved — payment pending',
   rejected: 'Rejected',
   paid: 'Paid',
   failed: 'Failed',
@@ -50,7 +50,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     setError(null);
     getPayout(partyId, payoutId)
       .then(p => { if (!cancelled) setPayout(p); })
-      .catch(err => { if (!cancelled) setError(err?.message || 'Failed to load reimbursement'); })
+      .catch(err => { if (!cancelled) setError(err?.message || 'Failed to load payment'); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, [partyId, payoutId]);
@@ -66,7 +66,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
       >
         <div className="flex items-start justify-between p-5 border-b border-theme-stroke">
           <div>
-            <h2 className="text-lg font-semibold text-theme-text">Reimbursement details</h2>
+            <h2 className="text-lg font-semibold text-theme-text">Payment details</h2>
             {payout && (
               <p className="text-xs text-theme-text-muted mt-0.5">
                 Submitted {new Date(payout.createdAt).toLocaleString()}
@@ -118,7 +118,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
 
               {/* Payout method */}
               <div className="rounded-lg bg-theme-surface-hover p-3 text-sm">
-                <p className="text-xs text-theme-text-muted mb-1">Reimbursement method</p>
+                <p className="text-xs text-theme-text-muted mb-1">Payment method</p>
                 <p className="inline-flex items-center gap-2 text-theme-text font-medium">
                   {methodIcon(payout.payoutMethod)}
                   {METHOD_LABEL[payout.payoutMethod]}

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -54,7 +54,7 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
 
   const handleCancel = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!confirm('Cancel this reimbursement request? This cannot be undone.')) return;
+    if (!confirm('Cancel this payment request? This cannot be undone.')) return;
     setCancelling(true);
     try {
       const ok = await cancelPayout(partyId, payout.id);

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -86,7 +86,7 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           value="usdc_base"
           icon={<Coins size={18} />}
           title="USDC on Base"
-          description="On-chain reimbursement to your wallet."
+          description="On-chain payment to your wallet."
         />
         <Option
           value="mercury_card"

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -42,16 +42,16 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
         <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-theme-surface-hover flex items-center justify-center">
           <ReceiptIcon className="w-7 h-7 text-theme-text-muted" />
         </div>
-        <h3 className="text-base font-semibold text-theme-text mb-1">No reimbursements yet</h3>
+        <h3 className="text-base font-semibold text-theme-text mb-1">No payments yet</h3>
         <p className="text-sm text-theme-text-muted mb-6">
-          Submit your first reimbursement to get paid back for pizza or venue costs.
+          Submit your first payment to get paid back for pizza or venue costs.
         </p>
         <button
           onClick={onStartNew}
           className="btn-secondary inline-flex items-center gap-2"
         >
           <Plus size={16} />
-          Submit your first reimbursement
+          Submit your first payment
         </button>
       </div>
     );

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -65,7 +65,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
       const data = await listPayouts(partyId);
       setPayouts(data);
     } catch (err: any) {
-      setError(err?.message || 'Failed to load reimbursements');
+      setError(err?.message || 'Failed to load payments');
     } finally {
       setLoading(false);
     }
@@ -99,9 +99,9 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
     return (
       <div className="card p-8 text-center max-w-lg mx-auto">
         <Lock className="w-10 h-10 text-white/40 mx-auto mb-4" />
-        <h3 className="text-lg font-semibold mb-2">Reimbursements — Coming Soon</h3>
+        <h3 className="text-lg font-semibold mb-2">Payments — Coming Soon</h3>
         <p className="text-sm text-white/60">
-          Host reimbursements are currently in soft launch for underbosses and admins.
+          Host payments are currently in soft launch for underbosses and admins.
           We'll open it up to all hosts soon — stay tuned.
         </p>
       </div>
@@ -149,7 +149,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           <div className="card p-6">
             <div className="flex items-center justify-between mb-2">
               <div>
-                <h2 className="text-lg font-semibold text-theme-text">Reimbursements</h2>
+                <h2 className="text-lg font-semibold text-theme-text">Payments</h2>
                 <p className="text-sm text-theme-text-secondary mt-1">
                   Upload receipts for expenses and choose how you want to get paid back.
                 </p>
@@ -159,7 +159,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
                 className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 whitespace-nowrap"
               >
                 <Plus size={16} />
-                New reimbursement
+                New payment
               </button>
             </div>
           </div>
@@ -183,7 +183,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             className="inline-flex items-center gap-2 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
           >
             <ArrowLeft size={16} />
-            Back to reimbursements
+            Back to payments
           </button>
           <NewPayoutForm
             partyId={partyId}

--- a/frontend/src/i18n/locales/de/admin.json
+++ b/frontend/src/i18n/locales/de/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "Super-Admin",
     "admin": "Admin",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "Admin entfernen",
     "tableHeaders": {
       "email": "E-Mail",

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "Super Admin",
     "admin": "Admin",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "Remove admin",
     "tableHeaders": {
       "email": "Email",

--- a/frontend/src/i18n/locales/es/admin.json
+++ b/frontend/src/i18n/locales/es/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "Super Admin",
     "admin": "Admin",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "Eliminar administrador",
     "tableHeaders": {
       "email": "Email",

--- a/frontend/src/i18n/locales/fr/admin.json
+++ b/frontend/src/i18n/locales/fr/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "Super administrateur",
     "admin": "Administrateur",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "Supprimer l'administrateur",
     "tableHeaders": {
       "email": "E-mail",

--- a/frontend/src/i18n/locales/ja/admin.json
+++ b/frontend/src/i18n/locales/ja/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "スーパー管理者",
     "admin": "管理者",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "管理者を削除",
     "tableHeaders": {
       "email": "メール",

--- a/frontend/src/i18n/locales/ko/admin.json
+++ b/frontend/src/i18n/locales/ko/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "슈퍼 관리자",
     "admin": "관리자",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "관리자 제거",
     "tableHeaders": {
       "email": "이메일",

--- a/frontend/src/i18n/locales/pt/admin.json
+++ b/frontend/src/i18n/locales/pt/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "Super Admin",
     "admin": "Admin",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "Remover admin",
     "tableHeaders": {
       "email": "E-mail",

--- a/frontend/src/i18n/locales/zh/admin.json
+++ b/frontend/src/i18n/locales/zh/admin.json
@@ -30,7 +30,7 @@
     "superAdmin": "超级管理员",
     "admin": "管理员",
     "paymentAdmin": "Payment Admin",
-    "paymentAdminDesc": "Manages host reimbursements only — cannot edit parties or other admins.",
+    "paymentAdminDesc": "Manages host payments only — cannot edit parties or other admins.",
     "removeAdmin": "移除管理员",
     "tableHeaders": {
       "email": "邮箱",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3874,7 +3874,7 @@ export async function exportAdminPayoutsCsv(filters?: AdminPayoutFilters): Promi
   const objectUrl = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = objectUrl;
-  a.download = `host-reimbursements-${new Date().toISOString().split('T')[0]}.csv`;
+  a.download = `host-payments-${new Date().toISOString().split('T')[0]}.csv`;
   a.click();
   URL.revokeObjectURL(objectUrl);
 }

--- a/frontend/src/lib/appDefinitions.ts
+++ b/frontend/src/lib/appDefinitions.ts
@@ -41,5 +41,5 @@ export const PINNABLE_APPS: PinnableApp[] = [
   { id: 'marketing-promo', name: 'Promo', tab: 'promo', icon: Megaphone },
   { id: 'flyer', name: 'Flyer', tab: 'flyer', icon: FileImage },
   { id: 'print-nametags', name: 'Print', tab: 'print', icon: Printer },
-  { id: 'payouts', name: 'Reimbursements', tab: 'payouts', icon: Receipt },
+  { id: 'payouts', name: 'Payments', tab: 'payouts', icon: Receipt },
 ];

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -643,7 +643,7 @@ export function AdminPage() {
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-50 text-emerald-800 text-sm font-medium hover:bg-emerald-100 border border-emerald-300"
             >
               <DollarSign size={16} />
-              Manage Host Reimbursements
+              Manage Host Payments
               <ArrowRight size={14} />
             </a>
           </div>

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -97,7 +97,7 @@ export function PaymentsAdminPage() {
       setTotals(res.totals);
       setNextCursor(res.nextCursor);
     } catch (err: any) {
-      setErrorMsg(err.message || 'Failed to load reimbursements');
+      setErrorMsg(err.message || 'Failed to load payments');
     } finally {
       if (append) setLoadingMore(false);
       else setLoading(false);
@@ -149,7 +149,7 @@ export function PaymentsAdminPage() {
       const d = await getAdminPayout(p.id);
       setDetail(d);
     } catch (err: any) {
-      setErrorMsg(err.message || 'Failed to load reimbursement');
+      setErrorMsg(err.message || 'Failed to load payment');
     } finally {
       setDetailLoading(false);
     }
@@ -198,7 +198,7 @@ export function PaymentsAdminPage() {
 
   async function handleBulkApprove() {
     if (selectedIds.size === 0) return;
-    if (!window.confirm(`Approve ${selectedIds.size} reimbursements?`)) return;
+    if (!window.confirm(`Approve ${selectedIds.size} payments?`)) return;
     setBulkBusy(true);
     try {
       for (const id of Array.from(selectedIds)) {
@@ -229,7 +229,7 @@ export function PaymentsAdminPage() {
 
   async function handleBulkMarkPaid() {
     if (selectedIds.size === 0) return;
-    if (!window.confirm(`Mark ${selectedIds.size} reimbursements as paid (no transaction refs)?`)) return;
+    if (!window.confirm(`Mark ${selectedIds.size} payments as paid (no transaction refs)?`)) return;
     setBulkBusy(true);
     try {
       for (const id of Array.from(selectedIds)) {
@@ -297,7 +297,7 @@ export function PaymentsAdminPage() {
           <div className="flex-1 min-w-0">
             <h1 className="text-2xl font-bold text-theme-text">Host Payments</h1>
             <p className="text-sm text-theme-text-muted">
-              Review, approve, and pay out host reimbursements ({role.role.replace('_', ' ')})
+              Review, approve, and pay out host payments ({role.role.replace('_', ' ')})
             </p>
           </div>
           {totals && totals.totalUsdPending > 0 && (


### PR DESCRIPTION
Inverts PR #444's user-facing rename per Snax preference. ~same file count and string count. Internal identifiers + reimbursement_cap_* DB columns unchanged.

## Summary
- Renamed user-facing "Reimbursement(s)/reimbursement(s)" to "Payment(s)/payment(s)" across 27 files
- Cap banner verb form: "We'll reimburse you up to $X" -> "We'll pay you up to $X"
- Cap banner secondary copy: "may not be fully reimbursed" -> "may not be fully paid"
- AppealCapModal title: "Appeal reimbursement cap" -> "Appeal payment cap"
- ExternalPaymentModal placeholder: "who is being reimbursed" -> "who is being paid"
- PayoutMethodPicker USDC description: "On-chain reimbursement" -> "On-chain payment"
- CSV filename: host-reimbursements-YYYY-MM-DD.csv -> host-payments-YYYY-MM-DD.csv
- Backend error messages updated (Reimbursement not found -> Payment not found, etc.)
- Soft-launch gating copy updated in PayoutsTab + backend
- All 8 i18n locales (en/de/es/fr/ja/ko/pt/zh) updated for paymentAdminDesc string
- AppsHub tile name "Reimbursements" -> "Payments" + description
- AdminPage button "Manage Host Reimbursements" -> "Manage Host Payments"
- PaymentsAdminPage subtitle + bulk-action confirms updated
- PaymentsStatsCards "Avg reimbursement" -> "Avg payment"

## Preserved (identifiers, not user-facing)
- Prisma models: Payout, PayoutDocument, PayoutAudit
- DB tables/columns: payouts, payout_documents, reimbursement_cap_usd/appeal_note/appealed_at
- TS interfaces/types: ReimbursementCapInput, ReimbursementCapResult, ReimbursementCapAppealResponse, ReimbursementCapCell
- Functions: computeSuggestedReimbursementCap, appealReimbursementCap
- Props/vars: reimbursementCapUsd, reimbursementCapAppealNote, reimbursementCapAppealedAt
- Backend routes: /api/parties/:partyId/reimbursement-cap/appeal, /api/parties/:id/payouts
- File names: PayoutsTab.tsx, payout.routes.ts, reimbursementCap.ts, ReimbursementCapCell.tsx
- AppsHub tile id: 'payouts', tab routing 'payouts'

## Test plan
- [ ] Vercel preview builds clean
- [ ] /payments admin page loads + "Avg payment" / "Loading payments…" / bulk confirms read correctly
- [ ] Host payouts tab shows "Payments" header + "New payment" button + empty-state copy
- [ ] Cap banner (when reimbursementCapUsd is set) shows "We'll pay you up to $X"
- [ ] Appeal modal title reads "Appeal payment cap" but still POSTs to /reimbursement-cap/appeal
- [ ] Apps hub tile reads "Payments" with new description