### PR TITLE
feat(basil-58219): hide firstRsvp / firstPoap / goalReached milestones

### DIFF
--- a/frontend/src/hooks/useMilestones.ts
+++ b/frontend/src/hooks/useMilestones.ts
@@ -24,16 +24,11 @@ const STORAGE_PREFIX = 'dashboardKPIs.celebrated.';
 
 // Hardcoded milestone list — order also controls "nextMilestone" priority.
 export const ALL_MILESTONES: Milestone[] = [
-  { id: 'firstRsvp',       statKey: 'totalRsvps',         threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstRsvp' },
   { id: 'rsvps25',         statKey: 'totalRsvps',         threshold: 25,  labelKey: 'host.dashboard.kpis.milestones.rsvps25' },
   { id: 'rsvps50',         statKey: 'totalRsvps',         threshold: 50,  labelKey: 'host.dashboard.kpis.milestones.rsvps50' },
   { id: 'rsvps100',        statKey: 'totalRsvps',         threshold: 100, labelKey: 'host.dashboard.kpis.milestones.rsvps100' },
   { id: 'firstWallet',     statKey: 'walletAddresses',    threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstWallet' },
   { id: 'firstNewsletter', statKey: 'newsletterSignups', threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstNewsletter' },
-  { id: 'firstPoap',       statKey: 'poapMints',          threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.firstPoap' },
-  // `goalReached` is computed dynamically — `statKey` and `threshold` here are
-  // placeholders so the type still works; the hook resolves it specially.
-  { id: 'goalReached',     statKey: '__goal__',           threshold: 1,   labelKey: 'host.dashboard.kpis.milestones.goalReached' },
 ];
 
 // Map a HostGoals key to its corresponding stat key.


### PR DESCRIPTION
## Summary

Hide three milestone badges from the host dashboard: `firstRsvp`, `firstPoap`, and `goalReached`.

Removed from `ALL_MILESTONES` in `frontend/src/hooks/useMilestones.ts`. Remaining 5 milestones (in order): `rsvps25`, `rsvps50`, `rsvps100`, `firstWallet`, `firstNewsletter`.

`MilestoneId` type union members and i18n strings are preserved intentionally — they're harmless when unreachable and avoid a ripple across 7 locale files / `types.ts`.

## Preview

https://rsvpizza-git-basil-58219-hide-milestones-pizza-dao.vercel.app

## Verification

- [ ] Load the host dashboard and confirm only 5 milestone chips show: 25 / 50 / 100 RSVPs, First wallet, First newsletter signup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)