### PR TITLE
feat(taleggio-30219): accept ENS names for USDC payout wallet

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -60,6 +60,7 @@ import onesheetRoutes from './routes/onesheet.routes.js';
 import scorecardRoutes from './routes/scorecard.routes.js';
 import citiesRoutes from './routes/cities.routes.js';
 import resendWebhookRouter from './routes/webhooks.resend.routes.js';
+import ensRoutes from './routes/ens.routes.js';
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -175,6 +176,7 @@ app.use('/api/events', eventRoutes);
 app.use('/api/nft', nftRoutes);
 app.use('/api/gpp', gppRoutes);
 app.use('/api/cities', citiesRoutes); // Public list of cities hosting GPP events
+app.use('/api/ens', ensRoutes); // taleggio-30219: ENS → 0x resolution utility (auth-optional)
 app.use('/api/checkin', checkinRoutes);
 app.use('/api/scorecard', scorecardRoutes);
 app.use('/api/display', displayRoutes); // Public display viewer routes

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -29,6 +29,7 @@ import {
   getUsdcDailyCapStatus,
 } from '../services/usdc-base.service.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
+import { resolveWalletInput } from '../services/ens.service.js';
 
 const router = Router();
 
@@ -881,9 +882,22 @@ router.patch(
       }
 
       if (payoutWalletAddress !== undefined) {
-        data.payoutWalletAddress = payoutWalletAddress === null
-          ? null
-          : String(payoutWalletAddress).trim();
+        // taleggio-30219: admin override also accepts ENS names; resolve to
+        // 0x before persisting so the execution path (which already expects
+        // 0x) stays untouched.
+        if (payoutWalletAddress === null) {
+          data.payoutWalletAddress = null;
+        } else {
+          try {
+            data.payoutWalletAddress = await resolveWalletInput(String(payoutWalletAddress));
+          } catch (err: any) {
+            throw new AppError(
+              err?.message || 'Could not resolve wallet address',
+              400,
+              'INVALID_WALLET_ADDRESS'
+            );
+          }
+        }
       }
 
       if (payoutBankDetails !== undefined) {

--- a/backend/src/routes/ens.routes.ts
+++ b/backend/src/routes/ens.routes.ts
@@ -1,0 +1,42 @@
+/**
+ * ENS resolution utility endpoint.
+ *
+ * Added by taleggio-30219 to back the PayoutMethodPicker's live-preview
+ * UX ("→ 0x1234…abcd"). Mounted at /api/ens (see backend/src/index.ts).
+ *
+ * Auth-optional, IP rate-limited. ENS lookups are cheap but we don't want
+ * to be a free public RPC.
+ */
+import { Router, Request, Response, NextFunction } from 'express';
+import { rateLimit } from 'express-rate-limit';
+import { looksLikeEnsName, resolveEns } from '../services/ens.service.js';
+
+const router = Router();
+
+// 60 calls/hour/IP — generous for normal UI usage, cheap to enforce.
+const ensResolveLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  message: { error: 'ENS resolve rate limit reached (60/hour). Please wait before trying again.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: false,
+});
+
+router.get('/resolve', ensResolveLimiter, async (req: Request, res: Response, _next: NextFunction) => {
+  try {
+    const name = String(req.query.name ?? '').trim();
+    if (!name) {
+      return res.status(400).json({ error: 'name is required' });
+    }
+    if (!looksLikeEnsName(name)) {
+      return res.status(400).json({ error: 'not an ENS-shaped name' });
+    }
+    const addr = await resolveEns(name);
+    return res.json({ address: addr });
+  } catch (err: any) {
+    return res.status(404).json({ error: err?.message || 'Could not resolve ENS name' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -22,6 +22,7 @@ import { AppError } from '../middleware/error.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
+import { looksLikeEnsName, resolveWalletInput } from '../services/ens.service.js';
 
 const router = Router();
 
@@ -169,9 +170,15 @@ function validateMethodSpecificFields(
 ) {
   if (method === 'usdc_base') {
     const addr = body.payoutWalletAddress;
-    if (typeof addr !== 'string' || !/^0x[0-9a-fA-F]{40}$/.test(addr.trim())) {
+    // taleggio-30219: accept either a 0x address OR an ENS-shaped name here.
+    // Actual ENS resolution is deferred to the async write site below — this
+    // validator is synchronous and only checks shape.
+    const trimmed = typeof addr === 'string' ? addr.trim() : '';
+    const is0x = /^0x[0-9a-fA-F]{40}$/.test(trimmed);
+    const isEns = trimmed.length > 0 && looksLikeEnsName(trimmed);
+    if (!is0x && !isEns) {
       throw new AppError(
-        'usdc_base requires a valid 0x… wallet address',
+        'usdc_base requires a valid 0x… wallet address or ENS name (e.g. alice.eth)',
         400,
         'INVALID_WALLET_ADDRESS'
       );
@@ -198,6 +205,23 @@ function validateMethodSpecificFields(
         'MISSING_BANK_DETAILS'
       );
     }
+  }
+}
+
+/**
+ * taleggio-30219: resolve a host-supplied wallet input (0x or ENS) to a
+ * canonical 0x address, converting thrown errors to a 400 AppError so the
+ * existing error-middleware shape carries through.
+ */
+async function resolveWalletOrThrow(input: string): Promise<string> {
+  try {
+    return await resolveWalletInput(input);
+  } catch (err: any) {
+    throw new AppError(
+      err?.message || 'Could not resolve wallet address',
+      400,
+      'INVALID_WALLET_ADDRESS'
+    );
   }
 }
 
@@ -485,6 +509,14 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       throw new AppError('Authenticated user has no userId', 500, 'NO_USER_ID');
     }
 
+    // taleggio-30219: resolve the wallet input once, BEFORE the create, so
+    // we persist a canonical 0x address even if the host typed an ENS name.
+    // Reused by the `saveAsDefault` write below so we don't resolve twice.
+    let resolvedWallet: string | null = null;
+    if (hasMethod && payoutMethod === 'usdc_base' && typeof payoutWalletAddress === 'string') {
+      resolvedWallet = await resolveWalletOrThrow(payoutWalletAddress);
+    }
+
     // pancetta-37195: stamp each new document with the uploader.
     const uploaderUserId = req.userId ?? null;
     const uploaderEmail = req.userEmail ?? null;
@@ -508,9 +540,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         // arugula-38633 v3 follow-up: payoutMethod is optional. Persist null
         // when the host hasn't set their payment details yet.
         payoutMethod: hasMethod ? payoutMethod : null,
-        payoutWalletAddress: hasMethod && payoutMethod === 'usdc_base'
-          ? (payoutWalletAddress as string).trim()
-          : null,
+        payoutWalletAddress: resolvedWallet,
         ...(hasMethod && payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
           ? { payoutBankDetails: payoutBankDetails as Prisma.InputJsonValue }
           : {}),
@@ -554,8 +584,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           where: { id: req.userId },
           data: {
             preferredPayoutMethod: payoutMethod,
-            ...(payoutMethod === 'usdc_base' && typeof payoutWalletAddress === 'string'
-              ? { payoutWalletAddress: payoutWalletAddress.trim() }
+            // taleggio-30219: reuse the already-resolved 0x — don't resolve
+            // twice (ENS lookups are cheap but not free, and we want a
+            // consistent address across the payout and the user default).
+            ...(payoutMethod === 'usdc_base' && resolvedWallet
+              ? { payoutWalletAddress: resolvedWallet }
               : {}),
             ...(payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
               ? { payoutBankDetails: payoutBankDetails as Prisma.InputJsonValue }
@@ -691,9 +724,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     }
 
     if (payoutWalletAddress !== undefined) {
+      // taleggio-30219: resolve ENS → 0x before persisting. Null clears the field.
       data.payoutWalletAddress = payoutWalletAddress === null
         ? null
-        : String(payoutWalletAddress).trim();
+        : await resolveWalletOrThrow(String(payoutWalletAddress));
     }
     if (payoutBankDetails !== undefined) {
       data.payoutBankDetails = payoutBankDetails === null

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { resolveWalletInput } from '../services/ens.service.js';
 
 const router = Router();
 
@@ -56,6 +57,27 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
       });
     }
 
+    // taleggio-30219: resolve ENS → 0x before storing the user-default
+    // payout wallet. Either a 0x address or an ENS-shaped name is accepted;
+    // resolution failures bubble out as 400 INVALID_WALLET_ADDRESS.
+    let resolvedWallet: string | null | undefined;
+    if (payoutWalletAddress !== undefined) {
+      if (!payoutWalletAddress) {
+        resolvedWallet = null;
+      } else {
+        try {
+          resolvedWallet = await resolveWalletInput(String(payoutWalletAddress));
+        } catch (err: any) {
+          return res.status(400).json({
+            error: {
+              message: err?.message || 'Could not resolve wallet address',
+              code: 'INVALID_WALLET_ADDRESS',
+            },
+          });
+        }
+      }
+    }
+
     const user = await prisma.user.update({
       where: { id: req.userId },
       data: {
@@ -65,9 +87,7 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
           preferredPayoutMethod: preferredPayoutMethod || null,
         }),
         ...(payoutWalletAddress !== undefined && {
-          payoutWalletAddress: payoutWalletAddress
-            ? String(payoutWalletAddress).trim()
-            : null,
+          payoutWalletAddress: resolvedWallet ?? null,
         }),
         ...(payoutBankDetails !== undefined && {
           payoutBankDetails: payoutBankDetails ?? null,

--- a/backend/src/services/ens.service.ts
+++ b/backend/src/services/ens.service.ts
@@ -1,0 +1,63 @@
+import { createPublicClient, http, isAddress } from 'viem';
+import { mainnet } from 'viem/chains';
+import { normalize } from 'viem/ens';
+
+/**
+ * ENS lives on Ethereum mainnet — even when our payouts go out on Base,
+ * we resolve names against L1 via the universal resolver. Uses a dedicated
+ * read-only public client (no signer needed).
+ *
+ * Added by taleggio-30219: hosts can type `vitalik.eth` instead of a
+ * 0x address when picking USDC on Base. We resolve at the API boundary
+ * and persist the resolved 0x; the original ENS string is not stored.
+ */
+let cachedClient: ReturnType<typeof createPublicClient> | null = null;
+function getMainnetClient() {
+  if (cachedClient) return cachedClient;
+  const rpc = process.env.ETH_MAINNET_RPC_URL || 'https://eth.llamarpc.com';
+  cachedClient = createPublicClient({ chain: mainnet, transport: http(rpc) });
+  return cachedClient;
+}
+
+// Looser than just `.eth` — supports subdomains like `alice.cb.id`.
+const ENS_NAME_RE = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i;
+
+export function looksLikeEnsName(input: string): boolean {
+  const trimmed = input.trim();
+  if (trimmed.startsWith('0x')) return false;
+  return ENS_NAME_RE.test(trimmed);
+}
+
+/**
+ * Resolve an ENS name to its 0x address. Throws if the name doesn't resolve.
+ * Returns the address checksummed by viem.
+ */
+export async function resolveEns(name: string): Promise<`0x${string}`> {
+  const client = getMainnetClient();
+  const normalized = normalize(name.trim());
+  const addr = await client.getEnsAddress({ name: normalized });
+  if (!addr || !isAddress(addr) || addr === '0x0000000000000000000000000000000000000000') {
+    throw new Error(`ENS name ${name} does not resolve to an address`);
+  }
+  return addr;
+}
+
+/**
+ * Accept a raw user-typed string and return a canonical 0x address.
+ * - If the input is already a valid 0x address: returns it (lower-cased trim).
+ * - If the input looks like an ENS name: resolves via mainnet.
+ * - Otherwise: throws.
+ *
+ * Caller is responsible for converting the thrown Error into the correct
+ * HTTP error (e.g. AppError 400 INVALID_WALLET_ADDRESS).
+ */
+export async function resolveWalletInput(input: string): Promise<`0x${string}`> {
+  const trimmed = input.trim();
+  if (/^0x[0-9a-fA-F]{40}$/.test(trimmed)) {
+    return trimmed.toLowerCase() as `0x${string}`;
+  }
+  if (looksLikeEnsName(trimmed)) {
+    return await resolveEns(trimmed);
+  }
+  throw new Error('Wallet address must be a 0x… address or an ENS name (e.g. alice.eth)');
+}

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -2,6 +2,22 @@ import React from 'react';
 import { CreditCard, Banknote, Coins, Mail, Wallet } from 'lucide-react';
 import { PayoutMethod, BankDetails } from '../../types';
 import { IconInput } from '../IconInput';
+import { resolveEnsName } from '../../lib/api';
+
+// taleggio-30219: mirror of backend `looksLikeEnsName` — accepts dotted
+// names like `vitalik.eth` or `alice.cb.id` and rejects 0x… inputs.
+const ENS_NAME_RE = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i;
+function looksLikeEnsName(input: string): boolean {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.startsWith('0x')) return false;
+  return ENS_NAME_RE.test(trimmed);
+}
+
+type EnsPreviewState =
+  | { kind: 'idle' }
+  | { kind: 'resolving'; name: string }
+  | { kind: 'resolved'; name: string; address: string }
+  | { kind: 'error'; name: string };
 
 interface PayoutMethodPickerProps {
   method: PayoutMethod;
@@ -40,6 +56,35 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
   userEmail,
   reimbursementCapUsd,
 }) => {
+  // taleggio-30219: debounced ENS preview state for the USDC sub-form.
+  const [ensPreview, setEnsPreview] = React.useState<EnsPreviewState>({ kind: 'idle' });
+  React.useEffect(() => {
+    if (method !== 'usdc_base') {
+      setEnsPreview({ kind: 'idle' });
+      return;
+    }
+    const trimmed = walletAddress.trim();
+    if (!trimmed || !looksLikeEnsName(trimmed)) {
+      setEnsPreview({ kind: 'idle' });
+      return;
+    }
+    setEnsPreview({ kind: 'resolving', name: trimmed });
+    let cancelled = false;
+    const handle = window.setTimeout(async () => {
+      const addr = await resolveEnsName(trimmed);
+      if (cancelled) return;
+      if (addr) {
+        setEnsPreview({ kind: 'resolved', name: trimmed, address: addr });
+      } else {
+        setEnsPreview({ kind: 'error', name: trimmed });
+      }
+    }, 500);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [method, walletAddress]);
+
   // For wire: prefill the field from the user's auth email if no saved value.
   // We mirror this into bankDetails on first render of the wire branch so the
   // auto-save persists it even if the host doesn't touch the field.
@@ -134,14 +179,30 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           <IconInput
             icon={Wallet}
             type="text"
-            placeholder="Your wallet address on Base (0x…)"
+            placeholder="Your wallet address or ENS name (0x… or alice.eth)"
             value={walletAddress}
             onChange={e => onWalletAddressChange(e.target.value)}
             required
           />
+          {/* taleggio-30219: live ENS preview. Hidden when the input is 0x or empty. */}
+          {ensPreview.kind === 'resolving' && (
+            <p className="text-xs text-theme-text-muted">
+              Resolving <span className="font-mono">{ensPreview.name}</span>…
+            </p>
+          )}
+          {ensPreview.kind === 'resolved' && (
+            <p className="text-xs text-theme-text-muted">
+              → <span className="font-mono">{ensPreview.address.slice(0, 6)}…{ensPreview.address.slice(-4)}</span>
+            </p>
+          )}
+          {ensPreview.kind === 'error' && (
+            <p className="text-xs text-red-400">
+              Could not resolve "<span className="font-mono">{ensPreview.name}</span>"
+            </p>
+          )}
           <p className="text-xs text-theme-text-muted">
             USDC on Base ({/* link omitted intentionally */}
-            <span className="font-mono">0x8335…2913</span>). Double-check this address — onchain transfers can't be reversed.
+            <span className="font-mono">0x8335…2913</span>). ENS names resolve against Ethereum mainnet. Double-check the resolved address — onchain transfers can't be reversed.
           </p>
         </div>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4342,3 +4342,22 @@ export async function updateUserMe(
   }>('/api/user/me', { method: 'PATCH', body: data, requireAuth: true });
   return res.user;
 }
+
+/**
+ * taleggio-30219: resolve an ENS name (e.g. `vitalik.eth`) to its 0x address
+ * via the backend's mainnet-resolver utility endpoint. Returns null on any
+ * failure (404, 400, network). Caller uses this for the live-preview UX in
+ * PayoutMethodPicker — actual persistence resolution happens server-side.
+ */
+export async function resolveEnsName(name: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/ens/resolve?name=${encodeURIComponent(name)}`
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data?.address === 'string' ? data.address : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- New `resolveWalletInput()` helper resolves ENS → 0x via Ethereum mainnet; 0x is what's stored. ENS string is not persisted (matches the existing flat storage shape).
- POST/PATCH payout + user-prefs + admin override all accept either 0x or `*.eth` / subdomain-shaped names.
- New `GET /api/ens/resolve?name=…` backs the frontend live-preview (\"→ 0x1234…abcd\").
- PayoutMethodPicker placeholder + helper text updated.

## Test plan
- [ ] Submit a payout with `vitalik.eth` as the wallet — resolves and saves `0xd8dA…`.
- [ ] Submit `0x…` as before — still works.
- [ ] Submit garbage (`alice.eth.xyz` that doesn't resolve) — 400 with a clear message.
- [ ] Frontend preview shows `Resolving…` then `→ 0x1234…abcd` as you type a valid ENS.
- [ ] Admin override accepts ENS.
- [ ] User-prefs wallet save accepts ENS.