### PR TITLE
feat(coppa-91827): hot wallet address + balances on /payments

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,7 +49,7 @@ import hostTelegramRoutes from './routes/host-telegram.routes.js';
 import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
-import adminPayoutRoutes from './routes/admin-payout.routes.js';
+import adminPayoutRoutes, { payoutWalletRouter } from './routes/admin-payout.routes.js';
 import graphicsAdminRoutes from './routes/graphics-admin.routes.js';
 import logoAuditRoutes from './routes/logoAudit.routes.js';
 import { sponsorUserAdminRouter, sponsorDashboardRouter } from './routes/sponsor-user.routes.js';
@@ -134,6 +134,7 @@ app.use('/api/rsvp', rsvpLimiter);
 // Routes
 app.use('/api/admin/logo-bg-audit', logoAuditRoutes); // Graphics-admin logo cleanup (before /api/admin catch-all)
 app.use('/api/admin/payouts', adminPayoutRoutes); // Host payouts admin dashboard (before /api/admin catch-all)
+app.use('/api/admin/payout-wallet', payoutWalletRouter); // coppa-91827: hot wallet address + balances (before /api/admin catch-all)
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/telegram/webhook', telegramWebhookRoutes); // Telegram inbound webhook (no auth — secret-token header gate)

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -27,7 +27,10 @@ import { AppError } from '../middleware/error.js';
 import {
   sendUsdcPayment,
   getUsdcDailyCapStatus,
+  getPayoutWalletAddress,
 } from '../services/usdc-base.service.js';
+import { createPublicClient, http, formatUnits, erc20Abi } from 'viem';
+import { base } from 'viem/chains';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { resolveWalletInput } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
@@ -1836,3 +1839,75 @@ router.post(
 export { requireAnyAdminOrPaymentAdmin, isFullAdmin };
 
 export default router;
+
+// ============================================
+// coppa-91827: payout-wallet info sub-router
+//
+// Mounted separately at `/api/admin/payout-wallet` (see backend/src/index.ts)
+// so the URL contract `/api/admin/payout-wallet/info` is a sibling of, not a
+// child under, `/api/admin/payouts/*`. Lives in this file so the auth helper
+// (`isPaymentAdmin`) and the wallet helper (`getPayoutWalletAddress`) stay
+// colocated with the rest of the payout admin surface.
+//
+// GET /info — returns the hot wallet's public address (derived from
+// USDC_PAYOUT_WALLET_PRIVATE_KEY) plus live ETH (gas) and USDC balances on
+// Base mainnet so admins can deposit funds and verify they landed without
+// leaving the dashboard.
+// ============================================
+const USDC_BASE_ADDRESS_FOR_INFO: `0x${string}` = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+export const payoutWalletRouter = Router();
+
+payoutWalletRouter.get(
+  '/info',
+  requireAuth,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      if (!(await isPaymentAdmin(req.userEmail))) {
+        throw new AppError('Admin only', 403, 'FORBIDDEN');
+      }
+
+      // Resolve the address before opening any RPC. If the env var is missing
+      // or malformed, surface a 503 with a clear remediation hint instead of
+      // leaking the underlying viem error.
+      let address: `0x${string}`;
+      try {
+        address = getPayoutWalletAddress();
+      } catch (err: any) {
+        console.error('[admin-payout-wallet] getPayoutWalletAddress failed:', err?.message || err);
+        throw new AppError(
+          'Hot wallet not configured — set USDC_PAYOUT_WALLET_PRIVATE_KEY on backend Vercel.',
+          503,
+          'HOT_WALLET_NOT_CONFIGURED',
+        );
+      }
+
+      const client = createPublicClient({
+        chain: base,
+        transport: http(process.env.BASE_RPC_URL || 'https://mainnet.base.org'),
+      });
+
+      const [ethRaw, usdcRaw] = await Promise.all([
+        client.getBalance({ address }),
+        client.readContract({
+          address: USDC_BASE_ADDRESS_FOR_INFO,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [address],
+        }) as Promise<bigint>,
+      ]);
+
+      res.json({
+        address,
+        chainId: 8453,
+        ethBalance: formatUnits(ethRaw, 18),
+        ethBalanceWei: ethRaw.toString(),
+        usdcBalance: formatUnits(usdcRaw, 6),
+        usdcBalanceUnits: usdcRaw.toString(),
+        fetchedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);

--- a/frontend/src/components/payments-admin/HotWalletCard.tsx
+++ b/frontend/src/components/payments-admin/HotWalletCard.tsx
@@ -1,0 +1,189 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Wallet, RefreshCcw, Copy, Check, AlertTriangle, Loader2 } from 'lucide-react';
+import { fetchPayoutWalletInfo, type PayoutWalletInfo } from '../../lib/api';
+
+/**
+ * coppa-91827: payout hot wallet info card.
+ *
+ * Self-fetches the wallet address + live ETH (gas) and USDC balances from
+ * `/api/admin/payout-wallet/info` on mount. Renders at the top of /payments
+ * (above PaymentsStatsCards) so admins know where to deposit funds and can
+ * verify deposits landed without leaving the dashboard.
+ *
+ * Visual states:
+ *  - Loading  → skeleton placeholders for the address + balance rows.
+ *  - Error    → amber-bordered alert with the backend message plus a
+ *               configuration hint when the wallet env var is unset.
+ *  - Ready    → address (full, monospaced) with a copy-to-clipboard button
+ *               and two balance tiles. ETH amount turns amber when below
+ *               LOW_GAS_THRESHOLD_ETH so admins notice they need to top up
+ *               gas before USDC payouts can be sent.
+ */
+
+// Below this threshold the ETH balance renders amber as a low-gas warning.
+// 0.005 ETH at Base mainnet gas prices comfortably covers many ERC-20
+// transfers, so dipping under it is the right "top me up" signal.
+const LOW_GAS_THRESHOLD_ETH = 0.005;
+
+/** Trim trailing zeros from a decimal string but keep at least 2 decimals. */
+function formatBalance(raw: string, decimals: number): string {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return raw;
+  // Show full precision for very small numbers so 0.0001 doesn't round to 0.00.
+  if (n > 0 && n < 0.01) {
+    return n.toLocaleString(undefined, { maximumFractionDigits: decimals });
+  }
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export const HotWalletCard: React.FC = () => {
+  const [info, setInfo] = useState<PayoutWalletInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErrorMsg(null);
+    try {
+      const data = await fetchPayoutWalletInfo();
+      setInfo(data);
+    } catch (err: any) {
+      setInfo(null);
+      setErrorMsg(err?.message || 'Failed to load hot wallet info');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleCopy = useCallback(async () => {
+    if (!info?.address) return;
+    try {
+      await navigator.clipboard.writeText(info.address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable — silently no-op (matches HostPaymentDetailsModal).
+    }
+  }, [info?.address]);
+
+  // Detect the "wallet not configured" 503 so we can surface a more pointed
+  // remediation hint (the backend already includes the env-var name, but we
+  // also want a styled callout that doesn't blend into a generic error).
+  const isUnconfigured = !!errorMsg && /USDC_PAYOUT_WALLET_PRIVATE_KEY/i.test(errorMsg);
+
+  const ethNum = info ? Number(info.ethBalance) : 0;
+  const lowGas = info != null && Number.isFinite(ethNum) && ethNum < LOW_GAS_THRESHOLD_ETH;
+
+  return (
+    <section className="card p-4 sm:p-5 mb-6">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="w-9 h-9 rounded-lg bg-emerald-500/15 flex items-center justify-center shrink-0">
+          <Wallet size={18} className="text-emerald-600" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h2 className="text-base font-semibold text-theme-text">Hot wallet (Base)</h2>
+          <p className="text-xs text-theme-text-muted">
+            Self-custodied payout wallet — funds outgoing USDC payments.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          disabled={loading}
+          className="p-2 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover disabled:opacity-50"
+          title="Refresh balances"
+          aria-label="Refresh balances"
+        >
+          {loading
+            ? <Loader2 size={14} className="animate-spin" />
+            : <RefreshCcw size={14} />}
+        </button>
+      </div>
+
+      {errorMsg ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 flex items-start gap-2">
+          <AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" />
+          <div className="text-sm text-amber-200">
+            <div className="font-medium">Hot wallet unavailable</div>
+            <div className="text-amber-200/80 mt-0.5 break-words">{errorMsg}</div>
+            {isUnconfigured && (
+              <div className="text-xs text-amber-200/70 mt-1">
+                Set <span className="font-mono">USDC_PAYOUT_WALLET_PRIVATE_KEY</span> on backend Vercel
+                and redeploy.
+              </div>
+            )}
+          </div>
+        </div>
+      ) : loading && !info ? (
+        <div className="space-y-3">
+          <div className="h-8 rounded-md bg-theme-surface-hover animate-pulse" />
+          <div className="grid grid-cols-2 gap-3">
+            <div className="h-16 rounded-md bg-theme-surface-hover animate-pulse" />
+            <div className="h-16 rounded-md bg-theme-surface-hover animate-pulse" />
+          </div>
+        </div>
+      ) : info ? (
+        <>
+          <div className="flex items-center gap-2 rounded-md border border-theme-stroke bg-theme-surface px-3 py-2 mb-3">
+            <span className="font-mono text-sm text-theme-text break-all flex-1 min-w-0">
+              {info.address}
+            </span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="p-1 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover shrink-0"
+              title="Copy address"
+              aria-label="Copy address"
+            >
+              {copied
+                ? <Check size={14} className="text-emerald-500" />
+                : <Copy size={14} />}
+            </button>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-md border border-theme-stroke bg-theme-surface p-3">
+              <div className="text-xs uppercase tracking-wide text-theme-text-secondary mb-1">
+                ETH for gas
+              </div>
+              <div
+                className={`text-lg font-semibold ${lowGas ? 'text-amber-300' : 'text-theme-text'}`}
+                title={`${info.ethBalanceWei} wei`}
+              >
+                {formatBalance(info.ethBalance, 6)}
+              </div>
+              {lowGas && (
+                <div className="text-[11px] text-amber-300/80 mt-1">
+                  Below {LOW_GAS_THRESHOLD_ETH} ETH — top up to avoid stalled payouts.
+                </div>
+              )}
+            </div>
+            <div className="rounded-md border border-theme-stroke bg-theme-surface p-3">
+              <div className="text-xs uppercase tracking-wide text-theme-text-secondary mb-1">
+                USDC
+              </div>
+              <div
+                className="text-lg font-semibold text-theme-text"
+                title={`${info.usdcBalanceUnits} base units`}
+              >
+                {formatBalance(info.usdcBalance, 6)}
+              </div>
+            </div>
+          </div>
+
+          <div className="text-xs text-theme-text-muted mt-3">
+            Send only ETH (gas) and USDC on Base (chainId {info.chainId}) — other tokens/chains will be lost.
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -9,3 +9,4 @@ export { CreatePrepaymentModal } from './CreatePrepaymentModal';
 export { HostPaymentDetailsModal } from './HostPaymentDetailsModal';
 export { ExportSafeJsonModal } from './ExportSafeJsonModal';
 export { RejectReasonModal } from './RejectReasonModal';
+export { HotWalletCard } from './HotWalletCard';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4031,6 +4031,28 @@ export async function getUsdcDailyCapRemaining(): Promise<{
 }
 
 /**
+ * coppa-91827: fetch the payout hot wallet's public address + live ETH (gas)
+ * and USDC balances on Base. Admin-only. Used by `HotWalletCard` at the top
+ * of /payments so admins know where to deposit and can verify funds landed.
+ *
+ * Returns 503 if `USDC_PAYOUT_WALLET_PRIVATE_KEY` is not set on backend Vercel
+ * — apiRequest will throw with the backend-provided remediation message.
+ */
+export interface PayoutWalletInfo {
+  address: string;
+  chainId: number;
+  ethBalance: string;        // human-readable, e.g. "0.05273"
+  ethBalanceWei: string;     // BigInt string in wei
+  usdcBalance: string;       // human-readable, e.g. "1250.00"
+  usdcBalanceUnits: string;  // BigInt string in 6-decimal base units
+  fetchedAt: string;         // ISO timestamp
+}
+
+export async function fetchPayoutWalletInfo(): Promise<PayoutWalletInfo> {
+  return apiRequest<PayoutWalletInfo>('/api/admin/payout-wallet/info');
+}
+
+/**
  * Triggers the CSV export endpoint and downloads the file to the browser.
  * Returns nothing — fires a download via a temporary <a> element.
  */

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -36,6 +36,7 @@ import {
   HostPaymentDetailsModal,
   ExportSafeJsonModal,
   RejectReasonModal,
+  HotWalletCard,
 } from '../components/payments-admin';
 
 type RoleState =
@@ -462,6 +463,10 @@ export function PaymentsAdminPage() {
             Export CSV
           </button>
         </div>
+
+        {/* coppa-91827: hot wallet address + ETH/USDC balances so admins know
+            where to deposit funds and can verify they landed. Self-fetches. */}
+        <HotWalletCard />
 
         <PaymentsStatsCards totals={totals} loading={loading && !totals} />
 


### PR DESCRIPTION
## Summary
- New admin-only `GET /api/admin/payout-wallet/info` returns address + ETH/USDC balances on Base.
- New HotWalletCard above the stats cards on /payments — shows address (copy), ETH balance (amber if < 0.005), USDC balance, "Base only" warning.
- No schema or env changes; relies on existing USDC_PAYOUT_WALLET_PRIVATE_KEY.

## Test plan
- [ ] Hit endpoint as admin → 200 with address + balances.
- [ ] Hit endpoint unauthed → 403.
- [ ] /payments page renders HotWalletCard with the live address Snax can deposit to.
- [ ] Low-gas styling triggers under 0.005 ETH.