### PR TITLE
feat(boscaiola-49102): Molto Benny payment DMs + inline tx link

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -35,6 +35,7 @@ import { base } from 'viem/chains';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { resolveWalletInput } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
+import { notifyHostOfPaymentExecution } from '../services/payoutTelegramNotify.js';
 
 const router = Router();
 
@@ -1725,6 +1726,12 @@ async function executePayout(params: {
         });
         return row;
       });
+      // boscaiola-49102: fire-and-forget Telegram DM to the linked host.
+      // NOT awaited — payout success must not depend on Telegram reachability.
+      // Skips silently when host hasn't linked Telegram (no chat_id).
+      void notifyHostOfPaymentExecution(existing.id, 'paid', {
+        txHash: result.txHash,
+      });
       return updated;
     } catch (err: any) {
       // Flip to failed + record the error so the admin UI shows what happened.
@@ -1746,6 +1753,11 @@ async function executePayout(params: {
             note: `USDC send failed: ${errMsg.slice(0, 500)}`,
           },
         });
+      });
+      // boscaiola-49102: fire-and-forget Telegram DM on failure too.
+      // Same fire-and-forget contract — never blocks or throws.
+      void notifyHostOfPaymentExecution(existing.id, 'failed', {
+        error: errMsg,
       });
       throw new AppError(`USDC payout failed: ${errMsg}`, 502, 'USDC_SEND_FAILED');
     }

--- a/backend/src/services/payoutTelegramNotify.ts
+++ b/backend/src/services/payoutTelegramNotify.ts
@@ -1,0 +1,89 @@
+/**
+ * boscaiola-49102: Molto Benny Telegram notifications for payout execution.
+ *
+ * Sends a Telegram DM via the Molto Benny bot (TELEGRAM_BOT_TOKEN) to the
+ * linked host when their USDC payout reaches a terminal state
+ * (`paid` or `failed`).
+ *
+ * Hosts opt in by linking their Telegram account via the bot's
+ * `/start <token>` deeplink (see backend/src/routes/telegram-webhook.routes.ts).
+ * When `parties.host_telegram_chat_id` is null, this helper silently no-ops.
+ *
+ * Fire-and-forget: callers should NOT await this function. We catch every
+ * possible failure inside so a Telegram outage never blocks payout execution.
+ *
+ * Only `usdc_base` execute paths notify — Mercury card flows are intentionally
+ * skipped (Mercury already emails the host their card details).
+ */
+import { prisma } from '../config/database.js';
+
+const BOT_API = 'https://api.telegram.org';
+
+export async function notifyHostOfPaymentExecution(
+  payoutId: string,
+  outcome: 'paid' | 'failed',
+  details?: { txHash?: string; error?: string },
+): Promise<void> {
+  try {
+    const token = process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) return;
+
+    const payout = await prisma.payout.findUnique({
+      where: { id: payoutId },
+      include: {
+        party: {
+          select: {
+            name: true,
+            customUrl: true,
+            inviteCode: true,
+            hostTelegramChatId: true,
+          },
+        },
+      },
+    });
+    if (!payout) return;
+    const chatId = payout.party.hostTelegramChatId;
+    if (!chatId) return; // host hasn't linked Telegram — silent skip
+
+    const amount = Number(payout.finalAmountUsd).toFixed(2);
+    // Strip "Global Pizza Party " prefix for compactness
+    const cityName =
+      payout.party.name.replace(/^Global Pizza Party\s+/i, '').trim() ||
+      payout.party.name;
+
+    let text: string;
+    if (outcome === 'paid') {
+      const txLine = details?.txHash
+        ? `\nTx: https://basescan.org/tx/${details.txHash}`
+        : '';
+      text = `🍕 *Pizza payment sent!*\n$${amount} USDC to your wallet for *${cityName}*.${txLine}`;
+    } else {
+      const errSuffix = details?.error
+        ? `: ${details.error.slice(0, 200)}`
+        : '';
+      text = `⚠️ Your $${amount} payment for *${cityName}* couldn't go through${errSuffix}. Admin will retry shortly.`;
+    }
+
+    await fetch(`${BOT_API}/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId.toString(),
+        text,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true,
+      }),
+    }).catch((err) => {
+      console.warn(
+        '[notifyHostOfPaymentExecution] Telegram send failed:',
+        err?.message || err,
+      );
+    });
+  } catch (err: any) {
+    // Never let a notification failure break the payout execution.
+    console.warn(
+      '[notifyHostOfPaymentExecution] error:',
+      err?.message || err,
+    );
+  }
+}

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Loader2, X, ChevronRight, CreditCard, Banknote, Coins, HelpCircle, ImageOff } from 'lucide-react';
+import { Loader2, X, ChevronRight, CreditCard, Banknote, Coins, HelpCircle, ImageOff, ExternalLink } from 'lucide-react';
 import { Payout, PayoutMethod, PayoutStatus } from '../../types';
 import { cancelPayout, fetchAdminMe } from '../../lib/api';
 import { useAuth } from '../../contexts/AuthContext';
@@ -112,6 +112,21 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
             <span className="text-xs text-theme-text-muted font-normal">
               ({payout.originalAmount.toLocaleString()} {payout.originalCurrency})
             </span>
+          )}
+          {/* boscaiola-49102: inline BaseScan tx link for paid payouts.
+              Mirrors the GPP dashboard Payments preview so the full list and
+              the dashboard preview render identically. */}
+          {payout.status === 'paid' && payout.transactionHash && (
+            <a
+              href={`https://basescan.org/tx/${payout.transactionHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="text-xs text-theme-text-muted hover:text-theme-text underline-offset-2 hover:underline ml-2 inline-flex items-center gap-0.5 font-normal"
+            >
+              view tx
+              <ExternalLink size={12} />
+            </a>
           )}
         </div>
         <div className="text-xs text-theme-text-muted flex items-center gap-2 mt-0.5">


### PR DESCRIPTION
## Summary
- Backend: new `notifyHostOfPaymentExecution(payoutId, outcome, details?)` helper. Called from both single + bulk USDC execute paths on paid/failed. Skips silently if `parties.host_telegram_chat_id` is null. Fire-and-forget.
- Frontend: `PayoutListRow` paid rows now show an inline "view tx ↗" BaseScan link, matching the GPP dashboard Payments preview.

## Test plan
- [ ] Linked host (chat_id set) → execute a USDC payout → DM lands with amount + city + BaseScan link.
- [ ] Unlinked host → execute proceeds, no error logged.
- [ ] Forced failure → DM lands with apology + "admin will retry".
- [ ] Paid row in /host/:slug/payments shows "view tx ↗" inline.
- [ ] Bulk send to 3 linked hosts → 3 DMs.
- [ ] Mercury card execute → no Telegram DM (intended).