### PR TITLE
feat(arugula-38633): payment method + receipts now optional

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1479,7 +1479,9 @@ model Payout {
   finalAmountUsd      Decimal   @map("final_amount_usd") @db.Decimal(12, 2)
 
   status              String    @default("pending")
-  payoutMethod        String    @map("payout_method")
+  // arugula-38633 v3 follow-up: optional — hosts can submit a payout with
+  // just an amount; admin nags the host for payment details before execute.
+  payoutMethod        String?   @map("payout_method")
 
   payoutWalletAddress String?   @map("payout_wallet_address")
   payoutBankDetails   Json?     @map("payout_bank_details")

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -471,7 +471,7 @@ router.get(
           escapeCSV(r.id),
           escapeCSV(r.createdAt.toISOString()),
           escapeCSV(r.status),
-          escapeCSV(r.payoutMethod),
+          escapeCSV(r.payoutMethod ?? ''),
           escapeCSV(r.host?.name || ''),
           escapeCSV(r.host?.email || ''),
           escapeCSV(r.party?.name || ''),
@@ -729,7 +729,10 @@ router.get(
 
       for (const r of allFiltered) {
         byStatus[r.status] = (byStatus[r.status] || 0) + 1;
-        byMethod[r.payoutMethod] = (byMethod[r.payoutMethod] || 0) + 1;
+        // arugula-38633 v3 follow-up: bucket null methods under 'unset' so the
+        // dashboard pills don't drop them from the count.
+        const methodKey = r.payoutMethod ?? 'unset';
+        byMethod[methodKey] = (byMethod[methodKey] || 0) + 1;
         const usd = Number(r.finalAmountUsd);
         sumUsd += usd;
         if (r.status === 'pending') {
@@ -1255,6 +1258,19 @@ async function executePayout(params: {
   }
 
   const finalAmountUsd = Number(existing.finalAmountUsd);
+
+  // arugula-38633 v3 follow-up: payout_method can be null when the host
+  // submitted before setting their payment details. Block execute with a
+  // clear message — admin should ask the host to set their details (or
+  // patch via PATCH /api/admin/payouts/:id).
+  if (existing.payoutMethod == null) {
+    throw new AppError(
+      'This payout has no payment method set. Ask the host to set their payment details, ' +
+        'or patch the payout method directly via PATCH /api/admin/payouts/:id.',
+      400,
+      'MISSING_PAYOUT_METHOD',
+    );
+  }
 
   if (existing.payoutMethod === 'usdc_base') {
     if (!existing.payoutWalletAddress) {

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -341,8 +341,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       validatedAttendance = n;
     }
 
-    if (!Array.isArray(receiptPhotos) || receiptPhotos.length === 0) {
-      throw new AppError('At least one receipt photo is required', 400, 'NO_RECEIPTS');
+    // arugula-38633 v3 follow-up: receipts are now optional. If the host
+    // submits with no receipts, we use `finalAmountUsd` as the source of
+    // truth and default FX fields to USD passthrough below.
+    if (!Array.isArray(receiptPhotos)) {
+      throw new AppError('receiptPhotos must be an array', 400, 'INVALID_RECEIPTS');
     }
     if (!Array.isArray(pizzaPhotos)) {
       throw new AppError('pizzaPhotos must be an array', 400, 'INVALID_PIZZA_PHOTOS');
@@ -353,9 +356,26 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     if (pizzaPhotos.length > 10) {
       throw new AppError('Max 10 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
     }
+    // When zero receipts are supplied, finalAmountUsd MUST be a positive number.
+    if (
+      receiptPhotos.length === 0
+      && (typeof finalAmountUsd !== 'number' || !(finalAmountUsd > 0))
+    ) {
+      throw new AppError(
+        'finalAmountUsd is required (and must be > 0) when no receipts are uploaded',
+        400,
+        'NO_AMOUNT',
+      );
+    }
 
-    validatePayoutMethod(payoutMethod);
-    validateMethodSpecificFields(payoutMethod, { payoutWalletAddress, payoutBankDetails });
+    // arugula-38633 v3 follow-up: payoutMethod is now optional. When the
+    // host hasn't set their payment details yet, the payout persists with
+    // payout_method=NULL and the admin nags before execute.
+    const hasMethod = payoutMethod !== undefined && payoutMethod !== null;
+    if (hasMethod) {
+      validatePayoutMethod(payoutMethod);
+      validateMethodSpecificFields(payoutMethod, { payoutWalletAddress, payoutBankDetails });
+    }
 
     // Validate every uploaded URL points into our bucket
     for (const r of receiptPhotos as IncomingDocument[]) {
@@ -371,23 +391,32 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       assertSupabasePayoutUrl(p.url, partyId);
     }
 
-    // OCR every receipt in parallel (Promise.allSettled so one failure doesn't kill the rest).
-    const ocrPromises = (receiptPhotos as IncomingDocument[]).map(async (r) => {
-      try {
-        const ocr = await analyzeReceipt(r.url);
-        const fx = await convertToUSD(ocr.amount, ocr.currency);
-        return { ok: true as const, doc: r, ocr, fx };
-      } catch (err: any) {
-        return { ok: false as const, doc: r, error: err?.message || 'OCR failed' };
-      }
-    });
-    const ocrResults = await Promise.allSettled(ocrPromises);
+    // arugula-38633 v3 follow-up: skip the parallel-OCR step when there are
+    // no receipts — the host supplied `finalAmountUsd` directly. FX fields
+    // collapse to USD passthrough below.
+    const ocrResults: PromiseSettledResult<
+      | { ok: true; doc: IncomingDocument; ocr: any; fx: any }
+      | { ok: false; doc: IncomingDocument; error: string }
+    >[] = receiptPhotos.length === 0
+      ? []
+      : await Promise.allSettled(
+          (receiptPhotos as IncomingDocument[]).map(async (r) => {
+            try {
+              const ocr = await analyzeReceipt(r.url);
+              const fx = await convertToUSD(ocr.amount, ocr.currency);
+              return { ok: true as const, doc: r, ocr, fx };
+            } catch (err: any) {
+              return { ok: false as const, doc: r, error: err?.message || 'OCR failed' };
+            }
+          })
+        );
 
     // Compute the OCR sum + locked exchange rate.
     // Strategy: sum the USD-converted amounts (already locked at submission time
     // via the fx call above). Use the first successful conversion's source/rate
     // as the "headline" exchangeRate + originalCurrency on the row. Per-receipt
-    // detail is preserved on the documents.
+    // detail is preserved on the documents. When there are no receipts at all,
+    // we fall back to USD passthrough using the host-supplied finalAmountUsd.
     let extractedUsdSum = 0;
     let originalAmount = 0;
     let originalCurrency = 'USD';
@@ -485,6 +514,18 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       );
     }
 
+    // arugula-38633 v3 follow-up: zero-receipts path — default the FX fields
+    // to USD passthrough using finalUsd. (extractedUsdSum stays 0; we surface
+    // finalUsd as both originalAmount and extractedAmountUsd so the row reads
+    // cleanly in the admin UI.)
+    const noReceiptsFallback = receiptPhotos.length === 0;
+    const effectiveExtractedUsd = noReceiptsFallback ? finalUsd : extractedUsdSum;
+    const effectiveOriginalAmount = noReceiptsFallback
+      ? finalUsd
+      : (originalAmount || extractedUsdSum);
+    const effectiveOriginalCurrency = noReceiptsFallback ? 'USD' : originalCurrency;
+    const effectiveExchangeRate = noReceiptsFallback ? 1 : exchangeRate;
+
     if (!req.userId) {
       throw new AppError('Authenticated user has no userId', 500, 'NO_USER_ID');
     }
@@ -494,18 +535,22 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       data: {
         partyId,
         hostUserId: req.userId,
-        originalAmount: new Decimal(originalAmount || extractedUsdSum),
-        originalCurrency,
-        exchangeRate: new Decimal(exchangeRate),
-        extractedAmountUsd: new Decimal(extractedUsdSum),
+        originalAmount: new Decimal(effectiveOriginalAmount),
+        originalCurrency: effectiveOriginalCurrency,
+        exchangeRate: new Decimal(effectiveExchangeRate),
+        extractedAmountUsd: new Decimal(effectiveExtractedUsd),
         finalAmountUsd: new Decimal(finalUsd),
         status: 'pending',
-        payoutMethod,
-        payoutWalletAddress: payoutMethod === 'usdc_base' ? (payoutWalletAddress as string).trim() : null,
-        ...(payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
+        // arugula-38633 v3 follow-up: payoutMethod is optional. Persist null
+        // when the host hasn't set their payment details yet.
+        payoutMethod: hasMethod ? payoutMethod : null,
+        payoutWalletAddress: hasMethod && payoutMethod === 'usdc_base'
+          ? (payoutWalletAddress as string).trim()
+          : null,
+        ...(hasMethod && payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
           ? { payoutBankDetails: payoutBankDetails as Prisma.InputJsonValue }
           : {}),
-        mercuryCardLast4: payoutMethod === 'mercury_card' && typeof mercuryCardLast4 === 'string'
+        mercuryCardLast4: hasMethod && payoutMethod === 'mercury_card' && typeof mercuryCardLast4 === 'string'
           ? mercuryCardLast4.slice(-4)
           : null,
         hostNotes: typeof hostNotes === 'string' && hostNotes.trim().length > 0
@@ -531,8 +576,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       }
     }
 
-    // Optional: save host defaults
-    if (saveAsDefault === true) {
+    // Optional: save host defaults. Only meaningful when a method is set —
+    // skip entirely on zero-method submissions (arugula-38633 v3 follow-up).
+    if (saveAsDefault === true && hasMethod) {
       try {
         await prisma.user.update({
           where: { id: req.userId },

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -347,7 +347,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
             {/* Payout target */}
             <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface text-sm space-y-1">
-              <h3 className="font-semibold text-theme-text mb-1">{PAYOUT_METHOD_LABELS[payout.payoutMethod]}</h3>
+              <h3 className="font-semibold text-theme-text mb-1">
+                {payout.payoutMethod
+                  ? PAYOUT_METHOD_LABELS[payout.payoutMethod]
+                  : 'Payment method not set'}
+              </h3>
+              {/* arugula-38633 v3 follow-up: when method is null, the host
+                  submitted before configuring their PaymentDetailsCard.
+                  Admin should ask them to set it (or PATCH the payout). */}
+              {payout.payoutMethod == null && (
+                <div className="text-xs text-amber-700">
+                  Host has not configured their payment details yet. Ask them to set their
+                  payment method, or edit this payment via the actions menu before executing.
+                </div>
+              )}
               {payout.payoutMethod === 'usdc_base' && payout.payoutWalletAddress && (
                 <div className="font-mono text-xs break-all text-theme-text-secondary">
                   {payout.payoutWalletAddress}
@@ -514,6 +527,16 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               <div className="rounded-xl border border-emerald-300 p-3 bg-emerald-50 text-sm space-y-2">
                 <h3 className="font-semibold text-emerald-900 mb-1">Execute payment</h3>
 
+                {/* arugula-38633 v3 follow-up: when host submitted without
+                    setting a method, execute is blocked until admin (or host)
+                    fills it in. The server returns MISSING_PAYOUT_METHOD. */}
+                {payout.payoutMethod == null && (
+                  <div className="rounded-md bg-amber-100 border border-amber-300 px-3 py-2 text-amber-900">
+                    No payment method is set on this payout. Ask the host to set their payment
+                    details, or edit this payment to set the method directly, before executing.
+                  </div>
+                )}
+
                 {payout.payoutMethod === 'usdc_base' && (
                   <div className="space-y-2">
                     <p className="text-emerald-900">
@@ -609,6 +632,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     }}
                     disabled={
                       busy ||
+                      payout.payoutMethod == null ||
                       (payout.payoutMethod === 'wire' && !execWireValid) ||
                       (payout.payoutMethod === 'mercury_card' && !execMercuryValid) ||
                       (payout.payoutMethod === 'usdc_base' && !payout.payoutWalletAddress)
@@ -616,7 +640,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
                   >
                     {busy && <Loader2 size={12} className="animate-spin" />}
-                    {payout.payoutMethod === 'usdc_base' ? 'Send Payment' :
+                    {payout.payoutMethod == null ? 'Method not set' :
+                      payout.payoutMethod === 'usdc_base' ? 'Send Payment' :
                       payout.payoutMethod === 'wire' ? 'Confirm wire sent' :
                       'Confirm card issued'}
                   </button>

--- a/frontend/src/components/payments-shared/PayoutMethodIcon.tsx
+++ b/frontend/src/components/payments-shared/PayoutMethodIcon.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { CreditCard, Banknote, Coins } from 'lucide-react';
+import { CreditCard, Banknote, Coins, HelpCircle } from 'lucide-react';
 import type { PayoutMethod } from '../../types';
 
 interface PayoutMethodIconProps {
-  method: PayoutMethod;
+  /** arugula-38633 v3 follow-up: null when the host hasn't set their payment details. */
+  method: PayoutMethod | null;
   size?: number;
   showLabel?: boolean;
   className?: string;
@@ -18,6 +19,9 @@ export const PAYOUT_METHOD_LABELS: Record<PayoutMethod, string> = {
 /**
  * Renders an icon (and optional label) for a payout method. Shared between the
  * host-facing PayoutsList (PR 3) and the admin PayoutsTable (PR 4).
+ *
+ * arugula-38633 v3 follow-up: payout method is now optional at submission
+ * time. When unset, renders a placeholder icon + "Not set" label.
  */
 export const PayoutMethodIcon: React.FC<PayoutMethodIconProps> = ({
   method,
@@ -26,14 +30,26 @@ export const PayoutMethodIcon: React.FC<PayoutMethodIconProps> = ({
   className = '',
 }) => {
   let Icon = CreditCard;
-  if (method === 'wire') Icon = Banknote;
-  else if (method === 'usdc_base') Icon = Coins;
+  let label: string = '—';
+  if (method == null) {
+    Icon = HelpCircle;
+    label = 'Not set';
+  } else if (method === 'wire') {
+    Icon = Banknote;
+    label = PAYOUT_METHOD_LABELS[method];
+  } else if (method === 'usdc_base') {
+    Icon = Coins;
+    label = PAYOUT_METHOD_LABELS[method];
+  } else {
+    // mercury_card
+    label = PAYOUT_METHOD_LABELS[method];
+  }
 
   return (
     <span className={`inline-flex items-center gap-1.5 ${className}`}>
       <Icon size={size} className="text-theme-text-secondary" />
       {showLabel && (
-        <span className="text-sm text-theme-text-secondary">{PAYOUT_METHOD_LABELS[method]}</span>
+        <span className="text-sm text-theme-text-secondary">{label}</span>
       )}
     </span>
   );

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote, BadgeDollarSign, Users, AlertCircle } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePizza } from '../../contexts/PizzaContext';
@@ -81,16 +81,17 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const [notes, setNotes] = useState('');
   const [overrideAmount, setOverrideAmount] = useState<number | null>(null);
 
-  // arugula-38633 v3: read payment method + destination from the
+  // arugula-38633 v3 (follow-up): read payment method + destination from the
   // authenticated user record (saved via PaymentDetailsCard at the top of
-  // the Payments tab). When unset, the submit button is disabled and an
-  // inline message points the host upward.
+  // the Payments tab). These are now PURELY optional at submit time — when
+  // unset, the payout persists with payout_method=NULL and admin asks the
+  // host to fill them in before execute.
   const savedMethod = user?.preferredPayoutMethod ?? null;
   const savedWallet = user?.payoutWalletAddress ?? null;
   const savedBank = user?.payoutBankDetails ?? null;
-  // Validity mirror of PaymentDetailsCard.methodValid (kept duplicated
-  // intentionally — the card may not yet have persisted a partially typed
-  // wire row when the host clicks Submit).
+  // We still gate the per-method payload (wallet for usdc, bank for wire)
+  // on a basic validity check so we don't post half-typed data. When
+  // invalid, we just don't forward the method — submit still works.
   const savedMethodValid = useMemo(() => {
     if (savedMethod == null) return false;
     if (savedMethod === 'usdc_base') {
@@ -124,7 +125,6 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   );
   const finalAmount = overrideAmount != null ? overrideAmount : ocrSum;
 
-  const hasUploadedReceipt = receipts.some(r => r.status === 'done' && r.url);
   const isProcessing = receipts.some(r => r.status === 'uploading' || r.status === 'ocring')
     || pizzaPhotos.some(p => p.status === 'uploading');
 
@@ -132,19 +132,24 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const attendanceValid = !askForAttendance
     || (estimatedAttendance != null && estimatedAttendance > 0);
 
-  const canSubmit = hasUploadedReceipt
-    && finalAmount > 0
-    && savedMethodValid
+  // arugula-38633 v3 follow-up: payment details + receipts are no longer
+  // required for submission. The submit button stays active whenever the
+  // host has entered a positive amount and nothing async is in flight.
+  const canSubmit = finalAmount > 0
     && attendanceValid
     && !isProcessing
     && !submitting;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canSubmit || !savedMethod) return;
+    if (!canSubmit) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
+      // arugula-38633 v3 follow-up: only forward the payout method (and its
+      // payload) when it's both set AND validates. Otherwise we omit it
+      // entirely so the backend persists payout_method=NULL.
+      const forwardMethod = savedMethod && savedMethodValid;
       const created = await createPayout(partyId, {
         receiptPhotos: receipts
           .filter(r => r.status === 'done' && r.url)
@@ -163,21 +168,25 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             mimeType: p.mimeType,
           })),
         hostNotes: notes.trim() || undefined,
-        // arugula-38633 v3: payout destination is sourced from the user's
-        // PaymentDetailsCard, not the form. Backend payout.routes still
-        // mirrors saveAsDefault → users.* on its end — kept for symmetry,
-        // though PaymentDetailsCard already writes them directly via PATCH
-        // /api/user/me on the host's first save.
-        payoutMethod: savedMethod,
-        ...(savedMethod === 'usdc_base' && savedWallet
-          ? { payoutWalletAddress: savedWallet.trim() }
+        ...(forwardMethod
+          ? {
+              payoutMethod: savedMethod!,
+              ...(savedMethod === 'usdc_base' && savedWallet
+                ? { payoutWalletAddress: savedWallet.trim() }
+                : {}),
+              ...(savedMethod === 'wire' && savedBank
+                ? { payoutBankDetails: savedBank }
+                : {}),
+              saveAsDefault: true,
+            }
           : {}),
-        ...(savedMethod === 'wire' && savedBank
-          ? { payoutBankDetails: savedBank }
-          : {}),
+        // arugula-38633 v3 follow-up: forward finalAmountUsd whenever the
+        // host has typed an override. Note: with zero receipts, canSubmit
+        // already requires `finalAmount > 0`, which can only come from the
+        // override (ocrSum is 0 with no receipts) — so override is always
+        // set on the no-receipts path.
         ...(overrideAmount != null ? { finalAmountUsd: overrideAmount } : {}),
         ...(estimatedAttendance != null ? { estimatedAttendance } : {}),
-        saveAsDefault: true,
       });
       onCreated(created);
     } catch (err: any) {
@@ -336,17 +345,11 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         </div>
       )}
 
-      {/* arugula-38633 v3: payout method is now configured in the
-          PaymentDetailsCard above. If the host hasn't set one yet, show an
-          inline hint and disable submit. */}
-      {!savedMethodValid && (
-        <div className="card p-4 border-l-4 border-l-amber-500 flex items-start gap-3">
-          <AlertCircle size={18} className="text-amber-500 mt-0.5 flex-shrink-0" />
-          <p className="text-sm text-theme-text">
-            Set your <span className="font-semibold">payment details</span> above before submitting a receipt.
-          </p>
-        </div>
-      )}
+      {/* arugula-38633 v3 (follow-up): the amber "set your payment details
+          above before submitting a receipt" notice was removed. Payment
+          details remain in the PaymentDetailsCard at the top of the
+          Payments tab but no longer gate submission — admin asks the host
+          for them later if absent. */}
 
       <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
         <button

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -1,20 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { X, Loader2, AlertCircle, ExternalLink } from 'lucide-react';
-import { Payout, PayoutStatus, PayoutMethod } from '../../types';
+import { Payout, PayoutStatus } from '../../types';
 import { getPayout } from '../../lib/api';
-import { methodIcon } from './PayoutListRow';
+import { methodIcon, methodLabel } from './PayoutListRow';
 
 interface PayoutDetailModalProps {
   partyId: string;
   payoutId: string;
   onClose: () => void;
 }
-
-const METHOD_LABEL: Record<PayoutMethod, string> = {
-  mercury_card: 'Mercury card',
-  wire: 'Wire transfer',
-  usdc_base: 'USDC on Base',
-};
 
 const STATUS_STYLES: Record<PayoutStatus, string> = {
   pending: 'bg-amber-500/20 text-amber-300',
@@ -121,7 +115,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 <p className="text-xs text-theme-text-muted mb-1">Payment method</p>
                 <p className="inline-flex items-center gap-2 text-theme-text font-medium">
                   {methodIcon(payout.payoutMethod)}
-                  {METHOD_LABEL[payout.payoutMethod]}
+                  {methodLabel(payout.payoutMethod)}
                 </p>
                 {payout.payoutMethod === 'usdc_base' && payout.payoutWalletAddress && (
                   <p className="text-xs text-theme-text-muted font-mono mt-1">

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Loader2, X, ChevronRight, CreditCard, Banknote, Coins, ImageOff } from 'lucide-react';
+import { Loader2, X, ChevronRight, CreditCard, Banknote, Coins, HelpCircle, ImageOff } from 'lucide-react';
 import { Payout, PayoutMethod, PayoutStatus } from '../../types';
 import { cancelPayout } from '../../lib/api';
 
@@ -32,11 +32,17 @@ const STATUS_LABEL: Record<PayoutStatus, string> = {
   failed: 'Failed',
 };
 
-export function methodIcon(method: PayoutMethod): React.ReactNode {
+// arugula-38633 v3 follow-up: helper to display a method (or "Not set" placeholder).
+export function methodLabel(method: PayoutMethod | null): string {
+  return method == null ? 'Not set' : METHOD_LABEL[method];
+}
+
+export function methodIcon(method: PayoutMethod | null): React.ReactNode {
   switch (method) {
     case 'mercury_card': return <CreditCard size={14} />;
     case 'wire':         return <Banknote size={14} />;
     case 'usdc_base':    return <Coins size={14} />;
+    default:             return <HelpCircle size={14} />;
   }
 }
 
@@ -95,7 +101,7 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
         <div className="text-xs text-theme-text-muted flex items-center gap-2 mt-0.5">
           <span className="inline-flex items-center gap-1">
             {methodIcon(payout.payoutMethod)}
-            {METHOD_LABEL[payout.payoutMethod]}
+            {methodLabel(payout.payoutMethod)}
           </span>
           <span aria-hidden>•</span>
           <span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3969,7 +3969,12 @@ export interface CreatePayoutData {
   pizzaPhotos: CreatePayoutPhotoInput[];
   receiptPhotos: CreatePayoutPhotoInput[];
   hostNotes?: string;
-  payoutMethod: PayoutMethod;
+  /**
+   * arugula-38633 v3 follow-up: optional. When omitted/null, the payout is
+   * persisted with payout_method=NULL and admin requests the host set their
+   * payment details before execute.
+   */
+  payoutMethod?: PayoutMethod | null;
   payoutWalletAddress?: string;
   payoutBankDetails?: BankDetails;
   mercuryCardLast4?: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1460,7 +1460,10 @@ export interface Payout {
   extractedAmountUsd: number;
   finalAmountUsd: number;
   status: PayoutStatus;
-  payoutMethod: PayoutMethod;
+  // arugula-38633 v3 follow-up: null when the host submitted before setting
+  // their payment details. Admin can patch later, or ask the host to set
+  // them via PaymentDetailsCard.
+  payoutMethod: PayoutMethod | null;
   payoutWalletAddress: string | null;
   payoutBankDetails: BankDetails | null;
   mercuryCardId: string | null;

--- a/supabase/migrations/20260520_payout_method_nullable.sql
+++ b/supabase/migrations/20260520_payout_method_nullable.sql
@@ -1,0 +1,13 @@
+-- arugula-38633 (v3 follow-up): make payouts.payout_method optional.
+--
+-- Hosts can now submit a payout with just an amount — payment method +
+-- receipts no longer gate submission. The DB CHECK that constrains the
+-- value set (mercury_card | wire | usdc_base) is preserved and continues
+-- to enforce the enumeration when a value IS provided. Postgres CHECKs
+-- treat NULL as "unknown" (passes), so this is the minimal change needed.
+--
+-- Rollback (if ever required): UPDATE payouts SET payout_method='wire'
+-- WHERE payout_method IS NULL; ALTER TABLE payouts ALTER COLUMN
+-- payout_method SET NOT NULL;
+
+ALTER TABLE payouts ALTER COLUMN payout_method DROP NOT NULL;


### PR DESCRIPTION
## Summary

Drops gating so hosts can submit a payment with just an amount.

- **(a) Submit button always active.** `NewPayoutForm.canSubmit` reduces to `finalAmount > 0` + processing/submitting checks. The receipt requirement (`hasUploadedReceipt`) and method requirement (`savedMethodValid`) are dropped.
- **(b) `payout_method` can now be `NULL`** in the DB + Prisma + backend POST handler. Zero-receipt submissions use `finalAmountUsd` as the source of truth (USD passthrough on the FX fields, OCR step skipped).
- **(c) Amber "Set your payment details above" notice removed** from `NewPayoutForm`.

The PaymentDetailsCard stays at the top of the Payments tab — it just no longer gates submit. Admin sees a clear "method not set" banner in the review modal + a 400 error from execute if `payout_method` is still NULL.

## CRITICAL: Migration ordering

**Apply the migration to prod BEFORE merging this PR.**

`supabase/migrations/20260520_payout_method_nullable.sql`:

```sql
ALTER TABLE payouts ALTER COLUMN payout_method DROP NOT NULL;
```

Per project memory: Prisma schema != DB schema; if the new backend code (which writes `payout_method=NULL`) ships before the migration applies, every no-method POST 500s. The CHECK that limits the value set to `mercury_card|wire|usdc_base` is preserved and continues to enforce when a value IS provided. Postgres CHECKs treat NULL as "unknown" (passes), so this is the minimal change.

Schema-drift CI is expected to fail on this PR until the migration is applied — that's the desired safety.

## Files changed

**Migration**
- `supabase/migrations/20260520_payout_method_nullable.sql` (new)

**Backend**
- `backend/prisma/schema.prisma` — `payoutMethod String?` on `Payout`
- `backend/src/routes/payout.routes.ts` — POST accepts null method + zero-receipt; OCR step skipped; FX fields default to USD passthrough on zero-receipt
- `backend/src/routes/admin-payout.routes.ts` — execute throws clear 400 (`MISSING_PAYOUT_METHOD`) when method is null; CSV export + totals null-safe

**Frontend**
- `frontend/src/types.ts` — `Payout.payoutMethod: PayoutMethod | null`
- `frontend/src/lib/api.ts` — `CreatePayoutData.payoutMethod` optional
- `frontend/src/components/payouts/NewPayoutForm.tsx` — gating dropped; amber notice removed
- `frontend/src/components/payments-shared/PayoutMethodIcon.tsx` — accepts null, renders `HelpCircle` + "Not set"
- `frontend/src/components/payouts/PayoutListRow.tsx` — added `methodLabel()` helper
- `frontend/src/components/payouts/PayoutDetailModal.tsx` — uses `methodLabel()`
- `frontend/src/components/payments-admin/PayoutReviewModal.tsx` — null-method banner + execute form blocks when method is null

## Test plan

- [ ] Apply migration to prod (Snax)
- [ ] Merge after migration applies
- [ ] On preview: submit a payment with just an override amount (no receipts, no payment method) — should persist with `payout_method=NULL`
- [ ] Submit a normal payment with receipts + payment method — unchanged behavior
- [ ] Admin: open the null-method payout in the review modal — should see "Payment method not set" + amber "ask host to set details" banner
- [ ] Admin: try to execute a null-method payout — should get clear 400 error
- [ ] Admin: PATCH `payoutMethod` on a null payout to set it, then execute — should work