### PR TITLE
fake-detection: surface flag metrics in pills

### DIFF
--- a/frontend/src/components/underboss/FakeDetectionTable.tsx
+++ b/frontend/src/components/underboss/FakeDetectionTable.tsx
@@ -58,12 +58,19 @@ function flagLabel(name: string): string {
 
 function FlagPill({ flag }: { flag: FakeDetectionRow['flags'][number] }) {
   if (!flag.fired) return null;
+  const hasDetail = !!flag.detail && flag.detail.trim().length > 0;
   return (
     <span
-      title={`${flag.name} — ${flag.detail}`}
-      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500/15 text-red-700 border border-red-500/30"
+      title={`${flag.name}${hasDetail ? ` — ${flag.detail}` : ''}`}
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500/15 text-red-700 border border-red-500/30 max-w-full"
     >
       <span>{flagLabel(flag.name)}</span>
+      {hasDetail && (
+        <>
+          <span className="text-red-700/50">·</span>
+          <span className="text-red-700/70 tabular-nums truncate max-w-[180px]">{flag.detail}</span>
+        </>
+      )}
       <span className="text-red-700/60 tabular-nums">+{flag.weight}</span>
     </span>
   );


### PR DESCRIPTION
## Summary
- Flag pills on the fake-detection table now show the heuristic's actual metric inline (e.g. `26/68 bounced`, `wallets=5/41`, `medianDeltaSec=47.1`) instead of hiding it behind hover.
- Pill layout is now `name · detail +weight`; detail is muted, tabular-nums, truncated to 180px (full string still in `title` for hover).
- If a flag has no `detail` string, the separator and detail span are omitted.

## Test plan
- [ ] /underboss → Fake detection tab: confirm pills show the metric inline.
- [ ] Hover a truncated pill: tooltip still shows the full detail string.
- [ ] Flags without a detail (legacy) render as before (name + weight, no middot).

Generated with Claude Code