### PR TITLE
fix(taleggio-69103): restrict swcOnly=true to approved events

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -845,6 +845,7 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
     let resultEvents = events;
     if (req.query.swcOnly === 'true') {
       resultEvents = events.filter((e: any) =>
+        e.underbossStatus === 'approved' &&
         Array.isArray(e.eventTags) && e.eventTags.some((t: string) => typeof t === 'string' && t.includes('swc') && t !== 'swc')
       );
     }


### PR DESCRIPTION
## Summary
`GET /api/gpp/events?swcOnly=true` (consumed by `/map/swc`) previously returned any non-rejected/non-hidden SWC-tagged event, including `pending` ones. Tightens the post-filter to also require `underbossStatus === 'approved'`.

## Notes
- Backend deploys only from `master`; after merge, run `cd backend && vercel --prod` from the master-deploy worktree to ship.
- No frontend change required.

## Test plan
- [ ] `curl https://api.rsv.pizza/api/gpp/events?swcOnly=true` returns only events with `approved: true` after backend redeploys.
- [ ] `/map/swc` no longer shows pending SWC events.
- [ ] `/api/gpp/events` (no `swcOnly`) still returns the full unfiltered set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)