### PR TITLE
fix(nduja-91384): unique realtime channel names (P0 prod hotfix)

### DIFF
--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1764,7 +1764,8 @@ export async function getAllParties(): Promise<DbParty[]> {
 // Subscribe to guest changes (real-time)
 export function subscribeToGuests(partyId: string, callback: (guests: DbGuest[]) => void) {
   const channel = supabase
-    .channel(`guests:${partyId}`)
+    // Unique channel name per subscription: HostPage and DayOfDashboard can both call this with the same partyId, and Supabase realtime throws "cannot add 'postgres_changes' callbacks after subscribe()" if the channel is reused. nduja-91384 prod incident 2026-05-20.
+    .channel(`guests:${partyId}:${crypto.randomUUID()}`)
     .on(
       'postgres_changes',
       {


### PR DESCRIPTION
## P0 hotfix

Day-Of feature crashes the React tree on prod for any admin/underboss opening `/run/:inviteCode` or the Day-Of HostPage tab. Console:

```
Uncaught Error: cannot add 'postgres_changes' callbacks for realtime:guests:<uuid> after 'subscribe()'
```

## Cause

`HostPage.tsx:70` and `DayOfDashboard.tsx:46` both call `useGuestsRealtime(party.id, ...)`. Both routed through `subscribeToGuests` which used `` `guests:${partyId}` `` as the channel name. Supabase realtime treats identical channel names as the same channel, so the second `.on('postgres_changes', ...)` ran on a channel that was already `.subscribe()`'d — error thrown — propagated past the error boundary — black page.

## Fix

Append `crypto.randomUUID()` to the channel name so each subscriber gets its own channel. One-line change in `frontend/src/lib/supabase.ts` `subscribeToGuests`.

## Tradeoff acknowledged

Two channels per partyId for hosts who open the Day-Of tab, but volume is bounded to admin+underboss during the soft-launch. A follow-up should make `DayOfDashboard` skip its own subscription when nested inside HostPage (HostPage already updates `party.guests` via its own realtime stream).

## Test plan

- [ ] Frontend Vercel preview builds clean
- [ ] Snax loads /run/:inviteCode on his phone as admin — Day-Of dashboard renders (no black screen, no console error)
- [ ] Check-in a guest in another tab — realtime update fires on /run/ (one of the two channels picks it up)

Generated with [Claude Code](https://claude.com/claude-code)