### PR TITLE
bresaola-49185: gate Payments app behind party approval

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -237,6 +237,32 @@ async function isAnyAdmin(email?: string): Promise<boolean> {
 }
 
 /**
+ * bresaola-49185: Payments app is gated on party approval. Unapproved parties
+ * cannot submit/edit payouts or run OCR previews — those actions all create or
+ * mutate Payout rows and we don't want them piling up before underboss review.
+ *
+ * GET and DELETE are NOT gated: hosts must still be able to see existing
+ * payouts and cancel pending ones even if approval is later revoked.
+ *
+ * Throws 403 PARTY_NOT_APPROVED when the party isn't approved (or doesn't
+ * exist — we don't leak the existence distinction since the action is gated
+ * regardless).
+ */
+async function assertPartyApproved(partyId: string): Promise<void> {
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: { underbossStatus: true },
+  });
+  if (!party || party.underbossStatus !== 'approved') {
+    throw new AppError(
+      'This event must be approved before submitting payments.',
+      403,
+      'PARTY_NOT_APPROVED',
+    );
+  }
+}
+
+/**
  * pepperoni-47301: Mercury (our virtual debit card issuer) cannot issue cards
  * to hosts in sanctioned/restricted countries. When the host (or admin) tries
  * to submit `mercury_card` for a party whose `country` matches the block list,
@@ -279,6 +305,11 @@ router.post(
       if (!canEdit) {
         throw new AppError('Party not found', 404, 'NOT_FOUND');
       }
+
+      // bresaola-49185: block OCR previews on unapproved parties — the
+      // surrounding Payments UI is hidden, but a determined direct caller
+      // would otherwise still burn OpenAI quota.
+      await assertPartyApproved(partyId);
 
       assertSupabasePayoutUrl(imageUrl, partyId);
 
@@ -358,6 +389,12 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         throw new AppError('Party not found', 404, 'NOT_FOUND');
       }
     }
+
+    // bresaola-49185: block payout creation on unapproved parties. Admins
+    // creating prepayments still need the party to be approved — there's no
+    // legitimate reason to disburse funds for a party the underboss hasn't
+    // approved yet.
+    await assertPartyApproved(partyId);
 
     // Validate optional one-shot attendance setup. Only persisted to the party
     // below if the party's current expectedGuests is null (see updateMany call).
@@ -787,6 +824,11 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
+
+    // bresaola-49185: block edits on unapproved parties (e.g. if approval
+    // was revoked after the payout was first created). GET + DELETE remain
+    // open so hosts can still see and cancel pending rows.
+    await assertPartyApproved(partyId);
 
     const existing = await prisma.payout.findFirst({
       where: { id: payoutId, partyId },

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -379,12 +379,16 @@ export function AppsHub({
   const { loadParty, party } = usePizza();
   const [pinnedApps, setPinnedApps] = useState<string[]>(initialPinnedApps);
   const isGppEvent = party?.eventType === 'gpp';
+  // bresaola-49185: hide the Payments tile from unapproved parties. The
+  // backend rejects POST/PATCH/ocr-preview with 403 in lockstep so direct
+  // API calls also fail until the party is approved.
+  const isApproved = party?.underbossStatus === 'approved';
 
-  // marzano-49102: Payments tile is unconditionally live for all signed-in
-  // party hosts/cohosts. The downstream cap-display gate (hide $ unless the
-  // 'go' event_tag is set) lives in HostPage where Party props are passed
+  // marzano-49102: Payments tile is live for hosts/cohosts of approved
+  // parties. The downstream cap-display gate (hide $ unless the 'go'
+  // event_tag is set) lives in HostPage where Party props are passed
   // into PayoutsTab.
-  const visibleApps = apps;
+  const visibleApps = isApproved ? apps : apps.filter(a => a.id !== 'payments');
 
   const handleTogglePin = async (appId: string, pin: boolean) => {
     // Optimistic update

--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -27,7 +27,10 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   // NOT pull loadParty here — that was v1's mistake and reintroduced the
   // tab-click-feels-like-reload pain. setParty(prev => ({...prev, coHosts}))
   // updates the context without a full refetch.
-  const { setParty } = usePizza();
+  // bresaola-49185: also read party.underbossStatus to gate the Payments
+  // permission row in the cohost picker for unapproved parties.
+  const { setParty, party } = usePizza();
+  const isApproved = party?.underbossStatus === 'approved';
 
   // Helper: check if a co-host is protected (auto-added partner or underboss)
   const isProtected = (h: CoHost) => h.isUnderboss === true || h.isPartner === true;
@@ -162,7 +165,9 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   };
 
   // Tabs available for permission assignment (exclude 'apps' which is always visible)
-  const permissionTabs = ALL_HOST_TABS.filter(t => t.id !== 'apps');
+  // bresaola-49185: also hide 'payments' from unapproved parties so cohost
+  // permissions don't drift against the actual UI / backend gate.
+  const permissionTabs = ALL_HOST_TABS.filter(t => t.id !== 'apps' && (isApproved || t.id !== 'payments'));
 
   const getPermissionSummary = (coHost: CoHost): string => {
     if (!Array.isArray(coHost.allowedTabs)) return 'All tabs';

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -112,6 +112,11 @@ function HostPageContent() {
   }, [isOwnerOrAdmin, party?.allowedTabs]);
 
   const isGPP = party?.eventType === 'gpp';
+  // bresaola-49185: gate the Payments app behind party approval. Unapproved
+  // parties never see Payments in the tab bar, in /apps, or via direct URL.
+  // Derived at component scope (above any early return) per the React Rules
+  // of Hooks — see arugula-38633 v2 incident in MEMORY.
+  const isApproved = party?.underbossStatus === 'approved';
   const defaultTab: TabType = isGPP ? 'dashboard' : 'details';
   const activeTab: TabType = (tab && ALL_VALID_TABS.includes(tab as TabType)) ? tab as TabType : defaultTab;
 
@@ -200,7 +205,6 @@ function HostPageContent() {
 
   // All hooks must be called before any conditional returns (React Rules of Hooks)
   const tabs = useMemo(() => {
-    const isApproved = party?.underbossStatus === 'approved';
     const coreTabs = [
       ...(isGPP ? [{ id: 'dashboard' as TabType, label: t('tabs.dashboard'), icon: Home }] : []),
       // pepperoni-58341 / salami-39204: Day-of host dashboard (also mirrored at
@@ -215,11 +219,15 @@ function HostPageContent() {
     ];
 
     // Build pinned tabs from party.pinnedApps
-    const pinnedTabs = (party?.pinnedApps ?? []).map(appId => {
-      const appDef = PINNABLE_APPS.find(a => a.id === appId);
-      if (!appDef) return null;
-      return { id: appDef.tab as TabType, label: appDef.name, icon: appDef.icon };
-    }).filter((t): t is { id: TabType; label: string; icon: React.ComponentType<{ size?: number; className?: string }> } => t !== null);
+    // bresaola-49185: filter out 'payments' for unapproved parties so the
+    // Payments tab is hidden from the pinned tab strip until approval lands.
+    const pinnedTabs = (party?.pinnedApps ?? [])
+      .filter(appId => isApproved || appId !== 'payments')
+      .map(appId => {
+        const appDef = PINNABLE_APPS.find(a => a.id === appId);
+        if (!appDef) return null;
+        return { id: appDef.tab as TabType, label: appDef.name, icon: appDef.icon };
+      }).filter((t): t is { id: TabType; label: string; icon: React.ComponentType<{ size?: number; className?: string }> } => t !== null);
 
     const allTabs = [...coreTabs, ...pinnedTabs, { id: 'apps' as TabType, label: t('tabs.apps'), icon: LayoutGrid }];
 
@@ -228,7 +236,7 @@ function HostPageContent() {
     return allowedTabs === 'all'
       ? allTabs
       : allTabs.filter(t => t.id === 'apps' || allowedTabs.includes(t.id));
-  }, [isGPP, party?.pinnedApps, party?.underbossStatus, allowedTabs, t]);
+  }, [isGPP, isApproved, party?.pinnedApps, allowedTabs, t]);
 
   // Redirect to first allowed tab if current tab is not permitted
   useEffect(() => {
@@ -241,6 +249,16 @@ function HostPageContent() {
       }
     }
   }, [activeTab, allowedTabs, party, tabs]);
+
+  // bresaola-49185: bounce direct navigation to /host/:invite/payments when
+  // the party isn't approved yet. The tab-bar filter hides the tab, but a
+  // user with a bookmark or pasted URL would still hit the active-tab branch.
+  useEffect(() => {
+    if (!party) return;
+    if (activeTab === 'payments' && !isApproved) {
+      setActiveTab(defaultTab);
+    }
+  }, [activeTab, isApproved, party, defaultTab]);
 
   if (authLoading || partyLoading || (inviteCode && inviteCode !== loadedCode)) {
     return (
@@ -528,7 +546,7 @@ function HostPageContent() {
                 <PrintTab />
               )}
 
-              {activeTab === 'payments' && party && (() => {
+              {activeTab === 'payments' && party && isApproved && (() => {
                 // marzano-49102: gate the cap dollar value by the 'go' event_tag.
                 // Pass null when 'go' is not set so every downstream consumer
                 // (PayoutsTab green banner, NewPayoutForm cap banner, PayoutsList


### PR DESCRIPTION
## Summary

Hide the Payments app from parties that aren't approved yet (`underbossStatus !== 'approved'`). Mirrors the Day-Of tab precedent.

## Changes

**Frontend (3 files):**
- `frontend/src/pages/HostPage.tsx` — derive `isApproved` at component scope (above any early return per Rules of Hooks). Filter `payments` from `pinnedTabs` for unapproved parties. Guard the active-tab `'payments'` render branch with `&& isApproved`. New `useEffect` bounces direct-URL navigation to `/host/:invite/payments` back to the default tab when the party isn't approved.
- `frontend/src/components/AppsHub.tsx` — derive `isApproved` from `usePizza().party`. Filter the Payments tile out of `visibleApps` when not approved (keeps the static `apps` definition intact for when approval lands).
- `frontend/src/components/HostsManager.tsx` — pull `party` from `usePizza()`. Hide `Payments` from the cohost permission picker for unapproved parties (avoids drift against the actual UI gate).

**Backend (1 file):**
- `backend/src/routes/payout.routes.ts` — new inline `assertPartyApproved(partyId)` helper. Wired into `POST /:partyId/payouts`, `PATCH /:partyId/payouts/:payoutId`, and `POST /:partyId/payouts/ocr-preview`. Returns 403 `PARTY_NOT_APPROVED` when `underbossStatus !== 'approved'`. **GET and DELETE remain open** so hosts can still see existing payouts and cancel pending ones even after approval is revoked.

## Behavior

| Surface | Unapproved | Approved |
|---|---|---|
| HostPage tab bar (pinned `payments`) | hidden | visible |
| /apps Payments tile | hidden | visible |
| Direct nav `/host/:invite/payments` | redirected to default tab | renders PayoutsTab |
| Cohost permission picker | `Payments` row hidden | row visible |
| `POST /payouts`, `PATCH /payouts/:id`, `POST /ocr-preview` | 403 PARTY_NOT_APPROVED | normal |
| `GET /payouts`, `GET /payouts/:id`, `DELETE /payouts/:id` | unchanged (still works) | unchanged |

## Test plan

- [ ] Unapproved party (`underbossStatus = 'pending'`): tab bar omits Payments, /apps tile is hidden, /payments URL redirects to default tab
- [ ] Direct `POST /api/parties/:id/payouts` against an unapproved party returns 403 with `PARTY_NOT_APPROVED`
- [ ] Approve the party from /underboss — Payments app appears in /apps, tab can be pinned, POST succeeds
- [ ] Cohost permission picker on an unapproved party omits the Payments row
- [ ] Existing payouts on a (now-unapproved) party remain visible and cancellable via DELETE

Backend changes deploy from master only — preview frontend talks to production backend, so the 403 behavior won't be visible on the preview URL until merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>