### PR TITLE
fix(crudo-91827): in-app reject modal + refresh prepay queue on reject/approve

### DIFF
--- a/frontend/src/components/payments-admin/RejectReasonModal.tsx
+++ b/frontend/src/components/payments-admin/RejectReasonModal.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, MessageSquare, Loader2 } from 'lucide-react';
+import { IconInput } from '../IconInput';
+
+export interface RejectReasonModalProps {
+  isOpen: boolean;
+  /**
+   * What we're rejecting — used in the modal heading.
+   *  - single: `Reject payment for {hostName}?`
+   *  - bulk:   `Reject {n} payments?`
+   */
+  context:
+    | { kind: 'single'; hostName: string }
+    | { kind: 'bulk'; count: number };
+  onCancel: () => void;
+  onConfirm: (reason: string) => Promise<void>;
+}
+
+const MAX_LEN = 1000;
+
+/**
+ * crudo-91827: In-app replacement for `window.prompt('Rejection reason...')`,
+ * which is silently blocked by popup blockers / Brave / Arc / many browser
+ * extensions — making the /payments Reject (X) button appear to do nothing
+ * for some admins.
+ *
+ * Uses the standard project modal pattern: createPortal → fixed backdrop
+ * (`bg-black/60 backdrop-blur-sm`) → `z-50` → click-outside-to-close → card
+ * body. Caller is responsible for closing the modal on success (so it can
+ * coordinate the surrounding refresh()).
+ */
+export const RejectReasonModal: React.FC<RejectReasonModalProps> = ({
+  isOpen,
+  context,
+  onCancel,
+  onConfirm,
+}) => {
+  const [reason, setReason] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Reset state whenever the modal transitions to closed (so re-opening is
+  // a clean slate).
+  useEffect(() => {
+    if (!isOpen) {
+      setReason('');
+      setBusy(false);
+      setErrorMsg(null);
+    }
+  }, [isOpen]);
+
+  // Close on Escape (only when the modal is open and not mid-submit).
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !busy) onCancel();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, busy, onCancel]);
+
+  if (!isOpen) return null;
+
+  const trimmed = reason.trim();
+  const disabled = busy || trimmed.length === 0;
+
+  const heading =
+    context.kind === 'single'
+      ? `Reject payment for ${context.hostName}?`
+      : `Reject ${context.count} payment${context.count === 1 ? '' : 's'}?`;
+
+  async function handleConfirm() {
+    if (disabled) return;
+    setErrorMsg(null);
+    setBusy(true);
+    try {
+      await onConfirm(trimmed);
+      // Caller closes the modal on success (so it can sequence refreshes
+      // first). If `onConfirm` resolves without the parent closing us, we'll
+      // still drop back to idle so the user can retry / cancel.
+    } catch (err: any) {
+      setErrorMsg(err?.message || 'Reject failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const body = (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={() => {
+        if (!busy) onCancel();
+      }}
+    >
+      <div
+        className="card p-6 w-full max-w-md max-h-[90vh] overflow-y-auto bg-theme-surface border border-theme-stroke rounded-2xl shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <h2 className="text-lg font-semibold text-theme-text">{heading}</h2>
+          <button
+            type="button"
+            onClick={() => {
+              if (!busy) onCancel();
+            }}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <IconInput
+          icon={MessageSquare}
+          multiline
+          rows={4}
+          placeholder="Why are you rejecting? (Visible to the host on their payouts list.)"
+          value={reason}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setReason(e.target.value.slice(0, MAX_LEN))
+          }
+          maxLength={MAX_LEN}
+          disabled={busy}
+          autoFocus
+        />
+        <div className="mt-1 text-xs text-theme-text-muted text-right">
+          {trimmed.length}/{MAX_LEN}
+        </div>
+
+        {errorMsg && (
+          <div className="mt-3 px-3 py-2 rounded-lg bg-red-100 text-red-700 border border-red-300 text-sm">
+            {errorMsg}
+          </div>
+        )}
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="px-4 py-2 rounded-lg text-sm text-theme-text-secondary hover:bg-theme-surface-hover disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={disabled}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium disabled:opacity-50"
+          >
+            {busy && <Loader2 size={14} className="animate-spin" />}
+            Reject
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(body, document.body);
+};

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -8,3 +8,4 @@ export { PrepayQueueTable } from './PrepayQueueTable';
 export { CreatePrepaymentModal } from './CreatePrepaymentModal';
 export { HostPaymentDetailsModal } from './HostPaymentDetailsModal';
 export { ExportSafeJsonModal } from './ExportSafeJsonModal';
+export { RejectReasonModal } from './RejectReasonModal';

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -34,6 +34,7 @@ import {
   CreatePrepaymentModal,
   HostPaymentDetailsModal,
   ExportSafeJsonModal,
+  RejectReasonModal,
 } from '../components/payments-admin';
 
 type RoleState =
@@ -84,6 +85,15 @@ export function PaymentsAdminPage() {
   // siciliana-69183: Safe Transaction Builder JSON export. Modal is mounted
   // when true; the modal itself filters non-USDC / missing-wallet rows.
   const [showSafeExportModal, setShowSafeExportModal] = useState(false);
+
+  // crudo-91827: in-app reject-reason modal target. Replaces window.prompt()
+  // which gets silently blocked by popup blockers / Brave / Arc / extensions.
+  // `null` = modal closed; either `single` (one row) or `bulk` (multi-select).
+  const [rejectTarget, setRejectTarget] = useState<
+    | { kind: 'single'; id: string; hostName: string }
+    | { kind: 'bulk'; ids: string[] }
+    | null
+  >(null);
 
   // siciliana-69183: tiny toast stack (matches AdminLogoCleanup pattern).
   // Surfaces post-prepayment success + post-export confirmations.
@@ -239,7 +249,9 @@ export function PaymentsAdminPage() {
     setRowBusyId(id);
     try {
       await approveAdminPayout(id);
-      await refresh();
+      // crudo-91827: refresh BOTH lists — an approved prepayment row stays in
+      // the payouts table but may affect prepay-queue derivations.
+      await Promise.all([refresh(), loadPrepayQueue()]);
     } catch (err: any) {
       setErrorMsg(err.message || 'Approve failed');
     } finally {
@@ -247,18 +259,15 @@ export function PaymentsAdminPage() {
     }
   }
 
+  // crudo-91827: opens the in-app reject-reason modal. The actual reject work
+  // is done by `confirmReject` once the admin types a reason and confirms.
   async function handleRowReject(id: string) {
-    const reason = window.prompt('Rejection reason (visible to host):');
-    if (!reason || !reason.trim()) return;
-    setRowBusyId(id);
-    try {
-      await rejectAdminPayout(id, reason.trim());
-      await refresh();
-    } catch (err: any) {
-      setErrorMsg(err.message || 'Reject failed');
-    } finally {
-      setRowBusyId(null);
-    }
+    const row = payouts.find((p) => p.id === id);
+    setRejectTarget({
+      kind: 'single',
+      id,
+      hostName: row?.host?.name ?? row?.host?.email ?? 'this host',
+    });
   }
 
   async function handleRowMarkPaid(p: AdminPayout) {
@@ -281,25 +290,49 @@ export function PaymentsAdminPage() {
         await approveAdminPayout(id).catch(() => null);
       }
       clearSelection();
-      await refresh();
+      // crudo-91827: refresh BOTH lists for the same reason as the row variant.
+      await Promise.all([refresh(), loadPrepayQueue()]);
     } finally {
       setBulkBusy(false);
     }
   }
 
+  // crudo-91827: opens the in-app reject-reason modal in bulk mode. Actual
+  // reject work is done by `confirmReject` once the admin confirms.
   async function handleBulkReject() {
     if (selectedIds.size === 0) return;
-    const reason = window.prompt('Rejection reason (applied to all selected):');
-    if (!reason || !reason.trim()) return;
-    setBulkBusy(true);
-    try {
-      for (const id of Array.from(selectedIds)) {
-        await rejectAdminPayout(id, reason.trim()).catch(() => null);
+    setRejectTarget({ kind: 'bulk', ids: Array.from(selectedIds) });
+  }
+
+  // crudo-91827: invoked by RejectReasonModal once the admin types a reason
+  // and clicks Reject. Performs the actual API call(s), refreshes BOTH the
+  // payouts list AND the prepay queue (a rejected prepayment correctly
+  // re-appears in the queue), and closes the modal on success.
+  async function confirmReject(reason: string) {
+    if (!rejectTarget) return;
+    if (rejectTarget.kind === 'single') {
+      setRowBusyId(rejectTarget.id);
+      try {
+        await rejectAdminPayout(rejectTarget.id, reason);
+        await Promise.all([refresh(), loadPrepayQueue()]);
+        setRejectTarget(null);
+      } catch (err: any) {
+        setErrorMsg(err.message || 'Reject failed');
+      } finally {
+        setRowBusyId(null);
       }
-      clearSelection();
-      await refresh();
-    } finally {
-      setBulkBusy(false);
+    } else {
+      setBulkBusy(true);
+      try {
+        for (const id of rejectTarget.ids) {
+          await rejectAdminPayout(id, reason).catch(() => null);
+        }
+        setSelectedIds(new Set());
+        await Promise.all([refresh(), loadPrepayQueue()]);
+        setRejectTarget(null);
+      } finally {
+        setBulkBusy(false);
+      }
     }
   }
 
@@ -594,6 +627,21 @@ export function PaymentsAdminPage() {
         <HostPaymentDetailsModal
           userId={hostDetailUserId}
           onClose={() => setHostDetailUserId(null)}
+        />
+
+        {/* crudo-91827: in-app reject-reason modal. Replaces window.prompt()
+            which gets silently blocked by popup blockers in some browsers. */}
+        <RejectReasonModal
+          isOpen={!!rejectTarget}
+          context={
+            rejectTarget?.kind === 'single'
+              ? { kind: 'single', hostName: rejectTarget.hostName }
+              : rejectTarget?.kind === 'bulk'
+              ? { kind: 'bulk', count: rejectTarget.ids.length }
+              : { kind: 'single', hostName: '' }
+          }
+          onCancel={() => setRejectTarget(null)}
+          onConfirm={confirmReject}
         />
 
         {/* siciliana-69183: Safe Transaction Builder batch export. */}


### PR DESCRIPTION
## Summary
- Replace `window.prompt()` rejection-reason dialog with `RejectReasonModal` (works in browsers that block native prompts).
- Single + bulk reject both use the new modal.
- Reject AND approve handlers now refresh BOTH the payouts list and the prepay queue, so a rejected prepayment correctly re-appears in the queue.
- No backend or schema changes.

## Test plan
- [ ] Click X on a pending row -> in-app reason modal pops (was: native prompt that got blocked).
- [ ] Cancel -> modal closes, no API call.
- [ ] Empty reason -> Reject button disabled.
- [ ] Submit reason -> payout becomes rejected; if it's a prepayment, city re-appears in prepay queue without page reload.
- [ ] Select N rows -> Bulk Reject -> modal shows "Reject N payments?" -> all N rejected with same reason; prepay queue refreshes.