### PR TITLE
burrata-72104: refresh party context after EventDetailsTab + HostsManager saves

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -414,6 +414,8 @@ export const EventDetailsTab: React.FC = () => {
           hideGuests,
           requireApproval,
         });
+        // Refresh PizzaContext so PartyHeader / GuestList / GPPDashboardTab consumers see the saved values
+        if (party?.inviteCode) await loadParty(party.inviteCode);
         // Clear the image file since it's been uploaded
         setEventImageFile(null);
         // Reset saved state after a moment
@@ -476,6 +478,8 @@ export const EventDetailsTab: React.FC = () => {
             })
           ),
         }));
+        // Refresh PizzaContext so PartyHeader / GuestList / GPPDashboardTab consumers see the saved values
+        if (party?.inviteCode) await loadParty(party.inviteCode);
         return true;
       } else {
         throw new Error('Failed to save');
@@ -494,7 +498,8 @@ export const EventDetailsTab: React.FC = () => {
     const success = await saveField('name', { name: name.trim() });
     if (success) {
       setOriginalValues((prev: any) => ({ ...prev, name: name.trim() }));
-      if (party) triggerFlyerRegen(party, loadParty);
+      // Pass the just-saved name explicitly — `party` closure may still hold the old value
+      if (party) triggerFlyerRegen({ ...party, name: name.trim() }, loadParty);
     }
   };
 
@@ -577,7 +582,11 @@ export const EventDetailsTab: React.FC = () => {
         address: newAddress.trim(),
         venueName: newVenueName,
       }));
-      if (party) triggerFlyerRegen(party, loadParty);
+      // Pass just-saved address/venue explicitly — `party` closure may still hold the old values
+      if (party) triggerFlyerRegen(
+        { ...party, address: newAddress.trim() || null, venueName: newVenueName || null },
+        loadParty,
+      );
     }
   };
 

--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -7,6 +7,7 @@ import { updateParty, addGuestByHost, proxyAvatarToStorage, uploadCoHostAvatar }
 import { fetchXAvatarToSupabase, isAutoFilledXAvatar } from '../utils/avatarUtils';
 import { uuid, normalizeUrl, stripToHandle } from '../lib/utils';
 import { ALL_HOST_TABS } from '../lib/tabPermissions';
+import { usePizza } from '../contexts/PizzaContext';
 
 interface HostsManagerProps {
   partyId: string;
@@ -21,6 +22,8 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   initialCoHosts,
   onCoHostsChange,
 }) => {
+  const { party, loadParty } = usePizza();
+
   // Helper: check if a co-host is protected (auto-added partner or underboss)
   const isProtected = (h: CoHost) => h.isUnderboss === true || h.isPartner === true;
 
@@ -167,6 +170,9 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
           }
         }
         onCoHostsChange?.(coHostsToSave);
+        // Refresh PizzaContext so PartyHeader / GuestList / GPPDashboardTab consumers
+        // see the updated co-hosts list without a hard reload
+        if (party?.inviteCode) await loadParty(party.inviteCode);
       }
     } catch (error) {
       console.error('Error saving co-hosts:', error);


### PR DESCRIPTION
## Summary
Adds `await loadParty(inviteCode)` to the save handlers in `EventDetailsTab.tsx` (`saveField`, `handleSave`) and `HostsManager.tsx` (`saveCoHostsArray`) so `PizzaContext.party` is re-read after every save. Without this, `PartyHeader`, `GuestList`, and `GPPDashboardTab` consumers stayed stale until F5 because the handlers only updated their local `originalValues` mirror.

Also fixes two stale-closure bugs in `EventDetailsTab.saveName` and `saveLocation` where `triggerFlyerRegen(party, ...)` was called with the pre-save `party` object — the flyer would regenerate with the old name/address. Now passes a merged object with the just-saved values, matching the canonical pattern already used in `saveDateTime`.

## Changes
- `frontend/src/components/EventDetailsTab.tsx`: `loadParty` in `saveField` + `handleSave`; pass merged party to `triggerFlyerRegen` in `saveName` and `saveLocation`
- `frontend/src/components/HostsManager.tsx`: hook `usePizza()`; `loadParty` in `saveCoHostsArray` (covers add/edit/remove co-host, toggleShowOnEvent, toggleCanEdit, toggleTabPermission, toggleAllTabs, drag-reorder)

No DB, backend, `supabase.ts`, `api.ts`, or `PizzaContext.tsx` changes.

## Vercel preview
https://rsvpizza-git-burrata-72104-stale-ui-pizza-dao.vercel.app

## Test plan
- [ ] Edit event name → save → header reflects new name without F5
- [ ] Edit address (via Location autocomplete) → header + GPP dashboard reflect new address without F5
- [ ] Toggle Require Approval / Hide Guests / Limit Guests → consumers reflect change without F5
- [ ] Save image / description / password / custom URL / Telegram group → consumers reflect change without F5
- [ ] Add/remove/edit a co-host → PartyHeader cohost avatars update without F5
- [ ] Toggle co-host "Show on event" and "Editor" → reflect without F5
- [ ] Drag-reorder co-hosts → order persists without F5
- [ ] GPP flyer regen still works correctly after a name save and after an address save (uses new values, not stale)