### PR TITLE
feat(prosciutto-58472): backend auto-populates pizzerias on event create/update

### DIFF
--- a/backend/src/lib/autoPopulatePizzerias.ts
+++ b/backend/src/lib/autoPopulatePizzerias.ts
@@ -1,0 +1,133 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../config/database.js';
+
+interface Args {
+  partyId: string;
+  lat: number | null;
+  lng: number | null;
+  address: string | null;
+}
+
+/**
+ * Geocode a free-form address to lat/lng using Nominatim. Returns null on any
+ * error or no result — never throws. (`lib/geocode.ts#geocodeCity` is the
+ * city-name variant; this targets the more specific `address` string and uses
+ * a shorter User-Agent.)
+ */
+async function nominatimGeocode(address: string): Promise<{ lat: number; lng: number } | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&limit=1`,
+      {
+        headers: { 'User-Agent': 'rsv.pizza-backend/1.0 (samgold24@gmail.com)' },
+        signal: controller.signal,
+      }
+    );
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const arr = await res.json();
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    const lat = parseFloat(arr[0].lat);
+    const lng = parseFloat(arr[0].lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    return { lat, lng };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Auto-populate `parties.selected_pizzerias` for a party by calling the
+ * Supabase `search-pizzerias` edge function.
+ *
+ * HARD CONSTRAINTS (prosciutto-58472):
+ * - Idempotent: never overwrite a host's preselected list.
+ * - Fire-and-forget: callers must `void` this and `.catch()` on the outside.
+ * - Never throws: wraps everything in try/catch and logs warnings only.
+ * - Race-safe: final write uses conditional Prisma `where` so two simultaneous
+ *   fires can't clobber each other.
+ */
+export async function autoPopulatePizzerias({ partyId, lat, lng, address }: Args): Promise<void> {
+  try {
+    // Idempotent guard — re-read to check current state (caller may have
+    // passed stale party.selectedPizzerias from a create response).
+    const current = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { selectedPizzerias: true, latitude: true, longitude: true, address: true },
+    });
+    if (!current) return;
+
+    const existing = current.selectedPizzerias as unknown;
+    if (Array.isArray(existing) && existing.length > 0) return;
+
+    // Resolve coords
+    let effectiveLat: number | null = lat ?? current.latitude;
+    let effectiveLng: number | null = lng ?? current.longitude;
+    if ((effectiveLat == null || effectiveLng == null) && address) {
+      const geo = await nominatimGeocode(address);
+      if (geo) {
+        effectiveLat = geo.lat;
+        effectiveLng = geo.lng;
+        // Persist resolved coords back so other features benefit.
+        await prisma.party
+          .update({
+            where: { id: partyId },
+            data: { latitude: geo.lat, longitude: geo.lng },
+          })
+          .catch(() => {});
+      }
+    }
+    if (effectiveLat == null || effectiveLng == null) return;
+
+    // Call edge function (server-side, uses service-role key so no CORS/anon issues)
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey) {
+      console.warn('[autoPopulatePizzerias] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    let res: Response;
+    try {
+      res = await fetch(`${supabaseUrl}/functions/v1/search-pizzerias`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${serviceKey}`,
+          'apikey': serviceKey,
+        },
+        body: JSON.stringify({ lat: effectiveLat, lng: effectiveLng, radius: 5000 }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      console.warn('[autoPopulatePizzerias] edge function returned', res.status);
+      return;
+    }
+    const data = await res.json();
+    const pizzerias = Array.isArray(data?.pizzerias) ? data.pizzerias.slice(0, 20) : [];
+    if (pizzerias.length === 0) return;
+
+    // Conditional update — only write if still empty (race-safe).
+    // Uses updateMany() (not update()) because `where` on update() only accepts
+    // unique fields; we need an extra `selectedPizzerias is null` filter.
+    // If another concurrent invocation already wrote, count comes back 0 — fine.
+    await prisma.party
+      .updateMany({
+        where: { id: partyId, selectedPizzerias: { equals: Prisma.DbNull } },
+        data: { selectedPizzerias: pizzerias },
+      })
+      .catch(() => {
+        // Race-lost or some other non-fatal reason — desired outcome (empty stays empty,
+        // or another fire already filled it). Non-fatal.
+      });
+  } catch (err) {
+    console.warn('[autoPopulatePizzerias]', err instanceof Error ? err.message : err);
+  }
+}

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -7,6 +7,7 @@ import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
+import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -231,7 +232,7 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
 router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const {
-      name, date, endTime, duration, pizzaStyle, address, placeId, venueName, city, maxGuests,
+      name, date, endTime, duration, pizzaStyle, address, latitude, longitude, placeId, venueName, city, maxGuests,
       availableBeverages, availableToppings, availableDietaryOptions, password, eventImageUrl, description,
       customUrl, timezone, hideGuests, requireApproval, coHosts,
       donationEnabled, donationGoal, donationMessage, suggestedAmounts, donationRecipient,
@@ -280,6 +281,8 @@ router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => 
         availableToppings: availableToppings || [],
         availableDietaryOptions: availableDietaryOptions || [],
         address: address || null,
+        latitude: latitude !== null && latitude !== undefined ? Number(latitude) : null,
+        longitude: longitude !== null && longitude !== undefined ? Number(longitude) : null,
         placeId: placeId || null,
         venueName: venueName || null,
         city: city || null,
@@ -324,6 +327,17 @@ router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => 
 
     // Trigger webhook for party creation
     await triggerWebhook('party.created', party, req.userId!);
+
+    // prosciutto-58472: fire-and-forget auto-populate of selected_pizzerias.
+    // Helper is idempotent + race-safe + never throws; we still wrap in .catch()
+    // as a paranoid second line of defense so a rejected Promise can't crash the
+    // process via unhandled rejection.
+    void autoPopulatePizzerias({
+      partyId: party.id,
+      lat: party.latitude,
+      lng: party.longitude,
+      address: party.address,
+    }).catch(err => console.warn('[autoPopulatePizzerias create]', err));
 
     // Return with hostName for backwards compatibility
     res.status(201).json({
@@ -680,6 +694,28 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
 
     // Trigger webhook for party update
     await triggerWebhook('party.updated', party, req.userId!);
+
+    // prosciutto-58472: fire-and-forget auto-populate of selected_pizzerias
+    // when the host changed the address AND hasn't preselected pizzerias
+    // AND isn't manually setting them in this PATCH. Helper is idempotent +
+    // race-safe + never throws, but we still wrap in .catch() for unhandled
+    // rejection safety.
+    const currentSelected = (party as any).selectedPizzerias;
+    const shouldAutoPopulate =
+      address !== undefined &&
+      address !== null &&
+      (!currentSelected ||
+        (Array.isArray(currentSelected) && currentSelected.length === 0)) &&
+      req.body.selectedPizzerias === undefined;
+
+    if (shouldAutoPopulate) {
+      void autoPopulatePizzerias({
+        partyId: party.id,
+        lat: party.latitude,
+        lng: party.longitude,
+        address: party.address,
+      }).catch(err => console.warn('[autoPopulatePizzerias update]', err));
+    }
 
     // Return with hostName for backwards compatibility
     res.json({

--- a/scripts/backfill-auto-pizzerias.js
+++ b/scripts/backfill-auto-pizzerias.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * scripts/backfill-auto-pizzerias.js — backfill parties.selected_pizzerias
+ * by calling the search-pizzerias edge function for each event with an
+ * address and an empty list. Idempotent. Dry-run by default.
+ *
+ * prosciutto-58472: pairs with backend auto-populate so existing events
+ * get the same pre-populated rank widget that new events get on creation.
+ *
+ * Env:
+ *   SUPABASE_URL (default: https://znpiwdvvsqaxuskpfleo.supabase.co)
+ *   SUPABASE_SERVICE_ROLE_KEY (required)
+ *
+ * Usage:
+ *   node scripts/backfill-auto-pizzerias.js                 # dry-run
+ *   node scripts/backfill-auto-pizzerias.js --limit 1       # 1-row smoke test
+ *   node scripts/backfill-auto-pizzerias.js --apply         # full apply
+ *   node scripts/backfill-auto-pizzerias.js --apply --delay-ms 2000
+ */
+const { createClient } = require('@supabase/supabase-js');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://znpiwdvvsqaxuskpfleo.supabase.co';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+if (!SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Set SUPABASE_SERVICE_ROLE_KEY env var');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const limitArg = args.indexOf('--limit');
+const LIMIT = limitArg >= 0 ? parseInt(args[limitArg + 1], 10) : Infinity;
+const delayArg = args.indexOf('--delay-ms');
+const DELAY_MS = delayArg >= 0 ? parseInt(args[delayArg + 1], 10) : 1500;
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+async function nominatim(address) {
+  try {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), 5000);
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&limit=1`,
+      {
+        headers: { 'User-Agent': 'rsv.pizza-backfill/1.0 (samgold24@gmail.com)' },
+        signal: ac.signal,
+      }
+    );
+    clearTimeout(t);
+    if (!res.ok) return null;
+    const arr = await res.json();
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    const lat = parseFloat(arr[0].lat);
+    const lng = parseFloat(arr[0].lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    return { lat, lng };
+  } catch {
+    return null;
+  }
+}
+
+async function callEdge(lat, lng) {
+  const res = await fetch(`${SUPABASE_URL}/functions/v1/search-pizzerias`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      'apikey': SUPABASE_SERVICE_ROLE_KEY,
+    },
+    body: JSON.stringify({ lat, lng, radius: 5000 }),
+  });
+  if (!res.ok) throw new Error(`edge ${res.status}`);
+  const data = await res.json();
+  return Array.isArray(data?.pizzerias) ? data.pizzerias.slice(0, 20) : [];
+}
+
+(async () => {
+  console.log(APPLY ? 'APPLY mode — writes enabled' : 'DRY RUN — no writes');
+  console.log(`delay between rows: ${DELAY_MS}ms`);
+
+  const { data: rows, error } = await supabase
+    .from('parties')
+    .select('id, custom_url, invite_code, address, latitude, longitude, selected_pizzerias')
+    .not('address', 'is', null)
+    .or('selected_pizzerias.is.null,selected_pizzerias.eq.[]')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  }
+
+  // Belt-and-suspenders client-side filter (some Supabase versions don't
+  // reliably evaluate `.eq.[]` against jsonb null vs. empty).
+  const candidates = rows.filter(r =>
+    !r.selected_pizzerias ||
+    (Array.isArray(r.selected_pizzerias) && r.selected_pizzerias.length === 0)
+  );
+  const slice = Number.isFinite(LIMIT) ? candidates.slice(0, LIMIT) : candidates;
+  console.log(`Found ${candidates.length} candidates; processing ${slice.length}`);
+
+  let ok = 0, skip = 0, fail = 0;
+  for (let i = 0; i < slice.length; i++) {
+    const row = slice[i];
+    const slug = row.custom_url || row.invite_code || row.id;
+    try {
+      let lat = row.latitude;
+      let lng = row.longitude;
+      if (lat == null || lng == null) {
+        const geo = await nominatim(row.address);
+        if (!geo) {
+          console.log(`[${i + 1}/${slice.length}] ${slug} — skip (no geocode)`);
+          skip++;
+          // Nominatim asks for ≥1s between requests
+          await sleep(DELAY_MS + 1000);
+          continue;
+        }
+        lat = geo.lat;
+        lng = geo.lng;
+        if (APPLY) {
+          await supabase.from('parties').update({ latitude: lat, longitude: lng }).eq('id', row.id);
+        }
+        // Respect Nominatim usage policy (≥1s between requests).
+        await sleep(1000);
+      }
+      const pizzerias = await callEdge(lat, lng);
+      if (pizzerias.length === 0) {
+        console.log(`[${i + 1}/${slice.length}] ${slug} — skip (0 results)`);
+        skip++;
+        await sleep(DELAY_MS);
+        continue;
+      }
+      if (APPLY) {
+        // Race-safe: only write if still empty.
+        const { error: upErr } = await supabase
+          .from('parties')
+          .update({ selected_pizzerias: pizzerias })
+          .eq('id', row.id)
+          .or('selected_pizzerias.is.null,selected_pizzerias.eq.[]');
+        if (upErr) throw upErr;
+      }
+      console.log(
+        `[${i + 1}/${slice.length}] ${slug} — ${pizzerias.length} pizzerias — ${APPLY ? 'ok' : 'dry-ok'}`
+      );
+      ok++;
+    } catch (e) {
+      console.log(`[${i + 1}/${slice.length}] ${slug} — fail: ${e.message}`);
+      fail++;
+    }
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`\nSummary: ok=${ok} skip=${skip} fail=${fail}`);
+})();


### PR DESCRIPTION
## Summary
Backend fires ONE `search-pizzerias` call per event lifetime and stores results in `parties.selected_pizzerias`. Guests see them on first page view with zero browser-side Google API calls.

- New helper `backend/src/lib/autoPopulatePizzerias.ts` — idempotent, race-safe, fire-and-forget, never throws.
- Wired into `POST /api/parties` (after webhook fires) and into `PATCH /api/parties/:id` when address changes AND `selected_pizzerias` is empty AND host isn't manually overriding.
- Backfill script `scripts/backfill-auto-pizzerias.js` for the 519 existing events without preselected pizzerias.

The nduja-49021 button stays as fallback for events where the backend call failed or returned 0 results.

## Manual post-merge steps
1. Deploy backend from `rsvpizza-master-deploy` worktree (NEVER from this feature branch — clobbers other in-flight work):
   ```
   cd /path/to/rsvpizza-master-deploy && git pull
   cd backend && vercel --prod --scope pizza-dao
   ```
2. Run backfill (1.5s/row x 519 ~ 13min, well under 2000/day Places cap):
   ```
   SUPABASE_SERVICE_ROLE_KEY=... node scripts/backfill-auto-pizzerias.js --apply --delay-ms 1500
   ```

## Test plan
- [ ] Create a new event with address via host UI; `selected_pizzerias` populates within seconds.
- [ ] Reload RSVP page in incognito: 0 `search-pizzerias` requests; rank widget renders immediately.
- [ ] Host edits and manually selects pizzerias: PATCH writes them; auto-populate does NOT overwrite.
- [ ] Dry-run backfill on 1 row, inspect output.
- [ ] Full backfill: monitor GCP Places traffic burst then quiet.
- [ ] 24h post-deploy: GCP traffic at floor.

Plan: `plans/prosciutto-58472-auto-pizzerias.md`

Generated with [Claude Code](https://claude.com/claude-code)