### PR TITLE
feat(oregano-49183): polish dashboard pills + hide low-signal stats

### DIFF
--- a/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
+++ b/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
@@ -9,6 +9,11 @@ import { useMilestones } from '../../hooks/useMilestones';
 import { useMomentum } from '../../hooks/useMomentum';
 import { useConfetti } from '../../hooks/useConfetti';
 
+// oregano-49183: low-signal stat keys hidden on the dashboard KPI grid.
+// Report tab (ReportKPIs editable mode) is unaffected — this is a render-time
+// override only; the host's persisted reportStatsConfig is untouched.
+const HIDDEN_ON_DASHBOARD = ['pageViews', 'attendees', 'socialPostViews', 'socialPosts', 'poapMints', 'poapMoments'] as const;
+
 interface DashboardKPIsProps {
   party: Party;
   guests: Guest[];
@@ -179,7 +184,20 @@ export const DashboardKPIs: React.FC<DashboardKPIsProps> = ({ party, guests }) =
 
   // Hand the report a hydrated copy with the local goals echoed in so the
   // gamified prop and the report share the same view of "current goals".
-  const reportForKpis: EventReport = { ...report, hostGoals: localGoals };
+  // oregano-49183: merge synthetic hidden flags so the dashboard grid shows
+  // only the 4 high-signal stats. This does NOT persist back to the DB; the
+  // host's reportStatsConfig (edited on the Report tab) is untouched.
+  const dashboardStatsConfig: Record<string, { override?: number | null; hidden?: boolean }> = {
+    ...(report.reportStatsConfig ?? {}),
+  };
+  for (const key of HIDDEN_ON_DASHBOARD) {
+    dashboardStatsConfig[key] = { ...dashboardStatsConfig[key], hidden: true };
+  }
+  const reportForKpis: EventReport = {
+    ...report,
+    hostGoals: localGoals,
+    reportStatsConfig: dashboardStatsConfig,
+  };
 
   const socialPostViews = (report.socialPosts || []).reduce(
     (sum, p) => sum + (p.views ?? 0),

--- a/frontend/src/components/gpp-dashboard/KPIBadge.tsx
+++ b/frontend/src/components/gpp-dashboard/KPIBadge.tsx
@@ -24,8 +24,8 @@ export const KPIBadge: React.FC<KPIBadgeProps> = ({ milestone, unlocked }) => {
       className={[
         'shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs whitespace-nowrap transition-all',
         unlocked
-          ? 'bg-[#ff393a]/15 border-[#ff393a]/40 text-theme-text'
-          : 'bg-theme-surface border-theme-stroke text-theme-text-faint opacity-60',
+          ? 'bg-theme-card border-[#ff393a]/60 text-theme-text shadow-sm'
+          : 'bg-theme-card border-theme-stroke text-theme-text-secondary opacity-80',
       ].join(' ')}
       title={label}
     >

--- a/frontend/src/components/gpp-dashboard/LeaderboardPill.tsx
+++ b/frontend/src/components/gpp-dashboard/LeaderboardPill.tsx
@@ -41,7 +41,7 @@ export const LeaderboardPill: React.FC<LeaderboardPillProps> = ({ partyId, metri
 
   if (loading) {
     return (
-      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-theme-surface border border-theme-stroke text-xs text-theme-text-faint">
+      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-theme-card border border-theme-stroke text-xs text-theme-text-faint">
         <span className="inline-block w-2 h-2 rounded-full bg-theme-text-faint/40 animate-pulse" />
         <span className="inline-block w-24 h-3 rounded bg-theme-text-faint/20 animate-pulse" />
       </div>
@@ -55,7 +55,7 @@ export const LeaderboardPill: React.FC<LeaderboardPillProps> = ({ partyId, metri
 
   return (
     <div className="inline-flex flex-col gap-0.5">
-      <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#ff393a]/15 border border-[#ff393a]/40 text-xs text-theme-text self-start">
+      <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-theme-card border border-[#ff393a]/60 text-xs text-theme-text self-start shadow-sm">
         <Medal size={12} className="text-[#ff393a]" />
         <span>
           {t('dashboard.kpis.leaderboardRank', {


### PR DESCRIPTION
## Summary

Small frontend polish on the gamified host dashboard (`quattro-71244`):

- **Dashboard KPI grid trimmed to 4 high-signal stats.** `pageViews`, `attendees`, `socialPostViews`, `socialPosts`, `poapMints`, `poapMoments` are now hidden on the dashboard. The visible four are Unique Visitors, Total RSVPs, Newsletter Sign-ups, Wallet Addresses.
  - Implemented as a render-time `reportStatsConfig` override in `DashboardKPIs.tsx`. No DB writes, no PATCH calls — the host's persisted `reportStatsConfig` (edited via the Report tab) is untouched.
  - `ReportKPIs.tsx` is not modified; the Report tab continues to show all 10 stats.
- **Pills made more opaque/legible.** `LeaderboardPill` and `KPIBadge` (both unlocked + locked variants) now use `bg-theme-card` with a `#ff393a/60` accent border + `shadow-sm`, replacing the `/15` translucent backgrounds that washed out against the sky-blue dashboard background. Locked badges go from `opacity-60` + `text-theme-text-faint` to `opacity-80` + `text-theme-text-secondary` for better legibility while still reading as "not yet unlocked."

## Preview

https://rsvpizza-git-oregano-49183-dashboard-kpi-polish-pizza-dao.vercel.app

## Test plan

- [ ] `npm run build` succeeds (verified locally)
- [ ] `npx tsc --noEmit` succeeds (verified locally)
- [ ] Dashboard shows only 4 stat tiles: Unique Visitors, Total RSVPs, Newsletter Sign-ups, Wallet Addresses
- [ ] Report tab (`/host/:inviteCode/report`) still shows all 10 stats — hide/show toggles persist as before
- [ ] LeaderboardPill renders with solid card background + red accent (not washed out)
- [ ] KPIBadge unlocked variant matches the leaderboard pill visually
- [ ] KPIBadge locked variant is dim but still legible

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>