### PR TITLE
feat(salsiccia-49102): bulk send USDC for selected payouts

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -28,6 +28,7 @@ import {
   sendUsdcPayment,
   getUsdcDailyCapStatus,
   getPayoutWalletAddress,
+  getPayoutWalletBalanceUsd,
 } from '../services/usdc-base.service.js';
 import { createPublicClient, http, formatUnits, erc20Abi } from 'viem';
 import { base } from 'viem/chains';
@@ -1882,6 +1883,213 @@ router.post(
       });
 
       res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// salsiccia-49102: POST /api/admin/payouts/bulk-execute
+//
+// Sequentially executes `sendUsdcPayment` for each eligible (USDC, approved,
+// valid 0x wallet) payout in the request body. Sequential — NOT Promise.all —
+// because the hot wallet has a single signer and viem's WalletClient manages
+// nonces per process; concurrent sends would race the nonce calculation.
+//
+// Pre-flight: fetches hot-wallet USDC balance once before the loop. If
+// balance < SUM(amounts), returns 400 INSUFFICIENT_BALANCE with the shortfall
+// so the admin doesn't watch payouts fail one-by-one mid-batch. (The per-tx
+// pre-flight inside sendUsdcPayment will still catch issues that arise after
+// the first sends drain the balance.)
+//
+// Each per-payout call delegates to the shared `executePayout` helper, which
+// already (a) sends the onchain tx, (b) flips status -> paid + writes a
+// mark_paid audit on success, (c) flips status -> failed + writes a
+// mark_failed audit on send-failure. We additionally write a single
+// `bulk_execute` audit per row so the batch context is preserved.
+//
+// Request body: { ids: string[] }   (max 50)
+// Response: BulkSendResult[] in the SAME order as the eligible ids submitted.
+// ============================================
+
+const BULK_EXECUTE_MAX_IDS = 50;
+const USDC_BASE_WALLET_RE = /^0x[0-9a-fA-F]{40}$/;
+
+interface BulkSendResult {
+  id: string;
+  success: boolean;
+  status: 'paid' | 'failed';
+  txHash?: string;
+  error?: string;
+}
+
+router.post(
+  '/bulk-execute',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+
+      const rawIds = (req.body && Array.isArray(req.body.ids)) ? req.body.ids : null;
+      if (!rawIds || rawIds.length === 0) {
+        throw new AppError('ids must be a non-empty array', 400, 'VALIDATION_ERROR');
+      }
+      if (rawIds.length > BULK_EXECUTE_MAX_IDS) {
+        throw new AppError(
+          `Too many ids: ${rawIds.length} > ${BULK_EXECUTE_MAX_IDS}. ` +
+            `Split the selection into smaller batches.`,
+          400,
+          'BULK_TOO_LARGE',
+        );
+      }
+
+      const ids: string[] = [];
+      for (const v of rawIds) {
+        if (typeof v !== 'string' || !v.trim()) {
+          throw new AppError('ids must be an array of non-empty strings', 400, 'VALIDATION_ERROR');
+        }
+        ids.push(v.trim());
+      }
+
+      // Single Prisma query for all candidates — then filter in-memory to the
+      // eligible subset (USDC + approved + valid 0x wallet). Anything missing
+      // from the DB result is silently skipped (caller's selection may
+      // include a row that was just paid/rejected by another admin).
+      const rows = await prisma.payout.findMany({
+        where: { id: { in: ids } },
+        select: {
+          id: true,
+          status: true,
+          payoutMethod: true,
+          payoutWalletAddress: true,
+          finalAmountUsd: true,
+          hostUserId: true,
+        },
+      });
+
+      const eligible: typeof rows = [];
+      for (const r of rows) {
+        if (r.payoutMethod !== 'usdc_base') continue;
+        // passata-49102: also accept 'failed' so admins can re-try previously
+        // failed USDC payouts from the same bulk-send UI without first
+        // flipping them back to 'approved'. Matches the single-execute
+        // handler's allowed-statuses set.
+        if (r.status !== 'approved' && r.status !== 'failed') continue;
+        if (!r.payoutWalletAddress || !USDC_BASE_WALLET_RE.test(r.payoutWalletAddress)) continue;
+        // Self-payout guard applies to payment_admin actors. Drop these from
+        // the eligible set so the batch doesn't 403 mid-loop; admin can
+        // execute them via another admin.
+        try {
+          assertNotSelfPayout(actor, r.hostUserId);
+        } catch {
+          continue;
+        }
+        eligible.push(r);
+      }
+
+      if (eligible.length === 0) {
+        // Empty batch is a 400 rather than a 200 with [] — the UI should
+        // never reach here (it filters client-side too) so this is most
+        // likely a stale selection.
+        throw new AppError(
+          'No eligible payouts in selection (need USDC + approved/failed + valid 0x wallet)',
+          400,
+          'NO_ELIGIBLE_PAYOUTS',
+        );
+      }
+
+      // Pre-flight balance check — one RPC call, bail the whole batch if
+      // funds are insufficient. Per-tx pre-flight inside sendUsdcPayment
+      // still runs (and will catch issues mid-batch if balance drains).
+      const totalUsd = eligible.reduce((sum, r) => sum + Number(r.finalAmountUsd), 0);
+      try {
+        const { address, balanceUsd } = await getPayoutWalletBalanceUsd();
+        if (balanceUsd < totalUsd) {
+          const shortfall = totalUsd - balanceUsd;
+          throw new AppError(
+            `Insufficient USDC balance: wallet ${address} has $${balanceUsd.toFixed(2)}, ` +
+              `batch needs $${totalUsd.toFixed(2)} (short $${shortfall.toFixed(2)})`,
+            400,
+            'INSUFFICIENT_BALANCE',
+          );
+        }
+      } catch (err: any) {
+        // Re-throw AppErrors as-is; wrap viem/RPC errors into a 503 so the
+        // admin sees a clear remediation hint instead of a raw stack.
+        if (err instanceof AppError) throw err;
+        const errMsg = err?.message || String(err);
+        console.error(`[admin-payout] bulk-execute pre-flight balance check failed: ${errMsg}`);
+        throw new AppError(
+          `Pre-flight balance check failed: ${errMsg}`,
+          503,
+          'BALANCE_CHECK_FAILED',
+        );
+      }
+
+      // SEQUENTIAL execution — nonce safety. Do NOT switch to Promise.all.
+      const results: BulkSendResult[] = [];
+      for (const row of eligible) {
+        const priorStatus = row.status; // 'approved' or 'failed' (passata-49102)
+        try {
+          const updated = await executePayout({
+            payoutId: row.id,
+            actor: { email: actor.email, actorKind: actor.actorKind },
+            body: {},
+          });
+          // Record a batch-context audit alongside the mark_paid audit that
+          // executePayout already wrote.
+          await prisma.payoutAudit.create({
+            data: {
+              payoutId: row.id,
+              action: 'bulk_execute',
+              oldStatus: priorStatus,
+              newStatus: 'paid',
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: `Bulk-send: ${eligible.length} payouts in batch`,
+            },
+          }).catch((e) => {
+            // Audit-row failure shouldn't bubble — the mark_paid audit was
+            // already written by executePayout.
+            console.warn(`[admin-payout] bulk_execute audit write failed for ${row.id}:`, e?.message || e);
+          });
+          results.push({
+            id: row.id,
+            success: true,
+            status: 'paid',
+            txHash: updated?.transactionHash ?? undefined,
+          });
+        } catch (err: any) {
+          // executePayout already flipped status -> failed + wrote a
+          // mark_failed audit for USDC send-failures (lines 1722-1744 above).
+          // Add a batch-context audit so the row's audit log shows "this
+          // failure was part of a bulk send".
+          const errMsg = err?.message || String(err);
+          await prisma.payoutAudit.create({
+            data: {
+              payoutId: row.id,
+              action: 'bulk_execute',
+              oldStatus: priorStatus,
+              newStatus: 'failed',
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: `Bulk-send failure: ${errMsg.slice(0, 400)}`,
+            },
+          }).catch((e) => {
+            console.warn(`[admin-payout] bulk_execute failure-audit write failed for ${row.id}:`, e?.message || e);
+          });
+          results.push({
+            id: row.id,
+            success: false,
+            status: 'failed',
+            error: errMsg,
+          });
+        }
+      }
+
+      res.json({ results });
     } catch (error) {
       next(error);
     }

--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Check, X, DollarSign, Loader2, FileJson } from 'lucide-react';
+import { Check, X, DollarSign, Loader2, FileJson, Send } from 'lucide-react';
 
 interface BulkActionsBarProps {
   selectedCount: number;
@@ -12,6 +12,17 @@ interface BulkActionsBarProps {
    * The modal itself filters non-USDC / missing-wallet rows.
    */
   onExportSafeJson?: () => void;
+  /**
+   * salsiccia-49102: open the BulkSendModal for the current selection.
+   * Button only enabled when `eligibleBulkSendCount > 0` (USDC + approved).
+   */
+  onBulkSend?: () => void;
+  /**
+   * Number of selected rows that are eligible for bulk USDC send
+   * (usdc_base + approved + valid 0x wallet). When 0, the "Bulk Send" button
+   * is grayed out + tooltip explains why.
+   */
+  eligibleBulkSendCount?: number;
   busy?: boolean;
 }
 
@@ -22,6 +33,8 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   onMarkPaid,
   onClear,
   onExportSafeJson,
+  onBulkSend,
+  eligibleBulkSendCount = 0,
   busy = false,
 }) => {
   if (selectedCount === 0) return null;
@@ -56,6 +69,22 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
           <DollarSign size={14} />
           Mark paid
         </button>
+        {onBulkSend && (
+          <button
+            type="button"
+            onClick={onBulkSend}
+            disabled={busy || eligibleBulkSendCount === 0}
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            title={
+              eligibleBulkSendCount === 0
+                ? 'No eligible USDC payouts selected (need approved or failed + valid 0x wallet)'
+                : `Send USDC from the hot wallet to ${eligibleBulkSendCount} recipient${eligibleBulkSendCount === 1 ? '' : 's'}`
+            }
+          >
+            <Send size={14} />
+            Bulk Send{eligibleBulkSendCount > 0 ? ` (${eligibleBulkSendCount})` : ''}
+          </button>
+        )}
         {onExportSafeJson && (
           <button
             type="button"

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -1,0 +1,320 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Send, Loader2, CheckCircle2, XCircle, ExternalLink, AlertTriangle } from 'lucide-react';
+import type { AdminPayout } from '../../types';
+import { bulkExecutePayouts, type BulkSendResult } from '../../lib/api';
+
+interface BulkSendModalProps {
+  isOpen: boolean;
+  /** Full current selection. Modal filters to eligible USDC-approved-valid-wallet rows itself. */
+  selectedPayouts: AdminPayout[];
+  onCancel: () => void;
+  onComplete: (results: BulkSendResult[]) => void;
+}
+
+type Phase = 'idle' | 'sending' | 'done' | 'error';
+
+const WALLET_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * salsiccia-49102: bulk USDC send for selected approved payouts on the
+ * /payments admin dashboard. Filters non-eligible rows client-side (so the
+ * preview count matches what the backend will actually attempt), shows a
+ * sending-progress indicator, and renders a per-row result list (paid /
+ * failed + tx link / error) after completion.
+ *
+ * Sequential execution happens server-side (one tx at a time — nonce
+ * safety). Client just POSTs the eligible ids and awaits the response.
+ */
+export const BulkSendModal: React.FC<BulkSendModalProps> = ({
+  isOpen,
+  selectedPayouts,
+  onCancel,
+  onComplete,
+}) => {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [results, setResults] = useState<BulkSendResult[]>([]);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Eligibility filter — keep in sync with backend bulk-execute filter
+  // (USDC + approved-or-failed + valid 0x wallet). passata-49102 added
+  // failed-status retry. Anything not matching is shown as "skipped".
+  const { eligible, skippedCount, totalUsd, distinctRecipients } = useMemo(() => {
+    const e: AdminPayout[] = [];
+    let skipped = 0;
+    const recipients = new Set<string>();
+    for (const p of selectedPayouts) {
+      if (
+        p.payoutMethod === 'usdc_base' &&
+        (p.status === 'approved' || p.status === 'failed') &&
+        p.payoutWalletAddress &&
+        WALLET_RE.test(p.payoutWalletAddress)
+      ) {
+        e.push(p);
+        recipients.add(p.payoutWalletAddress.toLowerCase());
+      } else {
+        skipped += 1;
+      }
+    }
+    const sum = e.reduce((acc, p) => acc + (Number(p.finalAmountUsd) || 0), 0);
+    return {
+      eligible: e,
+      skippedCount: skipped,
+      totalUsd: sum,
+      distinctRecipients: recipients.size,
+    };
+  }, [selectedPayouts]);
+
+  // Reset state every time the modal opens for a fresh selection.
+  useEffect(() => {
+    if (isOpen) {
+      setPhase('idle');
+      setResults([]);
+      setErrorMsg(null);
+    }
+  }, [isOpen]);
+
+  // Close on Escape (only when not sending — never cancel an in-flight batch)
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && phase !== 'sending') onCancel();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onCancel, phase]);
+
+  if (!isOpen) return null;
+
+  // Build a quick lookup from id -> payout for the result list (so we can
+  // render the recipient address + amount alongside the success/failure).
+  const eligibleById = new Map(eligible.map((p) => [p.id, p]));
+
+  async function handleSend() {
+    if (eligible.length === 0) return;
+    setPhase('sending');
+    setErrorMsg(null);
+    try {
+      const ids = eligible.map((p) => p.id);
+      const res = await bulkExecutePayouts(ids);
+      setResults(res);
+      setPhase('done');
+      onComplete(res);
+    } catch (err: any) {
+      setErrorMsg(err?.message || 'Bulk send failed');
+      setPhase('error');
+    }
+  }
+
+  const paidCount = results.filter((r) => r.status === 'paid').length;
+  const failedCount = results.filter((r) => r.status === 'failed').length;
+
+  const body = (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={() => {
+        if (phase !== 'sending') onCancel();
+      }}
+    >
+      <div
+        className="card p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start gap-3 mb-4">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-semibold text-theme-text">
+              {phase === 'done'
+                ? 'Bulk send complete'
+                : phase === 'sending'
+                ? 'Sending USDC payouts…'
+                : `Send ${eligible.length} payout${eligible.length === 1 ? '' : 's'}`}
+            </h2>
+            {phase === 'idle' && (
+              <p className="text-xs text-theme-text-muted mt-0.5">
+                Sequential — one transaction at a time from the hot wallet on Base.
+              </p>
+            )}
+          </div>
+          {phase !== 'sending' && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted"
+              aria-label="Close"
+            >
+              <X size={18} />
+            </button>
+          )}
+        </div>
+
+        {/* IDLE — preview the batch */}
+        {phase === 'idle' && (
+          <>
+            <div className="px-3 py-3 rounded-lg bg-theme-surface-hover border border-theme-stroke text-sm mb-4">
+              <p className="text-theme-text">
+                <span className="font-semibold">Total: ${totalUsd.toFixed(2)}</span>
+                {' — '}
+                {eligible.length} USDC transaction{eligible.length === 1 ? '' : 's'} from the hot
+                wallet to {distinctRecipients} recipient{distinctRecipients === 1 ? '' : 's'}.
+              </p>
+              {skippedCount > 0 && (
+                <div className="flex items-start gap-1.5 mt-2 text-xs text-amber-500/90">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <span>
+                    {skippedCount} selected payout{skippedCount === 1 ? '' : 's'} skipped (non-USDC,
+                    wrong status, or invalid wallet).
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {eligible.length === 0 && (
+              <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-xs text-red-400 mb-4">
+                <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                <span>
+                  No eligible payouts in selection — pick at least one USDC payout in approved or
+                  failed status with a valid 0x recipient wallet.
+                </span>
+              </div>
+            )}
+
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-theme-stroke">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-3 py-2 rounded-lg text-sm text-theme-text-muted hover:text-theme-text"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={eligible.length === 0}
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Send size={14} />
+                Send {eligible.length} payout{eligible.length === 1 ? '' : 's'}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* SENDING — in-flight (batch is server-driven, so we can't show per-tx
+            progress without a stream. Show a single spinner + "Sending N…"). */}
+        {phase === 'sending' && (
+          <div className="py-8 flex flex-col items-center justify-center text-center">
+            <Loader2 size={32} className="animate-spin text-emerald-500 mb-3" />
+            <p className="text-sm text-theme-text">
+              Sending {eligible.length} USDC payout{eligible.length === 1 ? '' : 's'}…
+            </p>
+            <p className="text-xs text-theme-text-muted mt-1">
+              Each tx waits for confirmation on Base — please don't close this tab.
+            </p>
+          </div>
+        )}
+
+        {/* ERROR — batch-level failure (insufficient balance, validation, etc.) */}
+        {phase === 'error' && (
+          <>
+            <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-sm text-red-400 mb-4">
+              <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+              <span>{errorMsg || 'Bulk send failed'}</span>
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-theme-stroke">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-3 py-2 rounded-lg text-sm bg-theme-surface-hover hover:bg-theme-surface text-theme-text"
+              >
+                Close
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* DONE — per-row result list */}
+        {phase === 'done' && (
+          <>
+            <div className="px-3 py-3 rounded-lg bg-theme-surface-hover border border-theme-stroke text-sm mb-3">
+              <div className="flex items-baseline gap-2 flex-wrap">
+                <span className="font-medium text-emerald-500">{paidCount}</span>
+                <span className="text-theme-text-muted">paid</span>
+                {failedCount > 0 && (
+                  <>
+                    <span className="text-theme-text-muted">•</span>
+                    <span className="font-medium text-red-500">{failedCount}</span>
+                    <span className="text-theme-text-muted">failed</span>
+                  </>
+                )}
+                {skippedCount > 0 && (
+                  <>
+                    <span className="text-theme-text-muted">•</span>
+                    <span className="font-medium text-amber-500">{skippedCount}</span>
+                    <span className="text-theme-text-muted">skipped</span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            <ul className="space-y-2 mb-4 max-h-[40vh] overflow-y-auto">
+              {results.map((r) => {
+                const p = eligibleById.get(r.id);
+                const addr = p?.payoutWalletAddress ?? '';
+                const shortAddr = addr.length >= 10 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+                const amount = p ? Number(p.finalAmountUsd).toFixed(2) : '?';
+                const isPaid = r.status === 'paid';
+                return (
+                  <li
+                    key={r.id}
+                    className={`flex items-start gap-2 px-3 py-2 rounded-lg text-sm border ${
+                      isPaid
+                        ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-100'
+                        : 'bg-red-500/10 border-red-500/30 text-red-100'
+                    }`}
+                  >
+                    {isPaid ? (
+                      <CheckCircle2 size={14} className="mt-0.5 shrink-0 text-emerald-400" />
+                    ) : (
+                      <XCircle size={14} className="mt-0.5 shrink-0 text-red-400" />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2 flex-wrap">
+                        <span className="font-mono text-xs">{shortAddr}</span>
+                        <span className="text-xs text-theme-text-muted">${amount}</span>
+                        {isPaid && r.txHash && (
+                          <a
+                            href={`https://basescan.org/tx/${r.txHash}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs underline hover:text-white"
+                          >
+                            tx <ExternalLink size={10} />
+                          </a>
+                        )}
+                      </div>
+                      {!isPaid && r.error && (
+                        <p className="text-xs mt-1 break-words text-red-200/90">{r.error}</p>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-theme-stroke">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-3 py-2 rounded-lg text-sm bg-emerald-600 hover:bg-emerald-700 text-white font-medium"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(body, document.body);
+};

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -8,5 +8,6 @@ export { PrepayQueueTable } from './PrepayQueueTable';
 export { CreatePrepaymentModal } from './CreatePrepaymentModal';
 export { HostPaymentDetailsModal } from './HostPaymentDetailsModal';
 export { ExportSafeJsonModal } from './ExportSafeJsonModal';
+export { BulkSendModal } from './BulkSendModal';
 export { RejectReasonModal } from './RejectReasonModal';
 export { HotWalletCard } from './HotWalletCard';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3936,6 +3936,34 @@ export async function executeAdminPayout(
 }
 
 /**
+ * salsiccia-49102: sequentially execute multiple approved USDC payouts.
+ * Backend bails the whole batch (400 INSUFFICIENT_BALANCE) if the hot
+ * wallet's USDC balance is less than the sum of amounts; per-row results
+ * include status='paid' (+ txHash) or status='failed' (+ error).
+ *
+ * The backend enforces:
+ *   - 50-id sanity cap per request (400 BULK_TOO_LARGE if over)
+ *   - eligibility filter (USDC + approved + valid 0x wallet) — non-eligible
+ *     ids are silently dropped from the response, NOT echoed back
+ *   - sequential execution (nonce safety for the single-signer hot wallet)
+ */
+export interface BulkSendResult {
+  id: string;
+  success: boolean;
+  status: 'paid' | 'failed';
+  txHash?: string;
+  error?: string;
+}
+
+export async function bulkExecutePayouts(ids: string[]): Promise<BulkSendResult[]> {
+  const res = await apiRequest<{ results: BulkSendResult[] }>(`/api/admin/payouts/bulk-execute`, {
+    method: 'POST',
+    body: { ids },
+  });
+  return res.results;
+}
+
+/**
  * Search-as-you-type for the Record External Payment modal (arugula-38633 v2).
  * Backend filters parties.underbossStatus === 'approved' and returns up to 20
  * matches by name/customUrl/inviteCode. Each row carries the main host plus

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -35,9 +35,11 @@ import {
   CreatePrepaymentModal,
   HostPaymentDetailsModal,
   ExportSafeJsonModal,
+  BulkSendModal,
   RejectReasonModal,
   HotWalletCard,
 } from '../components/payments-admin';
+import type { BulkSendResult } from '../lib/api';
 
 type RoleState =
   | { kind: 'loading' }
@@ -114,6 +116,11 @@ export function PaymentsAdminPage() {
   // siciliana-69183: Safe Transaction Builder JSON export. Modal is mounted
   // when true; the modal itself filters non-USDC / missing-wallet rows.
   const [showSafeExportModal, setShowSafeExportModal] = useState(false);
+
+  // salsiccia-49102: BulkSendModal — sequentially executes USDC payouts via
+  // backend POST /api/admin/payouts/bulk-execute. Modal does its own
+  // eligibility filter; we just hand it `selectedPayouts`.
+  const [showBulkSend, setShowBulkSend] = useState(false);
 
   // crudo-91827: in-app reject-reason modal target. Replaces window.prompt()
   // which gets silently blocked by popup blockers / Brave / Arc / extensions.
@@ -223,6 +230,23 @@ export function PaymentsAdminPage() {
     () => payouts.filter((p) => selectedIds.has(p.id)),
     [payouts, selectedIds],
   );
+
+  // salsiccia-49102: count of selected payouts eligible for bulk USDC send.
+  // Mirrors the backend filter (usdc_base + approved/failed + valid 0x
+  // wallet — passata-49102 added failed-status retry) so the BulkActionsBar
+  // button label + tooltip match what the server will actually execute.
+  // Kept in this file (not in BulkSendModal) so the bar can show the count
+  // even when the modal is closed.
+  const eligibleBulkSendCount = useMemo(() => {
+    const re = /^0x[0-9a-fA-F]{40}$/;
+    return selectedPayouts.filter(
+      (p) =>
+        p.payoutMethod === 'usdc_base' &&
+        (p.status === 'approved' || p.status === 'failed') &&
+        !!p.payoutWalletAddress &&
+        re.test(p.payoutWalletAddress),
+    ).length;
+  }, [selectedPayouts]);
 
   // pomodoro-58294: sort the prepay queue client-side. 'newest' is a no-op so
   // we preserve backend ordering; the city sort strips the "Global Pizza Party"
@@ -570,6 +594,8 @@ export function PaymentsAdminPage() {
           onReject={handleBulkReject}
           onMarkPaid={handleBulkMarkPaid}
           onExportSafeJson={() => setShowSafeExportModal(true)}
+          onBulkSend={() => setShowBulkSend(true)}
+          eligibleBulkSendCount={eligibleBulkSendCount}
           onClear={clearSelection}
           busy={bulkBusy}
         />
@@ -764,6 +790,25 @@ export function PaymentsAdminPage() {
             }}
           />
         )}
+
+        {/* salsiccia-49102: bulk USDC send for selected approved payouts.
+            onComplete refreshes BOTH the payouts list (so paid rows flip to
+            'paid') and the prepay queue (so the source rows drop off). */}
+        <BulkSendModal
+          isOpen={showBulkSend}
+          selectedPayouts={selectedPayouts}
+          onCancel={() => setShowBulkSend(false)}
+          onComplete={async (results: BulkSendResult[]) => {
+            const paid = results.filter((r) => r.status === 'paid').length;
+            const failed = results.filter((r) => r.status === 'failed').length;
+            pushToast(
+              `Bulk send: ${paid} paid${failed > 0 ? `, ${failed} failed` : ''}`,
+              failed > 0 ? 'error' : 'success',
+            );
+            clearSelection();
+            await Promise.all([refresh(), loadPrepayQueue()]);
+          }}
+        />
 
         {/* siciliana-69183: toast stack (bottom-right, 3s auto-dismiss). */}
         {toasts.length > 0 && (


### PR DESCRIPTION
## Summary
- New `POST /api/admin/payouts/bulk-execute` — admin-only, serial execution (nonce safety for the single-signer hot wallet), pre-flight USDC balance check, 50-id cap per request.
- New `BulkSendModal` + green "Bulk Send" button in `BulkActionsBar`.
- Eligible = USDC + (approved | failed — passata-49102) + valid 0x wallet. Skipped rows surfaced with a count.
- Per-row `bulk_execute` audit captures batch context alongside the existing `mark_paid` / `mark_failed` audit from the shared `executePayout` helper.
- After completion, refreshes both the payouts list and the prepay queue, then toasts a paid/failed summary.

## Test plan
- [ ] Select 3 USDC approved + 1 Mercury → modal shows 3 sends, 1 skipped.
- [ ] Click Send → sequential progress spinner → result list with per-row paid/failed status + BaseScan tx links.
- [ ] Insufficient USDC balance → batch bails up-front with `INSUFFICIENT_BALANCE` and shortfall amount.
- [ ] 50+ ids → 400 `BULK_TOO_LARGE`.
- [ ] Mix of approved + failed USDC payouts → both eligible (passata-49102 retry support).
- [ ] 0 eligible USDC selected → "Bulk Send" button disabled + tooltip.

Backend: `cd backend && npx tsc --noEmit` clean.
Frontend: `cd frontend && npx tsc --noEmit` clean.