### PR TITLE
feat(arugula-38633): party-kit cap from 'k<N>' event tag

### DIFF
--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -2,8 +2,10 @@ import React, { useMemo, useState } from 'react';
 import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { useAuth } from '../../contexts/AuthContext';
+import { usePizza } from '../../contexts/PizzaContext';
 import { Payout, PayoutMethod, BankDetails } from '../../types';
 import { createPayout } from '../../lib/api';
+import { parsePartyKitCapFromTags } from '../../lib/reimbursementCap';
 import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
@@ -62,6 +64,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   expectedGuests,
 }) => {
   const { user } = useAuth();
+  const { party } = usePizza();
+  // Party-kit cap: parsed from an event_tag of the form `k40`, `k50`, etc.
+  // When set, the cap banner appends " and up to $Y of party kit expenses".
+  const partyKitCapUsd = parsePartyKitCapFromTags(party?.eventTags);
   // Stable id for this in-flight form, used as the storage-path grouping key.
   const [payoutTempId] = useState(() => `tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
 
@@ -184,7 +190,11 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             <BadgeDollarSign size={22} className="text-[#ff393a] mt-0.5 flex-shrink-0" />
             <div>
               <p className="text-sm font-medium text-theme-text">
-                We'll reimburse you for up to ${reimbursementCapUsd!.toFixed(2)}.
+                We'll reimburse you for up to ${reimbursementCapUsd!.toFixed(2)}
+                {partyKitCapUsd != null && (
+                  <> of pizza and up to ${partyKitCapUsd.toFixed(2)} of party kit expenses</>
+                )}
+                .
                 {totalPaidUsd > 0 && (
                   <> ${totalPaidUsd.toFixed(2)} paid so far.</>
                 )}

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Lock, Info, BadgeDollarSign } from 'lucide-react';
 import { Payout } from '../../types';
 import { listPayouts, fetchUnderbossMe, fetchAdminMe } from '../../lib/api';
+import { usePizza } from '../../contexts/PizzaContext';
+import { parsePartyKitCapFromTags } from '../../lib/reimbursementCap';
 import { PayoutsList } from './PayoutsList';
 import { NewPayoutForm } from './NewPayoutForm';
 import { PayoutDetailModal } from './PayoutDetailModal';
@@ -46,6 +48,8 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   reimbursementCapAppealedAt,
   expectedGuests,
 }) => {
+  const { party } = usePizza();
+  const partyKitCapUsd = parsePartyKitCapFromTags(party?.eventTags);
   const [view, setView] = useState<View>('list');
   const [payouts, setPayouts] = useState<Payout[]>([]);
   const [loading, setLoading] = useState(true);
@@ -173,7 +177,11 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
         <div className="card p-4 sm:p-5 border-l-4 border-l-emerald-500 flex items-start gap-3">
           <BadgeDollarSign size={20} className="text-emerald-500 mt-0.5 flex-shrink-0" />
           <div className="text-sm font-medium text-theme-text">
-            Reimbursement cap: ${effectiveReimbursementCapUsd.toFixed(2)}
+            We'll reimburse you for up to ${effectiveReimbursementCapUsd.toFixed(2)}
+            {partyKitCapUsd != null && (
+              <> of pizza and up to ${partyKitCapUsd.toFixed(2)} of party kit expenses</>
+            )}
+            .
           </div>
         </div>
       ) : (

--- a/frontend/src/lib/reimbursementCap.ts
+++ b/frontend/src/lib/reimbursementCap.ts
@@ -39,3 +39,29 @@ export function parseNumericCapFromTags(
   }
   return max;
 }
+
+/**
+ * Party-kit reimbursement cap from event_tags shaped like `k40`, `k50`,
+ * `k200.50` etc. — letter `k` (case-insensitive) followed by a positive
+ * number. Returns the max if multiple tags match. Null if none.
+ *
+ * Independent from the pizza cap (parseNumericCapFromTags) — both can be
+ * set on the same event.
+ */
+export function parsePartyKitCapFromTags(
+  tags: string[] | null | undefined
+): number | null {
+  if (!Array.isArray(tags) || tags.length === 0) return null;
+  const re = /^k(\d+(?:\.\d{1,2})?)$/i;
+  let max: number | null = null;
+  for (const raw of tags) {
+    if (typeof raw !== 'string') continue;
+    const t = raw.trim();
+    const m = re.exec(t);
+    if (!m) continue;
+    const n = Number(m[1]);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    if (max == null || n > max) max = n;
+  }
+  return max;
+}


### PR DESCRIPTION
Adds a separate party-kit cap parsed from event_tags like 'k40'. Cap banners show 'X of pizza and up to Y of party kit expenses' when the tag is present.