### PR TITLE
feat(arugula-38633): setup-required notice + RSVP count hint

### DIFF
--- a/frontend/src/components/payouts/ExpectedGuestsCard.tsx
+++ b/frontend/src/components/payouts/ExpectedGuestsCard.tsx
@@ -25,7 +25,8 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
   partyId,
   expectedGuests,
 }) => {
-  const { party, loadParty } = usePizza();
+  const { party, loadParty, guests } = usePizza();
+  const rsvpCount = guests?.length ?? 0;
   // Edit mode is implicit when the value is null (no value yet → show input).
   // For non-null, the host clicks Edit to reveal the input.
   const [editing, setEditing] = useState(false);
@@ -153,6 +154,11 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
           )}
         </div>
       </div>
+
+      {/* RSVP count hint — helps the host estimate */}
+      <p className="text-xs text-theme-text-muted mt-2">
+        {rsvpCount === 1 ? '1 RSVP' : `${rsvpCount} RSVPs`} so far.
+      </p>
 
       {error && (
         <p className="text-xs text-[#ff393a] mt-2">{error}</p>

--- a/frontend/src/components/payouts/ExpectedGuestsCard.tsx
+++ b/frontend/src/components/payouts/ExpectedGuestsCard.tsx
@@ -27,11 +27,17 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
 }) => {
   const { party, loadParty, guests } = usePizza();
   const rsvpCount = guests?.length ?? 0;
+  // Default suggestion: 40% of current RSVPs (typical no-show buffer for
+  // pizza events). Pre-fills the input when no value is saved yet — host
+  // can edit before clicking Save; nothing auto-saves.
+  const suggestedDefault = rsvpCount > 0 ? Math.max(1, Math.round(rsvpCount * 0.4)) : null;
   // Edit mode is implicit when the value is null (no value yet → show input).
   // For non-null, the host clicks Edit to reveal the input.
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState<string>(
-    expectedGuests != null ? String(expectedGuests) : ''
+    expectedGuests != null
+      ? String(expectedGuests)
+      : suggestedDefault != null ? String(suggestedDefault) : ''
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -41,9 +47,13 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
   // editing so we don't clobber in-flight typing.
   useEffect(() => {
     if (!editing) {
-      setValue(expectedGuests != null ? String(expectedGuests) : '');
+      setValue(
+        expectedGuests != null
+          ? String(expectedGuests)
+          : suggestedDefault != null ? String(suggestedDefault) : ''
+      );
     }
-  }, [expectedGuests, editing]);
+  }, [expectedGuests, editing, suggestedDefault]);
 
   const hasValue = expectedGuests != null;
   const showInput = !hasValue || editing;

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -180,29 +180,53 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
         PartyHeader, /underboss EventRow, and NewPayoutForm's first-time
         prompt — single source of truth.
       */}
-      {/* Cap banner (arugula-38633 v2): always visible at the top of the
-          Payments section. When the underboss has set a cap (or a numeric
-          event_tag fallback exists), shows the value. When neither exists,
-          shows the prompt to set expected_guests + contact underboss. */}
-      {typeof effectiveReimbursementCapUsd === 'number' && effectiveReimbursementCapUsd > 0 ? (
-        <div className="card p-4 sm:p-5 border-l-4 border-l-emerald-500 flex items-start gap-3">
-          <BadgeDollarSign size={20} className="text-emerald-500 mt-0.5 flex-shrink-0" />
-          <div className="text-sm font-medium text-theme-text">
-            We'll reimburse you for up to ${effectiveReimbursementCapUsd.toFixed(2)}
-            {partyKitCapUsd != null && (
-              <> of pizza and up to ${partyKitCapUsd.toFixed(2)} of party kit expenses</>
-            )}
-            .
+      {/* Top banner priority (arugula-38633 v3):
+          1. Missing expected_guests or location → actionable "Set your X to
+             get your funding approved" (host can act on it)
+          2. Both set, no cap yet → "No cap set. Contact your underboss"
+          3. Cap set → emerald cap banner */}
+      {(() => {
+        const needsExpectedGuests = !party?.expectedGuests || party.expectedGuests <= 0;
+        const needsLocation = !party?.address;
+        const hasCap = typeof effectiveReimbursementCapUsd === 'number' && effectiveReimbursementCapUsd > 0;
+
+        if (needsExpectedGuests || needsLocation) {
+          const msg =
+            needsExpectedGuests && needsLocation
+              ? 'Set your expected guests and your location to get your funding approved.'
+              : needsExpectedGuests
+                ? 'Set your expected guests to get your funding approved.'
+                : 'Set your location to get your funding approved.';
+          return (
+            <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
+              <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
+              <div className="text-sm font-medium text-theme-text">{msg}</div>
+            </div>
+          );
+        }
+        if (hasCap) {
+          return (
+            <div className="card p-4 sm:p-5 border-l-4 border-l-emerald-500 flex items-start gap-3">
+              <BadgeDollarSign size={20} className="text-emerald-500 mt-0.5 flex-shrink-0" />
+              <div className="text-sm font-medium text-theme-text">
+                We'll reimburse you for up to ${effectiveReimbursementCapUsd!.toFixed(2)}
+                {partyKitCapUsd != null && (
+                  <> of pizza and up to ${partyKitCapUsd.toFixed(2)} of party kit expenses</>
+                )}
+                .
+              </div>
+            </div>
+          );
+        }
+        return (
+          <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
+            <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
+            <div className="text-sm font-medium text-theme-text">
+              No cap set. Contact your underboss to get your funding approved.
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
-          <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
-          <div className="text-sm font-medium text-theme-text">
-            No cap set. Set your expected guests and contact your underboss.
-          </div>
-        </div>
-      )}
+        );
+      })()}
 
       <PrepayCheckbox partyId={partyId} />
 


### PR DESCRIPTION
PayoutsTab top notice now prompts the host to set expected_guests / location when missing. ExpectedGuestsCard shows current RSVP count as an estimation aid.