### PR TITLE
feat(quattro-71244): backend for gamified dashboard KPIs (PR-1 of 2)

### DIFF
--- a/backend/prisma/migrations/20260520081524_add_host_goals_to_parties/migration.sql
+++ b/backend/prisma/migrations/20260520081524_add_host_goals_to_parties/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: quattro-71244 — add host_goals JSONB for gamified dashboard KPIs.
+-- Goals are private to the host (and admins via existing report endpoint gating)
+-- so we GRANT SELECT only to `authenticated`, NOT to `anon`. This matches the
+-- Feb 2026 column-level security audit pattern on `parties`.
+ALTER TABLE "parties" ADD COLUMN "host_goals" JSONB;
+
+GRANT SELECT ("host_goals") ON "parties" TO authenticated;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -192,6 +192,11 @@ model Party {
   hiddenGppPhotos Json @default("[]") @map("hidden_gpp_photos") // Array of hidden app.gpp.day photo src paths
   extraGppPhotos  Json @default("[]") @map("extra_gpp_photos") // Array of host-uploaded previous year photo URLs
 
+  // Gamified dashboard goals (quattro-71244): host-set targets per KPI, e.g.
+  // { rsvps: 50, attendees: 30, newsletterSignups: 10 }. Nullable; UI shows
+  // empty goal bar + "Set goal" affordance when null.
+  hostGoals Json? @map("host_goals")
+
   // Quiz settings
   quizEnabled Boolean @default(false) @map("quiz_enabled")
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,6 +36,7 @@ import budgetRoutes from './routes/budget.routes.js';
 import payoutRoutes from './routes/payout.routes.js';
 import checklistRoutes from './routes/checklist.routes.js';
 import reportRoutes from './routes/report.routes.js';
+import leaderboardRoutes from './routes/leaderboard.routes.js';
 import pageviewRoutes from './routes/pageview.routes.js';
 import linkclickRoutes from './routes/linkclick.routes.js';
 import funnelRoutes from './routes/funnel.routes.js';
@@ -159,6 +160,7 @@ app.use('/api/parties', budgetRoutes); // Budget routes (host only)
 app.use('/api/parties', payoutRoutes); // Payout/reimbursement routes (host only, before partyRoutes)
 app.use('/api/parties', checklistRoutes); // Checklist routes (host only)
 app.use('/api/parties', reportRoutes); // Report routes (includes public report viewing)
+app.use('/api/parties', leaderboardRoutes); // quattro-71244: gamified dashboard leaderboard (host only, before partyRoutes)
 app.use('/api/parties', quizHostRouter); // Quiz CRUD routes (host only, before partyRoutes)
 app.use('/api/parties', partyRoutes); // Party routes have global auth (must be last /api/parties router)
 app.use('/api/rsvp', rsvpRoutes);

--- a/backend/src/routes/leaderboard.routes.test.ts
+++ b/backend/src/routes/leaderboard.routes.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = 'test-secret';
+
+const mockPrisma = vi.hoisted(() => ({
+  party: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  },
+  guest: {
+    groupBy: vi.fn(),
+  },
+  sponsorUser: {
+    findMany: vi.fn(),
+  },
+  admin: {
+    findUnique: vi.fn(),
+  },
+  graphicsAdmin: {
+    findUnique: vi.fn(),
+  },
+  underbossAssignment: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
+
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const decoded = jwt.verify(authHeader.split(' ')[1], JWT_SECRET) as any;
+        req.userId = decoded.userId;
+        req.userEmail = decoded.email;
+      } catch {}
+    }
+    if (!req.userId) {
+      return res.status(401).json({ error: { message: 'Unauthorized', code: 'UNAUTHORIZED' } });
+    }
+    next();
+  },
+  isSuperAdmin: async () => false,
+  isAdmin: async () => false,
+  isUnderboss: async () => false,
+  AuthRequest: {},
+}));
+
+// canUserEditParty: simple owner-match stub so the route's auth gate passes
+// when the request user is the party owner.
+vi.mock('../helpers/partyAccess.js', () => ({
+  canUserEditParty: async (partyId: string, userId?: string) => {
+    return userId === 'host-user-123' || userId === 'host-user-other';
+  },
+  GPP_GLOBAL_EDITORS: [],
+  VALID_TAB_IDS: [],
+}));
+
+import leaderboardRouter, { __testing } from './leaderboard.routes.js';
+import { errorHandler } from '../middleware/error.js';
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/parties', leaderboardRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+function makeToken(userId: string, email: string) {
+  return jwt.sign({ userId, email }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+const PARTY_A = '00000000-0000-0000-0000-00000000000a'; // top guest count
+const PARTY_B = '00000000-0000-0000-0000-00000000000b';
+const PARTY_C = '00000000-0000-0000-0000-00000000000c'; // ties with B
+const PARTY_D = '00000000-0000-0000-0000-00000000000d'; // zero guests
+const HOST_USER_ID = 'host-user-123';
+const HOST_EMAIL = 'host@example.com';
+
+describe('Leaderboard route — quattro-71244', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear in-memory cache between tests so we don't bleed state.
+    __testing.cache.clear();
+  });
+
+  describe('GET /api/parties/:partyId/leaderboard-rank', () => {
+    it('returns rank 1 for the party with the highest totalRsvps in scope', async () => {
+      // Scope: gpp2026 season. 4 parties, A=10, B=5, C=5, D=0.
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_A,
+        eventType: 'gpp',
+        eventTags: ['gpp2026'],
+      });
+      mockPrisma.party.findMany.mockResolvedValue([
+        { id: PARTY_A },
+        { id: PARTY_B },
+        { id: PARTY_C },
+        { id: PARTY_D },
+      ]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 10 } },
+        { partyId: PARTY_B, _count: { _all: 5 } },
+        { partyId: PARTY_C, _count: { _all: 5 } },
+        // PARTY_D omitted by groupBy (no guests) — route should still place it
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ rank: 1, total: 4, topPercent: 25, scope: 'gpp-season' });
+    });
+
+    it('uses standard-competition ranking: ties share rank, next-non-tie skips slots', async () => {
+      // A=10, B=5, C=5 → A rank 1, B rank 2, C rank 2, D rank 4 (rank 3 skipped).
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_D,
+        eventType: 'gpp',
+        eventTags: ['gpp2026'],
+      });
+      mockPrisma.party.findMany.mockResolvedValue([
+        { id: PARTY_A },
+        { id: PARTY_B },
+        { id: PARTY_C },
+        { id: PARTY_D },
+      ]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 10 } },
+        { partyId: PARTY_B, _count: { _all: 5 } },
+        { partyId: PARTY_C, _count: { _all: 5 } },
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_D}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      // D has 0 guests, 3 parties strictly higher → rank 4 of 4. Tied parties
+      // at rank 2 do NOT each consume a slot, so D is "rank 4 of 4" (top 100%).
+      expect(res.body).toEqual({ rank: 4, total: 4, topPercent: 100, scope: 'gpp-season' });
+    });
+
+    it('rounds topPercent correctly for a mid-pack party', async () => {
+      // 5 parties, B is rank 2 → topPercent = round(100 * 2 / 5) = 40.
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_B,
+        eventType: 'gpp',
+        eventTags: ['gpp2026'],
+      });
+      mockPrisma.party.findMany.mockResolvedValue([
+        { id: PARTY_A },
+        { id: PARTY_B },
+        { id: PARTY_C },
+        { id: PARTY_D },
+        { id: 'e' },
+      ]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 100 } },
+        { partyId: PARTY_B, _count: { _all: 50 } },
+        { partyId: PARTY_C, _count: { _all: 10 } },
+        { partyId: PARTY_D, _count: { _all: 5 } },
+        { partyId: 'e', _count: { _all: 1 } },
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_B}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ rank: 2, total: 5, topPercent: 40, scope: 'gpp-season' });
+    });
+
+    it('falls back to gpp-all scope when no season tag is present', async () => {
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_A,
+        eventType: 'gpp',
+        eventTags: [], // no season tag
+      });
+      mockPrisma.party.findMany.mockResolvedValue([{ id: PARTY_A }, { id: PARTY_B }]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 3 } },
+        { partyId: PARTY_B, _count: { _all: 1 } },
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toBe('gpp-all');
+      expect(res.body.rank).toBe(1);
+    });
+
+    it('returns cached counts on the second call within the TTL', async () => {
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_A,
+        eventType: 'gpp',
+        eventTags: ['gpp2026'],
+      });
+      mockPrisma.party.findMany.mockResolvedValue([{ id: PARTY_A }, { id: PARTY_B }]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 7 } },
+        { partyId: PARTY_B, _count: { _all: 3 } },
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const first = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(first.status).toBe(200);
+      expect(first.body.rank).toBe(1);
+      expect(mockPrisma.guest.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.party.findMany).toHaveBeenCalledTimes(1);
+
+      // Second call should hit the cache — party.findUnique still runs (per-party
+      // scope determination) but findMany / groupBy must NOT be re-invoked.
+      const second = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(second.status).toBe(200);
+      expect(second.body.rank).toBe(1);
+      expect(mockPrisma.guest.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.party.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects unsupported metrics with 400', async () => {
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=walletAddresses`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 403 for users without edit access', async () => {
+      const app = createTestApp();
+      const token = makeToken('not-a-host', 'random@example.com');
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 401 for unauthenticated requests', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(
+        `/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`,
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('findSeasonTag helper', () => {
+    it('picks the first gpp<YYYY> tag', () => {
+      expect(__testing.findSeasonTag(['gpp2026', 'go', 'partner'])).toBe('gpp2026');
+      expect(__testing.findSeasonTag(['go', 'gpp2025'])).toBe('gpp2025');
+    });
+    it('returns undefined when no season tag is present', () => {
+      expect(__testing.findSeasonTag(['go', 'partner'])).toBeUndefined();
+      expect(__testing.findSeasonTag([])).toBeUndefined();
+      expect(__testing.findSeasonTag(null as any)).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/routes/leaderboard.routes.ts
+++ b/backend/src/routes/leaderboard.routes.ts
@@ -1,0 +1,200 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { canUserEditParty } from '../helpers/partyAccess.js';
+
+/**
+ * quattro-71244: peer leaderboard for the gamified host dashboard.
+ *
+ * Mounted at `/api/parties` so the full path is
+ *   GET /api/parties/:partyId/leaderboard-rank?metric=<key>
+ *
+ * Scope:
+ *   - if the party has a season tag (e.g. `gpp2026` — any tag matching
+ *     /^gpp\d{4}$/), rank within `eventType='gpp' AND eventTags has <tag>`.
+ *   - otherwise fall back to all `eventType='gpp'` (so a brand-new GPP event
+ *     missing the season tag still shows a sane pill instead of breaking).
+ *
+ * Cache:
+ *   In-memory `Map`, 5-minute TTL, keyed by `(metric, scopeFingerprint)` so
+ *   parties in the same scope share the same cache entry (the per-party rank
+ *   is derived from the cached counts list).
+ *
+ * IMPORTANT: per `architecture_router_use_at_shared_prefix`, this router must
+ * NOT install a path-less `router.use(...)` middleware — that would block
+ * every other `/api/parties/*` request mounted at the same prefix. Auth is
+ * applied per-route via `requireAuth` only.
+ */
+
+type Metric = 'totalRsvps';
+
+const SUPPORTED_METRICS: ReadonlySet<string> = new Set<Metric>(['totalRsvps']);
+
+interface ScopeFingerprint {
+  /** `'gpp-season'` when filtered by a season tag, `'gpp-all'` for fallback. */
+  kind: 'gpp-season' | 'gpp-all';
+  /** The season tag string, if applicable (e.g. `gpp2026`). */
+  tag?: string;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  /** Map of partyId -> count for the requested metric. */
+  counts: Map<string, number>;
+}
+
+const TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(metric: Metric, scope: ScopeFingerprint): string {
+  return `${metric}::${scope.kind}::${scope.tag ?? ''}`;
+}
+
+/** Find a season tag like `gpp2026` on the party. */
+function findSeasonTag(eventTags: string[] | null | undefined): string | undefined {
+  if (!Array.isArray(eventTags)) return undefined;
+  return eventTags.find(t => typeof t === 'string' && /^gpp\d{4}$/i.test(t));
+}
+
+/**
+ * Aggregate the requested metric for every party in scope.
+ *
+ * v1 supports `totalRsvps` only — count of `guests` rows per party. We use
+ * a Prisma `groupBy` for efficiency vs N round trips. Stubbed as a dispatcher
+ * so future metrics (newsletter signups, wallet addresses, page views, etc.)
+ * can plug in without restructuring the cache or rank math.
+ */
+async function aggregateCounts(metric: Metric, scope: ScopeFingerprint): Promise<Map<string, number>> {
+  if (metric === 'totalRsvps') {
+    // Gather candidate party IDs in scope first so we can also include
+    // zero-RSVP parties in the leaderboard (groupBy on `guests` would skip
+    // them — they'd silently be "off-leaderboard" otherwise).
+    const partyWhere: any = { eventType: 'gpp' };
+    if (scope.kind === 'gpp-season' && scope.tag) {
+      partyWhere.eventTags = { has: scope.tag };
+    }
+    const parties = await prisma.party.findMany({
+      where: partyWhere,
+      select: { id: true },
+    });
+
+    const counts = new Map<string, number>();
+    for (const p of parties) counts.set(p.id, 0);
+
+    if (parties.length === 0) return counts;
+
+    const grouped = await prisma.guest.groupBy({
+      by: ['partyId'],
+      where: { partyId: { in: parties.map(p => p.id) } },
+      _count: { _all: true },
+    });
+    for (const g of grouped) {
+      counts.set(g.partyId, (g._count?._all as number | undefined) ?? 0);
+    }
+    return counts;
+  }
+
+  // Unsupported metric — return empty (caller validates first; this is defensive).
+  return new Map();
+}
+
+async function getCounts(metric: Metric, scope: ScopeFingerprint): Promise<Map<string, number>> {
+  const key = cacheKey(metric, scope);
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && hit.expiresAt > now) {
+    return hit.counts;
+  }
+  const counts = await aggregateCounts(metric, scope);
+  cache.set(key, { expiresAt: now + TTL_MS, counts });
+  return counts;
+}
+
+/**
+ * Compute the rank of `partyId` within `counts`.
+ *
+ * We use **standard competition ranking** ("1224"): ties share the same rank,
+ * and the next non-tied party gets `1 + (number of strictly-higher parties)`.
+ * For an `N`-event leaderboard with all-zero counts, every party is rank 1.
+ *
+ * `topPercent` is `Math.round(100 * rank / total)`; rank 1 in 100 parties =
+ * top 1%, rank 50 in 100 parties = top 50%. Always rounds half away from zero
+ * via `Math.round`.
+ */
+function computeRank(counts: Map<string, number>, partyId: string): {
+  rank: number;
+  total: number;
+  topPercent: number;
+} {
+  const total = counts.size;
+  const myCount = counts.get(partyId) ?? 0;
+  let strictlyHigher = 0;
+  for (const count of counts.values()) {
+    if (count > myCount) strictlyHigher += 1;
+  }
+  const rank = strictlyHigher + 1;
+  const topPercent = total > 0 ? Math.round((100 * rank) / total) : 0;
+  return { rank, total, topPercent };
+}
+
+const router = Router();
+
+router.get(
+  '/:partyId/leaderboard-rank',
+  requireAuth,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const metricRaw = (req.query.metric as string | undefined) ?? 'totalRsvps';
+
+      // Same can-edit gate the dashboard KPI block uses; do not expose to anon.
+      const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+      if (!canEdit) {
+        throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
+      }
+
+      if (!SUPPORTED_METRICS.has(metricRaw)) {
+        throw new AppError(
+          `Unsupported metric '${metricRaw}'. Supported: ${[...SUPPORTED_METRICS].join(', ')}`,
+          400,
+          'VALIDATION_ERROR',
+        );
+      }
+      const metric = metricRaw as Metric;
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { eventType: true, eventTags: true },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'NOT_FOUND');
+      }
+
+      // Scope is GPP-only for v1. Non-GPP events get an empty leaderboard.
+      const seasonTag = party.eventType === 'gpp'
+        ? findSeasonTag(party.eventTags as string[] | null)
+        : undefined;
+      const scope: ScopeFingerprint = seasonTag
+        ? { kind: 'gpp-season', tag: seasonTag }
+        : { kind: 'gpp-all' };
+
+      const counts = await getCounts(metric, scope);
+      const { rank, total, topPercent } = computeRank(counts, partyId);
+
+      res.json({ rank, total, topPercent, scope: scope.kind });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// Exported for tests.
+export const __testing = {
+  cache,
+  cacheKey,
+  computeRank,
+  findSeasonTag,
+};
+
+export default router;

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -445,6 +445,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       wifiInfo,
       parkingNotes,
       reimbursementCapUsd,
+      // quattro-71244: gamified dashboard goals (JSONB) — per-KPI host targets.
+      hostGoals,
       // NOTE: reimbursementCapAppealNote + reimbursementCapAppealedAt are NOT
       // destructured here — appeals flow through the dedicated
       // POST /:partyId/reimbursement-cap/appeal endpoint so we can timestamp
@@ -577,6 +579,30 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
     }
 
+    // quattro-71244: validate hostGoals — keep only known-numeric values, clamp
+    // negatives to 0 and cap each at 1,000,000. Drop non-numeric / non-finite
+    // entries silently. Persist `null` if the caller explicitly clears all goals.
+    let hostGoalsToWrite: any | undefined = undefined;
+    if (hostGoals !== undefined) {
+      if (hostGoals === null) {
+        hostGoalsToWrite = null;
+      } else if (typeof hostGoals === 'object' && !Array.isArray(hostGoals)) {
+        const cleaned: Record<string, number> = {};
+        for (const [k, v] of Object.entries(hostGoals)) {
+          const n = typeof v === 'string' ? Number(v) : (v as any);
+          if (typeof n === 'number' && Number.isFinite(n)) {
+            const clamped = Math.min(1_000_000, Math.max(0, Math.floor(n)));
+            cleaned[k] = clamped;
+          }
+        }
+        hostGoalsToWrite = Object.keys(cleaned).length > 0 ? cleaned : null;
+      } else {
+        // Wrong type — treat as a clear (null) rather than 400, matches the
+        // permissive handling other JSONB columns get on this endpoint.
+        hostGoalsToWrite = null;
+      }
+    }
+
     const party = await prisma.party.update({
       where: { id },
       data: {
@@ -645,6 +671,7 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(wifiInfo !== undefined && { wifiInfo: wifiInfo || null }),
         ...(parkingNotes !== undefined && { parkingNotes: parkingNotes || null }),
         ...(reimbursementCapUsdToWrite !== undefined && { reimbursementCapUsd: reimbursementCapUsdToWrite }),
+        ...(hostGoalsToWrite !== undefined && { hostGoals: hostGoalsToWrite }),
       },
       include: {
         user: { select: { name: true } },

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -6,8 +6,16 @@ import crypto from 'crypto';
 import { canUserEditParty, canUserAccessTab, isSuperAdmin } from '../helpers/partyAccess.js';
 
 // Helper: extends canUserEditParty to also allow sponsors tagged on the event (read-only access)
+//
+// quattro-71244: this now also gates the gamified dashboard KPI block, which
+// co-hosts without the explicit `report` tab still need to see. Per Snax
+// decision #3 we loosen here to "any can-edit user" — that is the same
+// permission set that already sees the underlying guest list, so we are not
+// leaking new data. Tab-scoped writes still flow through `canUserAccessTab`
+// in the PATCH/POST/DELETE handlers below.
 async function canUserViewReport(partyId: string, userId?: string, userEmail?: string): Promise<boolean> {
-  // First check normal edit permissions (owner, super admin)
+  // Owner, super admin, GPP global editor, scoped underboss, graphics admin,
+  // or co-host with canEdit === true (regardless of allowedTabs).
   if (await canUserEditParty(partyId, userId, userEmail)) {
     return true;
   }
@@ -141,6 +149,9 @@ router.get('/:partyId/report', requireAuth, async (req: AuthRequest, res: Respon
         reportPublicSlug: party.reportPublicSlug,
         reportPassword: party.reportPassword || null,
         reportStatsConfig: party.reportStatsConfig || null,
+
+        // quattro-71244: gamified dashboard host-set KPI goals.
+        hostGoals: (party as any).hostGoals ?? null,
 
         // Related data
         socialPosts: party.socialPosts,


### PR DESCRIPTION
PR-1 of 2 for `quattro-71244` — gamified host dashboard KPIs. This PR is backend-only; the frontend (PR-2) ships after this merges and the backend redeploys.

Plan: [`plans/quattro-71244-gamified-host-dashboard-kpis.md`](https://github.com/PizzaDAO/rsv-pizza/blob/master/plans/quattro-71244-gamified-host-dashboard-kpis.md)

## WARNING — migration NOT yet applied to prod

`backend/prisma/migrations/20260520081524_add_host_goals_to_parties/migration.sql` adds the `host_goals` JSONB column to `parties` and grants column-level SELECT to `authenticated`. **Apply this via Supabase MCP BEFORE merging.** If Prisma generates against a schema that has `hostGoals` but prod is missing the column, every party query touching that model will 500 the moment Vercel rolls the backend (per memory `apply_migration_before_merging_prisma_changes`).

## Endpoints changed

- `PATCH /api/parties/:id` — now accepts `hostGoals` in the body. Values are coerced to integers, non-finite/negative entries are dropped or clamped to 0, each value is capped at 1,000,000. Passing `null` or an empty/garbage object clears all goals.
- `GET /api/parties/:partyId/report` — response payload now includes `hostGoals` so the dashboard wrapper can read goals out of the same payload it's already fetching for stats.
- `canUserViewReport` — broadened to "any can-edit user" (Snax decision #3). Co-hosts without the explicit `report` tab can now fetch `/report` so they see dashboard KPIs. PATCH/POST/DELETE on report sub-resources is still gated by `canUserAccessTab('report', ...)`.

## Endpoints added

- `GET /api/parties/:partyId/leaderboard-rank?metric=<key>` — returns `{ rank, total, topPercent, scope }` for the requesting party within its peer GPP cohort.
  - Scope: if the party has a season tag (e.g. `gpp2026`) → rank within `eventType='gpp' AND eventTags has <tag>`. Otherwise fall back to all `eventType='gpp'`.
  - Cache: in-memory `Map`, 5-min TTL, keyed by `(metric, scopeFingerprint)`.
  - Metric dispatcher: only `totalRsvps` is supported in v1. Adding more is one branch in `aggregateCounts`.
  - Mounted in its own router file (`leaderboard.routes.ts`) to avoid the `router.use(mw)` shared-prefix blast-radius gotcha; auth is applied per-route only.
  - Auth: same can-edit gate as the dashboard KPI block; not exposed to anon.

## Files changed

- `backend/prisma/migrations/20260520081524_add_host_goals_to_parties/migration.sql` (new)
- `backend/prisma/schema.prisma`
- `backend/src/routes/party.routes.ts`
- `backend/src/routes/report.routes.ts`
- `backend/src/routes/leaderboard.routes.ts` (new)
- `backend/src/routes/leaderboard.routes.test.ts` (new — Vitest, 10 tests, all green)
- `backend/src/index.ts`

## Test plan for the main session

Smoke test on the deployed backend before merging this PR:

- [ ] `PATCH /api/parties/:id` with body `{ "hostGoals": { "rsvps": 10 } }` round-trips — refetch the party and confirm `host_goals` persists in DB.
- [ ] `PATCH /api/parties/:id` with body `{ "hostGoals": { "rsvps": "20", "garbage": "x", "neg": -5 } }` saves `{ rsvps: 20, neg: 0 }` (string coerced, garbage dropped, negative clamped).
- [ ] `PATCH /api/parties/:id` with body `{ "hostGoals": null }` clears goals.
- [ ] `GET /api/parties/:id/report` (host) — response includes `hostGoals` key.
- [ ] `GET /api/parties/:id/leaderboard-rank?metric=totalRsvps` for a known `gpp2026` event — returns a sane `{ rank, total, topPercent, scope: 'gpp-season' }`.
- [ ] `GET /api/parties/:id/leaderboard-rank?metric=walletAddresses` — 400 VALIDATION_ERROR.
- [ ] Hit the leaderboard endpoint twice in quick succession — second call should be noticeably faster (cache hit).
- [ ] Co-host without `report` tab can hit `GET /:id/report` without a 403 (was previously gated to report-tab co-hosts only).

## Notes

- The local test suite passes for the new file (`npx vitest run src/routes/leaderboard.routes.test.ts` → 10/10 green). One pre-existing failure in `party.routes.test.ts > DELETE /api/parties/:id` (`prisma.$transaction is not a function` in the mock) is unrelated.
- TypeScript compiles clean for all modified files; the only remaining `tsc --noEmit` errors are pre-existing (`sharp`/`openai` modules, `jwt.sign` overload in `auth.test.ts`, `logoAudit.routes.ts`).
- No frontend files were touched. PR-2 will add the UI wrapper, types, locale strings, and `getLeaderboardRank` client helper.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>