### PR TITLE
fix(caciocavallo-71203): broadcast render bug + X logo + button text contrast

### DIFF
--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -51,7 +51,7 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
   );
 
   const baseClasses =
-    'relative flex-1 rounded-xl py-4 px-4 text-white text-center transition-opacity';
+    'relative block w-full rounded-xl py-4 px-4 text-white text-center transition-opacity';
 
   if (!ready || !url) {
     return (

--- a/frontend/src/components/day-of/StreamOnScreenCard.tsx
+++ b/frontend/src/components/day-of/StreamOnScreenCard.tsx
@@ -1,6 +1,23 @@
 import React from 'react';
-import { Tv, Youtube, Twitter } from 'lucide-react';
+import { Tv, Youtube } from 'lucide-react';
 import { STREAM_YOUTUBE_URL, STREAM_X_URL } from '../../lib/dayOfConfig';
+
+/**
+ * Inline X (formerly Twitter) logo. Lucide ships the legacy bird as
+ * `Twitter`, which is no longer X's brand mark — caciocavallo-71203
+ * swapped it for the official "X" path.
+ */
+const XLogo: React.FC<{ size?: number }> = ({ size = 18 }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    width={size}
+    height={size}
+    aria-hidden="true"
+  >
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
 
 /**
  * prosciutto-78201: Day-of prompt for hosts to put the global PizzaDAO
@@ -31,7 +48,7 @@ export const StreamOnScreenCard: React.FC = () => {
           href={STREAM_YOUTUBE_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex-1 flex items-center justify-center gap-2 rounded-xl py-3 px-4 bg-[#ff0000] hover:bg-[#cc0000] transition-colors text-white font-semibold text-base"
+          className="flex-1 flex items-center justify-center gap-2 rounded-xl py-3 px-4 bg-[#ff0000] hover:bg-[#cc0000] transition-colors text-[#ffffff] font-semibold text-base"
         >
           <Youtube size={18} />
           Watch on YouTube
@@ -40,9 +57,9 @@ export const StreamOnScreenCard: React.FC = () => {
           href={STREAM_X_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex-1 flex items-center justify-center gap-2 rounded-xl py-3 px-4 bg-black hover:bg-neutral-800 transition-colors text-white font-semibold text-base"
+          className="flex-1 flex items-center justify-center gap-2 rounded-xl py-3 px-4 bg-black hover:bg-neutral-800 transition-colors text-[#ffffff] font-semibold text-base"
         >
-          <Twitter size={18} />
+          <XLogo size={18} />
           Watch on X
         </a>
       </div>


### PR DESCRIPTION
## Summary
Two visual fixes on the Party Guide:

1. **BroadcastJoinCard buttons collapsed to slivers.** salsiccia-21859 (PR #580) restructured the Zoom column wrapper from `<div className=\"flex-1 flex flex-col gap-2\">` to `<div className=\"flex-1\">`. The BroadcastButton's `<a>` (inline by default) had `flex-1` in its base classes and was relying on the parent being a flex column to stretch full-width. Without the flex parent, the inline anchor collapsed to its intrinsic content width — which with `text-center` + a flex inner span produced the thin red bars on each column edge with text bleeding out. Fix: swap `flex-1` for `block w-full` in the BroadcastButton base classes so the anchor is block-level regardless of parent context.

2. **StreamOnScreenCard YouTube/X buttons.** Replaced lucide's `Twitter` bird with an inline X-logo SVG (the bird is no longer X's brand mark). Also moved the button text from `text-white` to the Tailwind arbitrary value `text-[#ffffff]` so the gpp-theme override (`.gpp-theme .text-white { color: #1a1a1a !important; }`) doesn't darken the labels on the red/black backgrounds.

### Stray pizza emoji
The 🍕 between the buttons in the screenshot is the global custom cursor defined at `frontend/src/index.css:388` (a CSS `cursor: url(...)` data-URI with a rotated 🍕 SVG). It's the user's mouse pointer, not a card decoration — nothing to fix.

## Test plan
- [ ] Broadcast buttons render as proper red rectangles in both columns (no slivers, no text overflow)
- [ ] No stray emoji bleed inside the broadcast card
- [ ] YouTube + X button labels fully readable white on red/black
- [ ] X icon is the X mark, not the Twitter bird

🤖 Generated with [Claude Code](https://claude.com/claude-code)