### PR TITLE
fix(vongole-83712): shrink /map/swc pin 20%

### DIFF
--- a/frontend/src/pages/EventsMapSwcPage.tsx
+++ b/frontend/src/pages/EventsMapSwcPage.tsx
@@ -187,10 +187,10 @@ export function EventsMapSwcPage() {
                 canModerate
                 isModerator={false}
                 iconUrl="/molto-benny-swc.svg"
-                iconWidth={80}
-                iconHeight={40}
-                iconAnchorX={17}
-                iconAnchorY={40}
+                iconWidth={64}
+                iconHeight={32}
+                iconAnchorX={14}
+                iconAnchorY={32}
                 cluster={false}
               />
             )}


### PR DESCRIPTION
## Summary
Drops the `/map/swc` composite pin from 80×40 to 64×32 (Benny + shield read slightly smaller on the map). Anchor scaled proportionally so Benny's foot stays on the lat/lng point.

## Test plan
- [ ] `/map/swc` pins are visibly smaller than before, no clipping or anchor drift.
- [ ] `/map` (regular Benny) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)