### PR TITLE
feat(nduja-58194): trim check-in/logistics, move SWC under music

### DIFF
--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -84,15 +84,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           hideOpenTabLink={isMobile}
         />
       </CollapsibleCard>
-      {isGpp && (
-        <CollapsibleCard
-          id="broadcast"
-          partyId={party.id}
-          title="Join the global PizzaDAO broadcast"
-        >
-          <BroadcastJoinCard partyId={party.id} layout={layout} />
-        </CollapsibleCard>
-      )}
       <CollapsibleCard id="check-in" partyId={party.id} title="Check-in">
         <CheckInPanel party={party} guests={guests} onGuestUpdated={refreshGuests} />
       </CollapsibleCard>
@@ -118,6 +109,15 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
       >
         <StreamOnScreenCard />
       </CollapsibleCard>
+      {isGpp && (
+        <CollapsibleCard
+          id="broadcast"
+          partyId={party.id}
+          title="Join the global PizzaDAO broadcast"
+        >
+          <BroadcastJoinCard partyId={party.id} layout={layout} />
+        </CollapsibleCard>
+      )}
       {isGpp && !briefingFirst && (
         <CollapsibleCard
           id="briefing"
@@ -127,17 +127,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           <BriefingCard party={party} />
         </CollapsibleCard>
       )}
-      <CollapsibleCard
-        id="checklist"
-        partyId={party.id}
-        title="Today's checklist"
-      >
-        <ChecklistTodayCard
-          partyId={party.id}
-          inviteCode={party.inviteCode}
-          hideOpenTabLink={isMobile}
-        />
-      </CollapsibleCard>
       <CollapsibleCard
         id="photo-quick-capture"
         partyId={party.id}

--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -4,10 +4,8 @@ import { useGuestsRealtime } from '../../hooks/useGuestsRealtime';
 import * as db from '../../lib/supabase';
 import { dbGuestToGuest } from '../../contexts/PizzaContext';
 import { StatusHeader } from './StatusHeader';
-import { CheckInPanel } from './CheckInPanel';
 import { AnnouncePanel } from './AnnouncePanel';
 import { AnnouncementHistory } from './AnnouncementHistory';
-import { LogisticsCard } from './LogisticsCard';
 import { PizzaStatusCard } from './PizzaStatusCard';
 import { MusicNowPlayingCard } from './MusicNowPlayingCard';
 import { ChecklistTodayCard } from './ChecklistTodayCard';
@@ -84,18 +82,15 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           hideOpenTabLink={isMobile}
         />
       </CollapsibleCard>
-      <CollapsibleCard id="check-in" partyId={party.id} title="Check-in">
-        <CheckInPanel party={party} guests={guests} onGuestUpdated={refreshGuests} />
+      {/* StandWithCryptoCard self-gates on party.eventTags containing 'swc' */}
+      <CollapsibleCard id="swc" partyId={party.id} title="Stand With Crypto">
+        <StandWithCryptoCard party={party} />
       </CollapsibleCard>
       <CollapsibleCard id="announce" partyId={party.id} title="Announce">
         <AnnouncePanel
           partyId={party.id}
           onSent={() => setAnnHistoryKey((k) => k + 1)}
         />
-      </CollapsibleCard>
-      {/* StandWithCryptoCard self-gates on party.eventTags containing 'swc' */}
-      <CollapsibleCard id="swc" partyId={party.id} title="Stand With Crypto">
-        <StandWithCryptoCard party={party} />
       </CollapsibleCard>
     </>
   );
@@ -158,9 +153,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
         title="Sent today"
       >
         <AnnouncementHistory partyId={party.id} refreshKey={annHistoryKey} />
-      </CollapsibleCard>
-      <CollapsibleCard id="logistics" partyId={party.id} title="Logistics">
-        <LogisticsCard party={party} />
       </CollapsibleCard>
     </>
   );


### PR DESCRIPTION
## Summary
Continues trimming the Party Guide dashboard to the must-have day-of actions.

**Left column**: Pizza - Music - **SWC** (moved up) - Announce
**Right column**: Stream-on-Screen - Broadcast - Briefing - Photo - SignedBox - BoxStack - AnnouncementHistory

Removed from the dashboard render (component files kept for easy re-enable):
- `CheckInPanel`
- `LogisticsCard`

## Supersedes PR lardo-91382
This branch is based on `lardo-91382-broadcast-right-hide-checklist` and includes all of its changes (Broadcast moved to right column, ChecklistTodayCard hidden). The parent session will close that PR.

## Test plan
- [ ] Check-in section no longer on Party Guide
- [ ] Logistics no longer on Party Guide
- [ ] SWC card sits directly under Music in left column
- [ ] Mobile single-column stack reflects the same priority

Generated with Claude Code