### PR TITLE
feat(coppa-91482): surface Zoom meeting ID + passcode on Party Guide

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -2129,8 +2129,10 @@ router.get('/:partyId/announcements', async (req: AuthRequest, res: Response, ne
 // the URLs never ship in the JS bundle for non-eligible viewers.
 //
 // Env vars (set on backend Vercel project):
-//   BROADCAST_ZOOM_URL       - global GPP Zoom meeting link (set when known)
-//   BROADCAST_STREAMYARD_URL - global GPP StreamYard studio link (set when known)
+//   BROADCAST_ZOOM_URL         - global GPP Zoom meeting link (set when known)
+//   BROADCAST_ZOOM_MEETING_ID  - display-formatted meeting ID (e.g. "860 6254 2262")
+//   BROADCAST_ZOOM_PASSCODE    - meeting passcode (e.g. "552142")
+//   BROADCAST_STREAMYARD_URL   - global GPP StreamYard studio link (set when known)
 // While unset, returns null URLs and the card shows "Coming soon".
 router.get('/:partyId/broadcast-urls', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
@@ -2146,11 +2148,19 @@ router.get('/:partyId/broadcast-urls', async (req: AuthRequest, res: Response, n
     if (!canAccess) throw new AppError('Forbidden', 403, 'FORBIDDEN');
 
     if (party.eventType !== 'gpp' || party.underbossStatus !== 'approved') {
-      return res.json({ zoomUrl: null, streamyardUrl: null, eligible: false });
+      return res.json({
+        zoomUrl: null,
+        zoomMeetingId: null,
+        zoomPasscode: null,
+        streamyardUrl: null,
+        eligible: false,
+      });
     }
 
     return res.json({
       zoomUrl: process.env.BROADCAST_ZOOM_URL || null,
+      zoomMeetingId: process.env.BROADCAST_ZOOM_MEETING_ID || null,
+      zoomPasscode: process.env.BROADCAST_ZOOM_PASSCODE || null,
       streamyardUrl: process.env.BROADCAST_STREAMYARD_URL || null,
       eligible: true,
     });

--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Radio, Video, Smartphone, ExternalLink } from 'lucide-react';
+import { Radio, Video, Smartphone, ExternalLink, Copy, Check } from 'lucide-react';
 import { isBroadcastUrlReady } from '../../lib/dayOfConfig';
 import { fetchBroadcastUrls } from '../../lib/api';
 
@@ -77,10 +77,50 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
 };
 
 /**
+ * Single "Label: value [Copy]" row for Zoom meeting ID / passcode. Shown
+ * beneath the Zoom button when the backend supplies the values. Copy uses
+ * `navigator.clipboard.writeText`; brief check-icon flash confirms success.
+ */
+interface CopyDetailRowProps {
+  label: string;
+  value: string;
+  copyKey: string;
+  copiedKey: string | null;
+  onCopy: (key: string, value: string) => void;
+}
+
+const CopyDetailRow: React.FC<CopyDetailRowProps> = ({
+  label,
+  value,
+  copyKey,
+  copiedKey,
+  onCopy,
+}) => {
+  const copied = copiedKey === copyKey;
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="text-theme-text-secondary">{label}:</span>
+      <span className="font-mono text-theme-text">{value}</span>
+      <button
+        type="button"
+        onClick={() => onCopy(copyKey, value)}
+        aria-label={`Copy ${label.toLowerCase()}`}
+        className="inline-flex items-center justify-center rounded p-1 text-[#ff393a] hover:bg-white/5 transition-colors"
+      >
+        {copied ? <Check size={12} /> : <Copy size={12} />}
+      </button>
+    </div>
+  );
+};
+
+/**
  * GPP-only broadcast launcher. Two equal-weight buttons (Zoom static cam,
  * StreamYard phone). URLs are fetched from an approval-gated backend endpoint
  * (parmigiano-58729) so they never ship in the client bundle. Visibility
  * gate (isGpp) is the caller's job (DayOfDashboard).
+ *
+ * coppa-91482: meeting ID + passcode also come from the same approval-gated
+ * endpoint and render beneath the Zoom button with one-click copy.
  *
  * States:
  *  - Loading                  → both buttons greyed with "Loading..." badge.
@@ -93,8 +133,11 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
   const [loading, setLoading] = useState(true);
   const [eligible, setEligible] = useState(false);
   const [zoomUrl, setZoomUrl] = useState<string | null>(null);
+  const [zoomMeetingId, setZoomMeetingId] = useState<string | null>(null);
+  const [zoomPasscode, setZoomPasscode] = useState<string | null>(null);
   const [streamyardUrl, setStreamyardUrl] = useState<string | null>(null);
   const [error, setError] = useState(false);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -106,6 +149,8 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
         if (cancelled) return;
         setEligible(res.eligible);
         setZoomUrl(res.zoomUrl);
+        setZoomMeetingId(res.zoomMeetingId);
+        setZoomPasscode(res.zoomPasscode);
         setStreamyardUrl(res.streamyardUrl);
       })
       .catch(() => {
@@ -126,6 +171,19 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
   const unavailableLabel =
     error || !eligible ? 'Not available for this event' : undefined;
 
+  const handleCopy = (key: string, value: string) => {
+    if (!value) return;
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopiedKey(key);
+      setTimeout(() => {
+        setCopiedKey((current) => (current === key ? null : current));
+      }, 1500);
+    });
+  };
+
+  const showZoomDetails =
+    eligible && !loading && !!zoomUrl && (zoomMeetingId || zoomPasscode);
+
   return (
     <div className="card p-5 space-y-3">
       <div className="flex items-center gap-2">
@@ -140,22 +198,48 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
       </p>
 
       <div className={isMobile ? 'flex flex-col gap-3' : 'flex flex-col sm:flex-row gap-3'}>
-        <BroadcastButton
-          url={eligible ? zoomUrl : null}
-          label="Join Zoom (static camera)"
-          subtitle="Set up a laptop on a tripod with a wide shot of the venue — leave it running."
-          icon={<Video size={18} />}
-          loading={loading}
-          unavailableLabel={unavailableLabel}
-        />
-        <BroadcastButton
-          url={eligible ? streamyardUrl : null}
-          label="Join StreamYard (phone)"
-          subtitle="Open this on your phone for live interviews and walkaround shots."
-          icon={<Smartphone size={18} />}
-          loading={loading}
-          unavailableLabel={unavailableLabel}
-        />
+        <div className="flex-1 flex flex-col gap-2">
+          <BroadcastButton
+            url={eligible ? zoomUrl : null}
+            label="Join Zoom (static camera)"
+            subtitle="Set up a laptop on a tripod with a wide shot of the venue — leave it running."
+            icon={<Video size={18} />}
+            loading={loading}
+            unavailableLabel={unavailableLabel}
+          />
+          {showZoomDetails && (
+            <div className="flex flex-col gap-1 px-1">
+              {zoomMeetingId && (
+                <CopyDetailRow
+                  label="Meeting ID"
+                  value={zoomMeetingId}
+                  copyKey="meeting-id"
+                  copiedKey={copiedKey}
+                  onCopy={handleCopy}
+                />
+              )}
+              {zoomPasscode && (
+                <CopyDetailRow
+                  label="Passcode"
+                  value={zoomPasscode}
+                  copyKey="passcode"
+                  copiedKey={copiedKey}
+                  onCopy={handleCopy}
+                />
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex-1">
+          <BroadcastButton
+            url={eligible ? streamyardUrl : null}
+            label="Join StreamYard (phone)"
+            subtitle="Open this on your phone for live interviews and walkaround shots."
+            icon={<Smartphone size={18} />}
+            loading={loading}
+            unavailableLabel={unavailableLabel}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,6 +70,8 @@ export async function apiRequest<T>(
 // null URLs means env vars aren't set yet (card shows "Coming soon").
 export interface BroadcastUrlsResponse {
   zoomUrl: string | null;
+  zoomMeetingId: string | null;
+  zoomPasscode: string | null;
   streamyardUrl: string | null;
   eligible: boolean;
 }


### PR DESCRIPTION
## Summary
Extends the parmigiano-58729 broadcast-urls endpoint with two new fields (`zoomMeetingId`, `zoomPasscode`) sourced from new env vars. The BroadcastJoinCard renders them with Copy buttons under the Zoom join button.

Same approval gate -- the meeting ID and passcode never enter the client bundle, only the authenticated approval-gated endpoint response.

## Env vars to set on backend Vercel project before merge (or after -- endpoint handles missing values gracefully):
- BROADCAST_ZOOM_MEETING_ID = "860 6254 2262"
- BROADCAST_ZOOM_PASSCODE = "552142"

## Backend deploy required
`party.routes.ts` changed. Backend must be redeployed from master tip after merge.

## Test plan
- [ ] Host of approved GPP party: meeting ID + passcode display under Zoom button with working Copy buttons
- [ ] Non-eligible (unapproved or non-GPP) party: still gets "Not available for this event"; no leaked values
- [ ] If env vars unset, card hides those lines gracefully

Generated with [Claude Code](https://claude.com/claude-code)