### PR TITLE
fix(chorizo-72831): stop billing Google Places per RSVP page view

### DIFF
--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { addGuestToParty, getUserPreferences, saveUserPreferences, ExistingGuestData, getExperimentFlag } from '../lib/supabase';
 import { getExcludedToppingIds } from '../constants/options';
-import { searchPizzerias, geocodeAddress } from '../lib/ordering';
+import { geocodeAddress } from '../lib/ordering';
 import { Pizzeria } from '../types';
 import { PublicEvent, trackRsvpFunnel } from '../lib/api';
 import { DbParty } from '../lib/supabase';
@@ -329,38 +329,16 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     }
   }, [isOpen, isEditing, existingGuest]);
 
-  // Fetch pizzerias based on event data
+  // Use host-preselected pizzerias only (no auto-search — avoids Google Places billing).
+  // chorizo-72831
   useEffect(() => {
-    async function fetchPizzerias() {
-      if (!isOpen) return;
-
-      // If host has selected specific pizzerias, use those
-      if (eventData.selectedPizzerias && eventData.selectedPizzerias.length > 0) {
-        setNearbyPizzerias(eventData.selectedPizzerias);
-        if (eventData.address) {
-          geocodeAddress(eventData.address).then(loc => { if (loc) setVenueLocation(loc); });
-        }
-        return;
-      }
-
-      // Otherwise, fall back to auto-fetching based on address
-      if (!eventData.address) return;
-
-      setLoadingPizzerias(true);
-      try {
-        const location = await geocodeAddress(eventData.address);
-        if (location) setVenueLocation(location);
-        if (location) {
-          const results = await searchPizzerias(location.lat, location.lng);
-          setNearbyPizzerias(results.slice(0, 3));
-        }
-      } catch (err) {
-        console.error('Failed to fetch pizzerias:', err);
-      } finally {
-        setLoadingPizzerias(false);
+    if (!isOpen) return;
+    if (eventData.selectedPizzerias && eventData.selectedPizzerias.length > 0) {
+      setNearbyPizzerias(eventData.selectedPizzerias);
+      if (eventData.address) {
+        geocodeAddress(eventData.address).then(loc => { if (loc) setVenueLocation(loc); });
       }
     }
-    fetchPizzerias();
   }, [eventData.address, eventData.selectedPizzerias, isOpen]);
 
   // ---- Handlers ----

--- a/supabase/functions/search-pizzerias/index.ts
+++ b/supabase/functions/search-pizzerias/index.ts
@@ -10,6 +10,37 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+// chorizo-72831: in-memory cache to avoid re-billing Google Places for the same coords.
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 1000;
+interface CacheEntry { payload: unknown; expiresAt: number; }
+const responseCache = new Map<string, CacheEntry>();
+
+function cacheKey(lat: number, lng: number, radius: number): string {
+  return `${lat.toFixed(3)}_${lng.toFixed(3)}_${radius}`;
+}
+
+function getCached(key: string): unknown | null {
+  const entry = responseCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    responseCache.delete(key);
+    return null;
+  }
+  // refresh LRU position
+  responseCache.delete(key);
+  responseCache.set(key, entry);
+  return entry.payload;
+}
+
+function setCached(key: string, payload: unknown): void {
+  if (responseCache.size >= CACHE_MAX_ENTRIES) {
+    const oldest = responseCache.keys().next().value;
+    if (oldest) responseCache.delete(oldest);
+  }
+  responseCache.set(key, { payload, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
 interface SearchRequest {
   lat: number;
   lng: number;
@@ -169,6 +200,17 @@ serve(async (req) => {
       );
     }
 
+    const key = cacheKey(lat, lng, radius);
+    const cached = getCached(key);
+    const successHeaders = {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    };
+    if (cached) {
+      return new Response(JSON.stringify(cached), { headers: successHeaders });
+    }
+
     // Search for pizzerias
     const pizzerias = await searchGooglePlaces(lat, lng, radius);
 
@@ -194,10 +236,9 @@ serve(async (req) => {
     };
     pizzerias.sort((a, b) => getScore(b) - getScore(a));
 
-    return new Response(
-      JSON.stringify({ pizzerias }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    const payload = { pizzerias };
+    setCached(key, payload);
+    return new Response(JSON.stringify(payload), { headers: successHeaders });
   } catch (error) {
     console.error('Search error:', error);
     return new Response(


### PR DESCRIPTION
## Summary
- Drops the auto-fetch fallback in `useRSVPForm` that called `searchPizzerias` on every public RSVP page view for events without preselected pizzerias.
- Adds a 24h in-memory LRU cache + `Cache-Control: public, max-age=86400` to the `search-pizzerias` edge function as defense-in-depth.

## Why
30-day DB stats showed 7,932 RSVPs to events with address + no preselected pizzerias. At ~2-5x viewer multiplier × \$32/1000 Places New Nearby Search calls = \$510-\$1,270/month. Bill confirmed.

## Manual post-merge step
Edge functions don't deploy from git. After merge:

\`\`\`
SUPABASE_ACCESS_TOKEN=<token> npx supabase functions deploy search-pizzerias --project-ref znpiwdvvsqaxuskpfleo
\`\`\`

Or via Supabase Dashboard → Edge Functions.

## Test plan
- [ ] Open an event RSVP URL where host did NOT preselect pizzerias; DevTools Network shows zero \`search-pizzerias\` requests on load and submit.
- [ ] Open an event WITH preselected pizzerias; list still renders.
- [ ] After edge deploy, curl POST /functions/v1/search-pizzerias twice with same lat/lng — second response has identical payload + Cache-Control header.
- [ ] 24-48h post-deploy, GCP Console shows ~95%+ drop in Places Nearby Search calls.

Plan: \`plans/chorizo-72831-google-bill.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)