### PR TITLE
tartufo-58291: hide payouts from unapproved events in admin queue

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -211,6 +211,12 @@ function buildPayoutWhere(query: Request['query']): any {
     }
   }
 
+  // tartufo-58291: hide payouts from unapproved parties from the admin queue
+  // + CSV export. Existing rows from before the bresaola-49185 backend gate
+  // shouldn't surface in routine review. Stats/totals reuse this same `where`
+  // so they stay consistent.
+  where.party = { underbossStatus: 'approved' };
+
   return where;
 }
 


### PR DESCRIPTION
## Summary

Add a single line to `buildPayoutWhere` in `backend/src/routes/admin-payout.routes.ts` so the admin /payments queue, stats/totals, and CSV export all filter to payouts whose parent party has `underbossStatus === 'approved'`.

- List endpoint (`GET /api/admin/payouts`) — `findMany` + `allFiltered` stats both inherit the filter via the shared `where`.
- CSV export (`GET /api/admin/payouts/export.csv`) — same `where`, also covered.
- Detail endpoint (`GET /api/admin/payouts/:id`) and individual approve/reject/execute/mark-paid mutations are **intentionally untouched**, so admins can still navigate to a specific payout by ID and act on stale pre-gate rows.

## Why

`bresaola-49185` already 403s new payout creation when the party isn't approved. This PR closes the inconsistency on the read side: rows that pre-date that gate (or otherwise bypassed it) shouldn't clutter routine review. The prepay queue already applies this same filter, so the admin queue now matches.

## Test plan

- [ ] After backend deploys from master: load `/payments` and confirm only payouts from approved parties appear in the list.
- [ ] Confirm the CSV export omits payouts from unapproved parties.
- [ ] Confirm `/payments/:id` still loads a payout whose party is unapproved (admin can investigate).
- [ ] Confirm approve/reject/execute on an unapproved-party payout still works (admin can resolve stale rows).
- [ ] Spot-check totals on `/payments` reflect the filtered set.

Note: Backend doesn't auto-deploy from preview branches, so the filter behavior won't be visible until backend is shipped from master. Frontend Vercel preview check should still pass since no frontend files changed.

Generated with [Claude Code](https://claude.com/claude-code)