### PR TITLE
fix(passata-49102): allow re-executing failed payouts

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1650,9 +1650,9 @@ async function executePayout(params: {
   if (!existing) {
     throw new AppError('Payout not found', 404, 'NOT_FOUND');
   }
-  if (existing.status !== 'approved') {
+  if (existing.status !== 'approved' && existing.status !== 'failed') {
     throw new AppError(
-      `Can only execute an approved payout (current status: ${existing.status})`,
+      `Can only execute an approved or previously-failed payout (current status: ${existing.status})`,
       400,
       'INVALID_STATE',
     );
@@ -1866,9 +1866,9 @@ router.post(
       if (!existing) {
         throw new AppError('Payout not found', 404, 'NOT_FOUND');
       }
-      if (existing.status !== 'approved') {
+      if (existing.status !== 'approved' && existing.status !== 'failed') {
         throw new AppError(
-          `Can only execute an approved payout (current status: ${existing.status})`,
+          `Can only execute an approved or previously-failed payout (current status: ${existing.status})`,
           400,
           'INVALID_STATE',
         );

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -108,9 +108,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const ocrSum = receipts.reduce((sum, r) => sum + (Number(r.ocrAmount) || 0), 0);
 
   const isPending = payout.status === 'pending';
-  const isApproved = payout.status === 'approved';
+  const isFailed = payout.status === 'failed';
+  // passata-49102: failed payouts are now re-executable, so treat them like
+  // 'approved' for the Execute affordance (button + form).
+  const isApproved = payout.status === 'approved' || isFailed;
   const isPaid = payout.status === 'paid';
-  const isClosed = payout.status === 'rejected' || payout.status === 'failed';
+  // 'failed' is no longer "closed" — it has the Execute (Retry) button instead
+  // of Re-open. Only 'rejected' remains terminal-until-reopened.
+  const isClosed = payout.status === 'rejected';
 
   // For Mercury, last4 must be exactly 4 digits before the button enables.
   const execMercuryValid = /^\d{4}$/.test(execCardLast4.trim());
@@ -763,7 +768,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
               >
                 <Send size={14} />
-                Execute Payment
+                {isFailed ? 'Retry Payment' : 'Execute Payment'}
               </button>
               <button
                 type="button"

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -90,14 +90,14 @@ function ActionsCell({
         </>
       )}
 
-      {status === 'approved' && (
+      {(status === 'approved' || status === 'failed') && (
         <>
           <button
             type="button"
             onClick={() => onExecute(payout)}
             disabled={busy}
             className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
-            title="Execute Payment"
+            title={status === 'failed' ? 'Retry Payment' : 'Execute Payment'}
           >
             {busy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
           </button>


### PR DESCRIPTION
## Summary
- Both admin "execute" handlers in `admin-payout.routes.ts` now accept `failed` as a valid source status (in addition to `approved`).
- Error message updated to reflect the new allowed set.
- Frontend Execute affordance unhidden on failed rows (if it was hidden).
- Audit trail unchanged — every execute attempt still logs via PayoutAudit.

## Test plan
- [ ] Force-fail a test payout (e.g. wrong wallet) → status becomes `failed`.
- [ ] Click Execute again → no more 400 NOT_EXECUTABLE; the attempt proceeds.
- [ ] Successful retry → `paid`. Failed retry → still `failed`, click again.