### PR TITLE
gorgonzola-83562: stale-UI fix follow-ups

### DIFF
--- a/frontend/src/components/DonationSettings.tsx
+++ b/frontend/src/components/DonationSettings.tsx
@@ -47,6 +47,12 @@ export const DonationSettings: React.FC = () => {
         if (party.inviteCode) {
           await loadParty(party.inviteCode);
         }
+      } else {
+        // Refresh party context on success so dependent widgets
+        // (e.g. DonationSummary) reflect the saved state without F5.
+        if (party.inviteCode) {
+          await loadParty(party.inviteCode);
+        }
       }
       return success;
     } catch (error) {

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -11,7 +11,7 @@ import { FindVenueModal } from '../checklist/FindVenueModal';
 export const GPPDashboardTab: React.FC = () => {
   const { inviteCode } = useParams<{ inviteCode: string }>();
   const navigate = useNavigate();
-  const { party, guests } = usePizza();
+  const { party, guests, loadParty } = usePizza();
   const [autoStates, setAutoStates] = useState<AutoCompleteStates | null>(null);
   const [dbItems, setDbItems] = useState<ChecklistItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -203,7 +203,7 @@ export const GPPDashboardTab: React.FC = () => {
                 setSaving(true);
                 try {
                   await updateUnderbossStatus(party.id, 'listed');
-                  window.location.reload();
+                  if (party?.inviteCode) await loadParty(party.inviteCode);
                 } catch (err) {
                   console.error('Failed to update status:', err);
                 } finally {
@@ -221,7 +221,7 @@ export const GPPDashboardTab: React.FC = () => {
                 setSaving(true);
                 try {
                   await updateUnderbossStatus(party.id, 'hidden');
-                  window.location.reload();
+                  if (party?.inviteCode) await loadParty(party.inviteCode);
                 } catch (err) {
                   console.error('Failed to update status:', err);
                 } finally {

--- a/frontend/src/components/venue/VenueWidget.tsx
+++ b/frontend/src/components/venue/VenueWidget.tsx
@@ -142,6 +142,9 @@ export const VenueWidget: React.FC<VenueWidgetProps> = ({ partyId, onVenueSelect
         ...v,
         isSelected: v.id === venueId ? false : v.isSelected,
       })));
+      // Notify parent to refresh party data so address/venue_name clears
+      // from the Settings tab without a full page reload.
+      onVenueSelect?.();
     } catch (error) {
       console.error('Error deselecting venue:', error);
     } finally {


### PR DESCRIPTION
## Summary

Three small stale-UI fixes from a recent audit, bundled because each is a tiny patch in the same pattern (refresh state instead of leaving it stale or hard-reloading).

- **DonationSettings.saveField**: was calling `loadParty` only on the failure/rollback branch. Now also refreshes on success so `DonationSummary` and other context consumers reflect the saved state without F5.
- **GPPDashboardTab**: two `window.location.reload()` calls in the underboss-status transition handlers ("List My Event Without Funding", "Maybe Next Year") replaced with `await loadParty(party.inviteCode)`. Banner updates without a hard reload.
- **VenueWidget.handleDeselect**: now fires the `onVenueSelect?.()` callback after deselecting, matching `handleSelect`. The `HostPage` parent's callback already calls `loadParty`, so the Settings-tab address/venue_name now clears without F5.

No DB, backend, API, or shared-type changes.

## Preview

https://rsvpizza-git-gorgonzola-83562-stale-ui-pizza-dao.vercel.app

## Test plan

- [ ] Donations: toggle Accept Donations, edit goal/message, add/remove a suggested-amount chip. Confirm the DonationSummary tile / public preview updates without a page refresh.
- [ ] Underboss-rejected event: open the dashboard, click "List My Event Without Funding". Banner switches to the green Listed-status callout without a page reload. Repeat for "Maybe Next Year" -> Hidden banner.
- [ ] Venue: select a venue, switch to Settings tab, confirm address populated. Return to Venue tab, click Deselect. Switch back to Settings tab -> address/venue_name cleared without F5.

`npx tsc --noEmit` passes clean.