### PR TITLE
feat(mortadella-58291): split camera + upload on Party Guide photo cards

### DIFF
--- a/frontend/src/components/day-of/PhotoQuickCaptureCard.tsx
+++ b/frontend/src/components/day-of/PhotoQuickCaptureCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Camera, Loader2 } from 'lucide-react';
+import { Camera, Loader2, ImagePlus } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi } from '../../lib/api';
@@ -11,13 +11,17 @@ interface PhotoQuickCaptureCardProps {
 }
 
 /**
- * Day-of one-tap photo capture. Mobile browsers open the rear camera via
- * `capture="environment"`. Reuses uploadEventPhoto for the storage write
- * + the public uploadPhoto API to register the photo on the party.
+ * Day-of one-tap photo capture. Two distinct buttons:
+ *   - "Take a Photo": opens the camera directly via `capture="environment"`
+ *   - "Upload from library": opens the file picker (no capture attribute)
+ *
+ * Both buttons share the same `handleFile` upload pipeline; the only
+ * difference is which hidden input is triggered.
  */
 export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ party, onUploaded }) => {
   const { user } = useAuth();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastSuccess, setLastSuccess] = useState(false);
@@ -54,8 +58,9 @@ export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ pa
   const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFile(file);
-    // Reset so the same file can be picked again
-    if (fileInputRef.current) fileInputRef.current.value = '';
+    // Reset both inputs so the same file can be picked again from either source
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
   };
 
   return (
@@ -67,7 +72,7 @@ export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ pa
 
       <button
         type="button"
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => cameraInputRef.current?.click()}
         disabled={uploading}
         className="w-full bg-[#ff393a] text-white rounded-xl py-6 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
       >
@@ -79,16 +84,33 @@ export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ pa
         ) : (
           <>
             <Camera size={20} />
-            Take a photo
+            Take a Photo
           </>
         )}
       </button>
 
+      <button
+        type="button"
+        onClick={() => libraryInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-3 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+      >
+        <ImagePlus size={16} />
+        Upload from library
+      </button>
+
       <input
-        ref={fileInputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
         capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={onSelected}
       />

--- a/frontend/src/components/day-of/PizzaBoxStackCard.tsx
+++ b/frontend/src/components/day-of/PizzaBoxStackCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Boxes, Loader2, Check, Camera } from 'lucide-react';
+import { Boxes, Loader2, Check, Camera, ImagePlus } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
@@ -17,13 +17,19 @@ interface PizzaBoxStackCardProps {
  * render-time check is a defensive fallback. Done-state is detected by
  * the existence of any party photo tagged 'Box Tower' (the existing
  * default photo tag from backend/src/routes/photo.routes.ts); the card
- * dims to 50% but keeps the upload button active (events often build
+ * dims to 50% but keeps the upload buttons active (events often build
  * multiple towers).
+ *
+ * Two distinct buttons:
+ *   - "Take a Photo": opens camera directly (`capture="environment"`)
+ *   - "Upload from library": opens file picker (no capture attribute)
+ * Both share the same `handleFile` upload pipeline.
  */
 export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasBoxTower, setHasBoxTower] = useState(false);
@@ -73,7 +79,8 @@ export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onU
   const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFile(file);
-    if (fileInputRef.current) fileInputRef.current.value = '';
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
   };
 
   return (
@@ -105,7 +112,7 @@ export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onU
 
       <button
         type="button"
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => cameraInputRef.current?.click()}
         disabled={uploading}
         className="w-full bg-[#ff393a] text-white rounded-xl py-4 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
       >
@@ -117,16 +124,33 @@ export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onU
         ) : (
           <>
             <Camera size={18} />
-            Upload box tower photo
+            Take a Photo
           </>
         )}
       </button>
 
+      <button
+        type="button"
+        onClick={() => libraryInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-3 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+      >
+        <ImagePlus size={16} />
+        Upload from library
+      </button>
+
       <input
-        ref={fileInputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
         capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={onSelected}
       />

--- a/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
+++ b/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { PenLine, Loader2, Check, Camera } from 'lucide-react';
+import { PenLine, Loader2, Check, Camera, ImagePlus } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
@@ -16,12 +16,18 @@ interface SignedPizzaBoxCardProps {
  * the responsibility of the caller (DayOfDashboard); render-time check is
  * a defensive fallback. Done-state is detected by the existence of any
  * party photo tagged 'signed-box'; the card dims to 50% but keeps the
- * upload button active (multiple boxes possible).
+ * upload buttons active (multiple boxes possible).
+ *
+ * Two distinct buttons:
+ *   - "Take a Photo": opens camera directly (`capture="environment"`)
+ *   - "Upload from library": opens file picker (no capture attribute)
+ * Both share the same `handleFile` upload pipeline.
  */
 export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSignedBox, setHasSignedBox] = useState(false);
@@ -71,7 +77,8 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
   const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFile(file);
-    if (fileInputRef.current) fileInputRef.current.value = '';
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
   };
 
   return (
@@ -103,7 +110,7 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
 
       <button
         type="button"
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => cameraInputRef.current?.click()}
         disabled={uploading}
         className="w-full bg-[#ff393a] text-white rounded-xl py-4 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
       >
@@ -115,16 +122,33 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
         ) : (
           <>
             <Camera size={18} />
-            Upload signed box photo
+            Take a Photo
           </>
         )}
       </button>
 
+      <button
+        type="button"
+        onClick={() => libraryInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-3 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+      >
+        <ImagePlus size={16} />
+        Upload from library
+      </button>
+
       <input
-        ref={fileInputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
         capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={onSelected}
       />

--- a/frontend/src/components/day-of/StandWithCryptoCard.tsx
+++ b/frontend/src/components/day-of/StandWithCryptoCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Shield, Loader2, Check, Camera, Video } from 'lucide-react';
+import { Shield, Loader2, Check, Camera, Video, ImagePlus, Upload } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto, uploadEventVideo } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
@@ -21,15 +21,22 @@ type UploadState = {
  *   2. Shoutout video (tagged 'swc-video', videos bucket)
  *
  * Each section shows a ✓ once its tagged file exists. Card dims to 50%
- * once BOTH are done; both upload buttons remain active throughout.
+ * once BOTH are done; all upload buttons remain active throughout.
+ *
+ * Each section has two distinct buttons:
+ *   - Photo: "Take a Photo" (capture) / "Upload from library" (no capture)
+ *   - Video: "Record video" (capture) / "Upload video" (no capture)
+ * Both buttons in a section share the same upload handler.
  *
  * Visibility gate (isGpp) is the caller's responsibility (DayOfDashboard).
  */
 export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
-  const photoInputRef = useRef<HTMLInputElement>(null);
-  const videoInputRef = useRef<HTMLInputElement>(null);
+  const photoCameraRef = useRef<HTMLInputElement>(null);
+  const photoLibraryRef = useRef<HTMLInputElement>(null);
+  const videoCameraRef = useRef<HTMLInputElement>(null);
+  const videoLibraryRef = useRef<HTMLInputElement>(null);
 
   const [photoState, setPhotoState] = useState<UploadState>({ uploading: false, error: null });
   const [videoState, setVideoState] = useState<UploadState>({ uploading: false, error: null });
@@ -110,13 +117,15 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
   const onPhotoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handlePhotoFile(file);
-    if (photoInputRef.current) photoInputRef.current.value = '';
+    if (photoCameraRef.current) photoCameraRef.current.value = '';
+    if (photoLibraryRef.current) photoLibraryRef.current.value = '';
   };
 
   const onVideoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleVideoFile(file);
-    if (videoInputRef.current) videoInputRef.current.value = '';
+    if (videoCameraRef.current) videoCameraRef.current.value = '';
+    if (videoLibraryRef.current) videoLibraryRef.current.value = '';
   };
 
   const bothDone = hasPhoto && hasVideo;
@@ -153,7 +162,7 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
         </p>
         <button
           type="button"
-          onClick={() => photoInputRef.current?.click()}
+          onClick={() => photoCameraRef.current?.click()}
           disabled={photoState.uploading}
           className="w-full bg-[#ff393a] text-white rounded-xl py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
         >
@@ -165,15 +174,31 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
           ) : (
             <>
               <Camera size={16} />
-              {hasPhoto ? 'Upload another group photo' : 'Upload group photo'}
+              Take a Photo
             </>
           )}
         </button>
+        <button
+          type="button"
+          onClick={() => photoLibraryRef.current?.click()}
+          disabled={photoState.uploading}
+          className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-2.5 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+        >
+          <ImagePlus size={14} />
+          Upload from library
+        </button>
         <input
-          ref={photoInputRef}
+          ref={photoCameraRef}
           type="file"
           accept="image/*"
           capture="environment"
+          className="hidden"
+          onChange={onPhotoSelected}
+        />
+        <input
+          ref={photoLibraryRef}
+          type="file"
+          accept="image/*"
           className="hidden"
           onChange={onPhotoSelected}
         />
@@ -197,7 +222,7 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
         </p>
         <button
           type="button"
-          onClick={() => videoInputRef.current?.click()}
+          onClick={() => videoCameraRef.current?.click()}
           disabled={videoState.uploading}
           className="w-full bg-[#ff393a] text-white rounded-xl py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
         >
@@ -209,15 +234,31 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
           ) : (
             <>
               <Video size={16} />
-              {hasVideo ? 'Upload another shoutout video' : 'Upload shoutout video'}
+              Record video
             </>
           )}
         </button>
+        <button
+          type="button"
+          onClick={() => videoLibraryRef.current?.click()}
+          disabled={videoState.uploading}
+          className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-2.5 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+        >
+          <Upload size={14} />
+          Upload video
+        </button>
         <input
-          ref={videoInputRef}
+          ref={videoCameraRef}
           type="file"
           accept="video/*"
           capture="environment"
+          className="hidden"
+          onChange={onVideoSelected}
+        />
+        <input
+          ref={videoLibraryRef}
+          type="file"
+          accept="video/*"
           className="hidden"
           onChange={onVideoSelected}
         />


### PR DESCRIPTION
## Summary
Splits the single-button upload pattern on the Party Guide photo cards into two distinct buttons: a prominent "Take a Photo" (camera direct via `capture="environment"`) and a secondary "Upload from library" (file picker, no capture).

## Cards updated
- PhotoQuickCaptureCard (Quick photo)
- SignedPizzaBoxCard (signed-box tag)
- PizzaBoxStackCard ('Box Tower' tag)
- StandWithCryptoCard (photo + video both get the dual-button treatment)

## Test plan
- [ ] On mobile (iOS Safari + Android Chrome), tapping "Take a Photo" opens camera directly with no picker
- [ ] Tapping "Upload from library" opens the photo library / file picker
- [ ] Desktop: both buttons open file picker (capture is ignored on desktop)
- [ ] Done states + tag-based detection unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)