### PR TITLE
feat(arugula-38633): party + host pickers in External Payment modal

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -281,6 +281,134 @@ function serializePayout(row: any): any {
 }
 
 // ============================================
+// GET /api/admin/payouts/parties/search?q=<query>
+//   - Autocomplete for the "Record External Payment" modal (arugula-38633 v2).
+//   - Filters parties.underbossStatus === 'approved'.
+//   - Matches name / customUrl / inviteCode (case-insensitive contains).
+//   - For each match, returns the main host + cohosts whose email maps to a
+//     User record so the modal can show a host picker dropdown.
+//   - Must be declared BEFORE GET /:id so the literal path wins.
+//   - Empty / <2 char query returns []  — we don't dump the full party list.
+// ============================================
+router.get(
+  '/parties/search',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const rawQ = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+      if (rawQ.length < 2) {
+        res.json({ parties: [] });
+        return;
+      }
+
+      // Pull approved parties matching name / customUrl / inviteCode. Cap at 20.
+      // Sorted createdAt DESC so the most recent approved events show first —
+      // matches how admins typically remember "the event that was just approved".
+      const parties = await prisma.party.findMany({
+        where: {
+          underbossStatus: 'approved',
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { customUrl: { contains: rawQ, mode: 'insensitive' } },
+            { inviteCode: { contains: rawQ, mode: 'insensitive' } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          inviteCode: true,
+          userId: true,
+          coHosts: true,
+          user: { select: { id: true, name: true, email: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 20,
+      });
+
+      // Collect every cohost email so we can resolve them all in a single
+      // User.findMany() instead of N round-trips per party.
+      const allCohostEmails = new Set<string>();
+      for (const p of parties) {
+        const list = Array.isArray(p.coHosts) ? (p.coHosts as any[]) : [];
+        for (const ch of list) {
+          if (ch && typeof ch === 'object' && typeof ch.email === 'string' && ch.email.trim()) {
+            allCohostEmails.add(ch.email.trim().toLowerCase());
+          }
+        }
+      }
+
+      const cohostUsers = allCohostEmails.size
+        ? await prisma.user.findMany({
+            where: { email: { in: Array.from(allCohostEmails) } },
+            select: { id: true, name: true, email: true },
+          })
+        : [];
+      const cohostUserByEmail = new Map<string, { id: string; name: string | null; email: string }>();
+      for (const u of cohostUsers) {
+        cohostUserByEmail.set(u.email.toLowerCase(), u);
+      }
+
+      const results = parties
+        // Skip parties with no linked main host — Payout.hostUserId is FK NOT NULL
+        // and the modal needs a default selection. (Vanishingly rare in practice.)
+        .filter((p) => !!p.user)
+        .map((p) => {
+          const hostCandidates: Array<{
+            userId: string;
+            name: string | null;
+            email: string | null;
+            role: 'host' | 'cohost';
+          }> = [];
+
+          // Main host always first.
+          hostCandidates.push({
+            userId: p.user!.id,
+            name: p.user!.name,
+            email: p.user!.email,
+            role: 'host',
+          });
+
+          const cohostList = Array.isArray(p.coHosts) ? (p.coHosts as any[]) : [];
+          const seenUserIds = new Set<string>([p.user!.id]);
+          for (const ch of cohostList) {
+            if (!ch || typeof ch !== 'object') continue;
+            const email = typeof ch.email === 'string' ? ch.email.trim().toLowerCase() : '';
+            if (!email) continue;
+            const u = cohostUserByEmail.get(email);
+            // Cohosts without a matching User record (or no email at all) are
+            // silently excluded — the modal can only set Payout.hostUserId to
+            // a real User.id.
+            if (!u) continue;
+            // Dedupe: if a cohost row happens to also be the main host (host
+            // listed themselves as cohost), skip the duplicate.
+            if (seenUserIds.has(u.id)) continue;
+            seenUserIds.add(u.id);
+            hostCandidates.push({
+              userId: u.id,
+              name: u.name,
+              email: u.email,
+              role: 'cohost',
+            });
+          }
+
+          return {
+            id: p.id,
+            name: p.name,
+            inviteCode: p.inviteCode,
+            hostUserId: p.user!.id,
+            hostCandidates,
+          };
+        });
+
+      res.json({ parties: results });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
 // GET /api/admin/payouts/export.csv
 //   - Must be declared BEFORE GET /:id so the literal path wins.
 // ============================================

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   X,
   DollarSign,
@@ -13,9 +13,15 @@ import {
   Coins,
   Banknote,
   HelpCircle,
+  Search,
+  Check,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
-import { recordExternalPayment } from '../../lib/api';
+import {
+  recordExternalPayment,
+  searchApprovedParties,
+  type ApprovedPartySearchResult,
+} from '../../lib/api';
 import { uploadPayoutPhoto } from '../../lib/supabase';
 import type { ExternalPaymentInput, PayoutMethod } from '../../types';
 
@@ -32,18 +38,29 @@ type ExternalMethod = PayoutMethod | 'other';
  * in `paid` status immediately so the host's "paid so far" total reflects it
  * and there's an audit trail.
  *
- * No party picker dropdown in v1 — admin pastes the partyId + hostUserId
- * directly (per the plan's "fallback" guidance). Snax can iterate later.
- *
- * arugula-38633 v2 follow-up.
+ * arugula-38633 v2 follow-up — replaces the bare partyId / hostUserId text
+ * inputs with:
+ *   - Party: search-as-you-type over approved parties.
+ *   - Host: dropdown of the selected party's main host + resolvable cohosts.
+ *     Cohosts whose email is not in the User table are excluded server-side.
  */
 export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
   onClose,
   onCreated,
 }) => {
-  // Form state
-  const [partyId, setPartyId] = useState('');
+  // Party picker state — `selectedParty` is the source of truth for partyId +
+  // the list of host candidates. `hostUserId` is the chosen userId within
+  // that list (defaults to the main host on selection).
+  const [selectedParty, setSelectedParty] = useState<ApprovedPartySearchResult | null>(null);
   const [hostUserId, setHostUserId] = useState('');
+
+  const [partyQuery, setPartyQuery] = useState('');
+  const [partyResults, setPartyResults] = useState<ApprovedPartySearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Other form state — unchanged from v1.
   const [amountStr, setAmountStr] = useState('');
   const [method, setMethod] = useState<ExternalMethod>('usdc_base');
   const [paidAt, setPaidAt] = useState(() => new Date().toISOString().split('T')[0]);
@@ -73,7 +90,44 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
+  // Debounced party search — only runs when the picker is "open" (no party
+  // selected yet) and the query has ≥2 chars.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (selectedParty) {
+      // Picker is collapsed; no need to search.
+      setPartyResults([]);
+      setSearching(false);
+      return;
+    }
+    const q = partyQuery.trim();
+    if (q.length < 2) {
+      setPartyResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    setSearchError(null);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const rows = await searchApprovedParties(q);
+        setPartyResults(rows);
+      } catch (e: any) {
+        setSearchError(e?.message || 'Search failed');
+        setPartyResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [partyQuery, selectedParty]);
+
   const amountNum = useMemo(() => Number(amountStr), [amountStr]);
+
+  // derived: the active partyId (only set once a party is picked).
+  const partyId = selectedParty?.id ?? '';
 
   const canSubmit = useMemo(() => {
     if (!partyId.trim()) return false;
@@ -83,11 +137,27 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     return !submitting && !uploading;
   }, [partyId, hostUserId, amountNum, adminNotes, submitting, uploading]);
 
+  function handlePickParty(p: ApprovedPartySearchResult) {
+    setSelectedParty(p);
+    // Pre-select the main host (always the first candidate, role==='host').
+    setHostUserId(p.hostUserId);
+    setPartyQuery('');
+    setPartyResults([]);
+    setSearchError(null);
+  }
+
+  function handleChangeParty() {
+    setSelectedParty(null);
+    setHostUserId('');
+    setPartyQuery('');
+    setPartyResults([]);
+  }
+
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
     if (!partyId.trim()) {
-      setUploadError('Enter party id first so we can group the upload correctly.');
+      setUploadError('Pick a party first so we can group the upload correctly.');
       e.target.value = '';
       return;
     }
@@ -188,33 +258,114 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-5 space-y-4">
-          {/* Party id */}
+          {/* Party picker — search-as-you-type, or selected card */}
           <div>
-            <IconInput
-              icon={Hash}
-              placeholder="Party id (uuid) *"
-              value={partyId}
-              onChange={(e) => setPartyId(e.target.value)}
-              required
-            />
-            <p className="text-xs text-theme-text-muted mt-1">
-              Paste the party's UUID — find it in the URL of the admin payments table or in the party admin page.
-            </p>
+            {selectedParty ? (
+              <div className="flex items-start gap-3 px-3 py-3 rounded-lg border border-emerald-500/40 bg-emerald-500/5">
+                <Check size={16} className="mt-0.5 text-emerald-500 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-theme-text truncate">
+                    {selectedParty.name}
+                  </div>
+                  <div className="text-xs text-theme-text-muted mt-0.5">
+                    Invite code: {selectedParty.inviteCode}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleChangeParty}
+                  className="text-xs text-theme-text-muted hover:text-theme-text underline shrink-0"
+                >
+                  change
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <IconInput
+                  icon={Search}
+                  placeholder="Search approved parties by name *"
+                  value={partyQuery}
+                  onChange={(e) => setPartyQuery(e.target.value)}
+                  autoComplete="off"
+                />
+                {/* Dropdown — only render when the input is "active" (has any
+                    text, or focus would have produced results). We key off
+                    `partyQuery.length > 0` to avoid an empty floating panel. */}
+                {partyQuery.trim().length > 0 && (
+                  <div className="absolute z-10 mt-1 w-full bg-theme-surface border border-theme-stroke rounded-lg shadow-lg max-h-64 overflow-y-auto">
+                    {searching && (
+                      <div className="flex items-center gap-2 px-3 py-3 text-xs text-theme-text-muted">
+                        <Loader2 size={14} className="animate-spin" />
+                        Searching…
+                      </div>
+                    )}
+                    {!searching && partyQuery.trim().length < 2 && (
+                      <div className="px-3 py-3 text-xs text-theme-text-muted">
+                        Type at least 2 characters to search.
+                      </div>
+                    )}
+                    {!searching && partyQuery.trim().length >= 2 && partyResults.length === 0 && !searchError && (
+                      <div className="px-3 py-3 text-xs text-theme-text-muted">
+                        No matching approved parties.
+                      </div>
+                    )}
+                    {searchError && (
+                      <div className="px-3 py-3 text-xs text-red-400">{searchError}</div>
+                    )}
+                    {partyResults.map((p) => (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => handlePickParty(p)}
+                        className="w-full text-left px-3 py-2 hover:bg-theme-surface-hover border-b border-theme-stroke last:border-b-0"
+                      >
+                        <div className="text-sm text-theme-text truncate">{p.name}</div>
+                        <div className="text-xs text-theme-text-muted mt-0.5">{p.inviteCode}</div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+            {!selectedParty && (
+              <p className="text-xs text-theme-text-muted mt-1">
+                Only approved events are searchable. Pick one to populate the party + host fields.
+              </p>
+            )}
           </div>
 
-          {/* Host user id */}
-          <div>
-            <IconInput
-              icon={UserIcon}
-              placeholder="Host user id (cuid) — who is being paid *"
-              value={hostUserId}
-              onChange={(e) => setHostUserId(e.target.value)}
-              required
-            />
-            <p className="text-xs text-theme-text-muted mt-1">
-              The user id of the host receiving this payment. Admin's responsibility to get right.
-            </p>
-          </div>
+          {/* Host picker — only shown once a party is selected */}
+          {selectedParty && (
+            <div>
+              <div className="relative">
+                <UserIcon
+                  size={20}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none"
+                />
+                <select
+                  value={hostUserId}
+                  onChange={(e) => setHostUserId(e.target.value)}
+                  required
+                  className="w-full !pl-14 appearance-none"
+                >
+                  {selectedParty.hostCandidates.map((c) => {
+                    const label = `[${c.role === 'host' ? 'Host' : 'Cohost'}] ` +
+                      `${c.name || 'Unnamed'}` +
+                      (c.email ? ` (${c.email})` : '');
+                    return (
+                      <option key={c.userId} value={c.userId}>
+                        {label}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+              <p className="text-xs text-theme-text-muted mt-1">
+                Main host plus cohosts whose email matches a User account. Cohosts without an
+                rsv.pizza account aren't selectable.
+              </p>
+            </div>
+          )}
 
           {/* Amount */}
           <IconInput

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3851,6 +3851,38 @@ export async function executeAdminPayout(
 }
 
 /**
+ * Search-as-you-type for the Record External Payment modal (arugula-38633 v2).
+ * Backend filters parties.underbossStatus === 'approved' and returns up to 20
+ * matches by name/customUrl/inviteCode. Each row carries the main host plus
+ * any cohosts whose email maps to a User record (others are silently
+ * excluded — Payout.hostUserId must reference a real User).
+ *
+ * Empty / sub-2-char queries return [] from the server.
+ */
+export interface ApprovedPartySearchResult {
+  id: string;
+  name: string;
+  inviteCode: string;
+  hostUserId: string;
+  hostCandidates: Array<{
+    userId: string;
+    name: string | null;
+    email: string | null;
+    role: 'host' | 'cohost';
+  }>;
+}
+
+export async function searchApprovedParties(
+  query: string,
+): Promise<ApprovedPartySearchResult[]> {
+  const params = new URLSearchParams({ q: query });
+  const res = await apiRequest<{ parties: ApprovedPartySearchResult[] }>(
+    `/api/admin/payouts/parties/search?${params.toString()}`,
+  );
+  return res.parties;
+}
+
+/**
  * Record an OUT-OF-BAND payment (Venmo, manual bank, etc.) — creates a new
  * payout row in `paid` status immediately. arugula-38633 v2 follow-up.
  *


### PR DESCRIPTION
## Summary
- Replaces bare CUID/UUID text inputs in the Record External Payment modal with:
  - **Party**: debounced search-as-you-type over approved parties.
  - **Host**: dropdown of the selected party's main host + resolvable cohosts (defaults to main host).
- New backend endpoint: \`GET /api/admin/payouts/parties/search?q=<query>\` — filters \`underbossStatus === 'approved'\`, matches name/customUrl/inviteCode, returns up to 20 results ordered by \`createdAt DESC\`. For each row it bundles main host + cohosts whose \`email\` resolves to a \`User\` (others silently skipped).

## Files changed
- \`backend/src/routes/admin-payout.routes.ts\` — new search route, declared before \`/:id\`.
- \`frontend/src/lib/api.ts\` — \`searchApprovedParties()\` + \`ApprovedPartySearchResult\` interface.
- \`frontend/src/components/payments-admin/ExternalPaymentModal.tsx\` — modal rewrite.

## Notes
- All other fields (amount, method, refs, proof URL/upload, notes) are unchanged.
- No DB / Prisma changes.
- Cohort resolution batches all cohost emails into one \`User.findMany\` to avoid N+1.
- Cohosts without an email or without a matching User row are silently excluded — \`Payout.hostUserId\` must FK a real user.
- Form-level validation still requires non-empty \`partyId\` + \`hostUserId\`; backend still 404s on bad ids.

## Test plan
- [ ] Open \`/payments\` admin dashboard.
- [ ] Click "Record External Payment".
- [ ] Type \"…\" into the party search — see debounced results, "Type at least 2 characters" + "No matching approved parties" empty states.
- [ ] Pick a party — selection card renders with invite code + change link.
- [ ] Host dropdown lists the main host (pre-selected) and any resolvable cohosts.
- [ ] Submit the modal end-to-end and confirm the payout shows up in the dashboard list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)