### PR TITLE
fix(bocconcini-19283): readable subtitles on broadcast buttons

### DIFF
--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -39,7 +39,7 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
         {label}
         {ready && <ExternalLink size={14} className="opacity-70" />}
       </span>
-      <span className="block text-xs font-normal text-white/70 mt-1.5 leading-snug">
+      <span className="block text-xs font-medium text-[#ffffff]/90 mt-1.5 leading-snug">
         {subtitle}
       </span>
       {!ready && (


### PR DESCRIPTION
## Summary
Bumps the Zoom + StreamYard button subtitles on BroadcastJoinCard from `text-white/70 font-normal` to `text-[#ffffff]/90 font-medium` — more readable on the red background, and the arbitrary-value class dodges the GPP theme's `text-white` override.

## Test plan
- [ ] Zoom button subtitle ("Set up a laptop on a tripod…") readable
- [ ] StreamYard button subtitle ("Open this on your phone…") readable
- [ ] No regression to button label or other broadcast card content

🤖 Generated with [Claude Code](https://claude.com/claude-code)