### PR TITLE
feat(arugula-38633): hosts can edit pending receipts after submission

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -669,6 +669,12 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       hostNotes,
       finalAmountUsd,
       mercuryCardLast4,
+      // arugula-38633 (edit-receipts): hosts can swap photos/receipts on
+      // payouts that are still pending. All three arrays are optional and
+      // are applied transactionally below.
+      receiptPhotos,
+      pizzaPhotos,
+      removeDocumentIds,
     } = req.body || {};
 
     await assertCanUsePayoutsForParty(req, partyId);
@@ -680,6 +686,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
 
     const existing = await prisma.payout.findFirst({
       where: { id: payoutId, partyId },
+      include: { documents: true },
     });
     if (!existing) {
       throw new AppError('Payment not found', 404, 'NOT_FOUND');
@@ -688,7 +695,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       throw new AppError(
         'Payments can only be edited while pending; this one is ' + existing.status,
         400,
-        'PAYOUT_NOT_PENDING'
+        'NOT_EDITABLE'
       );
     }
 
@@ -735,10 +742,281 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       data.finalAmountUsd = new Decimal(n);
     }
 
-    const updated = await prisma.payout.update({
-      where: { id: payoutId },
-      data,
-      include: { documents: { orderBy: { sortOrder: 'asc' } } },
+    // ---- arugula-38633 (edit-receipts): document edits ----
+
+    // Validate input shapes.
+    if (receiptPhotos !== undefined && !Array.isArray(receiptPhotos)) {
+      throw new AppError('receiptPhotos must be an array', 400, 'INVALID_RECEIPTS');
+    }
+    if (pizzaPhotos !== undefined && !Array.isArray(pizzaPhotos)) {
+      throw new AppError('pizzaPhotos must be an array', 400, 'INVALID_PIZZA_PHOTOS');
+    }
+    if (removeDocumentIds !== undefined && !Array.isArray(removeDocumentIds)) {
+      throw new AppError('removeDocumentIds must be an array', 400, 'INVALID_REMOVE_IDS');
+    }
+
+    const newReceipts: IncomingDocument[] = Array.isArray(receiptPhotos) ? receiptPhotos : [];
+    const newPizza: IncomingDocument[] = Array.isArray(pizzaPhotos) ? pizzaPhotos : [];
+    const removeIds: string[] = Array.isArray(removeDocumentIds)
+      ? removeDocumentIds.filter((s: unknown): s is string => typeof s === 'string')
+      : [];
+
+    if (newReceipts.length > 10) {
+      throw new AppError('Max 10 receipt photos', 400, 'TOO_MANY_RECEIPTS');
+    }
+    if (newPizza.length > 10) {
+      throw new AppError('Max 10 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
+    }
+
+    // Verify each new URL points into the bucket scoped to this party.
+    for (const r of newReceipts) {
+      if (!r || typeof r.url !== 'string') {
+        throw new AppError('Each receiptPhoto must have a url', 400, 'INVALID_RECEIPT');
+      }
+      assertSupabasePayoutUrl(r.url, partyId);
+    }
+    for (const p of newPizza) {
+      if (!p || typeof p.url !== 'string') {
+        throw new AppError('Each pizzaPhoto must have a url', 400, 'INVALID_PIZZA_PHOTO');
+      }
+      assertSupabasePayoutUrl(p.url, partyId);
+    }
+
+    // Verify every removeId actually belongs to this payout.
+    const existingDocIds = new Set(existing.documents.map(d => d.id));
+    for (const id of removeIds) {
+      if (!existingDocIds.has(id)) {
+        throw new AppError(
+          `Document ${id} does not belong to this payout`,
+          400,
+          'INVALID_REMOVE_ID'
+        );
+      }
+    }
+
+    // Run OCR on each new receipt in parallel BEFORE the transaction so the
+    // transaction stays short and we can roll up the new OCR sum cleanly.
+    const ocrResults = newReceipts.length === 0
+      ? []
+      : await Promise.allSettled(
+          newReceipts.map(async (r) => {
+            try {
+              const ocr = await analyzeReceipt(r.url);
+              const fx = await convertToUSD(ocr.amount, ocr.currency);
+              return { ok: true as const, doc: r, ocr, fx };
+            } catch (err: any) {
+              return { ok: false as const, doc: r, error: err?.message || 'OCR failed' };
+            }
+          })
+        );
+
+    // Build the receipt-document creates from the OCR results.
+    const newReceiptDocs: Array<{
+      kind: string;
+      url: string;
+      fileName: string;
+      fileSize: number;
+      mimeType: string;
+      ocrAmount: Decimal | null;
+      ocrCurrency: string | null;
+      ocrConfidence: Decimal | null;
+      ocrRaw: any;
+      ocrError: string | null;
+      sortOrder: number;
+    }> = [];
+    let newOcrSum = 0;
+    interface FxHeadline {
+      originalAmount: number;
+      originalCurrency: string;
+      exchangeRate: number;
+    }
+    // Note: typed via an array slot to avoid TS narrowing the `null` initializer
+    // through the forEach closure boundary.
+    const firstFxBox: { value: FxHeadline | null } = { value: null };
+
+    ocrResults.forEach((settled, i) => {
+      const doc = newReceipts[i];
+      const result = settled.status === 'fulfilled' ? settled.value : null;
+      if (result && result.ok) {
+        const { ocr, fx } = result;
+        newOcrSum += fx.usdAmount;
+        if (firstFxBox.value === null) {
+          firstFxBox.value = {
+            originalAmount: fx.originalAmount,
+            originalCurrency: fx.originalCurrency,
+            exchangeRate: fx.exchangeRate,
+          };
+        }
+        newReceiptDocs.push({
+          kind: 'receipt',
+          url: doc.url,
+          fileName: doc.fileName || extractFileName(doc.url),
+          fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
+          mimeType: doc.mimeType || 'image/jpeg',
+          ocrAmount: new Decimal(fx.usdAmount),
+          ocrCurrency: fx.originalCurrency,
+          ocrConfidence: new Decimal(ocr.confidence),
+          ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
+          ocrError: null,
+          sortOrder: i,
+        });
+      } else {
+        const err = result && !result.ok ? result.error : 'Unexpected OCR result';
+        newReceiptDocs.push({
+          kind: 'receipt',
+          url: doc.url,
+          fileName: doc.fileName || extractFileName(doc.url),
+          fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
+          mimeType: doc.mimeType || 'image/jpeg',
+          ocrAmount: null,
+          ocrCurrency: null,
+          ocrConfidence: null,
+          ocrRaw: null,
+          ocrError: err,
+          sortOrder: i,
+        });
+      }
+    });
+
+    const newPizzaDocs = newPizza.map((p, i) => ({
+      kind: 'pizza',
+      url: p.url,
+      fileName: p.fileName || extractFileName(p.url),
+      fileSize: typeof p.fileSize === 'number' ? p.fileSize : 0,
+      mimeType: p.mimeType || 'image/jpeg',
+      ocrAmount: null,
+      ocrCurrency: null,
+      ocrConfidence: null,
+      ocrRaw: null,
+      ocrError: null,
+      sortOrder: i,
+    }));
+
+    const documentsChanged = newReceiptDocs.length > 0 || newPizzaDocs.length > 0 || removeIds.length > 0;
+    const explicitAmount = data.finalAmountUsd !== undefined;
+
+    // If receipts changed AND host didn't pass finalAmountUsd, recompute from
+    // the remaining + newly-added receipt OCR sums. We compute *post-removal*
+    // sum by walking the existing docs minus the removed ids.
+    let recomputedAmount: Decimal | null = null;
+    let recomputedExtractedUsd: Decimal | null = null;
+    let recomputedOriginalAmount: Decimal | null = null;
+    let recomputedOriginalCurrency: string | null = null;
+    let recomputedExchangeRate: Decimal | null = null;
+
+    const receiptsChanged = newReceiptDocs.length > 0 || removeIds.some(
+      id => existing.documents.find(d => d.id === id)?.kind === 'receipt'
+    );
+
+    if (receiptsChanged) {
+      const removedSet = new Set(removeIds);
+      const survivingReceipts = existing.documents.filter(
+        d => d.kind === 'receipt' && !removedSet.has(d.id)
+      );
+      const survivingOcrSum = survivingReceipts.reduce(
+        (sum, d) => sum + (d.ocrAmount != null ? Number(d.ocrAmount.toString()) : 0),
+        0
+      );
+      const fullOcrSum = survivingOcrSum + newOcrSum;
+      recomputedExtractedUsd = new Decimal(fullOcrSum);
+
+      if (!explicitAmount && fullOcrSum > 0) {
+        recomputedAmount = new Decimal(fullOcrSum);
+      }
+
+      // If this is the first receipt OCR'd successfully, pull FX headline
+      // fields from it. Otherwise leave existing headline FX in place.
+      const hadAnyOcr = existing.documents.some(
+        d => d.kind === 'receipt' && !removedSet.has(d.id) && d.ocrAmount != null
+      );
+      const fx = firstFxBox.value;
+      if (!hadAnyOcr && fx) {
+        recomputedOriginalAmount = new Decimal(fx.originalAmount);
+        recomputedOriginalCurrency = fx.originalCurrency;
+        recomputedExchangeRate = new Decimal(fx.exchangeRate);
+      }
+    }
+
+    const oldAmount = Number(existing.finalAmountUsd.toString());
+    const newAmount = explicitAmount
+      ? Number((data.finalAmountUsd as Decimal).toString())
+      : (recomputedAmount != null ? Number(recomputedAmount.toString()) : oldAmount);
+    const amountChanged = newAmount !== oldAmount;
+
+    // Single transaction: delete removed docs, insert new docs, update payout,
+    // write the audit row(s).
+    const updated = await prisma.$transaction(async (tx) => {
+      if (removeIds.length > 0) {
+        await tx.payoutDocument.deleteMany({
+          where: { id: { in: removeIds }, payoutId: existing.id },
+        });
+      }
+      if (newReceiptDocs.length > 0 || newPizzaDocs.length > 0) {
+        await tx.payoutDocument.createMany({
+          data: [...newReceiptDocs, ...newPizzaDocs].map(d => ({
+            ...d,
+            payoutId: existing.id,
+            ocrRaw: d.ocrRaw === null ? Prisma.JsonNull : (d.ocrRaw as Prisma.InputJsonValue),
+          })),
+        });
+      }
+
+      // Apply scalar updates + (optionally) recomputed amount/FX.
+      const finalData = { ...data };
+      if (recomputedAmount && !explicitAmount) {
+        finalData.finalAmountUsd = recomputedAmount;
+      }
+      if (recomputedExtractedUsd) {
+        finalData.extractedAmountUsd = recomputedExtractedUsd;
+      }
+      if (recomputedOriginalAmount) {
+        finalData.originalAmount = recomputedOriginalAmount;
+        finalData.originalCurrency = recomputedOriginalCurrency;
+        finalData.exchangeRate = recomputedExchangeRate;
+      }
+
+      const row = Object.keys(finalData).length > 0
+        ? await tx.payout.update({
+            where: { id: payoutId },
+            data: finalData,
+            include: { documents: { orderBy: { sortOrder: 'asc' } } },
+          })
+        : await tx.payout.findUniqueOrThrow({
+            where: { id: payoutId },
+            include: { documents: { orderBy: { sortOrder: 'asc' } } },
+          });
+
+      // Audit: write a row when amount changes OR docs change. Mirror the
+      // admin edit_amount shape; use a distinct 'edit_documents' action when
+      // only documents (no amount) changed.
+      const auditActorEmail = req.userEmail || 'unknown';
+      if (amountChanged) {
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'edit_amount',
+            oldAmount: new Decimal(oldAmount) as any,
+            newAmount: new Decimal(newAmount) as any,
+            actorEmail: auditActorEmail,
+            actorKind: 'host',
+            note: documentsChanged
+              ? `Host edit (${newReceiptDocs.length} new receipt(s), ${newPizzaDocs.length} new photo(s), ${removeIds.length} removed)`
+              : 'Host edit',
+          },
+        });
+      } else if (documentsChanged) {
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'edit_documents',
+            actorEmail: auditActorEmail,
+            actorKind: 'host',
+            note: `Host edit (${newReceiptDocs.length} new receipt(s), ${newPizzaDocs.length} new photo(s), ${removeIds.length} removed)`,
+          },
+        });
+      }
+
+      return row;
     });
 
     res.json({ payout: serializePayout(updated) });

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -1,13 +1,21 @@
-import React, { useEffect, useState } from 'react';
-import { X, Loader2, AlertCircle, ExternalLink } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign } from 'lucide-react';
 import { Payout, PayoutStatus } from '../../types';
-import { getPayout } from '../../lib/api';
+import { getPayout, updatePayout } from '../../lib/api';
 import { methodIcon, methodLabel } from './PayoutListRow';
+import { IconInput } from '../IconInput';
+import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
+import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 
 interface PayoutDetailModalProps {
   partyId: string;
   payoutId: string;
   onClose: () => void;
+  /**
+   * Optional callback fired after a successful host edit. Lets the parent
+   * (PayoutsTab) refresh its list so totals / OCR sums stay in sync.
+   */
+  onUpdated?: () => void;
 }
 
 const STATUS_STYLES: Record<PayoutStatus, string> = {
@@ -27,16 +35,32 @@ const STATUS_LABEL: Record<PayoutStatus, string> = {
 };
 
 /**
- * Read-only detail view for a single payout. Click outside or X to close.
+ * Detail view for a single payout. Read-only by default; pending payouts
+ * gain an "Edit" affordance that lets the host swap receipts/photos, notes,
+ * and amount before an admin reviews.
  */
 export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   partyId,
   payoutId,
   onClose,
+  onUpdated,
 }) => {
   const [payout, setPayout] = useState<Payout | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // ---- edit state ----
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // New uploads since edit-mode was opened (existing docs aren't re-uploaded).
+  const [newReceipts, setNewReceipts] = useState<ReceiptItem[]>([]);
+  const [newPizzaPhotos, setNewPizzaPhotos] = useState<PizzaPhotoItem[]>([]);
+  // IDs of existing documents the host has clicked X on (deferred until save).
+  const [removedDocIds, setRemovedDocIds] = useState<Set<string>>(new Set());
+  const [editNotes, setEditNotes] = useState('');
+  const [editOverrideAmount, setEditOverrideAmount] = useState<string>('');
 
   useEffect(() => {
     let cancelled = false;
@@ -49,6 +73,119 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     return () => { cancelled = true; };
   }, [partyId, payoutId]);
 
+  // Pre-populate edit fields each time we enter edit mode.
+  const enterEdit = () => {
+    if (!payout) return;
+    setEditing(true);
+    setSaveError(null);
+    setNewReceipts([]);
+    setNewPizzaPhotos([]);
+    setRemovedDocIds(new Set());
+    setEditNotes(payout.hostNotes ?? '');
+    setEditOverrideAmount(
+      payout.finalAmountUsd != null ? String(payout.finalAmountUsd) : ''
+    );
+  };
+
+  const cancelEdit = () => {
+    setEditing(false);
+    setSaveError(null);
+    setNewReceipts([]);
+    setNewPizzaPhotos([]);
+    setRemovedDocIds(new Set());
+  };
+
+  // Surviving existing documents (not marked for removal) — drives the
+  // photo grids in edit mode so the host can see what's already attached.
+  const survivingReceipts = useMemo(
+    () => (payout?.documents ?? []).filter(d => d.kind === 'receipt' && !removedDocIds.has(d.id)),
+    [payout, removedDocIds]
+  );
+  const survivingPizzaPhotos = useMemo(
+    () => (payout?.documents ?? []).filter(d => d.kind === 'pizza' && !removedDocIds.has(d.id)),
+    [payout, removedDocIds]
+  );
+
+  const isProcessingUploads =
+    newReceipts.some(r => r.status === 'uploading' || r.status === 'ocring') ||
+    newPizzaPhotos.some(p => p.status === 'uploading');
+
+  const handleSave = async () => {
+    if (!payout || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      // Build the patch payload. Only include fields that actually changed.
+      const patch: Parameters<typeof updatePayout>[2] = {};
+
+      // Notes (treat empty string as a clear).
+      const trimmedNotes = editNotes.trim();
+      const originalNotes = (payout.hostNotes ?? '').trim();
+      if (trimmedNotes !== originalNotes) {
+        patch.hostNotes = trimmedNotes.length > 0 ? trimmedNotes : null;
+      }
+
+      // Amount override.
+      const amountStr = editOverrideAmount.trim();
+      if (amountStr !== '') {
+        const parsed = Number(amountStr);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error('Amount must be a positive number');
+        }
+        if (parsed !== payout.finalAmountUsd) {
+          patch.finalAmountUsd = parsed;
+        }
+      }
+
+      // New uploads only — items must be `done` with a URL.
+      const newReceiptPayload = newReceipts
+        .filter(r => r.status === 'done' && r.url)
+        .map(r => ({
+          url: r.url!,
+          fileName: r.fileName,
+          fileSize: r.fileSize,
+          mimeType: r.mimeType,
+        }));
+      if (newReceiptPayload.length > 0) {
+        patch.receiptPhotos = newReceiptPayload;
+      }
+      const newPizzaPayload = newPizzaPhotos
+        .filter(p => p.status === 'done' && p.url)
+        .map(p => ({
+          url: p.url!,
+          fileName: p.fileName,
+          fileSize: p.fileSize,
+          mimeType: p.mimeType,
+        }));
+      if (newPizzaPayload.length > 0) {
+        patch.pizzaPhotos = newPizzaPayload;
+      }
+
+      if (removedDocIds.size > 0) {
+        patch.removeDocumentIds = Array.from(removedDocIds);
+      }
+
+      if (Object.keys(patch).length === 0) {
+        // Nothing to do — just exit edit mode.
+        setEditing(false);
+        setSaving(false);
+        return;
+      }
+
+      const updated = await updatePayout(partyId, payoutId, patch);
+      setPayout(updated);
+      setEditing(false);
+      setNewReceipts([]);
+      setNewPizzaPhotos([]);
+      setRemovedDocIds(new Set());
+      onUpdated?.();
+    } catch (err: any) {
+      setSaveError(err?.message || 'Failed to save changes');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
@@ -60,20 +197,34 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
       >
         <div className="flex items-start justify-between p-5 border-b border-theme-stroke">
           <div>
-            <h2 className="text-lg font-semibold text-theme-text">Payment details</h2>
+            <h2 className="text-lg font-semibold text-theme-text">
+              {editing ? 'Edit payment' : 'Payment details'}
+            </h2>
             {payout && (
               <p className="text-xs text-theme-text-muted mt-0.5">
                 Submitted {new Date(payout.createdAt).toLocaleString()}
               </p>
             )}
           </div>
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
-            aria-label="Close"
-          >
-            <X size={18} />
-          </button>
+          <div className="flex items-center gap-2">
+            {payout && !editing && payout.status === 'pending' && (
+              <button
+                type="button"
+                onClick={enterEdit}
+                className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
+              >
+                <Pencil size={14} />
+                Edit
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
+              aria-label="Close"
+            >
+              <X size={18} />
+            </button>
+          </div>
         </div>
 
         <div className="p-5 space-y-5">
@@ -89,7 +240,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
             </div>
           )}
 
-          {payout && (
+          {payout && !editing && (
             <>
               {/* Status + amount */}
               <div className="flex items-start justify-between flex-wrap gap-3">
@@ -240,6 +391,156 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                   )}
                 </div>
               )}
+            </>
+          )}
+
+          {payout && editing && (
+            <>
+              <p className="text-xs text-theme-text-muted">
+                You can edit this payment until an admin reviews it. Removed
+                photos are deleted on save.
+              </p>
+
+              {/* Existing receipts — host can click X to mark for removal */}
+              {survivingReceipts.length > 0 && (
+                <div>
+                  <p className="text-xs text-theme-text-muted mb-2">Existing receipts</p>
+                  <ul className="space-y-2">
+                    {survivingReceipts.map(d => (
+                      <li key={d.id} className="flex items-center gap-3 p-2 rounded-lg bg-theme-surface-hover">
+                        <a href={d.url} target="_blank" rel="noreferrer" className="flex-shrink-0">
+                          <img src={d.url} alt="" className="w-14 h-14 rounded object-cover" />
+                        </a>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-theme-text truncate">{d.fileName}</p>
+                          {d.ocrAmount != null && (
+                            <p className="text-xs text-theme-text-muted">
+                              ${d.ocrAmount.toFixed(2)} USD
+                              {d.ocrCurrency && d.ocrCurrency !== 'USD' && ` (from ${d.ocrCurrency})`}
+                            </p>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setRemovedDocIds(prev => new Set(prev).add(d.id))}
+                          className="p-1.5 rounded-md text-theme-text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                          aria-label="Remove receipt"
+                        >
+                          <X size={16} />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Add receipts */}
+              <div>
+                <p className="text-xs text-theme-text-muted mb-2">Add receipts</p>
+                <ReceiptUpload
+                  partyId={partyId}
+                  payoutTempId={payout.id}
+                  items={newReceipts}
+                  onChange={setNewReceipts}
+                  maxItems={10}
+                />
+              </div>
+
+              {/* Existing pizza photos — host can click X to mark for removal */}
+              {survivingPizzaPhotos.length > 0 && (
+                <div>
+                  <p className="text-xs text-theme-text-muted mb-2">Existing pizza / event photos</p>
+                  <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+                    {survivingPizzaPhotos.map(d => (
+                      <div key={d.id} className="relative aspect-square rounded-lg overflow-hidden bg-theme-surface group">
+                        <img src={d.url} alt="" className="w-full h-full object-cover" />
+                        <button
+                          type="button"
+                          onClick={() => setRemovedDocIds(prev => new Set(prev).add(d.id))}
+                          className="absolute top-1 right-1 p-1 rounded-full bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity"
+                          aria-label="Remove"
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Add pizza photos */}
+              <div>
+                <p className="text-xs text-theme-text-muted mb-2">Add pizza / event photos</p>
+                <PizzaPhotoUpload
+                  partyId={partyId}
+                  payoutTempId={payout.id}
+                  items={newPizzaPhotos}
+                  onChange={setNewPizzaPhotos}
+                  maxItems={10}
+                />
+              </div>
+
+              {/* Notes */}
+              <div>
+                <p className="text-xs text-theme-text-muted mb-2">Notes</p>
+                <IconInput
+                  icon={StickyNote}
+                  multiline
+                  rows={3}
+                  placeholder="What was this for? Pizza + venue, etc."
+                  value={editNotes}
+                  onChange={e => setEditNotes(e.target.value)}
+                  maxLength={500}
+                />
+                <p className="text-xs text-theme-text-muted mt-1">{editNotes.length}/500</p>
+              </div>
+
+              {/* Amount override */}
+              <div>
+                <p className="text-xs text-theme-text-muted mb-2">Amount (USD)</p>
+                <IconInput
+                  icon={DollarSign}
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder="Override amount (USD) — leave blank to recompute from receipts"
+                  value={editOverrideAmount}
+                  onChange={e => setEditOverrideAmount(e.target.value)}
+                />
+                <p className="text-xs text-theme-text-muted mt-1">
+                  If you change receipts, we'll re-add the totals automatically unless you set a value here.
+                </p>
+              </div>
+
+              {saveError && (
+                <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-300 inline-flex items-center gap-2">
+                  <AlertCircle size={16} /> {saveError}
+                </div>
+              )}
+
+              <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={cancelEdit}
+                  className="btn-secondary"
+                  disabled={saving}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saving || isProcessingUploads}
+                  className="btn-primary inline-flex items-center gap-2 justify-center"
+                >
+                  {saving && <Loader2 size={16} className="animate-spin" />}
+                  {isProcessingUploads
+                    ? 'Waiting for uploads…'
+                    : saving
+                    ? 'Saving…'
+                    : 'Save changes'}
+                </button>
+              </div>
             </>
           )}
         </div>

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -273,6 +273,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           partyId={partyId}
           payoutId={detailPayoutId}
           onClose={() => setDetailPayoutId(null)}
+          onUpdated={loadPayouts}
         />
       )}
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4035,6 +4035,26 @@ export interface UpdatePayoutData {
   mercuryCardLast4?: string | null;
   hostNotes?: string | null;
   finalAmountUsd?: number;
+  /**
+   * arugula-38633 (edit-receipts): hosts can swap receipts/photos on a
+   * payout that is still `status === 'pending'`. New items are append-only
+   * (no IDs); the backend OCRs new receipts and recomputes `finalAmountUsd`
+   * unless an explicit value is supplied.
+   */
+  receiptPhotos?: Array<{
+    url: string;
+    fileName: string;
+    fileSize: number;
+    mimeType: string;
+  }>;
+  pizzaPhotos?: Array<{
+    url: string;
+    fileName: string;
+    fileSize: number;
+    mimeType: string;
+  }>;
+  /** IDs of existing payout_documents rows to delete (must belong to the payout). */
+  removeDocumentIds?: string[];
 }
 
 export async function updatePayout(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1444,7 +1444,7 @@ export interface BankDetails {
 
 export interface PayoutAuditEntry {
   id: string;
-  action: 'create' | 'approve' | 'reject' | 'edit_amount' | 'mark_paid' | 'mark_failed' | 'retry' | 'cancel';
+  action: 'create' | 'approve' | 'reject' | 'edit_amount' | 'edit_documents' | 'mark_paid' | 'mark_failed' | 'retry' | 'cancel';
   oldStatus: string | null;
   newStatus: string | null;
   oldAmount: number | null;


### PR DESCRIPTION
## Summary
- Hosts can now update their submitted receipts while a payout is still `status === 'pending'`. Once admin reviews/approves/rejects/pays, edits are blocked (backend AND frontend gate).
- Backend `PATCH /api/parties/:partyId/payouts/:payoutId` now accepts `receiptPhotos`, `pizzaPhotos`, and `removeDocumentIds` alongside the existing scalar fields. Add + remove are applied in a single transaction; OCR re-runs on each new receipt; final amount is recomputed from the post-edit OCR sum unless the host passes an explicit `finalAmountUsd`.
- Frontend `PayoutDetailModal` gains an Edit affordance for pending payouts. Pre-populates receipts/photos (with X-to-remove buttons backed by a deferred `removedDocIds` set), notes, and amount override. Reuses the existing `ReceiptUpload` + `PizzaPhotoUpload` components — the modal hands them the payout's own ID as the storage grouping key so uploads land at `payouts/{partyId}/{payoutId}/...`.

## Implementation notes
- **OCR re-run policy:** only newly uploaded receipts run through OCR. Existing receipts that survive the edit keep their original OCR rows untouched — we just sum them into the recomputed total.
- **Audit row shape:** writes `action='edit_amount'` (with `oldAmount`/`newAmount`) when the amount changed; writes `action='edit_documents'` when only docs changed. `actor_kind='host'`, `actor_email=req.userEmail`. The `PayoutAuditEntry` type union was extended for the new action.
- **Error code:** non-pending edits return `NOT_EDITABLE` (matches the plan).
- **Storage path:** new uploads use the payout's existing `id` as the grouping key (cleaner than a new tmp id, lives under the same bucket-scoped path the backend already validates).

## Test plan
- [ ] Open a pending payout, click Edit, add a new receipt, save — total recomputes including new OCR.
- [ ] Open a pending payout, click Edit, remove an existing photo + receipt — they disappear after save and total recomputes correctly.
- [ ] Edit notes only — saves without amount/document changes (no audit row for amount).
- [ ] Type an explicit override amount — that value is persisted even if receipts changed.
- [ ] Try to edit an approved/rejected/paid payout — Edit button is hidden and direct PATCH returns `NOT_EDITABLE`.
- [ ] Verify uploaded URLs outside `payouts/{partyId}/` are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)