### PR TITLE
prosciutto-41827: admins see approved events by default on /partner

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -802,6 +802,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         region: event.region || null,
         telegramGroup: event.telegramGroup || null,
         eventImageUrl: event.eventImageUrl,
+        underbossStatus: event.underbossStatus,
         hostName: event.user?.name || null,
         hostProfile: event.user ? {
           name: event.user.name,

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -6,6 +6,7 @@ import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
 import { IconInput } from '../components/IconInput';
+import { Checkbox } from '../components/Checkbox';
 import { useAuth } from '../contexts/AuthContext';
 import { fetchSponsorMe, fetchSponsorEvents, toggleSponsorChecklistItem, updatePartnerEventNote, getPartyPhotos } from '../lib/api';
 import {
@@ -260,6 +261,9 @@ export function PartnerDashboardPage() {
   // Region filter (simple dropdown like underboss)
   const [regionFilter, setRegionFilter] = useState<string>('all');
 
+  // Admin-only: default to showing only approved events (session-only, no localStorage)
+  const [approvedOnly, setApprovedOnly] = useState(true);
+
   // City chat Telegram links from the master Google Sheet
   const [cityChats, setCityChats] = useState<Map<string, string>>(new Map());
 
@@ -400,6 +404,11 @@ export function PartnerDashboardPage() {
       );
     }
 
+    // Admin-only: default to approved events
+    if (dashboardData?.isAdmin && approvedOnly) {
+      filtered = filtered.filter(e => e.underbossStatus === 'approved');
+    }
+
     // Region filter
     if (regionFilter !== 'all') {
       filtered = filtered.filter(e => e.region === regionFilter);
@@ -423,7 +432,7 @@ export function PartnerDashboardPage() {
     });
 
     return sorted;
-  }, [allEvents, searchQuery, sortBy, regionFilter]);
+  }, [allEvents, searchQuery, sortBy, regionFilter, approvedOnly, dashboardData?.isAdmin]);
 
   const uniqueRegions = useMemo(() => {
     const regions = new Set(allEvents.map(e => e.region).filter(Boolean));
@@ -796,6 +805,15 @@ export function PartnerDashboardPage() {
                     <option key={r.id} value={r.id}>{r.label}</option>
                   ))}
                 </select>
+              )}
+
+              {/* Admin-only: approved-only toggle (default on, session-only) */}
+              {dashboardData?.isAdmin && (
+                <Checkbox
+                  checked={approvedOnly}
+                  onChange={() => setApprovedOnly(v => !v)}
+                  label="Approved events only"
+                />
               )}
 
               {/* {t('filters.clearFilters')} */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1297,6 +1297,7 @@ export interface SponsorDashboardEvent {
   region: string | null;
   telegramGroup: string | null;
   eventImageUrl: string | null;
+  underbossStatus?: UnderbossStatus;
   hostName: string | null;
   hostProfile: {
     name: string | null;


### PR DESCRIPTION
## Summary

When an admin views `/partner`, the dashboard now defaults to showing only events with `underbossStatus === 'approved'`. A new admin-only `Checkbox` labeled "Approved events only" appears in the filters row (checked by default); unchecking it reveals the full list (pending, rejected, listed, hidden — current behavior).

- **Admin-only**: gated on `dashboardData?.isAdmin === true`. Non-admin partners see zero change.
- **Opt-out**: admins can uncheck the box to fall back to today's behavior. State is session-only — no localStorage.
- **Backend dependency**: the response from `/api/sponsor/events` now includes `underbossStatus`. The shared production backend must be deployed from `master` before the preview frontend can filter correctly (preview backends don't exist — preview frontends always hit prod backend).

## Changes

- `backend/src/routes/sponsor-user.routes.ts`: include `underbossStatus` in the formatted event response (already on the Prisma `parties` model, no schema/migration).
- `frontend/src/types.ts`: add `underbossStatus?: UnderbossStatus` to `SponsorDashboardEvent`.
- `frontend/src/pages/PartnerDashboardPage.tsx`: add `approvedOnly` state (default `true`), admin-gated filter step in the `events` useMemo, and an admin-only `Checkbox` in the filters row. Intentionally excluded from `hasActiveFilters` / `clearAllFilters` since it's the default state, not a user-applied filter.

## Test plan

- [ ] Backend deploys from master and `/api/sponsor/events` returns `underbossStatus` on each event.
- [ ] As a sponsor (non-admin), `/partner` is unchanged — no checkbox, all events visible.
- [ ] As an admin, `/partner` shows only `approved` events on load and the "Approved events only" checkbox is rendered, checked.
- [ ] Unchecking the box reveals pending/rejected/listed/hidden events.
- [ ] Re-checking the box hides them again. No "clear filters" link appears when only this filter is active.
- [ ] Session refresh resets the checkbox back to checked (no localStorage persistence).