### PR TITLE
feat(pancetta-37195): show payment submitter + per-receipt uploader

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
   apiKeys      ApiKey[]
   aiPhoneCalls AIPhoneCall[]
   payouts      Payout[]
+  uploadedPayoutDocuments PayoutDocument[] @relation("PayoutDocumentUploadedBy")
 }
 
 model Party {
@@ -1566,10 +1567,17 @@ model PayoutDocument {
   ocrConfidence Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
   ocrRaw        Json?    @map("ocr_raw")
   ocrError      String?  @map("ocr_error")
+  // pancetta-37195: per-receipt uploader attribution. Both nullable so
+  // historical rows are valid. uploadedByEmail caches the email at upload
+  // time so display still works if the User is later deleted.
+  uploadedByUserId String? @map("uploaded_by_user_id")
+  uploadedByEmail  String? @map("uploaded_by_email")
+  uploadedBy       User?   @relation("PayoutDocumentUploadedBy", fields: [uploadedByUserId], references: [id], onDelete: SetNull)
   sortOrder     Int      @default(0) @map("sort_order")
   createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   @@index([payoutId])
+  @@index([uploadedByUserId])
   @@map("payout_documents")
 }
 

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -248,6 +248,11 @@ function serializePayout(row: any): any {
       ocrConfidence: d.ocrConfidence == null ? null : Number(d.ocrConfidence),
       ocrError: d.ocrError,
       sortOrder: d.sortOrder,
+      // pancetta-37195: per-doc uploader attribution. Live name from the
+      // join; cached email is the fallback if the User is later deleted.
+      uploadedByUserId: d.uploadedByUserId ?? null,
+      uploadedByName: d.uploadedBy?.name ?? null,
+      uploadedByEmail: d.uploadedByEmail ?? d.uploadedBy?.email ?? null,
     })),
     party: row.party
       ? {
@@ -617,7 +622,10 @@ router.post(
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
-            documents: { orderBy: { sortOrder: 'asc' } },
+            documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
             audits: { orderBy: { createdAt: 'desc' } },
           },
         });
@@ -647,7 +655,10 @@ router.post(
         include: {
           party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
-          documents: { orderBy: { sortOrder: 'asc' } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
           audits: { orderBy: { createdAt: 'desc' } },
         },
       });
@@ -685,7 +696,10 @@ router.get(
         include: {
           party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
-          documents: { orderBy: { sortOrder: 'asc' } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
         },
         orderBy: { createdAt: 'desc' },
         take: limit + 1,
@@ -781,7 +795,10 @@ router.get(
         include: {
           party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
-          documents: { orderBy: { sortOrder: 'asc' } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
           audits: { orderBy: { createdAt: 'desc' } },
         },
       });
@@ -884,7 +901,10 @@ router.patch(
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
-            documents: { orderBy: { sortOrder: 'asc' } },
+            documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
             audits: { orderBy: { createdAt: 'desc' } },
           },
         });
@@ -954,7 +974,10 @@ router.post(
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
-            documents: { orderBy: { sortOrder: 'asc' } },
+            documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
             audits: { orderBy: { createdAt: 'desc' } },
           },
         });
@@ -1005,7 +1028,10 @@ router.post(
               include: {
                 party: { select: PAYOUT_PARTY_SELECT },
                 host: { select: { id: true, name: true, email: true } },
-                documents: { orderBy: { sortOrder: 'asc' } },
+                documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
                 audits: { orderBy: { createdAt: 'desc' } },
               },
             });
@@ -1078,7 +1104,10 @@ router.post(
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
-            documents: { orderBy: { sortOrder: 'asc' } },
+            documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
             audits: { orderBy: { createdAt: 'desc' } },
           },
         });
@@ -1161,7 +1190,10 @@ router.post(
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
-            documents: { orderBy: { sortOrder: 'asc' } },
+            documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
             audits: { orderBy: { createdAt: 'desc' } },
           },
         });
@@ -1295,7 +1327,10 @@ async function executePayout(params: {
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
-            documents: { orderBy: { sortOrder: 'asc' } },
+            documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
             audits: { orderBy: { createdAt: 'desc' } },
           },
         });
@@ -1357,7 +1392,10 @@ async function executePayout(params: {
         include: {
           party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
-          documents: { orderBy: { sortOrder: 'asc' } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
           audits: { orderBy: { createdAt: 'desc' } },
         },
       });
@@ -1403,7 +1441,10 @@ async function executePayout(params: {
         include: {
           party: { select: PAYOUT_PARTY_SELECT },
           host: { select: { id: true, name: true, email: true } },
-          documents: { orderBy: { sortOrder: 'asc' } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
           audits: { orderBy: { createdAt: 'desc' } },
         },
       });

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -68,6 +68,10 @@ function serializePayout(p: any) {
     id: p.id,
     partyId: p.partyId,
     hostUserId: p.hostUserId,
+    // pancetta-37195: surface the submitter so cohosts can tell who created
+    // the payout. host is included via the prisma findUnique/findMany below.
+    hostName: p.host?.name ?? null,
+    hostEmail: p.host?.email ?? null,
     originalAmount: numberFromDecimal(p.originalAmount),
     originalCurrency: p.originalCurrency,
     exchangeRate: numberFromDecimal(p.exchangeRate),
@@ -107,6 +111,12 @@ function serializeDocument(d: any) {
     ocrConfidence: d.ocrConfidence != null ? numberFromDecimal(d.ocrConfidence) : null,
     ocrError: d.ocrError ?? null,
     sortOrder: d.sortOrder,
+    // pancetta-37195: surface the per-doc uploader so cohosts can tell who
+    // attached each receipt/photo. Live name from the join; cached email is
+    // the fallback if the User row is later deleted.
+    uploadedByUserId: d.uploadedByUserId ?? null,
+    uploadedByName: d.uploadedBy?.name ?? null,
+    uploadedByEmail: d.uploadedByEmail ?? d.uploadedBy?.email ?? null,
   };
 }
 
@@ -528,6 +538,15 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       throw new AppError('Authenticated user has no userId', 500, 'NO_USER_ID');
     }
 
+    // pancetta-37195: stamp each new document with the uploader.
+    const uploaderUserId = req.userId ?? null;
+    const uploaderEmail = req.userEmail ?? null;
+    const docsToCreateStamped = docsToCreate.map(d => ({
+      ...d,
+      uploadedByUserId: uploaderUserId,
+      uploadedByEmail: uploaderEmail,
+    }));
+
     // Create the payout + its documents atomically.
     const payout = await prisma.payout.create({
       data: {
@@ -554,9 +573,15 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         hostNotes: typeof hostNotes === 'string' && hostNotes.trim().length > 0
           ? hostNotes.trim()
           : null,
-        documents: { create: docsToCreate },
+        documents: { create: docsToCreateStamped },
       },
-      include: { documents: { orderBy: { sortOrder: 'asc' } } },
+      include: {
+        host: { select: { id: true, name: true, email: true } },
+        documents: {
+          orderBy: { sortOrder: 'asc' },
+          include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+        },
+      },
     });
 
     // One-shot: persist the host's attendance estimate to the party, but only
@@ -615,7 +640,13 @@ router.get('/:partyId/payouts', async (req: AuthRequest, res: Response, next: Ne
 
     const payouts = await prisma.payout.findMany({
       where: { partyId },
-      include: { documents: { orderBy: { sortOrder: 'asc' } } },
+      include: {
+        host: { select: { id: true, name: true, email: true } },
+        documents: {
+          orderBy: { sortOrder: 'asc' },
+          include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+        },
+      },
       orderBy: { createdAt: 'desc' },
     });
 
@@ -642,7 +673,13 @@ router.get('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response
 
     const payout = await prisma.payout.findFirst({
       where: { id: payoutId, partyId },
-      include: { documents: { orderBy: { sortOrder: 'asc' } } },
+      include: {
+        host: { select: { id: true, name: true, email: true } },
+        documents: {
+          orderBy: { sortOrder: 'asc' },
+          include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+        },
+      },
     });
 
     if (!payout) {
@@ -950,10 +987,17 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         });
       }
       if (newReceiptDocs.length > 0 || newPizzaDocs.length > 0) {
+        // pancetta-37195: stamp the editing user on every new document so
+        // the per-receipt "Uploaded by X" line shows the cohost who added it,
+        // not the original payout submitter.
+        const uploaderUserId = req.userId ?? null;
+        const uploaderEmail = req.userEmail ?? null;
         await tx.payoutDocument.createMany({
           data: [...newReceiptDocs, ...newPizzaDocs].map(d => ({
             ...d,
             payoutId: existing.id,
+            uploadedByUserId: uploaderUserId,
+            uploadedByEmail: uploaderEmail,
             ocrRaw: d.ocrRaw === null ? Prisma.JsonNull : (d.ocrRaw as Prisma.InputJsonValue),
           })),
         });
@@ -977,11 +1021,23 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         ? await tx.payout.update({
             where: { id: payoutId },
             data: finalData,
-            include: { documents: { orderBy: { sortOrder: 'asc' } } },
+            include: {
+              host: { select: { id: true, name: true, email: true } },
+              documents: {
+                orderBy: { sortOrder: 'asc' },
+                include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+              },
+            },
           })
         : await tx.payout.findUniqueOrThrow({
             where: { id: payoutId },
-            include: { documents: { orderBy: { sortOrder: 'asc' } } },
+            include: {
+              host: { select: { id: true, name: true, email: true } },
+              documents: {
+                orderBy: { sortOrder: 'asc' },
+                include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+              },
+            },
           });
 
       // Audit: write a row when amount changes OR docs change. Mirror the

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -255,6 +255,10 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                       {' '}@ {payout.exchangeRate.toFixed(6)} (locked at submission)
                     </p>
                   )}
+                  {/* pancetta-37195: surface the cohost who created this payout. */}
+                  <p className="text-xs text-theme-text-muted">
+                    Submitted by {payout.hostName ?? payout.hostEmail ?? 'Unknown'}
+                  </p>
                 </div>
                 <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${STATUS_STYLES[payout.status]}`}>
                   {STATUS_LABEL[payout.status]}
@@ -332,6 +336,14 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                           ) : d.ocrError ? (
                             <p className="text-xs text-amber-300">OCR failed: {d.ocrError}</p>
                           ) : null}
+                          {/* pancetta-37195: per-receipt uploader attribution.
+                              Skip the line for historical rows (uploadedByUserId
+                              is null) — don't render "Unknown". */}
+                          {d.uploadedByUserId && (
+                            <p className="text-[10px] text-theme-text-muted truncate">
+                              Uploaded by {d.uploadedByName ?? d.uploadedByEmail ?? 'Unknown'}
+                            </p>
+                          )}
                         </div>
                         <a href={d.url} target="_blank" rel="noreferrer" className="p-1 text-theme-text-muted hover:text-theme-text">
                           <ExternalLink size={14} />
@@ -348,15 +360,23 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                   <p className="text-xs text-theme-text-muted mb-2">Pizza / event photos</p>
                   <div className="grid grid-cols-4 sm:grid-cols-5 gap-2">
                     {payout.documents.filter(d => d.kind === 'pizza').map(d => (
-                      <a
-                        key={d.id}
-                        href={d.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="aspect-square rounded-lg overflow-hidden bg-theme-surface"
-                      >
-                        <img src={d.url} alt="" className="w-full h-full object-cover hover:opacity-90 transition-opacity" />
-                      </a>
+                      <div key={d.id} className="space-y-1">
+                        <a
+                          href={d.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="block aspect-square rounded-lg overflow-hidden bg-theme-surface"
+                        >
+                          <img src={d.url} alt="" className="w-full h-full object-cover hover:opacity-90 transition-opacity" />
+                        </a>
+                        {/* pancetta-37195: per-photo uploader attribution.
+                            Hidden for historical rows (null uploadedByUserId). */}
+                        {d.uploadedByUserId && (
+                          <p className="text-[10px] text-theme-text-muted truncate">
+                            Uploaded by {d.uploadedByName ?? d.uploadedByEmail ?? 'Unknown'}
+                          </p>
+                        )}
+                      </div>
                     ))}
                   </div>
                 </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1459,6 +1459,11 @@ export interface PayoutDocument {
   ocrConfidence: number | null;
   ocrError: string | null;
   sortOrder: number;
+  // pancetta-37195: per-doc uploader attribution. Null on historical rows
+  // created before this feature shipped.
+  uploadedByUserId?: string | null;
+  uploadedByName?: string | null;
+  uploadedByEmail?: string | null;
 }
 
 export interface BankDetails {
@@ -1499,6 +1504,9 @@ export interface Payout {
   id: string;
   partyId: string;
   hostUserId: string;
+  // pancetta-37195: submitter name/email so cohosts see "Submitted by X".
+  hostName?: string | null;
+  hostEmail?: string | null;
   originalAmount: number;
   originalCurrency: string;
   exchangeRate: number;


### PR DESCRIPTION
## Summary
- New `payout_documents.uploaded_by_user_id` + `uploaded_by_email` columns (migration applied to prod).
- Backend joins host + per-doc uploader and emits `hostName` / `uploadedByName` in the serializer.
- PayoutDetailModal shows "Submitted by X" header + "Uploaded by Y" per document tile.

## Test plan
- [ ] Cohost A creates a payout -> both cohosts open it -> header reads "Submitted by A".
- [ ] Cohost B uploads a receipt to A's payout -> tile reads "Uploaded by B".
- [ ] Historical rows (uploaded_by null) render without an "Unknown" caption.
- [ ] Admin view still loads cleanly.