### PR TITLE
feat(pepperoni-47301): block Mercury card in sanctioned countries

### DIFF
--- a/backend/src/lib/mercuryBlockedCountries.ts
+++ b/backend/src/lib/mercuryBlockedCountries.ts
@@ -1,0 +1,38 @@
+/**
+ * Countries where Mercury (our virtual debit card issuer) cannot issue cards
+ * due to sanctions / regulatory restrictions. Block list verified 2026-05-20.
+ *
+ * Keep in sync with `frontend/src/lib/mercuryBlockedCountries.ts`.
+ *
+ * Matching is case-insensitive on the normalized country string. Normalization:
+ *   1. lowercase
+ *   2. strip parenthetical clarifications (e.g. "Iran (Islamic Republic of Iran)" → "iran")
+ *   3. trim whitespace
+ *
+ * Ukraine is fully blocked even though only Kherson/Zaporizhzhia/Donetsk/
+ * Luhansk/Crimea are sanctioned — we don't currently store region/oblast on
+ * `parties`, so over-blocking is the safe default. When the schema adds a
+ * `region` column, this can be tightened.
+ */
+const RAW = [
+  'Afghanistan', 'Angola', 'Bangladesh', 'Belarus', 'Bhutan', 'Burkina Faso',
+  'Central African Republic', 'Congo', 'Democratic Republic of the Congo',
+  'DRC', 'Cuba', 'Eritrea', 'Gambia', 'Haiti', 'Indonesia', 'Iran', 'Iraq',
+  'Kyrgyzstan', 'Latvia', 'Lesotho', 'Liberia', 'Maldives', 'Mali',
+  'Mozambique', 'Myanmar', 'Burma', 'Nepal', 'North Korea', 'DPRK',
+  'Palestine', 'Russia', 'South Sudan', 'Sudan', 'Syria', 'Ukraine',
+  'Uzbekistan', 'Vanuatu', 'Venezuela', 'Vietnam', 'Yemen',
+];
+
+export function normalizeCountry(input: string | null | undefined): string {
+  if (!input) return '';
+  return input.toLowerCase().replace(/\(.*?\)/g, '').replace(/\s+/g, ' ').trim();
+}
+
+const BLOCKED_SET = new Set(RAW.map(normalizeCountry));
+
+export function isMercuryBlocked(country: string | null | undefined): boolean {
+  const norm = normalizeCountry(country);
+  if (!norm) return false; // unknown country: don't block by default
+  return BLOCKED_SET.has(norm);
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -30,6 +30,7 @@ import {
 } from '../services/usdc-base.service.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { resolveWalletInput } from '../services/ens.service.js';
+import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 
 const router = Router();
 
@@ -832,6 +833,9 @@ router.patch(
           status: true,
           hostUserId: true,
           finalAmountUsd: true,
+          // pepperoni-47301: partyId is needed to look up `party.country` for
+          // the Mercury sanctioned-country gate below.
+          partyId: true,
         },
       });
 
@@ -877,6 +881,22 @@ router.patch(
       if (payoutMethod !== undefined) {
         if (!ALLOWED_PAYOUT_METHODS.includes(payoutMethod)) {
           throw new AppError('Invalid payoutMethod', 400, 'VALIDATION_ERROR');
+        }
+        // pepperoni-47301: admins are also blocked from forcing `mercury_card`
+        // on a party whose country is on Mercury's restricted list — the
+        // compliance restriction is on the host's location, not the actor.
+        if (payoutMethod === 'mercury_card') {
+          const party = await prisma.party.findUnique({
+            where: { id: existing.partyId },
+            select: { country: true },
+          });
+          if (isMercuryBlocked(party?.country)) {
+            throw new AppError(
+              `Mercury virtual cards are unavailable in ${party?.country ?? 'this country'} due to compliance restrictions. Please pick another payout method.`,
+              400,
+              'MERCURY_COUNTRY_BLOCKED',
+            );
+          }
         }
         data.payoutMethod = payoutMethod;
       }

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -23,6 +23,7 @@ import { canUserEditParty } from '../helpers/partyAccess.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
 import { looksLikeEnsName, resolveWalletInput } from '../services/ens.service.js';
+import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 
 const router = Router();
 
@@ -231,6 +232,31 @@ async function isAnyAdmin(email?: string): Promise<boolean> {
   return false;
 }
 
+/**
+ * pepperoni-47301: Mercury (our virtual debit card issuer) cannot issue cards
+ * to hosts in sanctioned/restricted countries. When the host (or admin) tries
+ * to submit `mercury_card` for a party whose `country` matches the block list,
+ * we reject with 400 `MERCURY_COUNTRY_BLOCKED`. No-op for any other method or
+ * when `method` is undefined.
+ */
+async function assertMercuryAllowed(
+  partyId: string,
+  method: string | null | undefined,
+): Promise<void> {
+  if (method !== 'mercury_card') return;
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: { country: true },
+  });
+  if (isMercuryBlocked(party?.country)) {
+    throw new AppError(
+      `Mercury virtual cards are unavailable in ${party?.country ?? 'this country'} due to compliance restrictions. Please pick another payout method.`,
+      400,
+      'MERCURY_COUNTRY_BLOCKED',
+    );
+  }
+}
+
 // ---------- POST /:partyId/payouts/ocr-preview ----------
 
 router.post(
@@ -354,6 +380,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     if (hasMethod) {
       validatePayoutMethod(payoutMethod);
       validateMethodSpecificFields(payoutMethod, { payoutWalletAddress, payoutBankDetails });
+      // pepperoni-47301: reject `mercury_card` for parties in sanctioned countries.
+      await assertMercuryAllowed(partyId, payoutMethod);
     }
 
     // Validate every uploaded URL points into our bucket
@@ -728,6 +756,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         payoutWalletAddress: payoutWalletAddress ?? existing.payoutWalletAddress,
         payoutBankDetails: payoutBankDetails ?? (existing.payoutBankDetails as any),
       });
+      // pepperoni-47301: reject `mercury_card` for parties in sanctioned countries.
+      await assertMercuryAllowed(partyId, payoutMethod);
       data.payoutMethod = payoutMethod;
       // Clear stale method-specific fields when method changes
       if (payoutMethod !== 'usdc_base') data.payoutWalletAddress = null;

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -5,6 +5,7 @@ import { usePizza } from '../../contexts/PizzaContext';
 import { BankDetails, PayoutMethod } from '../../types';
 import { updateUserMe } from '../../lib/api';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
+import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
 
 const EMPTY_BANK: BankDetails = {};
 
@@ -127,6 +128,18 @@ export const PaymentDetailsCard: React.FC = () => {
     if (snapshot === prevSnapshot.current) return;
     prevSnapshot.current = snapshot;
     isDirty.current = true;
+
+    // pepperoni-47301: never autosave `mercury_card` when the party's country
+    // is on Mercury's restricted list — the per-party payout submission would
+    // be rejected by the backend anyway. Surface the reason locally so the
+    // host knows to pick another method.
+    if (method === 'mercury_card' && isMercuryBlocked(party?.country)) {
+      setSaveStatus('error');
+      setSaveError(
+        `Mercury cards are unavailable in ${party?.country ?? 'your country'}. Pick another method.`
+      );
+      return;
+    }
 
     // Don't fire the save until the method-specific fields are valid.
     if (!methodValid) {

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -3,6 +3,8 @@ import { CreditCard, Banknote, Coins, Mail, Wallet } from 'lucide-react';
 import { PayoutMethod, BankDetails } from '../../types';
 import { IconInput } from '../IconInput';
 import { resolveEnsName } from '../../lib/api';
+import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
+import { usePizza } from '../../contexts/PizzaContext';
 
 // taleggio-30219: mirror of backend `looksLikeEnsName` — accepts dotted
 // names like `vitalik.eth` or `alice.cb.id` and rejects 0x… inputs.
@@ -99,37 +101,59 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [method, userEmail]);
 
+  // pepperoni-47301: Mercury card payout is unavailable in sanctioned/restricted
+  // countries. We read the party's country from PizzaContext and gate the
+  // Mercury Option below. Falls back to false when there's no party (e.g.
+  // unlikely render outside an event context).
+  const { party } = usePizza();
+  const mercuryBlocked = isMercuryBlocked(party?.country);
+  const mercuryDisabledReason = mercuryBlocked
+    ? `Mercury cards are unavailable in ${party?.country ?? 'your country'} due to compliance restrictions.`
+    : undefined;
+
   const Option: React.FC<{
     value: PayoutMethod;
     icon: React.ReactNode;
     title: string;
     description: string;
-  }> = ({ value, icon, title, description }) => {
+    disabled?: boolean;
+    disabledReason?: string;
+  }> = ({ value, icon, title, description, disabled, disabledReason }) => {
     const active = method === value;
     return (
       <button
         type="button"
-        onClick={() => onMethodChange(value)}
+        disabled={disabled}
+        title={disabled ? disabledReason : undefined}
+        onClick={() => {
+          if (disabled) return;
+          onMethodChange(value);
+        }}
         className={`w-full text-left rounded-xl border p-4 transition-colors ${
-          active
-            ? 'border-[#ff393a] bg-[#ff393a]/5'
-            : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
+          disabled
+            ? 'border-theme-stroke bg-theme-surface opacity-60 cursor-not-allowed'
+            : active
+              ? 'border-[#ff393a] bg-[#ff393a]/5'
+              : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
         }`}
       >
         <div className="flex items-start gap-3">
-          <div className={`mt-0.5 ${active ? 'text-[#ff393a]' : 'text-theme-text-muted'}`}>
+          <div className={`mt-0.5 ${active && !disabled ? 'text-[#ff393a]' : 'text-theme-text-muted'}`}>
             {icon}
           </div>
           <div className="flex-1">
             <div className="text-sm font-semibold text-theme-text">{title}</div>
             <div className="text-xs text-theme-text-muted mt-0.5">{description}</div>
+            {disabled && disabledReason && (
+              <div className="text-[10px] text-amber-300 mt-1">{disabledReason}</div>
+            )}
           </div>
           <div
             className={`mt-1 w-4 h-4 rounded-full border-2 flex-shrink-0 ${
-              active ? 'border-[#ff393a]' : 'border-theme-stroke'
+              active && !disabled ? 'border-[#ff393a]' : 'border-theme-stroke'
             }`}
           >
-            {active && <div className="w-2 h-2 rounded-full bg-[#ff393a] m-0.5" />}
+            {active && !disabled && <div className="w-2 h-2 rounded-full bg-[#ff393a] m-0.5" />}
           </div>
         </div>
       </button>
@@ -150,6 +174,8 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
           icon={<CreditCard size={18} />}
           title="Mercury virtual card"
           description="We issue you a debit card for the exact amount."
+          disabled={mercuryBlocked}
+          disabledReason={mercuryDisabledReason}
         />
         <Option
           value="wire"

--- a/frontend/src/lib/mercuryBlockedCountries.ts
+++ b/frontend/src/lib/mercuryBlockedCountries.ts
@@ -1,0 +1,38 @@
+/**
+ * Countries where Mercury (our virtual debit card issuer) cannot issue cards
+ * due to sanctions / regulatory restrictions. Block list verified 2026-05-20.
+ *
+ * Keep in sync with `backend/src/lib/mercuryBlockedCountries.ts`.
+ *
+ * Matching is case-insensitive on the normalized country string. Normalization:
+ *   1. lowercase
+ *   2. strip parenthetical clarifications (e.g. "Iran (Islamic Republic of Iran)" → "iran")
+ *   3. trim whitespace
+ *
+ * Ukraine is fully blocked even though only Kherson/Zaporizhzhia/Donetsk/
+ * Luhansk/Crimea are sanctioned — we don't currently store region/oblast on
+ * `parties`, so over-blocking is the safe default. When the schema adds a
+ * `region` column, this can be tightened.
+ */
+const RAW = [
+  'Afghanistan', 'Angola', 'Bangladesh', 'Belarus', 'Bhutan', 'Burkina Faso',
+  'Central African Republic', 'Congo', 'Democratic Republic of the Congo',
+  'DRC', 'Cuba', 'Eritrea', 'Gambia', 'Haiti', 'Indonesia', 'Iran', 'Iraq',
+  'Kyrgyzstan', 'Latvia', 'Lesotho', 'Liberia', 'Maldives', 'Mali',
+  'Mozambique', 'Myanmar', 'Burma', 'Nepal', 'North Korea', 'DPRK',
+  'Palestine', 'Russia', 'South Sudan', 'Sudan', 'Syria', 'Ukraine',
+  'Uzbekistan', 'Vanuatu', 'Venezuela', 'Vietnam', 'Yemen',
+];
+
+export function normalizeCountry(input: string | null | undefined): string {
+  if (!input) return '';
+  return input.toLowerCase().replace(/\(.*?\)/g, '').replace(/\s+/g, ' ').trim();
+}
+
+const BLOCKED_SET = new Set(RAW.map(normalizeCountry));
+
+export function isMercuryBlocked(country: string | null | undefined): boolean {
+  const norm = normalizeCountry(country);
+  if (!norm) return false; // unknown country: don't block by default
+  return BLOCKED_SET.has(norm);
+}


### PR DESCRIPTION
## Summary
- Mercury virtual card option is disabled in `PayoutMethodPicker` when `party.country` matches Mercury's restricted-country list (37 countries, normalized for case + parenthetical aliases).
- Backend POST/PATCH on `/api/parties/:partyId/payouts` + admin override path now reject `mercury_card` for blocked countries with 400 `MERCURY_COUNTRY_BLOCKED`.
- Shared logic in twin `mercuryBlockedCountries.ts` modules (frontend + backend) kept in sync by a leading comment — small enough to live in both places.
- Ukraine is fully blocked (over-broad — only 5 regions are actually sanctioned, but Party model has no region column).

## Test plan
- [ ] Party with `country: 'Iran'` -> Mercury radio is disabled + amber explanatory caption.
- [ ] Party with `country: 'Canada'` -> Mercury radio is normal.
- [ ] Direct API POST with `payoutMethod: 'mercury_card'` on a blocked-country party -> 400 `MERCURY_COUNTRY_BLOCKED`.
- [ ] Admin override to `mercury_card` on a blocked-country party -> 400 same.
- [ ] User preference can still be saved as `mercury_card` regardless of country (it's a default; per-party submission is where the gate lives).