### PR TITLE
feat(prosciutto-78201): Party Guide stream card, music reorder, collapsible sections, sign-box rename

### DIFF
--- a/frontend/src/components/day-of/ChecklistTodayCard.tsx
+++ b/frontend/src/components/day-of/ChecklistTodayCard.tsx
@@ -21,7 +21,7 @@ const DAY_OF_ITEM_NAMES = new Set([
   'Greet first guests',
   'Take group photo',
   'Pay venue final invoice',
-  'Get the pizza box signed',
+  'Sign a pizza box together',
   'Stack the pizza boxes',
   'Join the PizzaDAO Zoom (static camera)',
   'Join the PizzaDAO StreamYard (phone)',

--- a/frontend/src/components/day-of/CollapsibleCard.tsx
+++ b/frontend/src/components/day-of/CollapsibleCard.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+interface CollapsibleCardProps {
+  /** Unique key for localStorage, e.g. 'pizza', 'music'. */
+  id: string;
+  /** Party ID — collapse state is persisted per party. */
+  partyId: string;
+  /** Card title shown in the collapsed strip. */
+  title: string;
+  /** Default to expanded if no persisted state exists. */
+  defaultOpen?: boolean;
+  /** The original card (with its own `card` shell). */
+  children: React.ReactNode;
+}
+
+/**
+ * prosciutto-78201: Lightweight wrapper that makes a Day-of dashboard card
+ * collapsible. The wrapper is purely additive — the existing card retains
+ * its own visual shell when expanded; the chevron sits absolutely in the
+ * top-right corner so we don't double up the `card` outline.
+ *
+ * When collapsed, we replace the card entirely with a thin strip showing
+ * just the title and chevron so the host can re-open it.
+ *
+ * Persistence key: `dayof.collapsed.{id}.{partyId}` in localStorage.
+ *   '1' = collapsed, '0' or missing = open.
+ */
+export const CollapsibleCard: React.FC<CollapsibleCardProps> = ({
+  id,
+  partyId,
+  title,
+  defaultOpen = true,
+  children,
+}) => {
+  const storageKey = `dayof.collapsed.${id}.${partyId}`;
+
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    // Initialise from localStorage so we don't flash the open state before
+    // hydrating. SSR-safe: window check.
+    if (typeof window === 'undefined') return !defaultOpen;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (raw === '1') return true;
+      if (raw === '0') return false;
+    } catch {
+      /* ignore */
+    }
+    return !defaultOpen;
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, collapsed ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }, [collapsed, storageKey]);
+
+  const toggle = () => setCollapsed((c) => !c);
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={false}
+        aria-label={`Expand ${title}`}
+        className="card w-full flex items-center justify-between px-5 py-3 text-left hover:bg-white/5 transition-colors"
+      >
+        <span className="text-sm font-medium text-theme-text-secondary">{title}</span>
+        <ChevronDown size={16} className="text-theme-text-secondary" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={true}
+        aria-label={`Collapse ${title}`}
+        className="absolute top-3 right-3 z-10 inline-flex items-center justify-center rounded p-1 text-theme-text-secondary hover:text-theme-text hover:bg-white/10 transition-colors"
+      >
+        <ChevronUp size={16} />
+      </button>
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -17,6 +17,8 @@ import { SignedPizzaBoxCard } from './SignedPizzaBoxCard';
 import { PizzaBoxStackCard } from './PizzaBoxStackCard';
 import { BroadcastJoinCard } from './BroadcastJoinCard';
 import { StandWithCryptoCard } from './StandWithCryptoCard';
+import { StreamOnScreenCard } from './StreamOnScreenCard';
+import { CollapsibleCard } from './CollapsibleCard';
 
 interface DayOfDashboardProps {
   party: Party;
@@ -66,38 +68,111 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
   // genoa-44102: Two-column layout on desktop — important day-of actions on
   // the left, supporting/reference info on the right. Mobile stays single-
   // column stacked with the same left-then-right priority order.
+  //
+  // prosciutto-78201: MusicNowPlayingCard moved from the right column into
+  // the left column directly under PizzaStatusCard; new StreamOnScreenCard
+  // takes the top spot in the right column.
   const leftColumn = (
     <>
-      <PizzaStatusCard party={party} guests={guests} />
-      {isGpp && <BroadcastJoinCard partyId={party.id} layout={layout} />}
-      <CheckInPanel party={party} guests={guests} onGuestUpdated={refreshGuests} />
-      <AnnouncePanel
-        partyId={party.id}
-        onSent={() => setAnnHistoryKey((k) => k + 1)}
-      />
+      <CollapsibleCard id="pizza" partyId={party.id} title="Order the pizza">
+        <PizzaStatusCard party={party} guests={guests} />
+      </CollapsibleCard>
+      <CollapsibleCard id="music" partyId={party.id} title="Music">
+        <MusicNowPlayingCard
+          partyId={party.id}
+          inviteCode={party.inviteCode}
+          hideOpenTabLink={isMobile}
+        />
+      </CollapsibleCard>
+      {isGpp && (
+        <CollapsibleCard
+          id="broadcast"
+          partyId={party.id}
+          title="Join the global PizzaDAO broadcast"
+        >
+          <BroadcastJoinCard partyId={party.id} layout={layout} />
+        </CollapsibleCard>
+      )}
+      <CollapsibleCard id="check-in" partyId={party.id} title="Check-in">
+        <CheckInPanel party={party} guests={guests} onGuestUpdated={refreshGuests} />
+      </CollapsibleCard>
+      <CollapsibleCard id="announce" partyId={party.id} title="Announce">
+        <AnnouncePanel
+          partyId={party.id}
+          onSent={() => setAnnHistoryKey((k) => k + 1)}
+        />
+      </CollapsibleCard>
       {/* StandWithCryptoCard self-gates on party.eventTags containing 'swc' */}
-      <StandWithCryptoCard party={party} />
+      <CollapsibleCard id="swc" partyId={party.id} title="Stand With Crypto">
+        <StandWithCryptoCard party={party} />
+      </CollapsibleCard>
     </>
   );
 
   const rightColumn = (
     <>
-      <MusicNowPlayingCard
+      <CollapsibleCard
+        id="stream-on-screen"
         partyId={party.id}
-        inviteCode={party.inviteCode}
-        hideOpenTabLink={isMobile}
-      />
-      {isGpp && !briefingFirst && <BriefingCard party={party} />}
-      <ChecklistTodayCard
+        title="Put the stream on screen"
+      >
+        <StreamOnScreenCard />
+      </CollapsibleCard>
+      {isGpp && !briefingFirst && (
+        <CollapsibleCard
+          id="briefing"
+          partyId={party.id}
+          title="PizzaDAO mic-announcement"
+        >
+          <BriefingCard party={party} />
+        </CollapsibleCard>
+      )}
+      <CollapsibleCard
+        id="checklist"
         partyId={party.id}
-        inviteCode={party.inviteCode}
-        hideOpenTabLink={isMobile}
-      />
-      <PhotoQuickCaptureCard party={party} />
-      {isGpp && <SignedPizzaBoxCard party={party} />}
-      {isGpp && <PizzaBoxStackCard party={party} />}
-      <AnnouncementHistory partyId={party.id} refreshKey={annHistoryKey} />
-      <LogisticsCard party={party} />
+        title="Today's checklist"
+      >
+        <ChecklistTodayCard
+          partyId={party.id}
+          inviteCode={party.inviteCode}
+          hideOpenTabLink={isMobile}
+        />
+      </CollapsibleCard>
+      <CollapsibleCard
+        id="photo-quick-capture"
+        partyId={party.id}
+        title="Quick photo"
+      >
+        <PhotoQuickCaptureCard party={party} />
+      </CollapsibleCard>
+      {isGpp && (
+        <CollapsibleCard
+          id="signed-box"
+          partyId={party.id}
+          title="Sign a pizza box together"
+        >
+          <SignedPizzaBoxCard party={party} />
+        </CollapsibleCard>
+      )}
+      {isGpp && (
+        <CollapsibleCard
+          id="box-tower"
+          partyId={party.id}
+          title="Stack the pizza boxes"
+        >
+          <PizzaBoxStackCard party={party} />
+        </CollapsibleCard>
+      )}
+      <CollapsibleCard
+        id="announcement-history"
+        partyId={party.id}
+        title="Sent today"
+      >
+        <AnnouncementHistory partyId={party.id} refreshKey={annHistoryKey} />
+      </CollapsibleCard>
+      <CollapsibleCard id="logistics" partyId={party.id} title="Logistics">
+        <LogisticsCard party={party} />
+      </CollapsibleCard>
     </>
   );
 

--- a/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
+++ b/frontend/src/components/day-of/SignedPizzaBoxCard.tsx
@@ -91,7 +91,7 @@ export const SignedPizzaBoxCard: React.FC<SignedPizzaBoxCardProps> = ({ party, o
         <div className="flex items-center gap-2">
           <PenLine size={18} className="text-[#ff393a]" />
           <h3 className="text-lg font-semibold text-theme-text">
-            Get the pizza box signed
+            Sign a pizza box together
           </h3>
         </div>
         {hasSignedBox && (

--- a/frontend/src/components/day-of/StreamOnScreenCard.tsx
+++ b/frontend/src/components/day-of/StreamOnScreenCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Tv } from 'lucide-react';
+
+/**
+ * prosciutto-78201: Day-of prompt for hosts to put the global PizzaDAO
+ * livestream on a TV or projector at their venue. Universal (not GPP-gated)
+ * — even non-GPP events may want to display the broader PizzaDAO stream
+ * for the vibes; if a host has no screen they'll just ignore the card.
+ *
+ * Placeholder state: the real stream URL is TBD. Until it lands, render
+ * the same "Coming soon" disabled styling as BroadcastJoinCard so hosts
+ * recognise the pattern. Snax will swap in the URL later.
+ */
+export const StreamOnScreenCard: React.FC = () => {
+  return (
+    <div className="card p-5 space-y-3">
+      <div className="flex items-center gap-2">
+        <Tv size={18} className="text-[#ff393a]" />
+        <h3 className="text-lg font-semibold text-theme-text">
+          Put the stream on screen
+        </h3>
+      </div>
+
+      <p className="text-sm text-theme-text-secondary">
+        If you have a TV or projector at the venue, put the global PizzaDAO
+        stream up on it so guests can feel the worldwide party.
+      </p>
+
+      <div
+        aria-disabled="true"
+        className="relative w-full rounded-xl py-4 px-4 text-center bg-[#ff393a]/40 opacity-60 cursor-not-allowed text-white"
+      >
+        <span className="flex items-center justify-center gap-2 font-semibold text-base">
+          <Tv size={18} />
+          Open the stream
+        </span>
+        <span className="block text-xs font-normal text-white/70 mt-1.5 leading-snug">
+          A single shareable link to the GPP livestream — open it on the
+          venue's screen.
+        </span>
+        <span className="absolute top-1.5 right-2 text-[10px] uppercase tracking-wider text-white/60 bg-black/40 rounded px-1.5 py-0.5">
+          link coming
+        </span>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- New `StreamOnScreenCard` at the top of the right column ("link coming" placeholder)
- `MusicNowPlayingCard` moves from right column to left column, immediately under `PizzaStatusCard`
- All dashboard cards are now collapsible (chevron toggle, persisted per-card per-party in localStorage)
- Rename "Get the pizza box signed" -> "Sign a pizza box together" (card title + checklist allowlist)

## Test plan
- [ ] StreamOnScreenCard appears at top of right column with "link coming" label
- [ ] MusicNowPlayingCard is in left column under PizzaStatusCard (both desktop and mobile)
- [ ] Each card has a chevron - toggle collapses/expands and persists in localStorage
- [ ] Reload preserves collapse state per card per party
- [ ] "Sign a pizza box together" appears in card title + dropdown

Generated with Claude Code