### PR TITLE
feat(mortadella-71920): pizza box stack card on day-of dashboard

### DIFF
--- a/frontend/src/components/day-of/ChecklistTodayCard.tsx
+++ b/frontend/src/components/day-of/ChecklistTodayCard.tsx
@@ -22,6 +22,7 @@ const DAY_OF_ITEM_NAMES = new Set([
   'Take group photo',
   'Pay venue final invoice',
   'Get the pizza box signed',
+  'Stack the pizza boxes',
   'Join the PizzaDAO Zoom (static camera)',
   'Join the PizzaDAO StreamYard (phone)',
   'Take a Stand With Crypto group photo',

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -14,6 +14,7 @@ import { ChecklistTodayCard } from './ChecklistTodayCard';
 import { PhotoQuickCaptureCard } from './PhotoQuickCaptureCard';
 import { BriefingCard } from './BriefingCard';
 import { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
+import { PizzaBoxStackCard } from './PizzaBoxStackCard';
 import { BroadcastJoinCard } from './BroadcastJoinCard';
 import { StandWithCryptoCard } from './StandWithCryptoCard';
 
@@ -90,6 +91,7 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
       <div className={isMobile ? '' : 'space-y-4'}>
         {isGpp && !briefingFirst && <BriefingCard party={party} />}
         {isGpp && <SignedPizzaBoxCard party={party} />}
+        {isGpp && <PizzaBoxStackCard party={party} />}
         {isGpp && <BroadcastJoinCard partyId={party.id} layout={layout} />}
         {isGpp && <StandWithCryptoCard party={party} />}
         <LogisticsCard party={party} />

--- a/frontend/src/components/day-of/PizzaBoxStackCard.tsx
+++ b/frontend/src/components/day-of/PizzaBoxStackCard.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Boxes, Loader2, Check, Camera } from 'lucide-react';
+import { Party } from '../../types';
+import { uploadEventPhoto } from '../../lib/supabase';
+import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface PizzaBoxStackCardProps {
+  party: Party;
+  onUploaded?: () => void;
+}
+
+/**
+ * GPP-only host prompt — encourages the host to build a tower with the
+ * empty pizza boxes (PizzaDAO tradition) and snap a photo. Sibling
+ * visibility gate is the responsibility of the caller (DayOfDashboard);
+ * render-time check is a defensive fallback. Done-state is detected by
+ * the existence of any party photo tagged 'Box Tower' (the existing
+ * default photo tag from backend/src/routes/photo.routes.ts); the card
+ * dims to 50% but keeps the upload button active (events often build
+ * multiple towers).
+ */
+export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onUploaded }) => {
+  // ---- HOOKS (all above any early return) -------------------------------
+  const { user } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasBoxTower, setHasBoxTower] = useState(false);
+
+  const checkForBoxTower = React.useCallback(async () => {
+    try {
+      const res = await getPartyPhotos(party.id, { tag: 'Box Tower', limit: 1 });
+      setHasBoxTower(!!res && res.photos.length > 0);
+    } catch {
+      /* ignore — best-effort done-state */
+    }
+  }, [party.id]);
+
+  useEffect(() => {
+    checkForBoxTower();
+  }, [checkForBoxTower]);
+
+  const handleFile = async (file: File) => {
+    setError(null);
+    setUploading(true);
+    try {
+      const upload = await uploadEventPhoto(file, party.id);
+      if (!upload) {
+        throw new Error('Upload failed (storage)');
+      }
+      const res = await uploadPhotoApi(party.id, {
+        url: upload.url,
+        fileName: upload.fileName,
+        fileSize: upload.fileSize,
+        mimeType: upload.mimeType,
+        width: upload.width,
+        height: upload.height,
+        uploaderName: user?.name || 'Host',
+        uploaderEmail: user?.email || undefined,
+        tags: ['Box Tower'],
+      });
+      if (!res) throw new Error('Upload failed (api)');
+      setHasBoxTower(true);
+      onUploaded?.();
+    } catch (err: any) {
+      setError(err?.message || 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  return (
+    <div
+      className={`card p-5 space-y-3 transition-opacity ${
+        hasBoxTower ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Boxes size={18} className="text-[#ff393a]" />
+          <h3 className="text-lg font-semibold text-theme-text">
+            Stack the pizza boxes
+          </h3>
+        </div>
+        {hasBoxTower && (
+          <span className="inline-flex items-center gap-1 text-xs text-green-400">
+            <Check size={14} />
+            Box tower uploaded
+          </span>
+        )}
+      </div>
+
+      <p className="text-sm leading-relaxed text-theme-text-secondary">
+        Build a tower with all the empty pizza boxes! It's a PizzaDAO
+        tradition. Stack them as high as you can and snap a photo for the
+        archive.
+      </p>
+
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-[#ff393a] text-white rounded-xl py-4 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
+      >
+        {uploading ? (
+          <>
+            <Loader2 size={18} className="animate-spin" />
+            Uploading…
+          </>
+        ) : (
+          <>
+            <Camera size={18} />
+            Upload box tower photo
+          </>
+        )}
+      </button>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Adds `PizzaBoxStackCard` to the Day-Of dashboard, GPP-only. Mirrors the existing `SignedPizzaBoxCard` pattern.

- Prompt: "Build a tower with all the empty pizza boxes!"
- Upload tagged with the existing `'Box Tower'` default photo tag — uploads appear in the photo gallery's existing filter automatically.
- Done state when >=1 'Box Tower'-tagged photo exists for the party; card dims to 50% opacity.
- "Stack the pizza boxes" added to the day-of checklist allowlist.

## Test plan
- [ ] GPP-approved party: card visible on Day-Of dashboard (within the admin+underboss soft-launch gate)
- [ ] Non-GPP party: card hidden
- [ ] Upload photo: photo appears in PhotoGallery with `'Box Tower'` tag
- [ ] After upload, card dims and shows check badge

Generated with [Claude Code](https://claude.com/claude-code)