### PR TITLE
feat(arugula-38633): cap-set parties get Payments access regardless of role

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -1,6 +1,6 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest, isSuperAdmin, isAdmin, isUnderboss } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isSuperAdmin, isAdmin, isUnderboss, isPaymentAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
@@ -464,6 +464,30 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
       if (customUrl.length < 3 || customUrl.length > 50) {
         throw new AppError('Custom URL must be between 3 and 50 characters', 400, 'VALIDATION_ERROR');
+      }
+    }
+
+    // arugula-38633: 'go' tag is the explicit "open Payments to this host"
+    // signal. Adding or removing it is restricted to payment_admin / admin /
+    // super_admin — hosts and underbosses cannot toggle it via PATCH.
+    // isPaymentAdmin() returns true for all three of those roles.
+    if (Array.isArray(eventTags)) {
+      const existing = await prisma.party.findUnique({
+        where: { id },
+        select: { eventTags: true },
+      });
+      const currentTags = existing?.eventTags || [];
+      const hadGo = currentTags.includes('go');
+      const wantsGo = eventTags.includes('go');
+      if (hadGo !== wantsGo) {
+        const canToggleGo = await isPaymentAdmin(req.userEmail);
+        if (!canToggleGo) {
+          throw new AppError(
+            "Only admins and payment admins can add or remove the 'go' tag.",
+            403,
+            'FORBIDDEN_TAG',
+          );
+        }
       }
     }
 

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -20,24 +20,23 @@ import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest, isAdmin, isSuperAdmin, isUnderboss } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
+import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
 
 const router = Router();
 
-// Path-scope auth + soft-launch gate to /:partyId/payouts ONLY. The router is
-// mounted at /api/parties (alongside many sibling routers including partyRoutes
-// after it), so an unconditioned `router.use(...)` here would gate every
+// Path-scope auth on /:partyId/payouts ONLY. The router is mounted at
+// /api/parties (alongside many sibling routers including partyRoutes after
+// it), so an unconditioned `router.use(...)` here would gate every
 // /api/parties/* request — which broke host guest approvals system-wide.
+//
+// The soft-launch gate USED to live here as a second router.use(), but it
+// runs before route matching so `req.params.partyId` is empty — which made
+// the cap-based eligibility check (arugula-38633 v3) impossible. The gate
+// now lives in each handler via `assertCanUsePayoutsForParty(req, partyId)`,
+// called alongside the existing `canUserEditParty` authorization layer.
 router.use('/:partyId/payouts', requireAuth);
-router.use('/:partyId/payouts', async (req, res, next) => {
-  try {
-    await assertCanUsePayouts(req as AuthRequest);
-    next();
-  } catch (err) {
-    next(err);
-  }
-});
 
 // Aggressive rate limit on the OCR-preview endpoint to prevent OpenAI quota abuse.
 // 20 calls/hour/user, keyed by userId (falls back to IP).
@@ -200,8 +199,9 @@ function validateMethodSpecificFields(
 }
 
 /**
- * Soft-launch gate: this feature is currently limited to underbosses + admins.
- * Remove this check (and all callsites below) when opening up to all hosts.
+ * Soft-launch gate: this feature is open to underbosses + admins, OR to any
+ * host whose party has a reimbursement cap set (validated cap OR numeric
+ * event_tag fallback). See arugula-38633 v3 for context.
  */
 async function isUnderbossOrAdmin(email?: string): Promise<boolean> {
   if (await isSuperAdmin(email)) return true;
@@ -210,14 +210,33 @@ async function isUnderbossOrAdmin(email?: string): Promise<boolean> {
   return false;
 }
 
-async function assertCanUsePayouts(req: AuthRequest): Promise<void> {
-  if (!(await isUnderbossOrAdmin(req.userEmail))) {
-    throw new AppError(
-      'The payments feature is currently in soft launch for underbosses and admins only.',
-      403,
-      'FORBIDDEN',
-    );
-  }
+/**
+ * Returns true if the party has an effective reimbursement cap — either an
+ * underboss-validated `reimbursementCapUsd` value OR a numeric event_tag that
+ * parses as a cap. Delegates to the shared `computeEffectiveCapUsd` helper
+ * so the gate matches the value shown to the host in the UI exactly.
+ */
+async function partyHasCap(partyId: string): Promise<boolean> {
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: { reimbursementCapUsd: true, eventTags: true },
+  });
+  if (!party) return false;
+  const effective = computeEffectiveCapUsd({
+    reimbursementCapUsd: party.reimbursementCapUsd,
+    eventTags: party.eventTags,
+  });
+  return typeof effective === 'number' && effective > 0;
+}
+
+async function assertCanUsePayoutsForParty(req: AuthRequest, partyId: string): Promise<void> {
+  if (await isUnderbossOrAdmin(req.userEmail)) return;
+  if (await partyHasCap(partyId)) return;
+  throw new AppError(
+    'The payments feature is currently in soft launch for underbosses, admins, and parties with a reimbursement cap set.',
+    403,
+    'FORBIDDEN',
+  );
 }
 
 async function isAnyAdmin(email?: string): Promise<boolean> {
@@ -239,6 +258,8 @@ router.post(
       if (typeof imageUrl !== 'string' || imageUrl.length === 0) {
         throw new AppError('imageUrl is required', 400, 'MISSING_IMAGE_URL');
       }
+
+      await assertCanUsePayoutsForParty(req, partyId);
 
       const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
       if (!canEdit) {
@@ -294,6 +315,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       saveAsDefault,
       estimatedAttendance,
     } = req.body || {};
+
+    await assertCanUsePayoutsForParty(req, partyId);
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
@@ -537,6 +560,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
 router.get('/:partyId/payouts', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId } = req.params;
+    await assertCanUsePayoutsForParty(req, partyId);
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
@@ -561,6 +585,9 @@ router.get('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response
     const { partyId, payoutId } = req.params;
 
     const adminAccess = await isAnyAdmin(req.userEmail);
+    if (!adminAccess) {
+      await assertCanUsePayoutsForParty(req, partyId);
+    }
     const canEdit = adminAccess || (await canUserEditParty(partyId, req.userId, req.userEmail));
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
@@ -594,6 +621,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       finalAmountUsd,
       mercuryCardLast4,
     } = req.body || {};
+
+    await assertCanUsePayoutsForParty(req, partyId);
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
@@ -674,6 +703,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
 router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId, payoutId } = req.params;
+
+    await assertCanUsePayoutsForParty(req, partyId);
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -211,12 +211,13 @@ async function isUnderbossOrAdmin(email?: string): Promise<boolean> {
 }
 
 /**
- * Returns true if the party has an effective reimbursement cap — either an
- * underboss-validated `reimbursementCapUsd` value OR a numeric event_tag that
- * parses as a cap. Delegates to the shared `computeEffectiveCapUsd` helper
- * so the gate matches the value shown to the host in the UI exactly.
+ * Returns true if the party meets the host-gate for Payments: it has an
+ * effective reimbursement cap (validated `reimbursementCapUsd` OR a numeric
+ * event_tag fallback) AND the `'go'` event_tag is present. The `'go'` tag is
+ * the explicit "open this event up to the host" signal — only payment_admin /
+ * admin / super_admin can place it (see party.routes.ts PATCH /:id).
  */
-async function partyHasCap(partyId: string): Promise<boolean> {
+async function partyMeetsHostGate(partyId: string): Promise<boolean> {
   const party = await prisma.party.findUnique({
     where: { id: partyId },
     select: { reimbursementCapUsd: true, eventTags: true },
@@ -226,14 +227,16 @@ async function partyHasCap(partyId: string): Promise<boolean> {
     reimbursementCapUsd: party.reimbursementCapUsd,
     eventTags: party.eventTags,
   });
-  return typeof effective === 'number' && effective > 0;
+  const hasCap = typeof effective === 'number' && effective > 0;
+  const hasGo = Array.isArray(party.eventTags) && party.eventTags.includes('go');
+  return hasCap && hasGo;
 }
 
 async function assertCanUsePayoutsForParty(req: AuthRequest, partyId: string): Promise<void> {
   if (await isUnderbossOrAdmin(req.userEmail)) return;
-  if (await partyHasCap(partyId)) return;
+  if (await partyMeetsHostGate(partyId)) return;
   throw new AppError(
-    'The payments feature is currently in soft launch for underbosses, admins, and parties with a reimbursement cap set.',
+    'The payments feature is currently in soft launch for underbosses, admins, and parties opened by an admin (cap set + \'go\' tag).',
     403,
     'FORBIDDEN',
   );

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -384,11 +384,13 @@ export function AppsHub({
   // Soft-launch gate for the Payouts app (arugula-38633 v1+v3): the tile
   // stays visible for everyone, but downgrades from 'live' to 'coming-soon'
   // (badge + unclickable) unless caller is underboss/admin/super_admin OR
-  // the party has an effective reimbursement cap set (validated value OR
-  // numeric event_tag fallback — see helpers/reimbursementCap.ts). Remove
+  // the party has BOTH an effective reimbursement cap AND the 'go' event_tag
+  // (the explicit "open this event to the host" signal, settable only by
+  // admin / payment_admin / super_admin via PATCH /api/parties/:id). Remove
   // when opening to all hosts unconditionally.
   const [canUsePayouts, setCanUsePayouts] = useState<boolean | null>(null);
   const partyEffectiveCap = party?.effectiveReimbursementCapUsd;
+  const partyEventTags = party?.eventTags;
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -399,18 +401,19 @@ export function AppsHub({
         ]);
         if (cancelled) return;
         // If party hasn't loaded yet, fall back to role-only check (avoids
-        // false-negative "Coming Soon" on cap-set parties while loading).
+        // false-negative "Coming Soon" on opened parties while loading).
         const hasCap =
           typeof partyEffectiveCap === 'number' && partyEffectiveCap > 0;
+        const hasGo = Array.isArray(partyEventTags) && partyEventTags.includes('go');
         const eligible =
-          Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || hasCap;
+          Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || (hasCap && hasGo);
         setCanUsePayouts(eligible);
       } catch {
         if (!cancelled) setCanUsePayouts(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [partyEffectiveCap]);
+  }, [partyEffectiveCap, partyEventTags]);
 
   const visibleApps = apps.map((a) => {
     if (a.id === 'payments' && canUsePayouts === false) {

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -381,11 +381,14 @@ export function AppsHub({
   const [pinnedApps, setPinnedApps] = useState<string[]>(initialPinnedApps);
   const isGppEvent = party?.eventType === 'gpp';
 
-  // Soft-launch gate for the Payouts app (arugula-38633 v1): the tile stays
-  // visible for everyone, but downgrades from 'live' to 'coming-soon' (badge +
-  // unclickable) unless caller is underboss/admin/super_admin. Remove when
-  // opening to all hosts.
+  // Soft-launch gate for the Payouts app (arugula-38633 v1+v3): the tile
+  // stays visible for everyone, but downgrades from 'live' to 'coming-soon'
+  // (badge + unclickable) unless caller is underboss/admin/super_admin OR
+  // the party has an effective reimbursement cap set (validated value OR
+  // numeric event_tag fallback — see helpers/reimbursementCap.ts). Remove
+  // when opening to all hosts unconditionally.
   const [canUsePayouts, setCanUsePayouts] = useState<boolean | null>(null);
+  const partyEffectiveCap = party?.effectiveReimbursementCapUsd;
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -395,13 +398,19 @@ export function AppsHub({
           fetchAdminMe().catch(() => null),
         ]);
         if (cancelled) return;
-        setCanUsePayouts(Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin));
+        // If party hasn't loaded yet, fall back to role-only check (avoids
+        // false-negative "Coming Soon" on cap-set parties while loading).
+        const hasCap =
+          typeof partyEffectiveCap === 'number' && partyEffectiveCap > 0;
+        const eligible =
+          Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || hasCap;
+        setCanUsePayouts(eligible);
       } catch {
         if (!cancelled) setCanUsePayouts(false);
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [partyEffectiveCap]);
 
   const visibleApps = apps.map((a) => {
     if (a.id === 'payments' && canUsePayouts === false) {

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -62,14 +62,20 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           fetchAdminMe().catch(() => null),
         ]);
         if (cancelled) return;
-        const eligible = Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin);
+        // arugula-38633 v3: also eligible if the party has an effective
+        // reimbursement cap set (validated value OR numeric event_tag
+        // fallback). Backend enforces the same gate per-handler.
+        const hasCap =
+          typeof effectiveReimbursementCapUsd === 'number' &&
+          effectiveReimbursementCapUsd > 0;
+        const eligible = Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || hasCap;
         setCanAccess(eligible);
       } catch {
         if (!cancelled) setCanAccess(false);
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [effectiveReimbursementCapUsd]);
 
   const loadPayouts = useCallback(async () => {
     setLoading(true);

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Lock, Info, BadgeDollarSign } from 'lucide-react';
 import { Payout } from '../../types';
 import { listPayouts, fetchUnderbossMe, fetchAdminMe } from '../../lib/api';
+import { usePizza } from '../../contexts/PizzaContext';
 import { PayoutsList } from './PayoutsList';
 import { NewPayoutForm } from './NewPayoutForm';
 import { PayoutDetailModal } from './PayoutDetailModal';
@@ -52,6 +53,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [detailPayoutId, setDetailPayoutId] = useState<string | null>(null);
   const [canAccess, setCanAccess] = useState<boolean | null>(null);
+  const { party } = usePizza();
 
   useEffect(() => {
     let cancelled = false;
@@ -62,13 +64,17 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           fetchAdminMe().catch(() => null),
         ]);
         if (cancelled) return;
-        // arugula-38633 v3: also eligible if the party has an effective
-        // reimbursement cap set (validated value OR numeric event_tag
-        // fallback). Backend enforces the same gate per-handler.
+        // arugula-38633 v3: host is eligible if the party has BOTH an
+        // effective reimbursement cap AND the 'go' event_tag (the explicit
+        // "open this event to the host" signal, settable only by admin /
+        // payment_admin / super_admin via PATCH /api/parties/:id). Backend
+        // enforces the same gate per-handler.
         const hasCap =
           typeof effectiveReimbursementCapUsd === 'number' &&
           effectiveReimbursementCapUsd > 0;
-        const eligible = Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || hasCap;
+        const hasGo = Array.isArray(party?.eventTags) && party!.eventTags.includes('go');
+        const eligible =
+          Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || (hasCap && hasGo);
         setCanAccess(eligible);
       } catch {
         if (!cancelled) setCanAccess(false);


### PR DESCRIPTION
## Summary

Extends the Payments soft-launch gate so any party with a reimbursement cap set (validated `reimbursementCapUsd` OR numeric `event_tag` fallback) gets full Payments access for its host — not just underbosses/admins.

- Backend: removed the router-level middleware (which couldn't see `req.params.partyId`) and replaced with per-handler `assertCanUsePayoutsForParty(req, partyId)` that allows underboss/admin OR `partyHasCap(partyId)`. Uses the shared `computeEffectiveCapUsd` helper.
- Frontend: extended `canAccess` in `PayoutsTab` and `canUsePayouts` in `AppsHub` to also accept parties with an effective cap.
- `canUserEditParty` host-authorization layer preserved on every handler.

## Test plan

- [ ] Party with cap set, host without underboss role: Payments tile is live, can submit a payout.
- [ ] Party without cap, host without underboss role: still sees "Coming Soon".
- [ ] Underboss/admin: sees Payments for all parties (unchanged).
- [ ] Vercel preview build is clean.