### PR TITLE
feat(provolone-39042): check-in attestation history + attribution

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -234,6 +234,7 @@ model Party {
   payouts               Payout[]
   outreachAttempts      OutreachAttempt[]
   announcements         Announcement[]
+  attestations          GuestAttestation[]
 
   @@map("parties")
 }
@@ -345,8 +346,41 @@ model Guest {
   quizAnswers      QuizAnswer[]
   scorecardItems   GuestScorecardItem[]
 
+  // provolone-39042: peer/host/self attestations for check-in attribution
+  attestationsReceived GuestAttestation[] @relation("AttestationsOfGuest")
+  attestationsGiven    GuestAttestation[] @relation("AttestationsByGuest")
+
   @@index([email])
   @@map("guests")
+}
+
+// ============================================
+// Check-in Attestations (provolone-39042)
+// ============================================
+// Records every check-in attempt — host_admin, peer_guest, or self_host.
+// Multiple attestations per guest are allowed; the DB has a unique COALESCE
+// index on (guest_id, COALESCE(attester_user_id, attester_guest_id::text))
+// that Prisma can't express, so we omit @@unique here and catch
+// P2002/23505 in the route handler instead. DO NOT add a competing
+// @@unique — the migration would try to drop the COALESCE index.
+model GuestAttestation {
+  id               String   @id @default(uuid()) @db.Uuid
+  guestId          String   @map("guest_id") @db.Uuid
+  partyId          String   @map("party_id") @db.Uuid
+  attesterKind     String   @map("attester_kind") // 'host_admin' | 'peer_guest' | 'self_host'
+  attesterUserId   String?  @map("attester_user_id")
+  attesterGuestId  String?  @map("attester_guest_id") @db.Uuid
+  attesterEmail    String?  @map("attester_email")
+  attesterName     String?  @map("attester_name")
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  guest         Guest  @relation("AttestationsOfGuest", fields: [guestId], references: [id], onDelete: Cascade)
+  party         Party  @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  attesterGuest Guest? @relation("AttestationsByGuest", fields: [attesterGuestId], references: [id], onDelete: SetNull)
+
+  @@index([partyId, createdAt(sort: Desc)])
+  @@index([guestId])
+  @@map("guest_attestations")
 }
 
 // Social media posts about the event (for reports)

--- a/backend/src/routes/checkin.routes.ts
+++ b/backend/src/routes/checkin.routes.ts
@@ -7,6 +7,65 @@ import { triggerWebhook } from '../services/webhook.service.js';
 
 const router = Router();
 
+// provolone-39042: Write a single attestation row. Idempotent: re-attestation
+// by the same person is a no-op via a DB-level UNIQUE index on
+// (guest_id, COALESCE(attester_user_id, attester_guest_id::text)).
+// The unique COALESCE index can't be represented in Prisma's @@unique, so we
+// catch 23505/P2002 here instead.
+async function recordAttestation(params: {
+  partyId: string;
+  guestId: string;
+  attesterKind: 'host_admin' | 'peer_guest' | 'self_host';
+  attesterUserId?: string | null;
+  attesterGuestId?: string | null;
+  attesterEmail?: string | null;
+  attesterName?: string | null;
+}): Promise<void> {
+  try {
+    await prisma.guestAttestation.create({
+      data: {
+        partyId: params.partyId,
+        guestId: params.guestId,
+        attesterKind: params.attesterKind,
+        attesterUserId: params.attesterUserId ?? null,
+        attesterGuestId: params.attesterGuestId ?? null,
+        attesterEmail: params.attesterEmail ?? null,
+        attesterName: params.attesterName ?? null,
+      },
+    });
+  } catch (err: any) {
+    // 23505 = unique_violation. Idempotent: same attester re-scanning is a no-op.
+    if (
+      err?.code === 'P2002' ||
+      err?.code === '23505' ||
+      (typeof err?.message === 'string' && err.message.includes('guest_attestations_guest_attester_unique'))
+    ) {
+      return;
+    }
+    throw err;
+  }
+}
+
+// provolone-39042: helper to fetch attestation history for the API response.
+async function fetchAttestations(guestId: string) {
+  const rows = await prisma.guestAttestation.findMany({
+    where: { guestId },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      attesterKind: true,
+      attesterName: true,
+      attesterEmail: true,
+      createdAt: true,
+    },
+  });
+  return rows.map((a) => ({
+    kind: a.attesterKind,
+    name: a.attesterName,
+    email: a.attesterEmail,
+    at: a.createdAt.toISOString(),
+  }));
+}
+
 // Helper function to check if user can check in guests for a party (host or co-host)
 async function canUserCheckIn(partyId: string, userId?: string, userEmail?: string): Promise<boolean> {
   // Super admin can check in for any party
@@ -123,8 +182,25 @@ router.post('/:inviteCode/self-host', requireAuth, async (req: AuthRequest, res:
       });
     }
 
-    // Already checked in
+    // provolone-39042: look up host name/email for attestation attribution
+    const attester = req.userId
+      ? await prisma.user.findUnique({
+          where: { id: req.userId },
+          select: { email: true, name: true },
+        })
+      : null;
+
+    // Already checked in — still record attestation (no-op if duplicate)
     if (guest.checkedInAt) {
+      await recordAttestation({
+        partyId: party.id,
+        guestId: guest.id,
+        attesterKind: 'self_host',
+        attesterUserId: req.userId,
+        attesterEmail: attester?.email ?? req.userEmail ?? null,
+        attesterName: attester?.name ?? null,
+      });
+      const attestations = await fetchAttestations(guest.id);
       return res.status(200).json({
         success: true,
         alreadyCheckedIn: true,
@@ -134,6 +210,7 @@ router.post('/:inviteCode/self-host', requireAuth, async (req: AuthRequest, res:
           checkedInAt: guest.checkedInAt,
         },
         message: `${guest.name} is already checked in`,
+        attestations,
       });
     }
 
@@ -146,6 +223,17 @@ router.post('/:inviteCode/self-host', requireAuth, async (req: AuthRequest, res:
       },
     });
 
+    // provolone-39042: record self-host attestation
+    await recordAttestation({
+      partyId: party.id,
+      guestId: updatedGuest.id,
+      attesterKind: 'self_host',
+      attesterUserId: req.userId,
+      attesterEmail: attester?.email ?? req.userEmail ?? null,
+      attesterName: attester?.name ?? null,
+    });
+    const attestations = await fetchAttestations(updatedGuest.id);
+
     res.status(200).json({
       success: true,
       guest: {
@@ -154,6 +242,7 @@ router.post('/:inviteCode/self-host', requireAuth, async (req: AuthRequest, res:
         checkedInAt: updatedGuest.checkedInAt,
       },
       message: `${updatedGuest.name} has checked in!`,
+      attestations,
     });
   } catch (error) {
     next(error);
@@ -209,8 +298,25 @@ router.post('/:inviteCode/vouch', requireAuth, async (req: AuthRequest, res: Res
       throw new AppError('Guest not found or belongs to a different event', 404, 'GUEST_NOT_FOUND');
     }
 
-    // Already checked in
+    // provolone-39042: always record the peer attestation, even if already
+    // checked in. The DB UNIQUE index dedupes per attester so re-scans by the
+    // same voucher are no-ops, while NEW vouchers get counted as additional
+    // attestations.
+    await recordAttestation({
+      partyId: party.id,
+      guestId: targetGuest.id,
+      attesterKind: 'peer_guest',
+      attesterGuestId: voucher.id,
+      attesterEmail: voucher.email,
+      attesterName: voucher.name,
+    });
+
+    // Already checked in — don't flip checked_in_at, but DO return updated
+    // attestation list (the new voucher should now appear).
     if (targetGuest.checkedInAt) {
+      const attestations = await fetchAttestations(targetGuest.id);
+      // Auto-complete the voucher's "vouch" scorecard item (even for re-scans)
+      autoCompleteScorecardItem(voucher.id, party.id, 'vouch', undefined, 'auto');
       return res.status(200).json({
         success: true,
         alreadyCheckedIn: true,
@@ -220,6 +326,7 @@ router.post('/:inviteCode/vouch', requireAuth, async (req: AuthRequest, res: Res
           checkedInAt: targetGuest.checkedInAt,
         },
         message: `${targetGuest.name} is already checked in`,
+        attestations,
       });
     }
 
@@ -235,6 +342,8 @@ router.post('/:inviteCode/vouch', requireAuth, async (req: AuthRequest, res: Res
     // Auto-complete the voucher's "vouch" scorecard item
     autoCompleteScorecardItem(voucher.id, party.id, 'vouch', undefined, 'auto');
 
+    const attestations = await fetchAttestations(updatedGuest.id);
+
     res.status(200).json({
       success: true,
       guest: {
@@ -243,6 +352,7 @@ router.post('/:inviteCode/vouch', requireAuth, async (req: AuthRequest, res: Res
         checkedInAt: updatedGuest.checkedInAt,
       },
       message: `${updatedGuest.name} has been checked in!`,
+      attestations,
     });
   } catch (error) {
     next(error);
@@ -277,7 +387,28 @@ router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: 
       throw new AppError('Guest was rejected', 400, 'GUEST_REJECTED');
     }
 
+    // provolone-39042: look up host name/email for attestation attribution
+    const attester = req.userId
+      ? await prisma.user.findUnique({
+          where: { id: req.userId },
+          select: { email: true, name: true },
+        })
+      : null;
+
+    // provolone-39042: always record the host attestation (idempotent on
+    // re-scan by the same host). This must happen BEFORE the alreadyCheckedIn
+    // short-circuit so re-scans by NEW hosts add a row.
+    await recordAttestation({
+      partyId: party.id,
+      guestId: guest.id,
+      attesterKind: 'host_admin',
+      attesterUserId: req.userId,
+      attesterEmail: attester?.email ?? req.userEmail ?? null,
+      attesterName: attester?.name ?? null,
+    });
+
     if (guest.checkedInAt) {
+      const attestations = await fetchAttestations(guest.id);
       return res.status(200).json({
         success: true,
         alreadyCheckedIn: true,
@@ -289,6 +420,7 @@ router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: 
           checkedInBy: guest.checkedInBy,
         },
         message: `${guest.name} was already checked in`,
+        attestations,
       });
     }
 
@@ -299,6 +431,8 @@ router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: 
         checkedInBy: req.userId, // CUID string; `checkedInBy` column is text, not uuid
       },
     });
+
+    const attestations = await fetchAttestations(updatedGuest.id);
 
     res.status(200).json({
       success: true,
@@ -311,6 +445,7 @@ router.post('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: 
         checkedInBy: updatedGuest.checkedInBy,
       },
       message: `${updatedGuest.name} has been checked in!`,
+      attestations,
     });
   } catch (error) {
     next(error);
@@ -457,11 +592,15 @@ router.get('/:inviteCode/:guestId', requireAuth, async (req: AuthRequest, res: R
       throw new AppError('Guest not found', 404, 'GUEST_NOT_FOUND');
     }
 
+    // provolone-39042: include attestation history for attribution display
+    const attestations = await fetchAttestations(guest.id);
+
     res.json({
       guest,
       isCheckedIn: !!guest.checkedInAt,
       callerIsTarget: isTargetGuest,
       callerIsHost: isHostOrCohost,
+      attestations,
     });
   } catch (error) {
     next(error);

--- a/frontend/src/i18n/locales/de/checkin.json
+++ b/frontend/src/i18n/locales/de/checkin.json
@@ -2,6 +2,11 @@
   "title": "Gäste-Check-in",
   "loading": "Gast wird eingecheckt...",
   "vouching": "Bestätigung…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "Eingecheckt!",
     "backToDashboard": "Zurück zum Event-Dashboard"

--- a/frontend/src/i18n/locales/en/checkin.json
+++ b/frontend/src/i18n/locales/en/checkin.json
@@ -2,6 +2,11 @@
   "title": "Guest Check-In",
   "loading": "Checking in guest...",
   "vouching": "Vouching…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "Checked In!",
     "backToDashboard": "Back to Event Dashboard"

--- a/frontend/src/i18n/locales/es/checkin.json
+++ b/frontend/src/i18n/locales/es/checkin.json
@@ -2,6 +2,11 @@
   "title": "Check-In de Invitado",
   "loading": "Registrando invitado...",
   "vouching": "Avalando…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "¡Registrado!",
     "backToDashboard": "Volver al Panel del Evento"

--- a/frontend/src/i18n/locales/fr/checkin.json
+++ b/frontend/src/i18n/locales/fr/checkin.json
@@ -2,6 +2,11 @@
   "title": "Enregistrement des invités",
   "loading": "Enregistrement de l'invité...",
   "vouching": "Validation…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "Enregistré !",
     "backToDashboard": "Retour au tableau de bord"

--- a/frontend/src/i18n/locales/ja/checkin.json
+++ b/frontend/src/i18n/locales/ja/checkin.json
@@ -2,6 +2,11 @@
   "title": "ゲストチェックイン",
   "loading": "ゲストをチェックイン中...",
   "vouching": "認証中…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "チェックイン完了！",
     "backToDashboard": "イベントダッシュボードに戻る"

--- a/frontend/src/i18n/locales/ko/checkin.json
+++ b/frontend/src/i18n/locales/ko/checkin.json
@@ -2,6 +2,11 @@
   "title": "게스트 체크인",
   "loading": "게스트 체크인 중...",
   "vouching": "보증 중…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "체크인 완료!",
     "backToDashboard": "이벤트 대시보드로 돌아가기"

--- a/frontend/src/i18n/locales/pt/checkin.json
+++ b/frontend/src/i18n/locales/pt/checkin.json
@@ -2,6 +2,11 @@
   "title": "Check-in de Convidados",
   "loading": "Fazendo check-in do convidado...",
   "vouching": "Verificando…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "Check-in Realizado!",
     "backToDashboard": "Voltar ao Painel do Evento"

--- a/frontend/src/i18n/locales/zh/checkin.json
+++ b/frontend/src/i18n/locales/zh/checkin.json
@@ -2,6 +2,11 @@
   "title": "来宾签到",
   "loading": "正在签到...",
   "vouching": "验证中…",
+  "attribution": {
+    "checkedInBy": "Checked in by {{name}}",
+    "alsoVouchedBy_one": "Also vouched for by 1 more: {{names}}",
+    "alsoVouchedBy_other": "Also vouched for by {{count}} more: {{names}}"
+  },
   "success": {
     "title": "签到成功！",
     "backToDashboard": "返回活动面板"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1007,6 +1007,15 @@ export async function verifyTweet(slug: string, tweetUrl: string): Promise<{ ver
 }
 
 // Check-in API functions
+
+// provolone-39042: attestation history for "Checked in by X" attribution.
+export interface Attestation {
+  kind: 'host_admin' | 'peer_guest' | 'self_host';
+  name: string | null;
+  email: string | null;
+  at: string;
+}
+
 export interface CheckInResponse {
   success: boolean;
   alreadyCheckedIn: boolean;
@@ -1018,6 +1027,7 @@ export interface CheckInResponse {
     checkedInBy?: string;
   };
   message: string;
+  attestations?: Attestation[];
 }
 
 export async function checkInGuest(inviteCode: string, guestId: string): Promise<CheckInResponse> {
@@ -1059,6 +1069,9 @@ export interface CheckInStatusResponse {
     checkedInBy?: string;
   };
   isCheckedIn: boolean;
+  callerIsTarget?: boolean;
+  callerIsHost?: boolean;
+  attestations?: Attestation[];
 }
 
 export async function getCheckInStatus(inviteCode: string, guestId: string): Promise<CheckInStatusResponse> {
@@ -3318,6 +3331,7 @@ export interface VouchResponse {
     checkedInAt: string;
   };
   message?: string;
+  attestations?: Attestation[];
 }
 
 /** Host/co-host self-check-in (bootstraps the chain of trust) */

--- a/frontend/src/pages/CheckInPage.tsx
+++ b/frontend/src/pages/CheckInPage.tsx
@@ -5,9 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { Layout } from '../components/Layout';
 import { Loader2, CheckCircle2, XCircle, AlertCircle, QrCode } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-import { vouchForGuest, checkInGuest, getDiscountStatus, claimDiscount } from '../lib/api';
+import { vouchForGuest, checkInGuest, getDiscountStatus, claimDiscount, type Attestation } from '../lib/api';
 import { CheckInQRDisplay } from '../components/CheckInQRDisplay';
 import { GPPClouds } from '../components/GPPClouds';
+
+// provolone-39042: friendly display name for an attestation row.
+const attestationDisplay = (a: Attestation): string => a.name || a.email || 'someone';
 
 const DISCOUNT_CLOUDS = [
   // Mobile clouds — above and below content
@@ -46,6 +49,8 @@ export function CheckInPage() {
   const [hasAttempted, setHasAttempted] = useState(false);
   const [discountData, setDiscountData] = useState<any>(null);
   const [discountChecked, setDiscountChecked] = useState(false);
+  // provolone-39042: check-in attribution history
+  const [attestations, setAttestations] = useState<Attestation[]>([]);
 
   // Pre-auth discount check: if event has ended, show discount flow instead of check-in
   useEffect(() => {
@@ -123,6 +128,8 @@ export function CheckInPage() {
 
         const data = await resp.json();
         setGuestName(data.guest?.name || 'Guest');
+        // provolone-39042: capture attestation history from GET response
+        setAttestations(data.attestations || []);
 
         // If the target guest is already checked in
         if (data.isCheckedIn) {
@@ -145,6 +152,7 @@ export function CheckInPage() {
             const result = await checkInGuest(inviteCode, guestId);
             if (result.success) {
               setGuestName(result.guest?.name || guestName);
+              setAttestations(result.attestations || []);
               if (result.alreadyCheckedIn) {
                 setState('already-checked-in');
                 setCheckedInAt(result.guest?.checkedInAt || null);
@@ -169,6 +177,7 @@ export function CheckInPage() {
           const result = await vouchForGuest(inviteCode, guestId);
           if (result.success) {
             setGuestName(result.guest?.name || guestName);
+            setAttestations(result.attestations || []);
             if (result.alreadyCheckedIn) {
               setState('already-checked-in');
               setCheckedInAt(result.guest?.checkedInAt || null);
@@ -221,6 +230,30 @@ export function CheckInPage() {
       minute: '2-digit',
       hour12: true,
     });
+  };
+
+  // provolone-39042: render "Checked in by X" + optional "Also vouched for by N more"
+  const renderAttestationAttribution = () => {
+    if (!attestations || attestations.length === 0) return null;
+    const first = attestations[0];
+    const extras = attestations.slice(1);
+    const previewNames = extras.slice(0, 3).map(attestationDisplay).join(', ');
+    const moreSuffix = extras.length > 3 ? `, +${extras.length - 3} more` : '';
+    return (
+      <div className="mt-3 space-y-1 text-sm">
+        <p className="text-theme-text-secondary">
+          {t('attribution.checkedInBy', { name: attestationDisplay(first) })}
+        </p>
+        {extras.length > 0 && (
+          <p className="text-theme-text-muted text-xs">
+            {t('attribution.alsoVouchedBy', {
+              count: extras.length,
+              names: previewNames + moreSuffix,
+            })}
+          </p>
+        )}
+      </div>
+    );
   };
 
   const renderContent = () => {
@@ -316,6 +349,7 @@ export function CheckInPage() {
               <span>{formatCheckInTime(checkedInAt)}</span>
             </p>
           )}
+          {renderAttestationAttribution()}
         </div>
       );
     }
@@ -333,6 +367,7 @@ export function CheckInPage() {
               <span>{t('alreadyCheckedIn.checkedInAt', { time: formatCheckInTime(checkedInAt) })}</span>
             </p>
           )}
+          {renderAttestationAttribution()}
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- New `guest_attestations` table records every check-in attempt (host_admin / peer_guest / self_host). Unique index on (guest, attester) dedupes re-scans.
- The check-in page now shows **Checked in by [name]** on success + already-checked-in screens.
- When multiple people have attested (after first scan), shows **Also vouched for by N more: [names]**.
- Backend short-circuits removed — re-scans now record attestations idempotently rather than no-oping silently.

## Migration
- Applied to prod separately (additive, new table only).
- 700 historical check-ins backfilled as initial attestations.

## Test plan
- [ ] As a super_admin / host, scan a guest QR. Expect green success + "Checked in by [you]".
- [ ] Re-scan the same QR (or open in a new tab). Expect blue already-checked-in screen with same attribution.
- [ ] As a second host or a checked-in peer guest, scan the same QR. Expect "Also vouched for by 1 more: [your name]".
- [ ] Confirm `guest_attestations` has one row per (guest, attester) pair, no duplicates after repeat scans.
- [ ] As a non-host non-checked-in guest, scan a third guest's QR. Expect yellow "not checked in" screen (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)