### PR TITLE
porchetta-81402: cancel events instead of deleting

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -96,6 +96,13 @@ model Party {
   rollupGeneratedAt       DateTime? @map("rollup_generated_at") @db.Timestamptz
   description             String?
   rsvpClosedAt            DateTime? @map("rsvp_closed_at") @db.Timestamptz
+  // porchetta-81402: soft-cancel columns. Replaces the old hard-delete
+  // path (DELETE /api/parties/:id). When cancelled_at is non-null the
+  // public EventPage shows a cancellation banner and the RSVP form is
+  // replaced with a cancellation notice.
+  cancelledAt             DateTime? @map("cancelled_at") @db.Timestamptz
+  cancelledBy             String?   @map("cancelled_by")
+  cancellationReason      String?   @map("cancellation_reason")
   createdAt               DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt               DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 

--- a/backend/scripts/restore-host-cancellations.cjs
+++ b/backend/scripts/restore-host-cancellations.cjs
@@ -1,0 +1,554 @@
+#!/usr/bin/env node
+/**
+ * porchetta-81402: Restore parties (and their full child cascade) that
+ * hosts hard-deleted from the dashboard before the soft-cancel flow
+ * shipped. The companion migration
+ * `supabase/migrations/20260521_porchetta_81402_cancel_event.sql`
+ * adds `cancelled_at` / `cancelled_by` / `cancellation_reason`; this
+ * script populates them by replaying rows from `deletion_log` so the
+ * affected events show up on the host dashboard as cancelled (not
+ * lost) and keep their public URL.
+ *
+ * Run:
+ *   node backend/scripts/restore-host-cancellations.cjs            # dry-run
+ *   node backend/scripts/restore-host-cancellations.cjs --apply    # apply
+ *
+ * Connection:
+ *   Uses `pg` + DATABASE_URL from `backend/.env`. Prisma is intentionally
+ *   avoided — this script does pure SQL. `pg` is a root workspace dep,
+ *   so it's already on disk after `npm install` at the repo root.
+ *
+ * Realtime mitigation:
+ *   `guests` is in `supabase_realtime`. Bulk inserts during a restore
+ *   would fan out one WAL event per guest. We DROP guests from the
+ *   publication for the duration of the apply phase and ADD it back in
+ *   a try/finally so the publication is restored even on error.
+ *
+ * Slug collisions:
+ *   - custom_url collisions get rewritten to `<original>-cancelled-<shortid>`
+ *   - invite_code collisions get a fresh cuid
+ *   - When safe, we insert a `slug_aliases (old_slug → restored_party_id)`
+ *     row so existing links continue to resolve.
+ *
+ * FK insertion order: parents first → guests → grandchildren.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { Client } = require('pg');
+
+// ------------------------------------------------------------------
+// CLI flags + env loading
+// ------------------------------------------------------------------
+const APPLY = process.argv.includes('--apply');
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env');
+  if (!fs.existsSync(envPath)) {
+    console.error(`[restore] ${envPath} not found. Aborting.`);
+    process.exit(1);
+  }
+  const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+loadEnv();
+
+if (!process.env.DATABASE_URL) {
+  console.error('[restore] DATABASE_URL is not set in backend/.env. Aborting.');
+  process.exit(1);
+}
+
+function shortid(len = 6) {
+  return crypto.randomBytes(8).toString('base64url').slice(0, len);
+}
+
+// Cuid-like generator — we don't pull in cuid as a dep because this is a
+// one-shot script. The format roughly matches Prisma's default cuid() so the
+// `parties.invite_code` rotation collides with nothing else.
+function cuidLike() {
+  return 'c' + crypto.randomBytes(12).toString('hex');
+}
+
+// ------------------------------------------------------------------
+// Child table insertion order (parents first). Each entry includes the
+// fields we expect to find in `record_data` JSONB; we filter on insert
+// time to drop generated columns / unknown columns gracefully.
+// ------------------------------------------------------------------
+const CHILD_TABLES_IN_ORDER = [
+  'venues',
+  'venue_photos',
+  'party_kits',
+  'guests',
+  'sponsors',
+  'budget_items',
+  'checklist_items',
+  'staff',
+  'performers',
+  'displays',
+  'raffles',
+  'raffle_prizes',
+  'raffle_entries',
+  'raffle_winners',
+  'photos',
+  'notable_attendees',
+  'social_posts',
+  'orders',
+  'donations',
+  'sponsor_checklist_items',
+  'partner_event_notes',
+];
+
+// Generated columns we must NOT try to insert into. Currently only
+// co_hosts_public on parties (sanitize_co_hosts(co_hosts)).
+const GENERATED_COLUMNS_BY_TABLE = {
+  parties: new Set(['co_hosts_public']),
+};
+
+// JSONB columns per table — values from record_data need to be re-stringified
+// before binding (`pg` stringifies plain JS objects but Postgres needs
+// the JSON text representation for JSONB, and arrays in `record_data` are
+// already JSON-shaped).
+const JSONB_COLUMNS_BY_TABLE = {
+  parties: new Set([
+    'co_hosts',
+    'selected_pizzerias',
+    'suggested_amounts',
+    'pinned_apps',
+    'host_tags',
+    'host_goals',
+    'hidden_gpp_photos',
+    'extra_gpp_photos',
+    'flyer_config',
+    'external_links',
+    'report_stats_config',
+  ]),
+  guests: new Set(['suggested_pizzerias']),
+  displays: new Set(['content_config']),
+  raffles: new Set([]),
+  performers: new Set([]),
+  budget_items: new Set([]),
+  checklist_items: new Set([]),
+  social_posts: new Set([]),
+  notable_attendees: new Set([]),
+  party_kits: new Set([]),
+  orders: new Set(['pizzas']),
+  donations: new Set([]),
+  sponsors: new Set([]),
+  sponsor_checklist_items: new Set([]),
+  partner_event_notes: new Set([]),
+  raffle_prizes: new Set([]),
+  raffle_entries: new Set([]),
+  raffle_winners: new Set([]),
+  venues: new Set([]),
+  venue_photos: new Set([]),
+  staff: new Set([]),
+  photos: new Set([]),
+};
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+async function fetchTableColumns(client, tableName) {
+  const res = await client.query(
+    `
+    SELECT column_name, is_generated
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = $1
+    `,
+    [tableName],
+  );
+  const live = new Set();
+  const generated = new Set();
+  for (const row of res.rows) {
+    if (row.is_generated === 'ALWAYS') {
+      generated.add(row.column_name);
+    } else {
+      live.add(row.column_name);
+    }
+  }
+  // Merge static knowledge so an env without the column metadata still
+  // sees `co_hosts_public` as generated.
+  const staticallyKnown = GENERATED_COLUMNS_BY_TABLE[tableName];
+  if (staticallyKnown) {
+    for (const col of staticallyKnown) generated.add(col);
+  }
+  return { live, generated };
+}
+
+function buildInsertParams(tableName, recordData, columnInfo) {
+  const cols = [];
+  const placeholders = [];
+  const values = [];
+  const jsonb = JSONB_COLUMNS_BY_TABLE[tableName] || new Set();
+  let i = 1;
+  for (const [col, val] of Object.entries(recordData)) {
+    if (!columnInfo.live.has(col)) continue;
+    if (columnInfo.generated.has(col)) continue;
+    cols.push(`"${col}"`);
+    placeholders.push(`$${i++}`);
+    if (val === null || val === undefined) {
+      values.push(null);
+    } else if (jsonb.has(col)) {
+      // pg's JSONB binding expects a string OR will JSONify a JS object.
+      // Be explicit so arrays/objects from record_data round-trip correctly.
+      values.push(JSON.stringify(val));
+    } else if (typeof val === 'object' && !(val instanceof Date)) {
+      // Defensive: anything object-shaped that isn't in our jsonb allowlist
+      // is most likely also JSONB — stringify rather than risk a binding
+      // failure.
+      values.push(JSON.stringify(val));
+    } else {
+      values.push(val);
+    }
+  }
+  return { cols, placeholders, values };
+}
+
+// ------------------------------------------------------------------
+// Phase 1: load `deletion_log` rows by table + context filter
+// ------------------------------------------------------------------
+async function loadHostDeletions(client) {
+  console.log('[restore] loading deletion_log rows where context=host_dashboard');
+
+  // Distribution of contexts so the operator can sanity-check.
+  const ctxRes = await client.query(`
+    SELECT context, COUNT(*) AS n
+    FROM deletion_log
+    WHERE table_name = 'parties'
+    GROUP BY context
+    ORDER BY n DESC
+  `);
+  console.log('[restore] parties deletion_log context distribution:');
+  for (const row of ctxRes.rows) {
+    console.log(`  context=${row.context ?? '<null>'}  n=${row.n}`);
+  }
+
+  // Pick the latest deletion per record_id (so re-deleted IDs don't restore
+  // an older snapshot).
+  const partiesRes = await client.query(`
+    SELECT DISTINCT ON (record_id) record_id, deleted_at, deleted_by, record_data
+    FROM deletion_log
+    WHERE table_name = 'parties'
+      AND context = 'host_dashboard'
+    ORDER BY record_id, deleted_at DESC
+  `);
+  console.log(`[restore] candidate parties to restore: ${partiesRes.rows.length}`);
+
+  if (partiesRes.rows.length > 0) {
+    const sample = partiesRes.rows.slice(0, 3);
+    console.log('[restore] sample (first 3) record_data keys:');
+    for (const row of sample) {
+      const keys = Object.keys(row.record_data || {}).slice(0, 20).join(', ');
+      console.log(`  id=${row.record_id}  deleted_at=${row.deleted_at.toISOString?.() ?? row.deleted_at}  keys=[${keys}...]`);
+    }
+  }
+
+  return partiesRes.rows;
+}
+
+// ------------------------------------------------------------------
+// Phase 2: per-row preflight (FK + slug collision detection)
+// ------------------------------------------------------------------
+async function checkUserFk(client, userId) {
+  if (!userId) return true; // no FK to worry about
+  const res = await client.query(`SELECT 1 FROM "User" WHERE id = $1`, [userId]);
+  return res.rows.length > 0;
+}
+
+async function customUrlInUse(client, slug, partyIdToIgnore) {
+  if (!slug) return false;
+  const res = await client.query(
+    `SELECT id FROM parties WHERE custom_url = $1 AND id <> $2 AND cancelled_at IS NULL`,
+    [slug, partyIdToIgnore],
+  );
+  return res.rows.length > 0;
+}
+
+async function inviteCodeInUse(client, code, partyIdToIgnore) {
+  if (!code) return false;
+  const res = await client.query(
+    `SELECT id FROM parties WHERE invite_code = $1 AND id <> $2`,
+    [code, partyIdToIgnore],
+  );
+  return res.rows.length > 0;
+}
+
+async function aliasOrLiveOwnsSlug(client, slug) {
+  if (!slug) return true;
+  const liveRes = await client.query(
+    `SELECT 1 FROM parties WHERE custom_url = $1 OR invite_code = $1`,
+    [slug],
+  );
+  if (liveRes.rows.length > 0) return true;
+  const aliasRes = await client.query(`SELECT 1 FROM slug_aliases WHERE old_slug = $1`, [slug]);
+  return aliasRes.rows.length > 0;
+}
+
+// ------------------------------------------------------------------
+// Realtime publication helpers
+// ------------------------------------------------------------------
+async function publicationState(client, tableName) {
+  const res = await client.query(
+    `
+    SELECT 1
+    FROM pg_publication p
+    JOIN pg_publication_tables pt ON p.pubname = pt.pubname
+    WHERE p.pubname = 'supabase_realtime' AND pt.schemaname = 'public' AND pt.tablename = $1
+    `,
+    [tableName],
+  );
+  return res.rows.length > 0;
+}
+
+async function dropFromPublication(client, tableName) {
+  const present = await publicationState(client, tableName);
+  if (!present) {
+    console.log(`[restore] ${tableName} not currently in supabase_realtime — skipping DROP`);
+    return false;
+  }
+  await client.query(`ALTER PUBLICATION supabase_realtime DROP TABLE ${tableName}`);
+  console.log(`[restore] ALTER PUBLICATION supabase_realtime DROP TABLE ${tableName} — done`);
+  return true;
+}
+
+async function addToPublication(client, tableName) {
+  const present = await publicationState(client, tableName);
+  if (present) {
+    console.log(`[restore] ${tableName} already in supabase_realtime — skipping ADD`);
+    return;
+  }
+  await client.query(`ALTER PUBLICATION supabase_realtime ADD TABLE ${tableName}`);
+  console.log(`[restore] ALTER PUBLICATION supabase_realtime ADD TABLE ${tableName} — done`);
+}
+
+// ------------------------------------------------------------------
+// Main
+// ------------------------------------------------------------------
+async function main() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  console.log('[restore] mode:', APPLY ? 'APPLY' : 'DRY-RUN');
+
+  // Pre-print publication state.
+  for (const t of ['guests', 'parties']) {
+    const present = await publicationState(client, t);
+    console.log(`[restore] supabase_realtime contains ${t}? ${present}`);
+  }
+
+  const partyRows = await loadHostDeletions(client);
+  if (partyRows.length === 0) {
+    console.log('[restore] nothing to do — no host_dashboard deletions found.');
+    await client.end();
+    return;
+  }
+
+  const partiesColumnInfo = await fetchTableColumns(client, 'parties');
+
+  // Phase 2: classify each row
+  const plan = [];
+  let nullifiedUserIds = 0;
+  let customUrlRewrites = 0;
+  let inviteCodeRewrites = 0;
+
+  for (const row of partyRows) {
+    const data = { ...(row.record_data || {}) };
+    const originalCustomUrl = data.custom_url;
+    const originalInviteCode = data.invite_code;
+    const partyId = data.id ?? row.record_id;
+
+    // Orphaned userId — NULL it before insert.
+    if (data.user_id) {
+      const ok = await checkUserFk(client, data.user_id);
+      if (!ok) {
+        nullifiedUserIds += 1;
+        data.user_id = null;
+      }
+    }
+
+    // Slug collisions
+    if (data.custom_url) {
+      const taken = await customUrlInUse(client, data.custom_url, partyId);
+      if (taken) {
+        data.custom_url = `${originalCustomUrl}-cancelled-${shortid()}`;
+        customUrlRewrites += 1;
+      }
+    }
+    if (data.invite_code) {
+      const taken = await inviteCodeInUse(client, data.invite_code, partyId);
+      if (taken) {
+        data.invite_code = cuidLike();
+        inviteCodeRewrites += 1;
+      }
+    }
+
+    // Override cancellation columns with the snapshot's deletion metadata.
+    data.cancelled_at = row.deleted_at;
+    data.cancelled_by = row.deleted_by ?? 'host_dashboard_backfill';
+    data.cancellation_reason = null;
+
+    // Determine whether to create a slug alias afterwards
+    let aliasCandidate = null;
+    if (originalCustomUrl && originalCustomUrl !== data.custom_url) {
+      const conflict = await aliasOrLiveOwnsSlug(client, originalCustomUrl);
+      if (!conflict) {
+        aliasCandidate = { oldSlug: originalCustomUrl, partyId };
+      }
+    }
+
+    plan.push({
+      partyId,
+      data,
+      deletedAt: row.deleted_at,
+      originalCustomUrl,
+      originalInviteCode,
+      aliasCandidate,
+    });
+  }
+
+  console.log('[restore] preflight summary:');
+  console.log(`  parties to restore: ${plan.length}`);
+  console.log(`  orphaned user_id NULLed: ${nullifiedUserIds}`);
+  console.log(`  custom_url rewrites: ${customUrlRewrites}`);
+  console.log(`  invite_code rewrites: ${inviteCodeRewrites}`);
+  console.log(`  slug aliases queued: ${plan.filter(p => p.aliasCandidate).length}`);
+
+  if (!APPLY) {
+    console.log('[restore] dry-run complete. Re-run with --apply to insert.');
+    await client.end();
+    return;
+  }
+
+  // Phase 3: APPLY — wrap inserts so the realtime publication is restored
+  // even on failure.
+  let droppedGuestsFromPub = false;
+  const summary = {
+    partiesInserted: 0,
+    aliasesInserted: 0,
+    childRowsByTable: {},
+  };
+  try {
+    droppedGuestsFromPub = await dropFromPublication(client, 'guests');
+
+    // Insert parties first
+    for (const entry of plan) {
+      const { cols, placeholders, values } = buildInsertParams('parties', entry.data, partiesColumnInfo);
+      const sql = `
+        INSERT INTO parties (${cols.join(', ')})
+        VALUES (${placeholders.join(', ')})
+        ON CONFLICT (id) DO NOTHING
+      `;
+      try {
+        const result = await client.query(sql, values);
+        if (result.rowCount > 0) summary.partiesInserted += 1;
+      } catch (err) {
+        console.error(`[restore] FAILED inserting party ${entry.partyId}:`, err.message);
+      }
+    }
+
+    // Insert aliases (only the ones we previously verified as safe)
+    for (const entry of plan) {
+      if (!entry.aliasCandidate) continue;
+      try {
+        const result = await client.query(
+          `INSERT INTO slug_aliases (old_slug, party_id, created_at)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (old_slug) DO NOTHING`,
+          [entry.aliasCandidate.oldSlug, entry.aliasCandidate.partyId, entry.deletedAt],
+        );
+        if (result.rowCount > 0) summary.aliasesInserted += 1;
+      } catch (err) {
+        console.error(`[restore] FAILED inserting alias ${entry.aliasCandidate.oldSlug}:`, err.message);
+      }
+    }
+
+    // Build a Map<partyId, deletedAt> for window scoping the child queries
+    const restoredById = new Map(plan.map(p => [p.partyId, p.deletedAt]));
+    const restoredIds = [...restoredById.keys()];
+
+    for (const table of CHILD_TABLES_IN_ORDER) {
+      const colInfo = await fetchTableColumns(client, table);
+      // For each restored party, pull rows from deletion_log whose record_data
+      // has party_id matching, and whose deleted_at is within ±5 minutes of
+      // the parent deletion timestamp (so we capture the cascade, not
+      // unrelated earlier deletes of the same child).
+      let inserted = 0;
+      for (const [partyId, parentDeletedAt] of restoredById) {
+        const res = await client.query(
+          `
+          SELECT record_data
+          FROM deletion_log
+          WHERE table_name = $1
+            AND context = 'host_dashboard'
+            AND (record_data->>'party_id')::uuid = $2::uuid
+            AND deleted_at BETWEEN ($3::timestamptz - interval '5 minutes')
+                              AND ($3::timestamptz + interval '5 minutes')
+          `,
+          [table, partyId, parentDeletedAt],
+        );
+        for (const row of res.rows) {
+          const data = { ...(row.record_data || {}) };
+          const { cols, placeholders, values } = buildInsertParams(table, data, colInfo);
+          if (cols.length === 0) continue;
+          const sql = `
+            INSERT INTO ${table} (${cols.join(', ')})
+            VALUES (${placeholders.join(', ')})
+            ON CONFLICT (id) DO NOTHING
+          `;
+          try {
+            const result = await client.query(sql, values);
+            if (result.rowCount > 0) inserted += 1;
+          } catch (err) {
+            console.error(
+              `[restore] FAILED inserting ${table} row for party ${partyId}:`,
+              err.message,
+            );
+          }
+        }
+      }
+      summary.childRowsByTable[table] = inserted;
+      console.log(`[restore] ${table}: inserted ${inserted}`);
+      // Touch restoredIds so eslint/grep tools see we used it (also a sanity
+      // line — `restoredIds.length` should match `partiesInserted` modulo
+      // ON CONFLICT skips).
+      void restoredIds.length;
+    }
+
+    console.log('[restore] APPLY complete. Summary:', JSON.stringify(summary, null, 2));
+  } catch (err) {
+    console.error('[restore] FATAL during apply:', err);
+    throw err;
+  } finally {
+    if (droppedGuestsFromPub) {
+      try {
+        await addToPublication(client, 'guests');
+      } catch (err) {
+        console.error('[restore] FAILED to re-add guests to publication:', err.message);
+        console.error('[restore] You MUST run: ALTER PUBLICATION supabase_realtime ADD TABLE guests;');
+      }
+    }
+    // Post-print publication state.
+    for (const t of ['guests', 'parties']) {
+      const present = await publicationState(client, t);
+      console.log(`[restore] (post) supabase_realtime contains ${t}? ${present}`);
+    }
+    await client.end();
+  }
+}
+
+main().catch(err => {
+  console.error('[restore] unhandled error:', err);
+  process.exit(1);
+});

--- a/backend/src/routes/donation.routes.ts
+++ b/backend/src/routes/donation.routes.ts
@@ -159,11 +159,20 @@ router.post('/:id/donations', async (req: Request, res: Response, next: NextFunc
     // Validate party exists and has donations enabled
     const party = await prisma.party.findUnique({
       where: { id },
-      select: { id: true, donationEnabled: true },
+      select: { id: true, donationEnabled: true, cancelledAt: true },
     });
 
     if (!party) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // porchetta-81402: block donations on cancelled events. Stripe payment
+    // intents that are already in flight (created before cancel) may still
+    // charge — the donation row stays in status=pending until the webhook
+    // resolves them, which is acceptable since the donation itself is real
+    // money the host received. The check here only blocks NEW intents.
+    if (party.cancelledAt) {
+      throw new AppError('This event has been cancelled', 410, 'EVENT_CANCELLED');
     }
 
     if (!party.donationEnabled) {

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -41,6 +41,11 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         eventImageUrl: true,
         description: true,
         rsvpClosedAt: true,
+        // porchetta-81402: public event page renders a cancelled banner +
+        // disables the RSVP form when cancelledAt is non-null. The optional
+        // free-text reason is shown below the banner.
+        cancelledAt: true,
+        cancellationReason: true,
         coHosts: true,
         selectedPizzerias: true,
         eventType: true,
@@ -116,6 +121,11 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
           eventImageUrl: true,
           description: true,
           rsvpClosedAt: true,
+          // porchetta-81402: same as the invite-code branch — include cancel
+          // columns so the public event page can render the cancelled banner
+          // when reached via a customUrl.
+          cancelledAt: true,
+          cancellationReason: true,
           coHosts: true,
           selectedPizzerias: true,
           eventType: true,
@@ -293,6 +303,9 @@ router.get('/:slug', async (req: Request, res: Response, next: NextFunction) => 
         eventImageUrl: party.eventImageUrl,
         description: party.description,
         rsvpClosedAt: party.rsvpClosedAt,
+        // porchetta-81402: include cancelled state in the public event payload.
+        cancelledAt: party.cancelledAt,
+        cancellationReason: party.cancellationReason,
         coHosts: sanitizedCoHosts,
         selectedPizzerias: party.selectedPizzerias,
         eventType: party.eventType,

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -650,6 +650,10 @@ const gppEventSelect = {
   eventTags: true,
   underbossStatus: true,
   rsvpClosedAt: true,
+  // porchetta-81402: surface cancelled state so moderator views (which
+  // include cancelled events) can render a "Cancelled" badge.
+  cancelledAt: true,
+  cancellationReason: true,
   createdAt: true,
   coHosts: true,
   _count: {
@@ -712,6 +716,10 @@ function formatGppEvent(event: any, callerIsModerator = false) {
     approved: event.underbossStatus === 'approved',
     community: event.underbossStatus === 'listed',
     rsvpOpen: !event.rsvpClosedAt,
+    // porchetta-81402: included in the public GPP shape so consumers
+    // (apps.gpp.day, admin tools) can flag cancelled events even after
+    // they're filtered out of the default `/events` listing.
+    cancelledAt: event.cancelledAt ? new Date(event.cancelledAt).toISOString() : null,
   };
 
   if (!callerIsModerator) return base;
@@ -799,6 +807,12 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
     } else {
       where.underbossStatus = { notIn: ['rejected', 'hidden'] };
     }
+    // porchetta-81402: cancelled events are hidden from the public GPP map +
+    // listings (moderator views still see them so they can verify the cancel
+    // was intentional and reach out to the host if needed).
+    if (!includeAllStatuses) {
+      where.cancelledAt = null;
+    }
     if (city) {
       where.name = { contains: city as string, mode: 'insensitive' };
     }
@@ -845,6 +859,9 @@ router.get('/pizzerias', async (req: Request, res: Response, next: NextFunction)
       eventType: 'gpp',
       selectedPizzerias: { not: Prisma.DbNull },
       underbossStatus: { notIn: ['rejected', 'hidden'] },
+      // porchetta-81402: cancelled events shouldn't surface their pizzerias
+      // on the public /gpp/pizzerias roll-up.
+      cancelledAt: null,
     };
 
     const parties = await prisma.party.findMany({

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -86,6 +86,9 @@ router.get('/my-events', async (req: AuthRequest, res: Response, next: NextFunct
       address: true,
       eventImageUrl: true,
       coHosts: true,
+      // porchetta-81402: surface cancellation state so HomePage can render
+      // the "Cancelled" pill on cancelled events.
+      cancelledAt: true,
       _count: { select: { guests: true } },
     };
 
@@ -170,6 +173,8 @@ router.get('/my-events', async (req: AuthRequest, res: Response, next: NextFunct
       eventImageUrl: p.eventImageUrl,
       guestCount: p._count?.guests ?? 0,
       role: p.role,
+      // porchetta-81402: HomePage renders a "Cancelled" pill from this field.
+      cancelledAt: p.cancelledAt ? p.cancelledAt.toISOString() : null,
     }));
 
     // Sort by date ascending (nulls last)
@@ -425,6 +430,9 @@ router.get('/:id', async (req: AuthRequest, res: Response, next: NextFunction) =
           reimbursementCapUsd: (party as any).reimbursementCapUsd,
           eventTags: (party as any).eventTags,
         }),
+        // porchetta-81402: `findUnique` without `select` already returns the
+        // 3 cancel columns, so we don't need to splice them in here — the
+        // spread above carries them through. Listed for documentation.
       }
     });
   } catch (error) {
@@ -468,6 +476,10 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       reimbursementCapUsd,
       // quattro-71244: gamified dashboard goals (JSONB) — per-KPI host targets.
       hostGoals,
+      // porchetta-81402: host can edit the free-text cancellation reason
+      // without re-cancelling. Cancel/reinstate themselves go through their
+      // dedicated POST endpoints — NOT through this PATCH whitelist.
+      cancellationReason,
       // NOTE: reimbursementCapAppealNote + reimbursementCapAppealedAt are NOT
       // destructured here — appeals flow through the dedicated
       // POST /:partyId/reimbursement-cap/appeal endpoint so we can timestamp
@@ -706,6 +718,14 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(parkingNotes !== undefined && { parkingNotes: parkingNotes || null }),
         ...(reimbursementCapUsdToWrite !== undefined && { reimbursementCapUsd: reimbursementCapUsdToWrite }),
         ...(hostGoalsToWrite !== undefined && { hostGoals: hostGoalsToWrite }),
+        // porchetta-81402: allow editing the cancellation reason (truncated to
+        // 500 chars to match the cancel-handler limit). Empty string clears it.
+        ...(cancellationReason !== undefined && {
+          cancellationReason:
+            typeof cancellationReason === 'string' && cancellationReason.trim()
+              ? cancellationReason.trim().slice(0, 500)
+              : null,
+        }),
       },
       include: {
         user: { select: { name: true } },
@@ -774,23 +794,167 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
   }
 });
 
-// DELETE /api/parties/:id - Delete party
-router.delete('/:id', async (req: AuthRequest, res: Response, next: NextFunction) => {
+// ============================================
+// porchetta-81402: Cancel / reinstate endpoints
+// ============================================
+// `DELETE /api/parties/:id` used to hard-delete the party row, which
+// destroyed the public URL, every guest RSVP, sponsors, donations,
+// photos, and so on. The new flow soft-cancels by writing
+// `cancelled_at` / `cancelled_by` / `cancellation_reason` — the row
+// and its children stay intact, the public URL stays live (showing a
+// "this event has been cancelled" banner), and a host can reinstate
+// with one click. The DELETE route is preserved as a back-compat
+// alias that routes to the same soft-cancel handler.
+//
+// Audit: when the `party_status_audit` table exists in the DB we
+// also record cancel/reinstate transitions. The table was introduced
+// by pizzaiolo-97053 (2026-05-15); the existence check keeps the new
+// handlers running in environments where that migration hasn't been
+// applied yet.
+
+async function softCancelParty(
+  partyId: string,
+  userEmail: string | undefined,
+  reason: string | null,
+) {
+  return prisma.party.update({
+    where: { id: partyId },
+    data: {
+      cancelledAt: new Date(),
+      cancelledBy: userEmail || 'unknown',
+      cancellationReason:
+        reason && reason.trim() ? reason.trim().slice(0, 500) : null,
+    },
+  });
+}
+
+async function recordPartyStatusAuditIfTableExists(args: {
+  partyId: string;
+  action: 'cancel' | 'reinstate';
+  oldStatus: string | null;
+  newStatus: string;
+  actorEmail: string;
+  reason?: string | null;
+}) {
+  try {
+    const result = await prisma.$queryRaw<{ exists: boolean }[]>`
+      SELECT to_regclass('party_status_audit') IS NOT NULL AS exists
+    `;
+    if (!result[0]?.exists) return;
+    // Column shape mirrors the PartyStatusAudit Prisma model from
+    // pizzaiolo-97053 (action / old_status / new_status / actor_email /
+    // actor_kind / reason). We log actor_kind='host' because the cancel/
+    // reinstate routes are auth-gated to host + cohost-with-canEdit only;
+    // super_admins reach this path too but logging them as 'host' is the
+    // same convention used by the other party.routes audit writes.
+    await prisma.$executeRaw`
+      INSERT INTO party_status_audit
+        (party_id, action, old_status, new_status, actor_email, actor_kind, reason)
+      VALUES
+        (${args.partyId}::uuid, ${args.action}, ${args.oldStatus}, ${args.newStatus},
+         ${args.actorEmail}, 'host', ${args.reason ?? null})
+    `;
+  } catch (err) {
+    // Audit is best-effort — never let a logging failure roll back the
+    // user-visible cancel/reinstate.
+    console.warn('[porchetta-81402] party_status_audit insert failed:', err);
+  }
+}
+
+// POST /api/parties/:id/cancel - Soft-cancel the event
+router.post('/:id/cancel', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { id } = req.params;
 
-    // Verify ownership or super admin
     const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
 
-    await prisma.$transaction(async (tx) => {
-      await setDeleteContext(tx, req.userEmail, 'host_dashboard');
-      await tx.party.delete({ where: { id } });
+    const reason: string | null = (req.body || {}).reason ?? null;
+    const party = await softCancelParty(id, req.userEmail, reason);
+
+    await recordPartyStatusAuditIfTableExists({
+      partyId: id,
+      action: 'cancel',
+      oldStatus: 'active',
+      newStatus: 'cancelled',
+      actorEmail: req.userEmail || 'unknown',
+      reason: party.cancellationReason,
     });
 
-    // Trigger webhook for party deletion
+    // New event for new consumers + legacy `party.deleted` for back-compat.
+    await triggerWebhook('party.cancelled', party, req.userId!);
+    await triggerWebhook('party.deleted', { id }, req.userId!);
+
+    res.json({ success: true, party });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/parties/:id/reinstate - Un-cancel the event
+router.post('/:id/reinstate', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+
+    const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // NOTE: reinstating intentionally does NOT touch rsvp_closed_at — if
+    // the host had closed RSVPs separately, they stay closed.
+    const party = await prisma.party.update({
+      where: { id },
+      data: {
+        cancelledAt: null,
+        cancelledBy: null,
+        cancellationReason: null,
+      },
+    });
+
+    await recordPartyStatusAuditIfTableExists({
+      partyId: id,
+      action: 'reinstate',
+      oldStatus: 'cancelled',
+      newStatus: 'active',
+      actorEmail: req.userEmail || 'unknown',
+    });
+
+    await triggerWebhook('party.reinstated', party, req.userId!);
+
+    res.json({ success: true, party });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/parties/:id - LEGACY ALIAS that now soft-cancels instead of
+// destroying the row. Old API clients (and the frontend `deletePartyApi`
+// helper before this PR) hit this path; new code should use POST /cancel
+// with an optional reason in the body. There is no reason here because
+// DELETE bodies are not part of the existing API contract.
+router.delete('/:id', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+
+    const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    const party = await softCancelParty(id, req.userEmail, null);
+
+    await recordPartyStatusAuditIfTableExists({
+      partyId: id,
+      action: 'cancel',
+      oldStatus: 'active',
+      newStatus: 'cancelled',
+      actorEmail: req.userEmail || 'unknown',
+    });
+
+    await triggerWebhook('party.cancelled', party, req.userId!);
     await triggerWebhook('party.deleted', { id }, req.userId!);
 
     res.json({ success: true });
@@ -896,6 +1060,21 @@ router.post('/:id/open-rsvp', async (req: AuthRequest, res: Response, next: Next
     const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // porchetta-81402: a cancelled event must be reinstated before its RSVP
+    // toggle can be reopened — otherwise the host could "open" RSVPs that
+    // would then 410 on submit, which is confusing UX.
+    const current = await prisma.party.findUnique({
+      where: { id },
+      select: { cancelledAt: true },
+    });
+    if (current?.cancelledAt) {
+      throw new AppError(
+        'This event has been cancelled. Reinstate it before reopening RSVPs.',
+        410,
+        'EVENT_CANCELLED',
+      );
     }
 
     const party = await prisma.party.update({
@@ -1174,6 +1353,16 @@ router.post('/:id/guests', async (req: AuthRequest, res: Response, next: NextFun
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
       throw new AppError('Name is required', 400, 'VALIDATION_ERROR');
+    }
+
+    // porchetta-81402: block host-side adds on cancelled events. Hosts must
+    // reinstate first before they can keep adding guests.
+    const partyState = await prisma.party.findUnique({
+      where: { id },
+      select: { cancelledAt: true },
+    });
+    if (partyState?.cancelledAt) {
+      throw new AppError('This event has been cancelled', 410, 'EVENT_CANCELLED');
     }
 
     // Check if guest with this email already exists for this party

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -256,11 +256,16 @@ router.post('/:partyId/photos', async (req: AuthRequest, res: Response, next: Ne
     // Get party to check if photos are enabled and moderation setting
     const party = await prisma.party.findUnique({
       where: { id: partyId },
-      select: { id: true, photosEnabled: true, photoModeration: true },
+      select: { id: true, photosEnabled: true, photoModeration: true, cancelledAt: true },
     });
 
     if (!party) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+
+    // porchetta-81402: cancelled events are read-only.
+    if (party.cancelledAt) {
+      throw new AppError('This event has been cancelled', 410, 'EVENT_CANCELLED');
     }
 
     if (!party.photosEnabled) {

--- a/backend/src/routes/raffle.routes.ts
+++ b/backend/src/routes/raffle.routes.ts
@@ -349,6 +349,15 @@ router.post('/:partyId/raffles/:raffleId/enter', async (req: AuthRequest, res: R
       throw new AppError('Guest ID is required', 400, 'VALIDATION_ERROR');
     }
 
+    // porchetta-81402: cancelled events are read-only.
+    const partyState = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { cancelledAt: true },
+    });
+    if (partyState?.cancelledAt) {
+      throw new AppError('This event has been cancelled', 410, 'EVENT_CANCELLED');
+    }
+
     // Get raffle with current entry count
     const raffle = await prisma.raffle.findFirst({
       where: { id: raffleId, partyId },

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -349,6 +349,8 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
         customUrl: true,
         eventImageUrl: true,
         rsvpClosedAt: true,
+        // porchetta-81402: block RSVP submission on cancelled events.
+        cancelledAt: true,
         maxGuests: true,
         requireApproval: true,
         userId: true,
@@ -370,6 +372,8 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
           customUrl: true,
           eventImageUrl: true,
           rsvpClosedAt: true,
+          // porchetta-81402: block RSVP submission on cancelled events.
+          cancelledAt: true,
           maxGuests: true,
           requireApproval: true,
           userId: true,
@@ -397,6 +401,8 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             customUrl: true,
             eventImageUrl: true,
             rsvpClosedAt: true,
+            // porchetta-81402: block RSVP submission on cancelled events.
+            cancelledAt: true,
             maxGuests: true,
             requireApproval: true,
             userId: true,
@@ -409,6 +415,13 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
 
     if (!party) {
       throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+    }
+
+    // porchetta-81402: 410 GONE when the host has cancelled the event.
+    // Checked BEFORE the rsvp_closed_at check so the reason surfaced to the
+    // submitter is "cancelled" (more accurate) rather than "closed".
+    if ((party as any).cancelledAt) {
+      throw new AppError('This event has been cancelled', 410, 'EVENT_CANCELLED');
     }
 
     // Check if RSVPs are closed

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -55,13 +55,17 @@ sponsorUserAdminRouter.get('/list', requireAuth, async (req: AuthRequest, res: R
       },
     });
 
-    // Count events per tag for admin UI
+    // Count events per tag for admin UI.
+    // porchetta-81402: exclude cancelled events from tag counts so admins
+    // see "live" partner footprint, not historical-including-cancelled.
     const tagCounts: Record<string, number> = {};
     const uniqueTags = [...new Set(sponsorUsers.map(su => su.tag))];
     if (uniqueTags.length > 0) {
       for (const tag of uniqueTags) {
         const count = await prisma.party.count({
-          where: tag === 'pizzadao' ? {} : { eventTags: { has: tag } },
+          where: tag === 'pizzadao'
+            ? { cancelledAt: null }
+            : { eventTags: { has: tag }, cancelledAt: null },
         });
         tagCounts[tag] = count;
       }
@@ -545,6 +549,11 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       where.underbossStatus = 'approved';
     }
 
+    // porchetta-81402: cancelled events are excluded from sponsor-user
+    // listings/tag counts so partners don't see (and don't get billed for)
+    // events that won't happen.
+    where.cancelledAt = null;
+
     // Find events
     const events = await prisma.party.findMany({
       where,
@@ -995,6 +1004,9 @@ sponsorDashboardRouter.get('/events/timeseries', requireAuth, requireSponsorAuth
         points: [],
       });
     }
+
+    // porchetta-81402: exclude cancelled events from sponsor trend lines.
+    where.cancelledAt = null;
 
     const events = await prisma.party.findMany({
       where,

--- a/backend/src/routes/sponsor.routes.ts
+++ b/backend/src/routes/sponsor.routes.ts
@@ -387,6 +387,15 @@ router.post('/:partyId/sponsors', requireAuth, async (req: AuthRequest, res: Res
       throw new AppError(`Invalid sponsorship type. Must be one of: ${validTypes.join(', ')}`, 400, 'VALIDATION_ERROR');
     }
 
+    // porchetta-81402: cancelled events are read-only.
+    const partyState = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { cancelledAt: true },
+    });
+    if (partyState?.cancelledAt) {
+      throw new AppError('This event has been cancelled', 410, 'EVENT_CANCELLED');
+    }
+
     // Append to the end of the sort order for this party
     const lastSponsor = await prisma.sponsor.findFirst({
       where: { partyId },

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -174,6 +174,11 @@ function formatEvent(party: any, underbossEmails: string[] = [], latestSponsorMa
     flyerConfig: party.flyerConfig || null,
     latestSponsorAt: latestSponsorAtStr,
     flyerStale,
+    // porchetta-81402: surface cancelled state so the underboss dashboard
+    // can badge / filter cancelled events. Kept INCLUDED (not excluded) so
+    // an underboss can spot churn in their region.
+    cancelledAt: party.cancelledAt ? new Date(party.cancelledAt).toISOString() : null,
+    cancellationReason: party.cancellationReason || null,
     // Reimbursement cap (arugula-38633 v2) — exposed so the underboss
     // dashboard can render Validate/Override controls + appeal indicator.
     city: party.city || null,

--- a/backend/src/routes/v1/webhooks.ts
+++ b/backend/src/routes/v1/webhooks.ts
@@ -66,7 +66,7 @@ router.get('/', requireApiKey(SCOPES.WEBHOOKS_READ), async (req: ApiKeyRequest, 
  *                 type: array
  *                 items:
  *                   type: string
- *                   enum: [party.created, party.updated, party.deleted, party.rsvp_closed, party.rsvp_opened, guest.registered, guest.updated, guest.approved, guest.declined, guest.removed]
+ *                   enum: [party.created, party.updated, party.deleted, party.cancelled, party.reinstated, party.rsvp_closed, party.rsvp_opened, guest.registered, guest.updated, guest.approved, guest.declined, guest.removed]
  *     responses:
  *       201:
  *         description: Webhook created successfully

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -5,7 +5,14 @@ import { createWebhookSignature } from '../middleware/apiKey.js';
 export const WEBHOOK_EVENTS = [
   'party.created',
   'party.updated',
+  // porchetta-81402: `party.deleted` is now a legacy alias for `party.cancelled`.
+  // The DELETE /api/parties/:id route was converted to a soft-cancel handler so
+  // hosts can recover from accidental "delete" clicks and we stop losing guest
+  // history. Both events are fired; new consumers should listen to
+  // `party.cancelled` / `party.reinstated`.
   'party.deleted',
+  'party.cancelled',
+  'party.reinstated',
   'party.rsvp_closed',
   'party.rsvp_opened',
   'guest.registered',

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -57,7 +57,9 @@ Receive real-time notifications when events occur:
 |-------|-------------|
 | \`party.created\` | New party created |
 | \`party.updated\` | Party details updated |
-| \`party.deleted\` | Party deleted |
+| \`party.deleted\` | Party cancelled (legacy alias). \`DELETE /api/parties/:id\` no longer destroys data — it soft-cancels the event, preserving the public URL, guests, and child resources. Subscribers that previously listened for \`party.deleted\` should now subscribe to \`party.cancelled\`; the legacy event is kept for backwards compat. |
+| \`party.cancelled\` | Event cancelled (soft-delete). Public URL is preserved, guests stay attached, RSVPs are blocked. |
+| \`party.reinstated\` | Cancelled event was un-cancelled by the host. |
 | \`party.rsvp_closed\` | RSVPs closed |
 | \`party.rsvp_opened\` | RSVPs reopened |
 | \`guest.registered\` | New guest RSVP |

--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -2,10 +2,10 @@
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { User, Lock, Image as ImageIcon, FileText, Loader2, X, Square as SquareIcon, Trash2, Calendar, Play, DollarSign, Wand2, MessageCircle, Send, Check } from 'lucide-react';
+import { User, Lock, Image as ImageIcon, FileText, Loader2, X, Square as SquareIcon, Ban, RefreshCcw, Calendar, Play, DollarSign, Wand2, MessageCircle, Send, Check } from 'lucide-react';
 import { IconInput } from './IconInput';
 import { usePizza } from '../contexts/PizzaContext';
-import { updateParty, uploadEventImage, deleteParty } from '../lib/supabase';
+import { updateParty, uploadEventImage, cancelParty, reinstateParty } from '../lib/supabase';
 import { mintHostTelegramConnectToken, disconnectHostTelegram } from '../lib/api';
 import { CustomUrlInput } from './CustomUrlInput';
 import { LocationAutocomplete } from './LocationAutocomplete';
@@ -91,8 +91,12 @@ export const EventDetailsTab: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [savingField, setSavingField] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // porchetta-81402: cancel state (was `deleting` / `showDeleteConfirm` before
+  // the destructive delete was converted to a non-destructive soft-cancel).
+  const [cancelling, setCancelling] = useState(false);
+  const [reinstating, setReinstating] = useState(false);
+  const [showCancelPrompt, setShowCancelPrompt] = useState(false);
+  const [cancelReason, setCancelReason] = useState('');
   const [showDateTimeModal, setShowDateTimeModal] = useState(false);
   const [showImageModal, setShowImageModal] = useState(false);
   const [showDescriptionModal, setShowDescriptionModal] = useState(false);
@@ -448,27 +452,61 @@ export const EventDetailsTab: React.FC = () => {
     }
   };
 
-  const handleDelete = async () => {
+  // porchetta-81402: soft-cancel the event. The host stays on this page (no
+  // redirect to home), the public URL keeps working, and the host can
+  // reinstate via the symmetric button — no confirm modal needed for
+  // reinstate because the action is reversible.
+  const handleCancel = async () => {
     if (!party) return;
 
-    setDeleting(true);
+    setCancelling(true);
     setMessage(null);
 
     try {
-      const success = await deleteParty(party.id);
+      const success = await cancelParty(party.id, cancelReason);
       if (success) {
-        setMessage({ type: 'success', text: 'Event deleted successfully' });
-        // Redirect to home page after a short delay
-        setTimeout(() => {
-          navigate('/');
-        }, 1500);
+        const trimmed = cancelReason.trim().slice(0, 500) || null;
+        // Merge in-place so the dashboard renders the cancelled state without
+        // re-fetching — same pattern as `arugula-38633` v2 / `burrata-72104`.
+        mergeParty({
+          cancelledAt: new Date().toISOString(),
+          cancellationReason: trimmed,
+        });
+        setShowCancelPrompt(false);
+        setCancelReason('');
       } else {
-        throw new Error('Failed to delete event');
+        throw new Error('Failed to cancel event');
       }
     } catch (error) {
-      console.error('Error deleting party:', error);
-      setMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to delete event' });
-      setDeleting(false);
+      console.error('Error cancelling party:', error);
+      setMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to cancel event' });
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  const handleReinstate = async () => {
+    if (!party) return;
+
+    setReinstating(true);
+    setMessage(null);
+
+    try {
+      const success = await reinstateParty(party.id);
+      if (success) {
+        mergeParty({
+          cancelledAt: null,
+          cancelledBy: null,
+          cancellationReason: null,
+        });
+      } else {
+        throw new Error('Failed to reinstate event');
+      }
+    } catch (error) {
+      console.error('Error reinstating party:', error);
+      setMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to reinstate event' });
+    } finally {
+      setReinstating(false);
     }
   };
 
@@ -1138,48 +1176,86 @@ export const EventDetailsTab: React.FC = () => {
           </div>
         )}
 
-        {/* Cancel Event Button */}
-        <button
-          type="button"
-          onClick={() => setShowDeleteConfirm(true)}
-          disabled={deleting}
-          className="w-full bg-[#ff393a]/10 hover:bg-[#ff393a]/20 border border-[#ff393a]/30 text-[#ff393a] hover:text-[#ff5a5b] font-medium px-6 py-3 rounded-xl transition-all flex items-center justify-center gap-2"
-        >
-          <Trash2 size={18} />
-          {t('eventDetails.deleteEvent')}
-        </button>
+        {/* porchetta-81402: Cancel / Reinstate button — symmetric, no confirm
+            modal for reinstate because the action is reversible
+            (`feedback_reversible_actions_no_confirm`). Cancel still uses a
+            modal so the host can optionally provide a reason. */}
+        {party.cancelledAt ? (
+          <button
+            type="button"
+            onClick={handleReinstate}
+            disabled={reinstating}
+            className="w-full bg-[#39d98a]/10 hover:bg-[#39d98a]/20 border border-[#39d98a]/30 text-[#39d98a] hover:text-[#5be0a4] font-medium px-6 py-3 rounded-xl transition-all flex items-center justify-center gap-2"
+          >
+            {reinstating ? (
+              <>
+                <Loader2 size={18} className="animate-spin" />
+                {t('eventDetails.reinstating')}
+              </>
+            ) : (
+              <>
+                <RefreshCcw size={18} />
+                {t('eventDetails.reinstateEvent')}
+              </>
+            )}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowCancelPrompt(true)}
+            disabled={cancelling}
+            className="w-full bg-[#ff393a]/10 hover:bg-[#ff393a]/20 border border-[#ff393a]/30 text-[#ff393a] hover:text-[#ff5a5b] font-medium px-6 py-3 rounded-xl transition-all flex items-center justify-center gap-2"
+          >
+            <Ban size={18} />
+            {t('eventDetails.cancelEvent')}
+          </button>
+        )}
       </div>
 
-      {/* Delete Confirmation Modal */}
-      {showDeleteConfirm && createPortal(
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-          <div className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl p-6 w-full max-w-md">
-            <h2 className="text-xl font-bold text-theme-text mb-3">{t('eventDetails.deleteConfirmTitle')}</h2>
-            <p className="text-theme-text-secondary mb-6">
-              {t('eventDetails.deleteConfirmMessage')}
+      {/* porchetta-81402: Cancel modal — optional free-text reason input.
+          Backend truncates to 500 chars; we mirror the limit here. */}
+      {showCancelPrompt && createPortal(
+        <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={() => !cancelling && setShowCancelPrompt(false)}>
+          <div
+            className="bg-theme-header border border-theme-stroke rounded-2xl shadow-xl p-6 w-full max-w-md"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-xl font-bold text-theme-text mb-3">{t('eventDetails.cancelConfirmTitle')}</h2>
+            <p className="text-theme-text-secondary mb-4">
+              {t('eventDetails.cancelConfirmMessage')}
             </p>
+            <div className="mb-4">
+              <IconInput
+                icon={FileText}
+                multiline
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.target.value)}
+                maxLength={500}
+                placeholder={t('eventDetails.cancelReasonPlaceholder')}
+              />
+            </div>
             <div className="flex gap-3">
               <button
-                onClick={() => setShowDeleteConfirm(false)}
-                disabled={deleting}
+                onClick={() => setShowCancelPrompt(false)}
+                disabled={cancelling}
                 className="flex-1 btn-secondary"
               >
                 {t('eventDetails.cancel')}
               </button>
               <button
-                onClick={handleDelete}
-                disabled={deleting}
+                onClick={handleCancel}
+                disabled={cancelling}
                 className="flex-1 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-6 py-3 rounded-xl transition-all flex items-center justify-center gap-2"
               >
-                {deleting ? (
+                {cancelling ? (
                   <>
                     <Loader2 size={18} className="animate-spin" />
-                    Deleting...
+                    {t('eventDetails.cancelling')}
                   </>
                 ) : (
                   <>
-                    <Trash2 size={18} />
-                    {t('eventDetails.deleteConfirmButton')}
+                    <Ban size={18} />
+                    {t('eventDetails.cancelConfirmButton')}
                   </>
                 )}
               </button>

--- a/frontend/src/components/RSVPModal.tsx
+++ b/frontend/src/components/RSVPModal.tsx
@@ -136,6 +136,10 @@ export function RSVPModal({ isOpen, onClose, event, existingGuest, onRSVPSuccess
   };
 
   if (!isOpen) return null;
+  // porchetta-81402: defense-in-depth — EventPage already hides the RSVP
+  // button on cancelled events, but if a stale tab opens the modal anyway
+  // we don't want it to submit. Drop the modal silently.
+  if (event.cancelledAt) return null;
 
   const isEditing = !!existingGuest;
 

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -177,6 +177,10 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     parkingNotes: dbParty.parking_notes ?? null,
     // quattro-71244: gamified-dashboard goal targets.
     hostGoals: dbParty.host_goals ?? null,
+    // porchetta-81402: soft-cancel state.
+    cancelledAt: dbParty.cancelled_at ?? null,
+    cancelledBy: dbParty.cancelled_by ?? null,
+    cancellationReason: dbParty.cancellation_reason ?? null,
     guests,
   };
 }

--- a/frontend/src/i18n/locales/de/account.json
+++ b/frontend/src/i18n/locales/de/account.json
@@ -12,7 +12,8 @@
     "guest_one": "{{count}} Gast",
     "guest_other": "{{count}} Gäste",
     "alreadyCreated": "Bereits eine Party erstellt?",
-    "viewAllTest": "Alle Test-Events anzeigen"
+    "viewAllTest": "Alle Test-Events anzeigen",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "Ihr Profil",

--- a/frontend/src/i18n/locales/de/event.json
+++ b/frontend/src/i18n/locales/de/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "Passwort eingeben",
     "incorrectPassword": "Falsches Passwort",
     "viewReport": "Bericht ansehen"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "Event löschen",
     "deleteConfirmMessage": "Sind Sie sicher, dass Sie dieses Event löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
     "deleteConfirmButton": "Event löschen",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "Getränke",

--- a/frontend/src/i18n/locales/en/account.json
+++ b/frontend/src/i18n/locales/en/account.json
@@ -8,6 +8,7 @@
     "createParty": "Create Party",
     "noEvents": "No {{filter}} events",
     "host": "Host",
+    "cancelled": "Cancelled",
     "dateTbd": "Date TBD",
     "guest_one": "{{count}} guest",
     "guest_other": "{{count}} guests",

--- a/frontend/src/i18n/locales/en/event.json
+++ b/frontend/src/i18n/locales/en/event.json
@@ -37,6 +37,12 @@
   "rsvp": "RSVP",
   "editRsvp": "Edit RSVP",
   "rsvpsClosed": "RSVPs are closed for this event",
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
+  },
   "viewPhotos": "View Photos ({{count}})",
   "sharePhotos": "Share Photos",
   "pizzadaoDescription": "is an international pizza co-op that's bringing the pizza industry onchain. We throw a global pizza party every year, arrange conference events every month, and support other organizers' meetups with pizza.",

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -497,7 +497,15 @@
     "deleteConfirmTitle": "Delete Event",
     "deleteConfirmMessage": "Are you sure you want to delete this event? This action cannot be undone.",
     "deleteConfirmButton": "Delete Event",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "Drinks",

--- a/frontend/src/i18n/locales/es/account.json
+++ b/frontend/src/i18n/locales/es/account.json
@@ -12,7 +12,8 @@
     "guest_one": "{{count}} invitado",
     "guest_other": "{{count}} invitados",
     "alreadyCreated": "¿Ya creaste un evento?",
-    "viewAllTest": "Ver todos los eventos de prueba"
+    "viewAllTest": "Ver todos los eventos de prueba",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "Tu Perfil",

--- a/frontend/src/i18n/locales/es/event.json
+++ b/frontend/src/i18n/locales/es/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "Ingresa la contraseña",
     "incorrectPassword": "Contraseña incorrecta",
     "viewReport": "Ver Reporte"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "Eliminar Evento",
     "deleteConfirmMessage": "¿Estás seguro de que quieres eliminar este evento? Esta acción no se puede deshacer.",
     "deleteConfirmButton": "Eliminar Evento",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "Bebidas",

--- a/frontend/src/i18n/locales/fr/account.json
+++ b/frontend/src/i18n/locales/fr/account.json
@@ -12,7 +12,8 @@
     "guest_one": "{{count}} invité",
     "guest_other": "{{count}} invités",
     "alreadyCreated": "Vous avez déjà créé un événement ?",
-    "viewAllTest": "Voir tous les événements test"
+    "viewAllTest": "Voir tous les événements test",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "Votre profil",

--- a/frontend/src/i18n/locales/fr/event.json
+++ b/frontend/src/i18n/locales/fr/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "Entrez le mot de passe",
     "incorrectPassword": "Mot de passe incorrect",
     "viewReport": "Voir le rapport"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "Supprimer l'événement",
     "deleteConfirmMessage": "Êtes-vous sûr de vouloir supprimer cet événement ? Cette action est irréversible.",
     "deleteConfirmButton": "Supprimer l'événement",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "Boissons",

--- a/frontend/src/i18n/locales/ja/account.json
+++ b/frontend/src/i18n/locales/ja/account.json
@@ -12,7 +12,8 @@
     "guest_one": "{{count}}名のゲスト",
     "guest_other": "{{count}}名のゲスト",
     "alreadyCreated": "すでにパーティーを作成しましたか？",
-    "viewAllTest": "すべてのテストイベントを表示"
+    "viewAllTest": "すべてのテストイベントを表示",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "あなたのプロフィール",

--- a/frontend/src/i18n/locales/ja/event.json
+++ b/frontend/src/i18n/locales/ja/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "パスワードを入力",
     "incorrectPassword": "パスワードが正しくありません",
     "viewReport": "レポートを表示"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "イベントを削除",
     "deleteConfirmMessage": "このイベントを削除してもよろしいですか？この操作は取り消せません。",
     "deleteConfirmButton": "イベントを削除",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "ドリンク",

--- a/frontend/src/i18n/locales/ko/account.json
+++ b/frontend/src/i18n/locales/ko/account.json
@@ -12,7 +12,8 @@
     "guest_one": "게스트 {{count}}명",
     "guest_other": "게스트 {{count}}명",
     "alreadyCreated": "이미 파티를 만드셨나요?",
-    "viewAllTest": "모든 테스트 이벤트 보기"
+    "viewAllTest": "모든 테스트 이벤트 보기",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "내 프로필",

--- a/frontend/src/i18n/locales/ko/event.json
+++ b/frontend/src/i18n/locales/ko/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "비밀번호 입력",
     "incorrectPassword": "비밀번호가 올바르지 않습니다",
     "viewReport": "리포트 보기"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "이벤트 삭제",
     "deleteConfirmMessage": "이 이벤트를 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
     "deleteConfirmButton": "이벤트 삭제",
-    "cancel": "취소"
+    "cancel": "취소",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "음료",

--- a/frontend/src/i18n/locales/pt/account.json
+++ b/frontend/src/i18n/locales/pt/account.json
@@ -12,7 +12,8 @@
     "guest_one": "{{count}} convidado",
     "guest_other": "{{count}} convidados",
     "alreadyCreated": "Já criou uma festa?",
-    "viewAllTest": "Ver todos os eventos de teste"
+    "viewAllTest": "Ver todos os eventos de teste",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "Seu Perfil",

--- a/frontend/src/i18n/locales/pt/event.json
+++ b/frontend/src/i18n/locales/pt/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "Insira a senha",
     "incorrectPassword": "Senha incorreta",
     "viewReport": "Ver Relatório"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "Excluir Evento",
     "deleteConfirmMessage": "Tem certeza de que deseja excluir este evento? Esta ação não pode ser desfeita.",
     "deleteConfirmButton": "Excluir Evento",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "Bebidas",

--- a/frontend/src/i18n/locales/zh/account.json
+++ b/frontend/src/i18n/locales/zh/account.json
@@ -12,7 +12,8 @@
     "guest_one": "{{count}} 位来宾",
     "guest_other": "{{count}} 位来宾",
     "alreadyCreated": "已经创建了派对？",
-    "viewAllTest": "查看所有测试活动"
+    "viewAllTest": "查看所有测试活动",
+    "cancelled": "Cancelled"
   },
   "profile": {
     "title": "您的个人资料",

--- a/frontend/src/i18n/locales/zh/event.json
+++ b/frontend/src/i18n/locales/zh/event.json
@@ -77,5 +77,11 @@
     "enterPasswordPlaceholder": "输入密码",
     "incorrectPassword": "密码错误",
     "viewReport": "查看报告"
+  },
+  "cancelled": {
+    "bannerTitle": "This event has been cancelled",
+    "reasonLabel": "Reason",
+    "noticeTitle": "Event Cancelled",
+    "noticeBody": "RSVPs are closed for this event."
   }
 }

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -454,7 +454,15 @@
     "deleteConfirmTitle": "删除活动",
     "deleteConfirmMessage": "确定要删除此活动吗？此操作无法撤销。",
     "deleteConfirmButton": "删除活动",
-    "cancel": "取消"
+    "cancel": "取消",
+    "cancelEvent": "Cancel event",
+    "cancelConfirmTitle": "Cancel this event?",
+    "cancelConfirmMessage": "RSVPs will close and the event page will show a cancellation banner. Guests stay attached to the event and you can reinstate it at any time.",
+    "cancelConfirmButton": "Cancel Event",
+    "cancelReasonPlaceholder": "Optional: why is this event cancelled?",
+    "cancelling": "Cancelling...",
+    "reinstateEvent": "Reinstate event",
+    "reinstating": "Reinstating..."
   },
   "beverages": {
     "drinks": "饮品",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -88,6 +88,8 @@ export interface UserPartyListItem {
   eventImageUrl: string | null;
   guestCount: number;
   role: 'host' | 'guest' | 'cohost';
+  // porchetta-81402: HomePage renders a "Cancelled" pill on cancelled events.
+  cancelledAt?: string | null;
 }
 
 export async function fetchMyEvents(): Promise<UserPartyListItem[]> {
@@ -222,6 +224,9 @@ export interface UpdatePartyData {
   parkingNotes?: string | null;
   // quattro-71244: Gamified dashboard host-set goals (JSONB).
   hostGoals?: HostGoals | null;
+  // porchetta-81402: edit cancellation reason via PATCH (cancel/reinstate go
+  // through dedicated POST endpoints).
+  cancellationReason?: string | null;
 }
 
 export async function createPartyApi(data: CreatePartyData) {
@@ -340,6 +345,8 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       parkingNotes: data.parkingNotes,
       // quattro-71244: gamified-dashboard goal targets.
       hostGoals: data.hostGoals,
+      // porchetta-81402: edit cancellation reason via PATCH.
+      cancellationReason: data.cancellationReason,
     },
   });
 }
@@ -374,8 +381,27 @@ export async function getLeaderboardRank(
 }
 
 export async function deletePartyApi(partyId: string) {
+  // porchetta-81402: the backend handler is now a soft-cancel alias — the row
+  // and its children stay intact. New code should call `cancelPartyApi` to
+  // pass an optional reason; this helper is kept for back-compat.
   return apiRequest<{ success: boolean }>(`/api/parties/${partyId}`, {
     method: 'DELETE',
+  });
+}
+
+// porchetta-81402: cancel + reinstate. Reason is optional free text — the
+// backend trims and truncates to 500 chars. Reinstate symmetrically clears
+// the cancel columns and does NOT touch rsvp_closed_at.
+export async function cancelPartyApi(partyId: string, reason?: string) {
+  return apiRequest<{ success: boolean; party: any }>(`/api/parties/${partyId}/cancel`, {
+    method: 'POST',
+    body: { reason: reason || null },
+  });
+}
+
+export async function reinstatePartyApi(partyId: string) {
+  return apiRequest<{ success: boolean; party: any }>(`/api/parties/${partyId}/reinstate`, {
+    method: 'POST',
   });
 }
 
@@ -578,6 +604,10 @@ export interface PublicEvent {
   // reimbursementCapUsd → max(numeric event_tags) → null. Host-facing UI
   // reads this; /underboss still uses the raw reimbursementCapUsd.
   effectiveReimbursementCapUsd?: number | null;
+  // porchetta-81402: soft-cancel state. cancelledAt non-null = EventPage
+  // shows a cancelled banner + replaces the RSVP button with a notice card.
+  cancelledAt?: string | null;
+  cancellationReason?: string | null;
 }
 
 // Public Event API (no auth required)

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -3,6 +3,8 @@ import {
   createPartyApi,
   updatePartyApi,
   deletePartyApi,
+  cancelPartyApi,
+  reinstatePartyApi,
   addGuestByHostApi,
   removeGuestApi,
   updateGuestApprovalApi,
@@ -784,6 +786,10 @@ export interface DbParty {
   reimbursement_cap_appealed_at?: string | null;
   // quattro-71244: gamified-dashboard goal targets (JSONB on parties).
   host_goals?: HostGoals | null;
+  // porchetta-81402: soft-cancel columns. cancelledAt null = active event.
+  cancelled_at?: string | null;
+  cancelled_by?: string | null;
+  cancellation_reason?: string | null;
 }
 
 export type DbGuestStatus = 'PENDING' | 'CONFIRMED' | 'DECLINED' | 'WAITLISTED';
@@ -853,7 +859,8 @@ export const SAFE_PARTY_COLUMNS = `
   flyer_config,
   poster_image_url, poster_generated_at,
   rollup_image_url, rollup_generated_at,
-  reimbursement_cap_usd, reimbursement_cap_appeal_note, reimbursement_cap_appealed_at
+  reimbursement_cap_usd, reimbursement_cap_appeal_note, reimbursement_cap_appealed_at,
+  cancelled_at, cancelled_by, cancellation_reason
 `;
 
 /**
@@ -1907,6 +1914,9 @@ export async function updateParty(
     reimbursement_cap_usd?: number | null;
     // quattro-71244: gamified-dashboard goal targets.
     host_goals?: HostGoals | null;
+    // porchetta-81402: edit cancellation reason via PATCH. Cancel/reinstate
+    // themselves go through `cancelParty()` / `reinstateParty()`.
+    cancellation_reason?: string | null;
   }
 ): Promise<boolean> {
   // Use API if authenticated (secure path)
@@ -1988,6 +1998,8 @@ export async function updateParty(
         parkingNotes: updates.parking_notes,
         // quattro-71244: gamified-dashboard goal targets.
         hostGoals: updates.host_goals,
+        // porchetta-81402: edit cancellation reason via PATCH.
+        cancellationReason: updates.cancellation_reason,
       });
       return true;
     } catch (error) {
@@ -2010,7 +2022,10 @@ export async function updateParty(
 }
 
 export async function deleteParty(partyId: string): Promise<boolean> {
-  // Use API if authenticated (secure path)
+  // porchetta-81402: NOTE — the backend `DELETE /api/parties/:id` is now a
+  // soft-cancel alias (does NOT destroy the row). The frontend prefers
+  // `cancelParty()` directly so the host can pass an optional reason; this
+  // helper is kept for back-compat with any caller that hasn't been migrated.
   if (isAuthenticated()) {
     try {
       await deletePartyApi(partyId);
@@ -2021,7 +2036,8 @@ export async function deleteParty(partyId: string): Promise<boolean> {
     }
   }
 
-  // Fallback to direct Supabase
+  // Fallback to direct Supabase — also kept for back-compat; new code should
+  // use the API.
   const { error } = await supabase
     .from('parties')
     .delete()
@@ -2032,6 +2048,31 @@ export async function deleteParty(partyId: string): Promise<boolean> {
     return false;
   }
   return true;
+}
+
+// porchetta-81402: soft-cancel + reinstate helpers. These call the new
+// POST endpoints on party.routes.ts; they only require auth (the gate
+// is `canUserEditParty` server-side).
+export async function cancelParty(partyId: string, reason?: string): Promise<boolean> {
+  if (!isAuthenticated()) return false;
+  try {
+    await cancelPartyApi(partyId, reason);
+    return true;
+  } catch (e) {
+    console.error('Error cancelling party via API:', e);
+    return false;
+  }
+}
+
+export async function reinstateParty(partyId: string): Promise<boolean> {
+  if (!isAuthenticated()) return false;
+  try {
+    await reinstatePartyApi(partyId);
+    return true;
+  } catch (e) {
+    console.error('Error reinstating party via API:', e);
+    return false;
+  }
 }
 
 // Get parties for a user (RSVP'd or hosting)

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -289,6 +289,11 @@ export function EventPage() {
   };
 
   const handleRSVP = () => {
+    // porchetta-81402: defense-in-depth. The button is replaced with a
+    // cancellation card when `cancelledAt` is set, so this branch only
+    // fires if a caller bypasses the UI (e.g. a stale tab cached the old
+    // button). Drop the call rather than open a modal that would 410.
+    if (event?.cancelledAt) return;
     setShowRSVPModal(true);
   };
 
@@ -699,6 +704,23 @@ export function EventPage() {
       )}
 
       <div className="max-w-[1212px] mx-auto py-8 px-4">
+        {/* porchetta-81402: cancelled banner. Shown above the event card so
+            visitors see the cancel state before anything else. Past RSVPers
+            still see the full event details below — the page is preserved. */}
+        {event.cancelledAt && (
+          <div
+            className="mb-6 rounded-2xl border border-[#ff393a]/50 bg-[#ff393a]/10 p-6 text-center"
+            data-testid="event-cancelled-banner"
+          >
+            <h2 className="text-2xl font-bold text-[#ff5a5b]">{t('cancelled.bannerTitle')}</h2>
+            {event.cancellationReason && (
+              <p className="mt-2 text-base text-theme-text-secondary">
+                <span className="font-medium text-theme-text">{t('cancelled.reasonLabel')}:</span>{' '}
+                {event.cancellationReason}
+              </p>
+            )}
+          </div>
+        )}
         <div className="card overflow-hidden">
           <div className="grid md:grid-cols-[400px,1fr] gap-0 md:gap-8">
             {/* Left Column - Image and Host Info (Desktop only) */}
@@ -959,9 +981,21 @@ export function EventPage() {
                       </a>
                     )}
 
-                    {/* RSVP Button (+ Check In) - Desktop */}
+                    {/* RSVP Button (+ Check In) - Desktop
+                        porchetta-81402: replace with cancelled-card when the
+                        host has cancelled the event. Check-in button is also
+                        hidden — historical check-in records still exist via
+                        the dedicated /checkin route. */}
                     <div className="pt-1">
-                      {showCheckIn ? (
+                      {event.cancelledAt ? (
+                        <div
+                          className="w-full rounded-xl border border-[#ff393a]/30 bg-[#ff393a]/5 px-4 py-3 text-center"
+                          data-testid="rsvp-cancelled-card-desktop"
+                        >
+                          <p className="text-base font-medium text-[#ff5a5b]">{t('cancelled.noticeTitle')}</p>
+                          <p className="text-sm text-theme-text-secondary mt-1">{t('cancelled.noticeBody')}</p>
+                        </div>
+                      ) : showCheckIn ? (
                         <div className="flex gap-2">
                           <button
                             ref={mobileRsvpRef}
@@ -1090,9 +1124,18 @@ export function EventPage() {
                   </a>
                 )}
 
-                {/* RSVP Button (+ Check In) - Mobile only */}
+                {/* RSVP Button (+ Check In) - Mobile only
+                    porchetta-81402: same cancelled treatment as desktop. */}
                 <div className="pt-4 md:hidden">
-                  {showCheckIn ? (
+                  {event.cancelledAt ? (
+                    <div
+                      className="w-[85%] mx-auto rounded-xl border border-[#ff393a]/30 bg-[#ff393a]/5 px-4 py-3 text-center"
+                      data-testid="rsvp-cancelled-card-mobile"
+                    >
+                      <p className="text-base font-medium text-[#ff5a5b]">{t('cancelled.noticeTitle')}</p>
+                      <p className="text-sm text-theme-text-secondary mt-1">{t('cancelled.noticeBody')}</p>
+                    </div>
+                  ) : showCheckIn ? (
                     <div className="flex gap-2 w-[85%] mx-auto">
                       <button
                         data-testid="rsvp-button"
@@ -1429,8 +1472,9 @@ export function EventPage() {
         document.body
       )}
 
-      {/* Sticky RSVP button — mobile only, appears when inline button scrolls out of view */}
-      {showStickyRsvp && (
+      {/* Sticky RSVP button — mobile only, appears when inline button scrolls out of view.
+          porchetta-81402: hidden on cancelled events to mirror the inline button. */}
+      {showStickyRsvp && !event.cancelledAt && (
         <div className="md:hidden fixed top-0 left-0 right-0 z-40 bg-theme-card/95 backdrop-blur-sm border-b border-theme-stroke px-4 py-2.5">
           {showCheckIn ? (
             <div className="flex gap-2">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -148,6 +148,15 @@ export function HomePage() {
                             {t('home.host')}
                           </span>
                         )}
+                        {/* porchetta-81402: cancelled pill — hosts see this on
+                            their own cancelled events so they can recognize
+                            them at a glance and reinstate from the dashboard
+                            if it was an accident. */}
+                        {party.cancelledAt && (
+                          <span className="px-2 py-0.5 bg-[#ff393a]/15 border border-[#ff393a]/30 rounded-full text-xs text-[#ff393a] flex-shrink-0">
+                            {t('home.cancelled')}
+                          </span>
+                        )}
                       </div>
 
                       <p className="text-sm text-theme-text-secondary mb-1">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -345,6 +345,12 @@ export interface Party {
   // quattro-71244: Gamified host dashboard KPIs — host-private goal targets
   // keyed by ReportKPIs stat key. Lives in the `host_goals` JSONB column.
   hostGoals?: HostGoals | null;
+  // porchetta-81402: soft-cancel state. cancelledAt non-null = host has
+  // cancelled the event. EventPage renders a cancelled banner + replaces
+  // the RSVP form with a cancellation notice. Hosts can reinstate.
+  cancelledAt?: string | null;
+  cancelledBy?: string | null;
+  cancellationReason?: string | null;
 }
 
 export interface Donation {
@@ -1117,6 +1123,10 @@ export interface UnderbossEvent {
   // filter, and Mark-reviewed affordance — replaces the legacy
   // reimbursementCapAppealedAt signal which never cleared.
   hasOpenAppeal?: boolean;
+  // porchetta-81402: surfaced so /underboss can badge cancelled events
+  // (filterable so an underboss can spot churn in their region).
+  cancelledAt?: string | null;
+  cancellationReason?: string | null;
 }
 
 // quattro-12847: a single row from the appeal-history endpoint.

--- a/supabase/migrations/20260521_porchetta_81402_cancel_event.sql
+++ b/supabase/migrations/20260521_porchetta_81402_cancel_event.sql
@@ -1,0 +1,30 @@
+-- ============================================
+-- porchetta-81402: Convert event deletion to soft-cancel
+-- ============================================
+-- Adds three columns to the `parties` table so hosts can cancel
+-- (and reinstate) an event without destroying the row, guests,
+-- or any child resources.
+--
+-- Backfill of previously hard-deleted parties is handled by the
+-- companion script: backend/scripts/restore-host-cancellations.cjs
+-- ============================================
+
+ALTER TABLE parties
+  ADD COLUMN cancelled_at        TIMESTAMPTZ,
+  ADD COLUMN cancelled_by        TEXT,
+  ADD COLUMN cancellation_reason TEXT;
+
+-- Partial index — most queries care about "is this event cancelled" or
+-- "find all currently-cancelled events", neither of which need to scan
+-- the (much larger) set of live rows.
+CREATE INDEX idx_parties_cancelled_at
+  ON parties (cancelled_at)
+  WHERE cancelled_at IS NOT NULL;
+
+-- Additive grant only. The Feb 2026 security audit replaced the
+-- table-level SELECT grant with column-level grants (to hide
+-- `password`); new columns must be granted explicitly or the
+-- frontend Supabase queries return `permission denied for table
+-- parties` (42501).
+GRANT SELECT (cancelled_at, cancelled_by, cancellation_reason)
+  ON parties TO anon, authenticated;


### PR DESCRIPTION
## Summary

- Replace destructive `DELETE /api/parties/:id` with a soft-cancel flow that preserves the public URL, all guests, and every child resource. New endpoints: `POST /:id/cancel` (with optional free-text reason) and `POST /:id/reinstate`. The legacy `DELETE` route stays as a back-compat alias and now also routes to the soft-cancel handler.
- Public `EventPage` renders a cancelled banner above the existing event details and replaces the RSVP button (desktop + mobile + sticky) with a cancellation notice card. Past RSVPers still see their data. `EventDetailsTab` swaps the destructive Delete for a Cancel button (modal with optional reason) and a symmetric Reinstate button (no confirm — reversible).
- 410 `EVENT_CANCELLED` guards on every write path: public RSVP, host add-guest, photo upload, sponsor create, raffle entry, donation submit, and the open-rsvp toggle. `PATCH /:id` still works so hosts can edit the cancellation reason.
- DB migration `20260521_porchetta_81402_cancel_event.sql` adds `cancelled_at` / `cancelled_by` / `cancellation_reason` to `parties`, plus an additive column-level SELECT grant for anon/authenticated.
- Backfill script `backend/scripts/restore-host-cancellations.cjs` replays every party (and its full child cascade) that hosts hard-deleted from the dashboard before this PR, surfacing them as cancelled events with the original deletion timestamp + actor.
- New webhook events `party.cancelled` + `party.reinstated`; `party.deleted` is kept for legacy subscribers and is now ALSO fired alongside `party.cancelled` so nothing breaks.

## Deploy order (DO NOT MERGE before step 1)

1. Apply the migration via Supabase MCP to prod DB.
2. Verify the anon column-level SELECT GRANT (`cancelled_at`, `cancelled_by`, `cancellation_reason`).
3. Merge this PR → wait for the backend Vercel deploy.
4. Backfill dry-run: `node backend/scripts/restore-host-cancellations.cjs` — sanity-check the context distribution + collision report.
5. Backfill apply: `node backend/scripts/restore-host-cancellations.cjs --apply`.

## Test plan

- [ ] Migration applied; `SELECT cancelled_at FROM parties LIMIT 1` works
- [ ] Anon column-level GRANT verified (frontend Supabase queries don't 42501)
- [ ] `POST /:id/cancel` (with and without reason) returns 200 + the party row; `cancelled_at` is set
- [ ] `POST /:id/reinstate` clears the cancel columns and does NOT touch `rsvp_closed_at`
- [ ] Public RSVP submit on a cancelled event returns 410 `EVENT_CANCELLED`
- [ ] `EventPage` shows the cancelled banner + reason (when present) above the event card and the RSVP button is replaced with the notice card on both desktop and mobile
- [ ] `HomePage` shows a "Cancelled" pill on the host's own cancelled events
- [ ] `EventDetailsTab` modal collects an optional reason; symmetric Reinstate button shows when cancelled (no confirm modal)
- [ ] `PATCH /:id` accepts `cancellationReason` so the host can edit typos without un-cancelling
- [ ] Backfill dry-run prints sane counts + slug collision report
- [ ] Backfill apply restores parties + full child cascade; `slug_aliases` rows are inserted for safe redirects
- [ ] Cancelled events drop off `/api/gpp/events` + `/api/gpp/pizzerias` + sponsor-user tag counts; still visible (badged) on `/underboss`
- [ ] Vercel preview URL renders the cancelled banner end-to-end on a manually-cancelled test event

🤖 Generated with [Claude Code](https://claude.com/claude-code)