### PR TITLE
feat(bresaola-91482): SWC card gated by tag + swcbr Juntos Por Cripto variant

### DIFF
--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -93,7 +93,8 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
         {isGpp && <SignedPizzaBoxCard party={party} />}
         {isGpp && <PizzaBoxStackCard party={party} />}
         {isGpp && <BroadcastJoinCard partyId={party.id} layout={layout} />}
-        {isGpp && <StandWithCryptoCard party={party} />}
+        {/* StandWithCryptoCard self-gates on party.eventTags containing 'swc' */}
+        <StandWithCryptoCard party={party} />
         <LogisticsCard party={party} />
         <PizzaStatusCard party={party} />
         <MusicNowPlayingCard

--- a/frontend/src/components/day-of/PhotoQuickCaptureCard.tsx
+++ b/frontend/src/components/day-of/PhotoQuickCaptureCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Camera, Loader2 } from 'lucide-react';
+import { Camera, Loader2, ImagePlus } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi } from '../../lib/api';
@@ -11,13 +11,17 @@ interface PhotoQuickCaptureCardProps {
 }
 
 /**
- * Day-of one-tap photo capture. Mobile browsers open the rear camera via
- * `capture="environment"`. Reuses uploadEventPhoto for the storage write
- * + the public uploadPhoto API to register the photo on the party.
+ * Day-of one-tap photo capture. Two distinct buttons:
+ *   - "Take a Photo": opens the camera directly via `capture="environment"`
+ *   - "Upload from library": opens the file picker (no capture attribute)
+ *
+ * Both buttons share the same `handleFile` upload pipeline; the only
+ * difference is which hidden input is triggered.
  */
 export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ party, onUploaded }) => {
   const { user } = useAuth();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastSuccess, setLastSuccess] = useState(false);
@@ -54,8 +58,9 @@ export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ pa
   const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFile(file);
-    // Reset so the same file can be picked again
-    if (fileInputRef.current) fileInputRef.current.value = '';
+    // Reset both inputs so the same file can be picked again from either source
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
   };
 
   return (
@@ -67,7 +72,7 @@ export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ pa
 
       <button
         type="button"
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => cameraInputRef.current?.click()}
         disabled={uploading}
         className="w-full bg-[#ff393a] text-white rounded-xl py-6 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
       >
@@ -79,16 +84,33 @@ export const PhotoQuickCaptureCard: React.FC<PhotoQuickCaptureCardProps> = ({ pa
         ) : (
           <>
             <Camera size={20} />
-            Take a photo
+            Take a Photo
           </>
         )}
       </button>
 
+      <button
+        type="button"
+        onClick={() => libraryInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-3 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+      >
+        <ImagePlus size={16} />
+        Upload from library
+      </button>
+
       <input
-        ref={fileInputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
         capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={onSelected}
       />

--- a/frontend/src/components/day-of/PizzaBoxStackCard.tsx
+++ b/frontend/src/components/day-of/PizzaBoxStackCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Boxes, Loader2, Check, Camera } from 'lucide-react';
+import { Boxes, Loader2, Check, Camera, ImagePlus } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
@@ -17,13 +17,19 @@ interface PizzaBoxStackCardProps {
  * render-time check is a defensive fallback. Done-state is detected by
  * the existence of any party photo tagged 'Box Tower' (the existing
  * default photo tag from backend/src/routes/photo.routes.ts); the card
- * dims to 50% but keeps the upload button active (events often build
+ * dims to 50% but keeps the upload buttons active (events often build
  * multiple towers).
+ *
+ * Two distinct buttons:
+ *   - "Take a Photo": opens camera directly (`capture="environment"`)
+ *   - "Upload from library": opens file picker (no capture attribute)
+ * Both share the same `handleFile` upload pipeline.
  */
 export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasBoxTower, setHasBoxTower] = useState(false);
@@ -73,7 +79,8 @@ export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onU
   const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFile(file);
-    if (fileInputRef.current) fileInputRef.current.value = '';
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
   };
 
   return (
@@ -105,7 +112,7 @@ export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onU
 
       <button
         type="button"
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => cameraInputRef.current?.click()}
         disabled={uploading}
         className="w-full bg-[#ff393a] text-white rounded-xl py-4 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
       >
@@ -117,16 +124,33 @@ export const PizzaBoxStackCard: React.FC<PizzaBoxStackCardProps> = ({ party, onU
         ) : (
           <>
             <Camera size={18} />
-            Upload box tower photo
+            Take a Photo
           </>
         )}
       </button>
 
+      <button
+        type="button"
+        onClick={() => libraryInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-3 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+      >
+        <ImagePlus size={16} />
+        Upload from library
+      </button>
+
       <input
-        ref={fileInputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
         capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={onSelected}
       />

--- a/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
+++ b/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { PenLine, Loader2, Check, Camera } from 'lucide-react';
+import { PenLine, Loader2, Check, Camera, ImagePlus } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
@@ -16,12 +16,18 @@ interface SignedPizzaBoxCardProps {
  * the responsibility of the caller (DayOfDashboard); render-time check is
  * a defensive fallback. Done-state is detected by the existence of any
  * party photo tagged 'signed-box'; the card dims to 50% but keeps the
- * upload button active (multiple boxes possible).
+ * upload buttons active (multiple boxes possible).
+ *
+ * Two distinct buttons:
+ *   - "Take a Photo": opens camera directly (`capture="environment"`)
+ *   - "Upload from library": opens file picker (no capture attribute)
+ * Both share the same `handleFile` upload pipeline.
  */
 export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSignedBox, setHasSignedBox] = useState(false);
@@ -71,7 +77,8 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
   const onSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFile(file);
-    if (fileInputRef.current) fileInputRef.current.value = '';
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
   };
 
   return (
@@ -103,7 +110,7 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
 
       <button
         type="button"
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => cameraInputRef.current?.click()}
         disabled={uploading}
         className="w-full bg-[#ff393a] text-white rounded-xl py-4 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
       >
@@ -115,16 +122,33 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
         ) : (
           <>
             <Camera size={18} />
-            Upload signed box photo
+            Take a Photo
           </>
         )}
       </button>
 
+      <button
+        type="button"
+        onClick={() => libraryInputRef.current?.click()}
+        disabled={uploading}
+        className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-3 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+      >
+        <ImagePlus size={16} />
+        Upload from library
+      </button>
+
       <input
-        ref={fileInputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
         capture="environment"
+        className="hidden"
+        onChange={onSelected}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={onSelected}
       />

--- a/frontend/src/components/day-of/StandWithCryptoCard.tsx
+++ b/frontend/src/components/day-of/StandWithCryptoCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Shield, Loader2, Check, Camera, Video } from 'lucide-react';
+import { Shield, Loader2, Check, Camera, Video, ImagePlus, Upload } from 'lucide-react';
 import { Party } from '../../types';
 import { uploadEventPhoto, uploadEventVideo } from '../../lib/supabase';
 import { uploadPhoto as uploadPhotoApi, getPartyPhotos } from '../../lib/api';
@@ -21,15 +21,22 @@ type UploadState = {
  *   2. Shoutout video (tagged 'swc-video', videos bucket)
  *
  * Each section shows a ✓ once its tagged file exists. Card dims to 50%
- * once BOTH are done; both upload buttons remain active throughout.
+ * once BOTH are done; all upload buttons remain active throughout.
+ *
+ * Each section has two distinct buttons:
+ *   - Photo: "Take a Photo" (capture) / "Upload from library" (no capture)
+ *   - Video: "Record video" (capture) / "Upload video" (no capture)
+ * Both buttons in a section share the same upload handler.
  *
  * Visibility gate (isGpp) is the caller's responsibility (DayOfDashboard).
  */
 export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
-  const photoInputRef = useRef<HTMLInputElement>(null);
-  const videoInputRef = useRef<HTMLInputElement>(null);
+  const photoCameraRef = useRef<HTMLInputElement>(null);
+  const photoLibraryRef = useRef<HTMLInputElement>(null);
+  const videoCameraRef = useRef<HTMLInputElement>(null);
+  const videoLibraryRef = useRef<HTMLInputElement>(null);
 
   const [photoState, setPhotoState] = useState<UploadState>({ uploading: false, error: null });
   const [videoState, setVideoState] = useState<UploadState>({ uploading: false, error: null });
@@ -110,13 +117,15 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
   const onPhotoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handlePhotoFile(file);
-    if (photoInputRef.current) photoInputRef.current.value = '';
+    if (photoCameraRef.current) photoCameraRef.current.value = '';
+    if (photoLibraryRef.current) photoLibraryRef.current.value = '';
   };
 
   const onVideoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleVideoFile(file);
-    if (videoInputRef.current) videoInputRef.current.value = '';
+    if (videoCameraRef.current) videoCameraRef.current.value = '';
+    if (videoLibraryRef.current) videoLibraryRef.current.value = '';
   };
 
   const bothDone = hasPhoto && hasVideo;
@@ -153,7 +162,7 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
         </p>
         <button
           type="button"
-          onClick={() => photoInputRef.current?.click()}
+          onClick={() => photoCameraRef.current?.click()}
           disabled={photoState.uploading}
           className="w-full bg-[#ff393a] text-white rounded-xl py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
         >
@@ -165,15 +174,31 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
           ) : (
             <>
               <Camera size={16} />
-              {hasPhoto ? 'Upload another group photo' : 'Upload group photo'}
+              Take a Photo
             </>
           )}
         </button>
+        <button
+          type="button"
+          onClick={() => photoLibraryRef.current?.click()}
+          disabled={photoState.uploading}
+          className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-2.5 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+        >
+          <ImagePlus size={14} />
+          Upload from library
+        </button>
         <input
-          ref={photoInputRef}
+          ref={photoCameraRef}
           type="file"
           accept="image/*"
           capture="environment"
+          className="hidden"
+          onChange={onPhotoSelected}
+        />
+        <input
+          ref={photoLibraryRef}
+          type="file"
+          accept="image/*"
           className="hidden"
           onChange={onPhotoSelected}
         />
@@ -197,7 +222,7 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
         </p>
         <button
           type="button"
-          onClick={() => videoInputRef.current?.click()}
+          onClick={() => videoCameraRef.current?.click()}
           disabled={videoState.uploading}
           className="w-full bg-[#ff393a] text-white rounded-xl py-3 font-semibold flex items-center justify-center gap-2 disabled:opacity-50"
         >
@@ -209,15 +234,31 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
           ) : (
             <>
               <Video size={16} />
-              {hasVideo ? 'Upload another shoutout video' : 'Upload shoutout video'}
+              Record video
             </>
           )}
         </button>
+        <button
+          type="button"
+          onClick={() => videoLibraryRef.current?.click()}
+          disabled={videoState.uploading}
+          className="w-full bg-theme-surface-hover text-theme-text rounded-xl py-2.5 font-medium flex items-center justify-center gap-2 disabled:opacity-50 border border-white/10 hover:bg-white/10 transition-colors"
+        >
+          <Upload size={14} />
+          Upload video
+        </button>
         <input
-          ref={videoInputRef}
+          ref={videoCameraRef}
           type="file"
           accept="video/*"
           capture="environment"
+          className="hidden"
+          onChange={onVideoSelected}
+        />
+        <input
+          ref={videoLibraryRef}
+          type="file"
+          accept="video/*"
           className="hidden"
           onChange={onVideoSelected}
         />

--- a/frontend/src/components/day-of/StandWithCryptoCard.tsx
+++ b/frontend/src/components/day-of/StandWithCryptoCard.tsx
@@ -16,7 +16,7 @@ type UploadState = {
 };
 
 /**
- * GPP-only Stand With Crypto sponsor activation. Two independent uploads:
+ * Stand With Crypto sponsor activation. Two independent uploads:
  *   1. Group photo with SWC signs (tagged 'swc-photo', images bucket)
  *   2. Shoutout video (tagged 'swc-video', videos bucket)
  *
@@ -28,8 +28,26 @@ type UploadState = {
  *   - Video: "Record video" (capture) / "Upload video" (no capture)
  * Both buttons in a section share the same upload handler.
  *
- * Visibility gate (isGpp) is the caller's responsibility (DayOfDashboard).
+ * Visibility: self-gated on `party.eventTags` containing any tag with
+ * `'swc'` substring (case-insensitive) — `swc`, `swcbr`, `swceu`, etc.
+ * Variant copy (e.g. `swcbr` → "Juntos Por Cripto") is selected from
+ * SWC_VARIANT_LABELS; everything else falls through to the default.
  */
+const SWC_VARIANT_LABELS: Record<string, { title: string; signsLabel: string; shoutout: string }> = {
+  swcbr: {
+    title: 'Juntos Por Cripto',
+    signsLabel: 'Juntos Por Cripto signs',
+    shoutout: 'Juntos Por Cripto',
+  },
+  // default falls through to "Stand With Crypto"
+};
+
+const DEFAULT_LABEL = {
+  title: 'Stand With Crypto',
+  signsLabel: 'SWC signs',
+  shoutout: 'Stand With Crypto',
+};
+
 export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party, onUploaded }) => {
   // ---- HOOKS (all above any early return) -------------------------------
   const { user } = useAuth();
@@ -43,6 +61,18 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
 
   const [hasPhoto, setHasPhoto] = useState(false);
   const [hasVideo, setHasVideo] = useState(false);
+
+  // Tag-based visibility gate + variant label selection. The first eventTag
+  // whose lowercase form contains 'swc' wins (swc, swcbr, swceu, swcus, ...).
+  const swcTag = React.useMemo(
+    () =>
+      (party.eventTags ?? [])
+        .map((t) => t.toLowerCase())
+        .find((t) => t.includes('swc')),
+    [party.eventTags],
+  );
+  const hasSwcTag = !!swcTag;
+  const label = (swcTag && SWC_VARIANT_LABELS[swcTag]) || DEFAULT_LABEL;
 
   const refresh = React.useCallback(async () => {
     try {
@@ -130,6 +160,9 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
 
   const bothDone = hasPhoto && hasVideo;
 
+  // Self-gate: hide entirely unless party has an SWC-prefixed eventTag.
+  if (!hasSwcTag) return null;
+
   return (
     <div
       className={`card p-5 space-y-4 transition-opacity ${
@@ -138,11 +171,11 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
     >
       <div className="flex items-center gap-2">
         <Shield size={18} className="text-[#ff393a]" />
-        <h3 className="text-lg font-semibold text-theme-text">Stand With Crypto</h3>
+        <h3 className="text-lg font-semibold text-theme-text">{label.title}</h3>
       </div>
 
       <p className="text-sm leading-relaxed text-theme-text-secondary">
-        Stand With Crypto is sponsoring GPP 2026. Help us deliver:
+        {label.title} is sponsoring GPP 2026. Help us deliver:
       </p>
 
       {/* Photo section ----------------------------------------------------- */}
@@ -154,11 +187,11 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
             <span className="w-4 h-4" />
           )}
           <h4 className="text-sm font-semibold text-theme-text">
-            Upload group photo with SWC signs
+            Upload group photo with {label.signsLabel}
           </h4>
         </div>
         <p className="text-xs text-theme-text-muted">
-          Get everyone in the shot holding the SWC signs.
+          Get everyone in the shot holding the {label.signsLabel}.
         </p>
         <button
           type="button"
@@ -214,11 +247,11 @@ export const StandWithCryptoCard: React.FC<StandWithCryptoCardProps> = ({ party,
             <span className="w-4 h-4" />
           )}
           <h4 className="text-sm font-semibold text-theme-text">
-            Upload SWC shoutout video
+            Upload {label.shoutout} shoutout video
           </h4>
         </div>
         <p className="text-xs text-theme-text-muted">
-          ~10–20 seconds of the crowd shouting "Stand With Crypto!" at the camera works great.
+          ~10–20 seconds of the crowd shouting "{label.shoutout}!" at the camera works great.
         </p>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Replaces the GPP-only gate on the Stand With Crypto card with a tag-based gate: card appears whenever any `eventTags` entry contains `'swc'` (case-insensitive). Matches swc, swcbr, swceu, swcus, etc.
- For events tagged `'swcbr'`, displays the Brazil variant: title "Juntos Por Cripto", and matching label in the body + shoutout prompt.
- Photo/video upload tags unchanged (`'swc-photo'`, `'swc-video'`) — storage tag space stays consistent across variants for easier downstream filtering.

## Supersedes PR #562
This branch is based on `mortadella-58291-camera-upload-split` and includes all of #562's dual-button (camera + upload) changes. The parent session will close #562 in favor of this PR.

## Test plan
- [ ] Event tagged `'swc'`: card visible with "Stand With Crypto"
- [ ] Event tagged `'swcbr'`: card visible with "Juntos Por Cripto"
- [ ] Event tagged `'swceu'`: card visible with "Stand With Crypto"
- [ ] Event with NO swc-prefix tag: card hidden
- [ ] Camera + upload buttons (from #562) still work
- [ ] Uploaded photos still tag as `'swc-photo'` regardless of variant

Generated with [Claude Code](https://claude.com/claude-code)