### PR TITLE
fix(caprese-83104): remove stand from SWC pin, scale shield to Benny height

### DIFF
--- a/frontend/public/molto-benny-swc.svg
+++ b/frontend/public/molto-benny-swc.svg
@@ -1,4 +1,4 @@
-<svg width="1000" height="700" viewBox="0 0 1000 700" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="1400" height="700" viewBox="0 0 1400 700" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g id="benny" transform="translate(0, 27)">
 <g id="graphic" clip-path="url(#clip0_5803_3851)">
 <g id="white">
@@ -80,15 +80,9 @@
 </clipPath>
 </defs>
 </g>
-<g id="swc-stand">
-<ellipse cx="850" cy="660" rx="90" ry="14" fill="#2A2A2A"/>
-<ellipse cx="850" cy="654" rx="80" ry="10" fill="#4A4A4A"/>
-<rect x="840" y="320" width="20" height="335" fill="#3A3A3A"/>
-<rect x="840" y="320" width="4" height="335" fill="#5A5A5A"/>
-<g transform="translate(750, 110) scale(6.25)">
+<g id="swc-shield" transform="translate(730, 27) scale(20.1875)">
 <path d="M7.99953 0H0V14.3441C0.529429 21.8907 5.48357 28.3825 12.5714 30.8204L16 32V0H7.99953Z" fill="url(#paint0_linear_swc_shield)" stroke="#1a1a1a" stroke-width="0.25"/>
 <path d="M24.0005 0H16V32L19.4286 30.8185C26.5183 28.3806 31.4706 21.8878 32 14.3413V0H23.9995H24.0005Z" fill="url(#paint1_linear_swc_shield)" stroke="#1a1a1a" stroke-width="0.25"/>
-</g>
 </g>
 <defs>
 <linearGradient id="paint0_linear_swc_shield" x1="7.99953" y1="0" x2="7.99953" y2="32" gradientUnits="userSpaceOnUse">

--- a/frontend/src/pages/EventsMapSwcPage.tsx
+++ b/frontend/src/pages/EventsMapSwcPage.tsx
@@ -187,9 +187,9 @@ export function EventsMapSwcPage() {
                 canModerate
                 isModerator={false}
                 iconUrl="/molto-benny-swc.svg"
-                iconWidth={56}
+                iconWidth={80}
                 iconHeight={40}
-                iconAnchorX={16}
+                iconAnchorX={17}
                 iconAnchorY={40}
               />
             )}


### PR DESCRIPTION
## Summary
Drops the pedestal+pole "stand" from the `/map/swc` composite pin. Shield now stands on its own at the same height as Benny.

## Test plan
- [ ] Visit `/map/swc` as super admin — pin shows Benny + same-height purple shield, no stand.
- [ ] Existing `/map` page unchanged (regular Benny pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)