### PR TITLE
fix(caprese-41827): host QR scan auto-check-in

### DIFF
--- a/frontend/src/pages/CheckInPage.tsx
+++ b/frontend/src/pages/CheckInPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Layout } from '../components/Layout';
 import { Loader2, CheckCircle2, XCircle, AlertCircle, QrCode } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-import { vouchForGuest, getDiscountStatus, claimDiscount } from '../lib/api';
+import { vouchForGuest, checkInGuest, getDiscountStatus, claimDiscount } from '../lib/api';
 import { CheckInQRDisplay } from '../components/CheckInQRDisplay';
 import { GPPClouds } from '../components/GPPClouds';
 
@@ -137,11 +137,12 @@ export function CheckInPage() {
           return;
         }
 
-        // If caller is host or checked-in guest — vouch for them
-        if (data.callerIsHost || !data.callerIsTarget) {
+        // If caller is host/co-host/admin — use the manual host-check-in route
+        // (bypasses the peer-vouch "must be checked in" gate that doesn't honor admin roles)
+        if (data.callerIsHost) {
           setState('vouching');
           try {
-            const result = await vouchForGuest(inviteCode, guestId);
+            const result = await checkInGuest(inviteCode, guestId);
             if (result.success) {
               setGuestName(result.guest?.name || guestName);
               if (result.alreadyCheckedIn) {
@@ -156,14 +157,37 @@ export function CheckInPage() {
               setErrorMessage(result.message || 'Check-in failed');
             }
           } catch (err: any) {
-            if (err.message?.includes('SELF_VOUCH') || err.message?.includes("can't check yourself")) {
-              setState('show-qr');
-            } else if (err.message?.includes('NOT_CHECKED_IN') || err.message?.includes('must be checked in')) {
-              setState('not-checked-in');
+            setState('error');
+            setErrorMessage(err.message || 'Check-in failed');
+          }
+          return;
+        }
+
+        // Otherwise: peer attestation (caller is a fellow checked-in guest)
+        setState('vouching');
+        try {
+          const result = await vouchForGuest(inviteCode, guestId);
+          if (result.success) {
+            setGuestName(result.guest?.name || guestName);
+            if (result.alreadyCheckedIn) {
+              setState('already-checked-in');
+              setCheckedInAt(result.guest?.checkedInAt || null);
             } else {
-              setState('error');
-              setErrorMessage(err.message || 'Check-in failed');
+              setState('success');
+              setCheckedInAt(result.guest?.checkedInAt || null);
             }
+          } else {
+            setState('error');
+            setErrorMessage(result.message || 'Check-in failed');
+          }
+        } catch (err: any) {
+          if (err.message?.includes('SELF_VOUCH') || err.message?.includes("can't check yourself")) {
+            setState('show-qr');
+          } else if (err.message?.includes('NOT_CHECKED_IN') || err.message?.includes('must be checked in')) {
+            setState('not-checked-in');
+          } else {
+            setState('error');
+            setErrorMessage(err.message || 'Check-in failed');
           }
         }
       } catch (error: any) {


### PR DESCRIPTION
## Summary
- CheckInPage was unconditionally calling `vouchForGuest` for non-self scans, including for hosts/admins. The vouch endpoint requires the caller to be an RSVPd & checked-in guest of the party, and does **not** honor super_admin / host. Hosts who auto-enrolled as a guest (e.g. `submitted_via='host'`) but never self-checked-in hit `NOT_CHECKED_IN` and saw the yellow "find an attestor" screen instead of checking the guest in.
- Fix: when `data.callerIsHost === true`, call `checkInGuest` (the manual host check-in endpoint, which already bypasses for super_admin / host / co-host via `canUserCheckIn`). Peer-vouch stays for non-host attendees.
- Frontend-only change. No backend or DB changes.

## Repro (prod)
- `hello@rarepizzas.com` (super_admin) scans Oyunchimeg's QR for the Ulaanbaatar GPP party → "Not checked in" screen.

## Test plan
- [ ] Open Vercel preview as super_admin or as a party host (one who is NOT checked in as a guest).
- [ ] Visit `/checkin/{inviteCode}/{guestId}` for a guest on a party you can host-check-in. Expect green `success` screen, NOT the yellow `not-checked-in` screen.
- [ ] Verify `guests.checked_in_at` is set in DB after the click.
- [ ] Visit your own check-in URL while logged in as that guest. Expect the QR re-display (`show-qr` state), unchanged from before.
- [ ] As a non-host fellow guest who IS checked in, scan another guest's QR. Expect the peer-vouch path to still work (`success` state).
- [ ] As a non-host fellow guest who is NOT checked in, scan another guest's QR. Expect the yellow `not-checked-in` screen with "find an attestor" message (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)