### PR TITLE
fix(arugula-38633): PrepayCheckbox state persists across tab switches

### DIFF
--- a/frontend/src/components/payouts/PrepayCheckbox.tsx
+++ b/frontend/src/components/payouts/PrepayCheckbox.tsx
@@ -16,7 +16,7 @@ interface PrepayCheckboxProps {
  * unchecking removes it. Admins can also add/remove the tag via /underboss.
  */
 export const PrepayCheckbox: React.FC<PrepayCheckboxProps> = ({ partyId }) => {
-  const { party } = usePizza();
+  const { party, loadParty } = usePizza();
   const isChecked = Array.isArray(party?.eventTags) && party!.eventTags.includes('prepay');
   // Optimistic local mirror so the toggle feels instant even before the
   // updateParty round-trip resolves and PizzaContext rehydrates.
@@ -35,9 +35,13 @@ export const PrepayCheckbox: React.FC<PrepayCheckboxProps> = ({ partyId }) => {
       : current.filter(t => t !== 'prepay');
     try {
       await updateParty(partyId, { event_tags: nextTags });
-      // Local optimistic value is correct; PizzaContext will rehydrate on next
-      // natural navigation/refresh. No loadParty() here to avoid the same
-      // tab-click-reload UX bug we hit with the Expected Guests slider.
+      // Refresh PizzaContext so the new tag list is in the cached party object.
+      // Otherwise switching tabs unmounts this component, optimistic state is
+      // lost, and on remount isChecked reads from stale party.eventTags → the
+      // checkmark appears unset even though the DB has it.
+      // Fire-and-forget (don't await) — keeps the toggle snappy and avoids
+      // the tab-click-reload UX bug we hit with the slider when awaiting.
+      if (party?.inviteCode) loadParty(party.inviteCode);
     } catch {
       // Revert optimistic on failure
       setOptimistic(isChecked);


### PR DESCRIPTION
Fire-and-forget loadParty after the updateParty save so party.eventTags is fresh on remount.