### PR TITLE
feat(lardo-91382): broadcast -> right column, hide Checklist Today

### DIFF
--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -84,15 +84,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           hideOpenTabLink={isMobile}
         />
       </CollapsibleCard>
-      {isGpp && (
-        <CollapsibleCard
-          id="broadcast"
-          partyId={party.id}
-          title="Join the global PizzaDAO broadcast"
-        >
-          <BroadcastJoinCard partyId={party.id} layout={layout} />
-        </CollapsibleCard>
-      )}
       <CollapsibleCard id="check-in" partyId={party.id} title="Check-in">
         <CheckInPanel party={party} guests={guests} onGuestUpdated={refreshGuests} />
       </CollapsibleCard>
@@ -118,6 +109,15 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
       >
         <StreamOnScreenCard />
       </CollapsibleCard>
+      {isGpp && (
+        <CollapsibleCard
+          id="broadcast"
+          partyId={party.id}
+          title="Join the global PizzaDAO broadcast"
+        >
+          <BroadcastJoinCard partyId={party.id} layout={layout} />
+        </CollapsibleCard>
+      )}
       {isGpp && !briefingFirst && (
         <CollapsibleCard
           id="briefing"
@@ -127,17 +127,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           <BriefingCard party={party} />
         </CollapsibleCard>
       )}
-      <CollapsibleCard
-        id="checklist"
-        partyId={party.id}
-        title="Today's checklist"
-      >
-        <ChecklistTodayCard
-          partyId={party.id}
-          inviteCode={party.inviteCode}
-          hideOpenTabLink={isMobile}
-        />
-      </CollapsibleCard>
       <CollapsibleCard
         id="photo-quick-capture"
         partyId={party.id}


### PR DESCRIPTION
## Summary
- Move `BroadcastJoinCard` from the left column to the right column, immediately under `StreamOnScreenCard`. Groups the two broadcast surfaces together.
- Stop rendering `ChecklistTodayCard` on the Party Guide dashboard. Component file kept for easy re-enable later.

## Final column order
**Left**: Pizza - Music - CheckIn - Announce - SWC
**Right**: Stream-on-Screen - Broadcast - Briefing (non-promoted) - Photo - SignedBox - BoxStack - AnnouncementHistory - Logistics

## Test plan
- [ ] Broadcast card now under Stream-on-Screen in right column
- [ ] Today's Checklist no longer visible on Party Guide
- [ ] Mobile single-column stack reflects same priority
- [ ] Collapsible state still persists per card

Generated with Claude Code