### PR TITLE
feat(arugula-38633): surface reimbursement cap on host dashboard + /payments

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -28,6 +28,7 @@ import {
   sendUsdcPayment,
   getUsdcDailyCapStatus,
 } from '../services/usdc-base.service.js';
+import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 
 const router = Router();
 
@@ -49,6 +50,12 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   inviteCode: true,
   customUrl: true,
   expectedGuests: true,
+  // arugula-38633 v2 follow-up: surface the effective reimbursement cap on
+  // the /payments admin dashboard. Raw `reimbursementCapUsd` + `eventTags`
+  // are selected here so `serializePayout` can resolve them via the shared
+  // `computeEffectiveCapUsd` helper (validated cap OR max numeric tag).
+  reimbursementCapUsd: true,
+  eventTags: true,
   _count: {
     select: {
       guests: {
@@ -254,6 +261,12 @@ function serializePayout(row: any): any {
           // (excludes 'host' / 'host-checkin' / 'invite' rows).
           expectedGuests: row.party.expectedGuests ?? null,
           rsvpCount: row.party._count?.guests ?? 0,
+          // arugula-38633 (cap-everywhere): resolved cap (validated value OR
+          // max numeric event_tag). null = no cap set.
+          effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+            reimbursementCapUsd: row.party.reimbursementCapUsd,
+            eventTags: row.party.eventTags,
+          }),
         }
       : undefined,
     host: row.host

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -164,6 +164,31 @@ export const GPPDashboardTab: React.FC = () => {
             <div className="text-xs text-theme-text-muted mt-1">Event Status</div>
           </div>
         )}
+        {/* arugula-38633 (cap-everywhere): surface the effective reimbursement
+            cap on the dashboard so hosts see it at a glance. Clicking the tile
+            jumps to the Payments tab where they can submit receipts / appeal. */}
+        <button
+          type="button"
+          onClick={() => goToTab('payments')}
+          className="card p-4 text-center hover:bg-theme-surface-hover transition-colors cursor-pointer"
+          title={party.effectiveReimbursementCapUsd != null
+            ? 'Reimbursement cap — click to open the Payments tab'
+            : 'No reimbursement cap set yet — click to open the Payments tab'}
+        >
+          {party.effectiveReimbursementCapUsd != null ? (
+            <>
+              <div className="text-2xl font-bold text-theme-text">
+                ${Number(party.effectiveReimbursementCapUsd).toLocaleString()}
+              </div>
+              <div className="text-xs text-theme-text-muted">Reimbursement cap</div>
+            </>
+          ) : (
+            <>
+              <div className="text-sm font-medium text-amber-400">No cap set</div>
+              <div className="text-xs text-theme-text-muted mt-1">Reimbursement cap</div>
+            </>
+          )}
+        </button>
       </div>
 
       {/* Rejected status callout */}

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -166,7 +166,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 {payout.party.name}
               </a>
             </div>
-            {/* arugula-38633 v2 follow-up: planning vs actuals, prominent. */}
+            {/* arugula-38633 v2 follow-up: planning vs actuals, prominent.
+                arugula-38633 (cap-everywhere): cap appended when set. */}
             <div
               className="text-xs text-theme-text-secondary mt-1"
               title="Expected guests is the host's planning number. Confirmed RSVPs are direct submissions only (excludes bulk invites)."
@@ -176,6 +177,13 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               {' · '}
               <span className="font-medium">Confirmed RSVPs:</span>{' '}
               {payout.party.rsvpCount}
+              {payout.party.effectiveReimbursementCapUsd != null && (
+                <>
+                  {' · '}
+                  <span className="font-medium">Cap:</span>{' '}
+                  ${Number(payout.party.effectiveReimbursementCapUsd).toLocaleString()}
+                </>
+              )}
             </div>
           </div>
           <button

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -107,6 +107,16 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
             {admin.party.rsvpCount}
             {' RSVPs'}
           </div>
+          {/* arugula-38633 (cap-everywhere): show resolved reimbursement cap
+              when set. Null = omit the line entirely (the row is already dense). */}
+          {admin.party.effectiveReimbursementCapUsd != null && (
+            <div
+              className="text-xs text-theme-text-muted"
+              title="Reimbursement cap (validated value or max numeric event_tag)"
+            >
+              ${Number(admin.party.effectiveReimbursementCapUsd).toLocaleString()} cap
+            </div>
+          )}
         </td>
       )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1513,6 +1513,13 @@ export interface AdminPayout extends Payout {
      * Backend filter: status='CONFIRMED' AND submittedVia IN ('link','rsvp','api').
      */
     rsvpCount: number;
+    /**
+     * arugula-38633 (cap-everywhere): resolved reimbursement cap shown on
+     * the /payments admin dashboard rows + review modal. null = no cap.
+     * Precedence: underboss-validated `reimbursementCapUsd` → max numeric
+     * `event_tags` → null. See backend/src/helpers/reimbursementCap.ts.
+     */
+    effectiveReimbursementCapUsd: number | null;
   };
   host: {
     id: string;


### PR DESCRIPTION
## Summary
- Host Dashboard tab: compact tile showing the effective reimbursement cap (or "No cap set"), clickable jumps to the Payments tab.
- /payments admin: `PayoutRow` shows "$X cap" under expected/RSVP counts; `PayoutReviewModal` header subline appends "Cap: $X".
- Backend `serializePayout` now resolves and returns `party.effectiveReimbursementCapUsd` (uses existing `computeEffectiveCapUsd` helper — validated value OR max numeric `event_tag`).
- /underboss `ReimbursementCapCell` verified unchanged (already distinguishes suggested vs saved cleanly).

## Test plan
- [ ] /host/:inviteCode (dashboard tab) shows the new cap tile. With a validated cap → "\$X / Reimbursement cap". Without → "No cap set" amber.
- [ ] Click the tile → navigates to the Payments tab.
- [ ] /payments admin row: party cell now shows "\$X cap" line when a cap is set; omitted when null.
- [ ] /payments admin: open a payout review modal — header subline reads "Expected guests: X · Confirmed RSVPs: Y · Cap: \$Z".
- [ ] /underboss: existing cap controls (Validate / Override / Edit) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)