### PR TITLE
fix(capicola-22184): revert /maps/place/ URL on EventPage

### DIFF
--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -537,13 +537,15 @@ export function EventPage() {
   };
 
   // Interactive Google Maps JS SDK venue thumbnail (see VenueMap component).
-  // Prefer canonical place_id (ChIJ…) + address — opens the real place card.
+  // Per Google's Maps Universal URL spec, `/maps/search/?api=1` with both
+  // `query` and `query_place_id` opens the canonical place card. `/maps/place/?api=1`
+  // is not a valid action and Google falls back to a generic IP-located map view.
   // Skip query_place_id for Google's address-shell IDs (prefixes Ei…/Ek…), which
   // are autocomplete fallbacks that don't resolve to a Maps place page. Fall
   // back to address alone, then to lat/lng if no address.
   const hasCanonicalPlaceId = event.placeId?.startsWith('ChIJ') ?? false;
   const googleMapsUrl = hasCanonicalPlaceId && event.address
-    ? `https://www.google.com/maps/place/?api=1&query=${encodeURIComponent(event.address)}&query_place_id=${event.placeId}`
+    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}&query_place_id=${event.placeId}`
     : event.address
       ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`
       : event.latitude && event.longitude


### PR DESCRIPTION
## Bug

On user-facing EventPage (e.g. https://rsv.pizza/enugu), clicking the venue/address opens Google Maps centered on the user's IP location (e.g. Philadelphia) instead of the actual event venue in Enugu, Nigeria.

## Root cause

`frontend/src/pages/EventPage.tsx` was building a Google Maps URL using `/maps/place/?api=1&query=...&query_place_id=...`. That URL form is NOT a documented Google Maps Universal URL action — `/maps/place/?api=1` is not in the spec, so Google ignores the `query` and `query_place_id` params and falls back to a generic map centered on the requester's IP.

The documented form per Google's Maps URLs spec is `/maps/search/?api=1&query=<address>&query_place_id=<placeId>` — `search` action, with both params, opens the canonical place card.

Regression introduced in commit `4c7a0892` (prosciutto-31882, 2026-05-19), kept by `d894963a` (gorgonzola-31482, 2026-05-20).

## Fix

One-word change: `place` -> `search`. The `hasCanonicalPlaceId` gate from gorgonzola-31482 is untouched. Updated the explanatory comment to factually describe the Universal URL spec.

## Verification

- Visit https://www.google.com/maps/search/?api=1&query=1+Temple+Ave%2C+Enugu&query_place_id=ChIJOYkVCF6jRBARSXwk0Y_zC3A -> opens the Blockchain Hub Africa place card in Enugu, Nigeria (correct).
- Compare against https://www.google.com/maps/place/?api=1&query=1+Temple+Ave%2C+Enugu&query_place_id=ChIJOYkVCF6jRBARSXwk0Y_zC3A -> Google ignores params, centers on requester's IP location (broken).
- On preview: visit `/enugu`, click the address — should open the Enugu venue, not the requester's home city.