### PR TITLE
fix(tropea-58294): apply swcOnly filter in SQL to avoid take(500) truncation

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -799,7 +799,7 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
       includeAllStatuses = true;
     }
 
-    const where: any = { eventType: 'gpp' };
+    let where: any = { eventType: 'gpp' };
     if (req.query.curated === '1') {
       where.underbossStatus = { in: ['approved', 'listed'] };
     } else if (includeAllStatuses) {
@@ -823,6 +823,26 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
       where.region = region as string;
     }
 
+    // tropea-58294: swcOnly filter must run in SQL, not as a JS post-filter on
+    // the already-truncated take(N) result. Previously, take(500) capped the
+    // findMany BEFORE the JS .filter() ran, so SWC+approved events older than
+    // the 500th-newest GPP event were silently dropped (54 of 74 returned).
+    // We pre-fetch the distinct list of swc-* tags from event_tags and add
+    // hasSome + underbossStatus='approved' to the prisma where clause so the
+    // take/count happen against the filtered set.
+    if (req.query.swcOnly === 'true') {
+      const swcTagRows = await prisma.$queryRaw<Array<{ tag: string }>>`
+        SELECT DISTINCT t AS tag FROM parties, unnest(event_tags) t
+        WHERE t LIKE '%swc%' AND t <> 'swc'
+      `;
+      const swcTags = swcTagRows.map(r => r.tag);
+      where = {
+        eventType: 'gpp',
+        underbossStatus: 'approved',
+        eventTags: { hasSome: swcTags },
+      };
+    }
+
     const parsedLimit = Math.min(parseInt(limit as string, 10) || 500, 2000);
     const parsedOffset = parseInt(offset as string, 10) || 0;
 
@@ -837,26 +857,13 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
       prisma.party.count({ where }),
     ]);
 
-    // cacciatore-72814: optional post-filter for SWC-flagged events.
-    // Keeps an event when its `eventTags` array contains at least one tag
-    // including the substring "swc" (e.g. "swc-2026", "swc-bali") but NOT
-    // the bare string "swc". Done in JS so we don't have to teach Prisma
-    // about array-substring matching.
-    let resultEvents = events;
-    if (req.query.swcOnly === 'true') {
-      resultEvents = events.filter((e: any) =>
-        e.underbossStatus === 'approved' &&
-        Array.isArray(e.eventTags) && e.eventTags.some((t: string) => typeof t === 'string' && t.includes('swc') && t !== 'swc')
-      );
-    }
-
     res.set(
       'Cache-Control',
       callerIsModerator ? 'private, no-store' : 'public, max-age=300'
     );
     res.json({
-      events: resultEvents.map((e) => formatGppEvent(e, callerIsModerator)),
-      total: req.query.swcOnly === 'true' ? resultEvents.length : total,
+      events: events.map((e) => formatGppEvent(e, callerIsModerator)),
+      total,
       limit: parsedLimit,
       offset: parsedOffset,
     });


### PR DESCRIPTION
## Summary
`GET /api/gpp/events?swcOnly=true` was post-filtering in JS after a `take(500)` on the prisma findMany. With 568 non-rejected/hidden GPP events, 20 SWC+approved events older than the 500th-newest were silently dropped before the filter saw them — endpoint returned 54 of 74 actual SWC+approved events.

Moves the SWC tag check + `underbossStatus='approved'` constraint into the Prisma `where` clause. `take(500)` now applies to the already-filtered set, so all 74 events come back.

## Notes
- Backend deploys only from master; after merge, run `cd backend && vercel --prod` from the master-deploy worktree to ship.
- No frontend change required.

## Test plan
- [ ] `curl https://api.rsv.pizza/api/gpp/events?swcOnly=true | jq '.events | length'` → 74 (was 54).
- [ ] All returned events have `approved: true` and at least one `swc*` tag.
- [ ] `/api/gpp/events` without `swcOnly` returns the same set as before (no regression on the public endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)