### PR TITLE
feat(gouda-83912): lock payment edit/delete to submitting cohost

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -708,6 +708,18 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       );
     }
 
+    // gouda-83912: only the cohost who submitted the payout (or any admin)
+    // may edit it. Other cohosts on the same party can see the row but
+    // cannot mutate it.
+    const isAdminCaller = await isAnyAdmin(req.userEmail);
+    if (!isAdminCaller && existing.hostUserId !== req.userId) {
+      throw new AppError(
+        'Only the cohost who submitted this payment can edit it.',
+        403,
+        'FORBIDDEN_NOT_OWNER',
+      );
+    }
+
     const data: Record<string, any> = {};
 
     if (payoutMethod !== undefined) {
@@ -1076,6 +1088,18 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
         'Only pending payments can be cancelled',
         400,
         'PAYOUT_NOT_PENDING'
+      );
+    }
+
+    // gouda-83912: only the cohost who submitted the payout (or any admin)
+    // may delete it. Other cohosts on the same party can see the row but
+    // cannot mutate it.
+    const isAdminCaller = await isAnyAdmin(req.userEmail);
+    if (!isAdminCaller && existing.hostUserId !== req.userId) {
+      throw new AppError(
+        'Only the cohost who submitted this payment can cancel it.',
+        403,
+        'FORBIDDEN_NOT_OWNER',
       );
     }
 

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign } from 'lucide-react';
 import { Payout, PayoutStatus } from '../../types';
-import { getPayout, updatePayout } from '../../lib/api';
+import { getPayout, updatePayout, fetchAdminMe } from '../../lib/api';
+import { useAuth } from '../../contexts/AuthContext';
 import { methodIcon, methodLabel } from './PayoutListRow';
 import { IconInput } from '../IconInput';
 import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
@@ -45,9 +46,22 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   onClose,
   onUpdated,
 }) => {
+  const { user } = useAuth();
   const [payout, setPayout] = useState<Payout | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // gouda-83912: admin/superadmin viewers may edit any cohost's payout from
+  // the host-side modal (mirrors backend `isAnyAdmin` bypass). Non-admin
+  // cohosts can only edit their own submissions.
+  const [isAdmin, setIsAdmin] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    fetchAdminMe()
+      .then(r => { if (!cancelled) setIsAdmin(Boolean(r?.isAdmin)); })
+      .catch(() => { /* unauth or non-admin — leave false */ });
+    return () => { cancelled = true; };
+  }, []);
 
   // ---- edit state ----
   const [editing, setEditing] = useState(false);
@@ -109,6 +123,13 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   const isProcessingUploads =
     newReceipts.some(r => r.status === 'uploading' || r.status === 'ocring') ||
     newPizzaPhotos.some(p => p.status === 'uploading');
+
+  // gouda-83912: only the submitter (or any admin) may edit / cancel a payout.
+  // Other cohosts on the same party can still see the row but the affordances
+  // are hidden — a read-only caption points at the submitter instead.
+  const canModify = Boolean(
+    payout && (isAdmin || (user?.id != null && user.id === payout.hostUserId))
+  );
 
   const handleSave = async () => {
     if (!payout || saving) return;
@@ -207,7 +228,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {payout && !editing && payout.status === 'pending' && (
+            {payout && !editing && payout.status === 'pending' && canModify && (
               <button
                 type="button"
                 onClick={enterEdit}
@@ -264,6 +285,14 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                   {STATUS_LABEL[payout.status]}
                 </span>
               </div>
+
+              {/* gouda-83912: ownership notice for non-owners on pending payouts.
+                  Explains why Edit/Cancel buttons aren't shown. */}
+              {payout.status === 'pending' && !canModify && (
+                <p className="text-xs text-theme-text-muted">
+                  Only {payout.hostName ?? payout.hostEmail ?? 'the submitter'} can modify this.
+                </p>
+              )}
 
               {/* Payout method */}
               <div className="rounded-lg bg-theme-surface-hover p-3 text-sm">

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Loader2, X, ChevronRight, CreditCard, Banknote, Coins, HelpCircle, ImageOff } from 'lucide-react';
 import { Payout, PayoutMethod, PayoutStatus } from '../../types';
-import { cancelPayout } from '../../lib/api';
+import { cancelPayout, fetchAdminMe } from '../../lib/api';
+import { useAuth } from '../../contexts/AuthContext';
 
 interface PayoutListRowProps {
   payout: Payout;
@@ -52,7 +53,22 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
   onOpen,
   onCancelled,
 }) => {
+  const { user } = useAuth();
   const [cancelling, setCancelling] = useState(false);
+
+  // gouda-83912: only the submitter (or any admin) may cancel a payout from
+  // the host-side list. Other cohosts can still see and open the row, but
+  // the inline X button is hidden so they don't get a 403 on click.
+  const [isAdmin, setIsAdmin] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    fetchAdminMe()
+      .then(r => { if (!cancelled) setIsAdmin(Boolean(r?.isAdmin)); })
+      .catch(() => { /* unauth or non-admin — leave false */ });
+    return () => { cancelled = true; };
+  }, []);
+  const canModify =
+    isAdmin || (user?.id != null && user.id === payout.hostUserId);
 
   // First pizza photo, or first receipt as a fallback thumbnail
   const thumb = payout.documents.find(d => d.kind === 'pizza')
@@ -121,8 +137,8 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
         {STATUS_LABEL[payout.status]}
       </span>
 
-      {/* Cancel button (only while pending) */}
-      {payout.status === 'pending' && (
+      {/* Cancel button (only while pending, and only for the submitter/admin) */}
+      {payout.status === 'pending' && canModify && (
         <button
           onClick={handleCancel}
           disabled={cancelling}


### PR DESCRIPTION
## Summary
- Backend: PATCH + DELETE on `/api/parties/:partyId/payouts/:payoutId` now reject with 403 unless `req.userId === payout.host_user_id` (admins bypass).
- Frontend: PayoutDetailModal hides Edit + Cancel buttons when the viewer isn't the submitter or an admin; shows a "Only X can modify this" caption instead.
- Read access unchanged — cohosts still see each other's submissions.
- Admin override path (`admin-payout.routes.ts`) untouched.

## Test plan
- [ ] Cohost A submits a payout → cohost B opens it → no Edit/Cancel buttons, caption reads the submitter's name.
- [ ] B opens her own payout → Edit + Cancel work as before.
- [ ] Admin opens A's payout via /admin → can edit (admin path unchanged).
- [ ] PATCH/DELETE by a non-owner cohost → 403 FORBIDDEN_NOT_OWNER.