### PR TITLE
fix(napoletana-83920): exclude INVITED from host page query

### DIFF
--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1363,6 +1363,7 @@ export async function getPartyWithGuests(inviteCode: string): Promise<{ party: D
     .from('guests')
     .select('*')
     .eq('party_id', party.id)
+    .neq('status', 'INVITED')
     .order('submitted_at', { ascending: true });
 
   const [, { data: guests, error: guestsError }] = await Promise.all([enrichPromise, guestsPromise]);
@@ -1772,6 +1773,7 @@ export async function getGuestsByPartyId(partyId: string): Promise<DbGuest[]> {
     .from('guests')
     .select('*')
     .eq('party_id', partyId)
+    .neq('status', 'INVITED')
     .order('submitted_at', { ascending: true });
 
   if (error) {

--- a/plans/napoletana-83920-guest-cap.md
+++ b/plans/napoletana-83920-guest-cap.md
@@ -1,0 +1,21 @@
+# napoletana-83920 — Drop INVITED guests from host page query
+
+## Problem
+`frontend/src/lib/supabase.ts` `getPartyWithGuests` and `getGuestsByPartyId` do `.select('*').order('submitted_at', ascending: true)` with no explicit limit. PostgREST silently caps the response at 1000 rows (returned as HTTP 206 with `Content-Range: 0-999/<total>`). Events with >1000 guests (Guayaquil 1106, San Diego 1288, SF 1168) lose the newest rows. As of 2026-05-21, 37 PENDING RSVPs are invisible to hosts.
+
+## Fix
+Add `.neq('status', 'INVITED')` to both queries. Max non-INVITED across all events is 921 — well under the 1000 cap. The bulk INVITED-via-blast rows are noise on the host page; they only appear in the GuestList `invitedGuests` section which gates on length>0.
+
+## Files
+`frontend/src/lib/supabase.ts`
+- `getPartyWithGuests` (~L1295): add `.neq('status', 'INVITED')`
+- `getGuestsByPartyId` (~L1770): same
+
+## Out of scope
+- No `.range()` pagination defense (separate task if needed)
+- No GuestList UI changes
+- No backend changes
+
+## Verification
+- `/host/guayaquil` shows "Pending Approval: 13" and 13 Approve buttons
+- `/host/sandiego` shows 24 pending


### PR DESCRIPTION
## Problem
Guayaquil host reported (2026-05-21) that new RSVPs since May 10 don't appear in the Guests tab. Confirmed via SQL: 13 PENDING with `submitted_via IN ('link','rsvp')`, `approved IS NULL` exist but are invisible.

Root cause: PostgREST silently caps `.select()` at 1000 rows (returns 206 + `Content-Range: 0-999/1106`). Guayaquil has 1106 guests, 1061 from a bulk Telegram-invite blast. Sort ASC means the newest direct RSVPs (rows 1001-1013) get truncated.

Affects:
- Guayaquil: 13 invisible PENDING
- San Diego: 24 invisible PENDING
- SF: 0 PENDING but same vulnerability

## Fix
`.neq('status','INVITED')` on both `getPartyWithGuests` and `getGuestsByPartyId`. Max non-INVITED count across all events is 921 (verified in DB) — well under the 1000 cap.

## Verification (preview URL)
- `https://rsvpizza-git-napoletana-83920-guest-cap-pizza-dao.vercel.app/host/guayaquil` -> "Pending Approval: 13" tile, 13 names with Approve buttons
- `https://rsvpizza-git-napoletana-83920-guest-cap-pizza-dao.vercel.app/host/sandiego` -> 24 pending visible

## Out of scope
- `.range()` pagination defense if non-INVITED ever crosses 1000 — separate task
- No GuestList UI changes (invitedGuests section already gates on length>0)