### PR TITLE
pancetta-71284: add 'payments' to checklist link-tab dropdown

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -202,7 +202,7 @@ router.patch('/gpp-nft', requireAuth, async (req: AuthRequest, res: Response, ne
 const ALLOWED_LINK_TABS = [
   'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music',
   'report', 'staff', 'displays', 'raffle', 'budget', 'gpp', 'promo',
-  'flyer', 'print',
+  'flyer', 'print', 'payments',
 ];
 
 function isValidLinkTab(v: unknown): v is string | null {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -36,7 +36,7 @@ const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4
 const LINK_TAB_OPTIONS: readonly string[] = [
   'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music',
   'report', 'staff', 'displays', 'raffle', 'budget', 'gpp', 'promo',
-  'flyer', 'print',
+  'flyer', 'print', 'payments',
 ];
 
 function sortByDueDate(items: ChecklistDefault[]): ChecklistDefault[] {


### PR DESCRIPTION
## Summary
- Adds `'payments'` to `LINK_TAB_OPTIONS` in `AdminPage.tsx` so the admin checklist editor dropdown surfaces the Payments app.
- Adds `'payments'` to `ALLOWED_LINK_TABS` in `admin.routes.ts` so the backend accepts the value on PATCH/POST.
- `HostPage.tsx` already supports `'payments'` in `TabType` + `ALL_VALID_TABS` — no host-side changes needed.

## Test plan
- [ ] On Vercel preview as super admin: `/admin` → Event Setup Checklist → dropdown shows `payments`.
- [ ] Set "Submit payments info" `link_tab` to `payments` → save → success toast.
- [ ] Open a GPP event → checklist → click "Submit payments info" → routes to `/host/:invite/payments`.
- [ ] Backend deploy from master tip (separately, post-merge) is required before the option works on prod.

Generated with [Claude Code](https://claude.com/claude-code)