### PR TITLE
chore(arugula-38633): move no-cap notice to top of Payments section

### DIFF
--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote, BadgeDollarSign, Users, Info } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { useAuth } from '../../contexts/AuthContext';
 import { Payout, PayoutMethod, BankDetails } from '../../types';
@@ -173,7 +173,6 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const showCapBanner = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
   // arugula-38633 v2 follow-up: when there's no cap (neither underboss-validated
   // nor a numeric event_tag), show a polite notice in place of the cap banner.
-  const showNoCapNotice = !showCapBanner;
   const showPaidOnlyBanner = !showCapBanner && totalPaidUsd > 0;
 
   return (
@@ -221,19 +220,8 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         </div>
       )}
 
-      {/* No-cap notice (arugula-38633 v2 follow-up) — renders in place of the
-          cap banner when neither an underboss-validated cap nor a numeric
-          event_tag fallback exists. Same visual slot, muted-warning color. */}
-      {showNoCapNotice && (
-        <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
-          <Info size={22} className="text-amber-500 mt-0.5 flex-shrink-0" />
-          <div>
-            <p className="text-sm font-medium text-theme-text">
-              No cap set. Set your expected guests and contact your underboss.
-            </p>
-          </div>
-        </div>
-      )}
+      {/* No-cap notice was hoisted to PayoutsTab (top of the Payments section)
+          so it's always visible — removed here to avoid duplication. */}
 
       {/* 0. Estimated attendance — asked once per event */}
       {askForAttendance && (

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Plus, Receipt as ReceiptIcon, BadgeDollarSign, Info } from 'lucide-react';
+import { Plus, Receipt as ReceiptIcon, BadgeDollarSign } from 'lucide-react';
 import { Payout } from '../../types';
 import { PayoutListRow } from './PayoutListRow';
 
@@ -39,24 +39,13 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
   // state otherwise (matches v2 follow-up plan).
   const hasCap = typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0;
   const showStatHeader = totalPaidUsd > 0 || hasCap;
-  // arugula-38633 v2 follow-up: when neither an underboss-validated cap nor a
-  // numeric-tag fallback exists, show a polite notice asking the host to set
-  // their expected guests and contact their underboss.
-  const showNoCapNotice = !hasCap;
-
-  const noCapNotice = showNoCapNotice ? (
-    <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
-      <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
-      <div className="text-sm font-medium text-theme-text">
-        No cap set. Set your expected guests and contact your underboss.
-      </div>
-    </div>
-  ) : null;
+  // arugula-38633 v2 follow-up: the no-cap notice has been hoisted to
+  // PayoutsTab (top of the Payments section) so it's always visible in both
+  // list and new-payment views. PayoutsList no longer renders it locally.
 
   if (payouts.length === 0) {
     return (
       <div className="space-y-3">
-        {noCapNotice}
         <div className="card p-10 text-center">
           <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-theme-surface-hover flex items-center justify-center">
             <ReceiptIcon className="w-7 h-7 text-theme-text-muted" />
@@ -91,7 +80,6 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
         </div>
       )}
 
-      {noCapNotice}
 
       <div className="card p-4 sm:p-6">
         <div className="space-y-2">

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Lock } from 'lucide-react';
+import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Lock, Info } from 'lucide-react';
 import { Payout } from '../../types';
 import { listPayouts, fetchUnderbossMe, fetchAdminMe } from '../../lib/api';
 import { PayoutsList } from './PayoutsList';
@@ -164,6 +164,19 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
         PartyHeader, /underboss EventRow, and NewPayoutForm's first-time
         prompt — single source of truth.
       */}
+      {/* No-cap notice (arugula-38633 v2 follow-up): moved to the very top
+          of the Payments section so it's the first thing the host sees in
+          either the list or new-payment view. Renders whenever there's no
+          underboss-validated cap AND no numeric event_tag fallback. */}
+      {!(typeof effectiveReimbursementCapUsd === 'number' && effectiveReimbursementCapUsd > 0) && (
+        <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
+          <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
+          <div className="text-sm font-medium text-theme-text">
+            No cap set. Set your expected guests and contact your underboss.
+          </div>
+        </div>
+      )}
+
       <ExpectedGuestsCard partyId={partyId} expectedGuests={expectedGuests} />
 
       {view === 'list' && (


### PR DESCRIPTION
Single notice at the top of PayoutsTab, replaces the two duplicate render sites in PayoutsList and NewPayoutForm.