### PR TITLE
feat(fennel-49102): audit trail for reimbursement cap changes

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -246,6 +246,7 @@ model Party {
   announcements         Announcement[]
   attestations          GuestAttestation[]
   reimbursementCapAppeals ReimbursementCapAppeal[]
+  reimbursementCapAudits  ReimbursementCapAudit[]
 
   @@map("parties")
 }
@@ -306,6 +307,27 @@ model PartyStatusAudit {
   @@index([partyId])
   @@index([createdAt(sort: Desc)])
   @@map("party_status_audit")
+}
+
+// fennel-49102: Per-row audit trail for `parties.reimbursement_cap_usd`
+// changes. Mirrors the PartyStatusAudit shape from pizzaiolo-97053 so we
+// can answer "who set this party's $X cap?" — old/new cap values + the
+// actor's email and role (admin/super_admin/payment_admin/underboss/host/system).
+// No historical backfill: rows that pre-date this audit have no actor info.
+model ReimbursementCapAudit {
+  id          String   @id @default(uuid()) @db.Uuid
+  partyId     String   @map("party_id") @db.Uuid
+  party       Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  oldCapUsd   Decimal? @map("old_cap_usd") @db.Decimal(10, 2)
+  newCapUsd   Decimal? @map("new_cap_usd") @db.Decimal(10, 2)
+  actorEmail  String   @map("actor_email")
+  actorKind   String   @map("actor_kind")
+  setAt       DateTime @default(now()) @map("set_at") @db.Timestamptz
+  note        String?
+
+  @@index([partyId])
+  @@index([setAt(sort: Desc)])
+  @@map("reimbursement_cap_audit")
 }
 
 model Guest {

--- a/backend/src/helpers/reimbursementCapAudit.ts
+++ b/backend/src/helpers/reimbursementCapAudit.ts
@@ -1,0 +1,104 @@
+// fennel-49102: write-side helper for the reimbursement_cap_audit table.
+//
+// Mirrors backend/src/helpers/statusAudit.ts. Always call recordCapChange
+// AFTER the cap-bearing UPDATE has committed (the PATCH /:id handler does
+// the update outside an interactive transaction). Logging is best-effort:
+// if the audit insert throws, we log and swallow so we never roll back a
+// successful cap edit on the audit-table's behalf.
+import { prisma } from '../config/database.js';
+import { Decimal } from '@prisma/client/runtime/library';
+import { isSuperAdmin, isUnderboss } from '../middleware/auth.js';
+
+export type CapActorKind =
+  | 'super_admin'
+  | 'admin'
+  | 'payment_admin'
+  | 'underboss'
+  | 'host'
+  | 'system';
+
+/**
+ * Map a caller's email to the highest-privilege role label that applies.
+ * Order matters — most-privileged first so we report the right hat even
+ * when the caller technically wears several.
+ *
+ * Note: `isAdmin()` in auth.ts returns true for BOTH plain admins and
+ * super_admins, so we read `admins.role` directly to distinguish.
+ */
+export async function resolveCapActorKind(email?: string | null): Promise<CapActorKind> {
+  if (!email) return 'system';
+  if (await isSuperAdmin(email)) return 'super_admin';
+
+  const admin = await prisma.admin.findUnique({
+    where: { email: email.toLowerCase() },
+    select: { role: true },
+  });
+  if (admin?.role === 'admin') return 'admin';
+  if (admin?.role === 'payment_admin') return 'payment_admin';
+
+  if (await isUnderboss(email)) return 'underboss';
+  return 'host';
+}
+
+interface RecordCapChangeOpts {
+  partyId: string;
+  /** Previous cap value, as read from the DB before the UPDATE. `null` = no prior cap. */
+  oldCapUsd: Decimal | number | null;
+  /** New cap value being written. `null` = clearing the cap. */
+  newCapUsd: number | null;
+  actorEmail: string;
+  actorKind: CapActorKind;
+  /** Free-form context, e.g. 'Accepted host appeal: ...' or 'PATCH /api/parties/:id'. */
+  note?: string | null;
+}
+
+/**
+ * Append one row to reimbursement_cap_audit.
+ *
+ * Callers are expected to gate this on `oldCap !== newCap` — we don't log
+ * idempotent (no-op) writes. Failures are caught and logged but never
+ * propagated, so a transient audit-table issue can't break cap edits.
+ */
+export async function recordCapChange(opts: RecordCapChangeOpts): Promise<void> {
+  try {
+    const oldDec =
+      opts.oldCapUsd == null
+        ? null
+        : opts.oldCapUsd instanceof Decimal
+          ? opts.oldCapUsd
+          : new Decimal(opts.oldCapUsd as number);
+    const newDec = opts.newCapUsd == null ? null : new Decimal(opts.newCapUsd);
+
+    await prisma.reimbursementCapAudit.create({
+      data: {
+        partyId: opts.partyId,
+        oldCapUsd: oldDec,
+        newCapUsd: newDec,
+        actorEmail: (opts.actorEmail || 'unknown').toLowerCase(),
+        actorKind: opts.actorKind,
+        note: opts.note ?? null,
+      },
+    });
+  } catch (err) {
+    // Audit-trail failures must not break the cap edit itself.
+    console.warn('[recordCapChange] failed to write audit row', err);
+  }
+}
+
+/**
+ * Returns true when the cap actually changed. Treats `null`/`undefined` as
+ * the same "no cap set" state, and compares numeric values regardless of
+ * whether they arrive as Decimal | string | number.
+ */
+export function capValuesDiffer(
+  oldCap: Decimal | number | string | null | undefined,
+  newCap: number | null | undefined,
+): boolean {
+  const o = oldCap == null ? null : Number(oldCap as any);
+  const n = newCap == null ? null : Number(newCap);
+  if (o === null && n === null) return false;
+  if (o === null || n === null) return true;
+  if (!Number.isFinite(o) || !Number.isFinite(n)) return o !== n;
+  // Compare to 2 decimal places to match the column's numeric(10,2) precision.
+  return Math.round(o * 100) !== Math.round(n * 100);
+}

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -8,6 +8,11 @@ import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS }
 import { getUnderbossScope, partyMatchesScope } from '../helpers/underbossScope.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
+import {
+  capValuesDiffer,
+  recordCapChange,
+  resolveCapActorKind,
+} from '../helpers/reimbursementCapAudit.js';
 import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 
 // Helper function to get party with ownership check
@@ -595,6 +600,19 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
     }
 
+    // fennel-49102: snapshot the prior cap value so we can log only real
+    // changes to reimbursement_cap_audit. Skipped when the request doesn't
+    // touch the cap (either field omitted or caller wasn't authorized to
+    // write it) so non-cap PATCHes pay no extra round trip.
+    let priorCapUsd: any = undefined;
+    if (reimbursementCapUsdToWrite !== undefined) {
+      const prior = await prisma.party.findUnique({
+        where: { id },
+        select: { reimbursementCapUsd: true },
+      });
+      priorCapUsd = prior?.reimbursementCapUsd ?? null;
+    }
+
     // quattro-71244: validate hostGoals — keep only known-numeric values, clamp
     // negatives to 0 and cap each at 1,000,000. Drop non-numeric / non-finite
     // entries silently. Persist `null` if the caller explicitly clears all goals.
@@ -693,6 +711,25 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         user: { select: { name: true } },
       },
     });
+
+    // fennel-49102: log cap changes to reimbursement_cap_audit so admins
+    // can answer "who set this party's $X cap?". Idempotent edits (same
+    // value as already on record) are skipped so we don't fill the table
+    // with noise.
+    if (
+      reimbursementCapUsdToWrite !== undefined &&
+      capValuesDiffer(priorCapUsd, reimbursementCapUsdToWrite)
+    ) {
+      const actorKind = await resolveCapActorKind(req.userEmail);
+      await recordCapChange({
+        partyId: id,
+        oldCapUsd: priorCapUsd,
+        newCapUsd: reimbursementCapUsdToWrite,
+        actorEmail: req.userEmail || 'unknown',
+        actorKind,
+        note: 'PATCH /api/parties/:id',
+      });
+    }
 
     // Trigger webhook for party update
     await triggerWebhook('party.updated', party, req.userId!);
@@ -1051,6 +1088,65 @@ router.get('/:partyId/reimbursement-cap/appeals', async (req: AuthRequest, res: 
         reviewedByName: a.reviewedBy?.name ?? null,
         reviewedByEmail: a.reviewedBy?.email ?? null,
         reviewedNote: a.reviewedNote,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/parties/:partyId/reimbursement-cap/audit (fennel-49102)
+// Per-row history of cap changes — newest first, capped at 50 rows.
+// Authz mirrors the /reimbursement-cap/appeals endpoint above:
+// admin OR underboss-in-scope OR the party host (or an edit-permission
+// co-host).
+router.get('/:partyId/reimbursement-cap/audit', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, region: true, name: true, city: true, eventType: true, userId: true },
+    });
+    if (!party) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    let allowed = false;
+    if (party.userId && party.userId === req.userId) {
+      allowed = true;
+    } else if (await isAdmin(req.userEmail)) {
+      allowed = true;
+    } else if (await isUnderboss(req.userEmail)) {
+      const scope = await getUnderbossScope(req.userEmail);
+      if (partyMatchesScope(party, scope)) {
+        allowed = true;
+      }
+    } else {
+      // Co-host with edit permission can also view (delegated host).
+      const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+      if (canEdit) allowed = true;
+    }
+    if (!allowed) {
+      throw new AppError('Not authorized to view cap audit history', 403, 'FORBIDDEN');
+    }
+
+    const rows = await prisma.reimbursementCapAudit.findMany({
+      where: { partyId },
+      orderBy: { setAt: 'desc' },
+      take: 50,
+    });
+
+    res.json({
+      audits: rows.map((r) => ({
+        id: r.id,
+        partyId: r.partyId,
+        oldCapUsd: r.oldCapUsd != null ? Number(r.oldCapUsd) : null,
+        newCapUsd: r.newCapUsd != null ? Number(r.newCapUsd) : null,
+        actorEmail: r.actorEmail,
+        actorKind: r.actorKind,
+        setAt: r.setAt.toISOString(),
+        note: r.note,
       })),
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- New `reimbursement_cap_audit(party_id, old_cap_usd, new_cap_usd, actor_email, actor_kind, set_at, note)` table (migration already applied to prod).
- Write hook on `PATCH /api/parties/:id` — only when the cap value actually changes (idempotent edits skipped).
- Read endpoint `GET /api/parties/:partyId/reimbursement-cap/audit` (admin OR underboss-in-scope OR the host / edit-permission co-host).
- No frontend display — defer to follow-up.
- Mirrors the `party_status_audit` shape from `pizzaiolo-97053`.

## Test plan
- [ ] Change a party's cap via the underboss dashboard → new audit row with the right actor_email + actor_kind.
- [ ] Same-value PATCH → no audit row (idempotent).
- [ ] `GET /api/parties/<id>/reimbursement-cap/audit` returns history newest-first; unauthed → 401; non-host non-admin → 403.
- [ ] Clear-the-cap (`reimbursementCapUsd: null`) from a numeric value → row written with `new_cap_usd = NULL`.