### PR TITLE
feat(arugula-38633): payment picker copy + bank-wire email

### DIFF
--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -98,7 +98,13 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       return !!savedWallet && /^0x[0-9a-fA-F]{40}$/.test(savedWallet.trim());
     }
     if (savedMethod === 'wire') {
+      // arugula-38633 (follow-up): wire is now a single email field; legacy
+      // rows that still have account-holder + routing/IBAN are also accepted
+      // so we don't drop already-saved details from existing hosts.
       if (!savedBank) return false;
+      const email = savedBank.email?.trim() ?? '';
+      if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return true;
+      // Legacy fallback: account-holder + bank-name + (US OR Intl) routing.
       if (!savedBank.accountHolderName?.trim() || !savedBank.bankName?.trim()) return false;
       const hasUs = !!savedBank.routingNumber?.trim() && !!savedBank.accountNumber?.trim();
       const hasIntl = !!savedBank.iban?.trim() || !!savedBank.swift?.trim();

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -194,10 +194,6 @@ export const PaymentDetailsCard: React.FC = () => {
           <h3 className="text-base font-semibold text-theme-text">
             Payment details
           </h3>
-          <p className="text-xs text-theme-text-muted mt-1">
-            How do you want to be paid when your receipts are approved? We'll save
-            this for every future receipt.
-          </p>
         </div>
         <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
           {saveStatus === 'saving' && (

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Check, AlertCircle } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { usePizza } from '../../contexts/PizzaContext';
 import { BankDetails, PayoutMethod } from '../../types';
 import { updateUserMe } from '../../lib/api';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
 
-const EMPTY_BANK: BankDetails = {
-  accountHolderName: '',
-  bankName: '',
-};
+const EMPTY_BANK: BankDetails = {};
+
+// Loose email check — same shape used elsewhere in the app (e.g. invite forms).
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
 
@@ -29,6 +30,7 @@ type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
  */
 export const PaymentDetailsCard: React.FC = () => {
   const { user, setUser } = useAuth();
+  const { party } = usePizza();
 
   // Local mirrors of the user's persisted values. These drive PayoutMethodPicker
   // directly so the UI updates instantly; the debounced save flushes to the
@@ -68,6 +70,7 @@ export const PaymentDetailsCard: React.FC = () => {
   useEffect(() => {
     if (
       user?.payoutBankDetails !== undefined
+      && !bankDetails.email
       && !bankDetails.accountHolderName
       && !bankDetails.bankName
     ) {
@@ -84,10 +87,10 @@ export const PaymentDetailsCard: React.FC = () => {
       return /^0x[0-9a-fA-F]{40}$/.test(walletAddress.trim());
     }
     if (method === 'wire') {
-      if (!bankDetails.accountHolderName?.trim() || !bankDetails.bankName?.trim()) return false;
-      const hasUs = !!bankDetails.routingNumber?.trim() && !!bankDetails.accountNumber?.trim();
-      const hasIntl = !!bankDetails.iban?.trim() || !!bankDetails.swift?.trim();
-      return hasUs || hasIntl;
+      // arugula-38633 (follow-up): wire is now a single email field —
+      // our bank emails the host to complete the transaction.
+      const email = bankDetails.email?.trim() ?? '';
+      return EMAIL_REGEX.test(email);
     }
     return true; // mercury_card has no extra required fields
   }, [method, walletAddress, bankDetails]);
@@ -180,13 +183,9 @@ export const PaymentDetailsCard: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [method, walletAddress, bankDetails, methodValid]);
 
-  // PayoutMethodPicker requires non-null method + an amount. For the empty
-  // state we let the user pick a method first; the picker still renders all
-  // three radios and we treat "no method yet" as $0 in the Mercury copy line.
-  // (Mercury copy reads "$0.00 USD" until the host submits an actual receipt;
-  // that's fine — this card is about saving the destination, not amounts.)
+  // PayoutMethodPicker requires non-null method. For the empty state we let
+  // the user pick a method first; the picker still renders all three radios.
   const pickerMethod: PayoutMethod = method ?? 'mercury_card';
-  const hasNothingYet = method == null;
 
   return (
     <div className="card p-6">
@@ -225,13 +224,6 @@ export const PaymentDetailsCard: React.FC = () => {
         </div>
       </div>
 
-      {hasNothingYet && (
-        <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-theme-text-secondary">
-          Pick a payout method below to enable receipt submissions. You only have
-          to do this once.
-        </div>
-      )}
-
       <PayoutMethodPicker
         method={pickerMethod}
         onMethodChange={(next) => {
@@ -244,7 +236,7 @@ export const PaymentDetailsCard: React.FC = () => {
         bankDetails={bankDetails}
         onBankDetailsChange={setBankDetails}
         userEmail={user?.email}
-        amountUsd={0}
+        reimbursementCapUsd={party?.effectiveReimbursementCapUsd ?? null}
       />
 
       {saveError && (

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -122,11 +122,17 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                     {payout.payoutWalletAddress}
                   </p>
                 )}
-                {payout.payoutMethod === 'wire' && payout.payoutBankDetails && (
-                  <p className="text-xs text-theme-text-muted mt-1">
-                    {payout.payoutBankDetails.accountHolderName} • {payout.payoutBankDetails.bankName}
-                  </p>
-                )}
+                {payout.payoutMethod === 'wire' && payout.payoutBankDetails && (() => {
+                  // arugula-38633 (follow-up): wire is now a single email
+                  // field. Render the email for new rows; legacy rows still
+                  // have the full account-holder + bank-name pair.
+                  const b = payout.payoutBankDetails;
+                  const legacy = [b.accountHolderName, b.bankName].filter(Boolean).join(' • ');
+                  const text = b.email || legacy;
+                  return text ? (
+                    <p className="text-xs text-theme-text-muted mt-1">{text}</p>
+                  ) : null;
+                })()}
                 {payout.payoutMethod === 'mercury_card' && payout.mercuryCardLast4 && (
                   <p className="text-xs text-theme-text-muted mt-1">
                     Card ending •••• {payout.mercuryCardLast4}

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -98,13 +98,13 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           value="usdc_base"
           icon={<Coins size={18} />}
           title="USDC on Base"
-          description="On-chain payment to your wallet."
+          description="Onchain payment to your wallet."
         />
         <Option
           value="mercury_card"
           icon={<CreditCard size={18} />}
           title="Mercury virtual card"
-          description="We email you a debit card for the exact amount."
+          description="We issue you a debit card for the exact amount."
         />
         <Option
           value="wire"
@@ -124,11 +124,7 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
                 <span className="text-theme-text font-semibold">${reimbursementCapUsd.toFixed(2)}</span>
               </>
             ) : null}
-            . Mercury will email the card details
-            {userEmail ? <> directly to <span className="text-theme-text">{userEmail}</span></> : ' to the email on your account'}.
-          </p>
-          <p className="mt-2 text-xs text-theme-text-muted">
-            No card or bank info needs to leave RSV.Pizza.
+            .
           </p>
         </div>
       )}

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CreditCard, Banknote, Coins, User, Building, Globe, Wallet } from 'lucide-react';
+import { CreditCard, Banknote, Coins, Mail, Wallet } from 'lucide-react';
 import { PayoutMethod, BankDetails } from '../../types';
 import { IconInput } from '../IconInput';
 
@@ -13,19 +13,21 @@ interface PayoutMethodPickerProps {
   bankDetails: BankDetails;
   onBankDetailsChange: (b: BankDetails) => void;
 
-  /** Email shown to user for the Mercury card destination. */
+  /** Email shown to user for the Mercury card destination + prefilled for wire. */
   userEmail?: string;
-  /** Amount in USD, used in copy. */
-  amountUsd: number;
+  /**
+   * arugula-38633 (follow-up): the host's effective reimbursement cap. Used in
+   * the Mercury copy so the host understands the card has a LIMIT, not a fixed
+   * per-receipt amount. When null, we omit the dollar amount entirely.
+   */
+  reimbursementCapUsd?: number | null;
 }
-
-type BankMode = 'us' | 'intl';
 
 /**
  * Radio picker for payout method, with method-specific sub-form.
  *
  *   mercury_card → just a confirmation that we'll email a virtual card
- *   wire         → IconInput grid for bank details (US or international toggle)
+ *   wire         → single email field (our bank emails the host to complete)
  *   usdc_base    → wallet address IconInput
  */
 export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
@@ -36,11 +38,21 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
   bankDetails,
   onBankDetailsChange,
   userEmail,
-  amountUsd,
+  reimbursementCapUsd,
 }) => {
-  const [bankMode, setBankMode] = React.useState<BankMode>(
-    bankDetails.iban || bankDetails.swift ? 'intl' : 'us'
-  );
+  // For wire: prefill the field from the user's auth email if no saved value.
+  // We mirror this into bankDetails on first render of the wire branch so the
+  // auto-save persists it even if the host doesn't touch the field.
+  const wireEmail = bankDetails.email ?? userEmail ?? '';
+  React.useEffect(() => {
+    if (method !== 'wire') return;
+    if (bankDetails.email !== undefined) return; // already set (incl. empty string)
+    if (!userEmail) return;
+    onBankDetailsChange({ ...bankDetails, email: userEmail });
+    // We only want to seed on the first transition into wire mode; deps below
+    // intentionally exclude bankDetails/onBankDetailsChange so we don't loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [method, userEmail]);
 
   const Option: React.FC<{
     value: PayoutMethod;
@@ -105,9 +117,14 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
       {method === 'mercury_card' && (
         <div className="rounded-xl border border-theme-stroke bg-theme-surface p-4 text-sm text-theme-text-secondary">
           <p>
-            We'll issue you a Mercury virtual debit card for{' '}
-            <span className="text-theme-text font-semibold">${amountUsd.toFixed(2)} USD</span>.
-            Mercury will email the card details
+            We'll issue you a Mercury virtual debit card
+            {typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0 ? (
+              <>
+                {' '}with a limit of{' '}
+                <span className="text-theme-text font-semibold">${reimbursementCapUsd.toFixed(2)}</span>
+              </>
+            ) : null}
+            . Mercury will email the card details
             {userEmail ? <> directly to <span className="text-theme-text">{userEmail}</span></> : ' to the email on your account'}.
           </p>
           <p className="mt-2 text-xs text-theme-text-muted">
@@ -134,93 +151,18 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
       )}
 
       {method === 'wire' && (
-        <div className="space-y-3">
-          {/* US vs intl toggle */}
-          <div className="inline-flex rounded-lg border border-theme-stroke overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setBankMode('us')}
-              className={`px-3 py-1.5 text-xs font-medium ${
-                bankMode === 'us' ? 'bg-[#ff393a] text-white' : 'text-theme-text-secondary'
-              }`}
-            >
-              US bank
-            </button>
-            <button
-              type="button"
-              onClick={() => setBankMode('intl')}
-              className={`px-3 py-1.5 text-xs font-medium ${
-                bankMode === 'intl' ? 'bg-[#ff393a] text-white' : 'text-theme-text-secondary'
-              }`}
-            >
-              International
-            </button>
-          </div>
-
-          <div className="grid sm:grid-cols-2 gap-3">
-            <IconInput
-              icon={User}
-              type="text"
-              placeholder="Account holder name"
-              value={bankDetails.accountHolderName || ''}
-              onChange={e => onBankDetailsChange({ ...bankDetails, accountHolderName: e.target.value })}
-              required
-            />
-            <IconInput
-              icon={Building}
-              type="text"
-              placeholder="Bank name"
-              value={bankDetails.bankName || ''}
-              onChange={e => onBankDetailsChange({ ...bankDetails, bankName: e.target.value })}
-              required
-            />
-            {bankMode === 'us' ? (
-              <>
-                <IconInput
-                  type="text"
-                  placeholder="Routing number"
-                  value={bankDetails.routingNumber || ''}
-                  onChange={e => onBankDetailsChange({ ...bankDetails, routingNumber: e.target.value })}
-                  required
-                />
-                <IconInput
-                  type="text"
-                  placeholder="Account number"
-                  value={bankDetails.accountNumber || ''}
-                  onChange={e => onBankDetailsChange({ ...bankDetails, accountNumber: e.target.value })}
-                  required
-                />
-              </>
-            ) : (
-              <>
-                <IconInput
-                  icon={Globe}
-                  type="text"
-                  placeholder="IBAN"
-                  value={bankDetails.iban || ''}
-                  onChange={e => onBankDetailsChange({ ...bankDetails, iban: e.target.value })}
-                />
-                <IconInput
-                  type="text"
-                  placeholder="SWIFT / BIC"
-                  value={bankDetails.swift || ''}
-                  onChange={e => onBankDetailsChange({ ...bankDetails, swift: e.target.value })}
-                />
-              </>
-            )}
-            <IconInput
-              type="text"
-              placeholder="Bank address (optional)"
-              value={bankDetails.bankAddress || ''}
-              onChange={e => onBankDetailsChange({ ...bankDetails, bankAddress: e.target.value })}
-            />
-            <IconInput
-              type="text"
-              placeholder="Notes (intermediary bank, etc.)"
-              value={bankDetails.notes || ''}
-              onChange={e => onBankDetailsChange({ ...bankDetails, notes: e.target.value })}
-            />
-          </div>
+        <div className="space-y-2">
+          <IconInput
+            icon={Mail}
+            type="email"
+            placeholder="Email for bank correspondence"
+            value={wireEmail}
+            onChange={e => onBankDetailsChange({ ...bankDetails, email: e.target.value })}
+            required
+          />
+          <p className="text-xs text-theme-text-muted">
+            We'll send you an email from our bank to complete the transaction.
+          </p>
         </div>
       )}
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1423,8 +1423,14 @@ export interface PayoutDocument {
 }
 
 export interface BankDetails {
-  accountHolderName: string;
-  bankName: string;
+  // arugula-38633 (follow-up): the wire form was replaced with a single
+  // "email for bank correspondence" field — our bank emails the host to
+  // complete the transaction. Legacy rows (created before this change) still
+  // carry the full account-holder + routing/IBAN payload, so all fields are
+  // kept here as optional for backwards-compatible display in admin views.
+  email?: string;
+  accountHolderName?: string;
+  bankName?: string;
   bankAddress?: string;
   // US bank
   routingNumber?: string;


### PR DESCRIPTION
## Summary

Three changes to the PaymentDetailsCard / PayoutMethodPicker on the rsv.pizza Payments tab.

- **PaymentDetailsCard**: remove the "Pick a payout method below" amber tip — misleading post-#484 when payment method is optional.
- **Mercury card copy**: switch from per-receipt amount to the host's reimbursement CAP — "with a limit of \$X". Falls back to no dollar amount when cap is null.
- **Bank wire**: replace the full bank-details form (US vs intl, routing/account/IBAN/SWIFT, etc.) with a single email field, prefilled with the authenticated user's email. Helper text: "We'll send you an email from our bank to complete the transaction." Saves to ``payout_bank_details.email``.

## Implementation notes

- ``BankDetails`` type: all previously-required fields are now optional and a new ``email?`` field was added. Legacy rows with the full payload still render correctly in admin (PayoutDetailModal + PayoutReviewModal).
- ``PayoutMethodPicker``: ``amountUsd`` prop removed (it was unused everywhere post-#479). New ``reimbursementCapUsd`` prop used by the Mercury copy. Wire branch auto-seeds the bank-details email from ``userEmail`` on first render.
- ``PaymentDetailsCard``: validation for wire now requires a valid email instead of holder/bank/routing/IBAN. Now reads party from ``usePizza()`` to forward the effective cap.
- ``NewPayoutForm``: wire ``savedMethodValid`` accepts EITHER a valid email (new path) OR the legacy account-holder + bank-name + routing/IBAN payload, so existing hosts with old saved bank details continue to work.

## Test plan

- [ ] Wire branch shows single email field prefilled with the auth user's email
- [ ] Editing the email auto-saves to ``users.payout_bank_details`` JSONB
- [ ] Mercury copy reads "with a limit of \$X" when ``effectiveReimbursementCapUsd`` is set; omits dollar amount when null
- [ ] Amber "Pick a payout method below" tip no longer renders
- [ ] Admin Payout review/detail modal renders legacy bank-details rows (with account-holder + bank-name) without error
- [ ] Admin Payout review/detail modal renders new email-only rows
- [ ] ``tsc --noEmit`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)