### PR TITLE
calzone-71208: capture country (+lat/lng) on event create

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -232,7 +232,7 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
 router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const {
-      name, date, endTime, duration, pizzaStyle, address, latitude, longitude, placeId, venueName, city, maxGuests,
+      name, date, endTime, duration, pizzaStyle, address, latitude, longitude, country, placeId, venueName, city, maxGuests,
       availableBeverages, availableToppings, availableDietaryOptions, password, eventImageUrl, description,
       customUrl, timezone, hideGuests, requireApproval, coHosts,
       donationEnabled, donationGoal, donationMessage, suggestedAmounts, donationRecipient,
@@ -283,6 +283,7 @@ router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => 
         address: address || null,
         latitude: latitude !== null && latitude !== undefined ? Number(latitude) : null,
         longitude: longitude !== null && longitude !== undefined ? Number(longitude) : null,
+        country: country || null,
         placeId: placeId || null,
         venueName: venueName || null,
         city: city || null,

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -31,6 +31,11 @@ export function EventForm() {
   const [partyPlaceId, setPartyPlaceId] = useState<string | null>(null);
   const [partyVenueName, setPartyVenueName] = useState<string | null>(null);
   const [partyCity, setPartyCity] = useState<string | null>(null);
+  // calzone-71208: country + lat/lng were silently dropped on create — 61 of 982
+  // prod events shipped with country IS NULL. Capture them from autocomplete now.
+  const [partyCountry, setPartyCountry] = useState<string | null>(null);
+  const [partyLat, setPartyLat] = useState<number | null>(null);
+  const [partyLng, setPartyLng] = useState<number | null>(null);
   const [partyPassword, setPartyPassword] = useState('');
   const [eventImageUrl, setEventImageUrl] = useState('');
   const [eventImageFile, setEventImageFile] = useState<File | null>(null);
@@ -103,26 +108,28 @@ export function EventForm() {
 
       const imageUrl = formData.eventImageUrl?.trim() || undefined;
 
-      const party = await createPartyAPI(
-        formData.partyName?.trim() || undefined,
-        user?.name || undefined,
-        startDateTime,
-        'new-york',
-        guestCount,
-        formData.partyAddress?.trim() || undefined,
-        [],
+      const party = await createPartyAPI({
+        name: formData.partyName?.trim() || undefined,
+        hostName: user?.name || undefined,
+        date: startDateTime,
+        pizzaStyle: 'new-york',
+        expectedGuests: guestCount,
+        address: formData.partyAddress?.trim() || undefined,
+        availableBeverages: [],
         duration,
         password,
-        imageUrl,
+        eventImageUrl: imageUrl,
         description,
-        urlSlug,
-        formData.timezone || undefined,
-        undefined, // hostEmail
-        formData.hideGuests || false,
-        formData.partyPlaceId || undefined,
-        formData.partyVenueName || undefined,
-        formData.partyCity || undefined
-      );
+        customUrl: urlSlug,
+        timezone: formData.timezone || undefined,
+        hideGuests: formData.hideGuests || false,
+        placeId: formData.partyPlaceId || undefined,
+        venueName: formData.partyVenueName || undefined,
+        city: formData.partyCity || undefined,
+        country: formData.partyCountry ?? null,
+        latitude: formData.partyLat ?? null,
+        longitude: formData.partyLng ?? null,
+      });
 
       setCreating(false);
 
@@ -197,7 +204,11 @@ export function EventForm() {
     if (!user) {
       const formData = {
         partyName, startDate, startTime, endDate, endTime, timezone,
-        expectedGuests, partyAddress, partyPlaceId, partyVenueName, partyCity, partyPassword, eventImageUrl, eventDescription,
+        expectedGuests, partyAddress, partyPlaceId, partyVenueName, partyCity,
+        // calzone-71208: persist country + lat/lng across the auth roundtrip
+        // so we don't lose them when the form is restored post-login.
+        partyCountry, partyLat, partyLng,
+        partyPassword, eventImageUrl, eventDescription,
         customUrl, requireApproval, limitGuests, hideGuests
       };
       sessionStorage.setItem('pendingPartyForm', JSON.stringify(formData));
@@ -247,26 +258,28 @@ export function EventForm() {
         }
       }
 
-      const party = await createPartyAPI(
-        partyName.trim() || undefined,
-        user?.name || undefined,
-        startDateTime,
-        'new-york',
-        guestCount,
-        partyAddress.trim() || undefined,
-        [],
+      const party = await createPartyAPI({
+        name: partyName.trim() || undefined,
+        hostName: user?.name || undefined,
+        date: startDateTime,
+        pizzaStyle: 'new-york',
+        expectedGuests: guestCount,
+        address: partyAddress.trim() || undefined,
+        availableBeverages: [],
         duration,
         password,
-        imageUrl,
+        eventImageUrl: imageUrl,
         description,
-        urlSlug,
-        timezone || undefined,
-        undefined, // hostEmail
+        customUrl: urlSlug,
+        timezone: timezone || undefined,
         hideGuests,
-        partyPlaceId || undefined,
-        partyVenueName || undefined,
-        partyCity || undefined
-      );
+        placeId: partyPlaceId || undefined,
+        venueName: partyVenueName || undefined,
+        city: partyCity || undefined,
+        country: partyCountry,
+        latitude: partyLat,
+        longitude: partyLng,
+      });
 
       setCreating(false);
 
@@ -304,9 +317,21 @@ export function EventForm() {
             // Manual edits without picking from dropdown invalidate captured place_id + venue_name
             setPartyPlaceId(null);
             setPartyVenueName(null);
+            // calzone-71208: also invalidate country/lat/lng so we don't ship
+            // a stale Google answer attached to a hand-typed address.
+            setPartyCountry(null);
+            setPartyLat(null);
+            setPartyLng(null);
           }}
           onTimezoneChange={setTimezone}
-          onCitySelected={(cityData) => setPartyCity(cityData.cityName || null)}
+          onLocationSelected={(loc) => {
+            setPartyLat(loc?.lat ?? null);
+            setPartyLng(loc?.lng ?? null);
+          }}
+          onCitySelected={(cityData) => {
+            setPartyCity(cityData.cityName || null);
+            setPartyCountry(cityData.country || null);
+          }}
           onPlaceSelected={(address, venueName, placeId) => {
             setPartyAddress(address);
             setPartyPlaceId(placeId);

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -220,7 +220,20 @@ export const PizzaProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const createParty = async (name: string, hostName?: string, date?: string, expectedGuests?: number, address?: string, selectedBeverages?: string[], duration?: number, password?: string, eventImageUrl?: string, description?: string, customUrl?: string): Promise<string | null> => {
     setPartyLoading(true);
     try {
-      const dbParty = await db.createParty(name, hostName, date, pizzaSettings.style.id, expectedGuests, address, selectedBeverages, duration, password, eventImageUrl, description, customUrl);
+      const dbParty = await db.createParty({
+        name,
+        hostName,
+        date,
+        pizzaStyle: pizzaSettings.style.id,
+        expectedGuests,
+        address,
+        availableBeverages: selectedBeverages,
+        duration,
+        password,
+        eventImageUrl,
+        description,
+        customUrl,
+      });
       if (dbParty) {
         const newParty = dbPartyToParty(dbParty, []);
         setParty(newParty);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -125,6 +125,10 @@ export interface CreatePartyData {
   placeId?: string;
   venueName?: string | null;
   city?: string;
+  // calzone-71208: country + lat/lng must round-trip from autocomplete on create.
+  country?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
   maxGuests?: number;
   hideGuests?: boolean;
   requireApproval?: boolean;
@@ -235,6 +239,9 @@ export async function createPartyApi(data: CreatePartyData) {
       placeId: data.placeId,
       venueName: data.venueName,
       city: data.city,
+      country: data.country,
+      latitude: data.latitude,
+      longitude: data.longitude,
       maxGuests: data.maxGuests,
       hideGuests: data.hideGuests,
       requireApproval: data.requireApproval,

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -869,26 +869,58 @@ function normalizePartyCoHosts<T extends Record<string, any>>(party: T): T {
 }
 
 // Party operations
-export async function createParty(
-  name?: string,
-  hostName?: string,
-  date?: string,
-  pizzaStyle: string = 'new-york',
-  expectedGuests?: number,
-  address?: string,
-  availableBeverages?: string[],
-  duration?: number,
-  password?: string,
-  eventImageUrl?: string,
-  description?: string,
-  customUrl?: string,
-  timezone?: string,
-  hostEmail?: string,
-  hideGuests?: boolean,
-  placeId?: string,
-  venueName?: string,
-  city?: string
-): Promise<DbParty | null> {
+export interface CreatePartyOptions {
+  name?: string;
+  hostName?: string;
+  date?: string;
+  pizzaStyle?: string;
+  expectedGuests?: number;
+  address?: string;
+  availableBeverages?: string[];
+  duration?: number;
+  password?: string;
+  eventImageUrl?: string;
+  description?: string;
+  customUrl?: string;
+  timezone?: string;
+  hostEmail?: string;
+  hideGuests?: boolean;
+  placeId?: string;
+  venueName?: string;
+  city?: string;
+  // calzone-71208: capture country + lat/lng from autocomplete on create.
+  // Without these, ~6% of events (61 of 982 in prod 2026-05-20) shipped with
+  // country IS NULL because EventForm dropped Google's address_components.
+  country?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+export async function createParty(opts: CreatePartyOptions = {}): Promise<DbParty | null> {
+  const {
+    name,
+    hostName,
+    date,
+    pizzaStyle = 'new-york',
+    expectedGuests,
+    address,
+    availableBeverages,
+    duration,
+    password,
+    eventImageUrl,
+    description,
+    customUrl,
+    timezone,
+    hostEmail,
+    hideGuests,
+    placeId,
+    venueName,
+    city,
+    country,
+    latitude,
+    longitude,
+  } = opts;
+
   // Use API if authenticated (secure path)
   if (isAuthenticated()) {
     try {
@@ -902,6 +934,9 @@ export async function createParty(
         placeId,
         venueName,
         city,
+        country,
+        latitude,
+        longitude,
         availableBeverages,
         duration,
         password,
@@ -975,6 +1010,9 @@ export async function createParty(
       description: description || null,
       custom_url: customUrl || null,
       address: address || null,
+      latitude: latitude !== undefined && latitude !== null ? Number(latitude) : null,
+      longitude: longitude !== undefined && longitude !== null ? Number(longitude) : null,
+      country: country || null,
       place_id: placeId || null,
       venue_name: venueName || null,
       city: city || null,


### PR DESCRIPTION
## Summary

- 61 of 982 prod events had `country IS NULL` because `EventForm` wired `LocationAutocomplete` without `onCitySelected`, so Google's `address_components` were dropped before they ever reached the database. The PATCH (edit) path was correct, which is why later-edited events do have a country.
- Fixes the drop at all four layers: `EventForm.tsx` now captures country + lat/lng from the autocomplete, `supabase.ts createParty` was refactored from 17 positional args to an options object that forwards the new fields, `api.ts` `CreatePartyData` + POST body now include them, and the backend POST handler destructures + persists `country` (lat/lng were already wired backend-side).
- No schema migration: `country`, `latitude`, `longitude` already exist on the `Party` model. Backfill of existing `country IS NULL` rows is handled separately in the main session **after** this merges and the backend deploys.

## Test plan

- [ ] Pull this branch locally (or use the Vercel preview once the backend changes land on master).
- [ ] Sign in, open the home page event-create form.
- [ ] Type an address into the location field, **pick a result from the Google autocomplete dropdown** (so `address_components` get parsed).
- [ ] Open DevTools Network tab, click "Create Party," and inspect the `POST /api/parties` request body. Verify it contains `country`, `latitude`, `longitude` (non-null when a dropdown result was selected).
- [ ] After the event is created, query the row in Supabase: `select id, address, city, country, latitude, longitude from parties where id = '...'`. All three should be populated.
- [ ] Edge case: type an address but **do not pick** from the dropdown, then create. Country/lat/lng should be `null` (we don't ship stale Google answers attached to a hand-typed address). The existing PATCH path lets the host correct this from /host.
- [ ] Edge case: create as logged-out user, get redirected through login, confirm the form restores partyCountry/partyLat/partyLng (persisted to `sessionStorage` as `pendingPartyForm`).

## Out of scope

- Backfilling the 61 existing `country IS NULL` rows. Done separately after merge + backend deploy.
- Auto-deriving city/country from a typed-only address (no Google pick). Considered, but we'd rather have an explicit null than a wrong guess.

Preview URL pattern: `https://rsvpizza-git-calzone-71208-country-pizza-dao.vercel.app`

Generated with [Claude Code](https://claude.com/claude-code)