### PR TITLE
salumi-31802: add Payments to cohost tab permission picker

### DIFF
--- a/frontend/src/lib/tabPermissions.ts
+++ b/frontend/src/lib/tabPermissions.ts
@@ -5,6 +5,7 @@ import {
   Users,
   Pizza,
   Camera,
+  CreditCard,
   Handshake,
   MapPin,
   Music,
@@ -42,6 +43,7 @@ export type TabId =
   | 'promo'
   | 'flyer'
   | 'print'
+  | 'payments'
   | 'apps';
 
 export interface HostTab {
@@ -75,6 +77,7 @@ export const ALL_HOST_TABS: HostTab[] = [
   { id: 'promo', label: 'Promo', icon: Megaphone },
   { id: 'flyer', label: 'Flyer', icon: FileImage },
   { id: 'print', label: 'Print', icon: Printer },
+  { id: 'payments', label: 'Payments', icon: CreditCard },
   { id: 'apps', label: 'Apps', icon: LayoutGrid },
 ];
 

--- a/frontend/src/lib/tabPermissions.ts
+++ b/frontend/src/lib/tabPermissions.ts
@@ -5,7 +5,7 @@ import {
   Users,
   Pizza,
   Camera,
-  CreditCard,
+  Coins,
   Handshake,
   MapPin,
   Music,
@@ -77,7 +77,7 @@ export const ALL_HOST_TABS: HostTab[] = [
   { id: 'promo', label: 'Promo', icon: Megaphone },
   { id: 'flyer', label: 'Flyer', icon: FileImage },
   { id: 'print', label: 'Print', icon: Printer },
-  { id: 'payments', label: 'Payments', icon: CreditCard },
+  { id: 'payments', label: 'Payments', icon: Coins },
   { id: 'apps', label: 'Apps', icon: LayoutGrid },
 ];
 


### PR DESCRIPTION
## Summary
- Adds `payments` to `ALL_HOST_TABS` (and the `TabId` union) in `frontend/src/lib/tabPermissions.ts`, so the Payments tab now appears as a togglable option in the HostsManager cohost permission picker.
- Uses the `Coins` lucide icon.
- The Payments tab itself already exists end-to-end:
  - Backend `VALID_TAB_IDS` includes `'payments'`
  - `HostPage.tsx` `TabType` + `ALL_VALID_TABS` include `'payments'`
  - Host-side `PayoutsTab` renders at `/host/:invite/payments`

This PR closes the last gap: hosts couldn't previously grant a cohost access to the Payments tab via the permission picker.

## Test plan
- [ ] Open a GPP event → host settings → add/edit cohost → confirm `Payments` (Coins icon) appears in the allowed-tabs picker between Print and Apps.
- [ ] Toggle Payments on, save; confirm the cohost now sees the Payments tab on `/host/:invite`.
- [ ] Toggle Payments off, save; confirm the cohost no longer sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)