### PR TITLE
feat(bufala-83291): per-event payment opt-in via Submit button

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
   apiKeys      ApiKey[]
   aiPhoneCalls AIPhoneCall[]
   payouts      Payout[]
+  paymentOptIns PartyPaymentOptIn[] @relation("PartyPaymentOptIns")
   uploadedPayoutDocuments PayoutDocument[] @relation("PayoutDocumentUploadedBy")
   reimbursementCapAppealsSubmitted ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsByHost")
   reimbursementCapAppealsReviewed  ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsReviewedBy")
@@ -240,6 +241,7 @@ model Party {
   slugAliases           SlugAlias[]
   scorecardItems        GuestScorecardItem[]
   payouts               Payout[]
+  paymentOptIns         PartyPaymentOptIn[]
   outreachAttempts      OutreachAttempt[]
   announcements         Announcement[]
   attestations          GuestAttestation[]
@@ -1576,6 +1578,33 @@ model Payout {
   @@index([status])
   @@index([createdAt(sort: Desc)])
   @@map("payouts")
+}
+
+// ============================================
+// Per-event payment opt-in (bufala-83291)
+// ============================================
+// A row here means "this user has explicitly opted in to receive payment
+// for this event." The /payments prepay queue filters candidate hosts to
+// users with a matching opt-in row, so cohosts who set their user-level
+// payment details on one event don't automatically become prepay candidates
+// on every other event they're a cohost on.
+//
+// User-level payment prefs (`users.preferred_payout_method`, etc.) remain
+// the source of HOW to pay; this table answers WHETHER to consider them.
+//
+// Backfilled at migration time from `payouts` so any host who has already
+// submitted a real payout for an event keeps appearing as a candidate
+// without re-clicking Submit.
+model PartyPaymentOptIn {
+  partyId    String   @map("party_id") @db.Uuid
+  party      Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  userId     String   @map("user_id")
+  user       User     @relation("PartyPaymentOptIns", fields: [userId], references: [id], onDelete: Cascade)
+  optedInAt  DateTime @default(now()) @map("opted_in_at") @db.Timestamptz
+
+  @@id([partyId, userId])
+  @@index([partyId])
+  @@map("party_payment_opt_ins")
 }
 
 model PayoutDocument {

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -736,11 +736,17 @@ router.get(
         return;
       }
 
-      // 5. For each assembled row, drop it if ANY candidate already has an
-      //    in-flight payout for that party. "In-flight" = pending/approved/paid
-      //    (failed/rejected don't count — that prepayment never went through).
-      //    Run as a single grouped query: pull all matching payouts and bucket
-      //    by partyId in memory.
+      // 5. bufala-83291: filter each party's candidates to users who have
+      //    EXPLICITLY opted in via the Submit button on PaymentDetailsCard.
+      //    A user-level `preferredPayoutMethod` is the source of HOW to pay
+      //    them; the opt-in row in `party_payment_opt_ins` is the source of
+      //    WHETHER to consider them for a given event. This stops a cohost
+      //    who set payment details on event X from auto-appearing as a
+      //    candidate on every other event they're a cohost on.
+      //
+      //    Backfill at migration time inserted one opt-in row per existing
+      //    payout, so hosts who already submitted a payout remain candidates
+      //    without re-clicking Submit.
       const partyIds = assembled.map(r => r.partyMeta.id);
       const allCandidateUserIds = new Set<string>();
       for (const r of assembled) {
@@ -749,11 +755,59 @@ router.get(
         }
       }
 
-      const inFlight = allCandidateUserIds.size
-        ? await prisma.payout.findMany({
+      const optIns = allCandidateUserIds.size
+        ? await prisma.partyPaymentOptIn.findMany({
             where: {
               partyId: { in: partyIds },
-              hostUserId: { in: Array.from(allCandidateUserIds) },
+              userId: { in: Array.from(allCandidateUserIds) },
+            },
+            select: { partyId: true, userId: true },
+          })
+        : [];
+      const optInByParty = new Map<string, Set<string>>();
+      for (const row of optIns) {
+        let set = optInByParty.get(row.partyId);
+        if (!set) {
+          set = new Set<string>();
+          optInByParty.set(row.partyId, set);
+        }
+        set.add(row.userId);
+      }
+
+      // Apply opt-in filter in place; drop parties where no candidate remains.
+      const optedInAssembled: AssembledRow[] = [];
+      for (const r of assembled) {
+        const optInSet = optInByParty.get(r.partyMeta.id);
+        if (!optInSet || optInSet.size === 0) continue;
+        const filtered = r.candidates.filter(c => optInSet.has(c.userId));
+        if (filtered.length === 0) continue;
+        optedInAssembled.push({ partyMeta: r.partyMeta, candidates: filtered });
+      }
+
+      if (optedInAssembled.length === 0) {
+        res.json({ rows: [] });
+        return;
+      }
+
+      // Recompute candidate-id set after opt-in filtering so the in-flight
+      // query below only fetches payouts we still care about.
+      const filteredCandidateUserIds = new Set<string>();
+      for (const r of optedInAssembled) {
+        for (const c of r.candidates) {
+          filteredCandidateUserIds.add(c.userId);
+        }
+      }
+
+      // 6. For each assembled row, drop it if ANY candidate already has an
+      //    in-flight payout for that party. "In-flight" = pending/approved/paid
+      //    (failed/rejected don't count — that prepayment never went through).
+      //    Run as a single grouped query: pull all matching payouts and bucket
+      //    by partyId in memory.
+      const inFlight = filteredCandidateUserIds.size
+        ? await prisma.payout.findMany({
+            where: {
+              partyId: { in: optedInAssembled.map(r => r.partyMeta.id) },
+              hostUserId: { in: Array.from(filteredCandidateUserIds) },
               status: { in: ['pending', 'approved', 'paid'] },
             },
             select: { partyId: true, hostUserId: true },
@@ -770,7 +824,7 @@ router.get(
         set.add(row.hostUserId);
       }
 
-      const finalRows = assembled
+      const finalRows = optedInAssembled
         .filter(r => {
           const inFlightSet = inFlightByParty.get(r.partyMeta.id);
           if (!inFlightSet || inFlightSet.size === 0) return true;

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -1872,4 +1872,84 @@ router.get('/:partyId/broadcast-urls', async (req: AuthRequest, res: Response, n
   }
 });
 
+// ============================================
+// bufala-83291: per-event payment opt-in
+// ============================================
+// User-level payout prefs (`users.preferred_payout_method`) describe HOW to
+// pay a host across all of their events. The /payments prepay queue also
+// requires WHETHER the host has explicitly opted in for a specific event,
+// which is what these endpoints toggle.
+//
+// All three are gated by `canUserEditParty` (host or cohost), so each cohost
+// can only opt themselves in / out, not other cohosts.
+
+// GET /api/parties/:partyId/payment-opt-in — current user's opt-in state
+router.get('/:partyId/payment-opt-in', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const userId = req.userId;
+    if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+    const row = await prisma.partyPaymentOptIn.findUnique({
+      where: { partyId_userId: { partyId, userId } },
+      select: { optedInAt: true },
+    });
+
+    res.json({
+      optedIn: !!row,
+      optedInAt: row?.optedInAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:partyId/payment-opt-in — upsert opt-in for current user
+router.post('/:partyId/payment-opt-in', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const userId = req.userId;
+    if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+    // Upsert: refresh optedInAt on re-submit so the host's most recent
+    // "Submit" click is reflected even if a row already existed.
+    const row = await prisma.partyPaymentOptIn.upsert({
+      where: { partyId_userId: { partyId, userId } },
+      create: { partyId, userId },
+      update: { optedInAt: new Date() },
+      select: { optedInAt: true },
+    });
+
+    res.json({ optedIn: true, optedInAt: row.optedInAt.toISOString() });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/parties/:partyId/payment-opt-in — revoke for current user
+router.delete('/:partyId/payment-opt-in', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const userId = req.userId;
+    if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+    await prisma.partyPaymentOptIn.deleteMany({
+      where: { partyId, userId },
+    });
+
+    res.json({ optedIn: false });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -3,7 +3,12 @@ import { Loader2, Check, AlertCircle } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePizza } from '../../contexts/PizzaContext';
 import { BankDetails, PayoutMethod } from '../../types';
-import { updateUserMe } from '../../lib/api';
+import {
+  updateUserMe,
+  getPaymentOptIn,
+  submitPaymentOptIn,
+  removePaymentOptIn,
+} from '../../lib/api';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
 import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
 
@@ -200,6 +205,118 @@ export const PaymentDetailsCard: React.FC = () => {
   // the user pick a method first; the picker still renders all three radios.
   const pickerMethod: PayoutMethod = method ?? 'mercury_card';
 
+  // ============================================
+  // bufala-83291: per-event payment opt-in
+  // ============================================
+  // The autosave above persists the user-LEVEL payout prefs (HOW to pay).
+  // A separate opt-in row in `party_payment_opt_ins` controls WHETHER this
+  // host should be considered a prepay candidate for THIS specific event.
+  // Submitting on event X does not opt the host in on event Y.
+  const partyId = party?.id ?? null;
+  const partyName = party?.name ?? 'this event';
+  const [optInLoaded, setOptInLoaded] = useState(false);
+  const [optedIn, setOptedIn] = useState(false);
+  const [optedInAt, setOptedInAt] = useState<string | null>(null);
+  const [optInPending, setOptInPending] = useState(false);
+  const [optInError, setOptInError] = useState<string | null>(null);
+
+  // Hydrate opt-in state when the party becomes available.
+  useEffect(() => {
+    if (!partyId) {
+      setOptInLoaded(false);
+      setOptedIn(false);
+      setOptedInAt(null);
+      return;
+    }
+    let cancelled = false;
+    setOptInLoaded(false);
+    getPaymentOptIn(partyId)
+      .then((res) => {
+        if (cancelled) return;
+        setOptedIn(res.optedIn);
+        setOptedInAt(res.optedInAt);
+        setOptInLoaded(true);
+      })
+      .catch(() => {
+        // Soft-fail — the Submit button will surface a real error on click.
+        if (cancelled) return;
+        setOptInLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
+  const optedInLabel = useMemo(() => {
+    if (!optedInAt) return null;
+    try {
+      return new Date(optedInAt).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return null;
+    }
+  }, [optedInAt]);
+
+  async function handleSubmitOptIn() {
+    if (!partyId) return;
+    setOptInPending(true);
+    setOptInError(null);
+    // If there's a debounced autosave still pending, flush it now so the user
+    // record is up-to-date before we mark them as opted in. The autosave fires
+    // ~1s after the last edit; we just cancel the timer and run the save inline.
+    if (saveTimer.current) {
+      window.clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+    try {
+      if (isDirty.current && methodValid && method != null) {
+        const payload = buildPayload();
+        if (payload) {
+          setSaveStatus('saving');
+          const updated = await updateUserMe(payload);
+          setUser({
+            ...(user as NonNullable<typeof user>),
+            preferredPayoutMethod: updated.preferredPayoutMethod ?? null,
+            payoutWalletAddress: updated.payoutWalletAddress ?? null,
+            payoutBankDetails: updated.payoutBankDetails ?? null,
+          });
+          isDirty.current = false;
+          setSaveStatus('saved');
+        }
+      }
+      const res = await submitPaymentOptIn(partyId);
+      setOptedIn(true);
+      setOptedInAt(res.optedInAt);
+    } catch (err: any) {
+      setOptInError(err?.message || 'Failed to submit payment details for this event');
+    } finally {
+      setOptInPending(false);
+    }
+  }
+
+  async function handleRemoveOptIn() {
+    if (!partyId) return;
+    setOptInPending(true);
+    setOptInError(null);
+    try {
+      await removePaymentOptIn(partyId);
+      setOptedIn(false);
+      setOptedInAt(null);
+    } catch (err: any) {
+      setOptInError(err?.message || 'Failed to remove opt-in');
+    } finally {
+      setOptInPending(false);
+    }
+  }
+
+  // Submit is disabled until the host has picked a method and the
+  // method-specific fields validate. Reuses the existing `methodValid` calc
+  // so the gate matches the autosave gate.
+  const submitDisabled = !partyId || optInPending || !methodValid;
+
   return (
     <div className="card p-6">
       <div className="mb-4 flex items-start justify-between gap-3">
@@ -250,6 +367,66 @@ export const PaymentDetailsCard: React.FC = () => {
 
       {saveError && (
         <p className="text-xs text-[#ff393a] mt-2">{saveError}</p>
+      )}
+
+      {/*
+        bufala-83291: per-event Submit. The autosave above keeps the user's
+        global default in sync; this section ALSO opts them in for THIS event.
+        Without an opt-in row the host won't appear on /payments as a prepay
+        candidate even if their global payment method is set.
+      */}
+      {partyId && optInLoaded && (
+        <div className="mt-5 border-t border-white/10 pt-4">
+          {!optedIn ? (
+            <div>
+              <button
+                type="button"
+                onClick={handleSubmitOptIn}
+                disabled={submitDisabled}
+                className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {optInPending ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    Submitting…
+                  </>
+                ) : (
+                  'Submit my payment details for this event'
+                )}
+              </button>
+              <p className="text-xs text-white/40 mt-2">
+                Submitting opts you in to receive payment for {partyName}. You'll
+                only be paid for events you submit for.
+              </p>
+              {!methodValid && (
+                <p className="text-xs text-white/40 mt-1">
+                  Choose a payout method above before submitting.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div>
+              <div className="flex items-center gap-2 text-sm text-emerald-500">
+                <Check size={16} />
+                <span>
+                  Submitted for {partyName}
+                  {optedInLabel ? ` on ${optedInLabel}` : ''}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleRemoveOptIn}
+                disabled={optInPending}
+                className="mt-2 text-xs text-white/50 hover:text-white/80 underline disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {optInPending ? 'Removing…' : "Remove me from this event's payments"}
+              </button>
+            </div>
+          )}
+          {optInError && (
+            <p className="text-xs text-[#ff393a] mt-2">{optInError}</p>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4478,6 +4478,40 @@ export async function updateUserMe(
   return res.user;
 }
 
+// ============================================
+// bufala-83291: per-event payment opt-in
+// ============================================
+// Toggles whether the current user is a prepay candidate for a specific
+// event. User-pref autosave (`updateUserMe` above) still tracks HOW to pay;
+// these endpoints control WHETHER a host is considered for a given event.
+
+export interface PaymentOptInState {
+  optedIn: boolean;
+  optedInAt: string | null;
+}
+
+export function getPaymentOptIn(partyId: string): Promise<PaymentOptInState> {
+  return apiRequest<PaymentOptInState>(`/api/parties/${partyId}/payment-opt-in`);
+}
+
+export async function submitPaymentOptIn(
+  partyId: string
+): Promise<{ optedIn: true; optedInAt: string }> {
+  return apiRequest<{ optedIn: true; optedInAt: string }>(
+    `/api/parties/${partyId}/payment-opt-in`,
+    { method: 'POST' }
+  );
+}
+
+export async function removePaymentOptIn(
+  partyId: string
+): Promise<{ optedIn: false }> {
+  return apiRequest<{ optedIn: false }>(
+    `/api/parties/${partyId}/payment-opt-in`,
+    { method: 'DELETE' }
+  );
+}
+
 /**
  * taleggio-30219: resolve an ENS name (e.g. `vitalik.eth`) to its 0x address
  * via the backend's mainnet-resolver utility endpoint. Returns null on any


### PR DESCRIPTION
## Summary
- New `party_payment_opt_ins` join table (migration applied to prod, with backfill from existing payouts).
- New `Submit my payment details for this event` button on PaymentDetailsCard — explicitly opts the host in for the current event. "Remove from this event" reverses it.
- /payments prepay queue now filters candidates to users with a matching opt-in row.
- User-pref autosave unchanged.

## Test plan
- [ ] Host A is cohost on events X and Y; sets payment details and Submits on X only → A appears as a candidate on X, NOT on Y.
- [ ] Host A clicks Remove on X → X drops off the prepay queue (if A was the only candidate).
- [ ] Host who submitted a real payout on event Z before this PR → still appears as a candidate via the backfill.
- [ ] Admin view: prepay queue counts reflect only opted-in candidates.