### PR TITLE
bruschetta-58291: strip GPP prefix + show country + country filter on payouts queue

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -57,6 +57,9 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   name: true,
   inviteCode: true,
   customUrl: true,
+  // bruschetta-58291: surface the party's country on the /payments admin
+  // queue rows + power the Country filter dropdown in PayoutsFilterBar.
+  country: true,
   expectedGuests: true,
   // arugula-38633 v2 follow-up: surface the effective reimbursement cap on
   // the /payments admin dashboard. Raw `reimbursementCapUsd` + `eventTags`
@@ -213,11 +216,24 @@ function buildPayoutWhere(query: Request['query']): any {
     }
   }
 
+  // bruschetta-58291: optional country filter — pulled out before assembling
+  // `where.party` below so it merges cleanly with the tartufo-58291
+  // `underbossStatus: 'approved'` filter (must NOT overwrite that gate).
+  const country = query.country;
+  const countryClause =
+    typeof country === 'string' && country !== 'all' && country.trim().length > 0
+      ? { country: country.trim() }
+      : {};
+
   // tartufo-58291: hide payouts from unapproved parties from the admin queue
   // + CSV export. Existing rows from before the bresaola-49185 backend gate
   // shouldn't surface in routine review. Stats/totals reuse this same `where`
-  // so they stay consistent.
-  where.party = { underbossStatus: 'approved' };
+  // so they stay consistent. bruschetta-58291: merged with optional country
+  // filter so both apply.
+  where.party = {
+    underbossStatus: 'approved',
+    ...countryClause,
+  };
 
   return where;
 }
@@ -274,6 +290,10 @@ function serializePayout(row: any): any {
           name: row.party.name,
           inviteCode: row.party.inviteCode,
           customUrl: row.party.customUrl,
+          // bruschetta-58291: surface the party's country on the wire so the
+          // /payments queue can render it as a subtitle and populate the
+          // Country filter dropdown.
+          country: row.party.country ?? null,
           // arugula-38633 v2 follow-up: admin dashboard shows planning vs
           // actuals. `expectedGuests` is the host's planning number;
           // `rsvpCount` is the filtered _count of confirmed direct RSVPs

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -9,6 +9,12 @@ interface PayoutsFilterBarProps {
   onChange: (next: AdminPayoutFilters) => void;
   onReset: () => void;
   availableCurrencies: string[];
+  /**
+   * bruschetta-58291: distinct, non-null `party.country` values across the
+   * currently-loaded payouts. Mirrors the `availableCurrencies` pattern —
+   * derived in `PaymentsAdminPage` from the loaded set. Sorted ascending.
+   */
+  availableCountries: string[];
 }
 
 const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
@@ -39,6 +45,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   onChange,
   onReset,
   availableCurrencies,
+  availableCountries,
 }) => {
   const update = (patch: Partial<AdminPayoutFilters>) => {
     onChange({ ...filters, ...patch, cursor: undefined });
@@ -67,7 +74,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         })}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-2 items-start">
+      <div className="grid grid-cols-1 md:grid-cols-6 gap-2 items-start">
         {/* Host search */}
         <div className="md:col-span-2">
           <IconInput
@@ -114,6 +121,23 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
           >
             <option value="all">All currencies</option>
             {availableCurrencies.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* bruschetta-58291: Country dropdown — populated from the loaded
+            payout set (parallels availableCurrencies). Backend filters by
+            exact `parties.country` match. */}
+        <div>
+          <select
+            value={filters.country ?? 'all'}
+            onChange={(e) => update({ country: e.target.value })}
+            className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+            aria-label="Filter by country"
+          >
+            <option value="all">All countries</option>
+            {availableCountries.map((c) => (
               <option key={c} value={c}>{c}</option>
             ))}
           </select>

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -6,6 +6,16 @@ import { PayoutStatusPill } from './PayoutStatusPill';
 import { PayoutMethodIcon } from './PayoutMethodIcon';
 import { formatPayoutAmount } from './formatPayoutAmount';
 
+/**
+ * bruschetta-58291: strip the "Global Pizza Party " prefix from event names so
+ * the city stays visible on the /payments admin queue without burning column
+ * width. Same helper as PrepayQueueTable — inlined here for now (the helper is
+ * defined locally in both places).
+ */
+function stripGppPrefix(name: string): string {
+  return name.replace(/^Global Pizza Party\s+/i, '');
+}
+
 interface PayoutRowProps {
   /**
    * A Payout (host view) or AdminPayout (admin view, with embedded host +
@@ -118,8 +128,15 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
             className="text-theme-text hover:text-[#E52828] hover:underline"
             onClick={(e) => e.stopPropagation()}
           >
-            {admin.party.name}
+            {/* bruschetta-58291: strip "Global Pizza Party " so the city is
+                visible. Same convention as PrepayQueueTable. */}
+            {stripGppPrefix(admin.party.name)}
           </Link>
+          {/* bruschetta-58291: country subtitle so admins can scan by region
+              at a glance. Omitted when null to keep dense rows clean. */}
+          {admin.party.country && (
+            <div className="text-xs text-theme-text-muted">{admin.party.country}</div>
+          )}
           {/* arugula-38633 v2 follow-up: planning vs actuals at a glance. */}
           <div
             className="text-xs text-theme-text-muted"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3879,6 +3879,8 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.payoutMethod && filters.payoutMethod !== 'all') params.set('payoutMethod', filters.payoutMethod);
   if (filters.partyId) params.set('partyId', filters.partyId);
   if (filters.hostEmail) params.set('hostEmail', filters.hostEmail);
+  // bruschetta-58291: country filter — exact-match `parties.country`.
+  if (filters.country && filters.country !== 'all') params.set('country', filters.country);
   if (filters.currency && filters.currency !== 'all') params.set('currency', filters.currency);
   if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
   if (filters.dateTo) params.set('dateTo', filters.dateTo);

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -50,6 +50,8 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   status: 'all',
   payoutMethod: 'all',
   currency: 'all',
+  // bruschetta-58291: country filter default — 'all' means no filter.
+  country: 'all',
 };
 
 // lardo-58294: substring filter shared between the search input and the
@@ -219,6 +221,17 @@ export function PaymentsAdminPage() {
     const set = new Set<string>();
     for (const p of payouts) {
       if (p.originalCurrency) set.add(p.originalCurrency.toUpperCase());
+    }
+    return Array.from(set).sort();
+  }, [payouts]);
+
+  // bruschetta-58291: derive the country dropdown set from the currently-loaded
+  // payouts (mirrors `availableCurrencies` above). Backend exposes country via
+  // PAYOUT_PARTY_SELECT; null countries are skipped.
+  const availableCountries = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of payouts) {
+      if (p.party.country) set.add(p.party.country);
     }
     return Array.from(set).sort();
   }, [payouts]);
@@ -586,6 +599,7 @@ export function PaymentsAdminPage() {
           onChange={setFilters}
           onReset={() => setFilters(DEFAULT_FILTERS)}
           availableCurrencies={availableCurrencies}
+          availableCountries={availableCountries}
         />
 
         <BulkActionsBar

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1598,6 +1598,11 @@ export interface AdminPayout extends Payout {
     name: string;
     inviteCode: string;
     customUrl: string | null;
+    /**
+     * bruschetta-58291: surface country on the /payments admin queue.
+     * Free-form string from `parties.country` (e.g. 'USA', 'Spain').
+     */
+    country: string | null;
     /** Host's planning number (arugula-38633 v2 follow-up). */
     expectedGuests: number | null;
     /**
@@ -1629,6 +1634,8 @@ export interface AdminPayoutFilters {
   payoutMethod?: PayoutMethod | 'all';
   partyId?: string;
   hostEmail?: string;
+  /** bruschetta-58291: country filter — exact-match `parties.country`. `'all'` / undefined = no filter. */
+  country?: string;
   currency?: string;
   dateFrom?: string;
   dateTo?: string;


### PR DESCRIPTION
## Summary

- **Strip "Global Pizza Party " prefix** from event names displayed in `PayoutsTable` rows (precedent: `PrepayQueueTable.tsx` already does this exact replace).
- **Surface country** under each event name as a small muted subtitle.
- **Add Country dropdown** to `PayoutsFilterBar`, populated from the currently-loaded payouts (parallels the existing `availableCurrencies` pattern in `PaymentsAdminPage.tsx`).
- **Backend** exposes country via `PAYOUT_PARTY_SELECT` and accepts a `country` query param on `GET /api/admin/payouts`, merged with the existing `underbossStatus: 'approved'` party filter from `tartufo-58291` (does not overwrite it).

## Files changed

- `backend/src/routes/admin-payout.routes.ts` — add `country` to `PAYOUT_PARTY_SELECT`, surface it in `serializePayout`, accept `country` query param in `buildPayoutWhere` merged into the existing `where.party` block.
- `frontend/src/types.ts` — add `country: string | null` to `AdminPayout.party`, add `country?: string` to `AdminPayoutFilters`.
- `frontend/src/lib/api.ts` — propagate `country` in `buildPayoutQuery`.
- `frontend/src/components/payments-shared/PayoutRow.tsx` — local `stripGppPrefix` helper + render country subtitle.
- `frontend/src/components/payments-admin/PayoutsFilterBar.tsx` — new `availableCountries` prop, Country dropdown after Currency, grid bumped `md:grid-cols-5` → `md:grid-cols-6`.
- `frontend/src/pages/PaymentsAdminPage.tsx` — derive `availableCountries` via `useMemo` from loaded payouts, pass to FilterBar, include `country: 'all'` in `DEFAULT_FILTERS`.

## Preview caveat

Preview frontends talk to the **production backend**. The `country` query param + `party.country` on the response won't be visible on the preview until backend is redeployed from `master` post-merge. Frontend prefix-strip + UI render work immediately on preview (the country subtitle will only appear once the backend ships).

## Test plan

- [ ] Vercel preview builds green.
- [ ] On preview /payments, event names no longer show "Global Pizza Party " prefix.
- [ ] After backend redeploy from master: country subtitle appears under event names, Country dropdown populates with distinct countries from loaded set, picking a country narrows the queue.
- [ ] Country dropdown plays nicely with existing filters (status/method/currency/date) — no overwrite of `underbossStatus='approved'` server-side gate.

Generated with Claude Code