### PR TITLE
feat(marzano-49102): open Payments to all hosts; gate cap display by 'go' tag

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -17,10 +17,9 @@ import { rateLimit } from 'express-rate-limit';
 import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest, isAdmin, isSuperAdmin, isUnderboss } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isAdmin, isSuperAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
-import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
 
@@ -30,12 +29,6 @@ const router = Router();
 // /api/parties (alongside many sibling routers including partyRoutes after
 // it), so an unconditioned `router.use(...)` here would gate every
 // /api/parties/* request — which broke host guest approvals system-wide.
-//
-// The soft-launch gate USED to live here as a second router.use(), but it
-// runs before route matching so `req.params.partyId` is empty — which made
-// the cap-based eligibility check (arugula-38633 v3) impossible. The gate
-// now lives in each handler via `assertCanUsePayoutsForParty(req, partyId)`,
-// called alongside the existing `canUserEditParty` authorization layer.
 router.use('/:partyId/payouts', requireAuth);
 
 // Aggressive rate limit on the OCR-preview endpoint to prevent OpenAI quota abuse.
@@ -198,48 +191,6 @@ function validateMethodSpecificFields(
   }
 }
 
-/**
- * Soft-launch gate: this feature is open to underbosses + admins, OR to any
- * host whose party has a reimbursement cap set (validated cap OR numeric
- * event_tag fallback). See arugula-38633 v3 for context.
- */
-async function isUnderbossOrAdmin(email?: string): Promise<boolean> {
-  if (await isSuperAdmin(email)) return true;
-  if (await isAdmin(email)) return true;
-  if (await isUnderboss(email)) return true;
-  return false;
-}
-
-/**
- * Returns true if the party has an effective reimbursement cap — either an
- * underboss-validated `reimbursementCapUsd` value OR a numeric event_tag
- * fallback. Cap alone gates host access to Payments; the `'go'` tag is a
- * SEPARATE downstream signal that controls the reimbursement-promise banner
- * on the frontend (not gated here).
- */
-async function partyHasCap(partyId: string): Promise<boolean> {
-  const party = await prisma.party.findUnique({
-    where: { id: partyId },
-    select: { reimbursementCapUsd: true, eventTags: true },
-  });
-  if (!party) return false;
-  const effective = computeEffectiveCapUsd({
-    reimbursementCapUsd: party.reimbursementCapUsd,
-    eventTags: party.eventTags,
-  });
-  return typeof effective === 'number' && effective > 0;
-}
-
-async function assertCanUsePayoutsForParty(req: AuthRequest, partyId: string): Promise<void> {
-  if (await isUnderbossOrAdmin(req.userEmail)) return;
-  if (await partyHasCap(partyId)) return;
-  throw new AppError(
-    'The payments feature is currently in soft launch for underbosses, admins, and parties with a reimbursement cap set.',
-    403,
-    'FORBIDDEN',
-  );
-}
-
 async function isAnyAdmin(email?: string): Promise<boolean> {
   if (await isSuperAdmin(email)) return true;
   if (await isAdmin(email)) return true;
@@ -259,8 +210,6 @@ router.post(
       if (typeof imageUrl !== 'string' || imageUrl.length === 0) {
         throw new AppError('imageUrl is required', 400, 'MISSING_IMAGE_URL');
       }
-
-      await assertCanUsePayoutsForParty(req, partyId);
 
       const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
       if (!canEdit) {
@@ -316,8 +265,6 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       saveAsDefault,
       estimatedAttendance,
     } = req.body || {};
-
-    await assertCanUsePayoutsForParty(req, partyId);
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
@@ -607,7 +554,6 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
 router.get('/:partyId/payouts', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId } = req.params;
-    await assertCanUsePayoutsForParty(req, partyId);
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
@@ -632,9 +578,6 @@ router.get('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response
     const { partyId, payoutId } = req.params;
 
     const adminAccess = await isAnyAdmin(req.userEmail);
-    if (!adminAccess) {
-      await assertCanUsePayoutsForParty(req, partyId);
-    }
     const canEdit = adminAccess || (await canUserEditParty(partyId, req.userId, req.userEmail));
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
@@ -674,8 +617,6 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       pizzaPhotos,
       removeDocumentIds,
     } = req.body || {};
-
-    await assertCanUsePayoutsForParty(req, partyId);
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
@@ -1028,8 +969,6 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
 router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId, payoutId } = req.params;
-
-    await assertCanUsePayoutsForParty(req, partyId);
 
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Store,
@@ -23,7 +23,6 @@ import {
 import { updateParty } from '../lib/supabase';
 import { usePizza } from '../contexts/PizzaContext';
 import { PINNABLE_APPS } from '../lib/appDefinitions';
-import { fetchUnderbossMe, fetchAdminMe } from '../lib/api';
 
 type AppStatus = 'live' | 'preview' | 'coming-soon';
 type AppCategory = 'planning' | 'promotion' | 'day-of' | 'after-party';
@@ -381,43 +380,11 @@ export function AppsHub({
   const [pinnedApps, setPinnedApps] = useState<string[]>(initialPinnedApps);
   const isGppEvent = party?.eventType === 'gpp';
 
-  // Soft-launch gate for the Payouts app (arugula-38633 v1+v3): the tile
-  // stays visible for everyone, but downgrades from 'live' to 'coming-soon'
-  // (badge + unclickable) unless caller is underboss/admin/super_admin OR
-  // the party has an effective reimbursement cap (the 'go' tag is a separate
-  // downstream signal that only gates the reimbursement-promise banner inside
-  // the Payments tab — not access). Remove when opening to all hosts.
-  const [canUsePayouts, setCanUsePayouts] = useState<boolean | null>(null);
-  const partyEffectiveCap = party?.effectiveReimbursementCapUsd;
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const [ub, ad] = await Promise.all([
-          fetchUnderbossMe().catch(() => null),
-          fetchAdminMe().catch(() => null),
-        ]);
-        if (cancelled) return;
-        // If party hasn't loaded yet, fall back to role-only check (avoids
-        // false-negative "Coming Soon" on opened parties while loading).
-        const hasCap =
-          typeof partyEffectiveCap === 'number' && partyEffectiveCap > 0;
-        const eligible =
-          Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || hasCap;
-        setCanUsePayouts(eligible);
-      } catch {
-        if (!cancelled) setCanUsePayouts(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [partyEffectiveCap]);
-
-  const visibleApps = apps.map((a) => {
-    if (a.id === 'payments' && canUsePayouts === false) {
-      return { ...a, status: 'coming-soon' as const };
-    }
-    return a;
-  });
+  // marzano-49102: Payments tile is unconditionally live for all signed-in
+  // party hosts/cohosts. The downstream cap-display gate (hide $ unless the
+  // 'go' event_tag is set) lives in HostPage where Party props are passed
+  // into PayoutsTab.
+  const visibleApps = apps;
 
   const handleTogglePin = async (appId: string, pin: boolean) => {
     // Optimistic update

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -151,31 +151,39 @@ export const GPPDashboardTab: React.FC = () => {
             <div className="text-xs text-theme-text-muted mt-1">Event Status</div>
           </div>
         )}
-        {/* arugula-38633 (cap-everywhere): surface the effective reimbursement
-            cap on the dashboard so hosts see it at a glance. Clicking the tile
-            jumps to the Payments tab where they can submit receipts / appeal. */}
-        <button
-          type="button"
-          onClick={() => goToTab('payments')}
-          className="card p-4 text-center hover:bg-theme-surface-hover transition-colors cursor-pointer"
-          title={party.effectiveReimbursementCapUsd != null
-            ? 'Reimbursement cap — click to open the Payments tab'
-            : 'No reimbursement cap set yet — click to open the Payments tab'}
-        >
-          {party.effectiveReimbursementCapUsd != null ? (
-            <>
-              <div className="text-2xl font-bold text-theme-text">
-                ${Number(party.effectiveReimbursementCapUsd).toLocaleString()}
-              </div>
-              <div className="text-xs text-theme-text-muted">Reimbursement cap</div>
-            </>
-          ) : (
-            <>
-              <div className="text-sm font-medium text-amber-400">No cap set</div>
-              <div className="text-xs text-theme-text-muted mt-1">Reimbursement cap</div>
-            </>
-          )}
-        </button>
+        {/* arugula-38633 (cap-everywhere) / marzano-49102 (gate by 'go'):
+            surface the effective reimbursement cap on the dashboard so hosts
+            see it at a glance. The dollar value is hidden until the party has
+            the 'go' event_tag — without 'go' the tile falls through to the
+            "Under review" state. Clicking jumps to the Payments tab. */}
+        {(() => {
+          const hasGo = Array.isArray(party.eventTags) && party.eventTags.includes('go');
+          const showCap = hasGo && party.effectiveReimbursementCapUsd != null;
+          return (
+            <button
+              type="button"
+              onClick={() => goToTab('payments')}
+              className="card p-4 text-center hover:bg-theme-surface-hover transition-colors cursor-pointer"
+              title={showCap
+                ? 'Reimbursement cap — click to open the Payments tab'
+                : 'Your underboss is reviewing your event — click to open the Payments tab'}
+            >
+              {showCap ? (
+                <>
+                  <div className="text-2xl font-bold text-theme-text">
+                    ${Number(party.effectiveReimbursementCapUsd).toLocaleString()}
+                  </div>
+                  <div className="text-xs text-theme-text-muted">Reimbursement cap</div>
+                </>
+              ) : (
+                <>
+                  <div className="text-sm font-medium text-amber-400">Under review</div>
+                  <div className="text-xs text-theme-text-muted mt-1">Reimbursement cap</div>
+                </>
+              )}
+            </button>
+          );
+        })()}
       </div>
 
       {/* Rejected status callout */}

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Lock, Info, BadgeDollarSign } from 'lucide-react';
+import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Info, BadgeDollarSign } from 'lucide-react';
 import { Payout } from '../../types';
-import { listPayouts, fetchUnderbossMe, fetchAdminMe } from '../../lib/api';
+import { listPayouts } from '../../lib/api';
 import { usePizza } from '../../contexts/PizzaContext';
 import { parsePartyKitCapFromTags } from '../../lib/reimbursementCap';
 import { getUnderbossContact } from '../../utils/underbossContacts';
@@ -38,9 +38,10 @@ type View = 'list' | 'new';
  * Routes between the list view and the "new payout" form, and renders a
  * detail modal for past payouts.
  *
- * Soft-launch gate (arugula-38633 v1): only underbosses + admins see the
- * full UI; everyone else sees a "coming soon" placeholder. Backend enforces
- * the same restriction. Remove `canAccess` checks here when opening up.
+ * marzano-49102: Payments is open to all signed-in party hosts/cohosts.
+ * The cap dollar value is gated by the 'go' event_tag at the HostPage source
+ * (props arrive as null when 'go' isn't set), so downstream consumers
+ * naturally hide the number.
  */
 export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   partyId,
@@ -57,33 +58,6 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [detailPayoutId, setDetailPayoutId] = useState<string | null>(null);
-  const [canAccess, setCanAccess] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const [ub, ad] = await Promise.all([
-          fetchUnderbossMe().catch(() => null),
-          fetchAdminMe().catch(() => null),
-        ]);
-        if (cancelled) return;
-        // arugula-38633 v3: host is eligible if the party has an effective
-        // reimbursement cap. The 'go' tag is a SEPARATE downstream signal
-        // that only gates the reimbursement-promise banner (below) — NOT
-        // access. Backend enforces the same per-handler.
-        const hasCap =
-          typeof effectiveReimbursementCapUsd === 'number' &&
-          effectiveReimbursementCapUsd > 0;
-        const eligible =
-          Boolean(ub?.isUnderboss) || Boolean(ad?.isAdmin) || hasCap;
-        setCanAccess(eligible);
-      } catch {
-        if (!cancelled) setCanAccess(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [effectiveReimbursementCapUsd]);
 
   const loadPayouts = useCallback(async () => {
     setLoading(true);
@@ -99,41 +73,17 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   }, [partyId]);
 
   useEffect(() => {
-    if (canAccess) loadPayouts();
-  }, [loadPayouts, canAccess]);
+    loadPayouts();
+  }, [loadPayouts]);
 
   // arugula-38633 v2 follow-up: sum already-paid payouts so the host can see
-  // their running reimbursement total. MUST be declared before any conditional
-  // returns below — moving it after would break rules-of-hooks (hook count
-  // changes when canAccess flips null/false → true). Was the source of a hard
-  // React crash that black-screened the page.
+  // their running reimbursement total.
   const totalPaidUsd = useMemo(
     () => payouts
       .filter(p => p.status === 'paid')
       .reduce((s, p) => s + Number(p.finalAmountUsd || 0), 0),
     [payouts]
   );
-
-  if (canAccess === null) {
-    return (
-      <div className="card p-8 flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-[#ff393a]" />
-      </div>
-    );
-  }
-
-  if (canAccess === false) {
-    return (
-      <div className="card p-8 text-center max-w-lg mx-auto">
-        <Lock className="w-10 h-10 text-white/40 mx-auto mb-4" />
-        <h3 className="text-lg font-semibold mb-2">Payments — Coming Soon</h3>
-        <p className="text-sm text-white/60">
-          Host payments are currently in soft launch for underbosses and admins.
-          We'll open it up to all hosts soon — stay tuned.
-        </p>
-      </div>
-    );
-  }
 
   const handleCreated = (created: Payout) => {
     // Optimistic update: prepend to list, then close the form.
@@ -179,17 +129,20 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
         PartyHeader, /underboss EventRow, and NewPayoutForm's first-time
         prompt — single source of truth.
       */}
-      {/* Top banner priority (arugula-38633 v3):
+      {/* Top banner priority (marzano-49102):
           1. Missing expected_guests or location → actionable "Set your X to
              get your funding approved" (host can act on it)
-          2. Both set, no cap OR no 'go' tag → "Your underboss is reviewing"
-             (cap value isn't promised until BOTH cap AND go are in place)
-          3. Cap set AND 'go' tag present → emerald cap banner */}
+          2. No effective cap value → "Your underboss is reviewing"
+             (host won't see a $ amount until admin sets cap AND adds 'go')
+          3. Cap value present → emerald cap banner. Note: the cap value
+             arrives here as null when the 'go' event_tag isn't set, because
+             HostPage zeroes it at the source. So `hasCap` alone is the
+             correct gate — keeping `&& hasGo` would be dead, misleading
+             code about where the actual gate lives. */}
       {(() => {
         const needsExpectedGuests = !party?.expectedGuests || party.expectedGuests <= 0;
         const needsLocation = !party?.address;
         const hasCap = typeof effectiveReimbursementCapUsd === 'number' && effectiveReimbursementCapUsd > 0;
-        const hasGo = Array.isArray(party?.eventTags) && party!.eventTags.includes('go');
 
         if (needsExpectedGuests || needsLocation) {
           const msg =
@@ -205,7 +158,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             </div>
           );
         }
-        if (hasCap && hasGo) {
+        if (hasCap) {
           return (
             <div className="card p-4 sm:p-5 border-l-4 border-l-emerald-500 flex items-start gap-3">
               <BadgeDollarSign size={20} className="text-emerald-500 mt-0.5 flex-shrink-0" />

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -531,16 +531,25 @@ function HostPageContent() {
                 <PrintTab />
               )}
 
-              {activeTab === 'payments' && party && (
-                <PayoutsTab
-                  partyId={party.id}
-                  reimbursementCapUsd={party.reimbursementCapUsd}
-                  effectiveReimbursementCapUsd={party.effectiveReimbursementCapUsd}
-                  reimbursementCapAppealNote={party.reimbursementCapAppealNote}
-                  reimbursementCapAppealedAt={party.reimbursementCapAppealedAt}
-                  expectedGuests={party.expectedGuests}
-                />
-              )}
+              {activeTab === 'payments' && party && (() => {
+                // marzano-49102: gate the cap dollar value by the 'go' event_tag.
+                // Pass null when 'go' is not set so every downstream consumer
+                // (PayoutsTab green banner, NewPayoutForm cap banner, PayoutsList
+                // "/ $X remaining" suffix, PaymentDetailsCard → PayoutMethodPicker
+                // Mercury "with a limit of $X" text, AppealCapModal) hides the
+                // dollar amount automatically. Admin-facing UIs still see the cap.
+                const hasGo = Array.isArray(party.eventTags) && party.eventTags.includes('go');
+                return (
+                  <PayoutsTab
+                    partyId={party.id}
+                    reimbursementCapUsd={hasGo ? party.reimbursementCapUsd : null}
+                    effectiveReimbursementCapUsd={hasGo ? party.effectiveReimbursementCapUsd : null}
+                    reimbursementCapAppealNote={party.reimbursementCapAppealNote}
+                    reimbursementCapAppealedAt={party.reimbursementCapAppealedAt}
+                    expectedGuests={party.expectedGuests}
+                  />
+                );
+              })()}
 
               {activeTab === 'gpp' && party && (
                 <div className="space-y-4">


### PR DESCRIPTION
## Summary
- Removes the soft-launch gate — Payments tile is unconditionally live for all signed-in party hosts/cohosts.
- Host-facing cap dollar value is hidden everywhere until the party has the `'go'` event_tag (admins set this).
- Admin views unchanged — still show cap.

## Test plan
- [ ] Sign in as a host of a party with no cap / no 'go' → Payments tile is live (not "coming soon"); tab opens; no $X anywhere; setup-notice + "underboss is reviewing" notice render correctly.
- [ ] Same party + admin adds cap (no 'go' yet) → still no $X anywhere on host view.
- [ ] Admin adds 'go' tag → green "We'll reimburse you for up to $X" banner appears; Mercury text shows limit.
- [ ] Admin view of a host's payouts still shows the cap.