### PR TITLE
feat(bresaola-19384): move AnnouncementHistory to left column under Announce

### DIFF
--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -92,6 +92,13 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           onSent={() => setAnnHistoryKey((k) => k + 1)}
         />
       </CollapsibleCard>
+      <CollapsibleCard
+        id="announcement-history"
+        partyId={party.id}
+        title="Sent today"
+      >
+        <AnnouncementHistory partyId={party.id} refreshKey={annHistoryKey} />
+      </CollapsibleCard>
     </>
   );
 
@@ -147,13 +154,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           <PizzaBoxStackCard party={party} />
         </CollapsibleCard>
       )}
-      <CollapsibleCard
-        id="announcement-history"
-        partyId={party.id}
-        title="Sent today"
-      >
-        <AnnouncementHistory partyId={party.id} refreshKey={annHistoryKey} />
-      </CollapsibleCard>
     </>
   );
 


### PR DESCRIPTION
## Summary
Moves `AnnouncementHistory` from the right column to the left column, immediately under `AnnouncePanel`. Keeps the announcement send + history surfaces side-by-side.

## Final column order
**Left**: Pizza · Music · SWC · Announce · **AnnouncementHistory**
**Right**: Stream-on-Screen · Broadcast · Briefing · Photo · SignedBox · BoxStack

🤖 Generated with [Claude Code](https://claude.com/claude-code)