### PR TITLE
feat(tartufo-49271): live RSVP ticker on host dashboard

### DIFF
--- a/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
+++ b/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
@@ -4,6 +4,7 @@ import { getReport, getPageViewStats, updateHostGoals } from '../../lib/api';
 import type { PageViewStats } from '../../types';
 import { ReportKPIs } from '../report/ReportKPIs';
 import { LeaderboardPill } from './LeaderboardPill';
+import { LiveRSVPTicker } from './LiveRSVPTicker';
 import { useMilestones } from '../../hooks/useMilestones';
 import { useMomentum } from '../../hooks/useMomentum';
 import { useConfetti } from '../../hooks/useConfetti';
@@ -206,6 +207,7 @@ export const DashboardKPIs: React.FC<DashboardKPIsProps> = ({ party, guests }) =
 
   return (
     <div className="space-y-4">
+      <LiveRSVPTicker guests={guests} />
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <LeaderboardPill partyId={party.id} />
       </div>

--- a/frontend/src/components/gpp-dashboard/LiveRSVPTicker.tsx
+++ b/frontend/src/components/gpp-dashboard/LiveRSVPTicker.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { formatDistanceToNowStrict } from 'date-fns';
+import type { Guest } from '../../types';
+
+interface LiveRSVPTickerProps {
+  guests: Guest[];
+}
+
+const VISIBLE_LIMIT = 5;
+const DIRECT_RSVP_SOURCES = new Set(['link', 'rsvp', 'api']);
+const REFRESH_INTERVAL_MS = 30_000;
+
+function initialsFromName(name: string): string {
+  const parts = (name || '').trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  const letters = parts.slice(0, 2).map(p => p[0]?.toUpperCase() ?? '');
+  return letters.join('') || '?';
+}
+
+/**
+ * tartufo-49271: live RSVP ticker for the host dashboard.
+ *
+ * Reads from the `guests` prop already flowing through PizzaContext. The
+ * realtime subscription is mounted at HostPage via `useGuestsRealtime` — this
+ * component never subscribes on its own. Filters to direct-RSVP sources
+ * (link/rsvp/api) but accepts `submittedVia === undefined` so legacy rows
+ * still surface. Newly-arrived rows animate in with a staggered slide.
+ *
+ * Renders `null` when there's nothing to show.
+ */
+export const LiveRSVPTicker: React.FC<LiveRSVPTickerProps> = ({ guests }) => {
+  const { t } = useTranslation('host');
+
+  // Tick every 30s to refresh relative timestamps between live events.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick(n => n + 1), REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // Track previously-seen guest identities so newly-arrived rows animate in.
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  const visibleGuests = useMemo<Guest[]>(() => {
+    const filtered = guests.filter(g => {
+      if (g.submittedVia === undefined) return true;
+      return DIRECT_RSVP_SOURCES.has(g.submittedVia);
+    });
+    const sorted = filtered.slice().sort((a, b) => {
+      const aTs = a.submittedAt ? new Date(a.submittedAt).getTime() : 0;
+      const bTs = b.submittedAt ? new Date(b.submittedAt).getTime() : 0;
+      return bTs - aTs;
+    });
+    return sorted.slice(0, VISIBLE_LIMIT);
+  }, [guests]);
+
+  // Determine which rows in the current visible window are "new" so we only
+  // animate fresh arrivals (not the initial mount of an already-populated
+  // list).
+  const newKeysThisRender = useMemo(() => {
+    const fresh = new Set<string>();
+    if (seenIdsRef.current.size === 0) {
+      // First render: don't animate the initial backfill; just remember them.
+      return fresh;
+    }
+    for (const g of visibleGuests) {
+      const key = g.id ?? `${g.submittedAt ?? ''}__${g.name}`;
+      if (!seenIdsRef.current.has(key)) fresh.add(key);
+    }
+    return fresh;
+  }, [visibleGuests]);
+
+  // Commit the current visible keys to the "seen" set after each render so
+  // the next realtime delta only animates truly-new entries.
+  useEffect(() => {
+    for (const g of visibleGuests) {
+      const key = g.id ?? `${g.submittedAt ?? ''}__${g.name}`;
+      seenIdsRef.current.add(key);
+    }
+  }, [visibleGuests]);
+
+  if (visibleGuests.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="card p-4">
+      <div className="text-xs uppercase tracking-wide text-white/50 mb-3">
+        {t('dashboard.ticker.recentRsvps')}
+      </div>
+      <ul
+        className="space-y-2"
+        onMouseEnter={(e) => e.currentTarget.setAttribute('data-paused', 'true')}
+        onMouseLeave={(e) => e.currentTarget.removeAttribute('data-paused')}
+        onFocus={(e) => e.currentTarget.setAttribute('data-paused', 'true')}
+        onBlur={(e) => e.currentTarget.removeAttribute('data-paused')}
+      >
+        {visibleGuests.map((g, index) => {
+          const key = g.id ?? `${g.submittedAt ?? ''}__${g.name}`;
+          const isNew = newKeysThisRender.has(key);
+          const ago = g.submittedAt
+            ? formatDistanceToNowStrict(new Date(g.submittedAt), { addSuffix: true })
+            : t('dashboard.ticker.justNow');
+          return (
+            <li
+              key={key}
+              className={`flex items-center gap-3 ${isNew ? 'animate-ticker-in' : ''}`}
+              style={isNew ? { animationDelay: `${index * 60}ms` } : undefined}
+            >
+              <div
+                aria-hidden="true"
+                className="flex-shrink-0 h-8 w-8 rounded-full bg-theme-surface-hover flex items-center justify-center text-xs font-semibold text-white/80"
+              >
+                {initialsFromName(g.name)}
+              </div>
+              <div className="min-w-0 flex-1 flex items-baseline gap-2">
+                <div className="truncate text-sm text-white/90">{g.name || '—'}</div>
+                <div className="flex-shrink-0 text-xs text-white/40">{ago}</div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/index.ts
+++ b/frontend/src/components/gpp-dashboard/index.ts
@@ -1,2 +1,3 @@
 export { GPPDashboardTab } from './GPPDashboardTab';
 export { DashboardKPIs } from './DashboardKPIs';
+export { LiveRSVPTicker } from './LiveRSVPTicker';

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -90,6 +90,10 @@ export function dbGuestToGuest(dbGuest: db.DbGuest): Guest {
     status: dbGuest.status || 'CONFIRMED',
     waitlistPosition: dbGuest.waitlist_position || null,
     promotedAt: dbGuest.promoted_at || null,
+    // tartufo-49271: surface submitted_via so the live RSVP ticker can filter
+    // out bulk-invited rows. Optional on the app-level Guest; default-accept
+    // when undefined to keep legacy rows visible.
+    submittedVia: dbGuest.submitted_via,
   };
 }
 

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -785,6 +785,14 @@
         "firstPoap": "Erstes POAP-Mint",
         "goalReached": "Ziel erreicht"
       }
+    },
+    "ticker": {
+      "empty": "Noch keine Zusagen",
+      "justNow": "gerade eben",
+      "minutesAgo": "vor {{count}} Min.",
+      "hoursAgo": "vor {{count}} Std.",
+      "daysAgo": "vor {{count}} T.",
+      "recentRsvps": "Aktuelle Zusagen"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -830,6 +830,14 @@
         "firstPoap": "First POAP mint",
         "goalReached": "Goal reached"
       }
+    },
+    "ticker": {
+      "empty": "No RSVPs yet",
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago",
+      "recentRsvps": "Recent RSVPs"
     }
   }
 }

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -785,6 +785,14 @@
         "firstPoap": "Primer mint de POAP",
         "goalReached": "Meta alcanzada"
       }
+    },
+    "ticker": {
+      "empty": "Aún no hay confirmaciones",
+      "justNow": "justo ahora",
+      "minutesAgo": "hace {{count}} min",
+      "hoursAgo": "hace {{count}} h",
+      "daysAgo": "hace {{count}} d",
+      "recentRsvps": "Confirmaciones recientes"
     }
   }
 }

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -785,6 +785,14 @@
         "firstPoap": "Premier mint POAP",
         "goalReached": "Objectif atteint"
       }
+    },
+    "ticker": {
+      "empty": "Aucune confirmation pour l'instant",
+      "justNow": "à l'instant",
+      "minutesAgo": "il y a {{count}} min",
+      "hoursAgo": "il y a {{count}} h",
+      "daysAgo": "il y a {{count}} j",
+      "recentRsvps": "Confirmations récentes"
     }
   }
 }

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -785,6 +785,14 @@
         "firstPoap": "最初のPOAPミント",
         "goalReached": "目標達成"
       }
+    },
+    "ticker": {
+      "empty": "まだRSVPはありません",
+      "justNow": "たった今",
+      "minutesAgo": "{{count}}分前",
+      "hoursAgo": "{{count}}時間前",
+      "daysAgo": "{{count}}日前",
+      "recentRsvps": "最近のRSVP"
     }
   }
 }

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -785,6 +785,14 @@
         "firstPoap": "Primeiro mint de POAP",
         "goalReached": "Meta atingida"
       }
+    },
+    "ticker": {
+      "empty": "Ainda sem confirmações",
+      "justNow": "agora mesmo",
+      "minutesAgo": "há {{count}} min",
+      "hoursAgo": "há {{count}} h",
+      "daysAgo": "há {{count}} d",
+      "recentRsvps": "Confirmações recentes"
     }
   }
 }

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -785,6 +785,14 @@
         "firstPoap": "首次铸造 POAP",
         "goalReached": "目标达成"
       }
+    },
+    "ticker": {
+      "empty": "暂无 RSVP",
+      "justNow": "刚刚",
+      "minutesAgo": "{{count}} 分钟前",
+      "hoursAgo": "{{count}} 小时前",
+      "daysAgo": "{{count}} 天前",
+      "recentRsvps": "最近的 RSVP"
     }
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -742,6 +742,31 @@ body.gpp-theme-active .gpp-badge.gpp-badge-community { display: inline-flex !imp
   animation: pulse-once 600ms ease-out;
 }
 
+/* tartufo-49271: live RSVP ticker — newly-arrived rows slide in from the
+   top. `animation-delay: index * 60ms` is applied inline to stagger bursts.
+   Hovering/focusing the parent list pauses the animation via [data-paused]. */
+@keyframes ticker-slide-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-ticker-in {
+  animation: ticker-slide-in 320ms ease-out both;
+}
+[data-paused="true"] .animate-ticker-in {
+  animation-play-state: paused;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-ticker-in {
+    animation: none;
+  }
+}
+
 /* Pizzeria name label next to red pins on the Participating Pizzerias map.
    Google Maps applies this class to the label container that sits centered on
    the marker anchor — we offset it downward so it sits below the pin with a

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,10 @@ export interface Guest {
   status?: GuestStatus;
   waitlistPosition?: number | null;
   promotedAt?: string | null;
+  // tartufo-49271: surfaces guests.submitted_via so the live RSVP ticker can
+  // filter to direct-RSVP signals (link/rsvp/api) and skip bulk-invited rows.
+  // Optional + default-accept-undefined so older rows still flow through.
+  submittedVia?: string;
 }
 
 export interface PizzaStyle {


### PR DESCRIPTION
## Summary

Top of `DashboardKPIs` renders the last 5 incoming RSVPs as a live ticker with avatar initials, name, and relative timeago. Newly-arrived rows slide in with a staggered animation; hover/focus pauses; `prefers-reduced-motion` is honoured.

Reuses the existing `useGuestsRealtime` subscription already mounted on `HostPage.tsx` (no new PizzaContext subscription per the `calabrese-58204` rule). Widens `Guest` with an optional `submittedVia` so the ticker can filter to direct-RSVP signals (`link`, `rsvp`, `api`) while default-accepting undefined rows.

Plan: [`plans/tartufo-49271-live-rsvp-ticker.md`](https://github.com/PizzaDAO/rsv-pizza/blob/master/plans/tartufo-49271-live-rsvp-ticker.md)

Preview: https://rsvpizza-git-tartufo-49271-live-rsvp-ticker-pizza-dao.vercel.app

## Test plan

- [ ] Open host dashboard, RSVP from incognito, expect row to slide in within ~1s.

Generated with [Claude Code](https://claude.com/claude-code)