### PR TITLE
feat(bismarck-92103): prepay queue on admin /payments dashboard

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -510,6 +510,261 @@ router.get(
 );
 
 // ============================================
+// GET /api/admin/payouts/prepay-queue — bismarck-92103
+//
+// Surfaces parties flagged for prepayment (`'prepay' ∈ event_tags`) where at
+// least one host (primary host OR cohost matched by email) has saved a
+// `preferredPayoutMethod` on their User record. Drops parties that already
+// have an in-flight payout (pending/approved/paid) to any candidate — those
+// prepayments are already moving and don't need to be nagged about.
+//
+// Literal `/prepay-queue` MUST be declared before `/:id` so the literal path
+// wins on route matching.
+// ============================================
+router.get(
+  '/prepay-queue',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      // 1. All approved parties flagged for prepayment, with their primary host.
+      const parties = await prisma.party.findMany({
+        where: {
+          eventTags: { has: 'prepay' },
+          underbossStatus: 'approved',
+        },
+        select: {
+          id: true,
+          name: true,
+          customUrl: true,
+          country: true,
+          eventTags: true,
+          reimbursementCapUsd: true,
+          coHosts: true,
+          userId: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              preferredPayoutMethod: true,
+              payoutWalletAddress: true,
+              payoutBankDetails: true,
+            },
+          },
+        },
+      });
+
+      // Filter out parties with no effective cap — nothing to prepay against.
+      const partiesWithCap = parties
+        .map(p => ({
+          p,
+          cap: computeEffectiveCapUsd({
+            reimbursementCapUsd: p.reimbursementCapUsd,
+            eventTags: p.eventTags,
+          }),
+        }))
+        .filter(({ cap }) => cap != null && cap > 0);
+
+      if (partiesWithCap.length === 0) {
+        res.json({ rows: [] });
+        return;
+      }
+
+      // 2. Collect all cohost emails across the surviving parties.
+      const cohostEmails = new Set<string>();
+      for (const { p } of partiesWithCap) {
+        const list = Array.isArray(p.coHosts) ? (p.coHosts as any[]) : [];
+        for (const ch of list) {
+          if (ch && typeof ch === 'object' && typeof ch.email === 'string' && ch.email.trim()) {
+            cohostEmails.add(ch.email.trim().toLowerCase());
+          }
+        }
+      }
+
+      // 3. Resolve cohost emails → User rows (one batched query).
+      const cohostUsers = cohostEmails.size
+        ? await prisma.user.findMany({
+            where: { email: { in: Array.from(cohostEmails) } },
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              preferredPayoutMethod: true,
+              payoutWalletAddress: true,
+              payoutBankDetails: true,
+            },
+          })
+        : [];
+      const cohostUserByEmail = new Map<string, typeof cohostUsers[number]>();
+      for (const u of cohostUsers) {
+        cohostUserByEmail.set(u.email.toLowerCase(), u);
+      }
+
+      // 4. For each party, build the candidate list. Primary host first (if
+      //    they have a method), then cohost users with methods.
+      type CandidateInternal = {
+        userId: string;
+        name: string | null;
+        email: string;
+        method: 'mercury_card' | 'wire' | 'usdc_base';
+        walletAddress: string | null;
+        bankEmail: string | null;
+        isPrimaryHost: boolean;
+      };
+
+      function buildCandidate(
+        u: {
+          id: string;
+          name: string | null;
+          email: string;
+          preferredPayoutMethod: string | null;
+          payoutWalletAddress: string | null;
+          payoutBankDetails: any;
+        },
+        isPrimaryHost: boolean,
+      ): CandidateInternal | null {
+        const method = u.preferredPayoutMethod;
+        if (method !== 'mercury_card' && method !== 'wire' && method !== 'usdc_base') {
+          return null;
+        }
+        // For wire, dig bankEmail out of payoutBankDetails JSONB. Null is fine
+        // — PaymentDetailsCard will fill it in at payout-create time.
+        let bankEmail: string | null = null;
+        if (method === 'wire' && u.payoutBankDetails && typeof u.payoutBankDetails === 'object') {
+          const raw = (u.payoutBankDetails as any).email;
+          if (typeof raw === 'string' && raw.trim()) {
+            bankEmail = raw.trim();
+          }
+        }
+        return {
+          userId: u.id,
+          name: u.name,
+          email: u.email,
+          method,
+          walletAddress: method === 'usdc_base' ? u.payoutWalletAddress : null,
+          bankEmail,
+          isPrimaryHost,
+        };
+      }
+
+      type AssembledRow = {
+        partyMeta: {
+          id: string;
+          name: string;
+          customUrl: string | null;
+          country: string | null;
+          effectiveReimbursementCapUsd: number | null;
+          eventTags: string[];
+        };
+        candidates: CandidateInternal[];
+      };
+
+      const assembled: AssembledRow[] = [];
+
+      for (const { p, cap } of partiesWithCap) {
+        const candidates: CandidateInternal[] = [];
+        const seenUserIds = new Set<string>();
+
+        // Primary host first.
+        if (p.user) {
+          const c = buildCandidate(p.user, true);
+          if (c) {
+            candidates.push(c);
+            seenUserIds.add(c.userId);
+          }
+        }
+
+        // Cohosts (dedupe against the primary host id).
+        const cohostList = Array.isArray(p.coHosts) ? (p.coHosts as any[]) : [];
+        for (const ch of cohostList) {
+          if (!ch || typeof ch !== 'object') continue;
+          const email = typeof ch.email === 'string' ? ch.email.trim().toLowerCase() : '';
+          if (!email) continue;
+          const u = cohostUserByEmail.get(email);
+          if (!u) continue;
+          if (seenUserIds.has(u.id)) continue;
+          const c = buildCandidate(u, false);
+          if (!c) continue;
+          candidates.push(c);
+          seenUserIds.add(c.userId);
+        }
+
+        if (candidates.length === 0) continue;
+
+        assembled.push({
+          partyMeta: {
+            id: p.id,
+            name: p.name,
+            customUrl: p.customUrl,
+            country: p.country,
+            effectiveReimbursementCapUsd: cap,
+            eventTags: p.eventTags,
+          },
+          candidates,
+        });
+      }
+
+      if (assembled.length === 0) {
+        res.json({ rows: [] });
+        return;
+      }
+
+      // 5. For each assembled row, drop it if ANY candidate already has an
+      //    in-flight payout for that party. "In-flight" = pending/approved/paid
+      //    (failed/rejected don't count — that prepayment never went through).
+      //    Run as a single grouped query: pull all matching payouts and bucket
+      //    by partyId in memory.
+      const partyIds = assembled.map(r => r.partyMeta.id);
+      const allCandidateUserIds = new Set<string>();
+      for (const r of assembled) {
+        for (const c of r.candidates) {
+          allCandidateUserIds.add(c.userId);
+        }
+      }
+
+      const inFlight = allCandidateUserIds.size
+        ? await prisma.payout.findMany({
+            where: {
+              partyId: { in: partyIds },
+              hostUserId: { in: Array.from(allCandidateUserIds) },
+              status: { in: ['pending', 'approved', 'paid'] },
+            },
+            select: { partyId: true, hostUserId: true },
+          })
+        : [];
+
+      const inFlightByParty = new Map<string, Set<string>>();
+      for (const row of inFlight) {
+        let set = inFlightByParty.get(row.partyId);
+        if (!set) {
+          set = new Set<string>();
+          inFlightByParty.set(row.partyId, set);
+        }
+        set.add(row.hostUserId);
+      }
+
+      const finalRows = assembled
+        .filter(r => {
+          const inFlightSet = inFlightByParty.get(r.partyMeta.id);
+          if (!inFlightSet || inFlightSet.size === 0) return true;
+          // If ANY candidate has an in-flight payout, drop the row entirely.
+          return !r.candidates.some(c => inFlightSet.has(c.userId));
+        })
+        .map(r => ({
+          party: r.partyMeta,
+          candidates: r.candidates,
+          hasMultipleCandidates: r.candidates.length > 1,
+        }));
+
+      res.json({ rows: finalRows });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
 // POST /api/admin/payouts/external — record an OUT-OF-BAND payment
 //   - For payments that happened OUTSIDE the rsv.pizza flow (Venmo, manual
 //     bank transfer, etc.). Creates a payout row in `paid` status immediately

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -329,11 +329,28 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       finalAmountUsd,
       saveAsDefault,
       estimatedAttendance,
+      // bismarck-92103: admin-only override so the resulting Payout row is
+      // credited to the chosen cohost (not the admin creating it). When set
+      // AND the caller is an admin, `recipientHostUserId` replaces the
+      // default `req.userId` for `hostUserId`. Preserves pancetta-37195
+      // attribution — "Submitted by X" reads correctly.
+      recipientHostUserId,
     } = req.body || {};
 
-    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
-    if (!canEdit) {
-      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    // bismarck-92103: admins creating prepayments on behalf of a cohost don't
+    // need party edit access — they're operating from the /payments admin
+    // dashboard. When the recipient override is in play AND the caller is an
+    // admin, skip the canUserEditParty gate. (Self-edit access is still
+    // enforced for all other callers via the existing check.)
+    const recipientOverrideRequested =
+      typeof recipientHostUserId === 'string' && recipientHostUserId.trim().length > 0;
+    const skipPartyEditCheck =
+      recipientOverrideRequested && (await isAnyAdmin(req.userEmail));
+    if (!skipPartyEditCheck) {
+      const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+      if (!canEdit) {
+        throw new AppError('Party not found', 404, 'NOT_FOUND');
+      }
     }
 
     // Validate optional one-shot attendance setup. Only persisted to the party
@@ -542,6 +559,39 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       throw new AppError('Authenticated user has no userId', 500, 'NO_USER_ID');
     }
 
+    // bismarck-92103: admin-only override — if `recipientHostUserId` is set
+    // AND the caller is an admin (or super_admin), the payout is created
+    // ON BEHALF OF that user (`hostUserId` = the recipient, not the admin).
+    // Non-admin callers passing the field are silently ignored — falling
+    // through to `req.userId` keeps the existing behavior intact.
+    let effectiveHostUserId: string = req.userId;
+    const callerIsAdmin = await isAnyAdmin(req.userEmail);
+    if (typeof recipientHostUserId === 'string' && recipientHostUserId.trim()) {
+      if (callerIsAdmin) {
+        const targetUser = await prisma.user.findUnique({
+          where: { id: recipientHostUserId.trim() },
+          select: { id: true },
+        });
+        if (!targetUser) {
+          throw new AppError(
+            'recipientHostUserId does not match any User',
+            400,
+            'INVALID_RECIPIENT_HOST_USER_ID',
+          );
+        }
+        effectiveHostUserId = targetUser.id;
+      }
+    }
+
+    // bismarck-92103: admins can also stamp `adminNotes` directly on the new
+    // payout (used by the prepay-queue "Create prepayment" modal). Non-admin
+    // callers cannot set adminNotes via this endpoint.
+    const adminNotesRaw = (req.body || {}).adminNotes;
+    const initialAdminNotes =
+      callerIsAdmin && typeof adminNotesRaw === 'string' && adminNotesRaw.trim().length > 0
+        ? adminNotesRaw.trim()
+        : null;
+
     // taleggio-30219: resolve the wallet input once, BEFORE the create, so
     // we persist a canonical 0x address even if the host typed an ENS name.
     // Reused by the `saveAsDefault` write below so we don't resolve twice.
@@ -563,7 +613,10 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     const payout = await prisma.payout.create({
       data: {
         partyId,
-        hostUserId: req.userId,
+        // bismarck-92103: when admins create prepayments on behalf of a
+        // cohost, `effectiveHostUserId` is the cohost; otherwise it's the
+        // authenticated submitter (req.userId).
+        hostUserId: effectiveHostUserId,
         originalAmount: new Decimal(effectiveOriginalAmount),
         originalCurrency: effectiveOriginalCurrency,
         exchangeRate: new Decimal(effectiveExchangeRate),
@@ -583,6 +636,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         hostNotes: typeof hostNotes === 'string' && hostNotes.trim().length > 0
           ? hostNotes.trim()
           : null,
+        // bismarck-92103: admin-supplied adminNotes (e.g. "Prepayment for X")
+        // when an admin creates a prepayment on behalf of a cohost.
+        adminNotes: initialAdminNotes,
         documents: { create: docsToCreateStamped },
       },
       include: {

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { X, DollarSign, Loader2, Pencil, AlertTriangle, Star } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from '../payments-shared';
+import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
+import { createPayout } from '../../lib/api';
+import type { PrepayCandidate, PrepayQueueRow } from '../../types';
+
+interface CreatePrepaymentModalProps {
+  row: PrepayQueueRow;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+/**
+ * bismarck-92103: admin modal for issuing a prepayment to a host whose payment
+ * method is already on file. Submits as a regular Payout via the existing
+ * `POST /api/parties/:partyId/payouts` with the `recipientHostUserId` admin
+ * override so the resulting row is credited to the chosen cohost.
+ *
+ * The amount defaults to 50% of the event's effective reimbursement cap (the
+ * "prepay" convention — half upfront, half on reimbursement). Mercury card
+ * candidates are disabled when the party's country is on the Mercury block
+ * list (see `mercuryBlockedCountries`).
+ */
+export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
+  row,
+  onClose,
+  onCreated,
+}) => {
+  const { party, candidates } = row;
+  const cap = party.effectiveReimbursementCapUsd ?? 0;
+  const defaultAmount = Math.max(1, Math.round(0.5 * cap));
+
+  const mercuryBlocked = isMercuryBlocked(party.country);
+
+  // Auto-select the first non-disabled candidate. Most rows have one candidate,
+  // in which case it's pre-selected automatically.
+  const initialCandidateId = useMemo(() => {
+    const firstAllowed = candidates.find(
+      (c) => !(c.method === 'mercury_card' && mercuryBlocked),
+    );
+    return firstAllowed?.userId ?? candidates[0]?.userId ?? '';
+  }, [candidates, mercuryBlocked]);
+
+  const [selectedUserId, setSelectedUserId] = useState<string>(initialCandidateId);
+  const [amountStr, setAmountStr] = useState(String(defaultAmount));
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const selectedCandidate: PrepayCandidate | undefined = useMemo(
+    () => candidates.find((c) => c.userId === selectedUserId),
+    [candidates, selectedUserId],
+  );
+
+  const amountNum = useMemo(() => Number(amountStr), [amountStr]);
+
+  const canSubmit =
+    !!selectedCandidate &&
+    !(selectedCandidate.method === 'mercury_card' && mercuryBlocked) &&
+    Number.isFinite(amountNum) &&
+    amountNum > 0 &&
+    !submitting;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || !selectedCandidate) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createPayout(party.id, {
+        pizzaPhotos: [],
+        receiptPhotos: [],
+        payoutMethod: selectedCandidate.method,
+        payoutWalletAddress:
+          selectedCandidate.method === 'usdc_base' && selectedCandidate.walletAddress
+            ? selectedCandidate.walletAddress
+            : undefined,
+        payoutBankDetails:
+          selectedCandidate.method === 'wire' && selectedCandidate.bankEmail
+            ? { email: selectedCandidate.bankEmail }
+            : undefined,
+        finalAmountUsd: amountNum,
+        adminNotes: notes.trim() || `Prepayment for ${party.name}`,
+        hostNotes: 'Prepayment created by admin',
+        recipientHostUserId: selectedCandidate.userId,
+      });
+      onCreated();
+      onClose();
+    } catch (err: any) {
+      setError(err?.message || 'Failed to create prepayment');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-lg max-h-[95vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-semibold text-theme-text truncate">
+              Prepay {party.name}
+            </h2>
+            {cap > 0 && (
+              <p className="text-xs text-theme-text-muted mt-0.5">
+                Cap: ${cap.toLocaleString()}
+                {party.country ? ` • ${party.country}` : ''}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* Recipient radio list */}
+          <div>
+            <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
+              Recipient
+            </div>
+            <div className="space-y-2">
+              {candidates.map((c) => {
+                const disabled = c.method === 'mercury_card' && mercuryBlocked;
+                const active = selectedUserId === c.userId;
+                const label = c.name && c.name.trim() ? c.name : c.email;
+                return (
+                  <label
+                    key={c.userId}
+                    className={`flex items-start gap-3 px-3 py-2.5 rounded-lg border cursor-pointer transition-colors ${
+                      active && !disabled
+                        ? 'border-emerald-500 bg-emerald-500/10'
+                        : disabled
+                          ? 'border-theme-stroke bg-theme-surface opacity-60 cursor-not-allowed'
+                          : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="recipient"
+                      value={c.userId}
+                      checked={active}
+                      onChange={() => !disabled && setSelectedUserId(c.userId)}
+                      disabled={disabled}
+                      className="mt-1"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5 text-sm font-medium text-theme-text">
+                        {c.isPrimaryHost && (
+                          <Star size={12} className="text-amber-500 shrink-0" />
+                        )}
+                        <span className="truncate">{label}</span>
+                      </div>
+                      <div className="text-xs text-theme-text-muted truncate">
+                        {c.email}
+                      </div>
+                      <div className="mt-1 flex items-center gap-1.5">
+                        <PayoutMethodIcon method={c.method} size={12} />
+                        <span className="text-xs text-theme-text-secondary">
+                          {PAYOUT_METHOD_LABELS[c.method]}
+                        </span>
+                      </div>
+                      {disabled && (
+                        <div className="mt-1.5 flex items-start gap-1 text-xs text-amber-500">
+                          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                          <span>
+                            Mercury card unavailable in {party.country ?? 'this country'}
+                            — pick another method or recipient.
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Amount */}
+          <div>
+            <IconInput
+              icon={DollarSign}
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="Amount USD *"
+              value={amountStr}
+              onChange={(e) => setAmountStr(e.target.value)}
+              required
+            />
+            <p className="text-xs text-theme-text-muted mt-1">
+              Default is 50% of the event's reimbursement cap. Edit if needed.
+            </p>
+          </div>
+
+          {/* Internal note (optional) */}
+          <IconInput
+            icon={Pencil}
+            multiline
+            rows={3}
+            placeholder={`Internal note (optional, defaults to "Prepayment for ${party.name}")`}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            maxLength={500}
+          />
+
+          {error && (
+            <div className="px-3 py-2 rounded-lg bg-red-100 text-red-700 border border-red-300 text-sm">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-theme-stroke px-5 py-3 flex items-center justify-end gap-2 bg-theme-surface">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-theme-text-secondary hover:bg-theme-surface-hover text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
+          >
+            {submitting && <Loader2 size={14} className="animate-spin" />}
+            Create prepayment
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { AlertTriangle, Star } from 'lucide-react';
+import type { PrepayCandidate, PrepayQueueRow } from '../../types';
+import { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from '../payments-shared';
+
+interface PrepayQueueTableProps {
+  rows: PrepayQueueRow[];
+  onCreatePrepayment: (row: PrepayQueueRow) => void;
+}
+
+/**
+ * Strip the "Global Pizza Party " prefix from event names so the city stays
+ * visible without burning column width. Same convention as item #14 of the
+ * /payments dashboard polish (the partyName cell on PayoutRow).
+ */
+function stripGppPrefix(name: string): string {
+  return name.replace(/^Global Pizza Party\s+/i, '');
+}
+
+/**
+ * bismarck-92103: small chip rendered per candidate inside the Hosts cell.
+ * Method icon comes from the shared PayoutMethodIcon. Primary host gets a
+ * star prefix so the admin can distinguish them at a glance.
+ */
+const HostChip: React.FC<{ candidate: PrepayCandidate }> = ({ candidate }) => {
+  const displayName = candidate.name && candidate.name.trim()
+    ? candidate.name
+    : candidate.email;
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-theme-surface-hover border border-theme-stroke text-xs text-theme-text"
+      title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]}`}
+    >
+      {candidate.isPrimaryHost && (
+        <Star size={11} className="text-amber-500 shrink-0" aria-label="Primary host" />
+      )}
+      <PayoutMethodIcon method={candidate.method} size={12} />
+      <span className="truncate max-w-[12rem]">{displayName}</span>
+    </span>
+  );
+};
+
+export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
+  rows,
+  onCreatePrepayment,
+}) => {
+  return (
+    <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
+              <th className="px-3 py-3 font-medium">Event</th>
+              <th className="px-3 py-3 font-medium">Host(s)</th>
+              <th className="px-3 py-3 font-medium">Cap</th>
+              <th className="px-3 py-3 font-medium text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const cap = row.party.effectiveReimbursementCapUsd;
+              return (
+                <tr
+                  key={row.party.id}
+                  className="border-t border-theme-stroke hover:bg-theme-surface-hover"
+                >
+                  <td className="px-3 py-3 align-top">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-theme-text truncate">
+                        {stripGppPrefix(row.party.name)}
+                      </span>
+                      {row.hasMultipleCandidates && (
+                        <span
+                          className="inline-flex items-center text-amber-500"
+                          title="Multiple hosts have payment methods — pick one when creating the prepayment"
+                        >
+                          <AlertTriangle size={14} />
+                        </span>
+                      )}
+                    </div>
+                    {row.party.country && (
+                      <div className="text-xs text-theme-text-muted mt-0.5">
+                        {row.party.country}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <div className="flex flex-wrap gap-1.5">
+                      {row.candidates.map((c) => (
+                        <HostChip key={c.userId} candidate={c} />
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 align-top text-theme-text">
+                    {cap != null ? `$${cap.toLocaleString()}` : '—'}
+                  </td>
+                  <td className="px-3 py-3 align-top text-right">
+                    <button
+                      type="button"
+                      onClick={() => onCreatePrepayment(row)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
+                    >
+                      Create prepayment
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -4,3 +4,5 @@ export { PayoutReviewModal } from './PayoutReviewModal';
 export { PaymentsStatsCards } from './PaymentsStatsCards';
 export { BulkActionsBar } from './BulkActionsBar';
 export { ExternalPaymentModal } from './ExternalPaymentModal';
+export { PrepayQueueTable } from './PrepayQueueTable';
+export { CreatePrepaymentModal } from './CreatePrepaymentModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -3949,6 +3949,18 @@ export async function recordExternalPayment(
 }
 
 /**
+ * bismarck-92103: list approved parties flagged for prepayment whose host(s)
+ * have a saved payment method, excluding parties that already have an
+ * in-flight payout. Surfaced as the "Prepay queue" section on /payments.
+ */
+export async function fetchPrepayQueue(): Promise<PrepayQueueRow[]> {
+  const res = await apiRequest<{ rows: PrepayQueueRow[] }>(
+    '/api/admin/payouts/prepay-queue',
+  );
+  return res.rows;
+}
+
+/**
  * Get the running 24h USDC payout usage + remaining cap (PR 5). Used to render
  * the "Daily cap remaining: $X" hint before the admin confirms a USDC execute.
  */
@@ -4032,6 +4044,15 @@ export interface CreatePayoutData {
    * the party's current value is null. Sent only on the host's first payout.
    */
   estimatedAttendance?: number;
+  /**
+   * bismarck-92103: admin-only override. When set AND caller is an admin,
+   * the resulting Payout row is credited to this User (the recipient cohost)
+   * instead of the calling admin. Non-admin callers passing this field are
+   * silently ignored server-side.
+   */
+  recipientHostUserId?: string;
+  /** Optional admin-supplied note stored on the new payout. */
+  adminNotes?: string;
 }
 
 export async function createPayout(

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -13,12 +13,14 @@ import {
   executeAdminPayout,
   getUsdcDailyCapRemaining,
   exportAdminPayoutsCsv,
+  fetchPrepayQueue,
 } from '../lib/api';
 import type {
   AdminPayout,
   AdminPayoutDetail,
   AdminPayoutFilters,
   AdminPayoutTotals,
+  PrepayQueueRow,
 } from '../types';
 import { formatUsd } from '../components/payments-shared';
 import {
@@ -28,6 +30,8 @@ import {
   PaymentsStatsCards,
   BulkActionsBar,
   ExternalPaymentModal,
+  PrepayQueueTable,
+  CreatePrepaymentModal,
 } from '../components/payments-admin';
 
 type RoleState =
@@ -66,6 +70,21 @@ export function PaymentsAdminPage() {
 
   // External payment modal (arugula-38633 v2 follow-up)
   const [showExternalModal, setShowExternalModal] = useState(false);
+
+  // bismarck-92103: prepay queue + the "Create prepayment" modal target row.
+  const [prepayQueue, setPrepayQueue] = useState<PrepayQueueRow[]>([]);
+  const [prepayModalRow, setPrepayModalRow] = useState<PrepayQueueRow | null>(null);
+
+  const loadPrepayQueue = useCallback(async () => {
+    try {
+      const rows = await fetchPrepayQueue();
+      setPrepayQueue(rows);
+    } catch {
+      // Non-fatal — the rest of the dashboard works without it. Silently
+      // collapse the section by leaving the array empty.
+      setPrepayQueue([]);
+    }
+  }, []);
 
   // Role gate
   useEffect(() => {
@@ -110,6 +129,14 @@ export function PaymentsAdminPage() {
     loadPage(filters, false);
   }, [filters, role.kind, loadPage]);
 
+  // bismarck-92103: load the prepay queue once admin is allowed in. It's
+  // independent of the payouts filter set, so it doesn't refetch on filter
+  // changes — only after a prepayment is created (see refresh() below).
+  useEffect(() => {
+    if (role.kind !== 'allowed') return;
+    loadPrepayQueue();
+  }, [role.kind, loadPrepayQueue]);
+
   const availableCurrencies = useMemo(() => {
     const set = new Set<string>();
     for (const p of payouts) {
@@ -140,6 +167,13 @@ export function PaymentsAdminPage() {
 
   async function refresh() {
     await loadPage(filters, false);
+  }
+
+  // bismarck-92103: after a prepayment is created, refresh BOTH the payouts
+  // list (so the new pending payout shows up there) and the prepay queue (so
+  // the source row drops off — it now has an in-flight payout).
+  async function handlePrepaymentCreated() {
+    await Promise.all([refresh(), loadPrepayQueue()]);
   }
 
   async function openDetail(p: AdminPayout) {
@@ -326,6 +360,21 @@ export function PaymentsAdminPage() {
 
         <PaymentsStatsCards totals={totals} loading={loading && !totals} />
 
+        {/* bismarck-92103: Prepay queue — only renders when there's at least
+            one matching party (host flagged prepay + saved payment method,
+            no in-flight payouts). */}
+        {prepayQueue.length > 0 && (
+          <section className="mb-6">
+            <h2 className="text-base font-semibold text-theme-text mb-3">
+              Prepay queue ({prepayQueue.length} event{prepayQueue.length === 1 ? '' : 's'})
+            </h2>
+            <PrepayQueueTable
+              rows={prepayQueue}
+              onCreatePrepayment={(row) => setPrepayModalRow(row)}
+            />
+          </section>
+        )}
+
         <PayoutsFilterBar
           filters={filters}
           onChange={setFilters}
@@ -484,6 +533,14 @@ export function PaymentsAdminPage() {
           <ExternalPaymentModal
             onClose={() => setShowExternalModal(false)}
             onCreated={() => refresh()}
+          />
+        )}
+
+        {prepayModalRow && (
+          <CreatePrepaymentModal
+            row={prepayModalRow}
+            onClose={() => setPrepayModalRow(null)}
+            onCreated={handlePrepaymentCreated}
           />
         )}
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1616,6 +1616,40 @@ export interface AdminPayoutsResponse {
   totals: AdminPayoutTotals;
 }
 
+/**
+ * bismarck-92103: a "prepay candidate" for an event flagged for prepayment.
+ * Surfaced on the /payments admin dashboard so the admin can issue an
+ * advance to a cohost whose payment method is already on file.
+ */
+export interface PrepayCandidate {
+  userId: string;
+  name: string | null;
+  email: string;
+  method: PayoutMethod;
+  /** For usdc_base — the 0x recipient. Null for other methods. */
+  walletAddress: string | null;
+  /**
+   * For wire — the bank-correspondence email from `payoutBankDetails.email`.
+   * Null is OK; PaymentDetailsCard can fill it in later if needed.
+   */
+  bankEmail: string | null;
+  isPrimaryHost: boolean;
+}
+
+export interface PrepayQueueRow {
+  party: {
+    id: string;
+    name: string;
+    customUrl: string | null;
+    country: string | null;
+    effectiveReimbursementCapUsd: number | null;
+    eventTags: string[];
+  };
+  candidates: PrepayCandidate[];
+  /** True when the admin must disambiguate between ≥2 candidates. */
+  hasMultipleCandidates: boolean;
+}
+
 export interface OcrPreviewResult {
   amount: number;             // USD-converted total
   currency: 'USD';


### PR DESCRIPTION
## Summary
- New `GET /api/admin/prepay-queue` returns parties with `'prepay' ∈ event_tags` + ≥1 host whose User has `preferredPayoutMethod != null` (excluding parties that already have an in-flight payout to those candidates).
- New "Prepay queue" section above the existing payouts table on `/payments`.
- New `CreatePrepaymentModal` — radio-picks the recipient when there's more than one candidate, defaults amount to 50% of the reimbursement cap, submits as a regular Payout via existing POST endpoint.
- Additive `recipientHostUserId` admin-only override on POST /payouts so the resulting row credits the cohost as submitter (not the admin).
- Multi-candidate rows show an amber AlertTriangle badge.

## Test plan
- [ ] Party with `event_tags: ['prepay']` + a primary host who has saved Mercury method → row appears with single candidate, button creates a \$X prepayment.
- [ ] Same but two cohosts both have methods → amber badge shows, modal lets admin pick which one.
- [ ] After creating a prepayment, the row disappears from the queue and a new pending payout appears in the regular table with `hostName = the chosen cohost`.
- [ ] Party with `'prepay'` tag but no host has a method → row does NOT appear.
- [ ] Mercury-blocked country: the Mercury candidate option is disabled in the modal with the amber reason caption.