### PR TITLE
feat(bianca-58241): markdown-link parsing in AnnouncePanel email body

### DIFF
--- a/backend/src/lib/markdownLinks.test.ts
+++ b/backend/src/lib/markdownLinks.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidLinkUrl,
+  tokenizeMarkdownLinks,
+  renderAnnouncementBodyHtml,
+} from './markdownLinks.js';
+
+describe('isValidLinkUrl', () => {
+  it('accepts http, https, mailto', () => {
+    expect(isValidLinkUrl('https://rsv.pizza')).toBe(true);
+    expect(isValidLinkUrl('http://rsv.pizza')).toBe(true);
+    expect(isValidLinkUrl('mailto:hi@rsv.pizza')).toBe(true);
+  });
+  it('rejects javascript and other schemes', () => {
+    expect(isValidLinkUrl('javascript:alert(1)')).toBe(false);
+    expect(isValidLinkUrl('data:text/html,<script>')).toBe(false);
+    expect(isValidLinkUrl('ftp://example.com')).toBe(false);
+  });
+});
+
+describe('tokenizeMarkdownLinks', () => {
+  it('handles empty string', () => {
+    expect(tokenizeMarkdownLinks('')).toEqual([]);
+  });
+  it('handles plain text only', () => {
+    expect(tokenizeMarkdownLinks('hello')).toEqual([{ kind: 'text', text: 'hello' }]);
+  });
+  it('parses valid link', () => {
+    expect(tokenizeMarkdownLinks('a [b](https://x.com) c')).toEqual([
+      { kind: 'text', text: 'a ' },
+      { kind: 'link', label: 'b', url: 'https://x.com' },
+      { kind: 'text', text: ' c' },
+    ]);
+  });
+  it('treats invalid-scheme as literal text (regex stops at first `)`)', () => {
+    // After concatenation the user-visible text is the original full literal.
+    expect(tokenizeMarkdownLinks('[evil](javascript:alert(1))')).toEqual([
+      { kind: 'text', text: '[evil](javascript:alert(1)' },
+      { kind: 'text', text: ')' },
+    ]);
+  });
+});
+
+describe('renderAnnouncementBodyHtml', () => {
+  it('renders a plain message with newline as <br />', () => {
+    expect(renderAnnouncementBodyHtml('hi\nthere')).toBe('hi<br />there');
+  });
+
+  it('HTML-escapes text segments', () => {
+    expect(renderAnnouncementBodyHtml('<script>&"')).toBe('&lt;script&gt;&amp;"');
+  });
+
+  it('renders a valid link as anchor with style + target attrs', () => {
+    const out = renderAnnouncementBodyHtml('Visit [our site](https://rsv.pizza/x)');
+    expect(out).toBe(
+      'Visit <a href="https://rsv.pizza/x" style="color: #ff393a; text-decoration: underline;" target="_blank" rel="noopener noreferrer">our site</a>'
+    );
+  });
+
+  it('renders mailto link', () => {
+    const out = renderAnnouncementBodyHtml('Email [me](mailto:hi@rsv.pizza)');
+    expect(out).toContain('href="mailto:hi@rsv.pizza"');
+    expect(out).toContain('>me</a>');
+  });
+
+  it('renders invalid-scheme link as literal escaped text', () => {
+    const out = renderAnnouncementBodyHtml('[evil](javascript:alert(1))');
+    expect(out).toBe('[evil](javascript:alert(1))');
+    expect(out).not.toContain('<a ');
+  });
+
+  it('handles the spec scenario: mixed valid + invalid + newline', () => {
+    const out = renderAnnouncementBodyHtml(
+      'Join us — [RSVP here](https://rsv.pizza/test) tonight!\n[evil](javascript:alert(1))'
+    );
+    expect(out).toContain(
+      '<a href="https://rsv.pizza/test" style="color: #ff393a; text-decoration: underline;" target="_blank" rel="noopener noreferrer">RSVP here</a>'
+    );
+    expect(out).toContain('<br />');
+    expect(out).toContain('[evil](javascript:alert(1))');
+    expect(out).not.toContain('href="javascript:');
+  });
+
+  it('escapes quotes in URL attribute', () => {
+    const out = renderAnnouncementBodyHtml('[x](https://x.com/?a="b)');
+    expect(out).toContain('&quot;');
+    expect(out).not.toMatch(/href="https:\/\/x\.com\/\?a="b"/);
+  });
+
+  it('escapes < in label', () => {
+    const out = renderAnnouncementBodyHtml('[<b>bold</b>](https://x.com)');
+    expect(out).toContain('&lt;b&gt;bold&lt;/b&gt;');
+  });
+});

--- a/backend/src/lib/markdownLinks.ts
+++ b/backend/src/lib/markdownLinks.ts
@@ -1,0 +1,74 @@
+type Token =
+  | { kind: 'text'; text: string }
+  | { kind: 'link'; label: string; url: string };
+
+const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+const VALID_SCHEME = /^(https?:|mailto:)/i;
+
+export function isValidLinkUrl(url: string): boolean {
+  return VALID_SCHEME.test(url.trim());
+}
+
+export function tokenizeMarkdownLinks(body: string): Token[] {
+  const tokens: Token[] = [];
+  if (!body) return tokens;
+
+  let lastIndex = 0;
+  LINK_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = LINK_RE.exec(body)) !== null) {
+    const [full, label, url] = match;
+    const start = match.index;
+
+    if (start > lastIndex) {
+      tokens.push({ kind: 'text', text: body.slice(lastIndex, start) });
+    }
+
+    if (isValidLinkUrl(url)) {
+      tokens.push({ kind: 'link', label, url: url.trim() });
+    } else {
+      tokens.push({ kind: 'text', text: full });
+    }
+
+    lastIndex = start + full.length;
+  }
+
+  if (lastIndex < body.length) {
+    tokens.push({ kind: 'text', text: body.slice(lastIndex) });
+  }
+
+  return tokens;
+}
+
+function escapeHtmlText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Render an announcement body to HTML.
+ *
+ * - Text segments: HTML-escape, then convert newlines to `<br />`.
+ * - Link segments (`[label](url)`): valid `http(s):`/`mailto:` schemes
+ *   become anchors; anything else is rendered as the literal source.
+ */
+export function renderAnnouncementBodyHtml(body: string): string {
+  const tokens = tokenizeMarkdownLinks(body);
+  return tokens
+    .map((t) => {
+      if (t.kind === 'text') {
+        return escapeHtmlText(t.text).replace(/\n/g, '<br />');
+      }
+      return `<a href="${escapeHtmlAttr(t.url)}" style="color: #ff393a; text-decoration: underline;" target="_blank" rel="noopener noreferrer">${escapeHtmlText(t.label)}</a>`;
+    })
+    .join('');
+}

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -7,6 +7,7 @@ import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
+import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -1297,12 +1298,10 @@ router.post('/:partyId/announce', async (req: AuthRequest, res: Response, next: 
           ? `${baseUrl}/${party.customUrl}`
           : `${baseUrl}/${party.inviteCode}`;
 
-        // Build HTML once (per-recipient personalization only swaps the greeting)
-        const escapedBody = body
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/\n/g, '<br />');
+        // Build HTML once (per-recipient personalization only swaps the greeting).
+        // Body supports `[label](url)` markdown links (http/https/mailto only);
+        // invalid schemes (e.g. javascript:) render as literal text.
+        const escapedBody = renderAnnouncementBodyHtml(body);
 
         for (const recipient of recipients) {
           if (!recipient.email) continue;

--- a/frontend/src/components/day-of/AnnouncePanel.tsx
+++ b/frontend/src/components/day-of/AnnouncePanel.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Send, Megaphone, Loader2, MessageCircle, Mail } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { sendDayOfAnnouncement, AnnounceResponse } from '../../lib/api';
+import { tokenizeMarkdownLinks } from '../../lib/markdownLinks';
 
 interface AnnouncePanelProps {
   partyId: string;
@@ -27,6 +28,8 @@ export const AnnouncePanel: React.FC<AnnouncePanelProps> = ({ partyId, onSent })
     body.trim().length > 0 &&
     (telegramOn || emailOn) &&
     (!emailOn || subject.trim().length > 0);
+
+  const previewTokens = useMemo(() => tokenizeMarkdownLinks(body), [body]);
 
   const handleSend = async () => {
     if (!canSend || sending) return;
@@ -94,12 +97,29 @@ export const AnnouncePanel: React.FC<AnnouncePanelProps> = ({ partyId, onSent })
         value={body}
         onChange={(e) => setBody((e.target as HTMLTextAreaElement).value)}
       />
+      <p className="text-xs text-white/40">
+        Tip: embed a link with [label](https://url) — applies to email only.
+      </p>
 
       {body && (
         <div className="text-xs text-theme-text-muted bg-white/5 rounded p-3 whitespace-pre-line border border-white/10">
           <p className="uppercase tracking-wide mb-1 text-[10px]">Preview</p>
           {subject && <p className="font-semibold text-theme-text mb-1">{subject}</p>}
-          {body}
+          {previewTokens.map((tok, i) =>
+            tok.kind === 'link' ? (
+              <a
+                key={i}
+                href={tok.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: '#ff393a', textDecoration: 'underline' }}
+              >
+                {tok.label}
+              </a>
+            ) : (
+              <span key={i}>{tok.text}</span>
+            )
+          )}
         </div>
       )}
 

--- a/frontend/src/lib/markdownLinks.test.ts
+++ b/frontend/src/lib/markdownLinks.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { tokenizeMarkdownLinks, isValidLinkUrl } from './markdownLinks';
+
+describe('isValidLinkUrl', () => {
+  it('accepts https/http/mailto', () => {
+    expect(isValidLinkUrl('https://rsv.pizza')).toBe(true);
+    expect(isValidLinkUrl('http://rsv.pizza')).toBe(true);
+    expect(isValidLinkUrl('mailto:hi@rsv.pizza')).toBe(true);
+    expect(isValidLinkUrl('HTTPS://RSV.PIZZA')).toBe(true);
+  });
+
+  it('rejects javascript: and other schemes', () => {
+    expect(isValidLinkUrl('javascript:alert(1)')).toBe(false);
+    expect(isValidLinkUrl('data:text/html,<script>')).toBe(false);
+    expect(isValidLinkUrl('ftp://example.com')).toBe(false);
+    expect(isValidLinkUrl('/relative/path')).toBe(false);
+  });
+});
+
+describe('tokenizeMarkdownLinks', () => {
+  it('returns empty array for empty string', () => {
+    expect(tokenizeMarkdownLinks('')).toEqual([]);
+  });
+
+  it('returns a single text token when no links present', () => {
+    expect(tokenizeMarkdownLinks('Just a plain message')).toEqual([
+      { kind: 'text', text: 'Just a plain message' },
+    ]);
+  });
+
+  it('parses a single link', () => {
+    expect(tokenizeMarkdownLinks('Visit [our site](https://rsv.pizza)')).toEqual([
+      { kind: 'text', text: 'Visit ' },
+      { kind: 'link', label: 'our site', url: 'https://rsv.pizza' },
+    ]);
+  });
+
+  it('parses multiple links with text in between', () => {
+    const out = tokenizeMarkdownLinks(
+      'Join us — [RSVP here](https://rsv.pizza/test) tonight!'
+    );
+    expect(out).toEqual([
+      { kind: 'text', text: 'Join us — ' },
+      { kind: 'link', label: 'RSVP here', url: 'https://rsv.pizza/test' },
+      { kind: 'text', text: ' tonight!' },
+    ]);
+  });
+
+  it('treats invalid-scheme links as literal text', () => {
+    // Regex stops at first `)`, so the trailing `)` is its own text token —
+    // when concatenated for output the user still sees `[evil](javascript:alert(1))`.
+    const out = tokenizeMarkdownLinks('[evil](javascript:alert(1))');
+    expect(out).toEqual([
+      { kind: 'text', text: '[evil](javascript:alert(1)' },
+      { kind: 'text', text: ')' },
+    ]);
+  });
+
+  it('handles a mix of valid and invalid links', () => {
+    const out = tokenizeMarkdownLinks(
+      'Hi [there](https://rsv.pizza) and [evil](javascript:alert(1))'
+    );
+    expect(out).toEqual([
+      { kind: 'text', text: 'Hi ' },
+      { kind: 'link', label: 'there', url: 'https://rsv.pizza' },
+      { kind: 'text', text: ' and ' },
+      { kind: 'text', text: '[evil](javascript:alert(1)' },
+      { kind: 'text', text: ')' },
+    ]);
+  });
+
+  it('preserves newlines inside text segments', () => {
+    const out = tokenizeMarkdownLinks('line1\n[a](https://x.com)\nline3');
+    expect(out).toEqual([
+      { kind: 'text', text: 'line1\n' },
+      { kind: 'link', label: 'a', url: 'https://x.com' },
+      { kind: 'text', text: '\nline3' },
+    ]);
+  });
+
+  it('supports mailto links', () => {
+    const out = tokenizeMarkdownLinks('Email [me](mailto:hi@rsv.pizza)');
+    expect(out).toEqual([
+      { kind: 'text', text: 'Email ' },
+      { kind: 'link', label: 'me', url: 'mailto:hi@rsv.pizza' },
+    ]);
+  });
+});

--- a/frontend/src/lib/markdownLinks.ts
+++ b/frontend/src/lib/markdownLinks.ts
@@ -1,0 +1,42 @@
+export type Token =
+  | { kind: 'text'; text: string }
+  | { kind: 'link'; label: string; url: string };
+
+const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+const VALID_SCHEME = /^(https?:|mailto:)/i;
+
+export function isValidLinkUrl(url: string): boolean {
+  return VALID_SCHEME.test(url.trim());
+}
+
+export function tokenizeMarkdownLinks(body: string): Token[] {
+  const tokens: Token[] = [];
+  if (!body) return tokens;
+
+  let lastIndex = 0;
+  LINK_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = LINK_RE.exec(body)) !== null) {
+    const [full, label, url] = match;
+    const start = match.index;
+
+    if (start > lastIndex) {
+      tokens.push({ kind: 'text', text: body.slice(lastIndex, start) });
+    }
+
+    if (isValidLinkUrl(url)) {
+      tokens.push({ kind: 'link', label, url: url.trim() });
+    } else {
+      tokens.push({ kind: 'text', text: full });
+    }
+
+    lastIndex = start + full.length;
+  }
+
+  if (lastIndex < body.length) {
+    tokens.push({ kind: 'text', text: body.slice(lastIndex) });
+  }
+
+  return tokens;
+}


### PR DESCRIPTION
## Summary

Adds `[label](url)` markdown-link parsing to the day-of `AnnouncePanel` body. Email broadcasts render valid links as red underlined anchors; the in-UI Preview mirrors the same logic. Telegram remains plain text (parse_mode unchanged).

- **Only `http://`, `https://`, `mailto:`** schemes render as links. Anything else (notably `javascript:`) renders as literal escaped text.
- Anchor markup matches the existing email accent color (`#ff393a`), uses `target="_blank" rel="noopener noreferrer"`.
- Shared tokenizer extracted to `frontend/src/lib/markdownLinks.ts`; backend has a parallel `backend/src/lib/markdownLinks.ts` (backend can't import from frontend).
- Adds hint text under the body field: `Tip: embed a link with [label](https://url) — applies to email only.`

## Files changed (LOC)

- `backend/src/lib/markdownLinks.ts` (+72)
- `backend/src/lib/markdownLinks.test.ts` (+91)
- `backend/src/routes/party.routes.ts` (-5 / +4) — swap inline escape for `renderAnnouncementBodyHtml`, add import
- `frontend/src/lib/markdownLinks.ts` (+42)
- `frontend/src/lib/markdownLinks.test.ts` (+86)
- `frontend/src/components/day-of/AnnouncePanel.tsx` (+24 / -2) — `useMemo` over tokens, hint paragraph, Preview maps tokens to `<span>`/`<a>`

## Before vs after — Preview render

Body: `Join us — [RSVP here](https://rsv.pizza/test) tonight!\n[evil](javascript:alert(1))`

**Before:** literal text including the brackets.

**After (HTML output for email):**
```
Join us — <a href="https://rsv.pizza/test" style="color: #ff393a; text-decoration: underline;" target="_blank" rel="noopener noreferrer">RSVP here</a> tonight!<br />[evil](javascript:alert(1))
```

The `[evil](javascript:alert(1))` part renders as plain text because the URL scheme is rejected.

## Verification

- [x] `cd frontend && npm run build` passes
- [x] `cd backend && npx tsc --noEmit` — no errors from my changes (one pre-existing failure in `auth.test.ts` re: jwt typings, present on parent branch)
- [x] Frontend tokenizer unit tests: 10/10 pass (`markdownLinks.test.ts`)
- [x] Backend tokenizer + HTML renderer unit tests: 14/14 pass (`markdownLinks.test.ts`)
- [x] Manual trace through spec scenario via `npx tsx -e` confirms anchor markup + literal `[evil]…` + `<br />` for newline
- [x] Telegram branch unchanged (still sends `body` raw with `parse_mode: 'Markdown'`)

## Vercel preview

`https://rsvpizza-git-bianca-58241-announce-markdown-links-pizza-dao.vercel.app`

(May exceed the 63-char subdomain budget — branch name is 36 chars, pattern overhead is 24, so 60 total. Within limits.)

## Notes

- Targets `pepperoni-58341-day-of-app`, not master — the `AnnouncePanel` and `/announce` route only exist on that unmerged branch.
- Backend tokenizer is a duplicate of the frontend one (acknowledged trade-off — backend cannot import from `frontend/`). Diverging would silently desync Preview from delivered email.
- Regex `/\[([^\]]+)\]\(([^)]+)\)/g` per spec; this means `[x](javascript:alert(1))` is captured as URL `javascript:alert(1` with a trailing `)` text token. Concatenated output is still the user-expected literal. Tests document this behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)