### PR TITLE
fix(gorgonzola-31482): drop query_place_id for address-shell Place IDs

### DIFF
--- a/frontend/src/components/PizzeriaSearch.tsx
+++ b/frontend/src/components/PizzeriaSearch.tsx
@@ -316,7 +316,7 @@ export const PizzeriaSearch: React.FC<PizzeriaSearchProps> = ({
       !(pizzeria.location.lat === 0 && pizzeria.location.lng === 0);
 
     const googleMapsUrl = hasValidCoords
-      ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${pizzeria.name} ${pizzeria.address}`)}${pizzeria.placeId ? `&query_place_id=${pizzeria.placeId}` : ''}`
+      ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${pizzeria.name} ${pizzeria.address}`)}${pizzeria.placeId?.startsWith('ChIJ') ? `&query_place_id=${pizzeria.placeId}` : ''}`
       : null;
 
     // Construct static map URL (only for valid coords)

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -531,11 +531,13 @@ export function EventPage() {
     );
   };
 
-  // Interactive Google Maps JS SDK venue thumbnail (see VenueMap component)
-  // Prefer place_id + address (opens canonical place card). Fall back to address
-  // alone, then to lat/lng if no address. Both place_id and address are required
-  // for the place_id form per Google's docs.
-  const googleMapsUrl = event.placeId && event.address
+  // Interactive Google Maps JS SDK venue thumbnail (see VenueMap component).
+  // Prefer canonical place_id (ChIJ…) + address — opens the real place card.
+  // Skip query_place_id for Google's address-shell IDs (prefixes Ei…/Ek…), which
+  // are autocomplete fallbacks that don't resolve to a Maps place page. Fall
+  // back to address alone, then to lat/lng if no address.
+  const hasCanonicalPlaceId = event.placeId?.startsWith('ChIJ') ?? false;
+  const googleMapsUrl = hasCanonicalPlaceId && event.address
     ? `https://www.google.com/maps/place/?api=1&query=${encodeURIComponent(event.address)}&query_place_id=${event.placeId}`
     : event.address
       ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`


### PR DESCRIPTION
## Summary
- Google Maps' `query_place_id` URL parameter only renders canonical Place IDs (prefix `ChIJ`). When Google autocomplete returns an "address-shell" Place ID (prefix `Ei`/`Ek`, base64-encoded address), passing it as `query_place_id` lands users on "this page isn't available."
- Gate the `query_place_id` branch on `placeId?.startsWith('ChIJ')` in `EventPage.tsx` and `PizzeriaSearch.tsx`. Address-shell IDs fall through to the address-only Maps search URL.
- 8 affected events (barcelona, budapest, kolkata, agra1, muzaffarpur, santacruzdetenerife, pizzadayprague, plus one with no custom_url) now get a working venue link. 502 ChIJ events are unchanged.
- No DB migration, no backend change.

## Test plan
- [ ] Vercel preview loads
- [ ] /barcelona - click the address → opens Google Maps search for the address with a working pin (no "page isn't available")
- [ ] An event with a canonical `ChIJ` place_id (e.g. /losangeles or any recent US event) - click the address → still opens the canonical place card

🤖 Generated with [Claude Code](https://claude.com/claude-code)