### PR TITLE
fix(gorgonzola-31204): preserve cohost email on host edits

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -760,6 +760,40 @@ router.delete('/:id', async (req: AuthRequest, res: Response, next: NextFunction
   }
 });
 
+// GET /api/parties/:partyId/cohosts/full - Get unsanitized co_hosts JSONB
+//
+// gorgonzola-31204: Frontend Supabase reads strip `email` from co_hosts (PII).
+// HostsManager needs the unsanitized array so its edit modal preloads each
+// cohost's email and saves don't silently wipe the field — losing the email
+// breaks `check-host` matching and hides the Host Dashboard button on the
+// public EventPage for that cohost.
+//
+// Auth-gated by canUserEditParty (same gate as PATCH /api/parties/:id), so
+// only users who can already edit the party can read cohost emails.
+router.get('/:partyId/cohosts/full', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { coHosts: true },
+    });
+
+    if (!party) {
+      return res.status(404).json({ error: 'party not found' });
+    }
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      return res.status(403).json({ error: 'not authorized' });
+    }
+
+    return res.json({ coHosts: party.coHosts ?? [] });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // GET /api/parties/:id/invite-link - Get invite link
 router.get('/:id/invite-link', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {

--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -8,6 +8,7 @@ import { fetchXAvatarToSupabase, isAutoFilledXAvatar } from '../utils/avatarUtil
 import { uuid, normalizeUrl, stripToHandle } from '../lib/utils';
 import { ALL_HOST_TABS } from '../lib/tabPermissions';
 import { usePizza } from '../contexts/PizzaContext';
+import { apiRequest } from '../lib/api';
 
 interface HostsManagerProps {
   partyId: string;
@@ -31,7 +32,18 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   // Helper: check if a co-host is protected (auto-added partner or underboss)
   const isProtected = (h: CoHost) => h.isUnderboss === true || h.isPartner === true;
 
-  // Co-hosts state — includes ALL co-hosts (manual + protected)
+  // gorgonzola-31204: `initialCoHosts` is read through Supabase, which strips
+  // `email` via sanitizeCoHosts (PII protection for public reads). Use the
+  // backend GET /api/parties/:partyId/cohosts/full endpoint as the
+  // source-of-truth so the edit modal preloads emails and save handlers don't
+  // silently wipe them.
+  //
+  // IMPORTANT: All hooks must stay above any conditional/early return
+  // (see arugula-38633 incident in MEMORY).
+  const [fullCoHosts, setFullCoHosts] = useState<CoHost[] | null>(null);
+
+  // Co-hosts state — includes ALL co-hosts (manual + protected).
+  // Prefer the unsanitized fetch when available; fall back to props otherwise.
   const [coHosts, setCoHosts] = useState<CoHost[]>(initialCoHosts);
 
   // Visible co-hosts: filter out protected entries (auto-added underboss/partner)
@@ -41,10 +53,36 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
     [coHosts]
   );
 
-  // Sync from props when enriched data arrives asynchronously
+  // Sync from props when enriched data arrives asynchronously — but only if
+  // we don't have unsanitized data yet. Once `fullCoHosts` is populated, we
+  // trust local state (which save handlers keep in sync) over the sanitized
+  // props.
   useEffect(() => {
-    setCoHosts(initialCoHosts);
-  }, [initialCoHosts]);
+    if (fullCoHosts === null) {
+      setCoHosts(initialCoHosts);
+    }
+  }, [initialCoHosts, fullCoHosts]);
+
+  // Fetch the unsanitized cohosts (with email) on mount / partyId change.
+  // Silent fallback on error — render falls back to sanitized props.
+  useEffect(() => {
+    if (!partyId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiRequest<{ coHosts: CoHost[] }>(
+          `/api/parties/${partyId}/cohosts/full`
+        );
+        if (cancelled) return;
+        const next = Array.isArray(data.coHosts) ? data.coHosts : [];
+        setFullCoHosts(next);
+        setCoHosts(next);
+      } catch {
+        // Silent fallback — keep sanitized props as source of truth.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [partyId]);
 
   const [newCoHostName, setNewCoHostName] = useState('');
   const [newCoHostEmail, setNewCoHostEmail] = useState('');
@@ -167,6 +205,10 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
       // and preserves protected entry data from DB
       const success = await updateParty(partyId, { co_hosts: coHostsToSave });
       if (success) {
+        // gorgonzola-31204: keep the unsanitized source-of-truth in sync with
+        // what we just wrote, so a subsequent sanitized-prop refresh doesn't
+        // shadow it back to email-stripped data.
+        setFullCoHosts(coHostsToSave);
         // Only add as guest for non-protected co-hosts with email
         for (const coHost of coHostsToSave) {
           if (coHost.email && !isProtected(coHost)) {


### PR DESCRIPTION
## Bug
HostsManager's edit modal silently drops a cohost's `email` field. Without an email, the backend `check-host` endpoint can't match that cohost to their User record, so the "Host Dashboard" button stops appearing on the public event page even though `canEdit:true` is still set in the DB. Real incident: rsv.pizza/austin cohost Alizah (mediaofsociety@gmail.com) lost dashboard access; audit found 27 affected parties.

## Root cause
`sanitizeCoHosts` strips `email` on every Supabase read, so HostsManager reads sanitized data, the edit modal preloads `editHostEmail = ''`, and save writes `email: undefined`, dropping the field from the JSONB.

## Fix
- **Backend**: New authed `GET /api/parties/:partyId/cohosts/full` returns the unsanitized `coHosts` JSONB. Gated by `canUserEditParty` (same gate as `PATCH /api/parties/:id`); returns 401 (via `requireAuth` middleware), 404 if party missing, 403 if not authorized.
- **Frontend**: `HostsManager` fetches that endpoint on mount, stores it in `fullCoHosts` state (declared above all early returns to honor the rules-of-hooks), and uses it as the source-of-truth array for renders and every save handler. On save, `fullCoHosts` is updated to match so a subsequent sanitized-prop refresh can't shadow it.
- `sanitizeCoHosts` is unchanged - public reads still strip email.

## Smoke test checklist
- [ ] As a cohost, sign in, open Edit on your own cohost entry -> email field is populated
- [ ] Save without changing -> email still in DB
- [ ] As primary host, open Edit on another cohost -> email is populated
- [ ] Save -> that cohost's email still in DB; Host Dashboard button still visible for them on the public EventPage

## Notes
- Pre-existing test failures (party.routes.test.ts DELETE owner test, e2e specs, field-sync test, venue/partner form tests, missing `recharts` install in worktree) are unrelated to this change and reproduce on master.
- No new tests added (kept scope small per plan).
- Backfill of the 27 affected parties is a separate task.

Generated with [Claude Code](https://claude.com/claude-code)