### PR TITLE
feat(focaccia-58247): broadcast script for GPP Party Guide email

### DIFF
--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -526,7 +526,10 @@ async function runSend(recipients, opts) {
   const N = filtered.length;
   console.log(`Sending to ${N} recipient(s)...`);
 
-  const BATCH_SIZE = 10;
+  // Resend hard limit is 5 req/sec on our tier. Batch of 4 + 1100ms delay
+  // keeps us at ~3.6 req/sec with a safe margin. The bulk-invite pattern
+  // (10/500ms) breaches the limit and 429s most of the batch above ~50 sends.
+  const BATCH_SIZE = 4;
   let attempted = 0;
   for (let i = 0; i < filtered.length; i += BATCH_SIZE) {
     const batch = filtered.slice(i, i + BATCH_SIZE);
@@ -547,7 +550,7 @@ async function runSend(recipients, opts) {
       })
     );
     if (i + BATCH_SIZE < filtered.length) {
-      await new Promise((res) => setTimeout(res, 500));
+      await new Promise((res) => setTimeout(res, 1100));
     }
   }
 

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -144,9 +144,9 @@ function buildPartyGuideEmail(recipient) {
     <div style="background: #fff4e6; padding: 20px; border-radius: 12px; margin: 30px 0;">
       <h3 style="margin: 0 0 10px 0; color: #ff6b35; font-size: 16px;">Inside the guide:</h3>
       <ul style="margin: 0; padding-left: 20px; color: #444;">
-        <li>{bullet 1}</li>
-        <li>{bullet 2}</li>
-        <li>{bullet 3}</li>
+        <li>All the links and media you need</li>
+        <li>All the photos you should take</li>
+        <li>Reminders on everything you might forget!</li>
       </ul>
     </div>
 

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -1,0 +1,561 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/*
+ * One-off broadcast: send approved GPP 2026 hosts (and their non-partner co-hosts)
+ * a link to their Party Guide tab.
+ *
+ * Task: focaccia-58247
+ *
+ * USAGE:
+ *   node backend/scripts/send-gpp-guide-email.cjs --help
+ *   node backend/scripts/send-gpp-guide-email.cjs --dry-run
+ *   node backend/scripts/send-gpp-guide-email.cjs --send --confirm
+ *   node backend/scripts/send-gpp-guide-email.cjs --send --only=a@b.com,c@d.com
+ *   node backend/scripts/send-gpp-guide-email.cjs --send --confirm --skip-already-sent
+ *
+ * No new deps. Uses `pg` + `dotenv` (both already in backend/package.json).
+ * Does NOT import from ../src/ or @prisma/client.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+const HELP_TEXT = `
+send-gpp-guide-email.cjs — one-off GPP Party Guide broadcast
+
+USAGE:
+  node backend/scripts/send-gpp-guide-email.cjs --help
+  node backend/scripts/send-gpp-guide-email.cjs --dry-run
+  node backend/scripts/send-gpp-guide-email.cjs --send --confirm
+  node backend/scripts/send-gpp-guide-email.cjs --send --only=a@b.com,c@d.com
+  node backend/scripts/send-gpp-guide-email.cjs --send --confirm --skip-already-sent
+
+FLAGS:
+  --help                  Print this help and exit.
+  --dry-run               Query DB, write recipient CSV + sample HTML to OS temp dir.
+                          No network calls.
+  --send                  Actually POST to Resend. Requires --confirm OR --only.
+  --confirm               Required for a full --send (safety guard).
+  --only=a@b,c@d          Test-send to a specific comma-separated email allowlist.
+                          --confirm is not required when --only is present.
+  --skip-already-sent     Read the existing send log and exclude already-sent
+                          recipients before batching.
+
+ENV (loaded from backend/.env):
+  DATABASE_URL            Postgres connection string. Required.
+  RESEND_API_KEY          Resend API key. Required for --send.
+
+OUTPUT FILES (OS temp dir, ${os.tmpdir()}):
+  gpp-guide-recipients.csv
+  gpp-guide-sample.html
+  gpp-guide-send-log.json
+`.trim();
+
+function parseArgs(argv) {
+  const opts = {
+    help: false,
+    dryRun: false,
+    send: false,
+    confirm: false,
+    only: null, // null or array<string>
+    skipAlreadySent: false,
+  };
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') opts.help = true;
+    else if (arg === '--dry-run') opts.dryRun = true;
+    else if (arg === '--send') opts.send = true;
+    else if (arg === '--confirm') opts.confirm = true;
+    else if (arg === '--skip-already-sent') opts.skipAlreadySent = true;
+    else if (arg.startsWith('--only=')) {
+      const raw = arg.slice('--only='.length);
+      opts.only = raw
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      console.error('Run with --help to see usage.');
+      process.exit(2);
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Output paths (cross-platform via os.tmpdir)
+// ---------------------------------------------------------------------------
+
+const tmpDir = os.tmpdir();
+const CSV_PATH = path.join(tmpDir, 'gpp-guide-recipients.csv');
+const SAMPLE_PATH = path.join(tmpDir, 'gpp-guide-sample.html');
+const LOG_PATH = path.join(tmpDir, 'gpp-guide-send-log.json');
+
+// ---------------------------------------------------------------------------
+// Email template (hand-rolled, inline styles)
+// ---------------------------------------------------------------------------
+
+const SUBJECT = 'Your Global Pizza Party guide is ready 🍕';
+const FROM = 'RSV.Pizza <noreply@rsv.pizza>';
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildPartyGuideEmail(recipient) {
+  const firstName =
+    (recipient.name && String(recipient.name).split(/\s+/)[0]) || 'host';
+  const partyGuideUrl = `https://rsv.pizza/host/${recipient.invite_code}/party-guide`;
+  const eventName = recipient.event_name || 'your Global Pizza Party';
+
+  const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Global Pizza Party guide is ready</title>
+  </head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background: #ffffff;">
+    <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
+      <h1 style="color: #ffffff; font-size: 28px; margin: 0 0 10px 0;">Your Party Guide is ready 🍕</h1>
+      <p style="color: rgba(255,255,255,0.8); font-size: 16px; margin: 0;">${escapeHtml(eventName)}</p>
+    </div>
+
+    <p style="font-size: 16px; margin-bottom: 20px;">
+      Hi ${escapeHtml(firstName)},
+    </p>
+
+    <p style="font-size: 16px; margin-bottom: 20px;">
+      We've put together a Party Guide tab on your host dashboard to help you run a great Global Pizza Party 2026. Everything you need is now one click away.
+    </p>
+
+    <div style="background: #fff4e6; padding: 20px; border-radius: 12px; margin: 30px 0;">
+      <h3 style="margin: 0 0 10px 0; color: #ff6b35; font-size: 16px;">Inside the guide:</h3>
+      <ul style="margin: 0; padding-left: 20px; color: #444;">
+        <li>{bullet 1}</li>
+        <li>{bullet 2}</li>
+        <li>{bullet 3}</li>
+      </ul>
+    </div>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="${partyGuideUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-weight: 600; font-size: 16px;">
+        Open your Party Guide
+      </a>
+    </div>
+
+    <p style="font-size: 14px; color: #666; text-align: center; margin: 20px 0;">
+      Or paste this link into your browser:<br>
+      <a href="${partyGuideUrl}" style="color: #ff393a; word-break: break-all;">${partyGuideUrl}</a>
+    </p>
+
+    <div style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 30px; text-align: center; color: #666; font-size: 13px;">
+      <p>Questions? Reply to this email or reach out on <a href="https://t.me/pizzadao" style="color: #ff393a;">Telegram</a>.</p>
+      <p style="margin-top: 20px;">
+        Happy hosting!<br>
+        The PizzaDAO Team
+      </p>
+      <p style="margin-top: 24px; color: #999; font-size: 11px;">
+        Reply STOP to opt out of future broadcasts.
+      </p>
+    </div>
+  </body>
+</html>`;
+
+  return { subject: SUBJECT, html, partyGuideUrl };
+}
+
+// ---------------------------------------------------------------------------
+// DB query + flattening
+// ---------------------------------------------------------------------------
+
+const QUERY = `
+SELECT
+  p.id           AS party_id,
+  p.name         AS event_name,
+  p.invite_code,
+  p.custom_url,
+  p.city,
+  p.country,
+  p.date         AS event_date,
+  p.timezone,
+  p.co_hosts,
+  u.email        AS host_email,
+  u.name         AS host_name
+FROM parties p
+JOIN users u ON p.user_id = u.id
+WHERE p.event_type = 'gpp'
+  AND p.underboss_status = 'approved'
+ORDER BY p.date ASC NULLS LAST;
+`;
+
+async function queryRows() {
+  const { Client } = require('pg');
+  const client = new Client({
+    connectionString: process.env.DATABASE_URL,
+    // Supabase requires SSL in prod; allow self-signed since we don't ship a CA.
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+  try {
+    const result = await client.query(QUERY);
+    return result.rows;
+  } finally {
+    await client.end();
+  }
+}
+
+function flattenAndDedup(rows) {
+  const flat = [];
+  let partnerSkips = 0;
+  for (const row of rows) {
+    if (row.host_email && row.host_email.trim()) {
+      flat.push({
+        email: row.host_email.toLowerCase().trim(),
+        name: row.host_name,
+        role: 'host',
+        invite_code: row.invite_code,
+        event_name: row.event_name,
+        event_date: row.event_date,
+        country: row.country,
+      });
+    }
+    const coHosts = Array.isArray(row.co_hosts) ? row.co_hosts : [];
+    for (const ch of coHosts) {
+      if (ch && ch.isPartner === true) {
+        partnerSkips++;
+        continue;
+      }
+      if (!ch || !ch.email || !ch.email.trim()) continue;
+      flat.push({
+        email: ch.email.toLowerCase().trim(),
+        name: ch.name || row.host_name,
+        role: 'cohost',
+        invite_code: row.invite_code,
+        event_name: row.event_name,
+        event_date: row.event_date,
+        country: row.country,
+      });
+    }
+  }
+  const byEmail = new Map();
+  for (const r of flat) {
+    const existing = byEmail.get(r.email);
+    if (!existing) {
+      byEmail.set(r.email, r);
+      continue;
+    }
+    const promoteToHost = r.role === 'host' && existing.role !== 'host';
+    const earlier =
+      r.event_date &&
+      (!existing.event_date ||
+        new Date(r.event_date) < new Date(existing.event_date));
+    if (promoteToHost || earlier) byEmail.set(r.email, r);
+  }
+  const recipients = [...byEmail.values()];
+  return { flat, recipients, partnerSkips };
+}
+
+// ---------------------------------------------------------------------------
+// CSV helpers
+// ---------------------------------------------------------------------------
+
+function csvEscape(v) {
+  if (v == null) return '';
+  const s = String(v);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function buildCsv(recipients) {
+  const header = [
+    'email',
+    'name',
+    'role',
+    'event_name',
+    'invite_code',
+    'country',
+    'party_guide_url',
+  ].join(',');
+  const lines = [header];
+  for (const r of recipients) {
+    const url = `https://rsv.pizza/host/${r.invite_code}/party-guide`;
+    lines.push(
+      [r.email, r.name, r.role, r.event_name, r.invite_code, r.country, url]
+        .map(csvEscape)
+        .join(',')
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+function topByCountry(recipients, n = 10) {
+  const counts = new Map();
+  for (const r of recipients) {
+    const key = r.country || '(unknown)';
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n);
+}
+
+function countByRole(recipients) {
+  let host = 0;
+  let cohost = 0;
+  for (const r of recipients) {
+    if (r.role === 'host') host++;
+    else cohost++;
+  }
+  return { host, cohost };
+}
+
+// ---------------------------------------------------------------------------
+// Send mode
+// ---------------------------------------------------------------------------
+
+async function sendOne(recipient, resendApiKey) {
+  const { subject, html } = buildPartyGuideEmail(recipient);
+  const resp = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${resendApiKey}`,
+    },
+    body: JSON.stringify({
+      from: FROM,
+      to: [recipient.email],
+      subject,
+      html,
+      headers: {
+        'List-Unsubscribe':
+          '<mailto:unsubscribe@rsv.pizza?subject=unsubscribe>',
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
+    }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    const reason = `resend ${resp.status}${body ? ': ' + body.slice(0, 200) : ''}`;
+    throw new Error(reason);
+  }
+}
+
+async function runSend(recipients, opts) {
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (!resendApiKey) {
+    console.error('ERROR: RESEND_API_KEY is required for --send mode.');
+    console.error('Set it in backend/.env and re-run.');
+    process.exit(1);
+  }
+
+  // Skip-already-sent: read prior log
+  let alreadySent = new Set();
+  if (opts.skipAlreadySent) {
+    if (fs.existsSync(LOG_PATH)) {
+      try {
+        const prior = JSON.parse(fs.readFileSync(LOG_PATH, 'utf8'));
+        if (Array.isArray(prior.sent)) {
+          alreadySent = new Set(prior.sent.map((e) => String(e).toLowerCase()));
+        }
+        console.log(
+          `[skip-already-sent] loaded ${alreadySent.size} prior recipients from ${LOG_PATH}`
+        );
+      } catch (err) {
+        console.error(
+          `[skip-already-sent] failed to read prior log at ${LOG_PATH}: ${err.message}`
+        );
+        process.exit(1);
+      }
+    } else {
+      console.log(
+        `[skip-already-sent] no prior log at ${LOG_PATH}; sending to full list.`
+      );
+    }
+  }
+
+  const filtered = recipients.filter((r) => !alreadySent.has(r.email));
+  const skippedDueToLog = recipients.length - filtered.length;
+  if (skippedDueToLog > 0) {
+    console.log(`[skip-already-sent] excluding ${skippedDueToLog} recipients.`);
+  }
+
+  const startedAt = new Date().toISOString();
+  const results = {
+    startedAt,
+    finishedAt: null,
+    totalAttempted: filtered.length,
+    sentCount: 0,
+    failedCount: 0,
+    sent: [],
+    failed: [],
+  };
+
+  const N = filtered.length;
+  console.log(`Sending to ${N} recipient(s)...`);
+
+  const BATCH_SIZE = 10;
+  let attempted = 0;
+  for (let i = 0; i < filtered.length; i += BATCH_SIZE) {
+    const batch = filtered.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (r) => {
+        const idx = ++attempted;
+        try {
+          await sendOne(r, resendApiKey);
+          results.sent.push(r.email);
+          results.sentCount++;
+          console.log(`[${idx}/${N}] sent to ${r.email}`);
+        } catch (err) {
+          const reason = err && err.message ? err.message : String(err);
+          results.failed.push({ email: r.email, reason });
+          results.failedCount++;
+          console.log(`[${idx}/${N}] FAILED ${r.email}: ${reason}`);
+        }
+      })
+    );
+    if (i + BATCH_SIZE < filtered.length) {
+      await new Promise((res) => setTimeout(res, 500));
+    }
+  }
+
+  results.finishedAt = new Date().toISOString();
+
+  // Merge with prior log so --skip-already-sent stays useful across runs.
+  if (opts.skipAlreadySent && alreadySent.size > 0) {
+    const priorSent = [...alreadySent];
+    const merged = new Set([...priorSent, ...results.sent]);
+    results.sent = [...merged];
+  }
+
+  fs.writeFileSync(LOG_PATH, JSON.stringify(results, null, 2));
+  console.log('');
+  console.log(`Done. sent=${results.sentCount} failed=${results.failedCount}`);
+  console.log(`Log: ${LOG_PATH}`);
+}
+
+// ---------------------------------------------------------------------------
+// Dry run
+// ---------------------------------------------------------------------------
+
+function runDryRun(flat, recipients, partnerSkips) {
+  const roleCounts = countByRole(recipients);
+  const top = topByCountry(recipients, 10);
+
+  console.log('=== DRY RUN ===');
+  console.log(`raw flat count:       ${flat.length}`);
+  console.log(`deduped count:        ${recipients.length}`);
+  console.log(`partner co-host skip: ${partnerSkips}`);
+  console.log(`role counts:          host=${roleCounts.host} cohost=${roleCounts.cohost}`);
+  console.log('top countries:');
+  for (const [c, n] of top) {
+    console.log(`  ${c.padEnd(24)} ${n}`);
+  }
+
+  // CSV
+  fs.writeFileSync(CSV_PATH, buildCsv(recipients));
+
+  // Sample HTML — first 3 recipients
+  const samples = recipients.slice(0, 3);
+  const blocks = samples.map((r) => {
+    const { html } = buildPartyGuideEmail(r);
+    return `<!-- recipient: ${escapeHtml(r.email)} (${escapeHtml(r.role)}) -->\n${html}`;
+  });
+  const sampleHtml = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>GPP Guide Email — sample</title></head>
+<body>
+${blocks.join('\n<hr>\n')}
+</body>
+</html>`;
+  fs.writeFileSync(SAMPLE_PATH, sampleHtml);
+
+  console.log('');
+  console.log(`CSV:    ${CSV_PATH}`);
+  console.log(`Sample: ${SAMPLE_PATH}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (opts.help || (!opts.dryRun && !opts.send)) {
+    console.log(HELP_TEXT);
+    process.exit(opts.help ? 0 : 2);
+  }
+
+  if (opts.dryRun && opts.send) {
+    console.error('ERROR: --dry-run and --send are mutually exclusive.');
+    process.exit(2);
+  }
+
+  if (opts.send && !opts.confirm && !opts.only) {
+    console.error('ERROR: --send requires --confirm (or --only=<emails> for a test send).');
+    console.error('Run with --help for usage.');
+    process.exit(2);
+  }
+
+  if (!process.env.DATABASE_URL) {
+    console.error('ERROR: DATABASE_URL is required.');
+    console.error(`Looked for backend/.env at ${path.join(__dirname, '..', '.env')}`);
+    process.exit(1);
+  }
+
+  if (opts.send && !process.env.RESEND_API_KEY) {
+    console.error('ERROR: RESEND_API_KEY is required for --send mode.');
+    process.exit(1);
+  }
+
+  console.log('Querying production DB for approved GPP events...');
+  const rows = await queryRows();
+  console.log(`Got ${rows.length} approved GPP party row(s).`);
+
+  const { flat, recipients, partnerSkips } = flattenAndDedup(rows);
+
+  // --only filter (applies in send mode)
+  let finalRecipients = recipients;
+  if (opts.only && opts.only.length > 0) {
+    const allow = new Set(opts.only);
+    finalRecipients = recipients.filter((r) => allow.has(r.email));
+    console.log(
+      `[only] filtered to ${finalRecipients.length} recipient(s) from allowlist of ${opts.only.length}.`
+    );
+    const matched = new Set(finalRecipients.map((r) => r.email));
+    const missing = [...allow].filter((e) => !matched.has(e));
+    if (missing.length > 0) {
+      console.log(`[only] not in approved-GPP recipient set: ${missing.join(', ')}`);
+    }
+  }
+
+  if (opts.dryRun) {
+    runDryRun(flat, finalRecipients, partnerSkips);
+    return;
+  }
+
+  if (opts.send) {
+    await runSend(finalRecipients, opts);
+    return;
+  }
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -21,6 +21,10 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
+// Load .env.local first (real secrets live there per project convention),
+// then .env fills in any gaps. dotenv doesn't overwrite existing keys.
+const _envLocal = path.join(__dirname, '..', '.env.local');
+if (fs.existsSync(_envLocal)) require('dotenv').config({ path: _envLocal });
 require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 
 // ---------------------------------------------------------------------------
@@ -195,7 +199,7 @@ SELECT
   u.email        AS host_email,
   u.name         AS host_name
 FROM parties p
-JOIN users u ON p.user_id = u.id
+JOIN "User" u ON p.user_id = u.id
 WHERE p.event_type = 'gpp'
   AND p.underboss_status = 'approved'
 ORDER BY p.date ASC NULLS LAST;

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -689,7 +689,14 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error('FATAL:', err && err.stack ? err.stack : err);
-  process.exit(1);
-});
+// Expose helpers so one-off scripts can synthesize recipients (e.g., to
+// resend to an address that bypasses the DB-derived pool due to a typo'd
+// User.email that collides with a clean duplicate).
+module.exports = { buildPartyGuideEmail, formatEventDate, countdownText };
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('FATAL:', err && err.stack ? err.stack : err);
+    process.exit(1);
+  });
+}

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -105,7 +105,7 @@ const LOG_PATH = path.join(tmpDir, 'gpp-guide-send-log.json');
 // Email template (hand-rolled, inline styles)
 // ---------------------------------------------------------------------------
 
-const SUBJECT = 'Your Global Pizza Party guide is ready 🍕';
+const SUBJECT = 'Your Hosting Guide for the Global Pizza Party';
 const FROM = 'RSV.Pizza <noreply@rsv.pizza>';
 
 function escapeHtml(s) {

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -121,8 +121,41 @@ function escapeHtml(s) {
 function buildPartyGuideEmail(recipient) {
   const firstName =
     (recipient.name && String(recipient.name).split(/\s+/)[0]) || 'host';
-  const partyGuideUrl = `https://rsv.pizza/host/${recipient.invite_code}/party-guide`;
-  const eventName = recipient.event_name || 'your Global Pizza Party';
+  const events = recipient.events || [];
+  const single = events.length <= 1;
+  const primaryEvent = events[0] || {};
+  const primaryUrl = `https://rsv.pizza/host/${primaryEvent.invite_code}/party-guide`;
+  const heroSubtitle = single
+    ? primaryEvent.event_name || 'your Global Pizza Party'
+    : `Your ${events.length} Global Pizza Parties`;
+  const introLine = single
+    ? "We've put together a Party Guide tab on your host dashboard to help you run a great Global Pizza Party 2026. Everything you need is now one click away."
+    : `We've put together a Party Guide tab on each of your host dashboards to help you run great Global Pizza Parties 2026. Everything you need is now one click away — for all ${events.length} of your events.`;
+
+  const ctaBlock = single
+    ? `<div style="text-align: center; margin: 30px 0;">
+      <a href="${primaryUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-weight: 600; font-size: 16px;">
+        Open your Party Guide
+      </a>
+    </div>
+
+    <p style="font-size: 14px; color: #666; text-align: center; margin: 20px 0;">
+      Or paste this link into your browser:<br>
+      <a href="${primaryUrl}" style="color: #ff393a; word-break: break-all;">${primaryUrl}</a>
+    </p>`
+    : `<div style="margin: 30px 0;">
+      <p style="font-size: 14px; color: #666; text-align: center; margin: 0 0 16px 0;">Open your Party Guide for each event:</p>
+      ${events
+        .map((e) => {
+          const url = `https://rsv.pizza/host/${e.invite_code}/party-guide`;
+          return `<div style="text-align: center; margin: 0 0 10px 0;">
+        <a href="${url}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-weight: 600; font-size: 15px; min-width: 240px;">
+          ${escapeHtml(e.event_name || 'Open Party Guide')}
+        </a>
+      </div>`;
+        })
+        .join('\n      ')}
+    </div>`;
 
   const html = `<!DOCTYPE html>
 <html>
@@ -134,7 +167,7 @@ function buildPartyGuideEmail(recipient) {
   <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background: #ffffff;">
     <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
       <h1 style="color: #ffffff; font-size: 28px; margin: 0 0 10px 0;">Your Party Guide is ready 🍕</h1>
-      <p style="color: rgba(255,255,255,0.8); font-size: 16px; margin: 0;">${escapeHtml(eventName)}</p>
+      <p style="color: rgba(255,255,255,0.8); font-size: 16px; margin: 0;">${escapeHtml(heroSubtitle)}</p>
     </div>
 
     <p style="font-size: 16px; margin-bottom: 20px;">
@@ -142,7 +175,7 @@ function buildPartyGuideEmail(recipient) {
     </p>
 
     <p style="font-size: 16px; margin-bottom: 20px;">
-      We've put together a Party Guide tab on your host dashboard to help you run a great Global Pizza Party 2026. Everything you need is now one click away.
+      ${introLine}
     </p>
 
     <div style="background: #fff4e6; padding: 20px; border-radius: 12px; margin: 30px 0;">
@@ -154,16 +187,7 @@ function buildPartyGuideEmail(recipient) {
       </ul>
     </div>
 
-    <div style="text-align: center; margin: 30px 0;">
-      <a href="${partyGuideUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        Open your Party Guide
-      </a>
-    </div>
-
-    <p style="font-size: 14px; color: #666; text-align: center; margin: 20px 0;">
-      Or paste this link into your browser:<br>
-      <a href="${partyGuideUrl}" style="color: #ff393a; word-break: break-all;">${partyGuideUrl}</a>
-    </p>
+    ${ctaBlock}
 
     <div style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 30px; text-align: center; color: #666; font-size: 13px;">
       <p>Questions? Reply to this email or reach out on <a href="https://t.me/pizzadao" style="color: #ff393a;">Telegram</a>.</p>
@@ -178,7 +202,7 @@ function buildPartyGuideEmail(recipient) {
   </body>
 </html>`;
 
-  return { subject: SUBJECT, html, partyGuideUrl };
+  return { subject: SUBJECT, html, partyGuideUrl: primaryUrl };
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +226,7 @@ FROM parties p
 JOIN "User" u ON p.user_id = u.id
 WHERE p.event_type = 'gpp'
   AND p.underboss_status = 'approved'
+  AND (p.date IS NULL OR p.date >= CURRENT_DATE)
 ORDER BY p.date ASC NULLS LAST;
 `;
 
@@ -254,22 +279,55 @@ function flattenAndDedup(rows) {
       });
     }
   }
+  // Dedup by email, accumulating ALL of the recipient's events.
   const byEmail = new Map();
   for (const r of flat) {
+    const ev = {
+      event_name: r.event_name,
+      invite_code: r.invite_code,
+      event_date: r.event_date,
+      country: r.country,
+    };
     const existing = byEmail.get(r.email);
     if (!existing) {
-      byEmail.set(r.email, r);
+      byEmail.set(r.email, {
+        email: r.email,
+        name: r.name,
+        role: r.role,
+        country: r.country,
+        events: [ev],
+      });
       continue;
     }
-    const promoteToHost = r.role === 'host' && existing.role !== 'host';
-    const earlier =
-      r.event_date &&
-      (!existing.event_date ||
-        new Date(r.event_date) < new Date(existing.event_date));
-    if (promoteToHost || earlier) byEmail.set(r.email, r);
+    // Defensive: don't add the same event twice (a person listed twice in coHosts).
+    if (!existing.events.some((e) => e.invite_code === ev.invite_code)) {
+      existing.events.push(ev);
+    }
+    // Recipient-level role: 'host' if they're a host on ANY of their events.
+    if (r.role === 'host' && existing.role !== 'host') {
+      existing.role = 'host';
+      existing.name = r.name; // prefer host's User.name over co-host display name
+    }
   }
-  const recipients = [...byEmail.values()];
-  return { flat, recipients, partnerSkips };
+  const allDeduped = [...byEmail.values()];
+  // Sort each recipient's events by date ASC, NULL dates last.
+  for (const r of allDeduped) {
+    r.events.sort((a, b) => {
+      if (a.event_date && b.event_date) {
+        return new Date(a.event_date) - new Date(b.event_date);
+      }
+      if (a.event_date) return -1;
+      if (b.event_date) return 1;
+      return 0;
+    });
+  }
+  // Exclude coordinator-style recipients (>20 events). They're added as co-hosts
+  // for oversight, not because they're running each party day-of. Emailing them
+  // with 30–400 buttons is spam and a deliverability risk.
+  const HIGH_VOLUME_THRESHOLD = 20;
+  const highVolume = allDeduped.filter((r) => r.events.length > HIGH_VOLUME_THRESHOLD);
+  const recipients = allDeduped.filter((r) => r.events.length <= HIGH_VOLUME_THRESHOLD);
+  return { flat, recipients, partnerSkips, highVolume };
 }
 
 // ---------------------------------------------------------------------------
@@ -290,16 +348,20 @@ function buildCsv(recipients) {
     'email',
     'name',
     'role',
-    'event_name',
-    'invite_code',
-    'country',
-    'party_guide_url',
+    'event_count',
+    'event_names',
+    'party_guide_urls',
+    'primary_country',
   ].join(',');
   const lines = [header];
   for (const r of recipients) {
-    const url = `https://rsv.pizza/host/${r.invite_code}/party-guide`;
+    const events = r.events || [];
+    const eventNames = events.map((e) => e.event_name).join(' | ');
+    const urls = events
+      .map((e) => `https://rsv.pizza/host/${e.invite_code}/party-guide`)
+      .join(' | ');
     lines.push(
-      [r.email, r.name, r.role, r.event_name, r.invite_code, r.country, url]
+      [r.email, r.name, r.role, events.length, eventNames, urls, r.country]
         .map(csvEscape)
         .join(',')
     );
@@ -456,14 +518,22 @@ async function runSend(recipients, opts) {
 // Dry run
 // ---------------------------------------------------------------------------
 
-function runDryRun(flat, recipients, partnerSkips) {
+function runDryRun(flat, recipients, partnerSkips, highVolume) {
   const roleCounts = countByRole(recipients);
   const top = topByCountry(recipients, 10);
+  const multiEvent = recipients.filter((r) => r.events.length > 1).length;
 
   console.log('=== DRY RUN ===');
   console.log(`raw flat count:       ${flat.length}`);
   console.log(`deduped count:        ${recipients.length}`);
   console.log(`partner co-host skip: ${partnerSkips}`);
+  console.log(`high-volume excluded: ${highVolume.length} (>20 events each)`);
+  if (highVolume.length > 0) {
+    for (const r of highVolume) {
+      console.log(`  - ${r.email} (${r.events.length} events)`);
+    }
+  }
+  console.log(`multi-event recipients: ${multiEvent}`);
   console.log(`role counts:          host=${roleCounts.host} cohost=${roleCounts.cohost}`);
   console.log('top countries:');
   for (const [c, n] of top) {
@@ -473,8 +543,13 @@ function runDryRun(flat, recipients, partnerSkips) {
   // CSV
   fs.writeFileSync(CSV_PATH, buildCsv(recipients));
 
-  // Sample HTML — first 3 recipients
+  // Sample HTML — first 3 recipients, plus the recipient with the most events
+  // (if any have >1), so the multi-event design is visually reviewable.
   const samples = recipients.slice(0, 3);
+  const mostEvents = [...recipients].sort((a, b) => b.events.length - a.events.length)[0];
+  if (mostEvents && mostEvents.events.length > 1 && !samples.includes(mostEvents)) {
+    samples.push(mostEvents);
+  }
   const blocks = samples.map((r) => {
     const { html } = buildPartyGuideEmail(r);
     return `<!-- recipient: ${escapeHtml(r.email)} (${escapeHtml(r.role)}) -->\n${html}`;
@@ -531,7 +606,7 @@ async function main() {
   const rows = await queryRows();
   console.log(`Got ${rows.length} approved GPP party row(s).`);
 
-  const { flat, recipients, partnerSkips } = flattenAndDedup(rows);
+  const { flat, recipients, partnerSkips, highVolume } = flattenAndDedup(rows);
 
   // --only filter (applies in send mode)
   let finalRecipients = recipients;
@@ -549,7 +624,7 @@ async function main() {
   }
 
   if (opts.dryRun) {
-    runDryRun(flat, finalRecipients, partnerSkips);
+    runDryRun(flat, finalRecipients, partnerSkips, highVolume);
     return;
   }
 

--- a/backend/scripts/send-gpp-guide-email.cjs
+++ b/backend/scripts/send-gpp-guide-email.cjs
@@ -118,6 +118,69 @@ function escapeHtml(s) {
     .replace(/'/g, '&#39;');
 }
 
+function formatEventDate(dateStr, timezone) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return null;
+  const tz = timezone || 'UTC';
+  try {
+    const datePart = d.toLocaleDateString('en-US', {
+      weekday: 'long', month: 'long', day: 'numeric',
+      timeZone: tz,
+    });
+    const timePart = d.toLocaleTimeString('en-US', {
+      hour: 'numeric', minute: '2-digit',
+      timeZone: tz,
+    });
+    return `${datePart} at ${timePart}`;
+  } catch {
+    return d.toUTCString();
+  }
+}
+
+function countdownText(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return null;
+  const ms = d.getTime() - Date.now();
+  if (ms <= 0) return 'Happening now!';
+  const minutes = Math.round(ms / 60000);
+  const hours = Math.round(ms / 3600000);
+  const days = Math.round(ms / 86400000);
+  if (minutes < 60) return `See you in ${Math.max(1, minutes)} minute${minutes === 1 ? '' : 's'}`;
+  if (hours < 24) return `See you in ${hours} hour${hours === 1 ? '' : 's'}`;
+  if (days < 7) return `See you in ${days} day${days === 1 ? '' : 's'}`;
+  return null;
+}
+
+function renderEventCard(e, options = {}) {
+  const url = `https://rsv.pizza/host/${e.invite_code}/party-guide`;
+  const when = formatEventDate(e.event_date, e.timezone);
+  const countdown = options.showCountdown ? countdownText(e.event_date) : null;
+  const venueLine = e.venue_name ? escapeHtml(e.venue_name) : '';
+  const addressLine = e.address ? `<br><span style="color: #777; font-size: 14px;">${escapeHtml(e.address)}</span>` : '';
+  const whereBlock = (venueLine || addressLine)
+    ? `<p style="margin: 4px 0; color: #444;"><strong style="color: #333;">Where:</strong> ${venueLine}${addressLine}</p>`
+    : '';
+  const whenBlock = when
+    ? `<p style="margin: 4px 0; color: #444;"><strong style="color: #333;">When:</strong> ${escapeHtml(when)}</p>`
+    : '';
+  const countdownBlock = countdown
+    ? `<p style="margin: 14px 0 8px 0; color: #ff6b35; font-weight: 600; font-size: 15px;">${escapeHtml(countdown)}</p>`
+    : '';
+  return `<div style="border: 1px solid #e5e5e5; border-radius: 12px; padding: 24px; margin: 16px 0; background: #fafafa;">
+      <h2 style="margin: 0 0 12px 0; font-size: 20px; color: #222;">${escapeHtml(e.event_name || 'Global Pizza Party')}</h2>
+      ${whenBlock}
+      ${whereBlock}
+      ${countdownBlock}
+      <div style="text-align: center; margin-top: 16px;">
+        <a href="${url}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-weight: 600; font-size: 15px;">
+          Open Party Guide
+        </a>
+      </div>
+    </div>`;
+}
+
 function buildPartyGuideEmail(recipient) {
   const firstName =
     (recipient.name && String(recipient.name).split(/\s+/)[0]) || 'host';
@@ -129,33 +192,13 @@ function buildPartyGuideEmail(recipient) {
     ? primaryEvent.event_name || 'your Global Pizza Party'
     : `Your ${events.length} Global Pizza Parties`;
   const introLine = single
-    ? "We've put together a Party Guide tab on your host dashboard to help you run a great Global Pizza Party 2026. Everything you need is now one click away."
-    : `We've put together a Party Guide tab on each of your host dashboards to help you run great Global Pizza Parties 2026. Everything you need is now one click away — for all ${events.length} of your events.`;
+    ? "We've put together a Party Guide tab on your host dashboard. Everything you need to run a great Global Pizza Party is now one click away."
+    : `We've put together a Party Guide tab on each of your host dashboards — everything you need is one click away, for all ${events.length} of your events.`;
 
-  const ctaBlock = single
-    ? `<div style="text-align: center; margin: 30px 0;">
-      <a href="${primaryUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 16px 32px; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        Open your Party Guide
-      </a>
-    </div>
-
-    <p style="font-size: 14px; color: #666; text-align: center; margin: 20px 0;">
-      Or paste this link into your browser:<br>
-      <a href="${primaryUrl}" style="color: #ff393a; word-break: break-all;">${primaryUrl}</a>
-    </p>`
-    : `<div style="margin: 30px 0;">
-      <p style="font-size: 14px; color: #666; text-align: center; margin: 0 0 16px 0;">Open your Party Guide for each event:</p>
-      ${events
-        .map((e) => {
-          const url = `https://rsv.pizza/host/${e.invite_code}/party-guide`;
-          return `<div style="text-align: center; margin: 0 0 10px 0;">
-        <a href="${url}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-weight: 600; font-size: 15px; min-width: 240px;">
-          ${escapeHtml(e.event_name || 'Open Party Guide')}
-        </a>
-      </div>`;
-        })
-        .join('\n      ')}
-    </div>`;
+  // Show the countdown only on the soonest event card (events[0] after sort).
+  const cardsBlock = events
+    .map((e, i) => renderEventCard(e, { showCountdown: i === 0 }))
+    .join('\n    ');
 
   const html = `<!DOCTYPE html>
 <html>
@@ -166,7 +209,8 @@ function buildPartyGuideEmail(recipient) {
   </head>
   <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background: #ffffff;">
     <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 40px 20px; border-radius: 12px; text-align: center; margin-bottom: 30px;">
-      <h1 style="color: #ffffff; font-size: 28px; margin: 0 0 10px 0;">Your Party Guide is ready 🍕</h1>
+      <img src="https://rsv.pizza/molto-benny.png" alt="Molto Benny" width="96" height="96" style="display: block; margin: 0 auto 16px auto; width: 96px; height: 96px;">
+      <h1 style="color: #ffffff; font-size: 28px; margin: 0 0 10px 0;">Your Party Guide is ready</h1>
       <p style="color: rgba(255,255,255,0.8); font-size: 16px; margin: 0;">${escapeHtml(heroSubtitle)}</p>
     </div>
 
@@ -187,7 +231,7 @@ function buildPartyGuideEmail(recipient) {
       </ul>
     </div>
 
-    ${ctaBlock}
+    ${cardsBlock}
 
     <div style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 30px; text-align: center; color: #666; font-size: 13px;">
       <p>Questions? Reply to this email or reach out on <a href="https://t.me/pizzadao" style="color: #ff393a;">Telegram</a>.</p>
@@ -220,6 +264,8 @@ SELECT
   p.date         AS event_date,
   p.timezone,
   p.co_hosts,
+  p.address,
+  p.venue_name,
   u.email        AS host_email,
   u.name         AS host_name
 FROM parties p
@@ -250,15 +296,21 @@ function flattenAndDedup(rows) {
   const flat = [];
   let partnerSkips = 0;
   for (const row of rows) {
+    const eventFields = {
+      invite_code: row.invite_code,
+      event_name: row.event_name,
+      event_date: row.event_date,
+      country: row.country,
+      timezone: row.timezone,
+      venue_name: row.venue_name,
+      address: row.address,
+    };
     if (row.host_email && row.host_email.trim()) {
       flat.push({
         email: row.host_email.toLowerCase().trim(),
         name: row.host_name,
         role: 'host',
-        invite_code: row.invite_code,
-        event_name: row.event_name,
-        event_date: row.event_date,
-        country: row.country,
+        ...eventFields,
       });
     }
     const coHosts = Array.isArray(row.co_hosts) ? row.co_hosts : [];
@@ -272,10 +324,7 @@ function flattenAndDedup(rows) {
         email: ch.email.toLowerCase().trim(),
         name: ch.name || row.host_name,
         role: 'cohost',
-        invite_code: row.invite_code,
-        event_name: row.event_name,
-        event_date: row.event_date,
-        country: row.country,
+        ...eventFields,
       });
     }
   }
@@ -287,6 +336,9 @@ function flattenAndDedup(rows) {
       invite_code: r.invite_code,
       event_date: r.event_date,
       country: r.country,
+      timezone: r.timezone,
+      venue_name: r.venue_name,
+      address: r.address,
     };
     const existing = byEmail.get(r.email);
     if (!existing) {

--- a/plans/focaccia-58247.md
+++ b/plans/focaccia-58247.md
@@ -1,0 +1,212 @@
+# focaccia-58247: Email all approved GPP 2026 hosts (+ non-partner co-hosts) the Party Guide
+
+## Summary
+One-off broadcast pointing approved GPP hosts and their non-partner co-hosts at the Party Guide tab in the host dashboard, with a short good-luck note. Built as a `--dry-run`/`--send` Node script under `backend/scripts/` (mirrors `fix-gpp-host-avatars.js`, `tag-pfp-missing-avatars.js`, etc.). Triggered from Snax's machine against prod DB; no admin UI in v1.
+
+## Audience
+
+- **Filter:** `parties.event_type = 'gpp' AND parties.underboss_status = 'approved'`
+- **Recipients:**
+  - **Primary host:** `users.email` joined via `parties.user_id` for every approved GPP event.
+  - **Co-hosts (non-partner only):** Each entry in `parties.co_hosts` JSON array where `isPartner !== true` and `email` is non-empty.
+  - Partner co-hosts (`isPartner === true`) are excluded — they're sponsor/brand contacts (often with a `partnerTag`), not the people running the day-of. They get partner-specific comms separately.
+- **`CoHost` shape** (frontend/src/types.ts:102): `{ id, name, email?, ..., isPartner?: boolean, partnerTag?: string, isUnderboss?, canEdit?, allowedTabs? }`.
+- **Dedup:** Lowercase + dedupe by email across the entire list (a single person may host one event and co-host another — they get one email, not two). The deduped record keeps the **soonest-upcoming** event as the link target and the role label `host` if any record is a primary host (so the email copy can address them as "host" not "co-host").
+- **Expected count:** ~500–700 unique recipients (~350–400 primary hosts + ~150–300 unique non-partner co-host emails after dedup; dry-run prints exact figures).
+
+### Audience edge cases
+
+- **Co-hosts without Party Guide tab access** (`allowedTabs` set but missing `'party-guide'`): still emailed. The message has value beyond the tab link (good-luck note, day-of reminders), and the host can grant tab access if asked. Not worth a second filter.
+- **Co-hosts with no email:** skipped silently (shape allows `email?`).
+- **Multiple co-host entries for the same email across different events:** deduped; soonest-upcoming event wins the link slot.
+- **`isUnderboss` co-hosts:** treated as normal co-hosts (not excluded). They're still day-of hosts.
+
+## Email content
+
+- **Subject:** `Your Global Pizza Party guide is ready 🍕`
+- **From:** `RSV.Pizza <noreply@rsv.pizza>` (matches every other transactional email).
+- **HTML body** (inline-styled, same hand-rolled pattern as the rest of `backend/src/routes/*.ts` — no template engine):
+  ```
+  Hi {first_name or "host"},
+
+  Your Global Pizza Party is almost here — we're rooting for you.
+
+  We just shipped the Party Guide: a single tab in your dashboard with
+  everything you need on the day-of (timeline, checklist, photo prompts,
+  pizzeria contacts, Zoom info if you've got one).
+
+    → Open your Party Guide for {event_name}:
+      https://rsv.pizza/host/{invite_code}/party-guide
+
+  A few quick reminders:
+    • {bullet 1 — final to be drafted with Snax before send}
+    • {bullet 2}
+    • {bullet 3}
+
+  Questions? Just reply — this inbox is monitored.
+
+  Good luck and happy hosting,
+  The RSV.Pizza team
+  ```
+- **Plain-text alt:** same content stripped of HTML, link as bare URL. Helps deliverability.
+- **No role distinction in copy.** Co-hosts get the exact same email as hosts. They have the same access to the Party Guide tab (modulo `allowedTabs`), and "hi host" reads naturally for either role.
+
+## Compliance / unsubscribe
+
+No suppression infra exists on this codebase today (verified: no `email_unsubscribed` column on `User`, no suppression table). Two-tier approach:
+
+1. **Headers (mandatory):** Add `List-Unsubscribe: <mailto:unsubscribe@rsv.pizza?subject=unsubscribe>` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click`. Satisfies Gmail/Yahoo bulk-sender rules (2024+) for >5k/day senders. We're under that, but headers cost nothing and protect deliverability.
+2. **Footer line (mandatory):** Inline "Reply STOP to opt out of future broadcasts." Replies land in `noreply@rsv.pizza`'s inbox (already monitored). v1 = manual suppression; building a real suppression table is captured as a follow-up before the *next* broadcast.
+
+## Architecture
+
+**Why a script, not an endpoint:** Every other prod-data-touching tool on this repo is a script (`scripts/geocode-backfill.js`, `scripts/swc-geo-audit.cjs`, `backend/scripts/restore-mc-deletions.cjs`, the avatar backfill family). A one-off broadcast = a one-off script. An admin endpoint would add auth, route registration, UI surface, and a deploy cycle for a single send.
+
+- **File:** `backend/scripts/send-gpp-guide-email.cjs`
+- **CLI surface:**
+  ```
+  node backend/scripts/send-gpp-guide-email.cjs --dry-run
+    # Writes /tmp/gpp-guide-recipients.csv (email, name, role, event_name, invite_code, party_guide_url)
+    # Writes /tmp/gpp-guide-sample.html (rendered email for the first 3 recipients)
+    # Prints: raw recipient count, deduped count, # of partner co-hosts excluded
+    # Sends nothing.
+
+  node backend/scripts/send-gpp-guide-email.cjs --send --confirm
+    # Re-runs the query, sends via Resend with the existing 10/500ms batching pattern.
+    # Refuses without --confirm.
+    # Writes /tmp/gpp-guide-send-log.json: { sent: [...], failed: [{email, reason}] }.
+    # On retry: --send --skip-already-sent reads the log and skips successes (idempotency).
+
+  node backend/scripts/send-gpp-guide-email.cjs --send --only=email1,email2
+    # Single-recipient test mode. Snax runs this against her own email first.
+  ```
+
+**Reuses:**
+- `pg` client + `DATABASE_URL` from `backend/.env` (per memory `reference_db_backfill_fallback` — Supabase API token can die; raw `pg` is the reliable fallback).
+- `RESEND_API_KEY` from `backend/.env`.
+- Batching: `BATCH_SIZE = 10`, `await new Promise(r => setTimeout(r, 500))` between batches (copied from `backend/src/routes/v1/guests.ts:780`).
+
+**Does NOT need:**
+- Prisma client (raw SQL is fine for a one-off SELECT).
+- Backend deploy (script runs locally against prod DB + Resend; no code goes to Vercel).
+- Frontend changes.
+- DB migration (no schema changes in v1).
+
+## Implementation steps
+
+1. **Create `backend/scripts/send-gpp-guide-email.cjs`:**
+   - Load `backend/.env` via `require('dotenv').config({ path })`.
+   - Connect via `pg.Client` using `DATABASE_URL`.
+   - Run SQL (every approved GPP event with host + raw `co_hosts` JSON — flattening happens in JS so we can apply the `isPartner` filter and dedup cleanly):
+     ```sql
+     SELECT
+       p.id           AS party_id,
+       p.name         AS event_name,
+       p.invite_code,
+       p.custom_url,
+       p.city,
+       p.country,
+       p.date         AS event_date,
+       p.timezone,
+       p.co_hosts,
+       u.email        AS host_email,
+       u.name         AS host_name
+     FROM parties p
+     JOIN users u ON p.user_id = u.id
+     WHERE p.event_type = 'gpp'
+       AND p.underboss_status = 'approved'
+     ORDER BY p.date ASC NULLS LAST;
+     ```
+   - **Build the flat recipient list in JS:**
+     ```js
+     const flat = [];
+     let partnerSkips = 0;
+     for (const row of rows) {
+       // Primary host
+       if (row.host_email && row.host_email.trim()) {
+         flat.push({
+           email: row.host_email.toLowerCase().trim(),
+           name: row.host_name,
+           role: 'host',
+           invite_code: row.invite_code,
+           event_name: row.event_name,
+           event_date: row.event_date,
+         });
+       }
+       // Non-partner co-hosts
+       const coHosts = Array.isArray(row.co_hosts) ? row.co_hosts : [];
+       for (const ch of coHosts) {
+         if (ch?.isPartner === true) { partnerSkips++; continue; }
+         if (!ch?.email || !ch.email.trim()) continue;
+         flat.push({
+           email: ch.email.toLowerCase().trim(),
+           name: ch.name || row.host_name,
+           role: 'cohost',
+           invite_code: row.invite_code,
+           event_name: row.event_name,
+           event_date: row.event_date,
+         });
+       }
+     }
+     // Dedup by email; prefer host role over cohost; prefer soonest-upcoming event.
+     const byEmail = new Map();
+     for (const r of flat) {
+       const existing = byEmail.get(r.email);
+       if (!existing) { byEmail.set(r.email, r); continue; }
+       const promoteToHost = r.role === 'host' && existing.role !== 'host';
+       const earlier = r.event_date && (!existing.event_date || new Date(r.event_date) < new Date(existing.event_date));
+       if (promoteToHost || earlier) byEmail.set(r.email, r);
+     }
+     const recipients = [...byEmail.values()];
+     console.log(`Raw flat list: ${flat.length} | Deduped: ${recipients.length} | Partner co-hosts excluded: ${partnerSkips}`);
+     ```
+   - Build HTML using the inline-style template (mirror the GPP welcome-email block in `backend/src/routes/gpp.routes.ts` ~lines 280–360).
+   - Dry-run path: write CSV + sample HTML, no `fetch` calls.
+   - Send path: per-recipient Resend POST, batch of 10 with 500ms gap, append result to log.
+
+2. **Verify the URL pattern.** Confirm `https://rsv.pizza/host/{invite_code}/party-guide` lands on the Party Guide tab (PR #558 / #561 / #562 / #564 all merged). Open one sample event in browser before sending the blast.
+
+3. **Dry-run + review.** Open `/tmp/gpp-guide-sample.html` in browser, edit final copy in the script (bullets + sign-off), re-run `--dry-run` until happy.
+
+4. **Test send.** `--send --only=samgold24@gmail.com`. Confirm rendering in Gmail (subject, From, body, link, unsubscribe header visible in "show original").
+
+5. **Full send.** `--send --confirm`. Watch the log; expect ~5–10 minutes wall time for ~500–700 emails at 10/500ms.
+
+6. **Post-send check.** Spot-check Resend dashboard for bounces. If any "STOP" replies come in over the next 48h, log them somewhere durable so a future broadcast can suppress.
+
+## Acceptance criteria
+
+- [ ] `--dry-run` outputs CSV containing every approved-GPP primary host email + every non-partner co-host email, deduped by lowercased email. Prints both raw and deduped counts plus the partner-skip count so we can sanity-check the `isPartner` filter.
+- [ ] Spot-check: pick one event with a known partner co-host (e.g. `SELECT name, jsonb_pretty(co_hosts) FROM parties WHERE event_type='gpp' AND underboss_status='approved' AND co_hosts::text ILIKE '%isPartner%true%' LIMIT 5`) — confirm that partner's email is NOT in the dry-run CSV.
+- [ ] Sample HTML renders cleanly in Gmail + Apple Mail (no broken layout, link clickable, unsubscribe header present).
+- [ ] Test send to Snax succeeds and the email lands in inbox (not spam).
+- [ ] Full send log shows ≥98% sent, ≤2% failed (hard bounces; record them).
+- [ ] No recipient gets more than one email (dedup verified by spot-checking the log).
+- [ ] All Party Guide links resolve to the live tab (not 404).
+
+## Risks / pre-flight checks
+
+- **Resend rate limits.** Free tier = 100/day. Verify which tier `RESEND_API_KEY` is on before sending 500–700 in one run. Likely already paid given existing transactional volume — confirm in Resend dashboard.
+- **Stale recipient list between dry-run and send.** Re-query inside `--send`; don't rely on the dry-run CSV. New GPP events get approved daily.
+- **Partner-flag drift.** `isPartner` is set at the time the co-host is added/edited; a co-host added as a regular co-host before partner-tagging existed won't have `isPartner=true` even if they're a sponsor in spirit. Acceptable for this blast — the filter applies the explicit flag and nothing else.
+- **Hosts who already opened the Party Guide tab.** No downside to emailing them — the bullets + good-luck note still land. Don't filter.
+- **Memory note `feedback_check_vercel_logs_first_for_widespread_bugs`** doesn't apply here (no widespread bug), but if post-send we see "guide link 404s" reports, check Vercel logs before chasing DB hypotheses.
+
+## Follow-ups (separate tasks, not this PR)
+
+- **Real suppression infra.** Add `users.broadcast_unsubscribed_at TIMESTAMPTZ NULL` + a public `/unsubscribe?token=…` page. Build before the *next* broadcast.
+- **Co-host broadcast variants.** If we want different copy for hosts vs co-hosts, split the template; not worth doing for v1.
+- **Reusable broadcast tool under /underboss.** Build only if we send broadcasts more than 2–3 times.
+
+## Files touched
+
+- **New:** `backend/scripts/send-gpp-guide-email.cjs` (only file)
+- **No code changes** in `backend/src/`, `frontend/src/`, `supabase/`, `prisma/`.
+
+## Dispatch notes
+
+- **Branch name:** `focaccia-58247-gpp-guide-email`
+- **Worktree agent isolation:** `worktree`. Per memory `feedback_agent_worktree_git_sandbox`, agent commits/pushes are done from main session after agent finishes.
+- **No DB migration** — skip apply-migration step.
+- **No backend deploy** (script-only, runs locally).
+- **PR is informational** — merge doesn't trigger the send; Snax runs the script manually after PR merges. Skipping the PR is defensible since nothing deploys, but PR'ing it preserves the script for next time.


### PR DESCRIPTION
## Summary
One-off CLI under `backend/scripts/` to email approved GPP 2026 hosts (and their non-partner co-hosts) a link to their Party Guide tab.

- Filter: `event_type='gpp' AND underboss_status='approved'`
- Co-hosts where `isPartner !== true` are included (sponsor/brand contacts excluded)
- Dedups by lowercased email; host role wins over cohost; soonest-upcoming event provides the link
- Reuses Resend + the 10/500ms batching pattern from `backend/src/routes/v1/guests.ts`
- `List-Unsubscribe` + `List-Unsubscribe-Post` headers on every send
- Three modes: `--dry-run`, `--send --confirm`, `--send --only=a@b.com,c@d.com`
- `--skip-already-sent` reads the prior send log for retry idempotency

Plan: `plans/focaccia-58247.md` (also in this PR for reference).

## What this PR does NOT do
- **No deploy.** Script runs locally from Snax's machine against prod DB + Resend.
- **No schema change.** Pure read-only query.
- **No backend route, no frontend change.** Standalone script — does not import from `backend/src/` or `@prisma/client`.

## Test plan
- [ ] Vercel preview build passes (no frontend changes — should be a no-op build)
- [ ] `node -c backend/scripts/send-gpp-guide-email.cjs` exits 0 (syntax check)
- [ ] `node backend/scripts/send-gpp-guide-email.cjs --help` prints CLI surface
- [ ] **Dry-run review:** Snax fills bullet 1/2/3 + sign-off, runs `--dry-run`, opens `/tmp/gpp-guide-sample.html` in browser, verifies layout + Party Guide link
- [ ] **Spot-check partner filter:** confirm a known `isPartner=true` co-host email is NOT in the dry-run CSV
- [ ] **Test send:** `--send --only=samgold24@gmail.com`; confirm Gmail delivery + List-Unsubscribe header visible in "show original"
- [ ] **Full send:** `--send --confirm`; expect ~500-700 recipients across ~5-10 min wall time
- [ ] Send log shows >=98% sent

## Follow-ups (separate tasks)
- Real suppression infra (`users.broadcast_unsubscribed_at` + `/unsubscribe?token=...`) before the next broadcast
- Reusable `/underboss` broadcast UI if we send broadcasts more than 2-3 times

🤖 Generated with [Claude Code](https://claude.com/claude-code)