### PR TITLE
chore(arugula-38633): rename tab id 'payouts' -> 'payments'

### DIFF
--- a/backend/src/helpers/partyAccess.ts
+++ b/backend/src/helpers/partyAccess.ts
@@ -33,7 +33,7 @@ export const VALID_TAB_IDS = [
   'gpp',
   'promo',
   'flyer',
-  'payouts',
+  'payments',
   'print',
   'apps',
 ] as const;

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -173,13 +173,13 @@ const apps: AppItem[] = [
     tab: 'report',
   },
   {
-    id: 'payouts',
+    id: 'payments',
     name: 'Payments',
     description: 'Submit receipts for host payment',
     icon: Receipt,
     status: 'live',
     category: 'after-party',
-    tab: 'payouts',
+    tab: 'payments',
   },
   {
     id: 'merch',
@@ -404,7 +404,7 @@ export function AppsHub({
   }, []);
 
   const visibleApps = apps.map((a) => {
-    if (a.id === 'payouts' && canUsePayouts === false) {
+    if (a.id === 'payments' && canUsePayouts === false) {
       return { ...a, status: 'coming-soon' as const };
     }
     return a;

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -44,14 +44,14 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
         </div>
         <h3 className="text-base font-semibold text-theme-text mb-1">No payments yet</h3>
         <p className="text-sm text-theme-text-muted mb-6">
-          Submit your first payment to get paid back for pizza or venue costs.
+          Submit your receipts to get paid back for pizza or venue costs.
         </p>
         <button
           onClick={onStartNew}
           className="btn-secondary inline-flex items-center gap-2"
         >
           <Plus size={16} />
-          Submit your first payment
+          Submit your receipts
         </button>
       </div>
     );

--- a/frontend/src/lib/appDefinitions.ts
+++ b/frontend/src/lib/appDefinitions.ts
@@ -41,5 +41,5 @@ export const PINNABLE_APPS: PinnableApp[] = [
   { id: 'marketing-promo', name: 'Promo', tab: 'promo', icon: Megaphone },
   { id: 'flyer', name: 'Flyer', tab: 'flyer', icon: FileImage },
   { id: 'print-nametags', name: 'Print', tab: 'print', icon: Printer },
-  { id: 'payouts', name: 'Payments', tab: 'payouts', icon: Receipt },
+  { id: 'payments', name: 'Payments', tab: 'payments', icon: Receipt },
 ];

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -45,9 +45,9 @@ import { PayoutsTab } from '../components/payouts';
 // Super admin email that can edit any party
 const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
 
-type TabType = 'dashboard' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payouts' | 'apps';
+type TabType = 'dashboard' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payments' | 'apps';
 
-const ALL_VALID_TABS: TabType[] = ['dashboard', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'gpp', 'promo', 'flyer', 'print', 'payouts', 'apps'];
+const ALL_VALID_TABS: TabType[] = ['dashboard', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'gpp', 'promo', 'flyer', 'print', 'payments', 'apps'];
 
 function HostPageContent() {
   const { t } = useTranslation('host');
@@ -498,7 +498,7 @@ function HostPageContent() {
                 <PrintTab />
               )}
 
-              {activeTab === 'payouts' && party && (
+              {activeTab === 'payments' && party && (
                 <PayoutsTab
                   partyId={party.id}
                   reimbursementCapUsd={party.reimbursementCapUsd}


### PR DESCRIPTION
URL param + AppsHub tile id flipped from 'payouts' to 'payments'. Empty state CTA updated to 'Submit your receipts'.