### PR TITLE
feat(pancetta-19834): register Day-Of as pinnable app in Apps Hub

### DIFF
--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -19,6 +19,7 @@ import {
   ExternalLink,
   Pin,
   PinOff,
+  Zap,
 } from 'lucide-react';
 import { updateParty } from '../lib/supabase';
 import { usePizza } from '../contexts/PizzaContext';
@@ -133,6 +134,15 @@ const apps: AppItem[] = [
   },
 
   // Day-of
+  {
+    id: 'day-of',
+    name: 'Day Of',
+    description: 'Live event-day dashboard: check-in, announcements, photos, broadcast',
+    icon: Zap,
+    status: 'live',
+    category: 'day-of',
+    tab: 'day-of',
+  },
   {
     id: 'music-dj',
     name: 'Music / DJ',
@@ -388,7 +398,12 @@ export function AppsHub({
   // parties. The downstream cap-display gate (hide $ unless the 'go'
   // event_tag is set) lives in HostPage where Party props are passed
   // into PayoutsTab.
-  const visibleApps = isApproved ? apps : apps.filter(a => a.id !== 'payments');
+  // pancetta-19834: Day-Of tile is also gated on approval — the underlying
+  // tab is only added to HostPage's coreTabs when isApproved, so showing the
+  // tile to unapproved-party hosts would dead-end the click.
+  const visibleApps = isApproved
+    ? apps
+    : apps.filter(a => a.id !== 'payments' && a.id !== 'day-of');
 
   const handleTogglePin = async (appId: string, pin: boolean) => {
     // Optimistic update

--- a/frontend/src/lib/appDefinitions.ts
+++ b/frontend/src/lib/appDefinitions.ts
@@ -13,6 +13,7 @@ import {
   FileImage,
   Printer,
   Receipt,
+  Zap,
 } from 'lucide-react';
 
 /**
@@ -37,6 +38,7 @@ export const PINNABLE_APPS: PinnableApp[] = [
   { id: 'raffle', name: 'Raffle', tab: 'raffle', icon: Ticket },
   { id: 'budget', name: 'Budget', tab: 'budget', icon: Calculator },
   { id: 'checklist', name: 'Checklist', tab: 'checklist', icon: ListChecks },
+  { id: 'day-of', name: 'Day Of', tab: 'day-of', icon: Zap },
   { id: 'party-kit', name: 'Party Kit', tab: 'gpp', icon: Package },
   { id: 'marketing-promo', name: 'Promo', tab: 'promo', icon: Megaphone },
   { id: 'flyer', name: 'Flyer', tab: 'flyer', icon: FileImage },

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -221,8 +221,10 @@ function HostPageContent() {
     // Build pinned tabs from party.pinnedApps
     // bresaola-49185: filter out 'payments' for unapproved parties so the
     // Payments tab is hidden from the pinned tab strip until approval lands.
+    // pancetta-19834: same gate for 'day-of' — the core-tab listing already
+    // conditions Day Of on isApproved above, so an old pin shouldn't leak in.
     const pinnedTabs = (party?.pinnedApps ?? [])
-      .filter(appId => isApproved || appId !== 'payments')
+      .filter(appId => isApproved || (appId !== 'payments' && appId !== 'day-of'))
       .map(appId => {
         const appDef = PINNABLE_APPS.find(a => a.id === appId);
         if (!appDef) return null;


### PR DESCRIPTION
## Summary
Adds a Day-Of entry to:
- `PINNABLE_APPS` in `frontend/src/lib/appDefinitions.ts` — lets hosts pin it to the tab bar
- `apps[]` in `frontend/src/components/AppsHub.tsx` under the existing `'day-of'` category

Hidden for non-approved parties (party.underbossStatus !== 'approved') since the underlying feature itself is gated the same way. Mirrors the existing `bresaola-49185` pattern used for the Payments tile (AppsHub `visibleApps` filter + HostPage pinned-tab filter).

Icon: `Zap` (same lucide icon HostPage already uses for the day-of core tab).

## Test plan
- [ ] Approved party host: \"Day Of\" tile visible in Apps Hub day-of section
- [ ] Approved party host: can pin Day-Of to tab bar
- [ ] Unapproved party host: \"Day Of\" tile NOT visible in Apps Hub
- [ ] Pinning + clicking opens the existing day-of tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)