### PR TITLE
fix(tomato-71832): leaderboard counts only approved events

### DIFF
--- a/backend/src/routes/leaderboard.routes.test.ts
+++ b/backend/src/routes/leaderboard.routes.test.ts
@@ -119,6 +119,92 @@ describe('Leaderboard route — quattro-71244', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ rank: 1, total: 4, topPercent: 25, scope: 'gpp-season' });
+
+      // tomato-71832: the universe query must filter by underbossStatus='approved'.
+      expect(mockPrisma.party.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            eventType: 'gpp',
+            underbossStatus: 'approved',
+            eventTags: { has: 'gpp2026' },
+          }),
+        }),
+      );
+    });
+
+    it('excludes unapproved parties from the ranking universe (tomato-71832)', async () => {
+      // Mixed fixture: A is approved+top-rsvps, B is approved, C is pending
+      // (should NOT be counted), D is approved+zero-rsvps. The route relies on
+      // Prisma to filter by `underbossStatus: 'approved'`, so we simulate that
+      // by returning only the approved parties from `findMany`.
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_A,
+        eventType: 'gpp',
+        eventTags: ['gpp2026'],
+      });
+      // Note: C is intentionally absent — Prisma would have filtered it out
+      // server-side because its underbossStatus is 'pending', not 'approved'.
+      mockPrisma.party.findMany.mockResolvedValue([
+        { id: PARTY_A },
+        { id: PARTY_B },
+        { id: PARTY_D },
+      ]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 10 } },
+        { partyId: PARTY_B, _count: { _all: 5 } },
+        // D has zero guests; C would have had 99 but it's pending so excluded.
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      // total=3 (A, B, D) — pending party C is NOT counted in the denominator.
+      expect(res.body).toEqual({ rank: 1, total: 3, topPercent: 33, scope: 'gpp-season' });
+
+      // Verify the actual Prisma where clause requested the approved filter.
+      expect(mockPrisma.party.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            eventType: 'gpp',
+            underbossStatus: 'approved',
+          }),
+        }),
+      );
+    });
+
+    it('applies the approved filter on the gpp-all fallback scope too (tomato-71832)', async () => {
+      mockPrisma.party.findUnique.mockResolvedValue({
+        id: PARTY_A,
+        eventType: 'gpp',
+        eventTags: [], // no season tag → gpp-all fallback
+      });
+      mockPrisma.party.findMany.mockResolvedValue([{ id: PARTY_A }, { id: PARTY_B }]);
+      mockPrisma.guest.groupBy.mockResolvedValue([
+        { partyId: PARTY_A, _count: { _all: 2 } },
+        { partyId: PARTY_B, _count: { _all: 1 } },
+      ]);
+
+      const app = createTestApp();
+      const token = makeToken(HOST_USER_ID, HOST_EMAIL);
+
+      const res = await request(app)
+        .get(`/api/parties/${PARTY_A}/leaderboard-rank?metric=totalRsvps`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toBe('gpp-all');
+
+      // The fallback path still narrows by underbossStatus='approved'.
+      const call = mockPrisma.party.findMany.mock.calls[0][0];
+      expect(call.where.eventType).toBe('gpp');
+      expect(call.where.underbossStatus).toBe('approved');
+      // No season tag filter on gpp-all.
+      expect(call.where.eventTags).toBeUndefined();
     });
 
     it('uses standard-competition ranking: ties share rank, next-non-tie skips slots', async () => {

--- a/backend/src/routes/leaderboard.routes.ts
+++ b/backend/src/routes/leaderboard.routes.ts
@@ -45,6 +45,8 @@ interface CacheEntry {
 }
 
 const TTL_MS = 5 * 60 * 1000;
+// In-process cache resets naturally on every Vercel redeploy — no manual
+// invalidation needed when the universe filter changes (see tomato-71832).
 const cache = new Map<string, CacheEntry>();
 
 function cacheKey(metric: Metric, scope: ScopeFingerprint): string {
@@ -70,7 +72,11 @@ async function aggregateCounts(metric: Metric, scope: ScopeFingerprint): Promise
     // Gather candidate party IDs in scope first so we can also include
     // zero-RSVP parties in the leaderboard (groupBy on `guests` would skip
     // them — they'd silently be "off-leaderboard" otherwise).
-    const partyWhere: any = { eventType: 'gpp' };
+    //
+    // tomato-71832: narrow the universe to approved events only so the pill's
+    // denominator reflects approved GPP hosts (not pending/rejected). The
+    // approval field is `underbossStatus` (default `'pending'`), NOT `status`.
+    const partyWhere: any = { eventType: 'gpp', underbossStatus: 'approved' };
     if (scope.kind === 'gpp-season' && scope.tag) {
       partyWhere.eventTags = { has: scope.tag };
     }


### PR DESCRIPTION
## Summary

Narrows the leaderboard ranking universe to events with `underbossStatus='approved'` so the dashboard pill's `of N` denominator reflects the count of approved GPP hosts, not all GPP-tagged parties (which currently includes pending/rejected).

- Universe shrinks from "all GPP-tagged parties" to "approved GPP-tagged parties"
- Applies to BOTH scope branches (`gpp-season` and `gpp-all` fallback)
- In-process cache resets naturally on Vercel redeploy after merge — no manual invalidation
- Response shape (`{ rank, total, topPercent, scope }`) unchanged; frontend untouched

## Verify before merge

- [ ] Existing leaderboard tests still pass (10 prior cases, all green locally)
- [ ] New test asserts unapproved parties excluded (`total` drops by the pending count)
- [ ] After merge + backend redeploy, dashboard pill's `of N` denominator drops to reflect approved-only count

Generated with Claude Code