### PR TITLE
feat(quattro-12847): cap-appeal review workflow for underbosses

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -43,6 +43,8 @@ model User {
   aiPhoneCalls AIPhoneCall[]
   payouts      Payout[]
   uploadedPayoutDocuments PayoutDocument[] @relation("PayoutDocumentUploadedBy")
+  reimbursementCapAppealsSubmitted ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsByHost")
+  reimbursementCapAppealsReviewed  ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsReviewedBy")
 }
 
 model Party {
@@ -241,8 +243,31 @@ model Party {
   outreachAttempts      OutreachAttempt[]
   announcements         Announcement[]
   attestations          GuestAttestation[]
+  reimbursementCapAppeals ReimbursementCapAppeal[]
 
   @@map("parties")
+}
+
+// quattro-12847: Full history of host reimbursement-cap appeals.
+// The denormalized `parties.reimbursement_cap_appealed_at` / `_appeal_note`
+// columns remain as a cache of the latest appeal for legacy reads; new code
+// keys off this table so underbosses can mark appeals as reviewed and view
+// the full history of past appeals + resolutions.
+model ReimbursementCapAppeal {
+  id               String   @id @default(uuid()) @db.Uuid
+  partyId          String   @map("party_id") @db.Uuid
+  party            Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  hostUserId       String   @map("host_user_id")
+  host             User     @relation("ReimbursementCapAppealsByHost", fields: [hostUserId], references: [id])
+  note             String
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+  reviewedAt       DateTime? @map("reviewed_at") @db.Timestamptz
+  reviewedByUserId String?  @map("reviewed_by_user_id")
+  reviewedBy       User?    @relation("ReimbursementCapAppealsReviewedBy", fields: [reviewedByUserId], references: [id])
+  reviewedNote     String?  @map("reviewed_note")
+
+  @@index([partyId])
+  @@map("reimbursement_cap_appeals")
 }
 
 // pepperoni-58341: Audit log of day-of broadcasts (Telegram + email) sent from

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -5,6 +5,7 @@ import { AppError } from '../middleware/error.js';
 import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
+import { getUnderbossScope, partyMatchesScope } from '../helpers/underbossScope.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
@@ -912,11 +913,144 @@ router.post('/:partyId/reimbursement-cap/appeal', async (req: AuthRequest, res: 
       },
     });
 
+    // quattro-12847: also insert a row into the appeal-history table so
+    // underbosses can mark each appeal reviewed and view past appeals.
+    // The denormalized columns above are kept as a backwards-compat cache.
+    if (req.userId) {
+      await prisma.reimbursementCapAppeal.create({
+        data: {
+          partyId,
+          hostUserId: req.userId,
+          note: trimmed,
+        },
+      });
+    }
+
     res.json({
       partyId: updated.id,
       reimbursementCapUsd: updated.reimbursementCapUsd != null ? Number(updated.reimbursementCapUsd) : null,
       reimbursementCapAppealNote: updated.reimbursementCapAppealNote,
       reimbursementCapAppealedAt: updated.reimbursementCapAppealedAt ? updated.reimbursementCapAppealedAt.toISOString() : null,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/reimbursement-cap/appeals/review (quattro-12847)
+// Mark the latest unreviewed appeal as reviewed. Admin OR underboss-in-scope only.
+router.post('/:partyId/reimbursement-cap/appeals/review', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const { reviewedNote } = req.body ?? {};
+
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, region: true, name: true, city: true, eventType: true },
+    });
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // Authz: admin OR underboss whose scope includes this party.
+    let allowed = false;
+    if (await isAdmin(req.userEmail)) {
+      allowed = true;
+    } else if (await isUnderboss(req.userEmail)) {
+      const scope = await getUnderbossScope(req.userEmail);
+      if (partyMatchesScope(party, scope)) {
+        allowed = true;
+      }
+    }
+    if (!allowed) {
+      throw new AppError('Only an underboss or admin can review cap appeals', 403, 'FORBIDDEN');
+    }
+
+    const open = await prisma.reimbursementCapAppeal.findFirst({
+      where: { partyId, reviewedAt: null },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!open) {
+      throw new AppError('No open appeal to review', 404, 'NO_OPEN_APPEAL');
+    }
+    const updated = await prisma.reimbursementCapAppeal.update({
+      where: { id: open.id },
+      data: {
+        reviewedAt: new Date(),
+        reviewedByUserId: req.userId ?? null,
+        reviewedNote: typeof reviewedNote === 'string' && reviewedNote.trim() ? reviewedNote.trim() : null,
+      },
+    });
+    res.json({
+      id: updated.id,
+      partyId: updated.partyId,
+      reviewedAt: updated.reviewedAt ? updated.reviewedAt.toISOString() : null,
+      reviewedByUserId: updated.reviewedByUserId,
+      reviewedNote: updated.reviewedNote,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/parties/:partyId/reimbursement-cap/appeals (quattro-12847)
+// Return the full appeal history (newest first). Admin OR underboss-in-scope
+// OR the party host themselves may view.
+router.get('/:partyId/reimbursement-cap/appeals', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, region: true, name: true, city: true, eventType: true, userId: true },
+    });
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    let allowed = false;
+    if (party.userId && party.userId === req.userId) {
+      allowed = true;
+    } else if (await isAdmin(req.userEmail)) {
+      allowed = true;
+    } else if (await isUnderboss(req.userEmail)) {
+      const scope = await getUnderbossScope(req.userEmail);
+      if (partyMatchesScope(party, scope)) {
+        allowed = true;
+      }
+    } else {
+      // Co-host with edit permission can also view (delegated host).
+      const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+      if (canEdit) allowed = true;
+    }
+    if (!allowed) {
+      throw new AppError('Not authorized to view appeal history', 403, 'FORBIDDEN');
+    }
+
+    const appeals = await prisma.reimbursementCapAppeal.findMany({
+      where: { partyId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        host: { select: { id: true, name: true, email: true } },
+        reviewedBy: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    res.json({
+      appeals: appeals.map((a) => ({
+        id: a.id,
+        partyId: a.partyId,
+        hostUserId: a.hostUserId,
+        hostName: a.host?.name ?? null,
+        hostEmail: a.host?.email ?? '',
+        note: a.note,
+        createdAt: a.createdAt.toISOString(),
+        reviewedAt: a.reviewedAt ? a.reviewedAt.toISOString() : null,
+        reviewedByUserId: a.reviewedByUserId,
+        reviewedByName: a.reviewedBy?.name ?? null,
+        reviewedByEmail: a.reviewedBy?.email ?? null,
+        reviewedNote: a.reviewedNote,
+      })),
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -182,6 +182,14 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
     reimbursementCapAppealedAt: party.reimbursementCapAppealedAt
       ? new Date(party.reimbursementCapAppealedAt).toISOString()
       : null,
+    // quattro-12847: derived from `_count.reimbursementCapAppeals` (where
+    // reviewedAt IS NULL). The denormalized `reimbursementCapAppealedAt`
+    // column is kept above for backwards compat, but new client code (badge,
+    // filter, Mark-reviewed button) keys off this field.
+    hasOpenAppeal:
+      typeof party._count?.reimbursementCapAppeals === 'number'
+        ? party._count.reimbursementCapAppeals > 0
+        : false,
   };
 }
 
@@ -741,6 +749,9 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
   try {
     const { region } = req.params;
     const scope = scopeFromReq(req);
+    // quattro-12847: optional filter / sort over the open cap-appeal queue.
+    const appealsOnly = req.query.appealsOnly === 'true' || req.query.appealsOnly === '1';
+    const sortMode = typeof req.query.sort === 'string' ? req.query.sort : null;
 
     // Handle "all" region — admins see everything, underbosses see scoped events
     if (region === 'all') {
@@ -771,6 +782,14 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
       whereClause = scopedWhere ? { AND: [base, scopedWhere] } : base;
     }
 
+    // quattro-12847: appeals-only narrows further to events with at least one
+    // unreviewed appeal in history.
+    if (appealsOnly) {
+      whereClause = {
+        AND: [whereClause, { reimbursementCapAppeals: { some: { reviewedAt: null } } }],
+      };
+    }
+
     const events = await prisma.party.findMany({
       where: whereClause,
       include: {
@@ -780,10 +799,28 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
         },
         partyKit: { select: { status: true } },
         sponsors: { select: { status: true, amount: true } },
-        _count: { select: { guests: true, photos: true } },
+        _count: {
+          select: {
+            guests: true,
+            photos: true,
+            // quattro-12847: count of unreviewed appeals → `hasOpenAppeal`.
+            reimbursementCapAppeals: { where: { reviewedAt: null } },
+          },
+        },
       },
-      orderBy: { date: 'asc' },
+      orderBy: sortMode === 'appealsFirst' ? undefined : { date: 'asc' },
     });
+
+    if (sortMode === 'appealsFirst') {
+      events.sort((a: any, b: any) => {
+        const aOpen = (a._count?.reimbursementCapAppeals || 0) > 0 ? 1 : 0;
+        const bOpen = (b._count?.reimbursementCapAppeals || 0) > 0 ? 1 : 0;
+        if (aOpen !== bOpen) return bOpen - aOpen;
+        const aDate = a.date ? new Date(a.date).getTime() : Number.MAX_SAFE_INTEGER;
+        const bDate = b.date ? new Date(b.date).getTime() : Number.MAX_SAFE_INTEGER;
+        return aDate - bDate;
+      });
+    }
 
     // Get all underboss emails for co-host filtering
     const allUnderbosses = await prisma.underboss.findMany({
@@ -832,6 +869,9 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 50;
     const skip = (page - 1) * limit;
+    // quattro-12847: optional filter / sort over the open cap-appeal queue.
+    const appealsOnly = req.query.appealsOnly === 'true' || req.query.appealsOnly === '1';
+    const sortMode = typeof req.query.sort === 'string' ? req.query.sort : null;
 
     const scope = scopeFromReq(req);
     if (!scope.isAdmin && !scope.regions.includes(region) && scope.cities.length === 0) {
@@ -839,8 +879,15 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
     }
 
     const scopedWhere = buildScopedWhereClause(scope);
-    const base = { region, eventType: 'gpp' as const };
+    const base: any = { region, eventType: 'gpp' as const };
+    if (appealsOnly) {
+      base.reimbursementCapAppeals = { some: { reviewedAt: null } };
+    }
     const where: any = scopedWhere ? { AND: [base, scopedWhere] } : base;
+
+    // Note: Prisma cannot order directly by a filtered `_count` of a relation,
+    // so for `sort=appealsFirst` we fetch unsorted, then re-sort in JS below.
+    const orderBy: any = sortMode === 'appealsFirst' ? undefined : { date: 'asc' };
 
     const [events, total, allUnderbosses] = await Promise.all([
       prisma.party.findMany({
@@ -852,9 +899,16 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
           },
           partyKit: { select: { status: true } },
           sponsors: { select: { status: true, amount: true } },
-          _count: { select: { guests: true, photos: true } },
+          _count: {
+            select: {
+              guests: true,
+              photos: true,
+              // quattro-12847: count of unreviewed appeals → `hasOpenAppeal`.
+              reimbursementCapAppeals: { where: { reviewedAt: null } },
+            },
+          },
         },
-        orderBy: { date: 'asc' },
+        orderBy,
         skip,
         take: limit,
       }),
@@ -864,6 +918,17 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
         select: { email: true },
       }),
     ]);
+
+    if (sortMode === 'appealsFirst') {
+      events.sort((a: any, b: any) => {
+        const aOpen = (a._count?.reimbursementCapAppeals || 0) > 0 ? 1 : 0;
+        const bOpen = (b._count?.reimbursementCapAppeals || 0) > 0 ? 1 : 0;
+        if (aOpen !== bOpen) return bOpen - aOpen; // open appeals first
+        const aDate = a.date ? new Date(a.date).getTime() : Number.MAX_SAFE_INTEGER;
+        const bDate = b.date ? new Date(b.date).getTime() : Number.MAX_SAFE_INTEGER;
+        return aDate - bDate;
+      });
+    }
     const ubEmails = allUnderbosses.map(u => u.email.toLowerCase());
 
     // Get latest sponsor timestamp per party for flyer staleness detection
@@ -926,7 +991,14 @@ router.get('/:region/events/:partyId', requireAuth, requireUnderbossAuth, async 
           select: { id: true, name: true, category: true, cost: true, status: true },
           orderBy: { createdAt: 'desc' },
         },
-        _count: { select: { guests: true, photos: true } },
+        _count: {
+          select: {
+            guests: true,
+            photos: true,
+            // quattro-12847: feed `hasOpenAppeal` on the detail view too.
+            reimbursementCapAppeals: { where: { reviewedAt: null } },
+          },
+        },
       },
     });
 

--- a/frontend/src/components/underboss/AppealHistoryModal.tsx
+++ b/frontend/src/components/underboss/AppealHistoryModal.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CheckCircle2, Loader2, X } from 'lucide-react';
+import { fetchReimbursementCapAppeals } from '../../lib/api';
+import type { ReimbursementCapAppealRecord } from '../../types';
+
+interface AppealHistoryModalProps {
+  partyId: string;
+  onClose: () => void;
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * quattro-12847: Modal that lists the full history of reimbursement-cap
+ * appeals on a single party (newest first), plus any underboss resolution
+ * notes. Open from the underboss ReimbursementCapCell.
+ */
+export function AppealHistoryModal({ partyId, onClose }: AppealHistoryModalProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [appeals, setAppeals] = useState<ReimbursementCapAppealRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const rows = await fetchReimbursementCapAppeals(partyId);
+        if (!cancelled) setAppeals(rows);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message || 'Failed to load appeal history');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-card border border-theme-stroke rounded-2xl p-6 w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-theme-text">Cap appeal history</h3>
+            <p className="text-sm text-theme-text-muted mt-1">
+              All host appeals of the reimbursement cap for this event.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-theme-text-faint hover:text-theme-text-secondary"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center py-10 text-theme-text-muted">
+            <Loader2 size={20} className="animate-spin" />
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-sm text-red-500">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && appeals.length === 0 && (
+          <div className="text-center py-10 text-sm text-theme-text-muted">
+            No appeals on this event yet.
+          </div>
+        )}
+
+        {!loading && !error && appeals.length > 0 && (
+          <ul className="space-y-3">
+            {appeals.map((a) => {
+              const reviewed = !!a.reviewedAt;
+              return (
+                <li
+                  key={a.id}
+                  className="rounded-lg border border-theme-stroke p-4 bg-theme-surface"
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      {reviewed ? (
+                        <CheckCircle2 size={14} className="text-[#39d98a]" />
+                      ) : (
+                        <span className="inline-block w-2.5 h-2.5 rounded-full bg-amber-400" />
+                      )}
+                      <span className="text-xs text-theme-text-muted">
+                        {formatTimestamp(a.createdAt)}
+                      </span>
+                    </div>
+                    <span className="text-xs text-theme-text-faint">
+                      {reviewed ? 'Reviewed' : 'Open'}
+                    </span>
+                  </div>
+                  <div className="text-xs text-theme-text-muted mb-1">
+                    From{' '}
+                    <span className="text-theme-text">
+                      {a.hostName || a.hostEmail || 'host'}
+                    </span>
+                    {a.hostName && a.hostEmail && (
+                      <span className="text-theme-text-faint"> ({a.hostEmail})</span>
+                    )}
+                  </div>
+                  <div className="text-sm text-theme-text whitespace-pre-wrap break-words">
+                    {a.note}
+                  </div>
+
+                  {reviewed && (
+                    <div className="mt-3 pt-3 border-t border-theme-stroke text-xs">
+                      <div className="text-theme-text-muted">
+                        Reviewed{a.reviewedAt ? ` ${formatTimestamp(a.reviewedAt)}` : ''}
+                        {(a.reviewedByName || a.reviewedByEmail) && (
+                          <>
+                            {' '}by{' '}
+                            <span className="text-theme-text">
+                              {a.reviewedByName || a.reviewedByEmail}
+                            </span>
+                            {a.reviewedByName && a.reviewedByEmail && (
+                              <span className="text-theme-text-faint"> ({a.reviewedByEmail})</span>
+                            )}
+                          </>
+                        )}
+                      </div>
+                      {a.reviewedNote && (
+                        <div className="mt-1 text-sm text-theme-text whitespace-pre-wrap break-words">
+                          {a.reviewedNote}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Search, ArrowUpDown, ThumbsUp, ThumbsDown, ChevronDown, Check, X, DollarSign } from 'lucide-react';
 import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
 import { EventRow } from './EventRow';
 import { EventCard } from './EventCard';
 import { bulkUpdateUnderbossStatus, bulkDeleteEvents, bulkUpdateEventTags } from '../../lib/api';
@@ -21,7 +22,7 @@ interface EventTableProps {
   isAdmin?: boolean;
 }
 
-type SortField = 'name' | 'date' | 'guestCount' | 'progress';
+type SortField = 'name' | 'date' | 'guestCount' | 'progress' | 'appealsFirst';
 type SortDir = 'asc' | 'desc';
 
 // Filterable progress keys (skip "Event" always-true and "Prep" always-false)
@@ -98,6 +99,11 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   const [tagFilter, setTagFilter] = useState<string>('all');
   const [rsvpComparator, setRsvpComparator] = useState<'>' | '<'>('>');
   const [rsvpThreshold, setRsvpThreshold] = useState<string>('');
+  // quattro-12847: client-side "Open appeals only" filter. Client-side keeps
+  // the filter live (no refetch) and works against whatever `events` slice
+  // the parent passes in. Backend supports an equivalent `appealsOnly=true`
+  // query param for callers that want server-side narrowing.
+  const [appealsOnly, setAppealsOnly] = useState<boolean>(false);
 
   // Selection state for bulk actions
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -219,6 +225,11 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
       }
     }
 
+    // quattro-12847: "open cap appeals only" filter
+    if (appealsOnly) {
+      result = result.filter((e) => e.hasOpenAppeal === true);
+    }
+
     result = [...result].sort((a, b) => {
       let cmp = 0;
       switch (sortField) {
@@ -237,12 +248,25 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         case 'progress':
           cmp = countProgress(a) - countProgress(b);
           break;
+        case 'appealsFirst': {
+          // quattro-12847: events with open cap appeals first; tie-break by date asc.
+          const aOpen = a.hasOpenAppeal ? 1 : 0;
+          const bOpen = b.hasOpenAppeal ? 1 : 0;
+          if (aOpen !== bOpen) {
+            // Always show open appeals first regardless of sortDir
+            return bOpen - aOpen;
+          }
+          const aDate = a.date ? new Date(a.date).getTime() : Number.MAX_SAFE_INTEGER;
+          const bDate = b.date ? new Date(b.date).getTime() : Number.MAX_SAFE_INTEGER;
+          cmp = aDate - bDate;
+          break;
+        }
       }
       return sortDir === 'asc' ? cmp : -cmp;
     });
 
     return result;
-  }, [events, search, sortField, sortDir, progressIncludes, progressExcludes, regionFilter, showRegion, tagFilter, rsvpComparator, rsvpThreshold]);
+  }, [events, search, sortField, sortDir, progressIncludes, progressExcludes, regionFilter, showRegion, tagFilter, rsvpComparator, rsvpThreshold, appealsOnly]);
 
   useEffect(() => {
     onFilteredEventsChange?.(filteredEvents);
@@ -297,7 +321,8 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     progressExcludes.length > 0 ||
     regionFilter !== 'all' ||
     tagFilter !== 'all' ||
-    rsvpThreshold.trim() !== '';
+    rsvpThreshold.trim() !== '' ||
+    appealsOnly;
 
   return (
     <div className="space-y-3">
@@ -408,6 +433,33 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           />
         </div>
 
+        {/* quattro-12847: Open cap-appeals only + sort-by-appeals-first */}
+        <Checkbox
+          checked={appealsOnly}
+          onChange={() => setAppealsOnly((v) => !v)}
+          label="Open appeals only"
+          size={14}
+          labelClassName="text-xs text-theme-text-secondary"
+        />
+        <select
+          value={sortField === 'appealsFirst' ? 'appealsFirst' : 'default'}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === 'appealsFirst') {
+              setSortField('appealsFirst');
+              setSortDir('asc');
+            } else {
+              setSortField('date');
+              setSortDir('asc');
+            }
+          }}
+          className="bg-theme-surface border border-theme-stroke rounded-lg px-2 py-1.5 text-sm text-theme-text-secondary focus:outline-none focus:border-theme-stroke-hover"
+          aria-label="Sort"
+        >
+          <option value="default">Sort: default</option>
+          <option value="appealsFirst">Sort: appeals first</option>
+        </select>
+
         {/* Clear filters link */}
         {hasActiveFilters && (
           <button
@@ -417,6 +469,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
               setRegionFilter('all');
               setTagFilter('all');
               setRsvpThreshold('');
+              setAppealsOnly(false);
             }}
             className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
           >

--- a/frontend/src/components/underboss/ReimbursementCapCell.tsx
+++ b/frontend/src/components/underboss/ReimbursementCapCell.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { Check, Edit2, AlertCircle, X, Loader2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { computeSuggestedReimbursementCap } from '../../utils/reimbursementCap';
-import { updatePartyApi } from '../../lib/api';
+import { updatePartyApi, reviewReimbursementCapAppeal } from '../../lib/api';
 import type { UnderbossEvent } from '../../types';
+import { AppealHistoryModal } from './AppealHistoryModal';
 
 interface ReimbursementCapCellProps {
   event: UnderbossEvent;
@@ -33,7 +34,12 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
   const hasSuggestion = suggestedUsd != null;
 
   const currentCap = event.reimbursementCapUsd;
-  const hasAppeal = !!event.reimbursementCapAppealedAt;
+  // quattro-12847: switch from the legacy denormalized timestamp to the
+  // history-table-derived `hasOpenAppeal`. Fall back to the legacy field if
+  // the backend on this preview hasn't been redeployed yet.
+  const hasOpenAppeal = typeof event.hasOpenAppeal === 'boolean'
+    ? event.hasOpenAppeal
+    : !!event.reimbursementCapAppealedAt;
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<string>(
@@ -41,6 +47,69 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reviewing, setReviewing] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  async function handleMarkReviewed(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (reviewing) return;
+    setReviewing(true);
+    setReviewError(null);
+    try {
+      await reviewReimbursementCapAppeal(event.id);
+      onUpdate?.(event.id, { hasOpenAppeal: false });
+    } catch (err: any) {
+      setReviewError(err?.message || 'Failed to mark reviewed');
+    } finally {
+      setReviewing(false);
+    }
+  }
+
+  function renderAppealAffordance() {
+    if (!hasOpenAppeal) {
+      // Even with no open appeal, surface a History entry-point when there's
+      // a known past appeal (so reviewers can re-read the resolved note).
+      if (!event.reimbursementCapAppealedAt) return null;
+      return (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setHistoryOpen(true); }}
+          className="text-[9px] px-1 py-0.5 rounded border border-theme-stroke text-theme-text-faint hover:text-theme-text-muted transition-colors"
+          title="View appeal history"
+        >
+          History
+        </button>
+      );
+    }
+    return (
+      <>
+        <span title={event.reimbursementCapAppealNote || 'Host has an open appeal'}>
+          <AlertCircle size={10} className="text-amber-400" />
+        </span>
+        <button
+          type="button"
+          onClick={handleMarkReviewed}
+          disabled={reviewing}
+          className="text-[9px] px-1 py-0.5 rounded border border-theme-stroke text-theme-text-muted hover:text-theme-text transition-colors disabled:opacity-40"
+          title="Mark this appeal as reviewed"
+        >
+          {reviewing ? <Loader2 size={9} className="inline animate-spin" /> : 'Mark reviewed'}
+        </button>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setHistoryOpen(true); }}
+          className="text-[9px] px-1 py-0.5 rounded border border-theme-stroke text-theme-text-faint hover:text-theme-text-muted transition-colors"
+          title="View appeal history"
+        >
+          History
+        </button>
+        {reviewError && (
+          <span className="text-[9px] text-red-400" title={reviewError}>!</span>
+        )}
+      </>
+    );
+  }
 
   async function save(value: number | null) {
     setSaving(true);
@@ -136,10 +205,9 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
           >
             Override
           </button>
-          {hasAppeal && (
-            <span title={event.reimbursementCapAppealNote || 'Host has appealed'}>
-              <AlertCircle size={10} className="text-amber-400" />
-            </span>
+          {renderAppealAffordance()}
+          {historyOpen && (
+            <AppealHistoryModal partyId={event.id} onClose={() => setHistoryOpen(false)} />
           )}
         </div>
       );
@@ -166,10 +234,9 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
         >
           Override
         </button>
-        {hasAppeal && (
-          <span title={event.reimbursementCapAppealNote || 'Host has appealed'}>
-            <AlertCircle size={10} className="text-amber-400" />
-          </span>
+        {renderAppealAffordance()}
+        {historyOpen && (
+          <AppealHistoryModal partyId={event.id} onClose={() => setHistoryOpen(false)} />
         )}
       </div>
     );
@@ -188,10 +255,9 @@ export const ReimbursementCapCell: React.FC<ReimbursementCapCellProps> = ({ even
       >
         <Edit2 size={9} />
       </button>
-      {hasAppeal && (
-        <span title={event.reimbursementCapAppealNote || 'Host has appealed'}>
-          <AlertCircle size={10} className="text-amber-400" />
-        </span>
+      {renderAppealAffordance()}
+      {historyOpen && (
+        <AppealHistoryModal partyId={event.id} onClose={() => setHistoryOpen(false)} />
       )}
     </div>
   );

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -10,3 +10,4 @@ export { CityScopePicker } from './CityScopePicker';
 export { FakeDetectionTable } from './FakeDetectionTable';
 export { OutreachTab } from './OutreachTab';
 export { ReimbursementCapCell } from './ReimbursementCapCell';
+export { AppealHistoryModal } from './AppealHistoryModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4157,6 +4157,40 @@ export async function appealReimbursementCap(
   );
 }
 
+/**
+ * quattro-12847: Admin or scoped-underboss marks the latest open appeal as
+ * reviewed. Returns the updated appeal row.
+ */
+export async function reviewReimbursementCapAppeal(
+  partyId: string,
+  reviewedNote?: string
+): Promise<{
+  id: string;
+  partyId: string;
+  reviewedAt: string | null;
+  reviewedByUserId: string | null;
+  reviewedNote: string | null;
+}> {
+  return apiRequest(
+    `/api/parties/${partyId}/reimbursement-cap/appeals/review`,
+    { method: 'POST', body: reviewedNote ? { reviewedNote } : {}, requireAuth: true }
+  );
+}
+
+/**
+ * quattro-12847: Fetch full appeal history for an event (newest first).
+ * Admin, scoped underboss, host, or co-host-with-edit may view.
+ */
+export async function fetchReimbursementCapAppeals(
+  partyId: string
+): Promise<import('../types').ReimbursementCapAppealRecord[]> {
+  const res = await apiRequest<{ appeals: import('../types').ReimbursementCapAppealRecord[] }>(
+    `/api/parties/${partyId}/reimbursement-cap/appeals`,
+    { method: 'GET', requireAuth: true }
+  );
+  return res.appeals;
+}
+
 export async function previewReceiptOCR(
   partyId: string,
   imageUrl: string

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -139,6 +139,13 @@ export function UnderbossDashboard() {
     };
   }, [filteredData, activeTab, tableFilteredEvents]);
 
+  // quattro-12847: count of in-scope events with at least one unreviewed
+  // cap appeal — drives the red pill on the Events tab nav.
+  const openAppealCount = useMemo(() => {
+    if (!filteredData) return 0;
+    return filteredData.events.filter((e) => e.hasOpenAppeal === true).length;
+  }, [filteredData]);
+
   useEffect(() => {
     if (activeTab !== 'events') setTableFilteredEvents(null);
   }, [activeTab]);
@@ -519,6 +526,14 @@ export function UnderbossDashboard() {
               }`}
             >
               {t('underbossDashboard.tabs.events')} ({displayData.events.length})
+              {openAppealCount > 0 && (
+                <span
+                  className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-300 text-[10px] font-semibold ml-1.5"
+                  title={`${openAppealCount} event${openAppealCount === 1 ? '' : 's'} with an open cap appeal`}
+                >
+                  {openAppealCount}
+                </span>
+              )}
               {activeTab === 'events' && (
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1112,6 +1112,27 @@ export interface UnderbossEvent {
   reimbursementCapUsd?: number | null;
   reimbursementCapAppealNote?: string | null;
   reimbursementCapAppealedAt?: string | null;
+  // quattro-12847: derived server-side from `reimbursement_cap_appeals` rows
+  // where reviewed_at IS NULL. Drives the underboss "open appeal" badge,
+  // filter, and Mark-reviewed affordance — replaces the legacy
+  // reimbursementCapAppealedAt signal which never cleared.
+  hasOpenAppeal?: boolean;
+}
+
+// quattro-12847: a single row from the appeal-history endpoint.
+export interface ReimbursementCapAppealRecord {
+  id: string;
+  partyId: string;
+  hostUserId: string;
+  hostName: string | null;
+  hostEmail: string;
+  note: string;
+  createdAt: string;
+  reviewedAt: string | null;
+  reviewedByUserId: string | null;
+  reviewedByName: string | null;
+  reviewedByEmail: string | null;
+  reviewedNote: string | null;
 }
 
 export interface UnderbossStats {


### PR DESCRIPTION
## Summary
- New `reimbursement_cap_appeals` table — full appeal history with `reviewed_at`/`reviewed_by_user_id`/`reviewed_note`. (Migration applied to prod.)
- `POST /api/parties/:id/reimbursement-cap/appeal` (existing) now also inserts into history.
- New `POST /api/parties/:id/reimbursement-cap/appeals/review` (admin OR underboss-in-scope) marks the latest open appeal reviewed.
- New `GET /api/parties/:id/reimbursement-cap/appeals` returns history.
- Underboss list endpoint emits `hasOpenAppeal` derived from `_count(appeals where reviewedAt is null)`. New `appealsOnly` filter + `sort=appealsFirst` query params.
- `ReimbursementCapCell` shows amber icon, "Mark reviewed" button, "History" link when open.
- New `AppealHistoryModal` shows every past appeal + resolution.
- Tab-nav shows a red-pill count of open appeals.

## Test plan
- [ ] Host appeals twice → two rows in `reimbursement_cap_appeals`.
- [ ] Underboss in scope clicks Mark reviewed → latest row stamped; icon disappears.
- [ ] Underboss out of scope hitting review endpoint → 403.
- [ ] `appealsOnly=true` returns only events with open appeals.
- [ ] Tab badge shows correct count, hides when zero.
- [ ] Existing party.reimbursement_cap_appealed_at still updates so older code paths keep working.