### PR TITLE
fix(salsiccia-21859): symmetric BroadcastJoinCard layout

### DIFF
--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -198,7 +198,7 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
       </p>
 
       <div className={isMobile ? 'flex flex-col gap-3' : 'flex flex-col sm:flex-row gap-3'}>
-        <div className="flex-1 flex flex-col gap-2">
+        <div className="flex-1">
           <BroadcastButton
             url={eligible ? zoomUrl : null}
             label="Join Zoom (static camera)"
@@ -207,28 +207,6 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
             loading={loading}
             unavailableLabel={unavailableLabel}
           />
-          {showZoomDetails && (
-            <div className="flex flex-col gap-1 px-1">
-              {zoomMeetingId && (
-                <CopyDetailRow
-                  label="Meeting ID"
-                  value={zoomMeetingId}
-                  copyKey="meeting-id"
-                  copiedKey={copiedKey}
-                  onCopy={handleCopy}
-                />
-              )}
-              {zoomPasscode && (
-                <CopyDetailRow
-                  label="Passcode"
-                  value={zoomPasscode}
-                  copyKey="passcode"
-                  copiedKey={copiedKey}
-                  onCopy={handleCopy}
-                />
-              )}
-            </div>
-          )}
         </div>
         <div className="flex-1">
           <BroadcastButton
@@ -241,6 +219,29 @@ export const BroadcastJoinCard: React.FC<BroadcastJoinCardProps> = ({ partyId, l
           />
         </div>
       </div>
+
+      {showZoomDetails && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+          {zoomMeetingId && (
+            <CopyDetailRow
+              label="Meeting ID"
+              value={zoomMeetingId}
+              copyKey="meeting-id"
+              copiedKey={copiedKey}
+              onCopy={handleCopy}
+            />
+          )}
+          {zoomPasscode && (
+            <CopyDetailRow
+              label="Passcode"
+              value={zoomPasscode}
+              copyKey="passcode"
+              copiedKey={copiedKey}
+              onCopy={handleCopy}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Moves the Zoom Meeting ID + Passcode rows out of the Zoom button's column and into a full-width strip below both buttons. The Zoom and StreamYard buttons are now equal-width, equal-height side-by-side instead of the Zoom column being taller (which made the StreamYard side look lonely / broken).

## Test plan
- [ ] Desktop: both broadcast buttons equal size side-by-side
- [ ] Mobile: buttons stack as before, detail rows below
- [ ] Copy-to-clipboard on Meeting ID + Passcode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)