### PR TITLE
feat(arugula-38633): heuristic uses expected_guests + admin shows both counts

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -15,6 +15,7 @@
  * wires in the actual Mercury / wire / USDC-via-Privy execution paths.
  */
 import { Router, Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
 import {
   requireAuth,
@@ -32,6 +33,33 @@ const router = Router();
 
 const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed'] as const;
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
+
+/**
+ * Shared Prisma `select` for the embedded `party` on payout responses.
+ *
+ * `expectedGuests` is the host's planning number; `_count.guests` is a
+ * filtered count of confirmed direct RSVPs (status='CONFIRMED' AND
+ * submittedVia IN ('link','rsvp','api')) — bulk-invited rows are excluded
+ * per the project convention (see feedback_invite_vs_link_rsvps memory).
+ * `serializePayout` flattens this to `party.rsvpCount` on the wire.
+ */
+const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
+  id: true,
+  name: true,
+  inviteCode: true,
+  customUrl: true,
+  expectedGuests: true,
+  _count: {
+    select: {
+      guests: {
+        where: {
+          status: 'CONFIRMED',
+          submittedVia: { in: ['link', 'rsvp', 'api'] },
+        },
+      },
+    },
+  },
+};
 
 type AdminActorKind = 'admin' | 'super_admin' | 'payment_admin';
 
@@ -220,6 +248,12 @@ function serializePayout(row: any): any {
           name: row.party.name,
           inviteCode: row.party.inviteCode,
           customUrl: row.party.customUrl,
+          // arugula-38633 v2 follow-up: admin dashboard shows planning vs
+          // actuals. `expectedGuests` is the host's planning number;
+          // `rsvpCount` is the filtered _count of confirmed direct RSVPs
+          // (excludes 'host' / 'host-checkin' / 'invite' rows).
+          expectedGuests: row.party.expectedGuests ?? null,
+          rsvpCount: row.party._count?.guests ?? 0,
         }
       : undefined,
     host: row.host
@@ -260,7 +294,7 @@ router.get(
       const rows = await prisma.payout.findMany({
         where,
         include: {
-          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
         },
         orderBy: { createdAt: 'desc' },
@@ -440,7 +474,7 @@ router.post(
             reviewedAt: paidAt,
           },
           include: {
-            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
             documents: { orderBy: { sortOrder: 'asc' } },
             audits: { orderBy: { createdAt: 'desc' } },
@@ -470,7 +504,7 @@ router.post(
       const full = await prisma.payout.findUnique({
         where: { id: created.id },
         include: {
-          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
           documents: { orderBy: { sortOrder: 'asc' } },
           audits: { orderBy: { createdAt: 'desc' } },
@@ -508,7 +542,7 @@ router.get(
       const findArgs: any = {
         where,
         include: {
-          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
           documents: { orderBy: { sortOrder: 'asc' } },
         },
@@ -601,7 +635,7 @@ router.get(
       const row = await prisma.payout.findUnique({
         where: { id: req.params.id },
         include: {
-          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
           documents: { orderBy: { sortOrder: 'asc' } },
           audits: { orderBy: { createdAt: 'desc' } },
@@ -704,7 +738,7 @@ router.patch(
           where: { id: existing.id },
           data,
           include: {
-            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
             documents: { orderBy: { sortOrder: 'asc' } },
             audits: { orderBy: { createdAt: 'desc' } },
@@ -774,7 +808,7 @@ router.post(
             reviewedAt: new Date(),
           },
           include: {
-            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
             documents: { orderBy: { sortOrder: 'asc' } },
             audits: { orderBy: { createdAt: 'desc' } },
@@ -825,7 +859,7 @@ router.post(
             const refreshed = await prisma.payout.findUnique({
               where: { id: existing.id },
               include: {
-                party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+                party: { select: PAYOUT_PARTY_SELECT },
                 host: { select: { id: true, name: true, email: true } },
                 documents: { orderBy: { sortOrder: 'asc' } },
                 audits: { orderBy: { createdAt: 'desc' } },
@@ -898,7 +932,7 @@ router.post(
             reviewedAt: new Date(),
           },
           include: {
-            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
             documents: { orderBy: { sortOrder: 'asc' } },
             audits: { orderBy: { createdAt: 'desc' } },
@@ -981,7 +1015,7 @@ router.post(
           where: { id: existing.id },
           data,
           include: {
-            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
             documents: { orderBy: { sortOrder: 'asc' } },
             audits: { orderBy: { createdAt: 'desc' } },
@@ -1102,7 +1136,7 @@ async function executePayout(params: {
             transactionHash: result.txHash,
           },
           include: {
-            party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+            party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
             documents: { orderBy: { sortOrder: 'asc' } },
             audits: { orderBy: { createdAt: 'desc' } },
@@ -1164,7 +1198,7 @@ async function executePayout(params: {
           wireReference: wireRef,
         },
         include: {
-          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
           documents: { orderBy: { sortOrder: 'asc' } },
           audits: { orderBy: { createdAt: 'desc' } },
@@ -1210,7 +1244,7 @@ async function executePayout(params: {
           mercuryCardId: cardId,
         },
         include: {
-          party: { select: { id: true, name: true, inviteCode: true, customUrl: true } },
+          party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
           documents: { orderBy: { sortOrder: 'asc' } },
           audits: { orderBy: { createdAt: 'desc' } },

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -166,6 +166,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 {payout.party.name}
               </a>
             </div>
+            {/* arugula-38633 v2 follow-up: planning vs actuals, prominent. */}
+            <div
+              className="text-xs text-theme-text-secondary mt-1"
+              title="Expected guests is the host's planning number. Confirmed RSVPs are direct submissions only (excludes bulk invites)."
+            >
+              <span className="font-medium">Expected guests:</span>{' '}
+              {payout.party.expectedGuests != null ? payout.party.expectedGuests : '—'}
+              {' · '}
+              <span className="font-medium">Confirmed RSVPs:</span>{' '}
+              {payout.party.rsvpCount}
+            </div>
           </div>
           <button
             type="button"

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -97,6 +97,16 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
           >
             {admin.party.name}
           </a>
+          {/* arugula-38633 v2 follow-up: planning vs actuals at a glance. */}
+          <div
+            className="text-xs text-theme-text-muted"
+            title="Expected guests (host planning) vs confirmed RSVPs (direct submissions, excludes bulk invites)"
+          >
+            {admin.party.expectedGuests != null ? admin.party.expectedGuests : '—'}
+            {' expected / '}
+            {admin.party.rsvpCount}
+            {' RSVPs'}
+          </div>
         </td>
       )}
 

--- a/frontend/src/components/underboss/ReimbursementCapCell.tsx
+++ b/frontend/src/components/underboss/ReimbursementCapCell.tsx
@@ -26,18 +26,18 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
   const cityName = event.city
     || event.name.replace(/^Global Pizza Party\s*/i, '').trim()
     || null;
-  const confirmedRsvps = event.guestCount ?? 0;
   const { suggestedUsd, formula } = computeSuggestedReimbursementCap({
     city: cityName,
-    confirmedRsvpCount: confirmedRsvps,
+    expectedGuests: event.expectedGuests ?? null,
   });
+  const hasSuggestion = suggestedUsd != null;
 
   const currentCap = event.reimbursementCapUsd;
   const hasAppeal = !!event.reimbursementCapAppealedAt;
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<string>(
-    currentCap != null ? String(currentCap) : String(suggestedUsd)
+    currentCap != null ? String(currentCap) : (suggestedUsd != null ? String(suggestedUsd) : '')
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -57,6 +57,7 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
   }
 
   async function handleValidate() {
+    if (suggestedUsd == null) return;
     await save(suggestedUsd);
   }
 
@@ -88,7 +89,7 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
             if (e.key === 'Enter') { e.preventDefault(); handleOverrideSubmit(); }
             if (e.key === 'Escape') { setEditing(false); setError(null); }
           }}
-          placeholder={String(suggestedUsd)}
+          placeholder={suggestedUsd != null ? String(suggestedUsd) : 'amount'}
           className="!pl-6 py-0.5 text-[10px] w-16 bg-theme-surface border border-theme-stroke rounded text-theme-text"
           autoFocus
         />
@@ -118,6 +119,31 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
   }
 
   if (currentCap == null) {
+    if (!hasSuggestion) {
+      // No expected_guests set yet — underboss must fill it in first before
+      // we can produce a suggested cap. Override is still allowed (admin may
+      // know the amount independently).
+      return (
+        <div className="flex items-center gap-1 mt-0.5" title={formula}>
+          <span className="text-[10px] text-theme-text-faint italic">
+            Set expected guests first
+          </span>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-[9px] px-1 py-0.5 rounded border border-theme-stroke text-theme-text-muted hover:text-theme-text transition-colors"
+            title="Override with a custom value"
+          >
+            Override
+          </button>
+          {hasAppeal && (
+            <span title={event.reimbursementCapAppealNote || 'Host has appealed'}>
+              <AlertCircle size={10} className="text-amber-400" />
+            </span>
+          )}
+        </div>
+      );
+    }
     return (
       <div className="flex items-center gap-1 mt-0.5" title={formula}>
         <span className="text-[10px] text-theme-text-faint">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1502,6 +1502,13 @@ export interface AdminPayout extends Payout {
     name: string;
     inviteCode: string;
     customUrl: string | null;
+    /** Host's planning number (arugula-38633 v2 follow-up). */
+    expectedGuests: number | null;
+    /**
+     * Count of confirmed direct RSVPs — excludes bulk-invited rows.
+     * Backend filter: status='CONFIRMED' AND submittedVia IN ('link','rsvp','api').
+     */
+    rsvpCount: number;
   };
   host: {
     id: string;

--- a/frontend/src/utils/reimbursementCap.ts
+++ b/frontend/src/utils/reimbursementCap.ts
@@ -2,9 +2,13 @@
  * Reimbursement cap heuristic (arugula-38633 v2).
  *
  * Suggests a per-event reimbursement cap from the city tier (reused from
- * sponsorshipPricing.ts) plus the confirmed RSVP count. The result is a
- * starting point — underbosses validate or override before the cap takes
- * effect on the host-facing payout form.
+ * sponsorshipPricing.ts) plus the host's planning number for expected guests.
+ * The result is a starting point — underbosses validate or override before
+ * the cap takes effect on the host-facing payout form.
+ *
+ * If `expectedGuests` is null/0 the heuristic returns null (no suggested cap).
+ * It intentionally does NOT fall back to the live RSVP count — the underboss
+ * must set expected_guests first.
  *
  * Country-tier logic is intentionally out of scope for v1 (city tier only).
  */
@@ -15,31 +19,34 @@ export interface ReimbursementCapInput {
   city?: string | null;
   /** Reserved for v2 country-tier support — accepted but currently unused. */
   country?: string | null;
-  confirmedRsvpCount: number;
+  /** Host's planning number for expected guests. Null/0 → no suggestion. */
+  expectedGuests: number | null;
 }
 
 export interface ReimbursementCapResult {
-  suggestedUsd: number;
-  tier: 1 | 2 | 3;
-  /** Human-readable explanation, e.g. "Tier 2, 67 RSVPs → $300". */
+  /** Null when expected_guests is null/0. */
+  suggestedUsd: number | null;
+  /** Null when expected_guests is null/0. */
+  tier: 1 | 2 | 3 | null;
+  /** Human-readable explanation, e.g. "Tier 2, 67 expected guests → $300", or "expected guests not set". */
   formula: string;
 }
 
 interface TierConfig {
-  /** Floor RSVP count — anything ≤ this gets the floor amount. */
-  rsvpFloor: number;
-  /** Ceiling RSVP count — anything ≥ this gets the max amount. */
-  rsvpCeiling: number;
-  /** Minimum suggested cap (at or below rsvpFloor). */
+  /** Floor expected-guests count — anything ≤ this gets the floor amount. */
+  guestFloor: number;
+  /** Ceiling expected-guests count — anything ≥ this gets the max amount. */
+  guestCeiling: number;
+  /** Minimum suggested cap (at or below guestFloor). */
   minUsd: number;
-  /** Maximum suggested cap (at or above rsvpCeiling). */
+  /** Maximum suggested cap (at or above guestCeiling). */
   maxUsd: number;
 }
 
 const TIER_CONFIG: Record<1 | 2 | 3, TierConfig> = {
-  1: { rsvpFloor: 25, rsvpCeiling: 150, minUsd: 100, maxUsd: 625 },
-  2: { rsvpFloor: 25, rsvpCeiling: 100, minUsd: 75,  maxUsd: 400 },
-  3: { rsvpFloor: 35, rsvpCeiling: 150, minUsd: 50,  maxUsd: 300 },
+  1: { guestFloor: 25, guestCeiling: 150, minUsd: 100, maxUsd: 625 },
+  2: { guestFloor: 25, guestCeiling: 100, minUsd: 75,  maxUsd: 400 },
+  3: { guestFloor: 35, guestCeiling: 150, minUsd: 50,  maxUsd: 300 },
 };
 
 const ROUNDING_INCREMENT_USD = 25;
@@ -61,18 +68,27 @@ function roundToIncrement(value: number, increment: number): number {
 export function computeSuggestedReimbursementCap(
   input: ReimbursementCapInput
 ): ReimbursementCapResult {
-  const tier = resolveTier(input.city);
-  const { rsvpFloor, rsvpCeiling, minUsd, maxUsd } = TIER_CONFIG[tier];
+  const raw = input.expectedGuests;
+  const expected = raw == null ? 0 : Math.max(0, Math.floor(raw));
+  if (expected <= 0) {
+    return {
+      suggestedUsd: null,
+      tier: null,
+      formula: 'expected guests not set',
+    };
+  }
 
-  const rsvps = Math.max(0, Math.floor(input.confirmedRsvpCount ?? 0));
-  const clamped = Math.max(rsvpFloor, Math.min(rsvpCeiling, rsvps));
-  const ratio = (clamped - rsvpFloor) / (rsvpCeiling - rsvpFloor);
-  const raw = minUsd + ratio * (maxUsd - minUsd);
-  const suggestedUsd = roundToIncrement(raw, ROUNDING_INCREMENT_USD);
+  const tier = resolveTier(input.city);
+  const { guestFloor, guestCeiling, minUsd, maxUsd } = TIER_CONFIG[tier];
+
+  const clamped = Math.max(guestFloor, Math.min(guestCeiling, expected));
+  const ratio = (clamped - guestFloor) / (guestCeiling - guestFloor);
+  const rawUsd = minUsd + ratio * (maxUsd - minUsd);
+  const suggestedUsd = roundToIncrement(rawUsd, ROUNDING_INCREMENT_USD);
 
   return {
     suggestedUsd,
     tier,
-    formula: `Tier ${tier}, ${rsvps} RSVPs → $${suggestedUsd}`,
+    formula: `Tier ${tier}, ${expected} expected guests → $${suggestedUsd}`,
   };
 }


### PR DESCRIPTION
## Summary

Two follow-ups to arugula-38633 v2:

1. **Reimbursement cap heuristic now keys off `expected_guests`** instead of the live confirmed-RSVP count. If `expectedGuests` is null/0 the heuristic returns `null` (no fallback) and the underboss row shows *Set expected guests first* — they have to fill in the planning number before they get a suggestion. Override is still allowed.
2. **`/payments` admin dashboard shows BOTH numbers** (expected vs confirmed RSVPs) on every payment row in `PayoutsTable` and prominently in the `PayoutReviewModal` header so admins can sanity-check plan vs actuals before approving.

### Heuristic API change

```ts
ReimbursementCapInput: { city?, country?, expectedGuests: number | null }
ReimbursementCapResult: { suggestedUsd: number | null, tier: 1|2|3|null, formula: string }
```

Formula string switches from `"… 67 RSVPs → $300"` to `"… 67 expected guests → $300"` (or `"expected guests not set"` when null).

### Backend rsvpCount filter

`backend/src/routes/admin-payout.routes.ts` — added shared `PAYOUT_PARTY_SELECT` with filtered `_count`:

```
status = 'CONFIRMED' AND submittedVia IN ('link','rsvp','api')
```

Excludes bulk-invited rows per the `feedback_invite_vs_link_rsvps` memory. Serialized as `party.rsvpCount` on each `AdminPayout`. Also adds `party.expectedGuests`. The 13 `party: { select: {...} }` inline shapes were collapsed to the constant.

## Test plan
- [ ] `/underboss` cap cell: event w/ `expectedGuests=null` shows "Set expected guests first" + Override (no Validate)
- [ ] `/underboss` cap cell: event w/ `expectedGuests=50` shows suggested cap + Validate + Override (formula tooltip says "expected guests")
- [ ] `/payments` row: each row's party cell shows `X expected / Y RSVPs` under the party name
- [ ] `/payments` detail modal: header shows `Expected guests: X · Confirmed RSVPs: Y`
- [ ] Backend `/api/admin/payouts` list still returns existing shape (no breaking changes), now with `party.expectedGuests` + `party.rsvpCount` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)