### PR TITLE
feat(quattro-71244): frontend for gamified dashboard KPIs (PR-2 of 2)

### DIFF
--- a/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
+++ b/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
@@ -1,0 +1,213 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { Party, Guest, EventReport, HostGoals, MomentumDelta } from '../../types';
+import { getReport, getPageViewStats, updateHostGoals } from '../../lib/api';
+import type { PageViewStats } from '../../types';
+import { ReportKPIs } from '../report/ReportKPIs';
+import { LeaderboardPill } from './LeaderboardPill';
+import { MilestoneBadgeStrip } from './MilestoneBadgeStrip';
+import { useMilestones } from '../../hooks/useMilestones';
+import { useMomentum } from '../../hooks/useMomentum';
+import { useConfetti } from '../../hooks/useConfetti';
+
+interface DashboardKPIsProps {
+  party: Party;
+  guests: Guest[];
+}
+
+/**
+ * quattro-71244: gamified host-dashboard KPIs wrapper.
+ *
+ * Composes:
+ *  - LeaderboardPill (current-season GPP rank)
+ *  - MilestoneBadgeStrip (8 milestones, color/grey)
+ *  - ReportKPIs in read-only `gamified` mode (real grid + goals + deltas)
+ *  - ConfettiOverlay (fires once per newly-crossed milestone; single burst on batch)
+ *
+ * Hooks live above any conditional return per project convention.
+ * Realtime is NOT subscribed here — the parent (GPPDashboardTab) inherits the
+ * existing per-page subscription via `useGuestsRealtime` from HostPage.
+ */
+export const DashboardKPIs: React.FC<DashboardKPIsProps> = ({ party, guests }) => {
+  // Hooks: all at the top, before any conditional return.
+  const [report, setReport] = useState<EventReport | null>(null);
+  const [pageViewStats, setPageViewStats] = useState<PageViewStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [localGoals, setLocalGoals] = useState<HostGoals>(party.hostGoals ?? {});
+  const [pulseKeys, setPulseKeys] = useState<Set<string>>(new Set());
+
+  const prevGuestCountRef = useRef<number>(guests.length);
+  const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const confettiFiredRef = useRef<Set<string>>(new Set());
+
+  const { fireFromCenter, ConfettiOverlay } = useConfetti();
+
+  // Keep local goals in sync if party.hostGoals changes externally.
+  useEffect(() => {
+    setLocalGoals(party.hostGoals ?? {});
+  }, [party.hostGoals]);
+
+  // Fetch report + page-view stats once per partyId.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadFailed(false);
+    Promise.all([
+      getReport(party.id),
+      getPageViewStats(party.id).catch(() => null),
+    ]).then(([reportResult, viewsResult]) => {
+      if (cancelled) return;
+      if (!reportResult || !reportResult.report) {
+        // Auth/permission failure — graceful hide.
+        setLoadFailed(true);
+        setLoading(false);
+        return;
+      }
+      setReport(reportResult.report);
+      setPageViewStats(viewsResult);
+      // Hydrate local goals from the report if the party prop didn't carry them.
+      if (reportResult.report.hostGoals && Object.keys(localGoals).length === 0) {
+        setLocalGoals(reportResult.report.hostGoals);
+      }
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // We intentionally exclude `localGoals` — it should not refetch when the
+    // user edits a goal locally. Re-fetch only on partyId change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [party.id]);
+
+  // Stats map mirrors ReportKPIs' `allStats` key set.
+  const stats = useMemo<Record<string, number | null | undefined>>(() => {
+    if (!report) return {};
+    return {
+      pageViews: pageViewStats?.totalViews ?? null,
+      uniqueVisitors: pageViewStats?.uniqueViews ?? null,
+      socialPostViews: null, // not surfaced through this code path in v1
+      socialPosts: report.socialPosts?.length ?? null,
+      totalRsvps: report.stats?.totalRsvps ?? 0,
+      attendees: report.stats?.approvedGuests ?? 0,
+      newsletterSignups: report.stats?.mailingListSignups ?? 0,
+      walletAddresses: report.stats?.walletAddresses ?? 0,
+      poapMints: report.poapMints ?? 0,
+      poapMoments: report.poapMoments ?? 0,
+    };
+  }, [report, pageViewStats]);
+
+  const { unlocked, justCrossed, nextMilestone } = useMilestones(stats, party.id, localGoals);
+
+  const momentum = useMomentum(guests);
+  const deltas = useMemo<Record<string, MomentumDelta>>(() => ({
+    totalRsvps: momentum,
+  }), [momentum]);
+
+  // Pulse the RSVP tile when guests count grows between renders.
+  useEffect(() => {
+    if (guests.length > prevGuestCountRef.current) {
+      setPulseKeys(new Set(['totalRsvps']));
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+      pulseTimerRef.current = setTimeout(() => setPulseKeys(new Set()), 700);
+    }
+    prevGuestCountRef.current = guests.length;
+    return () => {
+      if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+    };
+  }, [guests.length]);
+
+  // Confetti — fire once per newly-crossed milestone. If multiple cross at the
+  // same time, batch into a single centered burst (per plan risk #5).
+  useEffect(() => {
+    if (justCrossed.length === 0) return;
+    const fingerprint = justCrossed.map(m => m.id).sort().join(',');
+    if (confettiFiredRef.current.has(fingerprint)) return;
+    confettiFiredRef.current.add(fingerprint);
+    fireFromCenter();
+  }, [justCrossed, fireFromCenter]);
+
+  // Goal-set handler — optimistic update with revert on failure.
+  const handleSetGoal = async (statKey: string, newGoal: number | null) => {
+    if (!report) return;
+    const goalKey = (
+      statKey === 'totalRsvps' ? 'rsvps' :
+      statKey === 'attendees' ? 'attendees' :
+      statKey === 'newsletterSignups' ? 'newsletterSignups' :
+      statKey === 'walletAddresses' ? 'walletAddresses' :
+      statKey === 'poapMints' ? 'poapMints' :
+      statKey === 'pageViews' ? 'pageViews' :
+      null
+    ) as keyof HostGoals | null;
+    if (!goalKey) return;
+
+    const prev = localGoals;
+    const next: HostGoals = { ...prev };
+    if (newGoal == null) {
+      delete next[goalKey];
+    } else {
+      next[goalKey] = newGoal;
+    }
+    setLocalGoals(next);
+    try {
+      await updateHostGoals(party.id, next);
+    } catch (error) {
+      console.error('Failed to save host goals — reverting:', error);
+      setLocalGoals(prev);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="card p-6">
+        <div className="h-4 w-32 bg-theme-surface-hover rounded animate-pulse mb-4" />
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="card p-4">
+              <div className="h-3 w-16 bg-theme-surface-hover rounded animate-pulse mb-2" />
+              <div className="h-7 w-12 bg-theme-surface-hover rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (loadFailed || !report) {
+    // Graceful hide — host page handles auth gating elsewhere.
+    return null;
+  }
+
+  // Hand the report a hydrated copy with the local goals echoed in so the
+  // gamified prop and the report share the same view of "current goals".
+  const reportForKpis: EventReport = { ...report, hostGoals: localGoals };
+
+  const socialPostViews = (report.socialPosts || []).reduce(
+    (sum, p) => sum + (p.views ?? 0),
+    0,
+  );
+  const socialPostCount = (report.socialPosts || []).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <LeaderboardPill partyId={party.id} />
+      </div>
+      <MilestoneBadgeStrip unlocked={unlocked} next={nextMilestone} />
+      <ReportKPIs
+        report={reportForKpis}
+        onChange={() => { /* noop — gamified mode is read-only for stat config */ }}
+        editable={false}
+        pageViewStats={pageViewStats}
+        socialPostViews={socialPostViews}
+        socialPostCount={socialPostCount}
+        gamified={{
+          goals: localGoals,
+          deltas,
+          pulseKeys,
+          onSetGoal: handleSetGoal,
+        }}
+      />
+      {ConfettiOverlay}
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, X, Lock, ShieldCheck, type LucideIcon } from 'lucide-react';
+import { PartyPopper, Package, Users, MapPin, DollarSign, Handshake, ClipboardCheck, Megaphone, Rocket, CheckCircle, Circle, Loader2, Eye, EyeOff, Check, Lock, ShieldCheck, type LucideIcon } from 'lucide-react';
 import { usePizza } from '../../contexts/PizzaContext';
 import { getChecklist, seedChecklist, updateUnderbossStatus, toggleChecklistItem } from '../../lib/api';
 import { AutoCompleteStates, ChecklistItem } from '../../types';
 import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
 import { FindVenueModal } from '../checklist/FindVenueModal';
+import { DashboardKPIs } from './DashboardKPIs';
 
 export const GPPDashboardTab: React.FC = () => {
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -127,34 +128,20 @@ export const GPPDashboardTab: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      {/* Quick stats */}
+      {/* quattro-71244: gamified KPI block (LeaderboardPill + Milestone strip +
+          ReportKPIs read-only with goals/deltas/pulse). Supersedes the legacy
+          "Invited / RSVPs / Days Until / Pending Approval" 4-tile mini-grid. */}
+      <DashboardKPIs party={party} guests={guests} />
+
+      {/* Status tiles — kept separate from the KPI block because they're
+          status callouts, not stats. */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <div className="card p-4 text-center">
-          <div className="text-2xl font-bold text-theme-text">
-            {guests.filter(g => g.approved !== false && g.status === 'INVITED').length}
-          </div>
-          <div className="text-xs text-theme-text-muted">Invited</div>
-        </div>
-        <div className="card p-4 text-center">
-          <div className="text-2xl font-bold text-theme-text">
-            {guests.filter(g => g.approved !== false && g.status !== 'INVITED').length}
-          </div>
-          <div className="text-xs text-theme-text-muted">RSVPs</div>
-        </div>
         <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-theme-text">
             {daysUntil !== null ? daysUntil : '—'}
           </div>
           <div className="text-xs text-theme-text-muted">Days Until Event</div>
         </div>
-        {party.requireApproval && (
-          <div className="card p-4 text-center">
-            <div className="text-2xl font-bold text-theme-text">
-              {guests.filter((g) => g.approved === null).length}
-            </div>
-            <div className="text-xs text-theme-text-muted">Pending Approval</div>
-          </div>
-        )}
         {party.underbossStatus === 'approved' && (
           <div className="card p-4 text-center border border-green-500/30">
             <div className="flex items-center justify-center gap-1.5 text-green-400">

--- a/frontend/src/components/gpp-dashboard/GoalBar.tsx
+++ b/frontend/src/components/gpp-dashboard/GoalBar.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Target } from 'lucide-react';
+
+interface GoalBarProps {
+  value: number;
+  goal: number | undefined;
+  onSetGoal: (newGoal: number | null) => void;
+}
+
+/**
+ * quattro-71244: inline goal-set / progress bar under a KPI tile.
+ *
+ * Modes:
+ * - `goal === undefined`: render a "Set goal" affordance. Click toggles input mode.
+ * - input mode: controlled number field. Blur commits, Enter commits, Escape cancels.
+ *   Empty / 0 / NaN  → `onSetGoal(null)` (clears).
+ * - `goal` is set: render a slim progress bar with percent label.
+ *   Hover surfaces a tiny edit affordance to re-enter input mode.
+ *
+ * No confirm modal — goal-setting is reversible per project convention.
+ */
+export const GoalBar: React.FC<GoalBarProps> = ({ value, goal, onSetGoal }) => {
+  const { t } = useTranslation('host');
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(goal != null ? String(goal) : '');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  // Keep draft in sync when external goal changes.
+  useEffect(() => {
+    if (!editing) setDraft(goal != null ? String(goal) : '');
+  }, [goal, editing]);
+
+  const commit = () => {
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      setEditing(false);
+      return;
+    }
+    const trimmed = draft.trim();
+    if (trimmed === '') {
+      onSetGoal(null);
+    } else {
+      const parsed = parseInt(trimmed, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        onSetGoal(parsed);
+      } else {
+        onSetGoal(null);
+      }
+    }
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div className="mt-2">
+        <input
+          ref={inputRef}
+          type="number"
+          inputMode="numeric"
+          min={0}
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancelledRef.current = true;
+              setEditing(false);
+            }
+          }}
+          placeholder={t('dashboard.kpis.setGoal')}
+          className="w-full bg-transparent text-xs text-theme-text outline-none border-b border-theme-stroke focus:border-[#ff393a] transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+      </div>
+    );
+  }
+
+  if (goal == null) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="mt-2 inline-flex items-center gap-1 text-[10px] text-theme-text-faint hover:text-theme-text-secondary transition-colors"
+      >
+        <Target size={10} />
+        {t('dashboard.kpis.setGoal')}
+      </button>
+    );
+  }
+
+  const pct = goal > 0 ? Math.min(100, Math.round((value / goal) * 100)) : 0;
+  const hit = pct >= 100;
+
+  return (
+    <div className="mt-2 group">
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="w-full text-left"
+        title={t('dashboard.kpis.setGoal')}
+      >
+        <div className="w-full h-1.5 bg-theme-surface-hover rounded-full overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-500"
+            style={{
+              width: `${pct}%`,
+              background: hit ? '#22c55e' : '#ff393a',
+            }}
+          />
+        </div>
+        <div className="flex items-center justify-between mt-1 text-[10px]">
+          <span className="text-theme-text-faint">{t('dashboard.kpis.goalLabel', { value: goal })}</span>
+          <span className={hit ? 'text-green-400' : 'text-theme-text-faint group-hover:text-theme-text-muted'}>
+            {hit ? t('dashboard.kpis.goalHit') : t('dashboard.kpis.percentToGoal', { percent: pct })}
+          </span>
+        </div>
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/KPIBadge.tsx
+++ b/frontend/src/components/gpp-dashboard/KPIBadge.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trophy, Lock } from 'lucide-react';
+import type { Milestone } from '../../types';
+
+interface KPIBadgeProps {
+  milestone: Milestone;
+  unlocked: boolean;
+}
+
+/**
+ * quattro-71244: single milestone chip rendered inside MilestoneBadgeStrip.
+ * Unlocked = colored trophy + bright label.
+ * Locked   = muted + lock icon + low-opacity label.
+ */
+export const KPIBadge: React.FC<KPIBadgeProps> = ({ milestone, unlocked }) => {
+  const { t } = useTranslation('host');
+  // Strip the `host.` prefix because useTranslation('host') is already scoped.
+  const key = milestone.labelKey.replace(/^host\./, '');
+  const label = t(key);
+
+  return (
+    <div
+      className={[
+        'shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs whitespace-nowrap transition-all',
+        unlocked
+          ? 'bg-[#ff393a]/15 border-[#ff393a]/40 text-theme-text'
+          : 'bg-theme-surface border-theme-stroke text-theme-text-faint opacity-60',
+      ].join(' ')}
+      title={label}
+    >
+      {unlocked ? (
+        <Trophy size={12} className="text-[#ff393a]" />
+      ) : (
+        <Lock size={12} className="text-theme-text-faint" />
+      )}
+      <span>{label}</span>
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/LeaderboardPill.tsx
+++ b/frontend/src/components/gpp-dashboard/LeaderboardPill.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Medal } from 'lucide-react';
+import { getLeaderboardRank } from '../../lib/api';
+
+interface LeaderboardPillProps {
+  partyId: string;
+  metric?: string;
+}
+
+interface RankData {
+  rank: number;
+  total: number;
+  topPercent: number;
+  scope: 'gpp-season' | 'gpp-all';
+}
+
+/**
+ * quattro-71244: leaderboard rank pill.
+ * Renders nothing on auth-fail / 404 (`getLeaderboardRank` returns null).
+ * Shows a brief skeleton while loading.
+ */
+export const LeaderboardPill: React.FC<LeaderboardPillProps> = ({ partyId, metric = 'totalRsvps' }) => {
+  const { t } = useTranslation('host');
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<RankData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setData(null);
+    getLeaderboardRank(partyId, metric).then(result => {
+      if (cancelled) return;
+      setData(result);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId, metric]);
+
+  if (loading) {
+    return (
+      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-theme-surface border border-theme-stroke text-xs text-theme-text-faint">
+        <span className="inline-block w-2 h-2 rounded-full bg-theme-text-faint/40 animate-pulse" />
+        <span className="inline-block w-24 h-3 rounded bg-theme-text-faint/20 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!data || data.total === 0) return null;
+
+  const scopeLabel = t('dashboard.kpis.leaderboardScopeGpp');
+  const showTopPct = data.topPercent > 0 && data.topPercent <= 10;
+
+  return (
+    <div className="inline-flex flex-col gap-0.5">
+      <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#ff393a]/15 border border-[#ff393a]/40 text-xs text-theme-text self-start">
+        <Medal size={12} className="text-[#ff393a]" />
+        <span>
+          {t('dashboard.kpis.leaderboardRank', {
+            rank: data.rank,
+            total: data.total,
+            scope: scopeLabel,
+          })}
+        </span>
+      </div>
+      {showTopPct && (
+        <span className="text-[10px] text-theme-text-faint pl-1">
+          {t('dashboard.kpis.leaderboardTopPct', { percent: data.topPercent, metric })}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/MilestoneBadgeStrip.tsx
+++ b/frontend/src/components/gpp-dashboard/MilestoneBadgeStrip.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { KPIBadge } from './KPIBadge';
+import { ALL_MILESTONES } from '../../hooks/useMilestones';
+import type { Milestone } from '../../types';
+
+interface MilestoneBadgeStripProps {
+  unlocked: Milestone[];
+  // `next` is accepted but not currently surfaced in the strip — kept on the
+  // prop signature so callers can pass it without ts errors when we add a
+  // dedicated "next milestone" hint in v2.
+  next?: Milestone | null;
+}
+
+/**
+ * quattro-71244: horizontal scrollable row of milestone chips. Renders the
+ * entire `ALL_MILESTONES` list — locked chips are visually muted, unlocked
+ * chips pop in color. Title text comes from `host.dashboard.kpis.title`.
+ */
+export const MilestoneBadgeStrip: React.FC<MilestoneBadgeStripProps> = ({ unlocked }) => {
+  const { t } = useTranslation('host');
+  const unlockedIds = new Set(unlocked.map(m => m.id));
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-theme-text-secondary">
+        {t('dashboard.kpis.title')}
+      </h3>
+      <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+        {ALL_MILESTONES.map(m => (
+          <KPIBadge key={m.id} milestone={m} unlocked={unlockedIds.has(m.id)} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/index.ts
+++ b/frontend/src/components/gpp-dashboard/index.ts
@@ -1,1 +1,2 @@
 export { GPPDashboardTab } from './GPPDashboardTab';
+export { DashboardKPIs } from './DashboardKPIs';

--- a/frontend/src/components/report/ReportKPIs.tsx
+++ b/frontend/src/components/report/ReportKPIs.tsx
@@ -1,9 +1,28 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, Users, Mail, Wallet, Award, Video, MousePointerClick, FileText } from 'lucide-react';
-import { EventReport, PageViewStats } from '../../types';
+import { EventReport, PageViewStats, HostGoals, MomentumDelta } from '../../types';
+import { GoalBar } from '../gpp-dashboard/GoalBar';
 
 type StatsConfig = Record<string, { override?: number | null; hidden?: boolean }>;
+
+// quattro-71244: optional gamification extras for the read-only branch.
+export interface GamifiedExtras {
+  goals: HostGoals;
+  deltas: Record<string, MomentumDelta>;
+  pulseKeys: Set<string>;
+  onSetGoal: (statKey: string, newGoal: number | null) => void;
+}
+
+// Stat key → matching HostGoals key (subset that supports goals).
+const STAT_TO_GOAL_KEY: Record<string, keyof HostGoals> = {
+  totalRsvps: 'rsvps',
+  attendees: 'attendees',
+  newsletterSignups: 'newsletterSignups',
+  walletAddresses: 'walletAddresses',
+  poapMints: 'poapMints',
+  pageViews: 'pageViews',
+};
 
 interface ReportKPIsProps {
   report: EventReport;
@@ -12,6 +31,7 @@ interface ReportKPIsProps {
   pageViewStats?: PageViewStats | null;
   socialPostViews?: number;
   socialPostCount?: number;
+  gamified?: GamifiedExtras;
 }
 
 interface StatItem {
@@ -22,7 +42,7 @@ interface StatItem {
   color: string;
 }
 
-export function ReportKPIs({ report, onChange, editable = true, pageViewStats, socialPostViews, socialPostCount }: ReportKPIsProps) {
+export function ReportKPIs({ report, onChange, editable = true, pageViewStats, socialPostViews, socialPostCount, gamified }: ReportKPIsProps) {
   const { t } = useTranslation('host');
   const config: StatsConfig = report.reportStatsConfig || {};
 
@@ -64,7 +84,11 @@ export function ReportKPIs({ report, onChange, editable = true, pageViewStats, s
   if (!editable) {
     // Read-only display mode for preview/public view
     const visibleStats = allStats.filter(s => !isHidden(s.key));
-    const hasAny = visibleStats.some(s => getDisplayValue(s) != null);
+    // When `gamified` is provided, render zero-state tiles too — zeros are
+    // motivating, and the gamified-dashboard wrapper expects the full grid.
+    const hasAny = gamified
+      ? visibleStats.length > 0
+      : visibleStats.some(s => getDisplayValue(s) != null);
     if (!hasAny) return null;
 
     return (
@@ -73,18 +97,49 @@ export function ReportKPIs({ report, onChange, editable = true, pageViewStats, s
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
           {visibleStats.map((stat) => {
             const value = getDisplayValue(stat);
-            if (value === null) return null;
+            // In non-gamified mode, hide null tiles (legacy behavior).
+            if (value === null && !gamified) return null;
             const Icon = stat.icon;
+            const numericValue = value ?? 0;
+
+            // quattro-71244: gamification extras (goals, deltas, pulse).
+            const goalKey = gamified ? STAT_TO_GOAL_KEY[stat.key] : undefined;
+            const goalValue = goalKey != null && gamified ? gamified.goals[goalKey] : undefined;
+            const delta = gamified ? gamified.deltas[stat.key] : undefined;
+            const pulse = gamified?.pulseKeys.has(stat.key) ?? false;
 
             return (
-              <div key={stat.key} className="card p-4">
+              <div
+                key={stat.key}
+                className={`card p-4 ${pulse ? 'animate-pulse-once' : ''}`}
+              >
                 <div className="flex items-center gap-2 mb-2">
                   <Icon size={16} className={stat.color} />
                   <span className="text-xs text-theme-text-secondary">{stat.label}</span>
                 </div>
                 <div className="text-2xl font-bold text-theme-text">
-                  {value.toLocaleString()}
+                  {numericValue.toLocaleString()}
                 </div>
+                {gamified && goalKey != null && (
+                  <GoalBar
+                    value={numericValue}
+                    goal={goalValue}
+                    onSetGoal={(g) => gamified.onSetGoal(stat.key, g)}
+                  />
+                )}
+                {gamified && delta && (delta.lastHour || delta.today || delta.busiestHourLabel) ? (
+                  <div className="mt-2 text-[10px] text-theme-text-faint space-y-0.5">
+                    {delta.lastHour != null && delta.lastHour > 0 && (
+                      <div>{t('dashboard.kpis.deltaLastHour', { n: delta.lastHour })}</div>
+                    )}
+                    {delta.today != null && delta.today > 0 && (
+                      <div>{t('dashboard.kpis.deltaToday', { n: delta.today })}</div>
+                    )}
+                    {delta.busiestHourLabel && (
+                      <div>{t('dashboard.kpis.busiestHour', { label: delta.busiestHourLabel })}</div>
+                    )}
+                  </div>
+                ) : null}
               </div>
             );
           })}

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -174,6 +174,8 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     // Day-of logistics (pepperoni-58341)
     wifiInfo: dbParty.wifi_info ?? null,
     parkingNotes: dbParty.parking_notes ?? null,
+    // quattro-71244: gamified-dashboard goal targets.
+    hostGoals: dbParty.host_goals ?? null,
     guests,
   };
 }

--- a/frontend/src/hooks/useMilestones.ts
+++ b/frontend/src/hooks/useMilestones.ts
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { HostGoals, Milestone, MilestoneId } from '../types';
+
+/**
+ * quattro-71244: deterministic milestone unlock computation for the gamified
+ * dashboard.
+ *
+ * - `unlocked`: milestones currently met by `stats`.
+ * - `justCrossed`: milestones newly unlocked since the previous render,
+ *   excluding any already-celebrated in this session (sessionStorage dedup).
+ * - `nextMilestone`: the smallest-threshold locked milestone, or null if all
+ *   are unlocked.
+ *
+ * First-mount suppression: we initialize the prev-unlocked ref with the
+ * current unlocked set so the very first render emits an empty `justCrossed`.
+ * sessionStorage key `dashboardKPIs.celebrated.<partyId>` persists the set
+ * across remounts within the same browser session.
+ *
+ * Hooks live at the top with no early returns to comply with rules-of-hooks.
+ * SSR-safe: guards `typeof window !== 'undefined'` before touching storage.
+ */
+
+const STORAGE_PREFIX = 'dashboardKPIs.celebrated.';
+
+// Hardcoded milestone list — order also controls "nextMilestone" priority.
+export const ALL_MILESTONES: Milestone[] = [
+  { id: 'firstRsvp',       statKey: 'totalRsvps',         threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstRsvp' },
+  { id: 'rsvps25',         statKey: 'totalRsvps',         threshold: 25,  labelKey: 'host.dashboard.kpis.milestones.rsvps25' },
+  { id: 'rsvps50',         statKey: 'totalRsvps',         threshold: 50,  labelKey: 'host.dashboard.kpis.milestones.rsvps50' },
+  { id: 'rsvps100',        statKey: 'totalRsvps',         threshold: 100, labelKey: 'host.dashboard.kpis.milestones.rsvps100' },
+  { id: 'firstWallet',     statKey: 'walletAddresses',    threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstWallet' },
+  { id: 'firstNewsletter', statKey: 'newsletterSignups', threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstNewsletter' },
+  { id: 'firstPoap',       statKey: 'poapMints',          threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstPoap' },
+  // `goalReached` is computed dynamically — `statKey` and `threshold` here are
+  // placeholders so the type still works; the hook resolves it specially.
+  { id: 'goalReached',     statKey: '__goal__',           threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.goalReached' },
+];
+
+// Map a HostGoals key to its corresponding stat key.
+const GOAL_TO_STAT: Record<keyof HostGoals, string> = {
+  rsvps: 'totalRsvps',
+  attendees: 'attendees',
+  newsletterSignups: 'newsletterSignups',
+  walletAddresses: 'walletAddresses',
+  poapMints: 'poapMints',
+  pageViews: 'pageViews',
+};
+
+function readCelebrated(partyId: string): Set<MilestoneId> {
+  if (typeof window === 'undefined' || !window.sessionStorage) return new Set();
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_PREFIX + partyId);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set(parsed as MilestoneId[]);
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeCelebrated(partyId: string, ids: Set<MilestoneId>): void {
+  if (typeof window === 'undefined' || !window.sessionStorage) return;
+  try {
+    window.sessionStorage.setItem(STORAGE_PREFIX + partyId, JSON.stringify([...ids]));
+  } catch {
+    // Quota exceeded or storage disabled — silently no-op.
+  }
+}
+
+function isGoalReached(
+  stats: Record<string, number | null | undefined>,
+  hostGoals: HostGoals | null | undefined,
+): boolean {
+  if (!hostGoals) return false;
+  for (const [goalKey, target] of Object.entries(hostGoals)) {
+    if (typeof target !== 'number' || target <= 0) continue;
+    const statKey = GOAL_TO_STAT[goalKey as keyof HostGoals];
+    if (!statKey) continue;
+    const value = stats[statKey];
+    if (typeof value === 'number' && value >= target) return true;
+  }
+  return false;
+}
+
+export function useMilestones(
+  stats: Record<string, number | null | undefined>,
+  partyId: string,
+  hostGoals?: HostGoals | null,
+): { unlocked: Milestone[]; justCrossed: Milestone[]; nextMilestone: Milestone | null } {
+  // Compute currently-unlocked milestones from stats + goals.
+  const unlocked = useMemo<Milestone[]>(() => {
+    const list: Milestone[] = [];
+    for (const m of ALL_MILESTONES) {
+      if (m.id === 'goalReached') {
+        if (isGoalReached(stats, hostGoals)) list.push(m);
+        continue;
+      }
+      const v = stats[m.statKey];
+      if (typeof v === 'number' && v >= m.threshold) list.push(m);
+    }
+    return list;
+  }, [stats, hostGoals]);
+
+  const nextMilestone = useMemo<Milestone | null>(() => {
+    const unlockedIds = new Set(unlocked.map(m => m.id));
+    for (const m of ALL_MILESTONES) {
+      if (m.id === 'goalReached') continue; // skip in "next" rotation; surface via dedicated UI
+      if (!unlockedIds.has(m.id)) return m;
+    }
+    return null;
+  }, [unlocked]);
+
+  // Track which milestones were unlocked on the previous render so we can
+  // diff. On first render this is initialized to the *current* unlocked set
+  // so we don't fire confetti for already-passed milestones.
+  const prevUnlockedRef = useRef<Set<MilestoneId>>(new Set(unlocked.map(m => m.id)));
+
+  // Read the persisted celebrated set ONCE per partyId mount.
+  const celebratedRef = useRef<Set<MilestoneId>>(new Set());
+  const lastPartyIdRef = useRef<string | null>(null);
+  if (lastPartyIdRef.current !== partyId) {
+    celebratedRef.current = readCelebrated(partyId);
+    // Reset prev set when partyId changes — treat as a fresh first-mount.
+    prevUnlockedRef.current = new Set(unlocked.map(m => m.id));
+    lastPartyIdRef.current = partyId;
+  }
+
+  // Newly-crossed = currently unlocked but not in prev set AND not already celebrated.
+  const justCrossed = useMemo<Milestone[]>(() => {
+    const prev = prevUnlockedRef.current;
+    const celebrated = celebratedRef.current;
+    return unlocked.filter(m => !prev.has(m.id) && !celebrated.has(m.id));
+  }, [unlocked]);
+
+  // Commit the new prev + celebrated sets after render. Must be in an effect
+  // so we don't mutate refs during render (would otherwise cause stale reads
+  // in StrictMode double-invocation).
+  useEffect(() => {
+    if (justCrossed.length > 0) {
+      const newCelebrated = new Set(celebratedRef.current);
+      for (const m of justCrossed) newCelebrated.add(m.id);
+      celebratedRef.current = newCelebrated;
+      writeCelebrated(partyId, newCelebrated);
+    }
+    prevUnlockedRef.current = new Set(unlocked.map(m => m.id));
+  }, [unlocked, justCrossed, partyId]);
+
+  return { unlocked, justCrossed, nextMilestone };
+}

--- a/frontend/src/hooks/useMomentum.ts
+++ b/frontend/src/hooks/useMomentum.ts
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import type { Guest, MomentumDelta } from '../types';
+
+/**
+ * quattro-71244: derives velocity stats from the guests list.
+ *
+ * - `lastHour`: guests submitted within the last 60 minutes.
+ * - `today`: guests submitted with local date == today.
+ * - `busiestHourLabel`: hour-of-day label (e.g. "7pm") with the most RSVPs.
+ *   Returns null when fewer than 5 guests exist (not statistically meaningful).
+ *
+ * `Guest.submittedAt` is the canonical timestamp (see frontend/src/types.ts).
+ * Invited rows have a `submittedAt` from when the invite landed; for v1 we
+ * count all rows uniformly — host can hide the metric per-tile if it feels
+ * misleading on a bulk-invite event.
+ */
+
+function hourLabel(hour: number): string {
+  // 12-hour clock with am/pm.
+  const h12 = ((hour + 11) % 12) + 1;
+  const ampm = hour < 12 ? 'am' : 'pm';
+  return `${h12}${ampm}`;
+}
+
+export function useMomentum(guests: Guest[]): MomentumDelta {
+  return useMemo<MomentumDelta>(() => {
+    if (!Array.isArray(guests) || guests.length === 0) {
+      return { lastHour: 0, today: 0, busiestHourLabel: null };
+    }
+
+    const now = new Date();
+    const oneHourAgo = now.getTime() - 60 * 60 * 1000;
+    const todayY = now.getFullYear();
+    const todayM = now.getMonth();
+    const todayD = now.getDate();
+
+    let lastHour = 0;
+    let today = 0;
+    const hourCounts: Record<number, number> = {};
+
+    for (const g of guests) {
+      if (!g.submittedAt) continue;
+      const ts = Date.parse(g.submittedAt);
+      if (Number.isNaN(ts)) continue;
+      if (ts >= oneHourAgo) lastHour += 1;
+      const d = new Date(ts);
+      if (d.getFullYear() === todayY && d.getMonth() === todayM && d.getDate() === todayD) {
+        today += 1;
+      }
+      const h = d.getHours();
+      hourCounts[h] = (hourCounts[h] || 0) + 1;
+    }
+
+    // Busiest hour requires at least 5 dated guests to avoid noise.
+    let busiestHourLabel: string | null = null;
+    const datedCount = Object.values(hourCounts).reduce((sum, n) => sum + n, 0);
+    if (datedCount >= 5) {
+      let bestHour = -1;
+      let bestCount = -1;
+      for (const [hStr, count] of Object.entries(hourCounts)) {
+        const h = Number(hStr);
+        if (count > bestCount) {
+          bestCount = count;
+          bestHour = h;
+        }
+      }
+      if (bestHour >= 0) busiestHourLabel = hourLabel(bestHour);
+    }
+
+    return { lastHour, today, busiestHourLabel };
+  }, [guests]);
+}

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -759,5 +759,32 @@
     "eligible": "{{count}} berechtigt",
     "pickAWinnerBtn": "Gewinner wählen",
     "winnersThisSession": "Gewinner dieser Sitzung ({{count}})"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "Deine Event-Statistik",
+      "setGoal": "Ziel festlegen",
+      "goalLabel": "Ziel: {{value}}",
+      "percentToGoal": "{{percent}}% bis zum Ziel",
+      "goalHit": "Ziel erreicht!",
+      "deltaLastHour": "+{{n}} in der letzten Stunde",
+      "deltaToday": "{{n}} heute",
+      "busiestHour": "Stärkste Stunde: {{label}}",
+      "leaderboardRank": "#{{rank}} von {{total}} {{scope}}",
+      "leaderboardTopPct": "Top {{percent}}% bei {{metric}}",
+      "leaderboardScopeGpp": "GPP-Gastgebern",
+      "badgeUnlocked": "Freigeschaltet",
+      "badgeLocked": "Nächstes: {{label}}",
+      "milestones": {
+        "firstRsvp": "Erste Zusage",
+        "rsvps25": "25 Zusagen",
+        "rsvps50": "50 Zusagen",
+        "rsvps100": "100 Zusagen",
+        "firstWallet": "Erste Wallet",
+        "firstNewsletter": "Erste Newsletter-Anmeldung",
+        "firstPoap": "Erstes POAP-Mint",
+        "goalReached": "Ziel erreicht"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -767,5 +767,32 @@
     "eligible": "{{count}} eligible",
     "pickAWinnerBtn": "Pick a Winner",
     "winnersThisSession": "Winners This Session ({{count}})"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "Your Event Stats",
+      "setGoal": "Set goal",
+      "goalLabel": "Goal: {{value}}",
+      "percentToGoal": "{{percent}}% to goal",
+      "goalHit": "Goal hit!",
+      "deltaLastHour": "+{{n}} in the last hour",
+      "deltaToday": "{{n}} today",
+      "busiestHour": "Busiest hour: {{label}}",
+      "leaderboardRank": "#{{rank}} of {{total}} {{scope}}",
+      "leaderboardTopPct": "Top {{percent}}% for {{metric}}",
+      "leaderboardScopeGpp": "GPP hosts",
+      "badgeUnlocked": "Unlocked",
+      "badgeLocked": "Next: {{label}}",
+      "milestones": {
+        "firstRsvp": "First RSVP",
+        "rsvps25": "25 RSVPs",
+        "rsvps50": "50 RSVPs",
+        "rsvps100": "100 RSVPs",
+        "firstWallet": "First wallet",
+        "firstNewsletter": "First newsletter signup",
+        "firstPoap": "First POAP mint",
+        "goalReached": "Goal reached"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -759,5 +759,32 @@
     "eligible": "{{count}} elegibles",
     "pickAWinnerBtn": "Elegir un Ganador",
     "winnersThisSession": "Ganadores de Esta Sesión ({{count}})"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "Estadísticas de tu evento",
+      "setGoal": "Definir meta",
+      "goalLabel": "Meta: {{value}}",
+      "percentToGoal": "{{percent}}% hacia la meta",
+      "goalHit": "¡Meta alcanzada!",
+      "deltaLastHour": "+{{n}} en la última hora",
+      "deltaToday": "{{n}} hoy",
+      "busiestHour": "Hora pico: {{label}}",
+      "leaderboardRank": "#{{rank}} de {{total}} {{scope}}",
+      "leaderboardTopPct": "Top {{percent}}% en {{metric}}",
+      "leaderboardScopeGpp": "anfitriones GPP",
+      "badgeUnlocked": "Desbloqueado",
+      "badgeLocked": "Siguiente: {{label}}",
+      "milestones": {
+        "firstRsvp": "Primera confirmación",
+        "rsvps25": "25 confirmaciones",
+        "rsvps50": "50 confirmaciones",
+        "rsvps100": "100 confirmaciones",
+        "firstWallet": "Primera wallet",
+        "firstNewsletter": "Primera suscripción al boletín",
+        "firstPoap": "Primer mint de POAP",
+        "goalReached": "Meta alcanzada"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -759,5 +759,32 @@
     "eligible": "{{count}} éligibles",
     "pickAWinnerBtn": "Choisir un gagnant",
     "winnersThisSession": "Gagnants de cette session ({{count}})"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "Statistiques de votre événement",
+      "setGoal": "Définir un objectif",
+      "goalLabel": "Objectif : {{value}}",
+      "percentToGoal": "{{percent}}% vers l'objectif",
+      "goalHit": "Objectif atteint !",
+      "deltaLastHour": "+{{n}} dans la dernière heure",
+      "deltaToday": "{{n}} aujourd'hui",
+      "busiestHour": "Heure de pointe : {{label}}",
+      "leaderboardRank": "#{{rank}} sur {{total}} {{scope}}",
+      "leaderboardTopPct": "Top {{percent}}% pour {{metric}}",
+      "leaderboardScopeGpp": "hôtes GPP",
+      "badgeUnlocked": "Débloqué",
+      "badgeLocked": "Suivant : {{label}}",
+      "milestones": {
+        "firstRsvp": "Première confirmation",
+        "rsvps25": "25 confirmations",
+        "rsvps50": "50 confirmations",
+        "rsvps100": "100 confirmations",
+        "firstWallet": "Premier portefeuille",
+        "firstNewsletter": "Première inscription à la newsletter",
+        "firstPoap": "Premier mint POAP",
+        "goalReached": "Objectif atteint"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -759,5 +759,32 @@
     "eligible": "対象{{count}}名",
     "pickAWinnerBtn": "当選者を選ぶ",
     "winnersThisSession": "今回の当選者（{{count}}）"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "イベント統計",
+      "setGoal": "目標を設定",
+      "goalLabel": "目標：{{value}}",
+      "percentToGoal": "目標まで{{percent}}%",
+      "goalHit": "目標達成！",
+      "deltaLastHour": "直近1時間で+{{n}}",
+      "deltaToday": "本日{{n}}件",
+      "busiestHour": "ピーク時間：{{label}}",
+      "leaderboardRank": "{{total}}名の{{scope}}中{{rank}}位",
+      "leaderboardTopPct": "{{metric}}でトップ{{percent}}%",
+      "leaderboardScopeGpp": "GPPホスト",
+      "badgeUnlocked": "解除済み",
+      "badgeLocked": "次：{{label}}",
+      "milestones": {
+        "firstRsvp": "最初のRSVP",
+        "rsvps25": "25件のRSVP",
+        "rsvps50": "50件のRSVP",
+        "rsvps100": "100件のRSVP",
+        "firstWallet": "最初のウォレット",
+        "firstNewsletter": "最初のニュースレター登録",
+        "firstPoap": "最初のPOAPミント",
+        "goalReached": "目標達成"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -759,5 +759,32 @@
     "eligible": "{{count}} elegíveis",
     "pickAWinnerBtn": "Sortear um Vencedor",
     "winnersThisSession": "Vencedores Desta Sessão ({{count}})"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "Estatísticas do seu evento",
+      "setGoal": "Definir meta",
+      "goalLabel": "Meta: {{value}}",
+      "percentToGoal": "{{percent}}% até a meta",
+      "goalHit": "Meta atingida!",
+      "deltaLastHour": "+{{n}} na última hora",
+      "deltaToday": "{{n}} hoje",
+      "busiestHour": "Hora de pico: {{label}}",
+      "leaderboardRank": "#{{rank}} de {{total}} {{scope}}",
+      "leaderboardTopPct": "Top {{percent}}% em {{metric}}",
+      "leaderboardScopeGpp": "anfitriões GPP",
+      "badgeUnlocked": "Desbloqueado",
+      "badgeLocked": "Próximo: {{label}}",
+      "milestones": {
+        "firstRsvp": "Primeira confirmação",
+        "rsvps25": "25 confirmações",
+        "rsvps50": "50 confirmações",
+        "rsvps100": "100 confirmações",
+        "firstWallet": "Primeira carteira",
+        "firstNewsletter": "Primeira inscrição na newsletter",
+        "firstPoap": "Primeiro mint de POAP",
+        "goalReached": "Meta atingida"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -759,5 +759,32 @@
     "eligible": "{{count}} 位符合条件",
     "pickAWinnerBtn": "抽取获奖者",
     "winnersThisSession": "本次获奖者（{{count}}）"
+  },
+  "dashboard": {
+    "kpis": {
+      "title": "活动数据",
+      "setGoal": "设定目标",
+      "goalLabel": "目标：{{value}}",
+      "percentToGoal": "已完成目标的 {{percent}}%",
+      "goalHit": "目标达成！",
+      "deltaLastHour": "过去 1 小时 +{{n}}",
+      "deltaToday": "今日 {{n}} 位",
+      "busiestHour": "高峰时段：{{label}}",
+      "leaderboardRank": "{{total}} 位{{scope}}中第 {{rank}} 名",
+      "leaderboardTopPct": "{{metric}}前 {{percent}}%",
+      "leaderboardScopeGpp": "GPP 主办人",
+      "badgeUnlocked": "已解锁",
+      "badgeLocked": "下一个：{{label}}",
+      "milestones": {
+        "firstRsvp": "首次 RSVP",
+        "rsvps25": "25 位 RSVP",
+        "rsvps50": "50 位 RSVP",
+        "rsvps100": "100 位 RSVP",
+        "firstWallet": "首个钱包",
+        "firstNewsletter": "首次订阅通讯",
+        "firstPoap": "首次铸造 POAP",
+        "goalReached": "目标达成"
+      }
+    }
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -732,6 +732,16 @@ body.gpp-theme-active .gpp-badge.gpp-badge-community { display: inline-flex !imp
   }
 }
 
+/* quattro-71244: gamified-dashboard KPI tile pulse on live counter increments. */
+@keyframes pulse-once {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.04); box-shadow: 0 0 0 4px rgba(255, 57, 58, 0.25); }
+  100% { transform: scale(1); }
+}
+.animate-pulse-once {
+  animation: pulse-once 600ms ease-out;
+}
+
 /* Pizzeria name label next to red pins on the Participating Pizzerias map.
    Google Maps applies this class to the label container that sits centered on
    the marker anchor — we offset it downward so it sits below the pin with a

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -216,6 +216,8 @@ export interface UpdatePartyData {
   // Day-of logistics (pepperoni-58341)
   wifiInfo?: string | null;
   parkingNotes?: string | null;
+  // quattro-71244: Gamified dashboard host-set goals (JSONB).
+  hostGoals?: HostGoals | null;
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -329,8 +331,39 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       // Day-of logistics (pepperoni-58341)
       wifiInfo: data.wifiInfo,
       parkingNotes: data.parkingNotes,
+      // quattro-71244: gamified-dashboard goal targets.
+      hostGoals: data.hostGoals,
     },
   });
+}
+
+/**
+ * quattro-71244: Convenience for the gamified dashboard's inline goal-setting
+ * UI. Thin wrapper around `updatePartyApi` so callers don't need to know about
+ * the broader UpdatePartyData shape.
+ */
+export async function updateHostGoals(partyId: string, hostGoals: HostGoals) {
+  return updatePartyApi(partyId, { hostGoals });
+}
+
+/**
+ * quattro-71244: Fetches this party's rank against peer GPP events.
+ * Returns null on 401/403/404/network failure so callers (the LeaderboardPill)
+ * can gracefully hide instead of crashing the dashboard.
+ */
+export async function getLeaderboardRank(
+  partyId: string,
+  metric: string = 'totalRsvps',
+): Promise<{ rank: number; total: number; topPercent: number; scope: 'gpp-season' | 'gpp-all' } | null> {
+  try {
+    return await apiRequest<{ rank: number; total: number; topPercent: number; scope: 'gpp-season' | 'gpp-all' }>(
+      `/api/parties/${partyId}/leaderboard-rank?metric=${encodeURIComponent(metric)}`,
+      { method: 'GET', requireAuth: true },
+    );
+  } catch (error) {
+    // Graceful hide — leaderboard is decorative, not load-bearing.
+    return null;
+  }
 }
 
 export async function deletePartyApi(partyId: string) {

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -11,6 +11,7 @@ import {
 } from './api';
 import { uuid } from './utils';
 import { sanitizeCoHosts } from './sanitizeCoHosts';
+import type { HostGoals } from '../types';
 
 const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL || '').trim();
 const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY || '').trim();
@@ -781,6 +782,8 @@ export interface DbParty {
   reimbursement_cap_usd?: number | null;
   reimbursement_cap_appeal_note?: string | null;
   reimbursement_cap_appealed_at?: string | null;
+  // quattro-71244: gamified-dashboard goal targets (JSONB on parties).
+  host_goals?: HostGoals | null;
 }
 
 export type DbGuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
@@ -1864,6 +1867,8 @@ export async function updateParty(
     host_telegram_link_token?: string | null;
     turtle_roles_enabled?: boolean;
     reimbursement_cap_usd?: number | null;
+    // quattro-71244: gamified-dashboard goal targets.
+    host_goals?: HostGoals | null;
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -1943,6 +1948,8 @@ export async function updateParty(
         // Day-of logistics (pepperoni-58341)
         wifiInfo: updates.wifi_info,
         parkingNotes: updates.parking_notes,
+        // quattro-71244: gamified-dashboard goal targets.
+        hostGoals: updates.host_goals,
       });
       return true;
     } catch (error) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -212,6 +212,39 @@ export interface VenueInfo {
   notes: string | null;
 }
 
+// quattro-71244: Gamified host dashboard KPIs
+export type HostGoals = Partial<{
+  rsvps: number;
+  attendees: number;
+  newsletterSignups: number;
+  walletAddresses: number;
+  poapMints: number;
+  pageViews: number;
+}>;
+
+export interface MomentumDelta {
+  lastHour?: number;
+  today?: number;
+  busiestHourLabel?: string | null;
+}
+
+export type MilestoneId =
+  | 'firstRsvp'
+  | 'rsvps25'
+  | 'rsvps50'
+  | 'rsvps100'
+  | 'firstWallet'
+  | 'firstNewsletter'
+  | 'firstPoap'
+  | 'goalReached';
+
+export interface Milestone {
+  id: MilestoneId;
+  labelKey: string;          // i18n key under host.dashboard.kpis.milestones.*
+  statKey: string;           // matches a ReportKPIs stat key
+  threshold: number;         // value of stat that unlocks this badge
+}
+
 export interface Party {
   id: string;
   name: string;
@@ -309,6 +342,9 @@ export interface Party {
   effectiveReimbursementCapUsd?: number | null;
   reimbursementCapAppealNote?: string | null;
   reimbursementCapAppealedAt?: string | null;
+  // quattro-71244: Gamified host dashboard KPIs — host-private goal targets
+  // keyed by ReportKPIs stat key. Lives in the `host_goals` JSONB column.
+  hostGoals?: HostGoals | null;
 }
 
 export interface Donation {
@@ -683,6 +719,9 @@ export interface EventReport {
 
   // Calculated stats
   stats: ReportStats;
+
+  // quattro-71244: host-set goal targets, surfaced to the dashboard KPI block.
+  hostGoals?: HostGoals | null;
 }
 
 // Staffing types


### PR DESCRIPTION
## Summary

PR-2 of 2 for `quattro-71244 — Gamified host dashboard KPIs`. Frontend-only — consumes the backend endpoints already merged in PR-1 (#483) and the `parties.host_goals` JSONB column already live in production Supabase.

Plan: `plans/quattro-71244-gamified-host-dashboard-kpis.md`
PR-1 (backend, already merged): #483

## What this adds

- **`DashboardKPIs` wrapper** rendered on `/host/:inviteCode` (GPPDashboardTab), between the new "Days Until / Event Status / Reimbursement cap" status row and the Event Setup checklist. Supersedes the legacy "Invited / RSVPs / Days Until / Pending Approval" 4-tile mini-grid.
- **Leaderboard rank pill** — current-season GPP (`totalRsvps` v1), graceful hide on 401/403/404.
- **Milestone badge strip** — 8 milestones (firstRsvp / 25 / 50 / 100, firstWallet, firstNewsletter, firstPoap, goalReached), color when unlocked, greyed when locked.
- **Inline goal-setting** — click "Set goal" on any tile → number input → blur to save → optimistic update with revert on failure. No confirm modal (reversible). Persisted to `parties.host_goals` JSONB via `updateHostGoals` → `updatePartyApi` (both PATCH whitelists updated).
- **Live counter pulse + confetti** on milestone crossings. SessionStorage dedup keyed by `partyId` so refreshes / tab switches don't re-fire. Batches simultaneous crossings into a single centered burst.
- **Velocity footer** per tile (`+N in the last hour`, `N today`, `Busiest hour: 7pm`) — `useMomentum` derives from `guests[].submittedAt`.
- **7 locales** updated: `de, en, es, fr, ja, pt, zh` (skipped `ko` per plan).
- **Types added**: `HostGoals`, `Milestone`, `MomentumDelta`, plus `Party.hostGoals` and `EventReport.hostGoals`.

## Files

- `frontend/src/types.ts` — new types + `Party.hostGoals` + `EventReport.hostGoals`.
- `frontend/src/lib/supabase.ts` — `DbParty.host_goals`, `updateParty` signature, threads `hostGoals` into `updatePartyApi`.
- `frontend/src/lib/api.ts` — `UpdatePartyData.hostGoals`, `updatePartyApi` body, new `updateHostGoals()` + `getLeaderboardRank()` helpers.
- `frontend/src/contexts/PizzaContext.tsx` — `dbPartyToParty` maps `host_goals` → `hostGoals`. **No realtime subscription changes** (per `calabrese-58204`).
- `frontend/src/hooks/useMilestones.ts` — pure milestone unlock + sessionStorage dedup hook.
- `frontend/src/hooks/useMomentum.ts` — pure velocity-from-guests derivation.
- `frontend/src/components/gpp-dashboard/{DashboardKPIs,KPIBadge,MilestoneBadgeStrip,LeaderboardPill,GoalBar}.tsx` — new.
- `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx` — wires `<DashboardKPIs />` in.
- `frontend/src/components/report/ReportKPIs.tsx` — optional `gamified` prop, read-only branch only (zero changes to editable branch).
- `frontend/src/index.css` — `@keyframes pulse-once` + `.animate-pulse-once`.
- 7 locale `host.json` files — new `dashboard.kpis.*` keys.

## Hard constraints respected

- All hooks above any early return (hooks-above-early-returns).
- Both PATCH whitelists (`updateParty` + `updatePartyApi`) carry `hostGoals`.
- No `PizzaContext` realtime subscription added.
- No `backend/` files touched.

## Test plan

- [ ] Dashboard shows zero-state KPIs on a fresh event (motivating zero state, not broken).
- [ ] Set a goal of 10 RSVPs → bar shows 0/10, persists across reload.
- [ ] RSVP from incognito → tile pulses, First RSVP badge unlocks with confetti, velocity shows "+1 in the last hour".
- [ ] RSVP to 10 → confetti once on goal hit.
- [ ] Refresh → no re-fire (sessionStorage dedupe).
- [ ] Co-host without report-tab access opens dashboard → KPIs still render.
- [ ] Leaderboard pill ranks consistently across two events from the same season.
- [ ] No regressions on report tab (read-only ReportKPIs unchanged for non-gamified callers).

Vercel preview: _(filled in by Vercel after deploy)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)