### PR TITLE
basil-72340: approval email shows event flyer + venue name

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -1038,6 +1038,7 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
             inviteCode: true,
             customUrl: true,
             eventImageUrl: true,
+            venueName: true,
           },
         });
 
@@ -1051,6 +1052,7 @@ router.patch('/:partyId/guests/:guestId/approve', async (req: AuthRequest, res: 
             partyTimezone: party.timezone,
             partyAddress: party.address,
             partyImageUrl: party.eventImageUrl,
+            venueName: party.venueName,
             inviteCode: party.inviteCode,
             customUrl: party.customUrl,
           });

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -901,7 +901,8 @@ export async function sendApprovalEmail(params: {
   partyDate: Date | null;
   partyTimezone: string | null;
   partyAddress: string | null;
-  partyImageUrl?: string | null;
+  partyImageUrl: string | null;
+  venueName: string | null;
   inviteCode: string;
   customUrl: string | null;
 }) {
@@ -937,13 +938,13 @@ export async function sendApprovalEmail(params: {
 
   const addressText = params.partyAddress || 'Location TBD';
 
-  const flyerBlock = params.partyImageUrl
-    ? `
-        <div style="text-align: center; margin-bottom: 20px;">
-          <img src="${params.partyImageUrl}" alt="${params.partyName}" style="max-width: 100%; border-radius: 12px;" />
-        </div>
-  `
+  const flyerImg = params.partyImageUrl
+    ? `<img src="${params.partyImageUrl}" alt="${params.partyName}" style="width: 100%; max-width: 540px; height: auto; border-radius: 12px; display: block; margin: 0 auto 20px auto;" />`
     : '';
+
+  const whereHtml = params.venueName
+    ? `<p style="margin: 10px 0;"><strong>Where:</strong> ${params.venueName}<br><span style="color: #666; font-size: 14px;">${addressText}</span></p>`
+    : `<p style="margin: 10px 0;"><strong>Where:</strong> ${addressText}</p>`;
 
   const emailHtml = `
     <!DOCTYPE html>
@@ -954,7 +955,6 @@ export async function sendApprovalEmail(params: {
         <title>RSVP Approved</title>
       </head>
       <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-        ${flyerBlock}
         <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
           <h1 style="color: #ffffff; font-size: 32px; margin: 0 0 10px 0;">🍕 You're Approved!</h1>
           <p style="color: rgba(255,255,255,0.8); font-size: 18px; margin: 0;">Your RSVP has been confirmed</p>
@@ -965,10 +965,11 @@ export async function sendApprovalEmail(params: {
         </div>
 
         <div style="background: #f9f9f9; padding: 30px; border-radius: 12px; margin-bottom: 20px;">
+          ${flyerImg}
           <h2 style="color: #1a1a2e; margin-top: 0; margin-bottom: 20px;">Event Details</h2>
           <p style="margin: 10px 0;"><strong>Event:</strong> ${params.partyName}</p>
           <p style="margin: 10px 0;"><strong>When:</strong> ${dateText}</p>
-          <p style="margin: 10px 0;"><strong>Where:</strong> ${addressText}</p>
+          ${whereHtml}
         </div>
 
         <div style="background: #f9f9f9; padding: 30px; border-radius: 12px; margin-bottom: 20px; text-align: center;">


### PR DESCRIPTION
## Summary
- `sendApprovalEmail` now embeds the event flyer (`party.eventImageUrl`) at the top of the Event Details card.
- Venue name (`party.venueName`) now renders above the address when set, mirroring the EventPage layout. Falls back to address-only when no venue is set.
- Backend-only change. Frontend unchanged. No schema or migration changes.

## Verification
- [ ] After merge to master + backend deploy, have a host approve a guest RSVP on an event that has both `event_image_url` and `venue_name` populated.
- [ ] Confirm the email shows the flyer image at top of Event Details and shows venue name above the street address.
- [ ] Test the fallback: approve on an event with no `event_image_url` (flyer block should be omitted, not a broken image) and no `venue_name` (address shows as single line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)