### PR TITLE
feat(parmigiano-58729): approval-gated broadcast URLs

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -1397,4 +1397,40 @@ router.get('/:partyId/announcements', async (req: AuthRequest, res: Response, ne
   }
 });
 
+// GET /api/parties/:partyId/broadcast-urls
+// parmigiano-58729: approval-gated Day-Of broadcast URLs. Replaces the
+// client-side ZOOM_URL / STREAMYARD_URL constants in lib/dayOfConfig.ts so
+// the URLs never ship in the JS bundle for non-eligible viewers.
+//
+// Env vars (set on backend Vercel project):
+//   BROADCAST_ZOOM_URL       - global GPP Zoom meeting link (set when known)
+//   BROADCAST_STREAMYARD_URL - global GPP StreamYard studio link (set when known)
+// While unset, returns null URLs and the card shows "Coming soon".
+router.get('/:partyId/broadcast-urls', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, underbossStatus: true, eventType: true, userId: true },
+    });
+    if (!party) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+    const canAccess = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canAccess) throw new AppError('Forbidden', 403, 'FORBIDDEN');
+
+    if (party.eventType !== 'gpp' || party.underbossStatus !== 'approved') {
+      return res.json({ zoomUrl: null, streamyardUrl: null, eligible: false });
+    }
+
+    return res.json({
+      zoomUrl: process.env.BROADCAST_ZOOM_URL || null,
+      streamyardUrl: process.env.BROADCAST_STREAMYARD_URL || null,
+      eligible: true,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Radio, Video, Smartphone, ExternalLink } from 'lucide-react';
-import {
-  ZOOM_URL,
-  STREAMYARD_URL,
-  isBroadcastUrlReady,
-} from '../../lib/dayOfConfig';
+import { isBroadcastUrlReady } from '../../lib/dayOfConfig';
+import { fetchBroadcastUrls } from '../../lib/api';
 
 interface BroadcastJoinCardProps {
+  /** Party ID — used to fetch approval-gated broadcast URLs from the backend. */
+  partyId: string;
   /** Layout hint from DayOfDashboard. Mobile stacks the buttons; desktop puts them side-by-side. */
   layout?: 'desktop' | 'mobile';
 }
 
 interface BroadcastButtonProps {
-  url: string;
+  url: string | null;
   label: string;
   subtitle: string;
   icon: React.ReactNode;
+  /** Loading state: render the button greyed out with "Loading..." badge. */
+  loading?: boolean;
+  /** Reason the URL isn't usable, surfaced in the corner badge. */
+  unavailableLabel?: string;
 }
 
 const BroadcastButton: React.FC<BroadcastButtonProps> = ({
@@ -23,8 +26,11 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
   label,
   subtitle,
   icon,
+  loading,
+  unavailableLabel,
 }) => {
-  const ready = isBroadcastUrlReady(url);
+  const ready = !loading && isBroadcastUrlReady(url);
+  const badgeLabel = loading ? 'Loading…' : unavailableLabel || 'Coming soon';
 
   const inner = (
     <>
@@ -38,7 +44,7 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
       </span>
       {!ready && (
         <span className="absolute top-1.5 right-2 text-[10px] uppercase tracking-wider text-white/60 bg-black/40 rounded px-1.5 py-0.5">
-          Coming soon
+          {badgeLabel}
         </span>
       )}
     </>
@@ -47,7 +53,7 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
   const baseClasses =
     'relative flex-1 rounded-xl py-4 px-4 text-white text-center transition-opacity';
 
-  if (!ready) {
+  if (!ready || !url) {
     return (
       <div
         aria-disabled="true"
@@ -72,12 +78,53 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
 
 /**
  * GPP-only broadcast launcher. Two equal-weight buttons (Zoom static cam,
- * StreamYard phone). URLs live in lib/dayOfConfig.ts. While URLs are
- * TODO_*, both render disabled with a "Coming soon" badge. Visibility
+ * StreamYard phone). URLs are fetched from an approval-gated backend endpoint
+ * (parmigiano-58729) so they never ship in the client bundle. Visibility
  * gate (isGpp) is the caller's job (DayOfDashboard).
+ *
+ * States:
+ *  - Loading                  → both buttons greyed with "Loading..." badge.
+ *  - eligible:false / error   → "Not available for this event" badge.
+ *  - eligible:true + no URLs  → "Coming soon" badge (env vars unset).
+ *  - eligible:true + URLs     → active buttons that open in a new tab.
  */
-export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ layout }) => {
+export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, layout }) => {
+  // ---- HOOKS (all above any early return) -------------------------------
+  const [loading, setLoading] = useState(true);
+  const [eligible, setEligible] = useState(false);
+  const [zoomUrl, setZoomUrl] = useState<string | null>(null);
+  const [streamyardUrl, setStreamyardUrl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+
+    fetchBroadcastUrls(partyId)
+      .then((res) => {
+        if (cancelled) return;
+        setEligible(res.eligible);
+        setZoomUrl(res.zoomUrl);
+        setStreamyardUrl(res.streamyardUrl);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError(true);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
   const isMobile = layout === 'mobile';
+  const unavailableLabel =
+    error || !eligible ? 'Not available for this event' : undefined;
 
   return (
     <div className="card p-5 space-y-3">
@@ -94,16 +141,20 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ layout }) 
 
       <div className={isMobile ? 'flex flex-col gap-3' : 'flex flex-col sm:flex-row gap-3'}>
         <BroadcastButton
-          url={ZOOM_URL}
+          url={eligible ? zoomUrl : null}
           label="Join Zoom (static camera)"
           subtitle="Set up a laptop on a tripod with a wide shot of the venue — leave it running."
           icon={<Video size={18} />}
+          loading={loading}
+          unavailableLabel={unavailableLabel}
         />
         <BroadcastButton
-          url={STREAMYARD_URL}
+          url={eligible ? streamyardUrl : null}
           label="Join StreamYard (phone)"
           subtitle="Open this on your phone for live interviews and walkaround shots."
           icon={<Smartphone size={18} />}
+          loading={loading}
+          unavailableLabel={unavailableLabel}
         />
       </div>
     </div>

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -90,7 +90,7 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
       <div className={isMobile ? '' : 'space-y-4'}>
         {isGpp && !briefingFirst && <BriefingCard party={party} />}
         {isGpp && <SignedPizzaBoxCard party={party} />}
-        {isGpp && <BroadcastJoinCard layout={layout} />}
+        {isGpp && <BroadcastJoinCard partyId={party.id} layout={layout} />}
         {isGpp && <StandWithCryptoCard party={party} />}
         <LogisticsCard party={party} />
         <PizzaStatusCard party={party} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -65,6 +65,19 @@ export async function apiRequest<T>(
   return response.json();
 }
 
+// parmigiano-58729: approval-gated Day-Of broadcast URLs. Backend returns
+// `eligible: false` for non-GPP or non-approved events; `eligible: true` with
+// null URLs means env vars aren't set yet (card shows "Coming soon").
+export interface BroadcastUrlsResponse {
+  zoomUrl: string | null;
+  streamyardUrl: string | null;
+  eligible: boolean;
+}
+
+export function fetchBroadcastUrls(partyId: string): Promise<BroadcastUrlsResponse> {
+  return apiRequest<BroadcastUrlsResponse>(`/api/parties/${partyId}/broadcast-urls`);
+}
+
 // Homepage events (single-call, slim payload)
 export interface UserPartyListItem {
   id: string;

--- a/frontend/src/lib/dayOfConfig.ts
+++ b/frontend/src/lib/dayOfConfig.ts
@@ -1,10 +1,10 @@
-// Centralised day-of config constants. Edit values here when GPP URLs / sponsor details change.
+// Centralised day-of config helpers.
 //
-// TODO(snax): set ZOOM_URL and STREAMYARD_URL before GPP day. While set to TODO_*,
-// the BroadcastJoinCard renders both buttons disabled with a "Coming soon" subtitle.
+// parmigiano-58729: ZOOM_URL / STREAMYARD_URL constants were removed. The
+// URLs are now fetched from an approval-gated backend endpoint
+// (`GET /api/parties/:partyId/broadcast-urls`) via `fetchBroadcastUrls`
+// in lib/api.ts. Env vars `BROADCAST_ZOOM_URL` and `BROADCAST_STREAMYARD_URL`
+// are set on the backend Vercel project.
 
-export const ZOOM_URL = 'TODO_ZOOM_URL';
-export const STREAMYARD_URL = 'TODO_STREAMYARD_URL';
-
-export const isBroadcastUrlReady = (url: string): boolean =>
-  !url.startsWith('TODO_') && url.length > 0;
+export const isBroadcastUrlReady = (url: string | null | undefined): boolean =>
+  !!url && !url.startsWith('TODO_') && url.length > 0;


### PR DESCRIPTION
## Summary
Zoom + StreamYard URLs for the Day-Of BroadcastJoinCard move out of the client bundle and behind an authenticated, approval-gated backend endpoint.

## Why
The URLs should be visible only to hosts of approved GPP events. Keeping them in dayOfConfig.ts meant the URLs would ship inside the JS bundle once set.

## What changed
- New backend endpoint: GET /api/parties/:partyId/broadcast-urls (requireAuth via existing router.use + canUserEditParty + party.underbossStatus === 'approved' + party.eventType === 'gpp'). Returns { zoomUrl, streamyardUrl, eligible }.
- BroadcastJoinCard now fetches via fetchBroadcastUrls(party.id) on mount instead of importing constants. New prop: partyId (passed from DayOfDashboard).
- ZOOM_URL / STREAMYARD_URL removed from frontend/src/lib/dayOfConfig.ts. isBroadcastUrlReady kept and broadened to accept null/undefined.

## Note on field name
The Party approval field is underbossStatus (not status). 'approved' is one of pending/approved/listed/rejected/hidden. Same value used by /partner, /underboss listings, etc.

## Env vars to set on backend Vercel project (handles missing gracefully):
- BROADCAST_ZOOM_URL
- BROADCAST_STREAMYARD_URL

## Test plan
- [ ] Host of approved GPP party -> sees buttons (or "Coming soon" if env unset)
- [ ] Host of non-approved or non-GPP party -> "Not available for this event"
- [ ] Cohost of approved GPP party -> sees buttons
- [ ] Logged-out / non-host -> 403, soft-launch gate still hides feature anyway
- [ ] Network failure during fetch -> buttons render with "Not available for this event"

Generated with Claude Code