### PR TITLE
feat(napoli-93184): shareable host-progress card

### DIFF
--- a/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
+++ b/frontend/src/components/gpp-dashboard/DashboardKPIs.tsx
@@ -4,6 +4,7 @@ import { getReport, getPageViewStats, updateHostGoals } from '../../lib/api';
 import type { PageViewStats } from '../../types';
 import { ReportKPIs } from '../report/ReportKPIs';
 import { LeaderboardPill } from './LeaderboardPill';
+import { ShareProgressButton } from './ShareProgressButton';
 import { useMilestones } from '../../hooks/useMilestones';
 import { useMomentum } from '../../hooks/useMomentum';
 import { useConfetti } from '../../hooks/useConfetti';
@@ -208,6 +209,7 @@ export const DashboardKPIs: React.FC<DashboardKPIsProps> = ({ party, guests }) =
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <LeaderboardPill partyId={party.id} />
+        <ShareProgressButton party={party} report={report} />
       </div>
       <ReportKPIs
         report={reportForKpis}

--- a/frontend/src/components/gpp-dashboard/ProgressCard.tsx
+++ b/frontend/src/components/gpp-dashboard/ProgressCard.tsx
@@ -1,0 +1,130 @@
+import { loadImg } from '../flyer/renderFlyer';
+import type { Party } from '../../types';
+
+/**
+ * napoli-93184: Pure render function that draws a 1200x630 host-progress
+ * card to the provided canvas. No React — call from a hook or event handler.
+ *
+ * Per FlyerGenerator prior-art (`FlyerGenerator.tsx`): we use the native
+ * Canvas 2D API rather than html-to-image / html2canvas, because DOM-snapshot
+ * libs mangle the project's custom font ("Hub 191 Display"). Same reason
+ * applies here for the hero number.
+ *
+ * Only same-origin assets are drawn — `pizzadao-logo.svg` is local. We
+ * deliberately skip `party.eventImageUrl` (could be cross-origin and would
+ * taint the canvas, blocking `toBlob`).
+ */
+
+export interface DrawProgressCardOpts {
+  party: Pick<Party, 'name' | 'date' | 'customUrl' | 'inviteCode'>;
+  totalRsvps: number;
+  rank: { rank: number; total: number } | null;
+}
+
+const CANVAS_W = 1200;
+const CANVAS_H = 630;
+
+const RED = '#ff393a';
+const WHITE = '#ffffff';
+const WHITE_DIM = 'rgba(255,255,255,0.85)';
+
+const TEXT_FONT = '"Hub 191", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+const HERO_FONT = '"Hub 191 Display", "Hub 191", -apple-system, BlinkMacSystemFont, system-ui, sans-serif';
+
+/**
+ * Resize the given canvas to 1200x630 and draw the progress card.
+ * Caller is responsible for awaiting `document.fonts.ready` before calling.
+ */
+export async function drawProgressCard(
+  canvas: HTMLCanvasElement,
+  opts: DrawProgressCardOpts,
+): Promise<void> {
+  canvas.width = CANVAS_W;
+  canvas.height = CANVAS_H;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('drawProgressCard: 2D context unavailable');
+
+  // 1) Solid red background
+  ctx.fillStyle = RED;
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // 2) Soft white radial gradient overlay top-left (12% peak alpha)
+  const grad = ctx.createRadialGradient(0, 0, 0, 0, 0, 900);
+  grad.addColorStop(0, 'rgba(255,255,255,0.12)');
+  grad.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  ctx.textBaseline = 'top';
+
+  // 3) Top-left: event name (48px) + date (24px)
+  ctx.fillStyle = WHITE;
+  ctx.font = `48px ${TEXT_FONT}`;
+  const eventName = (opts.party.name || '').trim() || 'Event';
+  // Soft truncation: cap to ~700px width
+  const nameMaxW = 700;
+  let displayName = eventName;
+  if (ctx.measureText(displayName).width > nameMaxW) {
+    while (displayName.length > 1 && ctx.measureText(displayName + '…').width > nameMaxW) {
+      displayName = displayName.slice(0, -1);
+    }
+    displayName = displayName + '…';
+  }
+  ctx.fillText(displayName, 60, 60);
+
+  // Date row — hide if no date
+  if (opts.party.date) {
+    let dateText = '';
+    try {
+      const d = new Date(opts.party.date);
+      if (!Number.isNaN(d.getTime())) {
+        const lang = typeof navigator !== 'undefined' ? navigator.language : 'en-US';
+        dateText = d.toLocaleDateString(lang, { dateStyle: 'long' });
+      }
+    } catch {
+      dateText = '';
+    }
+    if (dateText) {
+      ctx.fillStyle = WHITE_DIM;
+      ctx.font = `24px ${TEXT_FONT}`;
+      ctx.fillText(dateText, 60, 130);
+    }
+  }
+
+  // 4) Center hero — totalRsvps (240px, Hub 191 Display)
+  const heroText = String(opts.totalRsvps ?? 0);
+  ctx.fillStyle = WHITE;
+  ctx.font = `240px ${HERO_FONT}`;
+  ctx.textAlign = 'center';
+  ctx.fillText(heroText, CANVAS_W / 2, 220);
+
+  // Label beneath
+  ctx.font = `32px ${TEXT_FONT}`;
+  ctx.fillStyle = WHITE_DIM;
+  ctx.fillText('RSVPs', CANVAS_W / 2, 480);
+
+  ctx.textAlign = 'left';
+
+  // 5) Bottom-left: leaderboard rank (only if present)
+  if (opts.rank && opts.rank.total > 0) {
+    ctx.fillStyle = WHITE;
+    ctx.font = `28px ${TEXT_FONT}`;
+    ctx.fillText(`#${opts.rank.rank} of ${opts.rank.total}`, 60, 540);
+  }
+
+  // 6) Bottom-right: pizzadao logo (80x80) + URL
+  try {
+    const logo = await loadImg('/pizzadao-logo.svg');
+    ctx.drawImage(logo, 1040, 470, 80, 80);
+  } catch {
+    // Logo failed to load — skip silently, card still useful.
+  }
+
+  const slug = opts.party.customUrl || opts.party.inviteCode || '';
+  const urlText = slug ? `rsv.pizza/${slug}` : 'rsv.pizza';
+  ctx.fillStyle = WHITE_DIM;
+  ctx.font = `20px ${TEXT_FONT}`;
+  ctx.textAlign = 'right';
+  ctx.fillText(urlText, 1140, 570);
+  ctx.textAlign = 'left';
+}

--- a/frontend/src/components/gpp-dashboard/ShareProgressButton.tsx
+++ b/frontend/src/components/gpp-dashboard/ShareProgressButton.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Share2, X, Download, Copy, Loader2 } from 'lucide-react';
+import type { Party, EventReport } from '../../types';
+import { useProgressCardImage } from '../../hooks/useProgressCardImage';
+
+interface ShareProgressButtonProps {
+  party: Party;
+  report: EventReport;
+}
+
+/**
+ * napoli-93184: Share button + modal preview of the host-progress card.
+ *
+ * Lazy generation — card is only rendered when the modal opens. Blob is
+ * tracked in state and the corresponding object URL is revoked on unmount
+ * / close to avoid leaks (PNG blobs are big).
+ *
+ * Clipboard support is feature-detected at render: on platforms missing
+ * `ClipboardItem` (notably older iOS Safari) the Copy button is hidden
+ * entirely. Download is the always-available fallback.
+ */
+export const ShareProgressButton: React.FC<ShareProgressButtonProps> = ({ party, report }) => {
+  const { t } = useTranslation('host');
+  const { generate } = useProgressCardImage();
+
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [genError, setGenError] = useState(false);
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const blobRef = useRef<Blob | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Feature-detect ClipboardItem at render. `'ClipboardItem' in window` is
+  // safe across SSR-free Vite environments but we guard for completeness.
+  const canCopy = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    return (
+      'ClipboardItem' in window &&
+      !!navigator.clipboard &&
+      typeof navigator.clipboard.write === 'function'
+    );
+  }, []);
+
+  const showToast = useCallback((msg: string) => {
+    setToast(msg);
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 2500);
+  }, []);
+
+  // Run generation when the modal opens.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setBusy(true);
+    setGenError(false);
+    generate(party, report)
+      .then((blob) => {
+        if (cancelled) return;
+        blobRef.current = blob;
+        const url = URL.createObjectURL(blob);
+        setObjectUrl(url);
+      })
+      .catch((err) => {
+        console.error('napoli-93184: progress card generation failed', err);
+        if (!cancelled) setGenError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, generate, party, report]);
+
+  // Revoke object URL when it changes or the modal closes / unmounts.
+  useEffect(() => {
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [objectUrl]);
+
+  // Clear timers on unmount.
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    };
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    if (objectUrl) {
+      URL.revokeObjectURL(objectUrl);
+      setObjectUrl(null);
+    }
+    blobRef.current = null;
+    setGenError(false);
+  }, [objectUrl]);
+
+  const filename = useMemo(() => {
+    const slug = party.customUrl || party.inviteCode || 'event';
+    return `rsvpizza-progress-${slug}.png`;
+  }, [party.customUrl, party.inviteCode]);
+
+  const handleDownload = useCallback(() => {
+    if (!objectUrl) return;
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }, [objectUrl, filename]);
+
+  const handleCopy = useCallback(async () => {
+    if (!blobRef.current || !canCopy) return;
+    try {
+      const item = new ClipboardItem({ 'image/png': blobRef.current });
+      await navigator.clipboard.write([item]);
+      showToast(t('dashboard.share.copySuccess'));
+    } catch (err) {
+      console.error('napoli-93184: clipboard copy failed', err);
+      showToast(t('dashboard.share.copyFailed'));
+    }
+  }, [canCopy, showToast, t]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-theme-card border border-theme-stroke text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
+        aria-label={t('dashboard.share.buttonLabel')}
+        title={t('dashboard.share.buttonLabel')}
+      >
+        <Share2 size={16} />
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('dashboard.share.modalTitle')}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) handleClose();
+          }}
+        >
+          <div className="bg-theme-header rounded-2xl border border-theme-stroke w-full max-w-2xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-theme-stroke">
+              <div className="flex items-center gap-2">
+                <Share2 size={18} className="text-[#ff393a]" />
+                <h2 className="text-lg font-bold text-theme-text">
+                  {t('dashboard.share.modalTitle')}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="p-1.5 text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover rounded-lg transition-colors"
+                aria-label={t('dashboard.share.close')}
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-4 flex flex-col items-center gap-4">
+              <div
+                className="relative w-full bg-theme-card rounded-lg overflow-hidden border border-theme-stroke flex items-center justify-center"
+                style={{ aspectRatio: '1200 / 630', maxWidth: 600 }}
+              >
+                {busy && (
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-theme-text-muted">
+                    <Loader2 size={28} className="animate-spin" />
+                    <span className="text-sm">{t('dashboard.share.generating')}</span>
+                  </div>
+                )}
+                {!busy && genError && (
+                  <div className="text-sm text-theme-text-muted px-4 text-center">
+                    {t('dashboard.share.generateFailed')}
+                  </div>
+                )}
+                {!busy && !genError && objectUrl && (
+                  <img
+                    src={objectUrl}
+                    alt={t('dashboard.share.modalTitle')}
+                    width={600}
+                    height={315}
+                    className="block w-full h-auto"
+                  />
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center justify-center gap-2 w-full">
+                <button
+                  type="button"
+                  onClick={handleDownload}
+                  disabled={busy || !objectUrl}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#ff393a] text-white text-sm font-semibold hover:bg-[#ff5052] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  <Download size={16} />
+                  {t('dashboard.share.download')}
+                </button>
+                {canCopy && (
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    disabled={busy || !objectUrl}
+                    className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-theme-card border border-theme-stroke text-theme-text text-sm font-semibold hover:bg-theme-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Copy size={16} />
+                    {t('dashboard.share.copy')}
+                  </button>
+                )}
+              </div>
+
+              {toast && (
+                <div className="text-xs text-theme-text-muted bg-theme-card border border-theme-stroke px-3 py-1.5 rounded-full">
+                  {toast}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/gpp-dashboard/index.ts
+++ b/frontend/src/components/gpp-dashboard/index.ts
@@ -1,2 +1,3 @@
 export { GPPDashboardTab } from './GPPDashboardTab';
 export { DashboardKPIs } from './DashboardKPIs';
+export { ShareProgressButton } from './ShareProgressButton';

--- a/frontend/src/hooks/useProgressCardImage.ts
+++ b/frontend/src/hooks/useProgressCardImage.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState } from 'react';
+import { drawProgressCard } from '../components/gpp-dashboard/ProgressCard';
+import { getLeaderboardRank } from '../lib/api';
+import type { Party, EventReport } from '../types';
+
+/**
+ * napoli-93184: Generate a 1200x630 PNG blob of the host-progress card.
+ *
+ * Awaits `document.fonts.ready` so the Hub 191 webfont is measurable before
+ * drawing — otherwise the hero number renders with the fallback metric and
+ * looks visually off-spec.
+ */
+export interface UseProgressCardImageResult {
+  generate: (party: Party, report: EventReport) => Promise<Blob>;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useProgressCardImage(): UseProgressCardImageResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const generate = useCallback(async (party: Party, report: EventReport): Promise<Blob> => {
+    setLoading(true);
+    setError(null);
+    try {
+      // Wait for fonts before measuring — Hub 191 Display uses font-display: swap.
+      if (typeof document !== 'undefined' && document.fonts && document.fonts.ready) {
+        try {
+          await document.fonts.ready;
+        } catch {
+          // Non-fatal — fall back to system fonts.
+        }
+      }
+
+      // Leaderboard rank (graceful null on auth-fail or 404).
+      const rank = await getLeaderboardRank(party.id).catch(() => null);
+
+      const canvas = document.createElement('canvas');
+      await drawProgressCard(canvas, {
+        party,
+        totalRsvps: report.stats?.totalRsvps ?? 0,
+        rank: rank ? { rank: rank.rank, total: rank.total } : null,
+      });
+
+      const blob: Blob | null = await new Promise((resolve) =>
+        canvas.toBlob((b) => resolve(b), 'image/png'),
+      );
+      if (!blob) throw new Error('Failed to encode progress card as PNG');
+      return blob;
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      setError(e);
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { generate, loading, error };
+}

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -785,6 +785,17 @@
         "firstPoap": "Erstes POAP-Mint",
         "goalReached": "Ziel erreicht"
       }
+    },
+    "share": {
+      "buttonLabel": "Fortschritt teilen",
+      "modalTitle": "Teile deinen Fortschritt",
+      "download": "Herunterladen",
+      "copy": "Kopieren",
+      "copySuccess": "In die Zwischenablage kopiert",
+      "copyFailed": "Kopieren fehlgeschlagen",
+      "generating": "Wird erstellt…",
+      "generateFailed": "Bild konnte nicht erstellt werden",
+      "close": "Schließen"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -830,6 +830,17 @@
         "firstPoap": "First POAP mint",
         "goalReached": "Goal reached"
       }
+    },
+    "share": {
+      "buttonLabel": "Share progress",
+      "modalTitle": "Share your progress",
+      "download": "Download",
+      "copy": "Copy",
+      "copySuccess": "Copied to clipboard",
+      "copyFailed": "Copy failed",
+      "generating": "Generating…",
+      "generateFailed": "Could not generate image",
+      "close": "Close"
     }
   }
 }

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -785,6 +785,17 @@
         "firstPoap": "Primer mint de POAP",
         "goalReached": "Meta alcanzada"
       }
+    },
+    "share": {
+      "buttonLabel": "Compartir progreso",
+      "modalTitle": "Comparte tu progreso",
+      "download": "Descargar",
+      "copy": "Copiar",
+      "copySuccess": "Copiado al portapapeles",
+      "copyFailed": "Error al copiar",
+      "generating": "Generando…",
+      "generateFailed": "No se pudo generar la imagen",
+      "close": "Cerrar"
     }
   }
 }

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -785,6 +785,17 @@
         "firstPoap": "Premier mint POAP",
         "goalReached": "Objectif atteint"
       }
+    },
+    "share": {
+      "buttonLabel": "Partager les progrès",
+      "modalTitle": "Partagez vos progrès",
+      "download": "Télécharger",
+      "copy": "Copier",
+      "copySuccess": "Copié dans le presse-papiers",
+      "copyFailed": "Échec de la copie",
+      "generating": "Génération…",
+      "generateFailed": "Impossible de générer l'image",
+      "close": "Fermer"
     }
   }
 }

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -785,6 +785,17 @@
         "firstPoap": "最初のPOAPミント",
         "goalReached": "目標達成"
       }
+    },
+    "share": {
+      "buttonLabel": "進捗をシェア",
+      "modalTitle": "あなたの進捗をシェア",
+      "download": "ダウンロード",
+      "copy": "コピー",
+      "copySuccess": "クリップボードにコピーしました",
+      "copyFailed": "コピーに失敗しました",
+      "generating": "生成中…",
+      "generateFailed": "画像を生成できませんでした",
+      "close": "閉じる"
     }
   }
 }

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -785,6 +785,17 @@
         "firstPoap": "Primeiro mint de POAP",
         "goalReached": "Meta atingida"
       }
+    },
+    "share": {
+      "buttonLabel": "Compartilhar progresso",
+      "modalTitle": "Compartilhe seu progresso",
+      "download": "Baixar",
+      "copy": "Copiar",
+      "copySuccess": "Copiado para a área de transferência",
+      "copyFailed": "Falha ao copiar",
+      "generating": "Gerando…",
+      "generateFailed": "Não foi possível gerar a imagem",
+      "close": "Fechar"
     }
   }
 }

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -785,6 +785,17 @@
         "firstPoap": "首次铸造 POAP",
         "goalReached": "目标达成"
       }
+    },
+    "share": {
+      "buttonLabel": "分享进度",
+      "modalTitle": "分享你的进度",
+      "download": "下载",
+      "copy": "复制",
+      "copySuccess": "已复制到剪贴板",
+      "copyFailed": "复制失败",
+      "generating": "生成中…",
+      "generateFailed": "无法生成图片",
+      "close": "关闭"
     }
   }
 }


### PR DESCRIPTION
## Summary
- New `Share progress` icon button on the host dashboard (sits opposite the leaderboard pill in the existing flex row of `DashboardKPIs`).
- Opens a modal preview of a 1200x630 PNG card: event name, date, hero `totalRsvps`, `#rank of total` (when present), and `rsv.pizza/{slug}` next to the PizzaDAO logo.
- Native Canvas 2D rendering — `frontend/src/components/gpp-dashboard/ProgressCard.tsx` exports a pure `drawProgressCard(canvas, opts)` function. No new npm deps. Follows FlyerGenerator prior-art that explicitly rejects DOM-snapshot libs because they mangle the project's `Hub 191 Display` font.
- Download is always available. Copy-to-clipboard is feature-detected at render (`'ClipboardItem' in window && navigator.clipboard?.write`) — hidden on older iOS Safari / Firefox where unsupported.
- 7 locales added under `host.dashboard.share.*` (de, en, es, fr, ja, pt, zh).

Plan: `plans/napoli-93184-share-progress-card.md`

Vercel preview: https://rsvpizza-git-napoli-93184-share-card-pizza-dao.vercel.app (auto-deploys when the PR is opened)

## Test plan
- [ ] Open a host dashboard, look at the row above the KPI grid: leaderboard pill on the left, Share button on the right.
- [ ] Click Share. Modal opens with a spinner that resolves into a 1200x630 preview image.
- [ ] Event name + (long-format) date in the top-left, big white RSVP count in the center, `#rank of total` bottom-left if you're ranked, `rsv.pizza/{slug}` and the PizzaDAO logo bottom-right.
- [ ] Verify the hero number is crisp — that's the `Hub 191 Display` font; if it falls back to system sans we missed the `document.fonts.ready` await.
- [ ] Click Download — PNG saves as `rsvpizza-progress-{slug}.png`.
- [ ] Chrome/Edge desktop: Copy button visible; click → "Copied to clipboard" toast, paste into Slack/Notion produces the image.
- [ ] iOS Safari (or any browser without `ClipboardItem`): Copy button is absent; Download still works.
- [ ] Close the modal → no object-URL leak (DevTools → Memory → no lingering blob).
- [ ] Host with no `party.date` set: date row is hidden, card still renders.
- [ ] Host with no leaderboard rank (auth fail or first event): rank line is hidden, card still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)