### PR TITLE
chore(crust-23847): rename on-chain -> onchain

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -442,7 +442,7 @@ model Donation {
   chainId       Int?    @map("chain_id") // 1 = Ethereum, 8453 = Base
   tokenSymbol   String? @map("token_symbol") // "ETH", "USDC", etc.
   tokenAddress  String? @map("token_address") // null for native ETH
-  txHash        String? @map("tx_hash") // on-chain tx hash
+  txHash        String? @map("tx_hash") // onchain tx hash
   walletAddress String? @map("wallet_address") // donor's wallet
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz

--- a/backend/scripts/backfill-nft-mints.ts
+++ b/backend/scripts/backfill-nft-mints.ts
@@ -214,9 +214,9 @@ async function main() {
       }
 
       if (data.alreadyMinted) {
-        // Already minted on-chain, but missing from our DB
+        // Already minted onchain, but missing from our DB
         console.log(
-          `  -> Already minted on-chain. Token #${data.tokenId} (DB updated)`
+          `  -> Already minted onchain. Token #${data.tokenId} (DB updated)`
         );
         alreadyMinted++;
       } else {

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1216,7 +1216,7 @@ router.get(
  * transaction (so we can't leave status updated without an audit trail or
  * vice versa).
  *
- * For `usdc_base` the on-chain send happens BEFORE the DB transaction
+ * For `usdc_base` the onchain send happens BEFORE the DB transaction
  * (because waiting for a Base receipt can take 10-30s and we don't want to
  * hold a Postgres tx open that long). On send-failure we still open a tiny
  * tx to flip status -> failed + write the audit row, so the operator sees

--- a/backend/src/services/usdc-base.service.ts
+++ b/backend/src/services/usdc-base.service.ts
@@ -103,7 +103,7 @@ function getWalletClient() {
   return createWalletClient({ account: getPayoutAccount(), chain: base, transport: http(getRpcUrl()) });
 }
 
-/** Resolve the payout wallet's on-chain address (derived from the private key). */
+/** Resolve the payout wallet's onchain address (derived from the private key). */
 export function getPayoutWalletAddress(): `0x${string}` {
   return getPayoutAccount().address;
 }
@@ -156,7 +156,7 @@ export async function getUsdcDailyCapStatus(): Promise<UsdcDailyCapStatus> {
 
 /**
  * Send `amountUsd` USDC from the payout wallet to `toAddress` on Base.
- * Throws on any pre-flight failure or on-chain revert. Caller must persist the
+ * Throws on any pre-flight failure or onchain revert. Caller must persist the
  * resulting `txHash` on the payout row.
  */
 export async function sendUsdcPayment(toAddress: string, amountUsd: number): Promise<SendUsdcResult> {
@@ -233,7 +233,7 @@ export async function sendUsdcPayment(toAddress: string, amountUsd: number): Pro
     timeout: TX_RECEIPT_TIMEOUT_MS,
   });
   if (receipt.status !== 'success') {
-    throw new Error(`USDC transfer reverted on-chain: tx ${txHash}, status=${receipt.status}`);
+    throw new Error(`USDC transfer reverted onchain: tx ${txHash}, status=${receipt.status}`);
   }
 
   console.log(`[usdc-base] confirmed tx ${txHash} block=${receipt.blockNumber}`);

--- a/frontend/src/components/TransactionStatus.tsx
+++ b/frontend/src/components/TransactionStatus.tsx
@@ -49,7 +49,7 @@ export const TransactionStatus: React.FC<TransactionStatusProps> = ({
         <div>
           <h3 className="text-lg font-bold text-theme-text mb-1">Transaction Pending</h3>
           <p className="text-theme-text-muted text-sm">
-            Waiting for on-chain confirmation...
+            Waiting for onchain confirmation...
           </p>
         </div>
         {txHash && chainId && (

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -141,7 +141,7 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           />
           <p className="text-xs text-theme-text-muted">
             USDC on Base ({/* link omitted intentionally */}
-            <span className="font-mono">0x8335…2913</span>). Double-check this address — on-chain transfers can't be reversed.
+            <span className="font-mono">0x8335…2913</span>). Double-check this address — onchain transfers can't be reversed.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replace `on-chain` (with hyphen) with `onchain` (no hyphen) everywhere in repo — UI copy, comments, JSDoc, error messages.
- Per-occurrence case preserved.

## Test plan
- [ ] `git grep -in on-chain` returns nothing
- [ ] Vercel preview renders TransactionStatus + PayoutMethodPicker copy correctly