### PR TITLE
feat(siciliana-69183): clickable hosts + event links + Safe JSON export on /payments

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest, isAdmin, isSuperAdmin } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isAdmin, isSuperAdmin, isPaymentAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { createEmbeddedWalletForGuest } from '../services/privy.service.js';
@@ -137,6 +137,95 @@ router.delete('/:id', requireAuth, async (req: AuthRequest, res: Response, next:
     next(error);
   }
 });
+
+// ============================================
+// GET /api/admin/users/:userId/payment-details — siciliana-69183
+//
+// Returns a user's saved payment-details for the admin /payments dashboard.
+// Surfaced when an admin clicks a host chip / "Submitted by X" caption in the
+// prepay queue + payouts table. Gated to admin / super_admin / payment_admin
+// only (same role set that can already see the /payments dashboard).
+//
+// Returns only what the admin needs to verify / route a payment:
+// preferred method, wallet address (for usdc_base), bank email (for wire),
+// plus a "totalPayouts + latestPayoutAt" context blurb. We intentionally do
+// NOT return the full bank-details JSON (routing/account numbers etc.) —
+// admins don't need it on this surface (Mercury / wire happen out-of-band).
+// ============================================
+router.get(
+  '/users/:userId/payment-details',
+  requireAuth,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      if (!(await isPaymentAdmin(req.userEmail))) {
+        throw new AppError('Payments admin access required', 403, 'FORBIDDEN');
+      }
+
+      const userId = req.params.userId?.trim();
+      if (!userId) {
+        throw new AppError('userId is required', 400, 'VALIDATION_ERROR');
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          preferredPayoutMethod: true,
+          payoutWalletAddress: true,
+          payoutBankDetails: true,
+        },
+      });
+      if (!user) {
+        throw new AppError('User not found', 404, 'NOT_FOUND');
+      }
+
+      // Activity context — how many payouts this user has on the system, and
+      // the most recent one (any status). Helps the admin sanity-check: a
+      // user with 0 payouts and no latest is a brand-new host.
+      const [totalPayouts, latest] = await Promise.all([
+        prisma.payout.count({ where: { hostUserId: userId } }),
+        prisma.payout.findFirst({
+          where: { hostUserId: userId },
+          orderBy: { createdAt: 'desc' },
+          select: { createdAt: true },
+        }),
+      ]);
+
+      // Strip bank details to just the correspondence email (the only piece
+      // an admin needs to reach the host about the wire). Keeps routing /
+      // account numbers off the wire.
+      let bankEmail: string | null = null;
+      const bd = user.payoutBankDetails as any;
+      if (bd && typeof bd === 'object' && typeof bd.email === 'string' && bd.email.trim()) {
+        bankEmail = bd.email.trim();
+      }
+
+      // Validate the persisted method against the 3 hard rails. Anything else
+      // is treated as unset so the UI shows the "Not set" state instead of a
+      // garbage label.
+      const rawMethod = user.preferredPayoutMethod;
+      const method =
+        rawMethod === 'mercury_card' || rawMethod === 'wire' || rawMethod === 'usdc_base'
+          ? rawMethod
+          : null;
+
+      res.json({
+        userId: user.id,
+        name: user.name,
+        email: user.email,
+        preferredPayoutMethod: method,
+        payoutWalletAddress: user.payoutWalletAddress,
+        payoutBankDetails: bankEmail !== null ? { email: bankEmail } : null,
+        totalPayouts,
+        latestPayoutAt: latest?.createdAt ? latest.createdAt.toISOString() : null,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
 
 // GET /api/admin/gpp-nft — Get current GPP NFT settings
 router.get('/gpp-nft', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {

--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Check, X, DollarSign, Loader2 } from 'lucide-react';
+import { Check, X, DollarSign, Loader2, FileJson } from 'lucide-react';
 
 interface BulkActionsBarProps {
   selectedCount: number;
@@ -7,6 +7,11 @@ interface BulkActionsBarProps {
   onReject: () => void;
   onMarkPaid: () => void;
   onClear: () => void;
+  /**
+   * siciliana-69183: open the ExportSafeJsonModal for the current selection.
+   * The modal itself filters non-USDC / missing-wallet rows.
+   */
+  onExportSafeJson?: () => void;
   busy?: boolean;
 }
 
@@ -16,6 +21,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   onReject,
   onMarkPaid,
   onClear,
+  onExportSafeJson,
   busy = false,
 }) => {
   if (selectedCount === 0) return null;
@@ -50,6 +56,18 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
           <DollarSign size={14} />
           Mark paid
         </button>
+        {onExportSafeJson && (
+          <button
+            type="button"
+            onClick={onExportSafeJson}
+            disabled={busy}
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-violet-500 hover:bg-violet-600 text-white text-sm font-medium disabled:opacity-50"
+            title="Bundle selected USDC payouts as a Gnosis Safe Transaction Builder batch"
+          >
+            <FileJson size={14} />
+            Export Safe JSON
+          </button>
+        )}
         <button
           type="button"
           onClick={onClear}

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -9,7 +9,12 @@ import type { PrepayCandidate, PrepayQueueRow } from '../../types';
 interface CreatePrepaymentModalProps {
   row: PrepayQueueRow;
   onClose: () => void;
-  onCreated: () => void;
+  /**
+   * siciliana-69183: now receives a small summary so the parent can surface a
+   * post-create toast ("Created prepayment for X — $Y"). The arg is optional
+   * for backward-compat with any existing callsite that doesn't need it.
+   */
+  onCreated: (summary?: { hostName: string; amountUsd: number }) => void;
 }
 
 /**
@@ -95,7 +100,11 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
         hostNotes: 'Prepayment created by admin',
         recipientHostUserId: selectedCandidate.userId,
       });
-      onCreated();
+      onCreated({
+        hostName:
+          (selectedCandidate.name && selectedCandidate.name.trim()) || selectedCandidate.email,
+        amountUsd: amountNum,
+      });
       onClose();
     } catch (err: any) {
       setError(err?.message || 'Failed to create prepayment');

--- a/frontend/src/components/payments-admin/ExportSafeJsonModal.tsx
+++ b/frontend/src/components/payments-admin/ExportSafeJsonModal.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Download, AlertTriangle } from 'lucide-react';
+import type { AdminPayout } from '../../types';
+import {
+  buildSafeBatch,
+  downloadSafeBatch,
+  type SafeBatchLabel,
+} from '../../lib/safeTransactionBuilder';
+
+interface ExportSafeJsonModalProps {
+  /** All currently-selected payouts on the dashboard. */
+  selected: AdminPayout[];
+  onClose: () => void;
+  /**
+   * Fired after the download is triggered so the parent can flash a toast.
+   * The modal closes itself separately.
+   */
+  onExported?: (summary: { included: number; skipped: number; label: SafeBatchLabel }) => void;
+}
+
+const LABEL_OPTIONS: { value: SafeBatchLabel; label: string }[] = [
+  { value: 'prepayment_50', label: '50% Prepayment' },
+  { value: 'final', label: 'Final Payment' },
+  { value: 'custom', label: 'Custom' },
+];
+
+/**
+ * siciliana-69183: small modal that previews the Safe-batch export before the
+ * admin downloads it. Counts how many of the selected payouts are eligible
+ * (USDC + valid 0x wallet + positive amount) vs skipped, and lets the admin
+ * pick a label (50% Prepayment / Final / Custom) that controls the JSON's
+ * meta.name + meta.description + filename. Does NOT recalculate amounts —
+ * each transaction uses the payout's `finalAmountUsd` as-is.
+ */
+export const ExportSafeJsonModal: React.FC<ExportSafeJsonModalProps> = ({
+  selected,
+  onClose,
+  onExported,
+}) => {
+  const [label, setLabel] = useState<SafeBatchLabel>('prepayment_50');
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Preview-only build — cheap and pure, so we re-derive on every render to
+  // keep `included` / `skipped` in sync with the selection.
+  const preview = useMemo(() => buildSafeBatch(selected, label), [selected, label]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (preview.included === 0) return;
+    downloadSafeBatch(preview);
+    onExported?.({ included: preview.included, skipped: preview.skipped, label });
+    onClose();
+  }
+
+  const body = (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-semibold text-theme-text">Export Safe JSON</h2>
+            <p className="text-xs text-theme-text-muted mt-0.5">
+              Downloads a Gnosis Safe Transaction Builder v1.0 batch — drag the file into the
+              Safe app to execute.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {/* Label picker */}
+          <div>
+            <p className="text-xs uppercase tracking-wide text-theme-text-muted mb-1.5">
+              Transaction type
+            </p>
+            <select
+              value={label}
+              onChange={(e) => setLabel(e.target.value as SafeBatchLabel)}
+              className="w-full px-3 py-2 rounded-lg bg-theme-surface-hover border border-theme-stroke text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+            >
+              {LABEL_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-theme-text-muted mt-1.5">
+              Affects the batch label + filename only. Amounts come from each payout's
+              <code className="mx-1 px-1 py-0.5 rounded bg-theme-surface text-[11px]">finalAmountUsd</code>
+              as-is.
+            </p>
+          </div>
+
+          {/* Summary */}
+          <div className="px-3 py-3 rounded-lg bg-theme-surface-hover border border-theme-stroke text-sm">
+            <div className="flex items-baseline gap-2">
+              <span className="font-medium text-theme-text">{selected.length}</span>
+              <span className="text-theme-text-muted">selected</span>
+              <span className="text-theme-text-muted">•</span>
+              <span className="font-medium text-emerald-500">{preview.included}</span>
+              <span className="text-theme-text-muted">USDC eligible</span>
+              {preview.skipped > 0 && (
+                <>
+                  <span className="text-theme-text-muted">•</span>
+                  <span className="font-medium text-amber-500">{preview.skipped}</span>
+                  <span className="text-theme-text-muted">skipped</span>
+                </>
+              )}
+            </div>
+            {preview.skipped > 0 && (
+              <div className="flex items-start gap-1.5 mt-2 text-xs text-amber-500/90">
+                <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                <span>
+                  Skipped rows are non-USDC, have a malformed wallet, or have an amount of $0.
+                  Only USDC-on-Base payouts with a valid 0x recipient can be batched.
+                </span>
+              </div>
+            )}
+          </div>
+
+          {preview.included === 0 && (
+            <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-xs text-red-400">
+              <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+              <span>
+                No eligible payouts in the current selection — pick at least one USDC payout
+                with a valid 0x recipient.
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-theme-stroke">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 rounded-lg text-sm text-theme-text-muted hover:text-theme-text"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={preview.included === 0}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Download size={14} />
+            Download safe-batch.json
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+
+  return createPortal(body, document.body);
+};

--- a/frontend/src/components/payments-admin/HostPaymentDetailsModal.tsx
+++ b/frontend/src/components/payments-admin/HostPaymentDetailsModal.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Copy, Check, Loader2, AlertCircle } from 'lucide-react';
+import { fetchUserPaymentDetails, type UserPaymentDetails } from '../../lib/api';
+import { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from '../payments-shared';
+import { ClickableEmail } from '../ClickableEmail';
+
+interface HostPaymentDetailsModalProps {
+  /**
+   * The User.id whose saved payment-details we should display. When `null`
+   * the modal does not render — parent owns the open/closed state.
+   */
+  userId: string | null;
+  onClose: () => void;
+}
+
+/**
+ * siciliana-69183: read-only modal opened when an admin clicks a host name on
+ * the /payments dashboard (prepay queue chips OR payouts-table "Submitted by"
+ * captions). Fetches the host's saved payment details on mount and renders
+ * method, wallet (with copy), bank email (with copy), plus a small activity
+ * blurb. Does NOT mount until `userId` is set — keeps the parent free of any
+ * pre-load.
+ */
+export const HostPaymentDetailsModal: React.FC<HostPaymentDetailsModalProps> = ({
+  userId,
+  onClose,
+}) => {
+  const [data, setData] = useState<UserPaymentDetails | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!userId) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [userId, onClose]);
+
+  // Fetch when userId is set (and re-fetch when it changes).
+  useEffect(() => {
+    if (!userId) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setData(null);
+    fetchUserPaymentDetails(userId)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((err: any) => {
+        if (!cancelled) setError(err?.message || 'Failed to load payment details');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  if (!userId) return null;
+
+  const body = (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        className="card p-6 w-full max-w-md max-h-[90vh] overflow-y-auto bg-theme-surface border border-theme-stroke rounded-2xl shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold text-theme-text truncate">
+              {data?.name || (loading ? 'Loading…' : 'Host payment details')}
+            </h2>
+            {data?.email && (
+              <div className="text-xs text-theme-text-muted mt-0.5 flex items-center gap-1.5">
+                <ClickableEmail email={data.email} />
+                <CopyButton value={data.email} label="email" />
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted shrink-0"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center py-10 text-theme-text-muted">
+            <Loader2 size={20} className="animate-spin mr-2" />
+            Loading payment details…
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-sm text-red-400">
+            <AlertCircle size={16} className="mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {data && !loading && !error && (
+          <div className="space-y-4">
+            {/* Method row */}
+            <div>
+              <p className="text-xs uppercase tracking-wide text-theme-text-muted mb-1.5">
+                Preferred method
+              </p>
+              {data.preferredPayoutMethod ? (
+                <div className="flex items-center gap-2 text-sm text-theme-text">
+                  <PayoutMethodIcon method={data.preferredPayoutMethod} size={16} />
+                  <span>{PAYOUT_METHOD_LABELS[data.preferredPayoutMethod]}</span>
+                </div>
+              ) : (
+                <div className="text-sm text-theme-text-muted italic">
+                  No payment method on file
+                </div>
+              )}
+            </div>
+
+            {/* Method-specific body */}
+            {data.preferredPayoutMethod === 'usdc_base' && (
+              <div>
+                <p className="text-xs uppercase tracking-wide text-theme-text-muted mb-1.5">
+                  Wallet address
+                </p>
+                {data.payoutWalletAddress ? (
+                  <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface-hover border border-theme-stroke">
+                    <code className="text-xs text-theme-text break-all flex-1">
+                      {data.payoutWalletAddress}
+                    </code>
+                    <CopyButton value={data.payoutWalletAddress} label="address" />
+                  </div>
+                ) : (
+                  <div className="text-sm text-theme-text-muted italic">
+                    Wallet not set
+                  </div>
+                )}
+              </div>
+            )}
+
+            {data.preferredPayoutMethod === 'wire' && (
+              <div>
+                <p className="text-xs uppercase tracking-wide text-theme-text-muted mb-1.5">
+                  Bank correspondence email
+                </p>
+                {data.payoutBankDetails?.email ? (
+                  <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface-hover border border-theme-stroke">
+                    <span className="text-sm text-theme-text break-all flex-1">
+                      {data.payoutBankDetails.email}
+                    </span>
+                    <CopyButton value={data.payoutBankDetails.email} label="email" />
+                  </div>
+                ) : (
+                  <div className="text-sm text-theme-text-muted italic">
+                    No bank email on file
+                  </div>
+                )}
+                <p className="text-xs text-theme-text-muted mt-1.5">
+                  Routing / account details are intentionally not shown here — collect them
+                  out-of-band over the bank email.
+                </p>
+              </div>
+            )}
+
+            {data.preferredPayoutMethod === 'mercury_card' && (
+              <div className="text-sm text-theme-text-muted">
+                Card is emailed by Mercury — no recipient details to display.
+              </div>
+            )}
+
+            {/* Activity blurb */}
+            <div className="pt-3 border-t border-theme-stroke">
+              <p className="text-xs text-theme-text-muted">
+                {data.totalPayouts} payout{data.totalPayouts === 1 ? '' : 's'}
+                {data.latestPayoutAt
+                  ? ` • latest ${new Date(data.latestPayoutAt).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}`
+                  : ' • no payouts yet'}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(body, document.body);
+};
+
+/** Inline copy-to-clipboard button with a 1.5s "copied!" flash. */
+const CopyButton: React.FC<{ value: string; label: string }> = ({ value, label }) => {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={async (e) => {
+        e.stopPropagation();
+        try {
+          await navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          // Clipboard unavailable — silently no-op.
+        }
+      }}
+      className="p-1 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover shrink-0"
+      title={`Copy ${label}`}
+      aria-label={`Copy ${label}`}
+    >
+      {copied ? <Check size={14} className="text-emerald-500" /> : <Copy size={14} />}
+    </button>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -15,6 +15,11 @@ interface PayoutsTableProps {
   onMarkPaid: (payout: AdminPayout) => void;
   /** Opens the modal so the admin can execute via the method-specific confirmation form. */
   onExecute: (payout: AdminPayout) => void;
+  /**
+   * siciliana-69183: open the read-only HostPaymentDetailsModal for the given
+   * User.id. Surfaced when the admin clicks the host name in a row.
+   */
+  onHostClick?: (userId: string) => void;
   busyRowId?: string | null;
   loading?: boolean;
   loadingMore?: boolean;
@@ -122,6 +127,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
   onEdit,
   onMarkPaid,
   onExecute,
+  onHostClick,
   busyRowId,
   loading,
   loadingMore,
@@ -180,6 +186,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
                 selected={selectedIds.has(p.id)}
                 onSelectToggle={() => onToggleSelect(p.id)}
                 onClick={() => onRowClick(p)}
+                onHostClick={onHostClick}
                 actions={
                   <ActionsCell
                     payout={p}

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { AlertTriangle, Star } from 'lucide-react';
 import type { PrepayCandidate, PrepayQueueRow } from '../../types';
 import { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from '../payments-shared';
@@ -6,6 +7,12 @@ import { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from '../payments-shared';
 interface PrepayQueueTableProps {
   rows: PrepayQueueRow[];
   onCreatePrepayment: (row: PrepayQueueRow) => void;
+  /**
+   * siciliana-69183: open the read-only HostPaymentDetailsModal for the chosen
+   * candidate. Parent (`PaymentsAdminPage`) owns the modal state — we just
+   * surface the click event with the User.id.
+   */
+  onHostClick?: (userId: string) => void;
 }
 
 /**
@@ -21,21 +28,46 @@ function stripGppPrefix(name: string): string {
  * bismarck-92103: small chip rendered per candidate inside the Hosts cell.
  * Method icon comes from the shared PayoutMethodIcon. Primary host gets a
  * star prefix so the admin can distinguish them at a glance.
+ *
+ * siciliana-69183: becomes a button when `onClick` is supplied so the admin
+ * can drill into the candidate's saved payment details.
  */
-const HostChip: React.FC<{ candidate: PrepayCandidate }> = ({ candidate }) => {
+const HostChip: React.FC<{
+  candidate: PrepayCandidate;
+  onClick?: () => void;
+}> = ({ candidate, onClick }) => {
   const displayName = candidate.name && candidate.name.trim()
     ? candidate.name
     : candidate.email;
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-theme-surface-hover border border-theme-stroke text-xs text-theme-text"
-      title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]}`}
-    >
+  const inner = (
+    <>
       {candidate.isPrimaryHost && (
         <Star size={11} className="text-amber-500 shrink-0" aria-label="Primary host" />
       )}
       <PayoutMethodIcon method={candidate.method} size={12} />
       <span className="truncate max-w-[12rem]">{displayName}</span>
+    </>
+  );
+  const baseClass =
+    'inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-theme-surface-hover border border-theme-stroke text-xs text-theme-text';
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`${baseClass} hover:border-theme-stroke-hover hover:bg-theme-surface-active cursor-pointer`}
+        title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]} · click for payment details`}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <span
+      className={baseClass}
+      title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]}`}
+    >
+      {inner}
     </span>
   );
 };
@@ -43,6 +75,7 @@ const HostChip: React.FC<{ candidate: PrepayCandidate }> = ({ candidate }) => {
 export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
   rows,
   onCreatePrepayment,
+  onHostClick,
 }) => {
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
@@ -59,6 +92,11 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
           <tbody>
             {rows.map((row) => {
               const cap = row.party.effectiveReimbursementCapUsd;
+              // siciliana-69183: event name links into the host dashboard's
+              // Settings tab. Slug is `customUrl ?? id` to match user-facing
+              // URLs. Tab id `'details'` is the canonical Settings tab (see
+              // `frontend/src/lib/tabPermissions.ts`).
+              const eventSlug = row.party.customUrl ?? row.party.id;
               return (
                 <tr
                   key={row.party.id}
@@ -66,9 +104,12 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                 >
                   <td className="px-3 py-3 align-top">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium text-theme-text truncate">
+                      <Link
+                        to={`/host/${eventSlug}/details`}
+                        className="font-medium text-theme-text hover:text-[#E52828] hover:underline truncate"
+                      >
                         {stripGppPrefix(row.party.name)}
-                      </span>
+                      </Link>
                       {row.hasMultipleCandidates && (
                         <span
                           className="inline-flex items-center text-amber-500"
@@ -87,7 +128,11 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                   <td className="px-3 py-3 align-top">
                     <div className="flex flex-wrap gap-1.5">
                       {row.candidates.map((c) => (
-                        <HostChip key={c.userId} candidate={c} />
+                        <HostChip
+                          key={c.userId}
+                          candidate={c}
+                          onClick={onHostClick ? () => onHostClick(c.userId) : undefined}
+                        />
                       ))}
                     </div>
                   </td>

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -6,3 +6,5 @@ export { BulkActionsBar } from './BulkActionsBar';
 export { ExternalPaymentModal } from './ExternalPaymentModal';
 export { PrepayQueueTable } from './PrepayQueueTable';
 export { CreatePrepaymentModal } from './CreatePrepaymentModal';
+export { HostPaymentDetailsModal } from './HostPaymentDetailsModal';
+export { ExportSafeJsonModal } from './ExportSafeJsonModal';

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import type { AdminPayout, Payout } from '../../types';
 import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
@@ -22,6 +23,12 @@ interface PayoutRowProps {
   onClick?: () => void;
   /** Extra cell rendered at the end of the row (admin actions menu). */
   actions?: React.ReactNode;
+  /**
+   * siciliana-69183: when set + showAdminColumns is on, the host-name cell
+   * becomes a button that opens the read-only HostPaymentDetailsModal for
+   * `payout.hostUserId`. Parent owns the modal state.
+   */
+  onHostClick?: (userId: string) => void;
 }
 
 /**
@@ -38,6 +45,7 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
   onSelectToggle,
   onClick,
   actions,
+  onHostClick,
 }) => {
   const admin = payout as AdminPayout;
   const firstPizza = (payout.documents || []).find((d) => d.kind === 'pizza');
@@ -76,8 +84,22 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       </td>
 
       {showAdminColumns && admin.host && (
-        <td className="px-3 py-3 text-sm">
-          <div className="font-medium text-theme-text">{admin.host.name || '—'}</div>
+        <td className="px-3 py-3 text-sm" onClick={(e) => e.stopPropagation()}>
+          {/* siciliana-69183: when `onHostClick` is wired, the host name becomes
+              a button that opens the read-only HostPaymentDetailsModal. Falls
+              back to plain text for any callsite that doesn't want the modal. */}
+          {onHostClick && payout.hostUserId ? (
+            <button
+              type="button"
+              onClick={() => onHostClick(payout.hostUserId)}
+              className="font-medium text-theme-text hover:text-[#E52828] hover:underline text-left"
+              title="View saved payment details"
+            >
+              {admin.host.name || admin.host.email || '—'}
+            </button>
+          ) : (
+            <div className="font-medium text-theme-text">{admin.host.name || '—'}</div>
+          )}
           {admin.host.email && (
             <div className="text-xs text-theme-text-muted">
               <ClickableEmail email={admin.host.email} />
@@ -88,15 +110,16 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
 
       {showAdminColumns && admin.party && (
         <td className="px-3 py-3 text-sm">
-          <a
-            href={`/host/${admin.party.inviteCode}`}
-            className="text-theme-text hover:underline"
+          {/* siciliana-69183: link to the host dashboard's Settings tab. Slug is
+              customUrl ?? inviteCode to match user-facing URLs. Tab id 'details'
+              is the canonical Settings tab id (see tabPermissions.ts). */}
+          <Link
+            to={`/host/${admin.party.customUrl ?? admin.party.inviteCode}/details`}
+            className="text-theme-text hover:text-[#E52828] hover:underline"
             onClick={(e) => e.stopPropagation()}
-            target="_blank"
-            rel="noopener noreferrer"
           >
             {admin.party.name}
-          </a>
+          </Link>
           {/* arugula-38633 v2 follow-up: planning vs actuals at a glance. */}
           <div
             className="text-xs text-theme-text-muted"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3985,6 +3985,28 @@ export async function recordExternalPayment(
 }
 
 /**
+ * siciliana-69183: fetch a host's saved payment details for the admin
+ * HostPaymentDetailsModal (host-name click in prepay queue + payouts table).
+ * Backed by `GET /api/admin/users/:userId/payment-details`. Admin-gated.
+ */
+export interface UserPaymentDetails {
+  userId: string;
+  name: string | null;
+  email: string;
+  preferredPayoutMethod: PayoutMethod | null;
+  payoutWalletAddress: string | null;
+  payoutBankDetails: { email?: string | null } | null;
+  totalPayouts: number;
+  latestPayoutAt: string | null;
+}
+
+export async function fetchUserPaymentDetails(userId: string): Promise<UserPaymentDetails> {
+  return apiRequest<UserPaymentDetails>(
+    `/api/admin/users/${encodeURIComponent(userId)}/payment-details`,
+  );
+}
+
+/**
  * bismarck-92103: list approved parties flagged for prepayment whose host(s)
  * have a saved payment method, excluding parties that already have an
  * in-flight payout. Surfaced as the "Prepay queue" section on /payments.

--- a/frontend/src/lib/safeTransactionBuilder.ts
+++ b/frontend/src/lib/safeTransactionBuilder.ts
@@ -1,0 +1,143 @@
+import type { AdminPayout } from '../types';
+
+/**
+ * siciliana-69183: Build a Gnosis Safe Transaction Builder v1.0 batch JSON
+ * from a list of selected payouts on the admin /payments dashboard. The
+ * admin downloads the resulting file and drag-and-drops it into the Safe
+ * Transaction Builder app to execute the batch from the PizzaDAO Safe.
+ *
+ * Filter rules (must match the airdrop-CSV filter used elsewhere):
+ *   - payoutMethod === 'usdc_base'   (Mercury / wire can't be batched on Safe)
+ *   - payoutWalletAddress matches /^0x[0-9a-fA-F]{40}$/
+ *     (ENS strings should already be resolved per taleggio-30219 — anything
+ *      that doesn't match is malformed and is silently skipped, counted in
+ *      the modal's "skipped" tally)
+ *   - finalAmountUsd > 0
+ *
+ * Amount conversion: USDC on Base has 6 decimals. We multiply by 1e6 and
+ * round to the nearest integer, then `.toString()` the BigInt for the JSON
+ * "amount" field (Safe expects a decimal string).
+ *
+ * The `label` argument only affects the `meta.name` / `meta.description`
+ * and the downloaded filename — it does NOT re-derive amounts. The prepay
+ * queue already persists 50% of the cap as `finalAmountUsd`, so the math
+ * is already done by the time payouts reach this batcher.
+ */
+
+/** USDC contract on Base mainnet. */
+export const USDC_BASE_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+/** Base mainnet chainId, as a stringified number (Safe expects a string). */
+export const BASE_CHAIN_ID = '8453';
+
+/** Tx-builder schema version we target. */
+const SAFE_TX_BUILDER_VERSION = '1.16.5';
+
+export type SafeBatchLabel = 'prepayment_50' | 'final' | 'custom';
+
+export interface SafeBatchResult {
+  /** Pretty-printed JSON ready to drop into a Blob. */
+  json: string;
+  /** Count of payouts that made it into the batch. */
+  included: number;
+  /** Count of payouts that were filtered out (non-USDC / bad wallet / $0). */
+  skipped: number;
+  /** Suggested download filename, e.g. `safe-batch-prepayment-50-2026-05-20.json`. */
+  filename: string;
+}
+
+function humanLabel(label: SafeBatchLabel): string {
+  switch (label) {
+    case 'prepayment_50':
+      return '50% Prepayment';
+    case 'final':
+      return 'Final Payment';
+    case 'custom':
+    default:
+      return 'Custom batch';
+  }
+}
+
+/**
+ * Build the batch + filename + count summary. Pure — no DOM / fetch side
+ * effects. Caller is responsible for triggering the download.
+ */
+export function buildSafeBatch(
+  payouts: AdminPayout[],
+  label: SafeBatchLabel,
+): SafeBatchResult {
+  const walletRe = /^0x[0-9a-fA-F]{40}$/;
+
+  const valid = payouts.filter((p) => {
+    if (p.payoutMethod !== 'usdc_base') return false;
+    if (typeof p.payoutWalletAddress !== 'string') return false;
+    const addr = p.payoutWalletAddress.trim();
+    if (!walletRe.test(addr)) return false;
+    const amt = Number(p.finalAmountUsd);
+    if (!Number.isFinite(amt) || amt <= 0) return false;
+    return true;
+  });
+
+  const labelHuman = humanLabel(label);
+  const date = new Date().toISOString().slice(0, 10);
+
+  const batch = {
+    version: '1.0',
+    chainId: BASE_CHAIN_ID,
+    createdAt: Date.now(),
+    meta: {
+      name: `PizzaDAO ${labelHuman}`,
+      description:
+        `${valid.length} USDC-on-Base transfers from PizzaDAO Safe — generated ${date}`,
+      txBuilderVersion: SAFE_TX_BUILDER_VERSION,
+      createdFromSafeAddress: '',
+      createdFromOwnerAddress: '',
+      checksum: '',
+    },
+    transactions: valid.map((p) => ({
+      to: USDC_BASE_ADDRESS,
+      value: '0',
+      data: null as null,
+      contractMethod: {
+        inputs: [
+          { internalType: 'address', name: 'to', type: 'address' },
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'transfer',
+        payable: false,
+      },
+      contractInputsValues: {
+        to: (p.payoutWalletAddress as string).trim(),
+        amount: BigInt(Math.round(Number(p.finalAmountUsd) * 1_000_000)).toString(),
+      },
+    })),
+  };
+
+  const filename = `safe-batch-${label}-${date}.json`;
+
+  return {
+    json: JSON.stringify(batch, null, 2),
+    included: valid.length,
+    skipped: payouts.length - valid.length,
+    filename,
+  };
+}
+
+/**
+ * Trigger a browser download for the given Safe-batch result. Creates a Blob,
+ * binds it to a temporary <a download>, clicks it, and revokes the object
+ * URL. No-op when running in a non-DOM environment (e.g. unit tests via jsdom
+ * fallback).
+ */
+export function downloadSafeBatch(result: SafeBatchResult): void {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') return;
+  const blob = new Blob([result.json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = result.filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -32,6 +32,8 @@ import {
   ExternalPaymentModal,
   PrepayQueueTable,
   CreatePrepaymentModal,
+  HostPaymentDetailsModal,
+  ExportSafeJsonModal,
 } from '../components/payments-admin';
 
 type RoleState =
@@ -74,6 +76,29 @@ export function PaymentsAdminPage() {
   // bismarck-92103: prepay queue + the "Create prepayment" modal target row.
   const [prepayQueue, setPrepayQueue] = useState<PrepayQueueRow[]>([]);
   const [prepayModalRow, setPrepayModalRow] = useState<PrepayQueueRow | null>(null);
+
+  // siciliana-69183: clickable host name opens the read-only payment-details
+  // modal. Holds the User.id; null = modal closed.
+  const [hostDetailUserId, setHostDetailUserId] = useState<string | null>(null);
+
+  // siciliana-69183: Safe Transaction Builder JSON export. Modal is mounted
+  // when true; the modal itself filters non-USDC / missing-wallet rows.
+  const [showSafeExportModal, setShowSafeExportModal] = useState(false);
+
+  // siciliana-69183: tiny toast stack (matches AdminLogoCleanup pattern).
+  // Surfaces post-prepayment success + post-export confirmations.
+  type Toast = { id: number; message: string; kind: 'success' | 'error' };
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const pushToast = useCallback(
+    (message: string, kind: 'success' | 'error' = 'success') => {
+      const id = Date.now() + Math.random();
+      setToasts((prev) => [...prev, { id, message, kind }]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 3000);
+    },
+    [],
+  );
 
   const loadPrepayQueue = useCallback(async () => {
     try {
@@ -145,6 +170,14 @@ export function PaymentsAdminPage() {
     return Array.from(set).sort();
   }, [payouts]);
 
+  // siciliana-69183: derive the AdminPayout objects matching `selectedIds` for
+  // the Safe-export modal. The modal itself filters non-USDC / missing-wallet
+  // rows; we just hand it the full selection.
+  const selectedPayouts = useMemo(
+    () => payouts.filter((p) => selectedIds.has(p.id)),
+    [payouts, selectedIds],
+  );
+
   function toggleSelect(id: string) {
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -172,8 +205,17 @@ export function PaymentsAdminPage() {
   // bismarck-92103: after a prepayment is created, refresh BOTH the payouts
   // list (so the new pending payout shows up there) and the prepay queue (so
   // the source row drops off — it now has an in-flight payout).
-  async function handlePrepaymentCreated() {
+  // siciliana-69183: also flash a success toast with the host + amount so
+  // it's clear where the new payout went (the source row drops off the prepay
+  // queue silently otherwise).
+  async function handlePrepaymentCreated(summary?: { hostName: string; amountUsd: number }) {
     await Promise.all([refresh(), loadPrepayQueue()]);
+    if (summary) {
+      pushToast(
+        `Created prepayment for ${summary.hostName} — $${summary.amountUsd.toFixed(2)}`,
+        'success',
+      );
+    }
   }
 
   async function openDetail(p: AdminPayout) {
@@ -371,6 +413,7 @@ export function PaymentsAdminPage() {
             <PrepayQueueTable
               rows={prepayQueue}
               onCreatePrepayment={(row) => setPrepayModalRow(row)}
+              onHostClick={(userId) => setHostDetailUserId(userId)}
             />
           </section>
         )}
@@ -387,6 +430,7 @@ export function PaymentsAdminPage() {
           onApprove={handleBulkApprove}
           onReject={handleBulkReject}
           onMarkPaid={handleBulkMarkPaid}
+          onExportSafeJson={() => setShowSafeExportModal(true)}
           onClear={clearSelection}
           busy={bulkBusy}
         />
@@ -408,6 +452,7 @@ export function PaymentsAdminPage() {
           onEdit={openDetail}
           onMarkPaid={handleRowMarkPaid}
           onExecute={openDetail}
+          onHostClick={(userId) => setHostDetailUserId(userId)}
           busyRowId={rowBusyId}
           loading={loading}
           loadingMore={loadingMore}
@@ -542,6 +587,46 @@ export function PaymentsAdminPage() {
             onClose={() => setPrepayModalRow(null)}
             onCreated={handlePrepaymentCreated}
           />
+        )}
+
+        {/* siciliana-69183: read-only host payment-details modal — opens when
+            the admin clicks a host name on the prepay queue or payouts table. */}
+        <HostPaymentDetailsModal
+          userId={hostDetailUserId}
+          onClose={() => setHostDetailUserId(null)}
+        />
+
+        {/* siciliana-69183: Safe Transaction Builder batch export. */}
+        {showSafeExportModal && (
+          <ExportSafeJsonModal
+            selected={selectedPayouts}
+            onClose={() => setShowSafeExportModal(false)}
+            onExported={(summary) => {
+              pushToast(
+                `Exported Safe batch: ${summary.included} transfer${summary.included === 1 ? '' : 's'}` +
+                  (summary.skipped > 0 ? ` (${summary.skipped} skipped)` : ''),
+                'success',
+              );
+            }}
+          />
+        )}
+
+        {/* siciliana-69183: toast stack (bottom-right, 3s auto-dismiss). */}
+        {toasts.length > 0 && (
+          <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 max-w-sm pointer-events-none">
+            {toasts.map((t) => (
+              <div
+                key={t.id}
+                className={`pointer-events-auto rounded-lg px-4 py-3 text-sm shadow-lg border-l-4 ${
+                  t.kind === 'success'
+                    ? 'bg-emerald-500/15 border-emerald-500 text-emerald-100'
+                    : 'bg-red-500/15 border-red-500 text-red-100'
+                }`}
+              >
+                {t.message}
+              </div>
+            ))}
+          </div>
         )}
 
         {/* meUserId placeholder to silence unused-warning while client-side comparison stays optional */}


### PR DESCRIPTION
## Summary
- New `GET /api/admin/users/:id/payment-details` admin-only endpoint (returns method, wallet, bank email, payouts-count + latest-payout-at).
- New `HostPaymentDetailsModal` opens on host-name click in the prepay queue + payouts table (read-only, with copy buttons).
- Event names in the prepay queue + payouts table now link to `/host/:slug/details` (the canonical Settings tab — tab id is `'details'` in `tabPermissions.ts`).
- New `ExportSafeJsonModal` builds a Safe Transaction Builder v1.0 batch from selected USDC payouts. USDC contract `0x8335...2913` on Base (chainId 8453). USDC 6-decimal scaling baked in. Transaction-type selector (50% Prepayment / Final / Custom) controls only the batch meta + filename; amounts come straight from each payout's `finalAmountUsd`. Non-USDC / missing-wallet rows are silently skipped (count surfaced in the modal).
- Success toast on prepayment-create ("Created prepayment for X - $Y").

## Test plan
- [ ] Click a host chip in the prepay queue -> modal opens with wallet/email; copy buttons work.
- [ ] Click a host name in the payouts table -> same modal.
- [ ] Click an event name in either table -> opens that event's dashboard at the Settings tab.
- [ ] Select 3 USDC payouts + 1 mercury -> Export Safe JSON -> downloaded JSON has 3 transactions (1 skipped surfaced in modal).
- [ ] Drag the JSON into Safe Tx Builder app -> parses, shows 3 USDC transfers to the right addresses with right amounts.
- [ ] Create prepayment -> green toast bottom-right confirms the host + amount.
- [ ] Non-admin hitting `GET /api/admin/users/:id/payment-details` -> 403.

Generated with [Claude Code](https://claude.com/claude-code)