### PR TITLE
fix(gorgonzola-71082): bulletproof subtitle readability on broadcast buttons

### DIFF
--- a/frontend/src/components/day-of/BroadcastJoinCard.tsx
+++ b/frontend/src/components/day-of/BroadcastJoinCard.tsx
@@ -39,7 +39,10 @@ const BroadcastButton: React.FC<BroadcastButtonProps> = ({
         {label}
         {ready && <ExternalLink size={14} className="opacity-70" />}
       </span>
-      <span className="block text-xs font-medium text-[#ffffff]/90 mt-1.5 leading-snug">
+      <span
+        className="block text-xs font-medium mt-1.5 leading-snug"
+        style={{ color: '#ffffff', textShadow: '0 1px 2px rgba(0, 0, 0, 0.15)' }}
+      >
         {subtitle}
       </span>
       {!ready && (


### PR DESCRIPTION
## Summary
Subtitle on Zoom + StreamYard broadcast buttons now uses inline style `{ color: '#ffffff', textShadow: '0 1px 2px rgba(0,0,0,0.15)' }` instead of class-based color. Inline styles win against the GPP theme's class-overrides regardless of !important. Subtle shadow gives the text definition on the red background without changing the color.

## Test plan
- [ ] Zoom subtitle clearly readable as pure white on red
- [ ] StreamYard subtitle same
- [ ] No regression to button label or other broadcast card content
- [ ] Same effect on GPP-themed pages and elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)