### PR TITLE
pancetta-31624: refresh GPP dashboard checklist on in-tab side effects

### DIFF
--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -17,7 +17,6 @@ export const GPPDashboardTab: React.FC = () => {
   const [dbItems, setDbItems] = useState<ChecklistItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [hostsExpanded, setHostsExpanded] = useState(false);
-  const [coHostCount, setCoHostCount] = useState(party?.coHosts?.length ?? 0);
   const [showCompleted, setShowCompleted] = useState(false);
   const [saving, setSaving] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
@@ -42,7 +41,11 @@ export const GPPDashboardTab: React.FC = () => {
   useEffect(() => {
     if (!party?.id) return;
     loadChecklist();
-  }, [party?.id, loadChecklist]);
+    // pancetta-31624: refetch when in-tab side effects mutate signals that drive
+    // the server-computed autoStates. HostsManager expands inline (mutates
+    // party.coHosts via PizzaContext) and FindVenueModal sets party.address —
+    // without these deps the checkmarks stay stale until reload.
+  }, [party?.id, party?.coHosts?.length, party?.address, party?.addressIsCityDefault, loadChecklist]);
 
   // Map known item names to Lucide icons
   const ICON_MAP: Record<string, LucideIcon> = {
@@ -107,7 +110,7 @@ export const GPPDashboardTab: React.FC = () => {
       if (!b.dueDate) return -1;
       return a.dueDate.localeCompare(b.dueDate);
     });
-  }, [party, autoStates, dbItems, coHostCount]);
+  }, [party, autoStates, dbItems, party?.coHosts?.length]);
 
   const completedCount = checklist.filter((c) => c.done).length;
   const totalCount = checklist.length;
@@ -357,7 +360,6 @@ export const GPPDashboardTab: React.FC = () => {
                         partyId={party.id}
                         hostName={party.hostName || ''}
                         initialCoHosts={party.coHosts || []}
-                        onCoHostsChange={(coHosts) => setCoHostCount(coHosts.length)}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

The GPP dashboard checklist's auto-completion states (`autoStates` from `getChecklist(partyId)`) were only re-fetched when `party.id` changed. Two in-tab side effects didn't trigger a refresh:

- **Build a Team** — expands `HostsManager` inline. Adding a cohost mutates `party.coHosts` in PizzaContext but the checkmark stayed `O` until reload.
- **Find a Venue** — opens `FindVenueModal` inline. The modal already calls `onSaved={loadChecklist}` so it mostly worked, but the dep set is now also covered defensively.

### Changes

- Broaden `loadChecklist` `useEffect` deps to include `party?.coHosts?.length`, `party?.address`, and `party?.addressIsCityDefault` (the fields the backend's `team_built` and `venue_added` auto-rules depend on, per `backend/src/routes/checklist.routes.ts`).
- Use primitive deps (length/string) so unrelated `setParty` calls (which mint a new `coHosts` array ref) don't cause over-fetching.
- Remove the dead `coHostCount` `useState`, which was frozen at mount and misleading. Reference `party?.coHosts?.length` directly in the `checklist` `useMemo` deps.
- Drop the now-unused `onCoHostsChange` callback to `HostsManager` (the prop is optional).

## Vercel preview

https://rsvpizza-git-pancetta-31624-checklist-refresh-pizza-dao.vercel.app

## Test plan

- [ ] Open the GPP dashboard tab on a host page. "Build a Team" item shows `O`.
- [ ] Click "Build a Team" → `HostsManager` expands inline.
- [ ] Add a cohost from the expanded form → the "Build a Team" checklist item flips to a green check without a page reload.
- [ ] Click "Find a Venue" → `FindVenueModal` opens.
- [ ] Pick a venue (or type an address) and save → modal closes and the "Find a Venue" item flips to a green check without a page reload.
- [ ] Tabs that navigate elsewhere (Find Partners, Set Up Budget, etc.) still work as before since the dashboard remounts on return.