### PR TITLE
feat(arugula-38633): move 50% prepay checkbox to top of Payments section

### DIFF
--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,12 +1,9 @@
 import React, { useMemo, useState } from 'react';
 import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
 import { IconInput } from '../IconInput';
-import { Checkbox } from '../Checkbox';
 import { useAuth } from '../../contexts/AuthContext';
-import { usePizza } from '../../contexts/PizzaContext';
 import { Payout, PayoutMethod, BankDetails } from '../../types';
 import { createPayout } from '../../lib/api';
-import { updateParty } from '../../lib/supabase';
 import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
@@ -65,12 +62,6 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   expectedGuests,
 }) => {
   const { user } = useAuth();
-  const { party } = usePizza();
-  const eventHasPrepayTag = Array.isArray(party?.eventTags) && party!.eventTags.includes('prepay');
-  // Pre-check if the event is already tagged 'prepay' — host can leave it
-  // checked or uncheck (uncheck is a no-op; tag is only ever ADDED here, never
-  // removed — admins can remove it in /underboss).
-  const [needsPrepay, setNeedsPrepay] = useState<boolean>(eventHasPrepayTag);
   // Stable id for this in-flight form, used as the storage-path grouping key.
   const [payoutTempId] = useState(() => `tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
 
@@ -143,14 +134,6 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
     setSubmitting(true);
     setSubmitError(null);
     try {
-      // If host checked the 50% prepay box AND the event isn't already tagged,
-      // append 'prepay' to event_tags before submitting the payment. Non-fatal:
-      // a failed tag add still lets the payment go through (admin can tag manually).
-      if (needsPrepay && !eventHasPrepayTag && party) {
-        const nextTags = Array.from(new Set([...(party.eventTags || []), 'prepay']));
-        await updateParty(partyId, { event_tags: nextTags }).catch(() => null);
-      }
-
       const created = await createPayout(partyId, {
         receiptPhotos: receipts
           .filter(r => r.status === 'done' && r.url)
@@ -344,19 +327,6 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         {/* Hidden last4 field is intentionally omitted — Mercury card numbers come from admin, not host. */}
         {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
         {false && <input value={mercuryCardLast4} onChange={e => setMercuryCardLast4(e.target.value)} />}
-      </div>
-
-      {/* 6. 50% prepayment request — flags the event by adding the 'prepay' tag */}
-      <div className="card p-6">
-        <Checkbox
-          checked={needsPrepay}
-          onChange={() => setNeedsPrepay(v => !v)}
-          label={
-            eventHasPrepayTag
-              ? "I need 50% prepayment (already requested for this event)"
-              : "I need 50% prepayment for this event"
-          }
-        />
       </div>
 
       {/* 7. Submit */}

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -6,6 +6,7 @@ import { PayoutsList } from './PayoutsList';
 import { NewPayoutForm } from './NewPayoutForm';
 import { PayoutDetailModal } from './PayoutDetailModal';
 import { ExpectedGuestsCard } from './ExpectedGuestsCard';
+import { PrepayCheckbox } from './PrepayCheckbox';
 
 interface PayoutsTabProps {
   partyId: string;
@@ -176,6 +177,8 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           </div>
         </div>
       )}
+
+      <PrepayCheckbox partyId={partyId} />
 
       <ExpectedGuestsCard partyId={partyId} expectedGuests={expectedGuests} />
 

--- a/frontend/src/components/payouts/PrepayCheckbox.tsx
+++ b/frontend/src/components/payouts/PrepayCheckbox.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Checkbox } from '../Checkbox';
+import { updateParty } from '../../lib/supabase';
+import { usePizza } from '../../contexts/PizzaContext';
+
+interface PrepayCheckboxProps {
+  partyId: string;
+}
+
+/**
+ * arugula-38633 v2 follow-up: event-level "I need 50% prepayment" checkbox,
+ * surfaced at the top of the Payments tab so the host can flag/unflag
+ * regardless of whether they're in the list or new-payment view.
+ *
+ * Reads/writes `parties.event_tags` directly — checking adds `'prepay'`,
+ * unchecking removes it. Admins can also add/remove the tag via /underboss.
+ */
+export const PrepayCheckbox: React.FC<PrepayCheckboxProps> = ({ partyId }) => {
+  const { party } = usePizza();
+  const isChecked = Array.isArray(party?.eventTags) && party!.eventTags.includes('prepay');
+  // Optimistic local mirror so the toggle feels instant even before the
+  // updateParty round-trip resolves and PizzaContext rehydrates.
+  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  const checked = optimistic ?? isChecked;
+  const [saving, setSaving] = useState(false);
+
+  const handleToggle = async () => {
+    if (saving) return;
+    const next = !checked;
+    setOptimistic(next);
+    setSaving(true);
+    const current = Array.isArray(party?.eventTags) ? party!.eventTags : [];
+    const nextTags = next
+      ? Array.from(new Set([...current, 'prepay']))
+      : current.filter(t => t !== 'prepay');
+    try {
+      await updateParty(partyId, { event_tags: nextTags });
+      // Local optimistic value is correct; PizzaContext will rehydrate on next
+      // natural navigation/refresh. No loadParty() here to avoid the same
+      // tab-click-reload UX bug we hit with the Expected Guests slider.
+    } catch {
+      // Revert optimistic on failure
+      setOptimistic(isChecked);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="card p-4">
+      <Checkbox
+        checked={checked}
+        onChange={handleToggle}
+        label="I need 50% prepayment for this event"
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/index.ts
+++ b/frontend/src/components/payouts/index.ts
@@ -9,3 +9,4 @@ export { PayoutAmountSummary } from './PayoutAmountSummary';
 export { PayoutDetailModal } from './PayoutDetailModal';
 export { AppealCapModal } from './AppealCapModal';
 export { ExpectedGuestsCard } from './ExpectedGuestsCard';
+export { PrepayCheckbox } from './PrepayCheckbox';


### PR DESCRIPTION
New PrepayCheckbox component in PayoutsTab between no-cap notice and ExpectedGuestsCard. Two-way toggle on parties.event_tags. Removes the per-submission checkbox from NewPayoutForm.