### PR TITLE
feat(pepperoni-37294): mergeParty replaces post-save loadParty refetches

### DIFF
--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -21,7 +21,7 @@ import type { Party } from '../types';
 
 export const EventDetailsTab: React.FC = () => {
   const { t } = useTranslation('host');
-  const { party, loadParty, setParty } = usePizza();
+  const { party, loadParty, mergeParty, setParty } = usePizza();
   const navigate = useNavigate();
 
   const [name, setName] = useState('');
@@ -536,7 +536,7 @@ export const EventDetailsTab: React.FC = () => {
       // triggerFlyerRegen's second arg is its OWN flyer-URL refresh callback
       // (post-render); NOT a save-time refetch. Pass a forward-patched party
       // so the flyer renders with the just-saved name.
-      if (party) triggerFlyerRegen({ ...party, name: trimmed }, loadParty);
+      if (party) triggerFlyerRegen({ ...party, name: trimmed }, mergeParty);
     }
   };
 
@@ -588,7 +588,7 @@ export const EventDetailsTab: React.FC = () => {
         // regen doesn't race the React context refresh and render with stale values.
         triggerFlyerRegen(
           { ...party, timezone: timezone || null, date: startDateTime, duration: calculatedDuration },
-          loadParty,
+          mergeParty,
         );
       }
     }
@@ -655,7 +655,7 @@ export const EventDetailsTab: React.FC = () => {
       if (party) {
         triggerFlyerRegen(
           { ...party, address: trimmedAddress, venueName: newVenueName || null },
-          loadParty,
+          mergeParty,
         );
       }
     }

--- a/frontend/src/components/checklist/FindVenueModal.tsx
+++ b/frontend/src/components/checklist/FindVenueModal.tsx
@@ -14,7 +14,7 @@ interface FindVenueModalProps {
 
 export const FindVenueModal: React.FC<FindVenueModalProps> = ({ open, onClose, onSaved }) => {
   const { t } = useTranslation('host');
-  const { party, loadParty } = usePizza();
+  const { party, mergeParty } = usePizza();
   const [address, setAddress] = useState('');
   const [venueName, setVenueName] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -61,10 +61,20 @@ export const FindVenueModal: React.FC<FindVenueModalProps> = ({ open, onClose, o
         setError(t('venue.findVenueSaveError'));
         return;
       }
-      if (party.inviteCode) {
-        await loadParty(party.inviteCode);
-      }
-      triggerFlyerRegen(party, loadParty);
+      const trimmedAddress = address.trim();
+      mergeParty({
+        address: trimmedAddress,
+        venueName: venueName || null,
+        ...(pendingCoordsRef.current ? {
+          latitude: pendingCoordsRef.current.lat,
+          longitude: pendingCoordsRef.current.lng,
+        } : {}),
+        ...(pendingPlaceIdRef.current ? { placeId: pendingPlaceIdRef.current } : {}),
+      });
+      triggerFlyerRegen(
+        { ...party, address: trimmedAddress, venueName: venueName || null },
+        mergeParty,
+      );
       if (onSaved) {
         await onSaved();
       }

--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -32,7 +32,7 @@ const SPONSOR_BOX_MAX = 1080;
 
 export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean } = {}) {
   const { t } = useTranslation('host');
-  const { party, loadParty } = usePizza();
+  const { party, mergeParty } = usePizza();
   const previewRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
   const [downloading, setDownloading] = useState(false);
@@ -387,7 +387,7 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
       ? existing.map((c, i) => i === existingIdx ? { ...c, ...newCoHost, id: c.id } : c)
       : [...existing, newCoHost];
     await updateParty(party.id, { co_hosts: updated });
-    if (party.inviteCode) await loadParty(party.inviteCode);
+    mergeParty({ coHosts: updated });
   };
 
   // Load both Hub 191 fonts, then trigger re-render for accurate fitText measurements
@@ -759,9 +759,11 @@ export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean 
       // Cancel any pending auto-regen so it doesn't overwrite the manual flyer
       cancelFlyerRegen(party.id);
 
-      if (party.inviteCode) {
-        await loadParty(party.inviteCode);
-      }
+      mergeParty({
+        eventImageUrl: uploadedUrl,
+        flyerGeneratedAt: new Date().toISOString(),
+        flyerConfig: flyerConfigValue,
+      });
 
       setSetImageState('success');
       setTimeout(() => setSetImageState('idle'), 2000);

--- a/frontend/src/components/flyer/autoRegenFlyer.ts
+++ b/frontend/src/components/flyer/autoRegenFlyer.ts
@@ -2,7 +2,7 @@
  * Auto-regenerate GPP event flyers when partner status or event details change.
  *
  * Exports:
- *   triggerFlyerRegen(party, loadParty?)        — debounced entry point (3 s per party)
+ *   triggerFlyerRegen(party, mergeParty?)        — debounced entry point (3 s per party)
  *   triggerFlyerRegenForEvents(events)           — batch entry point for underboss context
  *   cancelFlyerRegen(partyId)                    — cancel a pending regen
  */
@@ -63,7 +63,7 @@ export function cancelFlyerRegen(partyId: string): void {
  */
 export function triggerFlyerRegen(
   party: Party,
-  loadParty?: (inviteCode: string) => Promise<boolean>,
+  mergeParty?: (updates: Partial<Party>) => void,
 ): void {
   // Only GPP events get auto-regen
   if (party.eventType !== 'gpp') return;
@@ -86,7 +86,7 @@ export function triggerFlyerRegen(
   // Schedule the regen with a 3-second debounce
   const timer = setTimeout(() => {
     pendingTimers.delete(party.id);
-    doRegen(party, loadParty).catch((err) => {
+    doRegen(party, mergeParty).catch((err) => {
       console.error('[autoRegenFlyer] failed:', err);
     });
   }, 3000);
@@ -167,7 +167,7 @@ export function triggerFlyerRegenForEvents(
 /** The actual render → upload → update pipeline. */
 async function doRegen(
   data: FlyerRegenData,
-  loadParty?: (inviteCode: string) => Promise<boolean>,
+  mergeParty?: (updates: Partial<Party>) => void,
 ): Promise<void> {
   // 1. Load fonts
   await ensureFonts();
@@ -277,8 +277,11 @@ async function doRegen(
     return;
   }
 
-  // 8. Optionally refresh UI
-  if (loadParty && data.inviteCode) {
-    await loadParty(data.inviteCode);
+  // 8. Push the new URL into context so consumers re-render
+  if (mergeParty) {
+    mergeParty({
+      eventImageUrl: uploadedUrl,
+      flyerGeneratedAt: new Date().toISOString(),
+    });
   }
 }

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -30,7 +30,7 @@ interface SponsorCRMProps {
 
 export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
   const { t } = useTranslation('host');
-  const { party, loadParty } = usePizza();
+  const { party, mergeParty } = usePizza();
   const [sponsors, setSponsors] = useState<Sponsor[]>([]);
   const [stats, setStats] = useState<SponsorStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -195,8 +195,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
           && (previousSponsor.logoUrl || null) !== (data.logoUrl || null);
 
         if (willBeOnFlyer || wasOnFlyer !== willBeOnFlyer || (wasOnFlyer && logoChanged)) {
-          if (party.inviteCode) await loadParty(party.inviteCode);
-          triggerFlyerRegen(party, loadParty);
+          triggerFlyerRegen(party, mergeParty);
         }
       }
 
@@ -225,8 +224,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
 
       // Auto-regenerate flyer if deleted sponsor was on the flyer
       if (party && deletedSponsor && FLYER_SPONSOR_STATUSES.has(deletedSponsor.status) && deletedSponsor.logoUrl) {
-        if (party.inviteCode) await loadParty(party.inviteCode);
-        triggerFlyerRegen(party, loadParty);
+        triggerFlyerRegen(party, mergeParty);
       }
     }
   };
@@ -282,8 +280,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
 
       // Auto-regenerate flyer when a sponsor transitions to/from a flyer status
       if (party && (FLYER_SPONSOR_STATUSES.has(oldStatus) || FLYER_SPONSOR_STATUSES.has(newStatus))) {
-        if (party.inviteCode) await loadParty(party.inviteCode);
-        triggerFlyerRegen(party, loadParty);
+        triggerFlyerRegen(party, mergeParty);
       }
     } catch {
       // Revert on failure

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -13,6 +13,7 @@ interface PizzaContextType {
   partyLoading: boolean;
   createParty: (name: string, hostName?: string, date?: string, expectedGuests?: number, address?: string, selectedBeverages?: string[], duration?: number, password?: string, eventImageUrl?: string, description?: string, customUrl?: string) => Promise<string | null>;
   loadParty: (inviteCode: string) => Promise<boolean>;
+  mergeParty: (updates: Partial<Party>) => void;
   clearParty: () => void;
   getInviteLink: () => string;
   getHostLink: () => string;
@@ -236,6 +237,10 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       setPartyLoading(false);
     }
   };
+
+  const mergeParty = useCallback((updates: Partial<Party>) => {
+    setParty(prev => prev ? { ...prev, ...updates } : prev);
+  }, []);
 
   const loadParty = useCallback(async (inviteCode: string): Promise<boolean> => {
     // Clear existing state before loading new party
@@ -528,6 +533,7 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       partyLoading,
       createParty,
       loadParty,
+      mergeParty,
       clearParty,
       getInviteLink,
       getHostLink,

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -55,7 +55,7 @@ function HostPageContent() {
   const { inviteCode, tab } = useParams<{ inviteCode: string; tab?: string }>();
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
-  const { loadParty, party, partyLoading, guests, generateRecommendations, orderExpectedGuests, setOrderExpectedGuests, setGuests, setParty } = usePizza();
+  const { loadParty, mergeParty, party, partyLoading, guests, generateRecommendations, orderExpectedGuests, setOrderExpectedGuests, setGuests, setParty } = usePizza();
   const [error, setError] = useState<string | null>(null);
   const [loadedCode, setLoadedCode] = useState<string | null>(null);
 
@@ -348,7 +348,7 @@ function HostPageContent() {
                 ? existing.map((c, i) => i === existingIdx ? { ...c, ...newCoHost, id: c.id } : c)
                 : [...existing, newCoHost];
               await updateParty(party.id, { co_hosts: updated });
-              if (party.inviteCode) await loadParty(party.inviteCode);
+              mergeParty({ coHosts: updated });
             }}
           />
         ) : activeTab !== 'apps' && activeTab !== 'dashboard' && activeTab !== 'day-of' && activeTab !== 'partners' && (

--- a/plans/pepperoni-37294.md
+++ b/plans/pepperoni-37294.md
@@ -1,0 +1,26 @@
+# pepperoni-37294 — Replace post-save loadParty() refetches with in-place mergeParty()
+
+## Problem
+
+Clicking "Use for Event" on the flyer page (FlyerGenerator.tsx) feels like a page reload: the flyer's local positions/edits/sponsor box state resets and the UI jumps. Root cause: after updateParty succeeds, the handler calls loadParty(inviteCode), which refetches the entire party from the server and replaces the PizzaContext party object. The FlyerGenerator re-renders against the fresh object, so derived state visibly resets.
+
+Same bug class exists on multiple other surfaces — the rule (per arugula-38633 and burrata-72104) is: prefer in-place context merge over refetch for save handlers. A mergeParty helper doesn't exist in PizzaContext yet.
+
+## Fix
+
+1. Add `mergeParty(updates: Partial<Party>)` to PizzaContext: `setParty(prev => prev ? { ...prev, ...updates } : prev)`.
+2. Replace `loadParty(party.inviteCode)` on SUCCESS paths with `mergeParty({ ...just-changed fields })` at these sites:
+   - FlyerGenerator.tsx `handleUseAsEventImage` (line ~691) and `handleAddAsCoHost` (line ~378)
+   - HostPage.tsx PartnerManagement onAddAsCoHost (line ~300)
+   - EventDetailsTab.tsx saveDateTime (line ~496); change triggerFlyerRegen callers to pass mergeParty
+   - SponsorCRM.tsx three sites (~170, ~196, ~245) — drop the explicit loadParty, switch triggerFlyerRegen to mergeParty
+   - autoRegenFlyer.ts: change `loadParty?` param to `mergeParty?`, replace the final loadParty call with mergeParty({ eventImageUrl, flyerGeneratedAt })
+
+3. Keep loadParty unchanged on failure-revert paths (PreviousYearPhotos, PlatformPublisher) and page-load paths.
+
+## Test plan
+
+- typecheck passes
+- Manual: GPP flyer page, drag a sponsor, click "Use for Event" → image updates without resetting positions
+- Manual: EventDetailsTab date/time blur save doesn't feel like reload
+- Manual: SponsorCRM status change → flyer auto-regens in background, no jarring rerender


### PR DESCRIPTION
## Summary
- Adds `PizzaContext.mergeParty(updates: Partial<Party>)` for in-place context updates after save handlers
- Swaps `loadParty()` refetches for `mergeParty()` at the flyer "Use for Event" button, EventDetailsTab saveDateTime, autoRegenFlyer chokepoint (used by name/location/date/sponsor saves), SponsorCRM (create/delete/status), FindVenueModal save, and the handleAddAsCoHost callbacks on FlyerGenerator + HostPage
- Failure-revert and page-load `loadParty()` calls are intentionally untouched (Telegram disconnect, HostPage initial load, etc.)

## Why
Clicking "Use for Event" on the flyer page felt like a page reload: the refetch replaced the PizzaContext party, FlyerGenerator re-derived all local state, and custom sponsor positions / inline edits visibly reset. Same root cause as `arugula-38633` and `burrata-72104` -- refetch on save success is overkill when we already know what changed.

## Test plan
- [ ] typecheck passes
- [ ] On a GPP flyer with custom sponsor positions, click "Use for Event" -> image updates, positions remain, no flicker
- [ ] EventDetailsTab date/time blur save doesn't feel like a reload
- [ ] Sponsor status flip -> flyer auto-regen runs in background, no jarring rerender
- [ ] FindVenueModal save still updates address everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)