### PR TITLE
feat(arugula-38633): numeric-tag reimbursement cap + null-cap notice

### DIFF
--- a/backend/src/helpers/reimbursementCap.ts
+++ b/backend/src/helpers/reimbursementCap.ts
@@ -1,0 +1,50 @@
+/**
+ * arugula-38633 v2 follow-up: numeric-tag reimbursement-cap fallback.
+ *
+ * Precedence for the "effective" reimbursement cap shown to hosts on the
+ * Payments tab:
+ *   1. `parties.reimbursement_cap_usd` (set by an underboss via the
+ *      /underboss validate / override UI). Wins when not null.
+ *   2. The MAX of any numeric strings in `parties.event_tags`. Tags like
+ *      '200', '500', '350.50' are parsed; non-numeric tags like 'pfp',
+ *      'cohost' are ignored. Returns null if no tag parses.
+ *   3. null — no cap; UI shows the "set your expected guests and contact
+ *      your underboss" notice.
+ *
+ * `/underboss` still operates on the raw `reimbursement_cap_usd` column +
+ * Validate/Override controls — the tag fallback is invisible there.
+ */
+export function computeEffectiveCapUsd(
+  party: { reimbursementCapUsd: unknown; eventTags: string[] | null | undefined }
+): number | null {
+  // 1. Underboss-validated value wins.
+  if (party.reimbursementCapUsd != null) {
+    const n = Number(party.reimbursementCapUsd);
+    if (Number.isFinite(n)) return n;
+  }
+
+  // 2. Numeric-tag fallback: max of `^\d+(\.\d{1,2})?$` tags.
+  return parseNumericCapFromTags(party.eventTags);
+}
+
+/**
+ * Parse the max numeric value from event_tags. Strict regex — must match
+ * `^\d+(\.\d{1,2})?$` so '200', '500', '350.50' parse but '200.123' (3
+ * decimals) and 'pfp', 'cohost' do not.
+ */
+export function parseNumericCapFromTags(
+  tags: string[] | null | undefined
+): number | null {
+  if (!Array.isArray(tags) || tags.length === 0) return null;
+  const re = /^\d+(\.\d{1,2})?$/;
+  let max: number | null = null;
+  for (const raw of tags) {
+    if (typeof raw !== 'string') continue;
+    const t = raw.trim();
+    if (!re.test(t)) continue;
+    const n = Number(t);
+    if (!Number.isFinite(n)) continue;
+    if (max == null || n > max) max = n;
+  }
+  return max;
+}

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -3,6 +3,7 @@ import { prisma } from '../config/database.js';
 import { AppError } from '../middleware/error.js';
 import { isAdmin } from '../middleware/auth.js';
 import { GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
+import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 
 const PIZZADAO_AVATAR_URL = 'https://znpiwdvvsqaxuskpfleo.supabase.co/storage/v1/object/public/profile-pictures/cmkgpzby50002f8y1d8md1dzn/1768937020563.jpg';
 
@@ -324,6 +325,12 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         sponsors,
         pageViewStats,
         reimbursementCapUsd: party.reimbursementCapUsd != null ? Number(party.reimbursementCapUsd) : null,
+        // arugula-38633 v2 follow-up: numeric-tag fallback when no
+        // underboss-validated cap exists. See helpers/reimbursementCap.ts.
+        effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+          reimbursementCapUsd: party.reimbursementCapUsd,
+          eventTags: party.eventTags,
+        }),
       },
     });
   } catch (error) {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -6,6 +6,7 @@ import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
+import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -398,6 +399,11 @@ router.get('/:id', async (req: AuthRequest, res: Response, next: NextFunction) =
         user: undefined,
         canEdit: true, // If we reached here, getPartyWithOwnershipCheck verified edit permissions
         allowedTabs, // undefined for owner/admin (all tabs), string[] for restricted co-hosts
+        // arugula-38633 v2 follow-up: numeric-tag fallback for the cap.
+        effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+          reimbursementCapUsd: (party as any).reimbursementCapUsd,
+          eventTags: (party as any).eventTags,
+        }),
       }
     });
   } catch (error) {
@@ -623,6 +629,11 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...party,
         hostName: (party as any).eventType === 'gpp' ? 'PizzaDAO' : (party.user?.name || null),
         user: undefined,
+        // arugula-38633 v2 follow-up: numeric-tag fallback for the cap.
+        effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+          reimbursementCapUsd: (party as any).reimbursementCapUsd,
+          eventTags: (party as any).eventTags,
+        }),
       }
     });
   } catch (error) {

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign, Users, Info } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { useAuth } from '../../contexts/AuthContext';
 import { Payout, PayoutMethod, BankDetails } from '../../types';
@@ -171,6 +171,9 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   };
 
   const showCapBanner = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
+  // arugula-38633 v2 follow-up: when there's no cap (neither underboss-validated
+  // nor a numeric event_tag), show a polite notice in place of the cap banner.
+  const showNoCapNotice = !showCapBanner;
   const showPaidOnlyBanner = !showCapBanner && totalPaidUsd > 0;
 
   return (
@@ -213,6 +216,20 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           <div>
             <p className="text-sm font-medium text-theme-text">
               ${totalPaidUsd.toFixed(2)} paid so far.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* No-cap notice (arugula-38633 v2 follow-up) — renders in place of the
+          cap banner when neither an underboss-validated cap nor a numeric
+          event_tag fallback exists. Same visual slot, muted-warning color. */}
+      {showNoCapNotice && (
+        <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
+          <Info size={22} className="text-amber-500 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-theme-text">
+              No cap set. Set your expected guests and contact your underboss.
             </p>
           </div>
         </div>

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Plus, Receipt as ReceiptIcon, BadgeDollarSign } from 'lucide-react';
+import { Plus, Receipt as ReceiptIcon, BadgeDollarSign, Info } from 'lucide-react';
 import { Payout } from '../../types';
 import { PayoutListRow } from './PayoutListRow';
 
@@ -14,7 +14,11 @@ interface PayoutsListProps {
    * follow-up). Renders a stat header above the list.
    */
   totalPaidUsd?: number;
-  /** Reimbursement cap, if any. Combined with totalPaidUsd in the stat header. */
+  /**
+   * Effective reimbursement cap (underboss-validated OR numeric-tag fallback),
+   * if any. Combined with totalPaidUsd in the stat header. When null, a
+   * "no cap set" notice card renders in its place.
+   */
   reimbursementCapUsd?: number | null;
 }
 
@@ -35,24 +39,40 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
   // state otherwise (matches v2 follow-up plan).
   const hasCap = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
   const showStatHeader = totalPaidUsd > 0 || hasCap;
+  // arugula-38633 v2 follow-up: when neither an underboss-validated cap nor a
+  // numeric-tag fallback exists, show a polite notice asking the host to set
+  // their expected guests and contact their underboss.
+  const showNoCapNotice = !hasCap;
+
+  const noCapNotice = showNoCapNotice ? (
+    <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
+      <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
+      <div className="text-sm font-medium text-theme-text">
+        No cap set. Set your expected guests and contact your underboss.
+      </div>
+    </div>
+  ) : null;
 
   if (payouts.length === 0) {
     return (
-      <div className="card p-10 text-center">
-        <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-theme-surface-hover flex items-center justify-center">
-          <ReceiptIcon className="w-7 h-7 text-theme-text-muted" />
+      <div className="space-y-3">
+        {noCapNotice}
+        <div className="card p-10 text-center">
+          <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-theme-surface-hover flex items-center justify-center">
+            <ReceiptIcon className="w-7 h-7 text-theme-text-muted" />
+          </div>
+          <h3 className="text-base font-semibold text-theme-text mb-1">No payments yet</h3>
+          <p className="text-sm text-theme-text-muted mb-6">
+            Submit your first payment to get paid back for pizza or venue costs.
+          </p>
+          <button
+            onClick={onStartNew}
+            className="btn-secondary inline-flex items-center gap-2"
+          >
+            <Plus size={16} />
+            Submit your first payment
+          </button>
         </div>
-        <h3 className="text-base font-semibold text-theme-text mb-1">No payments yet</h3>
-        <p className="text-sm text-theme-text-muted mb-6">
-          Submit your first payment to get paid back for pizza or venue costs.
-        </p>
-        <button
-          onClick={onStartNew}
-          className="btn-secondary inline-flex items-center gap-2"
-        >
-          <Plus size={16} />
-          Submit your first payment
-        </button>
       </div>
     );
   }
@@ -70,6 +90,8 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
           </div>
         </div>
       )}
+
+      {noCapNotice}
 
       <div className="card p-4 sm:p-6">
         <div className="space-y-2">

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -8,7 +8,17 @@ import { PayoutDetailModal } from './PayoutDetailModal';
 
 interface PayoutsTabProps {
   partyId: string;
+  /**
+   * Raw underboss-validated cap (DB column). Used for the appeal flow only —
+   * host-visible cap display should use `effectiveReimbursementCapUsd`.
+   */
   reimbursementCapUsd?: number | null;
+  /**
+   * arugula-38633 v2 follow-up: effective cap after numeric-tag fallback.
+   * Precedence: reimbursementCapUsd → max(numeric event_tags) → null.
+   * Host-visible UI (banner, stat header, null-cap notice) reads THIS.
+   */
+  effectiveReimbursementCapUsd?: number | null;
   reimbursementCapAppealNote?: string | null;
   reimbursementCapAppealedAt?: string | null;
   /** Threaded to NewPayoutForm — gates the "ask once" attendance prompt. */
@@ -29,6 +39,7 @@ type View = 'list' | 'new';
 export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   partyId,
   reimbursementCapUsd,
+  effectiveReimbursementCapUsd,
   reimbursementCapAppealNote,
   reimbursementCapAppealedAt,
   expectedGuests,
@@ -171,7 +182,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             onStartNew={() => setView('new')}
             partyId={partyId}
             totalPaidUsd={totalPaidUsd}
-            reimbursementCapUsd={reimbursementCapUsd ?? null}
+            reimbursementCapUsd={effectiveReimbursementCapUsd ?? null}
           />
         </>
       )}
@@ -189,7 +200,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             partyId={partyId}
             onCreated={handleCreated}
             onCancel={() => setView('list')}
-            reimbursementCapUsd={reimbursementCapUsd}
+            reimbursementCapUsd={effectiveReimbursementCapUsd}
             reimbursementCapAppealNote={reimbursementCapAppealNote}
             reimbursementCapAppealedAt={reimbursementCapAppealedAt}
             totalPaidUsd={totalPaidUsd}

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -5,6 +5,7 @@ import { generateBeverageRecommendations } from '../utils/beverageAlgorithm';
 import { generateWaveRecommendations } from '../utils/waveAlgorithm';
 import { TOPPINGS, DRINK_CATEGORIES, DIETARY_OPTIONS, PIZZA_STYLES, PIZZA_SIZES } from '../constants/options';
 import * as db from '../lib/supabase';
+import { computeEffectiveCapUsd } from '../lib/reimbursementCap';
 
 interface PizzaContextType {
   // Party management
@@ -162,6 +163,12 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     underbossStatus: (dbParty.underboss_status as any) || null,
     turtleRolesEnabled: dbParty.turtle_roles_enabled || false,
     reimbursementCapUsd: dbParty.reimbursement_cap_usd != null ? Number(dbParty.reimbursement_cap_usd) : null,
+    // arugula-38633 v2 follow-up: numeric-tag fallback. Computed client-side
+    // because the host party flows through Supabase (not /api/parties/:id).
+    effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+      reimbursementCapUsd: dbParty.reimbursement_cap_usd,
+      eventTags: dbParty.event_tags,
+    }),
     reimbursementCapAppealNote: dbParty.reimbursement_cap_appeal_note ?? null,
     reimbursementCapAppealedAt: dbParty.reimbursement_cap_appealed_at ?? null,
     guests,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -484,6 +484,10 @@ export interface PublicEvent {
   // banner can render before re-loading the Party context. NULL when an
   // underboss has not validated yet.
   reimbursementCapUsd?: number | null;
+  // arugula-38633 v2 follow-up: precedence resolution of
+  // reimbursementCapUsd → max(numeric event_tags) → null. Host-facing UI
+  // reads this; /underboss still uses the raw reimbursementCapUsd.
+  effectiveReimbursementCapUsd?: number | null;
 }
 
 // Public Event API (no auth required)

--- a/frontend/src/lib/reimbursementCap.test.ts
+++ b/frontend/src/lib/reimbursementCap.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { computeEffectiveCapUsd, parseNumericCapFromTags } from './reimbursementCap';
+
+describe('parseNumericCapFromTags', () => {
+  it('returns null for empty / nullish input', () => {
+    expect(parseNumericCapFromTags(null)).toBeNull();
+    expect(parseNumericCapFromTags(undefined)).toBeNull();
+    expect(parseNumericCapFromTags([])).toBeNull();
+  });
+
+  it('returns null when no tags are numeric', () => {
+    expect(parseNumericCapFromTags(['pfp', 'cohost', 'abc'])).toBeNull();
+  });
+
+  it('returns the max numeric tag, ignoring non-numerics', () => {
+    expect(parseNumericCapFromTags(['pfp', '200'])).toBe(200);
+    expect(parseNumericCapFromTags(['100', '500', 'cohost'])).toBe(500);
+  });
+
+  it('parses 1-2 decimal places', () => {
+    expect(parseNumericCapFromTags(['350.50'])).toBe(350.5);
+    expect(parseNumericCapFromTags(['12.3'])).toBe(12.3);
+  });
+
+  it('rejects 3+ decimal places', () => {
+    expect(parseNumericCapFromTags(['200.123'])).toBeNull();
+  });
+
+  it('trims whitespace before matching', () => {
+    expect(parseNumericCapFromTags(['  500  '])).toBe(500);
+  });
+
+  it('ignores negative / signed values (regex is unsigned)', () => {
+    expect(parseNumericCapFromTags(['-100'])).toBeNull();
+    expect(parseNumericCapFromTags(['+100'])).toBeNull();
+  });
+});
+
+describe('computeEffectiveCapUsd', () => {
+  it('prefers underboss-validated cap over tags', () => {
+    expect(
+      computeEffectiveCapUsd({ reimbursementCapUsd: 300, eventTags: ['500'] })
+    ).toBe(300);
+  });
+
+  it('falls back to numeric tag when raw cap is null', () => {
+    expect(
+      computeEffectiveCapUsd({ reimbursementCapUsd: null, eventTags: ['pfp', '200'] })
+    ).toBe(200);
+  });
+
+  it('returns null when neither raw cap nor numeric tag exists', () => {
+    expect(
+      computeEffectiveCapUsd({ reimbursementCapUsd: null, eventTags: ['pfp'] })
+    ).toBeNull();
+    expect(
+      computeEffectiveCapUsd({ reimbursementCapUsd: null, eventTags: [] })
+    ).toBeNull();
+    expect(
+      computeEffectiveCapUsd({ reimbursementCapUsd: null, eventTags: null })
+    ).toBeNull();
+  });
+
+  it('accepts string reimbursementCapUsd (Decimal from Prisma)', () => {
+    expect(
+      computeEffectiveCapUsd({ reimbursementCapUsd: '450.00', eventTags: [] })
+    ).toBe(450);
+  });
+});

--- a/frontend/src/lib/reimbursementCap.ts
+++ b/frontend/src/lib/reimbursementCap.ts
@@ -1,0 +1,41 @@
+/**
+ * arugula-38633 v2 follow-up: numeric-tag reimbursement-cap fallback.
+ *
+ * Mirror of `backend/src/helpers/reimbursementCap.ts` for the supabase
+ * data path — host pages load the Party via `db.getPartyWithGuests`
+ * (Supabase) rather than the backend, so the mapper computes the
+ * effective cap client-side.
+ *
+ * Precedence:
+ *   1. `reimbursementCapUsd` (underboss-validated) wins when not null.
+ *   2. Else max of numeric strings in `eventTags` matching
+ *      `^\d+(\.\d{1,2})?$` (e.g. '200', '500', '350.50').
+ *   3. Else null.
+ */
+export function computeEffectiveCapUsd(input: {
+  reimbursementCapUsd: number | string | null | undefined;
+  eventTags: string[] | null | undefined;
+}): number | null {
+  if (input.reimbursementCapUsd != null) {
+    const n = Number(input.reimbursementCapUsd);
+    if (Number.isFinite(n)) return n;
+  }
+  return parseNumericCapFromTags(input.eventTags);
+}
+
+export function parseNumericCapFromTags(
+  tags: string[] | null | undefined
+): number | null {
+  if (!Array.isArray(tags) || tags.length === 0) return null;
+  const re = /^\d+(\.\d{1,2})?$/;
+  let max: number | null = null;
+  for (const raw of tags) {
+    if (typeof raw !== 'string') continue;
+    const t = raw.trim();
+    if (!re.test(t)) continue;
+    const n = Number(t);
+    if (!Number.isFinite(n)) continue;
+    if (max == null || n > max) max = n;
+  }
+  return max;
+}

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -502,6 +502,7 @@ function HostPageContent() {
                 <PayoutsTab
                   partyId={party.id}
                   reimbursementCapUsd={party.reimbursementCapUsd}
+                  effectiveReimbursementCapUsd={party.effectiveReimbursementCapUsd}
                   reimbursementCapAppealNote={party.reimbursementCapAppealNote}
                   reimbursementCapAppealedAt={party.reimbursementCapAppealedAt}
                   expectedGuests={party.expectedGuests}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -299,6 +299,11 @@ export interface Party {
   // Reimbursement cap (arugula-38633 v2) — populated by underboss validation.
   // Banner on payout form only renders when reimbursementCapUsd != null.
   reimbursementCapUsd?: number | null;
+  // arugula-38633 v2 follow-up: precedence resolution of
+  // reimbursementCapUsd → max(numeric event_tags) → null. Host-facing UI
+  // (Payments tab) reads THIS field; /underboss still uses the raw
+  // reimbursementCapUsd. See lib/reimbursementCap.ts.
+  effectiveReimbursementCapUsd?: number | null;
   reimbursementCapAppealNote?: string | null;
   reimbursementCapAppealedAt?: string | null;
 }


### PR DESCRIPTION
## Summary

Two follow-up changes to the host payments feature (arugula-38633 v2):

### 1. Numeric `event_tags` → effective reimbursement cap fallback

When a party has a tag that looks like a number (`'200'`, `'500'`, `'350.50'`), use the **max** numeric value among the tags as the effective reimbursement cap when no underboss-validated value exists.

**Precedence**:
1. `parties.reimbursement_cap_usd` (NOT NULL) → use it (underboss-validated, wins)
2. Else max of numeric `event_tags` matching `/^\d+(\.\d{1,2})?$/`
3. Else null (no cap)

Underbosses who want a tag-based cap just add the number as a tag.

### 2. Null-cap notice on the Payments tab

When `effectiveReimbursementCapUsd === null`, show a polite muted-amber card with the message:

> No cap set. Set your expected guests and contact your underboss.

Rendered in **two places**:
- **PayoutsList** — above the table / empty-state
- **NewPayoutForm** — in place of the cap banner

## Files touched (12)

**Backend** (3)
- `backend/src/helpers/reimbursementCap.ts` (new) — `computeEffectiveCapUsd` + `parseNumericCapFromTags`
- `backend/src/routes/event.routes.ts` — `/api/events/:slug` response includes `effectiveReimbursementCapUsd`
- `backend/src/routes/party.routes.ts` — `/api/parties/:id` GET + PATCH responses include `effectiveReimbursementCapUsd`

**Frontend** (9)
- `frontend/src/lib/reimbursementCap.ts` (new) — client-side mirror
- `frontend/src/lib/reimbursementCap.test.ts` (new) — 11 tests, all pass
- `frontend/src/contexts/PizzaContext.tsx` — `dbPartyToParty` computes `effectiveReimbursementCapUsd` (host data path is Supabase, not backend)
- `frontend/src/types.ts` — adds `effectiveReimbursementCapUsd` to `Party`
- `frontend/src/lib/api.ts` — adds `effectiveReimbursementCapUsd` to `PublicEvent`
- `frontend/src/pages/HostPage.tsx` — threads new prop to `PayoutsTab`
- `frontend/src/components/payouts/PayoutsTab.tsx` — accepts both raw + effective, passes effective to children
- `frontend/src/components/payouts/PayoutsList.tsx` — renders null-cap notice above list/empty-state
- `frontend/src/components/payouts/NewPayoutForm.tsx` — renders null-cap notice in place of cap banner

## What does NOT change

- `/underboss` UI still operates on the raw `reimbursementCapUsd` + heuristic suggestion + Validate/Override
- Appeal flow still appeals against the raw underboss-validated cap
- No DB / migration changes (both `event_tags` and `reimbursement_cap_usd` already have column-level grants from the Feb 2026 audit)

## Edge cases handled (unit tests)

| Input | Expected |
|---|---|
| `['pfp', '200']` | 200 |
| `['100', '500', 'cohost']` | 500 |
| `['350.50']` | 350.5 |
| `['200.123']` (3 decimals) | null |
| `['abc', 'def']` | null |
| `[]` / `null` / `undefined` | null |
| `['  500  ']` (whitespace) | 500 |
| Raw cap `300` + tags `['500']` | 300 (raw wins) |
| Raw cap `'450.00'` string | 450 |

## Test plan

- [ ] `vitest run src/lib/reimbursementCap.test.ts` — 11/11 pass
- [ ] Visit a party with no `reimbursement_cap_usd` and no numeric tags → PayoutsList + NewPayoutForm show null-cap notice
- [ ] Add an `event_tag` like `200` to a party → notice disappears, cap banner shows `$200.00`
- [ ] Set `reimbursement_cap_usd` to 300 via /underboss → cap banner shows `$300.00` (overrides tag)
- [ ] `/underboss` UI unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)