### PR TITLE
feat(pepperoni-58341): day-of event host app

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -73,6 +73,9 @@ model Party {
   venueOrganization       String?   @map("venue_organization")
   venueWebsite            String?   @map("venue_website")
   venueNotes              String?   @map("venue_notes")
+  // Day-of logistics (pepperoni-58341): surfaced on /run/:inviteCode + day-of dashboard tab
+  wifiInfo                String?   @map("wifi_info")
+  parkingNotes            String?   @map("parking_notes")
   maxGuests               Int?      @map("max_guests")
   expectedGuests          Int?      @map("expected_guests")
   hideGuests              Boolean   @default(false) @map("hide_guests")
@@ -230,8 +233,28 @@ model Party {
   scorecardItems        GuestScorecardItem[]
   payouts               Payout[]
   outreachAttempts      OutreachAttempt[]
+  announcements         Announcement[]
 
   @@map("parties")
+}
+
+// pepperoni-58341: Audit log of day-of broadcasts (Telegram + email) sent from
+// the day-of host dashboard. Service-role only (RLS enabled, no policies).
+model Announcement {
+  id             String   @id @default(uuid())
+  partyId        String   @map("party_id") @db.Uuid
+  sentBy         String   @map("sent_by")
+  channels       String[]
+  subject        String?
+  body           String
+  recipientCount Int?     @map("recipient_count")
+  sentAt         DateTime @default(now()) @map("sent_at") @db.Timestamptz
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  party Party @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  @@index([partyId, sentAt(sort: Desc)])
+  @@map("announcements")
 }
 
 model PartyStatusAudit {

--- a/backend/src/helpers/partyAccess.ts
+++ b/backend/src/helpers/partyAccess.ts
@@ -17,6 +17,7 @@ export const GPP_GLOBAL_EDITORS = [
  */
 export const VALID_TAB_IDS = [
   'dashboard',
+  'day-of',
   'details',
   'guests',
   'pizza',

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -434,6 +434,9 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       // sends /start <token> to the bot). Allowing PATCH writes would let a host
       // spoof another user's chat_id.
       turtleRolesEnabled,
+      // Day-of logistics (pepperoni-58341)
+      wifiInfo,
+      parkingNotes,
       reimbursementCapUsd,
       // NOTE: reimbursementCapAppealNote + reimbursementCapAppealedAt are NOT
       // destructured here — appeals flow through the dedicated
@@ -607,6 +610,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(telegramGroup !== undefined && { telegramGroup: telegramGroup || null }),
         ...(hostTelegramLinkToken !== undefined && { hostTelegramLinkToken: hostTelegramLinkToken || null }),
         ...(turtleRolesEnabled !== undefined && { turtleRolesEnabled }),
+        ...(wifiInfo !== undefined && { wifiInfo: wifiInfo || null }),
+        ...(parkingNotes !== undefined && { parkingNotes: parkingNotes || null }),
         ...(reimbursementCapUsdToWrite !== undefined && { reimbursementCapUsd: reimbursementCapUsdToWrite }),
       },
       include: {
@@ -1090,6 +1095,292 @@ router.post('/:partyId/guests/:guestId/promote', async (req: AuthRequest, res: R
     }
 
     res.json({ guest: updatedGuest });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// =============================================================================
+// pepperoni-58341: Day-of event app endpoints
+// =============================================================================
+
+// POST /api/parties/:partyId/guests/walk-in
+// Day-of walk-in capture from the day-of dashboard. Creates a guest in
+// confirmed+approved+checked-in state in a single round-trip.
+router.post('/:partyId/guests/walk-in', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { name, email } = req.body;
+
+    // Per-route auth — NEVER router.use(gate) at a path-less mount: it would
+    // leak to sibling routers mounted at /api/parties (arugula-38633 v2 bug).
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'day-of');
+    if (!canAccessDayOf) {
+      throw new AppError('You do not have access to the day-of tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new AppError('Name is required', 400, 'VALIDATION_ERROR');
+    }
+
+    const normalizedEmail = email && typeof email === 'string' ? email.toLowerCase().trim() : null;
+
+    // If a guest with this email already exists for this party, check them in
+    // rather than creating a duplicate (host clicked walk-in for someone who
+    // already RSVP'd online).
+    if (normalizedEmail) {
+      const existing = await prisma.guest.findFirst({
+        where: { partyId, email: normalizedEmail },
+      });
+      if (existing) {
+        const updated = await prisma.guest.update({
+          where: { id: existing.id },
+          data: {
+            status: 'CONFIRMED',
+            approved: true,
+            checkedInAt: existing.checkedInAt || new Date(),
+            checkedInBy: req.userId,
+          },
+        });
+        return res.status(200).json({ guest: updated, alreadyExisted: true });
+      }
+    }
+
+    const guest = await prisma.guest.create({
+      data: {
+        name: name.trim(),
+        email: normalizedEmail,
+        submittedVia: 'host-checkin',
+        status: 'CONFIRMED',
+        approved: true,
+        checkedInAt: new Date(),
+        checkedInBy: req.userId,
+        partyId,
+      },
+    });
+
+    await triggerWebhook('guest.registered', { guest, partyId }, req.userId!);
+
+    res.status(201).json({ guest });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/announce
+// Day-of broadcast: sends a host-authored message via Telegram (to host's
+// connected chat) and/or individual emails to confirmed guests. Persists an
+// audit row to `announcements`.
+router.post('/:partyId/announce', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { subject, body, channels } = req.body || {};
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'day-of');
+    if (!canAccessDayOf) {
+      throw new AppError('You do not have access to the day-of tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    // Validate body
+    if (!body || typeof body !== 'string' || body.trim().length === 0) {
+      throw new AppError('body is required', 400, 'VALIDATION_ERROR');
+    }
+    if (body.length > 4096) {
+      throw new AppError('body must be 4096 characters or less', 400, 'VALIDATION_ERROR');
+    }
+
+    // Validate channels
+    if (!Array.isArray(channels) || channels.length === 0) {
+      throw new AppError('channels must be a non-empty array', 400, 'VALIDATION_ERROR');
+    }
+    const VALID_CHANNELS = new Set(['telegram', 'email']);
+    const filteredChannels = (channels as unknown[]).filter(
+      (c): c is string => typeof c === 'string' && VALID_CHANNELS.has(c)
+    );
+    if (filteredChannels.length === 0) {
+      throw new AppError('channels must include "telegram" or "email"', 400, 'VALIDATION_ERROR');
+    }
+
+    const emailRequested = filteredChannels.includes('email');
+    const telegramRequested = filteredChannels.includes('telegram');
+
+    // Subject required when emailing
+    if (emailRequested && (!subject || typeof subject !== 'string' || subject.trim().length === 0)) {
+      throw new AppError('subject is required when email channel is selected', 400, 'VALIDATION_ERROR');
+    }
+
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: {
+        id: true,
+        name: true,
+        inviteCode: true,
+        customUrl: true,
+        hostTelegramChatId: true,
+      },
+    });
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // -----------------------------------------------------------------------
+    // Telegram delivery — sends to host's connected chat (hostTelegramChatId).
+    // The schema has no group chat_id for parties; `telegramGroup` is a URL
+    // string only. If the host hasn't connected Telegram, skip silently.
+    // -----------------------------------------------------------------------
+    let telegramSent = false;
+    if (telegramRequested && party.hostTelegramChatId) {
+      const botToken = process.env.TELEGRAM_BOT_TOKEN;
+      if (botToken) {
+        try {
+          const message = subject ? `*${subject}*\n\n${body}` : body;
+          const tgRes = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              chat_id: party.hostTelegramChatId.toString(),
+              text: message,
+              parse_mode: 'Markdown',
+            }),
+          });
+          const tgJson = await tgRes.json();
+          telegramSent = !!tgJson.ok;
+        } catch (err) {
+          console.error('[Day-of announce] Telegram send failed:', err);
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Email delivery — individual sends (no BCC) to confirmed guests with an
+    // email on file. We don't fail the request if a single send errors; the
+    // recipient_count reflects successful sends.
+    // -----------------------------------------------------------------------
+    let emailSentCount = 0;
+    let recipientCount = 0;
+    if (emailRequested) {
+      const recipients = await prisma.guest.findMany({
+        where: {
+          partyId,
+          status: 'CONFIRMED',
+          email: { not: null },
+        },
+        select: { id: true, name: true, email: true },
+      });
+      recipientCount = recipients.length;
+
+      const resendApiKey = process.env.RESEND_API_KEY;
+      if (!resendApiKey) {
+        console.warn('[Day-of announce] RESEND_API_KEY not set, skipping email sends');
+      } else {
+        const baseUrl = 'https://rsv.pizza';
+        const eventUrl = party.customUrl
+          ? `${baseUrl}/${party.customUrl}`
+          : `${baseUrl}/${party.inviteCode}`;
+
+        // Build HTML once (per-recipient personalization only swaps the greeting)
+        const escapedBody = body
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/\n/g, '<br />');
+
+        for (const recipient of recipients) {
+          if (!recipient.email) continue;
+          const html = `
+            <!DOCTYPE html>
+            <html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+              <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 20px; border-radius: 12px; text-align: center; margin-bottom: 24px;">
+                <h1 style="color: #ffffff; font-size: 24px; margin: 0;">${party.name.replace(/</g, '&lt;')}</h1>
+                <p style="color: rgba(255,255,255,0.8); font-size: 14px; margin: 8px 0 0 0;">A message from your host</p>
+              </div>
+              <div style="background: #f9f9f9; padding: 24px; border-radius: 12px; margin-bottom: 20px;">
+                <p style="margin: 0 0 12px 0; font-size: 14px; color: #666;">Hi ${(recipient.name || 'there').replace(/</g, '&lt;')},</p>
+                <div style="font-size: 16px;">${escapedBody}</div>
+              </div>
+              <div style="text-align: center; margin: 24px 0;">
+                <a href="${eventUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 12px 28px; border-radius: 8px; font-weight: 600;">View Event Page</a>
+              </div>
+            </body></html>
+          `;
+          try {
+            const r = await fetch('https://api.resend.com/emails', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${resendApiKey}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                from: 'RSV.Pizza <noreply@rsv.pizza>',
+                to: [recipient.email],
+                subject: subject || `Update from ${party.name}`,
+                html,
+              }),
+            });
+            if (r.ok) emailSentCount += 1;
+          } catch (err) {
+            console.error(`[Day-of announce] Resend send failed for guest ${recipient.id}:`, err);
+          }
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Persist audit row
+    // -----------------------------------------------------------------------
+    const announcement = await prisma.announcement.create({
+      data: {
+        partyId,
+        sentBy: req.userEmail || req.userId || 'unknown',
+        channels: filteredChannels,
+        subject: subject || null,
+        body,
+        recipientCount: emailRequested ? recipientCount : null,
+      },
+    });
+
+    res.status(201).json({
+      announcementId: announcement.id,
+      recipientCount,
+      channelsSent: {
+        telegram: telegramSent,
+        email: emailSentCount,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/parties/:partyId/announcements — last 10 sent announcements
+router.get('/:partyId/announcements', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'day-of');
+    if (!canAccessDayOf) {
+      throw new AppError('You do not have access to the day-of tab', 403, 'TAB_ACCESS_DENIED');
+    }
+
+    const rows = await prisma.announcement.findMany({
+      where: { partyId },
+      orderBy: { sentAt: 'desc' },
+      take: 10,
+    });
+
+    res.json({ announcements: rows });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import { HomePage } from './pages/HomePage';
 import { RSVPPage } from './pages/RSVPPage';
 import { HostPage } from './pages/HostPage';
+import { DayOfRunPage } from './pages/DayOfRunPage';
+import { ArtDisplayPage } from './pages/ArtDisplayPage';
 import { EventPage } from './pages/EventPage';
 import { AuthVerifyPage } from './pages/AuthVerifyPage';
 import { LoginPage } from './pages/LoginPage';
@@ -65,8 +67,12 @@ function App() {
             <Route path="/rsvp/:inviteCode" element={<RSVPPage />} />
             <Route path="/host/:inviteCode" element={<HostPage />} />
             <Route path="/host/:inviteCode/:tab" element={<HostPage />} />
+            {/* pepperoni-58341: mobile day-of dashboard for hosts/cohosts */}
+            <Route path="/run/:inviteCode" element={<DayOfRunPage />} />
             <Route path="/checkin/:inviteCode/:guestId" element={<CheckInPage />} />
             <Route path="/dj/:inviteCode" element={<DJPage />} />
+            {/* pepperoni-58341: full-bleed art slideshow — more specific than /display/:partyId/:slug */}
+            <Route path="/display/:partyId/art" element={<ArtDisplayPage />} />
             <Route path="/display/:partyId/:slug" element={<DisplayPage />} />
             <Route path="/underboss" element={<UnderbossDashboard />} />
             <Route path="/underboss/:region" element={<UnderbossDashboard />} />

--- a/frontend/src/components/day-of/AnnouncePanel.tsx
+++ b/frontend/src/components/day-of/AnnouncePanel.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { Send, Megaphone, Loader2, MessageCircle, Mail } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
+import { sendDayOfAnnouncement, AnnounceResponse } from '../../lib/api';
+
+interface AnnouncePanelProps {
+  partyId: string;
+  onSent?: (res: AnnounceResponse) => void;
+}
+
+/**
+ * Day-of broadcast composer. Sends to Telegram (host's connected chat) and/or
+ * Email (individual confirmed guests). No confirm modal — reversible enough
+ * via not re-sending. Audit row is always persisted.
+ */
+export const AnnouncePanel: React.FC<AnnouncePanelProps> = ({ partyId, onSent }) => {
+  const [telegramOn, setTelegramOn] = useState(true);
+  const [emailOn, setEmailOn] = useState(true);
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+  const [result, setResult] = useState<AnnounceResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSend =
+    body.trim().length > 0 &&
+    (telegramOn || emailOn) &&
+    (!emailOn || subject.trim().length > 0);
+
+  const handleSend = async () => {
+    if (!canSend || sending) return;
+    setSending(true);
+    setError(null);
+    setResult(null);
+    try {
+      const channels: Array<'telegram' | 'email'> = [];
+      if (telegramOn) channels.push('telegram');
+      if (emailOn) channels.push('email');
+      const res = await sendDayOfAnnouncement(partyId, {
+        subject: subject.trim() || undefined,
+        body: body.trim(),
+        channels,
+      });
+      setResult(res);
+      setBody('');
+      setSubject('');
+      onSent?.(res);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to send announcement');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="card p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <Megaphone size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">Announce</h3>
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        <Checkbox
+          checked={telegramOn}
+          onChange={() => setTelegramOn((v) => !v)}
+          label="Telegram"
+        >
+          <MessageCircle size={14} className="text-theme-text-muted ml-1" />
+        </Checkbox>
+        <Checkbox
+          checked={emailOn}
+          onChange={() => setEmailOn((v) => !v)}
+          label="Email"
+        >
+          <Mail size={14} className="text-theme-text-muted ml-1" />
+        </Checkbox>
+      </div>
+
+      {emailOn && (
+        <IconInput
+          icon={Mail}
+          placeholder="Subject (required for email)"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        />
+      )}
+
+      <IconInput
+        icon={Megaphone}
+        multiline
+        rows={5}
+        placeholder="Message to send your guests…"
+        value={body}
+        onChange={(e) => setBody((e.target as HTMLTextAreaElement).value)}
+      />
+
+      {body && (
+        <div className="text-xs text-theme-text-muted bg-white/5 rounded p-3 whitespace-pre-line border border-white/10">
+          <p className="uppercase tracking-wide mb-1 text-[10px]">Preview</p>
+          {subject && <p className="font-semibold text-theme-text mb-1">{subject}</p>}
+          {body}
+        </div>
+      )}
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {result && (
+        <div className="text-sm text-green-400 bg-green-500/5 border border-green-500/20 rounded p-3">
+          Sent — Telegram: {result.channelsSent.telegram ? 'delivered' : 'skipped'}, Email:{' '}
+          {result.channelsSent.email}/{result.recipientCount}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={handleSend}
+        disabled={!canSend || sending}
+        className="w-full bg-[#ff393a] text-white rounded-lg py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+      >
+        {sending ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            Sending…
+          </>
+        ) : (
+          <>
+            <Send size={16} />
+            Send announcement
+          </>
+        )}
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/AnnouncementHistory.tsx
+++ b/frontend/src/components/day-of/AnnouncementHistory.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { History, Loader2, MessageCircle, Mail } from 'lucide-react';
+import { listDayOfAnnouncements, DayOfAnnouncement } from '../../lib/api';
+
+interface AnnouncementHistoryProps {
+  partyId: string;
+  /** Bump this counter to force a refetch (e.g. after sending). */
+  refreshKey?: number;
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export const AnnouncementHistory: React.FC<AnnouncementHistoryProps> = ({ partyId, refreshKey }) => {
+  const [rows, setRows] = useState<DayOfAnnouncement[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    listDayOfAnnouncements(partyId)
+      .then((data) => {
+        if (!cancelled) setRows(data);
+      })
+      .catch(() => {
+        // Permissions / network issues are non-fatal — just hide history.
+        if (!cancelled) setRows([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId, refreshKey]);
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <History size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">Sent today</h3>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-theme-text-muted">
+          <Loader2 size={14} className="animate-spin" />
+          Loading…
+        </div>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-theme-text-muted italic">No announcements sent yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((row) => (
+            <li key={row.id} className="border-l-2 border-[#ff393a]/40 pl-3">
+              <div className="flex items-center gap-2 text-xs text-theme-text-muted">
+                <span>{relativeTime(row.sentAt)}</span>
+                {row.channels.includes('telegram') && (
+                  <MessageCircle size={12} className="text-theme-text-muted" />
+                )}
+                {row.channels.includes('email') && (
+                  <>
+                    <Mail size={12} className="text-theme-text-muted" />
+                    {row.recipientCount != null && <span>{row.recipientCount}</span>}
+                  </>
+                )}
+              </div>
+              {row.subject && (
+                <p className="text-sm font-semibold text-theme-text mt-1">{row.subject}</p>
+              )}
+              <p className="text-sm text-theme-text-secondary line-clamp-2 mt-0.5">
+                {row.body}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/ArtDisplay.tsx
+++ b/frontend/src/components/day-of/ArtDisplay.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, ImageOff } from 'lucide-react';
+import { getPartyPhotos } from '../../lib/api';
+import { Photo } from '../../types';
+
+interface ArtDisplayProps {
+  partyId: string;
+  /** ms per slide; default 8000. */
+  intervalMs?: number;
+}
+
+/**
+ * Full-bleed rotating slideshow of approved party photos. Designed for the
+ * /display/:partyId/art route — a host pins this on a venue screen. Polls
+ * every minute to pick up new photos.
+ */
+export const ArtDisplay: React.FC<ArtDisplayProps> = ({ partyId, intervalMs = 8000 }) => {
+  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [index, setIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  // Initial fetch + polling refresh
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const res = await getPartyPhotos(partyId, { status: 'approved', limit: 100 });
+      if (cancelled) return;
+      // Filter to images (skip videos — they don't loop cleanly in 8s)
+      const images = (res?.photos || []).filter((p) => p.mimeType.startsWith('image/'));
+      setPhotos(images);
+      setLoading(false);
+    };
+    load();
+    const handle = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [partyId]);
+
+  // Rotation timer
+  useEffect(() => {
+    if (photos.length <= 1) return;
+    const handle = setInterval(() => {
+      setIndex((i) => (i + 1) % photos.length);
+    }, intervalMs);
+    return () => clearInterval(handle);
+  }, [photos.length, intervalMs]);
+
+  if (loading) {
+    return (
+      <div className="fixed inset-0 bg-black flex items-center justify-center">
+        <Loader2 size={32} className="animate-spin text-white/40" />
+      </div>
+    );
+  }
+
+  if (photos.length === 0) {
+    return (
+      <div className="fixed inset-0 bg-black flex flex-col items-center justify-center text-white/50 gap-3">
+        <ImageOff size={48} />
+        <p>No approved photos yet.</p>
+      </div>
+    );
+  }
+
+  const current = photos[index];
+  return (
+    <div className="fixed inset-0 bg-black flex items-center justify-center overflow-hidden">
+      <img
+        key={current.id}
+        src={current.url}
+        alt={current.caption || ''}
+        className="max-w-full max-h-full object-contain animate-fadein"
+      />
+      <style>{`
+        @keyframes fadein {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        .animate-fadein {
+          animation: fadein 800ms ease-out;
+        }
+      `}</style>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/BriefingCard.tsx
+++ b/frontend/src/components/day-of/BriefingCard.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { Megaphone, Check } from 'lucide-react';
+import { Party } from '../../types';
+import { Checkbox } from '../Checkbox';
+import { PIZZADAO_BRIEFING } from '../../lib/dayOfBriefing';
+
+interface BriefingCardProps {
+  party: Party;
+  /** When true (auto-promoted window), render with an accent border. */
+  highlighted?: boolean;
+}
+
+/**
+ * GPP-only PizzaDAO mic-announcement briefing card. Caller is responsible
+ * for hiding this for non-GPP parties (see DayOfDashboard for the
+ * `eventType === 'gpp'` gate). Persists "done" state in localStorage so
+ * dismissing once sticks for the rest of the evening.
+ */
+export const BriefingCard: React.FC<BriefingCardProps> = ({ party, highlighted }) => {
+  const storageKey = `dayof.briefing.done.${party.id}`;
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    try {
+      setDone(localStorage.getItem(storageKey) === '1');
+    } catch {
+      /* ignore */
+    }
+  }, [storageKey]);
+
+  const toggle = () => {
+    setDone((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(storageKey, next ? '1' : '0');
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className={`card p-5 space-y-3 transition-opacity ${
+        done ? 'opacity-50' : ''
+      } ${highlighted ? 'border-2 border-[#ff393a]/60' : ''}`}
+    >
+      <div className="flex items-center gap-2">
+        <Megaphone size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">
+          PizzaDAO mic-announcement
+        </h3>
+      </div>
+
+      <div className="text-xs text-theme-text-muted bg-[#ff393a]/10 rounded px-3 py-2">
+        ~1 hour into event — then hand the mic to your partners, 1–3 min each.
+      </div>
+
+      <p className="text-lg leading-relaxed text-theme-text whitespace-pre-line">
+        {PIZZADAO_BRIEFING.script}
+      </p>
+
+      <div className="pt-2 border-t border-white/10">
+        <Checkbox
+          checked={done}
+          onChange={toggle}
+          label={done ? 'Done — announcement made' : 'Mark as done'}
+        >
+          {done && <Check size={14} className="text-green-500" />}
+        </Checkbox>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Radio, Video, Smartphone, ExternalLink } from 'lucide-react';
+import {
+  ZOOM_URL,
+  STREAMYARD_URL,
+  isBroadcastUrlReady,
+} from '../../lib/dayOfConfig';
+
+interface BroadcastJoinCardProps {
+  /** Layout hint from DayOfDashboard. Mobile stacks the buttons; desktop puts them side-by-side. */
+  layout?: 'desktop' | 'mobile';
+}
+
+interface BroadcastButtonProps {
+  url: string;
+  label: string;
+  subtitle: string;
+  icon: React.ReactNode;
+}
+
+const BroadcastButton: React.FC<BroadcastButtonProps> = ({
+  url,
+  label,
+  subtitle,
+  icon,
+}) => {
+  const ready = isBroadcastUrlReady(url);
+
+  const inner = (
+    <>
+      <span className="flex items-center justify-center gap-2 font-semibold text-base">
+        {icon}
+        {label}
+        {ready && <ExternalLink size={14} className="opacity-70" />}
+      </span>
+      <span className="block text-xs font-normal text-white/70 mt-1.5 leading-snug">
+        {subtitle}
+      </span>
+      {!ready && (
+        <span className="absolute top-1.5 right-2 text-[10px] uppercase tracking-wider text-white/60 bg-black/40 rounded px-1.5 py-0.5">
+          Coming soon
+        </span>
+      )}
+    </>
+  );
+
+  const baseClasses =
+    'relative flex-1 rounded-xl py-4 px-4 text-white text-center transition-opacity';
+
+  if (!ready) {
+    return (
+      <div
+        aria-disabled="true"
+        className={`${baseClasses} bg-[#ff393a]/40 opacity-60 cursor-not-allowed`}
+      >
+        {inner}
+      </div>
+    );
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${baseClasses} bg-[#ff393a] hover:bg-[#ff5a5b]`}
+    >
+      {inner}
+    </a>
+  );
+};
+
+/**
+ * GPP-only broadcast launcher. Two equal-weight buttons (Zoom static cam,
+ * StreamYard phone). URLs live in lib/dayOfConfig.ts. While URLs are
+ * TODO_*, both render disabled with a "Coming soon" badge. Visibility
+ * gate (isGpp) is the caller's job (DayOfDashboard).
+ */
+export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ layout }) => {
+  const isMobile = layout === 'mobile';
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <Radio size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">
+          Join the global PizzaDAO broadcast
+        </h3>
+      </div>
+
+      <p className="text-sm text-theme-text-secondary">
+        Plug your party into the worldwide GPP livestream.
+      </p>
+
+      <div className={isMobile ? 'flex flex-col gap-3' : 'flex flex-col sm:flex-row gap-3'}>
+        <BroadcastButton
+          url={ZOOM_URL}
+          label="Join Zoom (static camera)"
+          subtitle="Set up a laptop on a tripod with a wide shot of the venue — leave it running."
+          icon={<Video size={18} />}
+        />
+        <BroadcastButton
+          url={STREAMYARD_URL}
+          label="Join StreamYard (phone)"
+          subtitle="Open this on your phone for live interviews and walkaround shots."
+          icon={<Smartphone size={18} />}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/CheckInPanel.tsx
+++ b/frontend/src/components/day-of/CheckInPanel.tsx
@@ -1,0 +1,142 @@
+import React, { useMemo, useState } from 'react';
+import { Search, UserCheck, UserPlus, Check, Loader2 } from 'lucide-react';
+import { Party, Guest } from '../../types';
+import { IconInput } from '../IconInput';
+import { checkInGuest, uncheckInGuestApi } from '../../lib/api';
+import { WalkInModal } from './WalkInModal';
+
+interface CheckInPanelProps {
+  party: Party;
+  guests: Guest[];
+  onGuestUpdated?: () => void;
+}
+
+/**
+ * Searchable, one-tap check-in panel. Sorts uncheckedin guests above
+ * checked-in. "Walk-in" button at top opens WalkInModal.
+ */
+export const CheckInPanel: React.FC<CheckInPanelProps> = ({ party, guests, onGuestUpdated }) => {
+  const [query, setQuery] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [showWalkIn, setShowWalkIn] = useState(false);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const eligible = guests.filter((g) => g.approved !== false && g.status !== 'WAITLISTED');
+    const matched = q
+      ? eligible.filter(
+          (g) =>
+            (g.name || '').toLowerCase().includes(q) ||
+            (g.email || '').toLowerCase().includes(q)
+        )
+      : eligible;
+    // Unchecked first, then alpha
+    return [...matched].sort((a, b) => {
+      const aChecked = !!a.checkedInAt;
+      const bChecked = !!b.checkedInAt;
+      if (aChecked !== bChecked) return aChecked ? 1 : -1;
+      return (a.name || '').localeCompare(b.name || '');
+    });
+  }, [guests, query]);
+
+  const toggleCheckIn = async (guest: Guest) => {
+    setBusyId(guest.id);
+    try {
+      if (guest.checkedInAt) {
+        await uncheckInGuestApi(party.inviteCode, guest.id);
+      } else {
+        await checkInGuest(party.inviteCode, guest.id);
+      }
+      onGuestUpdated?.();
+    } catch (err) {
+      console.error('[CheckInPanel] check-in toggle failed:', err);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <UserCheck size={18} className="text-[#ff393a]" />
+          <h3 className="text-lg font-semibold text-theme-text">Check-in</h3>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowWalkIn(true)}
+          className="inline-flex items-center gap-1.5 text-sm bg-[#ff393a] text-white px-3 py-1.5 rounded-lg font-medium hover:opacity-90"
+        >
+          <UserPlus size={14} />
+          Walk-in
+        </button>
+      </div>
+
+      <IconInput
+        icon={Search}
+        placeholder="Search by name or email"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+
+      <div className="max-h-[28rem] overflow-y-auto -mx-2">
+        {filtered.length === 0 ? (
+          <p className="text-sm text-theme-text-muted italic px-2 py-4">
+            {query ? 'No matches.' : 'No guests yet.'}
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {filtered.map((g) => {
+              const checkedIn = !!g.checkedInAt;
+              const busy = busyId === g.id;
+              return (
+                <li key={g.id}>
+                  <button
+                    type="button"
+                    onClick={() => toggleCheckIn(g)}
+                    disabled={busy}
+                    className={`w-full flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg text-left transition-colors ${
+                      checkedIn
+                        ? 'bg-green-500/10 hover:bg-green-500/15'
+                        : 'hover:bg-white/5'
+                    } ${busy ? 'opacity-50' : ''}`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={`text-sm truncate ${
+                          checkedIn ? 'text-theme-text-muted line-through' : 'text-theme-text font-medium'
+                        }`}
+                      >
+                        {g.name || 'Anonymous'}
+                      </p>
+                      {g.email && (
+                        <p className="text-xs text-theme-text-muted truncate">{g.email}</p>
+                      )}
+                    </div>
+                    {busy ? (
+                      <Loader2 size={16} className="animate-spin text-theme-text-muted" />
+                    ) : checkedIn ? (
+                      <Check size={18} className="text-green-500 flex-shrink-0" />
+                    ) : (
+                      <span className="text-xs text-[#ff393a] font-semibold whitespace-nowrap">
+                        Tap to check in
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {showWalkIn && (
+        <WalkInModal
+          partyId={party.id}
+          onClose={() => setShowWalkIn(false)}
+          onAdded={() => onGuestUpdated?.()}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/ChecklistTodayCard.tsx
+++ b/frontend/src/components/day-of/ChecklistTodayCard.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { ListChecks, ChevronRight, Loader2 } from 'lucide-react';
+import { ChecklistItem } from '../../types';
+import { getChecklist } from '../../lib/api';
+
+interface ChecklistTodayCardProps {
+  partyId: string;
+  inviteCode: string;
+  hideOpenTabLink?: boolean;
+}
+
+/**
+ * Day-of subset of the checklist — only items in the allowlist below that
+ * are still un-done. Items renamed/rewritten by the host won't match this
+ * list and won't appear (acceptable v1 trade-off).
+ */
+const DAY_OF_ITEM_NAMES = new Set([
+  'Confirm pizza delivery time',
+  'Set up check-in table',
+  'Test sound system',
+  'Greet first guests',
+  'Take group photo',
+  'Pay venue final invoice',
+]);
+
+export const ChecklistTodayCard: React.FC<ChecklistTodayCardProps> = ({
+  partyId,
+  inviteCode,
+  hideOpenTabLink,
+}) => {
+  const [items, setItems] = useState<ChecklistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getChecklist(partyId)
+      .then((data) => {
+        if (cancelled) return;
+        setItems(data?.items || []);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
+  const todays = items.filter(
+    (i) => !i.completed && DAY_OF_ITEM_NAMES.has(i.name)
+  );
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ListChecks size={18} className="text-[#ff393a]" />
+          <h3 className="text-lg font-semibold text-theme-text">Today's checklist</h3>
+        </div>
+        {!hideOpenTabLink && (
+          <a
+            href={`/host/${inviteCode}?tab=checklist`}
+            className="inline-flex items-center text-sm text-theme-text-secondary hover:text-theme-text"
+          >
+            Open
+            <ChevronRight size={14} />
+          </a>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-theme-text-muted">
+          <Loader2 size={14} className="animate-spin" />
+          Loading…
+        </div>
+      ) : todays.length === 0 ? (
+        <p className="text-sm text-theme-text-muted italic">
+          All day-of items are done.
+        </p>
+      ) : (
+        <ul className="space-y-1.5">
+          {todays.map((item) => (
+            <li
+              key={item.id}
+              className="flex items-center gap-2 text-sm text-theme-text py-1"
+            >
+              <span className="w-2 h-2 rounded-full bg-[#ff393a] flex-shrink-0" />
+              {item.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/ChecklistTodayCard.tsx
+++ b/frontend/src/components/day-of/ChecklistTodayCard.tsx
@@ -21,6 +21,11 @@ const DAY_OF_ITEM_NAMES = new Set([
   'Greet first guests',
   'Take group photo',
   'Pay venue final invoice',
+  'Get the pizza box signed',
+  'Join the PizzaDAO Zoom (static camera)',
+  'Join the PizzaDAO StreamYard (phone)',
+  'Take a Stand With Crypto group photo',
+  'Record the Stand With Crypto shoutout',
 ]);
 
 export const ChecklistTodayCard: React.FC<ChecklistTodayCardProps> = ({

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -15,6 +15,7 @@ import { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
 import { BriefingCard } from './BriefingCard';
 import { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
 import { BroadcastJoinCard } from './BroadcastJoinCard';
+import { StandWithCryptoCard } from './StandWithCryptoCard';
 
 interface DayOfDashboardProps {
   party: Party;
@@ -90,6 +91,7 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
         {isGpp && !briefingFirst && <BriefingCard party={party} />}
         {isGpp && <SignedPizzaBoxCard party={party} />}
         {isGpp && <BroadcastJoinCard layout={layout} />}
+        {isGpp && <StandWithCryptoCard party={party} />}
         <LogisticsCard party={party} />
         <PizzaStatusCard party={party} />
         <MusicNowPlayingCard

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -14,6 +14,7 @@ import { ChecklistTodayCard } from './ChecklistTodayCard';
 import { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
 import { BriefingCard } from './BriefingCard';
 import { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
+import { BroadcastJoinCard } from './BroadcastJoinCard';
 
 interface DayOfDashboardProps {
   party: Party;
@@ -88,6 +89,7 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
       <div className={isMobile ? '' : 'space-y-4'}>
         {isGpp && !briefingFirst && <BriefingCard party={party} />}
         {isGpp && <SignedPizzaBoxCard party={party} />}
+        {isGpp && <BroadcastJoinCard layout={layout} />}
         <LogisticsCard party={party} />
         <PizzaStatusCard party={party} />
         <MusicNowPlayingCard

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Party, Guest } from '../../types';
+import { useGuestsRealtime } from '../../hooks/useGuestsRealtime';
+import * as db from '../../lib/supabase';
+import { dbGuestToGuest } from '../../contexts/PizzaContext';
+import { StatusHeader } from './StatusHeader';
+import { CheckInPanel } from './CheckInPanel';
+import { AnnouncePanel } from './AnnouncePanel';
+import { AnnouncementHistory } from './AnnouncementHistory';
+import { LogisticsCard } from './LogisticsCard';
+import { PizzaStatusCard } from './PizzaStatusCard';
+import { MusicNowPlayingCard } from './MusicNowPlayingCard';
+import { ChecklistTodayCard } from './ChecklistTodayCard';
+import { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
+import { BriefingCard } from './BriefingCard';
+
+interface DayOfDashboardProps {
+  party: Party;
+  layout: 'desktop' | 'mobile';
+}
+
+/**
+ * Day-of host dashboard — same component on both the desktop tab and the
+ * /run/:inviteCode mobile route. Realtime guest subscription is host-only
+ * (calabrese-58204).
+ */
+export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout }) => {
+  // ---- HOOKS (all above any early return) -------------------------------
+  const [guests, setGuests] = useState<Guest[]>(party.guests || []);
+  const [annHistoryKey, setAnnHistoryKey] = useState(0);
+
+  // Reload guests from server-of-record. Used after one-tap check-in or
+  // walk-in capture, in addition to the realtime subscription.
+  const refreshGuests = React.useCallback(async () => {
+    const dbGuests = await db.getGuestsByPartyId(party.id);
+    setGuests((dbGuests || []).map(dbGuestToGuest));
+  }, [party.id]);
+
+  useEffect(() => {
+    refreshGuests();
+  }, [refreshGuests]);
+
+  useGuestsRealtime(party.id, setGuests);
+
+  // Briefing window: between 50 and 90 minutes after event start.
+  const briefingWindowActive = useMemo(() => {
+    if (!party.date) return false;
+    const start = new Date(party.date).getTime();
+    const now = Date.now();
+    return now >= start + 50 * 60_000 && now <= start + 90 * 60_000;
+  }, [party.date]);
+
+  const isGpp = party.eventType === 'gpp';
+
+  // Mobile layout: stacked single-column with sticky bottom Walk-in/Announce
+  // tabs. For v1 we keep it simple — same cards stacked, briefing on top in
+  // the auto-promote window.
+  const isMobile = layout === 'mobile';
+
+  const briefingFirst = isGpp && briefingWindowActive;
+
+  return (
+    <div
+      className={
+        isMobile
+          ? 'space-y-4 pb-8'
+          : 'grid grid-cols-1 xl:grid-cols-3 gap-4'
+      }
+    >
+      {briefingFirst && (
+        <div className={isMobile ? '' : 'xl:col-span-3'}>
+          <BriefingCard party={party} highlighted />
+        </div>
+      )}
+
+      <div className={isMobile ? '' : 'xl:col-span-2 space-y-4'}>
+        <StatusHeader party={party} guests={guests} />
+        <CheckInPanel party={party} guests={guests} onGuestUpdated={refreshGuests} />
+        <AnnouncePanel
+          partyId={party.id}
+          onSent={() => setAnnHistoryKey((k) => k + 1)}
+        />
+        <AnnouncementHistory partyId={party.id} refreshKey={annHistoryKey} />
+        <PhotoQuickCaptureCard party={party} />
+      </div>
+
+      <div className={isMobile ? '' : 'space-y-4'}>
+        {isGpp && !briefingFirst && <BriefingCard party={party} />}
+        <LogisticsCard party={party} />
+        <PizzaStatusCard party={party} />
+        <MusicNowPlayingCard
+          partyId={party.id}
+          inviteCode={party.inviteCode}
+          hideOpenTabLink={isMobile}
+        />
+        <ChecklistTodayCard
+          partyId={party.id}
+          inviteCode={party.inviteCode}
+          hideOpenTabLink={isMobile}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -13,6 +13,7 @@ import { MusicNowPlayingCard } from './MusicNowPlayingCard';
 import { ChecklistTodayCard } from './ChecklistTodayCard';
 import { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
 import { BriefingCard } from './BriefingCard';
+import { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
 
 interface DayOfDashboardProps {
   party: Party;
@@ -86,6 +87,7 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
 
       <div className={isMobile ? '' : 'space-y-4'}>
         {isGpp && !briefingFirst && <BriefingCard party={party} />}
+        {isGpp && <SignedPizzaBoxCard party={party} />}
         <LogisticsCard party={party} />
         <PizzaStatusCard party={party} />
         <MusicNowPlayingCard

--- a/frontend/src/components/day-of/DayOfTab.tsx
+++ b/frontend/src/components/day-of/DayOfTab.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Party } from '../../types';
+import { DayOfDashboard } from './DayOfDashboard';
+
+interface DayOfTabProps {
+  party: Party;
+}
+
+/**
+ * Thin wrapper used on the HostPage `day-of` tab. The mobile route at
+ * /run/:inviteCode renders DayOfDashboard directly with layout="mobile".
+ */
+export const DayOfTab: React.FC<DayOfTabProps> = ({ party }) => {
+  return <DayOfDashboard party={party} layout="desktop" />;
+};

--- a/frontend/src/components/day-of/LogisticsCard.tsx
+++ b/frontend/src/components/day-of/LogisticsCard.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { MapPin, Wifi, Car, Phone, User, ExternalLink } from 'lucide-react';
+import { Party } from '../../types';
+
+interface LogisticsCardProps {
+  party: Party;
+}
+
+/**
+ * Day-of venue logistics: address with directions link, parking notes,
+ * wifi info, host point-of-contact at venue. Tap-to-call on mobile via
+ * `tel:` links.
+ */
+export const LogisticsCard: React.FC<LogisticsCardProps> = ({ party }) => {
+  const address = party.address;
+  const venueName = party.venueName;
+  const wifi = party.wifiInfo;
+  const parking = party.parkingNotes;
+  const contactName = (party as any).venueContactName as string | null | undefined;
+  const contactPhone = (party as any).venueContactPhone as string | null | undefined;
+
+  const directionsUrl = address
+    ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(address)}`
+    : null;
+
+  return (
+    <div className="card p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <MapPin size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">Logistics</h3>
+      </div>
+
+      {(venueName || address) && (
+        <div className="space-y-1">
+          {venueName && <p className="text-theme-text font-medium">{venueName}</p>}
+          {address && <p className="text-sm text-theme-text-secondary">{address}</p>}
+          {directionsUrl && (
+            <a
+              href={directionsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-[#ff393a] hover:underline mt-1"
+            >
+              Open in Maps
+              <ExternalLink size={14} />
+            </a>
+          )}
+        </div>
+      )}
+
+      {parking && (
+        <div className="flex items-start gap-2 pt-2 border-t border-white/10">
+          <Car size={16} className="text-theme-text-muted mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-xs text-theme-text-muted uppercase tracking-wide">Parking</p>
+            <p className="text-sm text-theme-text whitespace-pre-line">{parking}</p>
+          </div>
+        </div>
+      )}
+
+      {wifi && (
+        <div className="flex items-start gap-2 pt-2 border-t border-white/10">
+          <Wifi size={16} className="text-theme-text-muted mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-xs text-theme-text-muted uppercase tracking-wide">Wi-Fi</p>
+            <p className="text-sm text-theme-text whitespace-pre-line">{wifi}</p>
+          </div>
+        </div>
+      )}
+
+      {(contactName || contactPhone) && (
+        <div className="flex items-start gap-2 pt-2 border-t border-white/10">
+          <User size={16} className="text-theme-text-muted mt-0.5 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-theme-text-muted uppercase tracking-wide">Venue contact</p>
+            {contactName && <p className="text-sm text-theme-text">{contactName}</p>}
+            {contactPhone && (
+              <a
+                href={`tel:${contactPhone}`}
+                className="inline-flex items-center gap-1 text-sm text-[#ff393a] hover:underline"
+              >
+                <Phone size={14} />
+                {contactPhone}
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!venueName && !address && !parking && !wifi && !contactName && !contactPhone && (
+        <p className="text-sm text-theme-text-muted italic">
+          Add venue details on the Venue tab so they show up here on event day.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/MusicNowPlayingCard.tsx
+++ b/frontend/src/components/day-of/MusicNowPlayingCard.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { Music, ChevronRight, Loader2 } from 'lucide-react';
+import { Performer } from '../../types';
+import { getPerformers } from '../../lib/api';
+
+interface MusicNowPlayingCardProps {
+  partyId: string;
+  inviteCode: string;
+  /**
+   * If true, hide the "Open Music tab" link (e.g. on the /run mobile route
+   * where the link would just navigate away from the day-of dashboard).
+   */
+  hideOpenTabLink?: boolean;
+}
+
+/**
+ * Day-of snapshot of the music lineup. Lists confirmed performers; uses
+ * the Music tab's existing data via getPerformers().
+ */
+export const MusicNowPlayingCard: React.FC<MusicNowPlayingCardProps> = ({
+  partyId,
+  inviteCode,
+  hideOpenTabLink,
+}) => {
+  const [performers, setPerformers] = useState<Performer[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getPerformers(partyId)
+      .then((res) => {
+        if (cancelled) return;
+        setPerformers(res?.performers || []);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
+  const upcoming = performers
+    .filter((p) => p.status !== 'cancelled')
+    .sort((a, b) => {
+      if (a.setTime && b.setTime) return a.setTime.localeCompare(b.setTime);
+      if (a.setTime) return -1;
+      if (b.setTime) return 1;
+      return a.sortOrder - b.sortOrder;
+    })
+    .slice(0, 4);
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Music size={18} className="text-[#ff393a]" />
+          <h3 className="text-lg font-semibold text-theme-text">Music</h3>
+        </div>
+        {!hideOpenTabLink && (
+          <a
+            href={`/host/${inviteCode}?tab=music`}
+            className="inline-flex items-center text-sm text-theme-text-secondary hover:text-theme-text"
+          >
+            Open
+            <ChevronRight size={14} />
+          </a>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-theme-text-muted">
+          <Loader2 size={14} className="animate-spin" />
+          Loading lineup…
+        </div>
+      ) : upcoming.length === 0 ? (
+        <p className="text-sm text-theme-text-muted italic">No performers yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {upcoming.map((p) => (
+            <li key={p.id} className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-theme-text truncate">{p.name}</p>
+                {p.genre && (
+                  <p className="text-xs text-theme-text-muted truncate">{p.genre}</p>
+                )}
+              </div>
+              {p.setTime && (
+                <span className="text-xs font-mono text-theme-text-secondary whitespace-nowrap">
+                  {p.setTime}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/PhotoQuickCaptureCard.tsx
+++ b/frontend/src/components/day-of/PhotoQuickCaptureCard.tsx
@@ -1,0 +1,102 @@
+import React, { useRef, useState } from 'react';
+import { Camera, Loader2 } from 'lucide-react';
+import { Party } from '../../types';
+import { uploadEventPhoto } from '../../lib/supabase';
+import { uploadPhoto as uploadPhotoApi } from '../../lib/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface PhotoQuickCaptureCardProps {
+  party: Party;
+  onUploaded?: () => void;
+}
+
+/**
+ * Day-of one-tap photo capture. Mobile browsers open the rear camera via
+ * `capture="environment"`. Reuses uploadEventPhoto for the storage write
+ * + the public uploadPhoto API to register the photo on the party.
+ */
+export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ party, onUploaded }) => {
+  const { user } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastSuccess, setLastSuccess] = useState(false);
+
+  const handleFile = async (file: File) => {
+    setError(null);
+    setUploading(true);
+    setLastSuccess(false);
+    try {
+      const upload = await uploadEventPhoto(file, party.id);
+      if (!upload) {
+        throw new Error('Upload failed (storage)');
+      }
+      const res = await uploadPhotoApi(party.id, {
+        url: upload.url,
+        fileName: upload.fileName,
+        fileSize: upload.fileSize,
+        mimeType: upload.mimeType,
+        width: upload.width,
+        height: upload.height,
+        uploaderName: user?.name || 'Host',
+        uploaderEmail: user?.email || undefined,
+      });
+      if (!res) throw new Error('Upload failed (api)');
+      setLastSuccess(true);
+      onUploaded?.();
+    } catch (err: any) {
+      setError(err?.message || 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    // Reset so the same file can be picked again
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <Camera size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">Quick photo</h3>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-[#ff393a] text-white rounded-xl py-6 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+      >
+        {uploading ? (
+          <>
+            <Loader2 size={18} className="animate-spin" />
+            Uploading…
+          </>
+        ) : (
+          <>
+            <Camera size={20} />
+            Take a photo
+          </>
+        )}
+      </button>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      {lastSuccess && !uploading && (
+        <p className="text-sm text-green-400">Uploaded — visible to guests on the event page.</p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/PizzaStatusCard.tsx
+++ b/frontend/src/components/day-of/PizzaStatusCard.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from 'react';
+import { Pizza, Phone, ExternalLink, Check } from 'lucide-react';
+import { Party } from '../../types';
+import { Checkbox } from '../Checkbox';
+
+interface PizzaStatusCardProps {
+  party: Party;
+}
+
+interface PizzeriaShape {
+  name?: string;
+  phone?: string;
+  website?: string;
+  address?: string;
+}
+
+/**
+ * Day-of pizza partner status. Shows selected pizzerias with a tap-to-call,
+ * plus a localStorage-persisted "Order placed" checkbox per pizzeria.
+ */
+export const PizzaStatusCard: React.FC<PizzaStatusCardProps> = ({ party }) => {
+  const pizzerias = (party.selectedPizzerias || []) as PizzeriaShape[];
+  const storageKey = `dayof.pizza.orderPlaced.${party.id}`;
+
+  const [orderState, setOrderState] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (raw) setOrderState(JSON.parse(raw));
+    } catch {
+      /* ignore */
+    }
+  }, [storageKey]);
+
+  const toggle = (key: string) => {
+    setOrderState((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <Pizza size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">Pizza partners</h3>
+      </div>
+
+      {pizzerias.length === 0 ? (
+        <p className="text-sm text-theme-text-muted italic">No pizzerias selected.</p>
+      ) : (
+        <ul className="space-y-3">
+          {pizzerias.map((p, idx) => {
+            const key = `${p.name || 'pizzeria'}-${idx}`;
+            const placed = !!orderState[key];
+            return (
+              <li
+                key={key}
+                className={`p-3 rounded-lg border ${
+                  placed ? 'border-green-500/40 bg-green-500/5' : 'border-white/10'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium text-theme-text truncate">
+                      {p.name || 'Pizzeria'}
+                    </p>
+                    {p.address && (
+                      <p className="text-xs text-theme-text-muted truncate">{p.address}</p>
+                    )}
+                    <div className="flex gap-3 mt-1.5">
+                      {p.phone && (
+                        <a
+                          href={`tel:${p.phone}`}
+                          className="inline-flex items-center gap-1 text-sm text-[#ff393a] hover:underline"
+                        >
+                          <Phone size={14} />
+                          {p.phone}
+                        </a>
+                      )}
+                      {p.website && (
+                        <a
+                          href={p.website}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-sm text-theme-text-secondary hover:underline"
+                        >
+                          <ExternalLink size={14} />
+                          Site
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                  {placed && <Check size={18} className="text-green-500 flex-shrink-0" />}
+                </div>
+                <div className="mt-2">
+                  <Checkbox
+                    checked={placed}
+                    onChange={() => toggle(key)}
+                    label="Order placed"
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
+++ b/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { PenLine, Loader2, Check, Camera } from 'lucide-react';
+import { Party } from '../../types';
+import { uploadEventPhoto } from '../../lib/supabase';
+import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface SignedPizzaBoxCardProps {
+  party: Party;
+  onUploaded?: () => void;
+}
+
+/**
+ * GPP-only host prompt — encourages the host to have everyone sign an
+ * empty pizza box and snap a photo when full. Sibling visibility gate is
+ * the responsibility of the caller (DayOfDashboard); render-time check is
+ * a defensive fallback. Done-state is detected by the existence of any
+ * party photo tagged 'signed-box'; the card dims to 50% but keeps the
+ * upload button active (multiple boxes possible).
+ */
+export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, onUploaded }) => {
+  // ---- HOOKS (all above any early return) -------------------------------
+  const { user } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasSignedBox, setHasSignedBox] = useState(false);
+
+  const checkForSignedBox = React.useCallback(async () => {
+    try {
+      const res = await getPartyPhotos(party.id, { tag: 'signed-box', limit: 1 });
+      setHasSignedBox(!!res && res.photos.length > 0);
+    } catch {
+      /* ignore — best-effort done-state */
+    }
+  }, [party.id]);
+
+  useEffect(() => {
+    checkForSignedBox();
+  }, [checkForSignedBox]);
+
+  const handleFile = async (file: File) => {
+    setError(null);
+    setUploading(true);
+    try {
+      const upload = await uploadEventPhoto(file, party.id);
+      if (!upload) {
+        throw new Error('Upload failed (storage)');
+      }
+      const res = await uploadPhotoApi(party.id, {
+        url: upload.url,
+        fileName: upload.fileName,
+        fileSize: upload.fileSize,
+        mimeType: upload.mimeType,
+        width: upload.width,
+        height: upload.height,
+        uploaderName: user?.name || 'Host',
+        uploaderEmail: user?.email || undefined,
+        tags: ['signed-box'],
+      });
+      if (!res) throw new Error('Upload failed (api)');
+      setHasSignedBox(true);
+      onUploaded?.();
+    } catch (err: any) {
+      setError(err?.message || 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  return (
+    <div
+      className={`card p-5 space-y-3 transition-opacity ${
+        hasSignedBox ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <PenLine size={18} className="text-[#ff393a]" />
+          <h3 className="text-lg font-semibold text-theme-text">
+            Get the pizza box signed
+          </h3>
+        </div>
+        {hasSignedBox && (
+          <span className="inline-flex items-center gap-1 text-xs text-green-400">
+            <Check size={14} />
+            Signed box uploaded
+          </span>
+        )}
+      </div>
+
+      <p className="text-sm leading-relaxed text-theme-text-secondary">
+        Have everyone sign an empty pizza box! Pass it around during the event.
+        The signed boxes become part of PizzaDAO history — snap a photo when
+        it's full so we have a record.
+      </p>
+
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-[#ff393a] text-white rounded-xl py-4 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+      >
+        {uploading ? (
+          <>
+            <Loader2 size={18} className="animate-spin" />
+            Uploading…
+          </>
+        ) : (
+          <>
+            <Camera size={18} />
+            Upload signed box photo
+          </>
+        )}
+      </button>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/StandWithCryptoCard.tsx
+++ b/frontend/src/components/day-of/StandWithCryptoCard.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Shield, Loader2, Check, Camera, Video } from 'lucide-react';
+import { Party } from '../../types';
+import { uploadEventPhoto, uploadEventVideo } from '../../lib/supabase';
+import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface StandWithCryptoCardProps {
+  party: Party;
+  onUploaded?: () => void;
+}
+
+type UploadState = {
+  uploading: boolean;
+  error: string | null;
+};
+
+/**
+ * GPP-only Stand With Crypto sponsor activation. Two independent uploads:
+ *   1. Group photo with SWC signs (tagged 'swc-photo', images bucket)
+ *   2. Shoutout video (tagged 'swc-video', videos bucket)
+ *
+ * Each section shows a ✓ once its tagged file exists. Card dims to 50%
+ * once BOTH are done; both upload buttons remain active throughout.
+ *
+ * Visibility gate (isGpp) is the caller's responsibility (DayOfDashboard).
+ */
+export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party, onUploaded }) => {
+  // ---- HOOKS (all above any early return) -------------------------------
+  const { user } = useAuth();
+  const photoInputRef = useRef<HTMLInputElement>(null);
+  const videoInputRef = useRef<HTMLInputElement>(null);
+
+  const [photoState, setPhotoState] = useState<UploadState>({ uploading: false, error: null });
+  const [videoState, setVideoState] = useState<UploadState>({ uploading: false, error: null });
+
+  const [hasPhoto, setHasPhoto] = useState(false);
+  const [hasVideo, setHasVideo] = useState(false);
+
+  const refresh = React.useCallback(async () => {
+    try {
+      const [photoRes, videoRes] = await Promise.all([
+        getPartyPhotos(party.id, { tag: 'swc-photo', limit: 1 }),
+        getPartyPhotos(party.id, { tag: 'swc-video', limit: 1 }),
+      ]);
+      setHasPhoto(!!photoRes && photoRes.photos.length > 0);
+      setHasVideo(!!videoRes && videoRes.photos.length > 0);
+    } catch {
+      /* ignore — best-effort done-state */
+    }
+  }, [party.id]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handlePhotoFile = async (file: File) => {
+    setPhotoState({ uploading: true, error: null });
+    try {
+      const upload = await uploadEventPhoto(file, party.id);
+      if (!upload) throw new Error('Upload failed (storage)');
+      const res = await uploadPhotoApi(party.id, {
+        url: upload.url,
+        fileName: upload.fileName,
+        fileSize: upload.fileSize,
+        mimeType: upload.mimeType,
+        width: upload.width,
+        height: upload.height,
+        uploaderName: user?.name || 'Host',
+        uploaderEmail: user?.email || undefined,
+        tags: ['swc-photo'],
+      });
+      if (!res) throw new Error('Upload failed (api)');
+      setHasPhoto(true);
+      onUploaded?.();
+    } catch (err: any) {
+      setPhotoState({ uploading: false, error: err?.message || 'Upload failed' });
+      return;
+    }
+    setPhotoState({ uploading: false, error: null });
+  };
+
+  const handleVideoFile = async (file: File) => {
+    setVideoState({ uploading: true, error: null });
+    try {
+      const upload = await uploadEventVideo(file, party.id);
+      if (!upload) throw new Error('Upload failed (storage)');
+      const res = await uploadPhotoApi(party.id, {
+        url: upload.url,
+        fileName: upload.fileName,
+        fileSize: upload.fileSize,
+        mimeType: upload.mimeType,
+        width: upload.width,
+        height: upload.height,
+        duration: upload.duration,
+        uploaderName: user?.name || 'Host',
+        uploaderEmail: user?.email || undefined,
+        tags: ['swc-video'],
+      });
+      if (!res) throw new Error('Upload failed (api)');
+      setHasVideo(true);
+      onUploaded?.();
+    } catch (err: any) {
+      setVideoState({ uploading: false, error: err?.message || 'Upload failed' });
+      return;
+    }
+    setVideoState({ uploading: false, error: null });
+  };
+
+  const onPhotoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handlePhotoFile(file);
+    if (photoInputRef.current) photoInputRef.current.value = '';
+  };
+
+  const onVideoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleVideoFile(file);
+    if (videoInputRef.current) videoInputRef.current.value = '';
+  };
+
+  const bothDone = hasPhoto && hasVideo;
+
+  return (
+    <div
+      className={`card p-5 space-y-4 transition-opacity ${
+        bothDone ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <Shield size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">Stand With Crypto</h3>
+      </div>
+
+      <p className="text-sm leading-relaxed text-theme-text-secondary">
+        Stand With Crypto is sponsoring GPP 2026. Help us deliver:
+      </p>
+
+      {/* Photo section ----------------------------------------------------- */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          {hasPhoto ? (
+            <Check size={16} className="text-green-400" />
+          ) : (
+            <span className="w-4 h-4" />
+          )}
+          <h4 className="text-sm font-semibold text-theme-text">
+            Upload group photo with SWC signs
+          </h4>
+        </div>
+        <p className="text-xs text-theme-text-muted">
+          Get everyone in the shot holding the SWC signs.
+        </p>
+        <button
+          type="button"
+          onClick={() => photoInputRef.current?.click()}
+          disabled={photoState.uploading}
+          className="w-full bg-[#ff393a] text-white rounded-xl py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+        >
+          {photoState.uploading ? (
+            <>
+              <Loader2 size={16} className="animate-spin" />
+              Uploading…
+            </>
+          ) : (
+            <>
+              <Camera size={16} />
+              {hasPhoto ? 'Upload another group photo' : 'Upload group photo'}
+            </>
+          )}
+        </button>
+        <input
+          ref={photoInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="hidden"
+          onChange={onPhotoSelected}
+        />
+        {photoState.error && <p className="text-xs text-red-400">{photoState.error}</p>}
+      </div>
+
+      {/* Video section ----------------------------------------------------- */}
+      <div className="space-y-2 pt-2 border-t border-white/10">
+        <div className="flex items-center gap-2">
+          {hasVideo ? (
+            <Check size={16} className="text-green-400" />
+          ) : (
+            <span className="w-4 h-4" />
+          )}
+          <h4 className="text-sm font-semibold text-theme-text">
+            Upload SWC shoutout video
+          </h4>
+        </div>
+        <p className="text-xs text-theme-text-muted">
+          ~10–20 seconds of the crowd shouting "Stand With Crypto!" at the camera works great.
+        </p>
+        <button
+          type="button"
+          onClick={() => videoInputRef.current?.click()}
+          disabled={videoState.uploading}
+          className="w-full bg-[#ff393a] text-white rounded-xl py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+        >
+          {videoState.uploading ? (
+            <>
+              <Loader2 size={16} className="animate-spin" />
+              Uploading…
+            </>
+          ) : (
+            <>
+              <Video size={16} />
+              {hasVideo ? 'Upload another shoutout video' : 'Upload shoutout video'}
+            </>
+          )}
+        </button>
+        <input
+          ref={videoInputRef}
+          type="file"
+          accept="video/*"
+          capture="environment"
+          className="hidden"
+          onChange={onVideoSelected}
+        />
+        {videoState.error && <p className="text-xs text-red-400">{videoState.error}</p>}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/StatusHeader.tsx
+++ b/frontend/src/components/day-of/StatusHeader.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { Clock, Users } from 'lucide-react';
+import { Party, Guest } from '../../types';
+
+interface StatusHeaderProps {
+  party: Party;
+  guests: Guest[];
+}
+
+function formatDelta(ms: number): { label: string; value: string } {
+  const abs = Math.abs(ms);
+  const minutes = Math.floor(abs / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days >= 1) {
+    const remainingHours = hours - days * 24;
+    return { label: '', value: `${days}d ${remainingHours}h` };
+  }
+  if (hours >= 1) {
+    const remainingMins = minutes - hours * 60;
+    return { label: '', value: `${hours}h ${remainingMins}m` };
+  }
+  return { label: '', value: `${minutes}m` };
+}
+
+/**
+ * Day-of status header: time-relative-to-start + checked-in/capacity counter.
+ * Re-renders every 30s while mounted.
+ */
+export const StatusHeader: React.FC<StatusHeaderProps> = ({ party, guests }) => {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const handle = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(handle);
+  }, []);
+
+  const startMs = party.date ? new Date(party.date).getTime() : null;
+  const checkedIn = guests.filter((g) => g.checkedInAt).length;
+  const confirmed = guests.filter((g) => g.approved !== false && g.status !== 'WAITLISTED').length;
+  const capacity = party.maxGuests || null;
+
+  let timeBlock: React.ReactNode = null;
+  if (startMs !== null) {
+    const delta = startMs - now;
+    const isFuture = delta > 0;
+    const { value } = formatDelta(delta);
+    timeBlock = (
+      <div className="flex items-center gap-2">
+        <Clock size={18} className="text-[#ff393a]" />
+        <div>
+          <p className="text-xs uppercase tracking-wide text-theme-text-muted">
+            {isFuture ? 'Starts in' : 'Elapsed'}
+          </p>
+          <p className="text-lg font-mono font-semibold text-theme-text">{value}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card p-4 flex flex-wrap items-center justify-between gap-4">
+      {timeBlock}
+      <div className="flex items-center gap-2">
+        <Users size={18} className="text-[#ff393a]" />
+        <div>
+          <p className="text-xs uppercase tracking-wide text-theme-text-muted">
+            Checked in
+          </p>
+          <p className="text-lg font-mono font-semibold text-theme-text">
+            {checkedIn}
+            <span className="text-theme-text-muted"> / {capacity ?? confirmed}</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/WalkInModal.tsx
+++ b/frontend/src/components/day-of/WalkInModal.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { X, UserPlus, Mail, Loader2 } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { addWalkInGuest } from '../../lib/api';
+
+interface WalkInModalProps {
+  partyId: string;
+  onClose: () => void;
+  /** Called after a successful add. Caller may refresh the guest list. */
+  onAdded?: (alreadyExisted: boolean) => void;
+}
+
+/**
+ * Day-of walk-in capture. Name required, email optional. Backend creates
+ * the guest with `submitted_via='host-checkin'`, `status='CONFIRMED'`,
+ * `approved=true`, and a timestamped `checked_in_at`/`checked_in_by`.
+ */
+export const WalkInModal: React.FC<WalkInModalProps> = ({ partyId, onClose, onAdded }) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await addWalkInGuest(partyId, {
+        name: name.trim(),
+        email: email.trim() || undefined,
+      });
+      onAdded?.(res.alreadyExisted === true);
+      onClose();
+    } catch (err: any) {
+      setError(err?.message || 'Failed to add walk-in');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="card p-6 w-full max-w-md space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-theme-text">Add walk-in</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-theme-text-muted hover:text-theme-text"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <IconInput
+            icon={UserPlus}
+            placeholder="Guest name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            autoFocus
+          />
+          <IconInput
+            icon={Mail}
+            type="email"
+            placeholder="Email (optional)"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+
+          {error && (
+            <p className="text-sm text-red-400">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting || !name.trim()}
+            className="w-full bg-[#ff393a] text-white rounded-lg py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                Adding…
+              </>
+            ) : (
+              'Add and check in'
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/index.ts
+++ b/frontend/src/components/day-of/index.ts
@@ -14,3 +14,4 @@ export { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
 export { ArtDisplay } from './ArtDisplay';
 export { BriefingCard } from './BriefingCard';
 export { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
+export { BroadcastJoinCard } from './BroadcastJoinCard';

--- a/frontend/src/components/day-of/index.ts
+++ b/frontend/src/components/day-of/index.ts
@@ -13,3 +13,4 @@ export { ChecklistTodayCard } from './ChecklistTodayCard';
 export { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
 export { ArtDisplay } from './ArtDisplay';
 export { BriefingCard } from './BriefingCard';
+export { SignedPizzaBoxCard } from './SignedPizzaBoxCard';

--- a/frontend/src/components/day-of/index.ts
+++ b/frontend/src/components/day-of/index.ts
@@ -1,0 +1,15 @@
+// pepperoni-58341: Day-of event app components
+export { DayOfDashboard } from './DayOfDashboard';
+export { DayOfTab } from './DayOfTab';
+export { StatusHeader } from './StatusHeader';
+export { CheckInPanel } from './CheckInPanel';
+export { WalkInModal } from './WalkInModal';
+export { AnnouncePanel } from './AnnouncePanel';
+export { AnnouncementHistory } from './AnnouncementHistory';
+export { LogisticsCard } from './LogisticsCard';
+export { PizzaStatusCard } from './PizzaStatusCard';
+export { MusicNowPlayingCard } from './MusicNowPlayingCard';
+export { ChecklistTodayCard } from './ChecklistTodayCard';
+export { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
+export { ArtDisplay } from './ArtDisplay';
+export { BriefingCard } from './BriefingCard';

--- a/frontend/src/components/day-of/index.ts
+++ b/frontend/src/components/day-of/index.ts
@@ -15,3 +15,4 @@ export { ArtDisplay } from './ArtDisplay';
 export { BriefingCard } from './BriefingCard';
 export { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
 export { BroadcastJoinCard } from './BroadcastJoinCard';
+export { StandWithCryptoCard } from './StandWithCryptoCard';

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -164,6 +164,9 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     reimbursementCapUsd: dbParty.reimbursement_cap_usd != null ? Number(dbParty.reimbursement_cap_usd) : null,
     reimbursementCapAppealNote: dbParty.reimbursement_cap_appeal_note ?? null,
     reimbursementCapAppealedAt: dbParty.reimbursement_cap_appealed_at ?? null,
+    // Day-of logistics (pepperoni-58341)
+    wifiInfo: dbParty.wifi_info ?? null,
+    parkingNotes: dbParty.parking_notes ?? null,
     guests,
   };
 }

--- a/frontend/src/hooks/useIsAdminOrUnderboss.ts
+++ b/frontend/src/hooks/useIsAdminOrUnderboss.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { fetchAdminMe, fetchUnderbossMe } from '../lib/api';
+
+/**
+ * Returns whether the current user is an admin OR underboss.
+ *
+ * Mirrors the canonical check used elsewhere in the app (e.g. `AppsHub`'s
+ * Payouts soft-launch gate): fan out to `fetchAdminMe()` + `fetchUnderbossMe()`
+ * and combine `isAdmin || isUnderboss`. Both calls are auth-gated; logged-out
+ * users resolve to `false`.
+ *
+ * State machine:
+ * - `null`  — still loading (caller should render a spinner / nothing)
+ * - `true`  — admin or underboss
+ * - `false` — neither (caller should redirect or render denied UI)
+ *
+ * Used for soft-launch gates (pepperoni-58341: Day-Of feature).
+ */
+export function useIsAdminOrUnderboss(): boolean | null {
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [ub, ad] = await Promise.all([
+          fetchUnderbossMe().catch(() => null),
+          fetchAdminMe().catch(() => null),
+        ]);
+        if (cancelled) return;
+        setAllowed(Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin));
+      } catch {
+        if (!cancelled) setAllowed(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return allowed;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4123,3 +4123,67 @@ export async function searchPartiesForOutreach(q: string): Promise<OutreachParty
   return res.parties;
 }
 
+// =============================================================================
+// pepperoni-58341: Day-of event app
+// =============================================================================
+
+export interface DayOfAnnouncement {
+  id: string;
+  partyId: string;
+  sentBy: string;
+  channels: string[];
+  subject: string | null;
+  body: string;
+  recipientCount: number | null;
+  sentAt: string;
+  createdAt: string;
+}
+
+export interface AnnounceResponse {
+  announcementId: string;
+  recipientCount: number;
+  channelsSent: { telegram: boolean; email: number };
+}
+
+export async function sendDayOfAnnouncement(
+  partyId: string,
+  payload: { subject?: string; body: string; channels: Array<'telegram' | 'email'> }
+): Promise<AnnounceResponse> {
+  return apiRequest<AnnounceResponse>(`/api/parties/${partyId}/announce`, {
+    method: 'POST',
+    body: payload,
+    requireAuth: true,
+  });
+}
+
+export async function listDayOfAnnouncements(partyId: string): Promise<DayOfAnnouncement[]> {
+  const res = await apiRequest<{ announcements: DayOfAnnouncement[] }>(
+    `/api/parties/${partyId}/announcements`,
+    { method: 'GET', requireAuth: true }
+  );
+  return res.announcements;
+}
+
+export interface WalkInGuestResponse {
+  guest: {
+    id: string;
+    name: string;
+    email: string | null;
+    checkedInAt: string | null;
+    submittedVia: string;
+    status: string;
+    approved: boolean | null;
+  };
+  alreadyExisted?: boolean;
+}
+
+export async function addWalkInGuest(
+  partyId: string,
+  payload: { name: string; email?: string }
+): Promise<WalkInGuestResponse> {
+  return apiRequest<WalkInGuestResponse>(`/api/parties/${partyId}/guests/walk-in`, {
+    method: 'POST',
+    body: payload,
+    requireAuth: true,
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -199,6 +199,9 @@ export interface UpdatePartyData {
   hostTelegramLinkToken?: string | null;
   turtleRolesEnabled?: boolean;
   reimbursementCapUsd?: number | null;
+  // Day-of logistics (pepperoni-58341)
+  wifiInfo?: string | null;
+  parkingNotes?: string | null;
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -308,6 +311,9 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       hostTelegramLinkToken: data.hostTelegramLinkToken,
       turtleRolesEnabled: data.turtleRolesEnabled,
       reimbursementCapUsd: data.reimbursementCapUsd,
+      // Day-of logistics (pepperoni-58341)
+      wifiInfo: data.wifiInfo,
+      parkingNotes: data.parkingNotes,
     },
   });
 }

--- a/frontend/src/lib/dayOfBriefing.ts
+++ b/frontend/src/lib/dayOfBriefing.ts
@@ -1,0 +1,14 @@
+// pepperoni-58341: PizzaDAO mic-announcement script for GPP hosts.
+// Surfaced via BriefingCard on the day-of dashboard for GPP parties only,
+// auto-promoted in the 50–90 min window after event start.
+export const PIZZADAO_BRIEFING = {
+  timing:
+    'Make this announcement about 1 hour into your event. Afterwards, hand the mic to your major partners — brief them that their announcement should be 1–3 minutes.',
+  script: `PizzaDAO is an international pizza co-op that has thrown a Global Pizza Party every Bitcoin Pizza Day since 2021. Today, we're bringing together well over 20,000 people across hundreds of parties in more than 100 countries. We've spent well over $1 million dollars on pizza since we started!
+
+Beyond the Global Pizza Party, we throw pizza parties all year around crypto conferences. You might have been to one!
+
+For the rest of 2026, we'll be focused on building open source software solutions for independent pizzerias.
+
+Want to be part of PizzaDAO? Join at pizzadao.org. You can also support us by minting a Rare Pizza NFT at rarepizzas.com`,
+};

--- a/frontend/src/lib/dayOfConfig.ts
+++ b/frontend/src/lib/dayOfConfig.ts
@@ -1,0 +1,10 @@
+// Centralised day-of config constants. Edit values here when GPP URLs / sponsor details change.
+//
+// TODO(snax): set ZOOM_URL and STREAMYARD_URL before GPP day. While set to TODO_*,
+// the BroadcastJoinCard renders both buttons disabled with a "Coming soon" subtitle.
+
+export const ZOOM_URL = 'TODO_ZOOM_URL';
+export const STREAMYARD_URL = 'TODO_STREAMYARD_URL';
+
+export const isBroadcastUrlReady = (url: string): boolean =>
+  !url.startsWith('TODO_') && url.length > 0;

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -725,6 +725,9 @@ export interface DbParty {
   city?: string | null;
   place_id?: string | null;
   venue_name: string | null;
+  // Day-of logistics (pepperoni-58341) — host-only data; NOT added to SAFE_PARTY_COLUMNS
+  wifi_info?: string | null;
+  parking_notes?: string | null;
   rsvp_closed_at: string | null;
   selected_pizzerias: any[] | null;
   co_hosts: any[];
@@ -1809,6 +1812,9 @@ export async function updateParty(
     venueOrganization?: string | null;
     venueWebsite?: string | null;
     venueNotes?: string | null;
+    // Day-of logistics (pepperoni-58341)
+    wifi_info?: string | null;
+    parking_notes?: string | null;
     description?: string | null;
     password?: string | null;
     custom_url?: string | null;
@@ -1931,6 +1937,9 @@ export async function updateParty(
         hostTelegramLinkToken: updates.host_telegram_link_token,
         turtleRolesEnabled: updates.turtle_roles_enabled,
         reimbursementCapUsd: updates.reimbursement_cap_usd,
+        // Day-of logistics (pepperoni-58341)
+        wifiInfo: updates.wifi_info,
+        parkingNotes: updates.parking_notes,
       });
       return true;
     } catch (error) {

--- a/frontend/src/lib/tabPermissions.ts
+++ b/frontend/src/lib/tabPermissions.ts
@@ -1,5 +1,6 @@
 import {
   Home,
+  Zap,
   Settings,
   Users,
   Pizza,
@@ -23,6 +24,7 @@ import { CoHost } from '../types';
 
 export type TabId =
   | 'dashboard'
+  | 'day-of'
   | 'details'
   | 'guests'
   | 'pizza'
@@ -55,6 +57,7 @@ export interface HostTab {
  */
 export const ALL_HOST_TABS: HostTab[] = [
   { id: 'dashboard', label: 'Dashboard', icon: Home },
+  { id: 'day-of', label: 'Day Of', icon: Zap },
   { id: 'details', label: 'Settings', icon: Settings },
   { id: 'guests', label: 'Guests', icon: Users },
   { id: 'pizza', label: 'Pizza & Drinks', icon: Pizza },

--- a/frontend/src/pages/ArtDisplayPage.tsx
+++ b/frontend/src/pages/ArtDisplayPage.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { ArtDisplay } from '../components/day-of';
+import { fetchMyEvents } from '../lib/api';
+
+const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
+
+/**
+ * /display/:partyId/art — full-bleed slideshow of approved party photos
+ * for venue screens. Host/cohost auth required (NOT public anon access).
+ */
+export function ArtDisplayPage() {
+  const { partyId } = useParams<{ partyId: string }>();
+  const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      navigate(`/login?redirect=${encodeURIComponent(`/display/${partyId}/art`)}`, {
+        replace: true,
+      });
+      return;
+    }
+    if (!partyId) {
+      setAllowed(false);
+      return;
+    }
+    // Super admin bypass
+    if (user.email.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) {
+      setAllowed(true);
+      return;
+    }
+    // Otherwise: must be a host/cohost of the party (not just a guest)
+    fetchMyEvents()
+      .then((parties) => {
+        const match = parties.find(
+          (p) => p.id === partyId && (p.role === 'host' || p.role === 'cohost')
+        );
+        setAllowed(!!match);
+      })
+      .catch(() => setAllowed(false));
+  }, [authLoading, user, partyId, navigate]);
+
+  if (authLoading || allowed === null) {
+    return (
+      <div className="fixed inset-0 bg-black flex items-center justify-center">
+        <Loader2 size={32} className="animate-spin text-white/40" />
+      </div>
+    );
+  }
+
+  if (!allowed || !partyId) {
+    return (
+      <div className="fixed inset-0 bg-black flex items-center justify-center text-white/50">
+        Access denied.
+      </div>
+    );
+  }
+
+  return <ArtDisplay partyId={partyId} />;
+}

--- a/frontend/src/pages/ArtDisplayPage.tsx
+++ b/frontend/src/pages/ArtDisplayPage.tsx
@@ -1,21 +1,24 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { ArtDisplay } from '../components/day-of';
-import { fetchMyEvents } from '../lib/api';
-
-const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
+import { useIsAdminOrUnderboss } from '../hooks/useIsAdminOrUnderboss';
 
 /**
  * /display/:partyId/art — full-bleed slideshow of approved party photos
- * for venue screens. Host/cohost auth required (NOT public anon access).
+ * for venue screens.
+ *
+ * pepperoni-58341 soft-launch gate: admins + underbosses only. The host/cohost
+ * + super-admin-email check that previously lived here was replaced with the
+ * canonical `useIsAdminOrUnderboss()` hook for consistency with HostPage's
+ * Day-Of tab and DayOfRunPage. Loosen this when we widen the Day-Of rollout.
  */
 export function ArtDisplayPage() {
   const { partyId } = useParams<{ partyId: string }>();
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
-  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const isAdminOrUnderboss = useIsAdminOrUnderboss();
 
   useEffect(() => {
     if (authLoading) return;
@@ -23,29 +26,10 @@ export function ArtDisplayPage() {
       navigate(`/login?redirect=${encodeURIComponent(`/display/${partyId}/art`)}`, {
         replace: true,
       });
-      return;
     }
-    if (!partyId) {
-      setAllowed(false);
-      return;
-    }
-    // Super admin bypass
-    if (user.email.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) {
-      setAllowed(true);
-      return;
-    }
-    // Otherwise: must be a host/cohost of the party (not just a guest)
-    fetchMyEvents()
-      .then((parties) => {
-        const match = parties.find(
-          (p) => p.id === partyId && (p.role === 'host' || p.role === 'cohost')
-        );
-        setAllowed(!!match);
-      })
-      .catch(() => setAllowed(false));
   }, [authLoading, user, partyId, navigate]);
 
-  if (authLoading || allowed === null) {
+  if (authLoading || isAdminOrUnderboss === null) {
     return (
       <div className="fixed inset-0 bg-black flex items-center justify-center">
         <Loader2 size={32} className="animate-spin text-white/40" />
@@ -53,7 +37,7 @@ export function ArtDisplayPage() {
     );
   }
 
-  if (!allowed || !partyId) {
+  if (!isAdminOrUnderboss || !partyId) {
     return (
       <div className="fixed inset-0 bg-black flex items-center justify-center text-white/50">
         Access denied.

--- a/frontend/src/pages/DayOfRunPage.tsx
+++ b/frontend/src/pages/DayOfRunPage.tsx
@@ -5,13 +5,14 @@ import { PizzaProvider, usePizza } from '../contexts/PizzaContext';
 import { useAuth } from '../contexts/AuthContext';
 import { ThemeProvider } from '../contexts/ThemeContext';
 import { DayOfDashboard } from '../components/day-of';
-
-const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
+import { useIsAdminOrUnderboss } from '../hooks/useIsAdminOrUnderboss';
 
 /**
  * /run/:inviteCode — mobile-optimised day-of host dashboard. No `<Layout>`
  * chrome (no header/footer/sidebar) so the entire viewport is dashboard.
- * Auth-gated to host or canEdit cohost; logged-out visitors bounce to /login.
+ *
+ * pepperoni-58341 soft-launch: admin/underboss only (see `useIsAdminOrUnderboss`).
+ * Logged-out visitors bounce to /login; logged-in non-admins bounce to /.
  */
 function DayOfRunPageContent() {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -19,34 +20,39 @@ function DayOfRunPageContent() {
   const { user, loading: authLoading } = useAuth();
   const { loadParty, party, partyLoading } = usePizza();
   const [loaded, setLoaded] = useState(false);
+  // pepperoni-58341 soft-launch gate: route is admin/underboss only.
+  const isAdminOrUnderboss = useIsAdminOrUnderboss();
 
   useEffect(() => {
     if (!inviteCode || loaded) return;
     loadParty(inviteCode).then((ok) => setLoaded(true));
   }, [inviteCode, loadParty, loaded]);
 
-  // Gate: must be owner / super-admin / canEdit cohost.
-  const canEdit = (() => {
-    if (!party || !user) return false;
-    if (user.email.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
-    if (party.userId === user.id) return true;
-    if (party.canEdit) return true;
-    return false;
-  })();
+  // pepperoni-58341 soft-launch: only admins/underbosses can access /run/
+  // during the gated rollout. They can access ANY party regardless of
+  // host/cohost status (so Snax can dogfood on any event). When we widen
+  // the rollout, restore a `canEdit`-style gate (party.userId === user.id
+  // || party.canEdit || super-admin email — see HostPage.tsx for the
+  // pattern) and combine it with this admin/underboss check.
+  const accessAllowed = isAdminOrUnderboss === true;
 
   useEffect(() => {
     if (authLoading || partyLoading) return;
     if (!loaded) return;
-    if (party && !canEdit) {
-      if (!user) {
-        navigate(`/login?redirect=${encodeURIComponent(`/run/${inviteCode}`)}`, { replace: true });
-      } else {
-        navigate(`/rsvp/${inviteCode}`, { replace: true });
-      }
+    // Logged-out users → bounce to /login so they can sign in.
+    if (!user) {
+      navigate(`/login?redirect=${encodeURIComponent(`/run/${inviteCode}`)}`, { replace: true });
+      return;
     }
-  }, [authLoading, partyLoading, loaded, party, canEdit, user, navigate, inviteCode]);
+    // Wait for admin/underboss check to resolve before deciding.
+    if (isAdminOrUnderboss === null) return;
+    // Non-admin/underboss users are blocked during soft-launch — redirect to /.
+    if (party && !accessAllowed) {
+      navigate('/', { replace: true });
+    }
+  }, [authLoading, partyLoading, loaded, party, accessAllowed, isAdminOrUnderboss, user, navigate, inviteCode]);
 
-  if (authLoading || partyLoading || !loaded || !party) {
+  if (authLoading || partyLoading || !loaded || !party || isAdminOrUnderboss === null) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-theme-bg">
         <Loader2 size={32} className="animate-spin text-theme-text-muted" />
@@ -54,7 +60,7 @@ function DayOfRunPageContent() {
     );
   }
 
-  if (!canEdit) {
+  if (!accessAllowed) {
     return null;
   }
 

--- a/frontend/src/pages/DayOfRunPage.tsx
+++ b/frontend/src/pages/DayOfRunPage.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { PizzaProvider, usePizza } from '../contexts/PizzaContext';
+import { useAuth } from '../contexts/AuthContext';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import { DayOfDashboard } from '../components/day-of';
+
+const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
+
+/**
+ * /run/:inviteCode — mobile-optimised day-of host dashboard. No `<Layout>`
+ * chrome (no header/footer/sidebar) so the entire viewport is dashboard.
+ * Auth-gated to host or canEdit cohost; logged-out visitors bounce to /login.
+ */
+function DayOfRunPageContent() {
+  const { inviteCode } = useParams<{ inviteCode: string }>();
+  const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
+  const { loadParty, party, partyLoading } = usePizza();
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!inviteCode || loaded) return;
+    loadParty(inviteCode).then((ok) => setLoaded(true));
+  }, [inviteCode, loadParty, loaded]);
+
+  // Gate: must be owner / super-admin / canEdit cohost.
+  const canEdit = (() => {
+    if (!party || !user) return false;
+    if (user.email.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
+    if (party.userId === user.id) return true;
+    if (party.canEdit) return true;
+    return false;
+  })();
+
+  useEffect(() => {
+    if (authLoading || partyLoading) return;
+    if (!loaded) return;
+    if (party && !canEdit) {
+      if (!user) {
+        navigate(`/login?redirect=${encodeURIComponent(`/run/${inviteCode}`)}`, { replace: true });
+      } else {
+        navigate(`/rsvp/${inviteCode}`, { replace: true });
+      }
+    }
+  }, [authLoading, partyLoading, loaded, party, canEdit, user, navigate, inviteCode]);
+
+  if (authLoading || partyLoading || !loaded || !party) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-theme-bg">
+        <Loader2 size={32} className="animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+
+  if (!canEdit) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-theme-bg text-theme-text">
+      <div className="px-4 py-4 max-w-2xl mx-auto">
+        <header className="mb-4 flex items-center justify-between">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs uppercase tracking-wide text-theme-text-muted">
+              Day-of
+            </p>
+            <h1 className="text-xl font-bold text-theme-text truncate">{party.name}</h1>
+          </div>
+          <a
+            href={`/host/${party.inviteCode}`}
+            className="text-xs text-theme-text-muted hover:text-theme-text whitespace-nowrap ml-3"
+          >
+            Full host page
+          </a>
+        </header>
+
+        <DayOfDashboard party={party} layout="mobile" />
+      </div>
+    </div>
+  );
+}
+
+function DayOfRunPageThemeWrapper() {
+  const { party } = usePizza();
+  const isGPP = party?.eventType === 'gpp';
+  return (
+    <ThemeProvider theme={isGPP ? 'gpp' : 'dark'}>
+      <DayOfRunPageContent />
+    </ThemeProvider>
+  );
+}
+
+export function DayOfRunPage() {
+  return (
+    <PizzaProvider>
+      <DayOfRunPageThemeWrapper />
+    </PizzaProvider>
+  );
+}

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Loader2, AlertCircle, Settings, Pizza, Users, Camera, LayoutGrid, Home } from 'lucide-react';
+import { Loader2, AlertCircle, Settings, Pizza, Users, Camera, LayoutGrid, Home, Zap } from 'lucide-react';
 import { PizzaProvider, usePizza } from '../contexts/PizzaContext';
 import { useGuestsRealtime } from '../hooks/useGuestsRealtime';
 import { useAuth } from '../contexts/AuthContext';
@@ -41,13 +41,14 @@ import { PreviousYearPhotos } from '../components/PreviousYearPhotos';
 import { PINNABLE_APPS } from '../lib/appDefinitions';
 import { GPPDashboardTab } from '../components/gpp-dashboard';
 import { PayoutsTab } from '../components/payouts';
+import { DayOfTab } from '../components/day-of';
 
 // Super admin email that can edit any party
 const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
 
-type TabType = 'dashboard' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payouts' | 'apps';
+type TabType = 'dashboard' | 'day-of' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payouts' | 'apps';
 
-const ALL_VALID_TABS: TabType[] = ['dashboard', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'gpp', 'promo', 'flyer', 'print', 'payouts', 'apps'];
+const ALL_VALID_TABS: TabType[] = ['dashboard', 'day-of', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'gpp', 'promo', 'flyer', 'print', 'payouts', 'apps'];
 
 function HostPageContent() {
   const { t } = useTranslation('host');
@@ -180,6 +181,8 @@ function HostPageContent() {
   const tabs = useMemo(() => {
     const coreTabs = [
       ...(isGPP ? [{ id: 'dashboard' as TabType, label: t('tabs.dashboard'), icon: Home }] : []),
+      // pepperoni-58341: Day-of host dashboard (also mirrored at /run/:inviteCode for mobile)
+      { id: 'day-of' as TabType, label: 'Day Of', icon: Zap },
       { id: 'details' as TabType, label: t('tabs.settings'), icon: Settings },
       { id: 'guests' as TabType, label: t('tabs.guests'), icon: Users },
       { id: 'pizza' as TabType, label: isGPP ? t('tabs.pizza') : t('tabs.pizzaAndDrinks'), icon: Pizza },
@@ -281,6 +284,8 @@ function HostPageContent() {
 
         {activeTab === 'dashboard' && party ? (
           <GPPDashboardTab />
+        ) : activeTab === 'day-of' && party ? (
+          <DayOfTab party={party} />
         ) : activeTab === 'apps' && party ? (
           <AppsHub inviteCode={party.inviteCode} pinnedApps={party.pinnedApps ?? []} partyId={party.id} />
         ) : activeTab === 'partners' && party ? (
@@ -321,7 +326,7 @@ function HostPageContent() {
               if (party.inviteCode) await loadParty(party.inviteCode);
             }}
           />
-        ) : activeTab !== 'apps' && activeTab !== 'dashboard' && activeTab !== 'partners' && (
+        ) : activeTab !== 'apps' && activeTab !== 'dashboard' && activeTab !== 'day-of' && activeTab !== 'partners' && (
           <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
             <div className="xl:col-span-2 space-y-3">
               {activeTab === 'guests' && (

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -5,6 +5,7 @@ import { Loader2, AlertCircle, Settings, Pizza, Users, Camera, LayoutGrid, Home,
 import { PizzaProvider, usePizza } from '../contexts/PizzaContext';
 import { useGuestsRealtime } from '../hooks/useGuestsRealtime';
 import { useAuth } from '../contexts/AuthContext';
+import { useIsAdminOrUnderboss } from '../hooks/useIsAdminOrUnderboss';
 import { ThemeProvider } from '../contexts/ThemeContext';
 import { Layout } from '../components/Layout';
 import { PartyHeader } from '../components/PartyHeader';
@@ -55,6 +56,11 @@ function HostPageContent() {
   const { inviteCode, tab } = useParams<{ inviteCode: string; tab?: string }>();
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
+  // pepperoni-58341 soft-launch gate: Day-Of tab is only visible to
+  // admins + underbosses while the feature is in private beta. `null`
+  // means "still loading" — treat as not allowed for tab visibility
+  // (the tab simply doesn't appear until the check resolves).
+  const isAdminOrUnderboss = useIsAdminOrUnderboss();
   const { loadParty, party, partyLoading, guests, generateRecommendations, orderExpectedGuests, setOrderExpectedGuests, setGuests, setParty } = usePizza();
   const [error, setError] = useState<string | null>(null);
   const [loadedCode, setLoadedCode] = useState<string | null>(null);
@@ -181,8 +187,9 @@ function HostPageContent() {
   const tabs = useMemo(() => {
     const coreTabs = [
       ...(isGPP ? [{ id: 'dashboard' as TabType, label: t('tabs.dashboard'), icon: Home }] : []),
-      // pepperoni-58341: Day-of host dashboard (also mirrored at /run/:inviteCode for mobile)
-      { id: 'day-of' as TabType, label: 'Day Of', icon: Zap },
+      // pepperoni-58341: Day-of host dashboard (also mirrored at /run/:inviteCode for mobile).
+      // Soft-launch gate: only visible to admins + underbosses for now.
+      ...(isAdminOrUnderboss ? [{ id: 'day-of' as TabType, label: 'Day Of', icon: Zap }] : []),
       { id: 'details' as TabType, label: t('tabs.settings'), icon: Settings },
       { id: 'guests' as TabType, label: t('tabs.guests'), icon: Users },
       { id: 'pizza' as TabType, label: isGPP ? t('tabs.pizza') : t('tabs.pizzaAndDrinks'), icon: Pizza },
@@ -203,7 +210,7 @@ function HostPageContent() {
     return allowedTabs === 'all'
       ? allTabs
       : allTabs.filter(t => t.id === 'apps' || allowedTabs.includes(t.id));
-  }, [isGPP, party?.pinnedApps, allowedTabs]);
+  }, [isGPP, party?.pinnedApps, allowedTabs, isAdminOrUnderboss, t]);
 
   // Redirect to first allowed tab if current tab is not permitted
   useEffect(() => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -253,6 +253,9 @@ export interface Party {
   venueOrganization: string | null;
   venueWebsite: string | null;
   venueNotes: string | null;
+  // Day-of logistics (pepperoni-58341)
+  wifiInfo?: string | null;
+  parkingNotes?: string | null;
   rsvpClosedAt: string | null;
   coHosts: CoHost[];
   selectedPizzerias?: Pizzeria[];

--- a/plans/pepperoni-58341-day-of-app.md
+++ b/plans/pepperoni-58341-day-of-app.md
@@ -1,0 +1,213 @@
+# pepperoni-58341: Day-Of Event app for hosts
+
+**Priority**: P1
+**Type**: Full feature (worktree + draft PR + Vercel preview)
+**Pizza-id**: `pepperoni-58341` (local-assigned; sheets-claude `create` is broken — Snax to backfill row)
+**Branch**: `pepperoni-58341-day-of-app`
+
+## Problem
+
+On event day, a host bounces between ~5 HostPage tabs (Guests, Photos, Venue, Music, Checklist) and none of it is mobile-optimized. There's no single "where am I right now" dashboard, no broadcast channel to message guests live, no quick walk-in capture, no on-event photo/art display surface, and no mobile-first URL to pin to a phone home screen.
+
+## Approach
+
+Two surfaces, one feature set:
+1. **`day-of` HostPage tab** — desktop view via the existing tab system.
+2. **`/run/:inviteCode` mobile route** — phone view, auth-gated to host + cohosts.
+
+Both render the same `<DayOfDashboard layout="desktop|mobile">` component.
+
+**Reuse:** existing `POST /api/checkin/:inviteCode/:guestId`, `useGuestsRealtime` hook (host-only — never PizzaContext), PhotoGallery, MusicWidget data, ChecklistTab data, venue fields on Party.
+
+**Build:** `POST /api/parties/:partyId/announce`, `POST /api/parties/:partyId/guests/walk-in`, 2 new `parties` columns, `announcements` audit table, `ArtDisplay` + `/display/:partyId/art` route, ~12 day-of components, GPP-only briefing card.
+
+## Database
+
+### Migration: `supabase/migrations/20260520_pepperoni_day_of_app.sql`
+
+```sql
+-- pepperoni-58341: Day-of event app
+
+ALTER TABLE parties
+  ADD COLUMN wifi_info     TEXT,
+  ADD COLUMN parking_notes TEXT;
+
+GRANT SELECT (wifi_info, parking_notes) ON parties TO anon, authenticated;
+
+CREATE TABLE announcements (
+  id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  party_id        UUID NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  sent_by         TEXT NOT NULL,
+  channels        TEXT[] NOT NULL,
+  subject         TEXT,
+  body            TEXT NOT NULL,
+  recipient_count INT,
+  sent_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_announcements_party ON announcements(party_id, sent_at DESC);
+ALTER TABLE announcements ENABLE ROW LEVEL SECURITY;
+```
+
+### Prisma additions in `backend/prisma/schema.prisma`
+
+Add to `Party`:
+```prisma
+wifiInfo       String? @map("wifi_info")
+parkingNotes   String? @map("parking_notes")
+announcements  Announcement[]
+```
+
+New model:
+```prisma
+model Announcement {
+  id              String   @id @default(uuid())
+  partyId         String   @map("party_id") @db.Uuid
+  sentBy          String   @map("sent_by")
+  channels        String[]
+  subject         String?
+  body            String
+  recipientCount  Int?     @map("recipient_count")
+  sentAt          DateTime @default(now()) @map("sent_at")
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  party Party @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  @@index([partyId, sentAt(sort: Desc)])
+  @@map("announcements")
+}
+```
+
+**DO NOT apply the migration.** You have no Supabase MCP. The main session applies it before merge.
+
+## Backend
+
+### `POST /api/parties/:partyId/announce` in `backend/src/routes/party.routes.ts`
+
+Per-route middleware `requireAuth, requirePartyAccess` (NEVER path-less `router.use(gate)` — broke prod once).
+
+Body: `{ subject?: string, body: string, channels: ('telegram' | 'email')[] }`.
+- Telegram: reuse pattern from `backend/src/routes/telegram.routes.ts:78`. Send to `party.telegramGroupId` if set, else skip silently.
+- Email: Resend. Query guests where `partyId AND status='confirmed' AND email IS NOT NULL`. Individual sends (no BCC). Subject required when email in channels (400 otherwise).
+- Insert `announcements` row with computed `recipient_count`.
+- Return `{ announcementId, recipientCount, channelsSent: { telegram: boolean, email: number } }`.
+
+### `POST /api/parties/:partyId/guests/walk-in` in `backend/src/routes/party.routes.ts`
+
+Same per-route middleware. Body: `{ name: string, email?: string }`. Creates guest with `submitted_via='host-checkin'`, `status='confirmed'`, `approved=true`, `checked_in_at=now()`, `checked_in_by=req.userId`. Returns new row.
+
+### `PATCH /api/parties/:id` allowlist
+
+Add `wifiInfo`, `parkingNotes` to the PATCH handler field allowlist.
+
+### Tab whitelist
+
+Add `'day-of'` to `VALID_TAB_IDS` in `backend/src/helpers/partyAccess.ts`.
+
+## Frontend — 7-place column add for wifi_info + parking_notes
+
+Per CLAUDE.md "Common Gotchas." Migration + grant covered. Remaining sites:
+1. `backend/prisma/schema.prisma` — Prisma fields above.
+2. Backend PATCH handler allowlist — covered.
+3. `frontend/src/lib/api.ts` `updatePartyApi` — add fields.
+4. `frontend/src/lib/supabase.ts` `updateParty` — add fields. **Leave `safeColumns` alone** (host-only data).
+5. `frontend/src/contexts/PizzaContext.tsx` `dbPartyToParty` — snake→camel map.
+6. `DbParty` and `Party` TS interfaces — grep to find.
+
+**Both `updateParty` AND `updatePartyApi` must be updated** — missing either = silent saves (garlic-34476 bug).
+
+## Frontend — tab triplet
+
+Add `'day-of'` to all THREE enumeration sites:
+1. `frontend/src/pages/HostPage.tsx` TabType union (~line 46), render `<DayOfTab party={party} />`.
+2. `frontend/src/lib/tabPermissions.ts` `ALL_HOST_TABS` (~line 53-71): label `'Day Of'`, pick a lucide icon (`Zap` or `Calendar`).
+3. `backend/src/helpers/partyAccess.ts` `VALID_TAB_IDS` (~line 17-36).
+
+Place visually after `dashboard`, before `details`.
+
+## Frontend — new routes
+
+In `frontend/src/App.tsx`:
+```tsx
+<Route path="/run/:inviteCode" element={<DayOfRunPage />} />
+<Route path="/display/:partyId/art" element={<ArtDisplayPage />} />
+```
+
+`DayOfRunPage` (`frontend/src/pages/DayOfRunPage.tsx`): fetch party by inviteCode, gate on host/cohost auth, render `<DayOfDashboard party={party} layout="mobile" />` with NO `<Layout>` chrome.
+
+`ArtDisplayPage`: full-bleed rotating slideshow of approved party photos, host/cohost auth (NOT anon).
+
+## Frontend — `frontend/src/components/day-of/`
+
+```
+DayOfDashboard.tsx         — shell; layout="desktop" → CSS grid; layout="mobile" → stacked + sticky bottom action bar
+StatusHeader.tsx           — countdown to start | checked-in / capacity | time elapsed if started
+CheckInPanel.tsx           — searchable guest list w/ one-tap check-in; "Walk-in" button at top
+WalkInModal.tsx            — IconInput for name + optional email → POST /guests/walk-in; no confirm
+AnnouncePanel.tsx          — Telegram + Email checkboxes (both default ON), IconInput multiline body, optional subject (required when email checked), live preview pane, sticky "Send" button — NO confirm modal
+AnnouncementHistory.tsx    — last 10 sent announcements: time, channels, recipient_count, body excerpt
+LogisticsCard.tsx          — address (directions link), parking_notes, wifi_info, venueContactName/Phone (tap-to-call via tel:)
+PizzaStatusCard.tsx        — selectedPizzerias + contact info + "Order placed" checkbox in localStorage
+MusicNowPlayingCard.tsx    — top playlist + first 3 songs from MusicWidget data; "Open Music tab" link
+ChecklistTodayCard.tsx     — ChecklistTab items filtered by DAY_OF_ITEM_NAMES; only un-done
+PhotoQuickCaptureCard.tsx  — big "Take a Photo" button with <input type="file" accept="image/*" capture="environment">; uploads via existing PhotoGallery upload handler
+ArtDisplay.tsx             — full-bleed slideshow of approved party Photos, 8s per slide
+BriefingCard.tsx           — see "Briefing card" below
+DayOfTab.tsx               — thin wrapper rendering <DayOfDashboard layout="desktop" />
+```
+
+### Briefing card
+
+Create `frontend/src/lib/dayOfBriefing.ts`:
+
+```ts
+export const PIZZADAO_BRIEFING = {
+  timing: 'Make this announcement about 1 hour into your event. Afterwards, hand the mic to your major partners — brief them that their announcement should be 1–3 minutes.',
+  script: `PizzaDAO is an international pizza co-op that has thrown a Global Pizza Party every Bitcoin Pizza Day since 2021. Today, we're bringing together well over 20,000 people across hundreds of parties in more than 100 countries. We've spent well over $1 million dollars on pizza since we started!
+
+Beyond the Global Pizza Party, we throw pizza parties all year around crypto conferences. You might have been to one!
+
+For the rest of 2026, we'll be focused on building open source software solutions for independent pizzerias.
+
+Want to be part of PizzaDAO? Join at pizzadao.org. You can also support us by minting a Rare Pizza NFT at rarepizzas.com`,
+};
+```
+
+`BriefingCard.tsx`:
+- Visible ONLY for GPP parties — grep Party type for `is_gpp_2026` / `gpp_status`; prefer `gpp_status === 'approved'` if both exist.
+- Header bar: `~1 hour into event — then hand mic to partners, 1–3 min each`.
+- Body: `PIZZADAO_BRIEFING.script` with preserved line breaks, `text-lg leading-relaxed`.
+- Bottom "Done" checkbox → localStorage `dayof.briefing.done.{partyId}`. Done = dim to 50% opacity.
+- Time window: when `Date.now()` ∈ [eventStart+50min, eventStart+90min], render this card FIRST in the dashboard grid with a subtle accent border (not `animate-pulse` — too aggressive).
+
+### Day-of checklist allowlist
+
+In `ChecklistTodayCard.tsx`:
+```ts
+const DAY_OF_ITEM_NAMES = new Set([
+  'Confirm pizza delivery time',
+  'Set up check-in table',
+  'Test sound system',
+  'Greet first guests',
+  'Take group photo',
+  'Pay venue final invoice',
+]);
+```
+
+### Realtime
+
+`DayOfDashboard` and ONLY `DayOfDashboard` calls `useGuestsRealtime(party.id)`. Do NOT touch PizzaContext.
+
+## What's NOT in scope
+
+No cohost on-site indicator, no SMS, no run-of-show editor (only the briefing card auto-promotes), no per-pie ETA, no weather, no `category` column on ChecklistItem (deferred).
+
+## Defaults (Snax dispatched without resolving open questions)
+
+- Telegram + Email channel checkboxes both default ON.
+- Walk-in: name + optional email.
+- URL: `/run/`.
+- Checklist allowlist: the 6 items above.
+- Art display: party photos only.
+- Briefing card: GPP-only (hidden for non-GPP).

--- a/supabase/migrations/20260520_pepperoni_day_of_app.sql
+++ b/supabase/migrations/20260520_pepperoni_day_of_app.sql
@@ -1,0 +1,30 @@
+-- pepperoni-58341: Day-of event app
+-- Adds wifi_info + parking_notes columns to parties (logistics surfacing on day-of dashboard)
+-- and an announcements audit table for the day-of broadcast feature.
+
+ALTER TABLE parties
+  ADD COLUMN wifi_info     TEXT,
+  ADD COLUMN parking_notes TEXT;
+
+-- Column-level SELECT grants required since the Feb 2026 security audit
+-- switched parties from table-level to column-level SELECT.
+GRANT SELECT (wifi_info, parking_notes) ON parties TO anon, authenticated;
+
+CREATE TABLE announcements (
+  id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  party_id        UUID NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  sent_by         TEXT NOT NULL,
+  channels        TEXT[] NOT NULL,
+  subject         TEXT,
+  body            TEXT NOT NULL,
+  recipient_count INT,
+  sent_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_announcements_party ON announcements(party_id, sent_at DESC);
+
+-- RLS enabled with no policies => deny-all for anon/authenticated.
+-- Service-role (backend) bypasses RLS, so the day-of announce endpoint can
+-- insert + read freely while the table stays inaccessible to browser clients.
+ALTER TABLE announcements ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- New `day-of` HostPage tab + `/run/:inviteCode` mobile route bundling check-in, announcements, venue logistics, pizza partner contact, music now-playing, day-of checklist, photo quick-capture, art display
- GPP-only briefing card with the PizzaDAO mic-announcement script; auto-promotes 50-90 min after event start
- New: `POST /api/parties/:id/announce` (Telegram + Resend), `POST /api/parties/:id/guests/walk-in`, `GET /api/parties/:id/announcements`, `announcements` audit table, `wifi_info` + `parking_notes` columns on `parties`
- Reuses: `useGuestsRealtime` (host-only), PhotoGallery upload pipeline, MusicWidget data (getPerformers), ChecklistTab data, existing checkin endpoints

## Deviations from plan
- **Telegram target**: schema has no group chat_id on `parties` (`telegramGroup` is a URL string). Backend sends to `hostTelegramChatId` (host's connected Telegram chat) instead — effectively a "copy to host's phone" channel. If the host hasn't run the bot link flow, Telegram delivery is skipped silently.
- **Walk-in dedup**: if a guest with that email already exists on the party, backend updates them to checked-in (`alreadyExisted: true`) rather than 409'ing — matches existing manual-add behaviour.
- **Mobile layout**: kept the same card stack for mobile rather than a separate sticky bottom action bar — keeps the JSX simple and lets cards flex naturally.

## Ship order
Blocker before merge: apply migration `supabase/migrations/20260520_pepperoni_day_of_app.sql` to prod via Supabase MCP. Backend re-deploys from master tip after merge.

## Test plan
- [ ] /run/:inviteCode loads on mobile for host + cohost, redirects unauth to /login with redirect param
- [ ] day-of tab visible in HostPage for host + when granted to cohost via permissions picker
- [ ] walk-in creates guest with submitted_via='host-checkin', approved=true, checked_in_at set
- [ ] one-tap check-in toggles checkedInAt in the list (and via realtime in /run)
- [ ] realtime updates flow to both desktop tab and /run/ route simultaneously
- [ ] announce sends to Telegram + email, audit row appears with correct recipient_count, history card updates
- [ ] photo quick-capture opens device camera on mobile Safari + Chrome (capture="environment")
- [ ] /display/:partyId/art rotates approved photos every 8s; denies non-host visitors
- [ ] briefing card auto-promotes (accent border + top of grid) in the 50-90 min window for GPP parties only
- [ ] briefing "Done" dim sticks via localStorage
- [ ] no hooks-rules ESLint regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)