### PR TITLE
feat(arugula-38633): payment details card + Receipts rename

### DIFF
--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -18,6 +18,11 @@ router.get('/me', async (req: AuthRequest, res: Response, next: NextFunction) =>
         name: true,
         defaultAddress: true,
         createdAt: true,
+        // arugula-38633 v3: payout prefs surfaced for the host-side
+        // "Payment details" card in the Payments tab.
+        preferredPayoutMethod: true,
+        payoutWalletAddress: true,
+        payoutBankDetails: true,
       },
     });
 
@@ -30,19 +35,52 @@ router.get('/me', async (req: AuthRequest, res: Response, next: NextFunction) =>
 // PATCH /api/user/me - Update user profile
 router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    const { name, defaultAddress } = req.body;
+    const {
+      name,
+      defaultAddress,
+      // arugula-38633 v3 follow-up: persistent payout prefs editable from
+      // PaymentDetailsCard on the Payments tab. All three are nullable.
+      preferredPayoutMethod,
+      payoutWalletAddress,
+      payoutBankDetails,
+    } = req.body;
+
+    // Validate payoutMethod if provided (DB CHECK constraint mirrors this).
+    if (
+      preferredPayoutMethod !== undefined
+      && preferredPayoutMethod !== null
+      && !['mercury_card', 'wire', 'usdc_base'].includes(preferredPayoutMethod)
+    ) {
+      return res.status(400).json({
+        error: { message: 'Invalid preferredPayoutMethod', code: 'VALIDATION_ERROR' },
+      });
+    }
 
     const user = await prisma.user.update({
       where: { id: req.userId },
       data: {
         ...(name !== undefined && { name }),
         ...(defaultAddress !== undefined && { defaultAddress }),
+        ...(preferredPayoutMethod !== undefined && {
+          preferredPayoutMethod: preferredPayoutMethod || null,
+        }),
+        ...(payoutWalletAddress !== undefined && {
+          payoutWalletAddress: payoutWalletAddress
+            ? String(payoutWalletAddress).trim()
+            : null,
+        }),
+        ...(payoutBankDetails !== undefined && {
+          payoutBankDetails: payoutBankDetails ?? null,
+        }),
       },
       select: {
         id: true,
         email: true,
         name: true,
         defaultAddress: true,
+        preferredPayoutMethod: true,
+        payoutWalletAddress: true,
+        payoutBankDetails: true,
       },
     });
 

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,14 +1,13 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign, Users, AlertCircle } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePizza } from '../../contexts/PizzaContext';
-import { Payout, PayoutMethod, BankDetails } from '../../types';
+import { Payout } from '../../types';
 import { createPayout } from '../../lib/api';
 import { parsePartyKitCapFromTags } from '../../lib/reimbursementCap';
 import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
-import { PayoutMethodPicker } from './PayoutMethodPicker';
 import { PayoutAmountSummary } from './PayoutAmountSummary';
 import { AppealCapModal } from './AppealCapModal';
 
@@ -36,11 +35,6 @@ interface NewPayoutFormProps {
   expectedGuests?: number | null;
 }
 
-const EMPTY_BANK: BankDetails = {
-  accountHolderName: '',
-  bankName: '',
-};
-
 /**
  * Single-page submission form (no multi-step wizard — matches pizza-faucet-v2).
  *
@@ -50,8 +44,13 @@ const EMPTY_BANK: BankDetails = {
  *   2. Pizza / event photos (multi-upload, no OCR)
  *   3. Notes
  *   4. Amount summary (auto-summed + manual override)
- *   5. Payout method picker
- *   6. Submit
+ *   5. Submit
+ *
+ * Note (arugula-38633 v3): the payout-method picker was hoisted to a
+ * persistent PaymentDetailsCard at the top of the Payments tab. This form
+ * now reads the user's saved `preferredPayoutMethod` / `payoutWalletAddress`
+ * / `payoutBankDetails` from AuthContext and forwards them to `createPayout`
+ * — it no longer asks the host per submission.
  */
 export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   partyId,
@@ -82,10 +81,30 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const [notes, setNotes] = useState('');
   const [overrideAmount, setOverrideAmount] = useState<number | null>(null);
 
-  const [method, setMethod] = useState<PayoutMethod>('mercury_card');
-  const [walletAddress, setWalletAddress] = useState('');
-  const [bankDetails, setBankDetails] = useState<BankDetails>(EMPTY_BANK);
-  const [mercuryCardLast4, setMercuryCardLast4] = useState('');
+  // arugula-38633 v3: read payment method + destination from the
+  // authenticated user record (saved via PaymentDetailsCard at the top of
+  // the Payments tab). When unset, the submit button is disabled and an
+  // inline message points the host upward.
+  const savedMethod = user?.preferredPayoutMethod ?? null;
+  const savedWallet = user?.payoutWalletAddress ?? null;
+  const savedBank = user?.payoutBankDetails ?? null;
+  // Validity mirror of PaymentDetailsCard.methodValid (kept duplicated
+  // intentionally — the card may not yet have persisted a partially typed
+  // wire row when the host clicks Submit).
+  const savedMethodValid = useMemo(() => {
+    if (savedMethod == null) return false;
+    if (savedMethod === 'usdc_base') {
+      return !!savedWallet && /^0x[0-9a-fA-F]{40}$/.test(savedWallet.trim());
+    }
+    if (savedMethod === 'wire') {
+      if (!savedBank) return false;
+      if (!savedBank.accountHolderName?.trim() || !savedBank.bankName?.trim()) return false;
+      const hasUs = !!savedBank.routingNumber?.trim() && !!savedBank.accountNumber?.trim();
+      const hasIntl = !!savedBank.iban?.trim() || !!savedBank.swift?.trim();
+      return hasUs || hasIntl;
+    }
+    return true; // mercury_card has no extra required destination data
+  }, [savedMethod, savedWallet, savedBank]);
 
   // Estimated attendance: asked once per event. Pre-fills from the party's
   // existing `expectedGuests` if set; otherwise the host is prompted.
@@ -109,34 +128,20 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const isProcessing = receipts.some(r => r.status === 'uploading' || r.status === 'ocring')
     || pizzaPhotos.some(p => p.status === 'uploading');
 
-  // Method-specific validity
-  const methodValid = useMemo(() => {
-    if (method === 'usdc_base') {
-      return /^0x[0-9a-fA-F]{40}$/.test(walletAddress.trim());
-    }
-    if (method === 'wire') {
-      if (!bankDetails.accountHolderName?.trim() || !bankDetails.bankName?.trim()) return false;
-      const hasUs = !!bankDetails.routingNumber?.trim() && !!bankDetails.accountNumber?.trim();
-      const hasIntl = !!bankDetails.iban?.trim() || !!bankDetails.swift?.trim();
-      return hasUs || hasIntl;
-    }
-    return true;
-  }, [method, walletAddress, bankDetails]);
-
   // When the attendance section is shown, require a positive integer before submit.
   const attendanceValid = !askForAttendance
     || (estimatedAttendance != null && estimatedAttendance > 0);
 
   const canSubmit = hasUploadedReceipt
     && finalAmount > 0
-    && methodValid
+    && savedMethodValid
     && attendanceValid
     && !isProcessing
     && !submitting;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canSubmit) return;
+    if (!canSubmit || !savedMethod) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
@@ -158,11 +163,17 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             mimeType: p.mimeType,
           })),
         hostNotes: notes.trim() || undefined,
-        payoutMethod: method,
-        ...(method === 'usdc_base' ? { payoutWalletAddress: walletAddress.trim() } : {}),
-        ...(method === 'wire' ? { payoutBankDetails: bankDetails } : {}),
-        ...(method === 'mercury_card' && mercuryCardLast4
-          ? { mercuryCardLast4 }
+        // arugula-38633 v3: payout destination is sourced from the user's
+        // PaymentDetailsCard, not the form. Backend payout.routes still
+        // mirrors saveAsDefault → users.* on its end — kept for symmetry,
+        // though PaymentDetailsCard already writes them directly via PATCH
+        // /api/user/me on the host's first save.
+        payoutMethod: savedMethod,
+        ...(savedMethod === 'usdc_base' && savedWallet
+          ? { payoutWalletAddress: savedWallet.trim() }
+          : {}),
+        ...(savedMethod === 'wire' && savedBank
+          ? { payoutBankDetails: savedBank }
           : {}),
         ...(overrideAmount != null ? { finalAmountUsd: overrideAmount } : {}),
         ...(estimatedAttendance != null ? { estimatedAttendance } : {}),
@@ -170,7 +181,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       });
       onCreated(created);
     } catch (err: any) {
-      setSubmitError(err?.message || 'Failed to submit payment');
+      setSubmitError(err?.message || 'Failed to submit receipt');
     } finally {
       setSubmitting(false);
     }
@@ -318,31 +329,22 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         />
       </div>
 
-      {/* 5. Payout method */}
-      <div className="card p-6">
-        <div className="mb-3">
-          <h3 className="text-base font-semibold text-theme-text">How do you want to be paid?</h3>
-        </div>
-        <PayoutMethodPicker
-          method={method}
-          onMethodChange={setMethod}
-          walletAddress={walletAddress}
-          onWalletAddressChange={setWalletAddress}
-          bankDetails={bankDetails}
-          onBankDetailsChange={setBankDetails}
-          userEmail={user?.email}
-          amountUsd={finalAmount}
-        />
-
-        {/* Hidden last4 field is intentionally omitted — Mercury card numbers come from admin, not host. */}
-        {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
-        {false && <input value={mercuryCardLast4} onChange={e => setMercuryCardLast4(e.target.value)} />}
-      </div>
-
-      {/* 7. Submit */}
+      {/* 5. Submit */}
       {submitError && (
         <div className="card p-4 border-red-500/40 bg-red-500/10 text-sm text-red-300">
           {submitError}
+        </div>
+      )}
+
+      {/* arugula-38633 v3: payout method is now configured in the
+          PaymentDetailsCard above. If the host hasn't set one yet, show an
+          inline hint and disable submit. */}
+      {!savedMethodValid && (
+        <div className="card p-4 border-l-4 border-l-amber-500 flex items-start gap-3">
+          <AlertCircle size={18} className="text-amber-500 mt-0.5 flex-shrink-0" />
+          <p className="text-sm text-theme-text">
+            Set your <span className="font-semibold">payment details</span> above before submitting a receipt.
+          </p>
         </div>
       )}
 
@@ -364,7 +366,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             ? 'Waiting for uploads…'
             : submitting
             ? 'Submitting…'
-            : `Submit $${finalAmount.toFixed(2)} payment`}
+            : `Submit $${finalAmount.toFixed(2)} receipt`}
         </button>
       </div>
 

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -1,0 +1,255 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Loader2, Check, AlertCircle } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { BankDetails, PayoutMethod } from '../../types';
+import { updateUserMe } from '../../lib/api';
+import { PayoutMethodPicker } from './PayoutMethodPicker';
+
+const EMPTY_BANK: BankDetails = {
+  accountHolderName: '',
+  bankName: '',
+};
+
+type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
+
+/**
+ * arugula-38633 v3: persistent "Payment details" card at the top of the
+ * Payments tab. Hoists the per-receipt PayoutMethodPicker out of
+ * NewPayoutForm so the host configures their payout method ONCE, then every
+ * subsequent receipt submission reads from the saved user record.
+ *
+ * Persistence target: `users.preferred_payout_method`,
+ * `users.payout_wallet_address`, `users.payout_bank_details` via
+ * `PATCH /api/user/me`. AuthContext hydrates these on mount; we save through
+ * `updateUserMe` and optimistically patch the local user via `setUser`.
+ *
+ * Save behavior: debounced 1s after the last change (mirrors
+ * ExpectedGuestsCard's optimistic + auto-save pattern, but without the
+ * explicit Save button — the picker UI is already interactive).
+ */
+export const PaymentDetailsCard: React.FC = () => {
+  const { user, setUser } = useAuth();
+
+  // Local mirrors of the user's persisted values. These drive PayoutMethodPicker
+  // directly so the UI updates instantly; the debounced save flushes to the
+  // backend ~1s after the host stops typing.
+  const [method, setMethod] = useState<PayoutMethod | null>(
+    user?.preferredPayoutMethod ?? null
+  );
+  const [walletAddress, setWalletAddress] = useState<string>(
+    user?.payoutWalletAddress ?? ''
+  );
+  const [bankDetails, setBankDetails] = useState<BankDetails>(
+    user?.payoutBankDetails ?? EMPTY_BANK
+  );
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Resync local mirrors when AuthContext hydrates user payout prefs from
+  // /api/user/me (the initial mount sees `user` from localStorage without
+  // payout fields; the GET resolves a moment later).
+  // Only resync when the user-record value differs from local — otherwise we'd
+  // clobber in-flight edits. Done per-field for clarity.
+  useEffect(() => {
+    if (user?.preferredPayoutMethod !== undefined && method === null) {
+      setMethod(user.preferredPayoutMethod ?? null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.preferredPayoutMethod]);
+
+  useEffect(() => {
+    if (user?.payoutWalletAddress !== undefined && walletAddress === '') {
+      setWalletAddress(user.payoutWalletAddress ?? '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.payoutWalletAddress]);
+
+  useEffect(() => {
+    if (
+      user?.payoutBankDetails !== undefined
+      && !bankDetails.accountHolderName
+      && !bankDetails.bankName
+    ) {
+      setBankDetails(user.payoutBankDetails ?? EMPTY_BANK);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.payoutBankDetails]);
+
+  // Validity mirror of NewPayoutForm's old methodValid — used to gate the
+  // debounced save (don't push half-typed wire details to the backend).
+  const methodValid = useMemo(() => {
+    if (method == null) return false;
+    if (method === 'usdc_base') {
+      return /^0x[0-9a-fA-F]{40}$/.test(walletAddress.trim());
+    }
+    if (method === 'wire') {
+      if (!bankDetails.accountHolderName?.trim() || !bankDetails.bankName?.trim()) return false;
+      const hasUs = !!bankDetails.routingNumber?.trim() && !!bankDetails.accountNumber?.trim();
+      const hasIntl = !!bankDetails.iban?.trim() || !!bankDetails.swift?.trim();
+      return hasUs || hasIntl;
+    }
+    return true; // mercury_card has no extra required fields
+  }, [method, walletAddress, bankDetails]);
+
+  // Debounced auto-save. We track the "intended" payload in a ref so the
+  // timeout callback always reads the latest values without re-creating the
+  // timer on every keystroke. Mirror the cadence (1s) called for in the
+  // task brief; ExpectedGuestsCard uses an explicit Save button so it doesn't
+  // model debounce — PrepayCheckbox saves immediately (no debounce needed for
+  // a single toggle). 1s feels right for free-form text.
+  const saveTimer = useRef<number | null>(null);
+  const isDirty = useRef(false);
+
+  // Build the body that would be sent right now.
+  const buildPayload = () => {
+    if (method == null) return null;
+    return {
+      preferredPayoutMethod: method,
+      payoutWalletAddress: method === 'usdc_base' ? walletAddress.trim() : null,
+      payoutBankDetails: method === 'wire' ? bankDetails : null,
+    };
+  };
+
+  // Track previous values so the auto-save only fires on actual change (not
+  // on the initial setState from hydration).
+  const prevSnapshot = useRef<string>(JSON.stringify({
+    method: user?.preferredPayoutMethod ?? null,
+    walletAddress: user?.payoutWalletAddress ?? '',
+    bankDetails: user?.payoutBankDetails ?? EMPTY_BANK,
+  }));
+
+  useEffect(() => {
+    const snapshot = JSON.stringify({ method, walletAddress, bankDetails });
+    if (snapshot === prevSnapshot.current) return;
+    prevSnapshot.current = snapshot;
+    isDirty.current = true;
+
+    // Don't fire the save until the method-specific fields are valid.
+    if (!methodValid) {
+      setSaveStatus('pending');
+      return;
+    }
+
+    setSaveStatus('pending');
+    if (saveTimer.current) window.clearTimeout(saveTimer.current);
+    saveTimer.current = window.setTimeout(async () => {
+      const payload = buildPayload();
+      if (!payload) return;
+      setSaveStatus('saving');
+      setSaveError(null);
+      try {
+        const updated = await updateUserMe(payload);
+        // Optimistic context patch: merge new payout prefs into AuthContext.
+        // Mirror the pattern used by ExpectedGuestsCard (loadParty) /
+        // PrepayCheckbox (setParty) — here the equivalent is setUser, plus a
+        // localStorage write so a refresh doesn't lose the values.
+        setUser({
+          ...(user as NonNullable<typeof user>),
+          preferredPayoutMethod: updated.preferredPayoutMethod ?? null,
+          payoutWalletAddress: updated.payoutWalletAddress ?? null,
+          payoutBankDetails: updated.payoutBankDetails ?? null,
+        });
+        try {
+          const stored = localStorage.getItem('user');
+          const parsed = stored ? JSON.parse(stored) : {};
+          localStorage.setItem('user', JSON.stringify({
+            ...parsed,
+            preferredPayoutMethod: updated.preferredPayoutMethod ?? null,
+            payoutWalletAddress: updated.payoutWalletAddress ?? null,
+            payoutBankDetails: updated.payoutBankDetails ?? null,
+          }));
+        } catch { /* quota — ignore */ }
+        isDirty.current = false;
+        setSaveStatus('saved');
+        // Clear the "Saved" badge after a moment so it doesn't stick.
+        window.setTimeout(() => {
+          setSaveStatus(s => (s === 'saved' ? 'idle' : s));
+        }, 1800);
+      } catch (err: any) {
+        setSaveStatus('error');
+        setSaveError(err?.message || 'Failed to save payment details');
+      }
+    }, 1000);
+
+    return () => {
+      if (saveTimer.current) window.clearTimeout(saveTimer.current);
+    };
+    // We intentionally exclude buildPayload from deps — it closes over the
+    // latest values via the surrounding effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [method, walletAddress, bankDetails, methodValid]);
+
+  // PayoutMethodPicker requires non-null method + an amount. For the empty
+  // state we let the user pick a method first; the picker still renders all
+  // three radios and we treat "no method yet" as $0 in the Mercury copy line.
+  // (Mercury copy reads "$0.00 USD" until the host submits an actual receipt;
+  // that's fine — this card is about saving the destination, not amounts.)
+  const pickerMethod: PayoutMethod = method ?? 'mercury_card';
+  const hasNothingYet = method == null;
+
+  return (
+    <div className="card p-6">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-theme-text">
+            Payment details
+          </h3>
+          <p className="text-xs text-theme-text-muted mt-1">
+            How do you want to be paid when your receipts are approved? We'll save
+            this for every future receipt.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+          {saveStatus === 'saving' && (
+            <>
+              <Loader2 size={12} className="animate-spin text-theme-text-muted" />
+              <span className="text-theme-text-muted">Saving…</span>
+            </>
+          )}
+          {saveStatus === 'saved' && (
+            <>
+              <Check size={12} className="text-emerald-500" />
+              <span className="text-emerald-500">Saved</span>
+            </>
+          )}
+          {saveStatus === 'pending' && method != null && (
+            <span className="text-theme-text-muted">Editing…</span>
+          )}
+          {saveStatus === 'error' && (
+            <>
+              <AlertCircle size={12} className="text-[#ff393a]" />
+              <span className="text-[#ff393a]">Save failed</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {hasNothingYet && (
+        <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-theme-text-secondary">
+          Pick a payout method below to enable receipt submissions. You only have
+          to do this once.
+        </div>
+      )}
+
+      <PayoutMethodPicker
+        method={pickerMethod}
+        onMethodChange={(next) => {
+          setMethod(next);
+          // When switching methods we DON'T wipe the other method's stored
+          // details — they stay so the host can swap back without retyping.
+        }}
+        walletAddress={walletAddress}
+        onWalletAddressChange={setWalletAddress}
+        bankDetails={bankDetails}
+        onBankDetailsChange={setBankDetails}
+        userEmail={user?.email}
+        amountUsd={0}
+      />
+
+      {saveError && (
+        <p className="text-xs text-[#ff393a] mt-2">{saveError}</p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/PayoutsList.tsx
+++ b/frontend/src/components/payouts/PayoutsList.tsx
@@ -50,7 +50,7 @@ export const PayoutsList: React.FC<PayoutsListProps> = ({
           <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-theme-surface-hover flex items-center justify-center">
             <ReceiptIcon className="w-7 h-7 text-theme-text-muted" />
           </div>
-          <h3 className="text-base font-semibold text-theme-text mb-1">No payments yet</h3>
+          <h3 className="text-base font-semibold text-theme-text mb-1">No receipts yet</h3>
           <p className="text-sm text-theme-text-muted mb-6">
             Submit your receipts to get paid back for pizza or venue costs.
           </p>

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -9,6 +9,7 @@ import { NewPayoutForm } from './NewPayoutForm';
 import { PayoutDetailModal } from './PayoutDetailModal';
 import { ExpectedGuestsCard } from './ExpectedGuestsCard';
 import { PrepayCheckbox } from './PrepayCheckbox';
+import { PaymentDetailsCard } from './PaymentDetailsCard';
 
 interface PayoutsTabProps {
   partyId: string;
@@ -82,7 +83,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
       const data = await listPayouts(partyId);
       setPayouts(data);
     } catch (err: any) {
-      setError(err?.message || 'Failed to load payments');
+      setError(err?.message || 'Failed to load receipts');
     } finally {
       setLoading(false);
     }
@@ -197,22 +198,28 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
 
       <ExpectedGuestsCard partyId={partyId} expectedGuests={expectedGuests} />
 
+      {/*
+        arugula-38633 v3: persistent payment-method picker. Lives above the
+        receipts list so the host configures once and every future receipt
+        submission reads from the user record (NewPayoutForm no longer asks
+        per-submission). Same vertical band as ExpectedGuestsCard so the
+        "settings vs. activity" split is obvious.
+      */}
+      <PaymentDetailsCard />
+
       {view === 'list' && (
         <>
           <div className="card p-6">
             <div className="flex items-center justify-between mb-2">
               <div>
-                <h2 className="text-lg font-semibold text-theme-text">Payments</h2>
-                <p className="text-sm text-theme-text-secondary mt-1">
-                  Upload receipts for expenses and choose how you want to get paid back.
-                </p>
+                <h2 className="text-lg font-semibold text-theme-text">Receipts</h2>
               </div>
               <button
                 onClick={() => setView('new')}
                 className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 whitespace-nowrap"
               >
                 <Plus size={16} />
-                New payment
+                New receipt
               </button>
             </div>
           </div>
@@ -236,7 +243,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             className="inline-flex items-center gap-2 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
           >
             <ArrowLeft size={16} />
-            Back to payments
+            Back to receipts
           </button>
           <NewPayoutForm
             partyId={partyId}

--- a/frontend/src/components/payouts/index.ts
+++ b/frontend/src/components/payouts/index.ts
@@ -10,3 +10,4 @@ export { PayoutDetailModal } from './PayoutDetailModal';
 export { AppealCapModal } from './AppealCapModal';
 export { ExpectedGuestsCard } from './ExpectedGuestsCard';
 export { PrepayCheckbox } from './PrepayCheckbox';
+export { PaymentDetailsCard } from './PaymentDetailsCard';

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { AUTH_EXPIRED_EVENT } from '../lib/api';
+import type { BankDetails, PayoutMethod } from '../types';
 
 interface User {
   id: string;
@@ -14,6 +15,13 @@ interface User {
   tiktok?: string;
   linkedin?: string;
   website?: string;
+  // arugula-38633 v3: persistent payout prefs, edited from PaymentDetailsCard
+  // on the Payments tab. Hydrated by AuthContext via fetchUserMe() on mount
+  // (when an auth token is present) so PaymentDetailsCard can render the
+  // saved values without an extra round-trip.
+  preferredPayoutMethod?: PayoutMethod | null;
+  payoutWalletAddress?: string | null;
+  payoutBankDetails?: BankDetails | null;
 }
 
 interface AuthContextType {
@@ -59,6 +67,46 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     setLoading(false);
   }, []);
+
+  // arugula-38633 v3: once we have an auth token, fetch the full /me record so
+  // payout prefs (preferredPayoutMethod, payoutWalletAddress, payoutBankDetails)
+  // are available to PaymentDetailsCard + NewPayoutForm without per-component
+  // round-trips. We deliberately MERGE the response into the existing user
+  // (rather than replacing it) — `/api/user/me` selects a narrower field set
+  // than what's in localStorage, and we don't want to drop username/social
+  // links that other UIs depend on.
+  useEffect(() => {
+    const token = localStorage.getItem('authToken');
+    if (!token || !user?.id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${API_URL}/api/user/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        const me = data?.user;
+        if (!me || cancelled) return;
+        setUser(prev => {
+          if (!prev) return prev;
+          const merged: User = {
+            ...prev,
+            preferredPayoutMethod: me.preferredPayoutMethod ?? null,
+            payoutWalletAddress: me.payoutWalletAddress ?? null,
+            payoutBankDetails: me.payoutBankDetails ?? null,
+          };
+          try { localStorage.setItem('user', JSON.stringify(merged)); } catch { /* quota */ }
+          return merged;
+        });
+      } catch {
+        // Network blip — fine, PaymentDetailsCard can still operate from its
+        // own state; the merge will retry on next mount.
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   // Listen for auth expiration events
   useEffect(() => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4238,3 +4238,35 @@ export async function addWalkInGuest(
     requireAuth: true,
   });
 }
+
+// ============================================================
+// User /me payout preferences (arugula-38633 v3)
+// ============================================================
+
+export interface UserMePayoutPrefs {
+  preferredPayoutMethod: PayoutMethod | null;
+  payoutWalletAddress: string | null;
+  payoutBankDetails: BankDetails | null;
+}
+
+export interface UpdateUserMeInput {
+  name?: string;
+  defaultAddress?: string | null;
+  preferredPayoutMethod?: PayoutMethod | null;
+  payoutWalletAddress?: string | null;
+  payoutBankDetails?: BankDetails | null;
+}
+
+/**
+ * PATCH /api/user/me — persistent user record edits. arugula-38633 v3 added
+ * the three payout-preference fields here so the Payment Details card on
+ * the Payments tab can persist them in one round-trip.
+ */
+export async function updateUserMe(
+  data: UpdateUserMeInput
+): Promise<{ id: string; email: string; name?: string | null } & Partial<UserMePayoutPrefs>> {
+  const res = await apiRequest<{
+    user: { id: string; email: string; name?: string | null } & Partial<UserMePayoutPrefs>;
+  }>('/api/user/me', { method: 'PATCH', body: data, requireAuth: true });
+  return res.user;
+}


### PR DESCRIPTION
## Summary
- New persistent **PaymentDetailsCard** in the Payments tab (below ExpectedGuestsCard) — hoists `PayoutMethodPicker` out of NewPayoutForm. Saves to `users.preferred_payout_method` / `payout_wallet_address` / `payout_bank_details` via debounced 1s `PATCH /api/user/me`, with optimistic local + AuthContext update.
- **NewPayoutForm** no longer prompts per submission: reads the user's saved payout prefs from AuthContext and forwards them to `createPayout`. Submit button disabled with an inline "Set your payment details above" hint when unset/invalid.
- Copy rename: "Payments" section header -> **"Receipts"** (subtitle dropped), "+ New Payment" -> **"+ New Receipt"**, "Back to payments" -> **"Back to receipts"**, "No payments yet" -> **"No receipts yet"**, submit button reads **"Submit \$X receipt"**.
- AppsHub tile name "Payments" and admin `/payments` dashboard intentionally untouched (different scope).

Backend: extended `GET`/`PATCH /api/user/me` to return + accept the three payout-pref fields.

## Test plan
- [ ] Visit a host's Payments tab as an underboss/admin — Payment details card renders below the Expected guests card.
- [ ] Pick "Mercury virtual card" — debounced ~1s "Saving..." then "Saved" indicator; refresh page, selection persists.
- [ ] Pick "USDC on Base" + paste a valid 0x... address; "Saved" appears; backend `users.payout_wallet_address` updated.
- [ ] Pick "Bank wire", fill US fields; saves after debounce.
- [ ] With no payout method set, click "+ New receipt" — submit button is disabled and the amber hint card explains why.
- [ ] After setting method, submit a receipt — backend receives the saved method/destination; submit button reads "Submit \$X receipt".
- [ ] Section header reads "Receipts" (not "Payments") and subtitle is gone.
- [ ] Empty-state CTA still says "Submit your receipts" (unchanged per brief).
- [ ] AppsHub tile + `/payments` admin dashboard unchanged.

Preview: https://rsvpizza-git-arugula-38633-payment-details-card-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)