### PR TITLE
fix(formaggio-19287): hotfix flyer crash - re-add loadParty destructure

### DIFF
--- a/frontend/src/components/flyer/FlyerGenerator.tsx
+++ b/frontend/src/components/flyer/FlyerGenerator.tsx
@@ -32,7 +32,7 @@ const SPONSOR_BOX_MAX = 1080;
 
 export function FlyerGenerator({ sponsorLogoOnly }: { sponsorLogoOnly?: boolean } = {}) {
   const { t } = useTranslation('host');
-  const { party, mergeParty } = usePizza();
+  const { party, loadParty, mergeParty } = usePizza();
   const previewRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
   const [downloading, setDownloading] = useState(false);


### PR DESCRIPTION
## Summary
- Re-adds `loadParty` to `FlyerGenerator.tsx` `usePizza()` destructure.
- Fixes site-wide `Uncaught ReferenceError: loadParty is not defined` introduced by pepperoni-37294 / PR #513.

## Test plan
- [ ] Reload rsv.pizza homepage on mobile + desktop - no console error.
- [ ] Open an event page - flyer renders.