### PR TITLE
fix(puttanesca-58194): shrink Benny to 50% within SWC pin

### DIFF
--- a/frontend/public/molto-benny-swc.svg
+++ b/frontend/public/molto-benny-swc.svg
@@ -1,5 +1,5 @@
 <svg width="1400" height="700" viewBox="0 0 1400 700" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="benny" transform="translate(0, 27)">
+<g id="benny" transform="translate(170, 350) scale(0.5)">
 <g id="graphic" clip-path="url(#clip0_5803_3851)">
 <g id="white">
 <path id="Vector" d="M305.28 188.452C320.797 240.483 327.447 231.616 285.777 234.107C265.254 238.167 251.43 253.51 236.162 219.337C220.868 185.164 218.477 148.276 243.061 142.024C262.165 133.481 294.57 152.61 305.28 188.477V188.452Z" fill="white"/>


### PR DESCRIPTION
## Summary
Halves Benny inside the `/map/swc` composite SVG. Shield retains its current size — now visually dominant. Benny bottom-aligns with the shield.

## Test plan
- [ ] `/map/swc` pins show a small Benny next to a same-size-as-before shield.
- [ ] Marker anchor stays on Benny's foot (no perceived drift when zooming in).
- [ ] `/map` regular Benny pin unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)