### PR TITLE
feat(provolone-71839): rename Day Of to Party Guide + checklist linkTab option

### DIFF
--- a/backend/src/helpers/partyAccess.ts
+++ b/backend/src/helpers/partyAccess.ts
@@ -17,7 +17,7 @@ export const GPP_GLOBAL_EDITORS = [
  */
 export const VALID_TAB_IDS = [
   'dashboard',
-  'day-of',
+  'party-guide',
   'details',
   'guests',
   'pizza',

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -291,7 +291,7 @@ router.patch('/gpp-nft', requireAuth, async (req: AuthRequest, res: Response, ne
 const ALLOWED_LINK_TABS = [
   'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music',
   'report', 'staff', 'displays', 'raffle', 'budget', 'gpp', 'promo',
-  'flyer', 'print', 'payments',
+  'flyer', 'print', 'party-guide', 'payments',
 ];
 
 function isValidLinkTab(v: unknown): v is string | null {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -1855,9 +1855,9 @@ router.post('/:partyId/guests/walk-in', async (req: AuthRequest, res: Response, 
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
-    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'day-of');
+    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'party-guide');
     if (!canAccessDayOf) {
-      throw new AppError('You do not have access to the day-of tab', 403, 'TAB_ACCESS_DENIED');
+      throw new AppError('You do not have access to the party-guide tab', 403, 'TAB_ACCESS_DENIED');
     }
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -1921,9 +1921,9 @@ router.post('/:partyId/announce', async (req: AuthRequest, res: Response, next: 
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
-    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'day-of');
+    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'party-guide');
     if (!canAccessDayOf) {
-      throw new AppError('You do not have access to the day-of tab', 403, 'TAB_ACCESS_DENIED');
+      throw new AppError('You do not have access to the party-guide tab', 403, 'TAB_ACCESS_DENIED');
     }
 
     // Validate body
@@ -2106,9 +2106,9 @@ router.get('/:partyId/announcements', async (req: AuthRequest, res: Response, ne
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
-    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'day-of');
+    const canAccessDayOf = await canUserAccessTab(partyId, req.userEmail, req.userId, 'party-guide');
     if (!canAccessDayOf) {
-      throw new AppError('You do not have access to the day-of tab', 403, 'TAB_ACCESS_DENIED');
+      throw new AppError('You do not have access to the party-guide tab', 403, 'TAB_ACCESS_DENIED');
     }
 
     const rows = await prisma.announcement.findMany({

--- a/frontend/src/components/AppsHub.tsx
+++ b/frontend/src/components/AppsHub.tsx
@@ -135,13 +135,13 @@ const apps: AppItem[] = [
 
   // Day-of
   {
-    id: 'day-of',
-    name: 'Day Of',
+    id: 'party-guide',
+    name: 'Party Guide',
     description: 'Live event-day dashboard: check-in, announcements, photos, broadcast',
     icon: Zap,
     status: 'live',
     category: 'day-of',
-    tab: 'day-of',
+    tab: 'party-guide',
   },
   {
     id: 'music-dj',
@@ -398,12 +398,12 @@ export function AppsHub({
   // parties. The downstream cap-display gate (hide $ unless the 'go'
   // event_tag is set) lives in HostPage where Party props are passed
   // into PayoutsTab.
-  // pancetta-19834: Day-Of tile is also gated on approval — the underlying
+  // pancetta-19834: Party Guide tile is also gated on approval — the underlying
   // tab is only added to HostPage's coreTabs when isApproved, so showing the
   // tile to unapproved-party hosts would dead-end the click.
   const visibleApps = isApproved
     ? apps
-    : apps.filter(a => a.id !== 'payments' && a.id !== 'day-of');
+    : apps.filter(a => a.id !== 'payments' && a.id !== 'party-guide');
 
   const handleTogglePin = async (appId: string, pin: boolean) => {
     // Optimistic update

--- a/frontend/src/lib/appDefinitions.ts
+++ b/frontend/src/lib/appDefinitions.ts
@@ -38,7 +38,7 @@ export const PINNABLE_APPS: PinnableApp[] = [
   { id: 'raffle', name: 'Raffle', tab: 'raffle', icon: Ticket },
   { id: 'budget', name: 'Budget', tab: 'budget', icon: Calculator },
   { id: 'checklist', name: 'Checklist', tab: 'checklist', icon: ListChecks },
-  { id: 'day-of', name: 'Day Of', tab: 'day-of', icon: Zap },
+  { id: 'party-guide', name: 'Party Guide', tab: 'party-guide', icon: Zap },
   { id: 'party-kit', name: 'Party Kit', tab: 'gpp', icon: Package },
   { id: 'marketing-promo', name: 'Promo', tab: 'promo', icon: Megaphone },
   { id: 'flyer', name: 'Flyer', tab: 'flyer', icon: FileImage },

--- a/frontend/src/lib/tabPermissions.ts
+++ b/frontend/src/lib/tabPermissions.ts
@@ -25,7 +25,7 @@ import { CoHost } from '../types';
 
 export type TabId =
   | 'dashboard'
-  | 'day-of'
+  | 'party-guide'
   | 'details'
   | 'guests'
   | 'pizza'
@@ -59,7 +59,7 @@ export interface HostTab {
  */
 export const ALL_HOST_TABS: HostTab[] = [
   { id: 'dashboard', label: 'Dashboard', icon: Home },
-  { id: 'day-of', label: 'Day Of', icon: Zap },
+  { id: 'party-guide', label: 'Party Guide', icon: Zap },
   { id: 'details', label: 'Settings', icon: Settings },
   { id: 'guests', label: 'Guests', icon: Users },
   { id: 'pizza', label: 'Pizza & Drinks', icon: Pizza },

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -36,7 +36,7 @@ const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4
 const LINK_TAB_OPTIONS: readonly string[] = [
   'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music',
   'report', 'staff', 'displays', 'raffle', 'budget', 'gpp', 'promo',
-  'flyer', 'print', 'payments',
+  'flyer', 'print', 'party-guide', 'payments',
 ];
 
 function sortByDueDate(items: ChecklistDefault[]): ChecklistDefault[] {

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -46,9 +46,9 @@ import { DayOfTab } from '../components/day-of';
 // Super admin email that can edit any party
 const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
 
-type TabType = 'dashboard' | 'day-of' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payments' | 'apps';
+type TabType = 'dashboard' | 'party-guide' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payments' | 'apps';
 
-const ALL_VALID_TABS: TabType[] = ['dashboard', 'day-of', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'gpp', 'promo', 'flyer', 'print', 'payments', 'apps'];
+const ALL_VALID_TABS: TabType[] = ['dashboard', 'party-guide', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'gpp', 'promo', 'flyer', 'print', 'payments', 'apps'];
 
 function HostPageContent() {
   const { t } = useTranslation('host');
@@ -211,7 +211,7 @@ function HostPageContent() {
       // /run/:inviteCode for mobile). Approval gate: visible to hosts/cohosts of
       // approved parties (underbossStatus === 'approved'), regardless of admin
       // or underboss role.
-      ...(isApproved ? [{ id: 'day-of' as TabType, label: 'Day Of', icon: Zap }] : []),
+      ...(isApproved ? [{ id: 'party-guide' as TabType, label: 'Party Guide', icon: Zap }] : []),
       { id: 'details' as TabType, label: t('tabs.settings'), icon: Settings },
       { id: 'guests' as TabType, label: t('tabs.guests'), icon: Users },
       { id: 'pizza' as TabType, label: isGPP ? t('tabs.pizza') : t('tabs.pizzaAndDrinks'), icon: Pizza },
@@ -221,10 +221,10 @@ function HostPageContent() {
     // Build pinned tabs from party.pinnedApps
     // bresaola-49185: filter out 'payments' for unapproved parties so the
     // Payments tab is hidden from the pinned tab strip until approval lands.
-    // pancetta-19834: same gate for 'day-of' — the core-tab listing already
-    // conditions Day Of on isApproved above, so an old pin shouldn't leak in.
+    // pancetta-19834: same gate for 'party-guide' — the core-tab listing already
+    // conditions Party Guide on isApproved above, so an old pin shouldn't leak in.
     const pinnedTabs = (party?.pinnedApps ?? [])
-      .filter(appId => isApproved || (appId !== 'payments' && appId !== 'day-of'))
+      .filter(appId => isApproved || (appId !== 'payments' && appId !== 'party-guide'))
       .map(appId => {
         const appDef = PINNABLE_APPS.find(a => a.id === appId);
         if (!appDef) return null;
@@ -329,7 +329,7 @@ function HostPageContent() {
 
         {activeTab === 'dashboard' && party ? (
           <GPPDashboardTab />
-        ) : activeTab === 'day-of' && party ? (
+        ) : activeTab === 'party-guide' && party ? (
           <DayOfTab party={party} />
         ) : activeTab === 'apps' && party ? (
           <AppsHub inviteCode={party.inviteCode} pinnedApps={party.pinnedApps ?? []} partyId={party.id} />
@@ -371,7 +371,7 @@ function HostPageContent() {
               mergeParty({ coHosts: updated });
             }}
           />
-        ) : activeTab !== 'apps' && activeTab !== 'dashboard' && activeTab !== 'day-of' && activeTab !== 'partners' && (
+        ) : activeTab !== 'apps' && activeTab !== 'dashboard' && activeTab !== 'party-guide' && activeTab !== 'partners' && (
           <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
             <div className="xl:col-span-2 space-y-3">
               {activeTab === 'guests' && (


### PR DESCRIPTION
## Summary
- Rename the user-facing "Day Of" feature to "Party Guide": tab id `day-of` -> `party-guide`, label "Day Of" -> "Party Guide".
- Add `'party-guide'` to the checklist `linkTab` dropdown options (frontend `LINK_TAB_OPTIONS` + backend `ALLOWED_LINK_TABS`) so checklist items can link to it.

## Files touched
- `frontend/src/pages/HostPage.tsx` — `TabType`, `ALL_VALID_TABS`, core-tab listing, pinned-tab filter, render branches
- `frontend/src/lib/tabPermissions.ts` — `TabId` union, `ALL_HOST_TABS` entry
- `frontend/src/lib/appDefinitions.ts` — `PINNABLE_APPS` entry
- `frontend/src/components/AppsHub.tsx` — apps[] entry (id/name/tab), unapproved-filter
- `frontend/src/pages/AdminPage.tsx` — `LINK_TAB_OPTIONS`
- `backend/src/helpers/partyAccess.ts` — `VALID_TAB_IDS`
- `backend/src/routes/admin.routes.ts` — `ALLOWED_LINK_TABS`
- `backend/src/routes/party.routes.ts` — three `canUserAccessTab(..., 'day-of')` -> `'party-guide'` callsites + error string

## What stayed the same
- The `frontend/src/components/day-of/` directory and `DayOf*` component / function / interface class names — internal, unaffected.
- `AppCategory` type `'day-of'` and `CATEGORY_ORDER` entry — that's the temporal phase grouping (planning / lead-up / day-of / after-party) shown as a section header in Apps Hub. Not the feature tab id.
- The mobile route `/run/:inviteCode` — separate surface, separate name.
- Comments and module-internal vocabulary mentioning "day-of" (e.g. import paths, log strings).

## URL effect
`/host/<inviteCode>/day-of` -> `/host/<inviteCode>/party-guide`. Sub-tab URLs aren't typically shared externally, so the bookmark break is low-impact.

## Backend deploy required
`backend/src/helpers/partyAccess.ts` `VALID_TAB_IDS`, `backend/src/routes/admin.routes.ts` `ALLOWED_LINK_TABS`, and three callsites in `backend/src/routes/party.routes.ts` changed. Backend must be redeployed from master tip after merge.

## Test plan
- [ ] Party Guide tab visible (was: Day Of) for hosts of approved events
- [ ] Apps Hub tile renamed "Party Guide" with Zap icon under Day-of section
- [ ] Pinning works under the new id (`party-guide`)
- [ ] Checklist row dropdown now shows "party-guide" as a linkable target
- [ ] Direct nav to `/host/<code>/party-guide` works; nav to `/host/<code>/day-of` falls back to default tab
- [ ] Walk-in capture + announcement endpoints still gate by new tab id (`/run`, `/announce`, `/announcements`)

Generated with [Claude Code](https://claude.com/claude-code)