### PR TITLE
fix(oregano-44102): prevent duplicate checklist item seed race

### DIFF
--- a/backend/src/routes/checklist.routes.ts
+++ b/backend/src/routes/checklist.routes.ts
@@ -176,26 +176,35 @@ router.post('/:partyId/checklist/seed', async (req: AuthRequest, res: Response, 
       return;
     }
 
-    // Delete stale defaults if any (preserves custom items)
-    if (existingDefaults > 0) {
-      await prisma.checklistItem.deleteMany({
-        where: { partyId, isDefault: true },
-      });
-    }
+    // Seed defaults transactionally with row-by-row ON CONFLICT DO NOTHING.
+    // The partial unique index `checklist_items_party_default_name_unique`
+    // on (party_id, name) WHERE is_default = true guarantees that concurrent
+    // seeders cannot both insert the same default row.
+    try {
+      await prisma.$transaction(async (tx) => {
+        // Delete stale defaults if any (preserves custom items).
+        // Only triggers when an earlier partial seed exists (count > 0 but < expected).
+        if (existingDefaults > 0 && existingDefaults < defaults.length) {
+          await tx.checklistItem.deleteMany({
+            where: { partyId, isDefault: true },
+          });
+        }
 
-    // Seed from checklist_defaults table
-    await prisma.checklistItem.createMany({
-      data: defaults.map(d => ({
-        partyId,
-        name: d.name,
-        dueDate: d.due_date,
-        isAuto: d.is_auto,
-        autoRule: d.auto_rule,
-        linkTab: d.link_tab,
-        sortOrder: d.sort_order,
-        isDefault: true,
-      })),
-    });
+        for (const d of defaults) {
+          await tx.$executeRaw`
+            INSERT INTO checklist_items
+              (id, party_id, name, due_date, is_auto, auto_rule, link_tab, sort_order, is_default, created_at, updated_at)
+            VALUES
+              (gen_random_uuid(), ${partyId}::uuid, ${d.name}, ${d.due_date}, ${d.is_auto},
+               ${d.auto_rule}, ${d.link_tab}, ${d.sort_order}, true, now(), now())
+            ON CONFLICT ON CONSTRAINT checklist_items_party_default_name_unique DO NOTHING
+          `;
+        }
+      });
+    } catch (err: any) {
+      // P2002 = unique violation; another concurrent seeder won. Fall through to re-fetch.
+      if (err?.code !== 'P2002') throw err;
+    }
 
     const items = await prisma.checklistItem.findMany({
       where: { partyId },

--- a/backend/src/routes/checklist.routes.ts
+++ b/backend/src/routes/checklist.routes.ts
@@ -197,7 +197,7 @@ router.post('/:partyId/checklist/seed', async (req: AuthRequest, res: Response, 
             VALUES
               (gen_random_uuid(), ${partyId}::uuid, ${d.name}, ${d.due_date}, ${d.is_auto},
                ${d.auto_rule}, ${d.link_tab}, ${d.sort_order}, true, now(), now())
-            ON CONFLICT ON CONSTRAINT checklist_items_party_default_name_unique DO NOTHING
+            ON CONFLICT (party_id, name) WHERE is_default = true DO NOTHING
           `;
         }
       });

--- a/plans/oregano-44102-checklist-seed-race.md
+++ b/plans/oregano-44102-checklist-seed-race.md
@@ -1,0 +1,20 @@
+# oregano-44102 — Fix duplicate checklist item seed race
+
+**Priority:** P0 — visible on 3 prod events (Auckland 32/32, Utete Rufiji, Jinja) and a latent landmine for every new GPP host.
+
+## Problem
+Dashboard checklist renders every default item twice on some events. DB has 32 rows with is_default=true, 16 distinct names, two timestamps ~19ms apart per party.
+
+## Root cause
+`POST /:partyId/checklist/seed` in backend/src/routes/checklist.routes.ts does check-then-insert with no DB-level guard. Concurrent calls insert defaults twice. Both `GPPDashboardTab.tsx` and `ChecklistTab.tsx` call seedChecklist() on first load.
+
+## Fix
+1. Migration `supabase/migrations/20260520_oregano_44102_checklist_default_unique.sql` — dedup existing duplicates + add partial unique index `(party_id, name) WHERE is_default = true`.
+2. Backend: swap `createMany` for row-by-row `INSERT ... ON CONFLICT DO NOTHING` inside a `prisma.$transaction`. Catch Prisma P2002 and re-fetch instead of 500ing.
+
+## Files
+- backend/src/routes/checklist.routes.ts
+- supabase/migrations/20260520_oregano_44102_checklist_default_unique.sql (new)
+
+## Order of operations
+Apply migration to prod BEFORE deploying backend (migration is idempotent + does dedup in same txn as index creation, so prod stays consistent).

--- a/supabase/migrations/20260520_oregano_44102_checklist_default_unique.sql
+++ b/supabase/migrations/20260520_oregano_44102_checklist_default_unique.sql
@@ -1,0 +1,31 @@
+-- oregano-44102: prevent duplicate default checklist items per party.
+--
+-- Background: POST /:partyId/checklist/seed was a check-then-insert with no
+-- DB-level guard. Two concurrent calls inserted defaults twice. Three parties
+-- in prod currently have 32 default rows instead of 16.
+--
+-- This migration:
+--   1. Dedups existing duplicates, preferring any completed row, then lowest id.
+--   2. Adds a partial unique index on (party_id, name) WHERE is_default = true,
+--      so future races fail-safe via ON CONFLICT in the seed handler.
+
+BEGIN;
+
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY party_id, name
+      ORDER BY completed DESC, id ASC
+    ) AS rn
+  FROM checklist_items
+  WHERE is_default = true
+)
+DELETE FROM checklist_items
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX IF NOT EXISTS checklist_items_party_default_name_unique
+  ON checklist_items (party_id, name)
+  WHERE is_default = true;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Three prod GPP events (Auckland, Utete Rufiji, Jinja) have 32 default checklist rows instead of 16 because two concurrent `POST /:partyId/checklist/seed` calls both pass the check-then-insert idempotency gate and both `createMany` defaults ~19ms apart.
- Adds a partial unique index on `checklist_items(party_id, name) WHERE is_default = true` and rewrites the seed handler as a `prisma.$transaction` of row-by-row `INSERT ... ON CONFLICT ON CONSTRAINT checklist_items_party_default_name_unique DO NOTHING`. The loser of a race still gets a clean 201 with the canonical row set.
- Migration dedups the existing duplicate rows (preferring any completed row, then lowest id) before creating the index, so prod stays consistent the moment the index lands.

## Order of operations
1. Review + merge this PR.
2. Apply `supabase/migrations/20260520_oregano_44102_checklist_default_unique.sql` to prod via the Supabase dashboard. The migration is a single transaction: dedup then add index.
3. Deploy backend from master via the master-deploy worktree.

Step 2 must run before step 3, otherwise the new backend would 23505 on the bare table. Doing 2 before 3 is safe because the old backend still works against a deduped+indexed table (single-call seeds never violate the index; double-call seeds would 23505 the loser, but the old check-then-insert path makes a second concurrent call very rare in practice and the existing 500 path is no worse than today).

## Vercel preview
`https://rsvpizza-git-oregano-44102-checklist-seed-race-pizza-dao.vercel.app`
Branch is 33 chars, total subdomain is 56 chars (under the 63-char DNS limit).

## Test plan
- [ ] Apply migration to prod and confirm Auckland/Utete Rufiji/Jinja now show 16/16 default rows.
- [ ] On a fresh GPP host event, load `GPPDashboardTab` and `ChecklistTab` near-simultaneously; verify only 16 default rows are created.
- [ ] Manual concurrent-seed test in psql or via two parallel curl calls — both calls should 201 with the same 16 rows; no 500s, no duplicates.
- [ ] Confirm idempotent re-seed (calling `/seed` twice) still returns 201 with 16 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)