### PR TITLE
fix(provolone-58291): hide cancelled events on /underboss

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -787,6 +787,11 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
       whereClause = scopedWhere ? { AND: [base, scopedWhere] } : base;
     }
 
+    // porchetta-81402 + provolone-58291: hide cancelled events from underboss
+    // list/stats/rollups, mirroring sponsor-user behavior. Cancelled events
+    // remain reachable by direct ID via /:region/events/:partyId.
+    whereClause = { ...whereClause, cancelledAt: null };
+
     // quattro-12847: appeals-only narrows further to events with at least one
     // unreviewed appeal in history.
     if (appealsOnly) {
@@ -884,7 +889,10 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
     }
 
     const scopedWhere = buildScopedWhereClause(scope);
-    const base: any = { region, eventType: 'gpp' as const };
+    // porchetta-81402 + provolone-58291: hide cancelled events from underboss
+    // paginated event list, mirroring sponsor-user behavior. `count` shares the
+    // same `where`, so pagination totals stay in sync with the visible rows.
+    const base: any = { region, eventType: 'gpp' as const, cancelledAt: null };
     if (appealsOnly) {
       base.reimbursementCapAppeals = { some: { reviewedAt: null } };
     }
@@ -1053,7 +1061,9 @@ router.get('/:region/stats', requireAuth, requireUnderbossAuth, async (req: Unde
     }
 
     const scopedWhere = buildScopedWhereClause(scope);
-    const base = { region, eventType: 'gpp' as const };
+    // porchetta-81402 + provolone-58291: hide cancelled events from underboss
+    // aggregate stats, mirroring sponsor-user behavior.
+    const base = { region, eventType: 'gpp' as const, cancelledAt: null };
     const where: any = scopedWhere ? { AND: [base, scopedWhere] } : base;
 
     const [events, allUnderbosses] = await Promise.all([

--- a/plans/provolone-58291-underboss-hide-cancelled.md
+++ b/plans/provolone-58291-underboss-hide-cancelled.md
@@ -1,0 +1,29 @@
+# provolone-58291 — Underboss hides cancelled events
+
+## Problem
+
+The deployed `/api/sponsor/events` (partner endpoint) filters out cancelled events via `where.cancelledAt = null` (porchetta-81402). The `/api/underboss/:region` endpoints do NOT — they include cancelled events in event lists, region stats, RSVP/approved totals, and city rollups. Per porchetta-81402's commit message:
+
+> GPP + sponsor-user list endpoints filter out cancelled events; underboss + admin endpoints keep them visible (badged) so an underboss can spot churn in their region.
+
+Snax has decided to reverse that "keep visible (badged)" choice for the underboss dashboard: hide cancelled events outright, no toggle, no filter chip. The cancel/uncancel escape hatch already lives on the event-detail page.
+
+## Implementation
+
+Edit `backend/src/routes/underboss.routes.ts`, add `cancelledAt: null` to three handler whereClauses:
+
+1. `GET /:region` — after the `let whereClause = ...` if/else block, add `whereClause = { ...whereClause, cancelledAt: null };`
+2. `GET /:region/events` — add `cancelledAt: null` to BOTH the `prisma.party.findMany` where AND the `prisma.party.count` where
+3. `GET /:region/stats` — add `cancelledAt: null` to the `prisma.party.findMany` where
+
+## Deliberately NOT touched
+
+- `GET /:region/events/:partyId` (single event by ID) — admins still need to open cancelled events to uncancel them. Detail page is the home of the uncancel UI.
+- All `bulk-*` endpoints — operate on explicit IDs from admin
+- Co-host sync queries (`/admin/create`, `/admin/:id`, `backfill-cohosts`) — should still keep bookkeeping current for cancelled events in case of reinstatement
+
+## Frontend
+
+Zero changes. Backend filter propagates through `events` props to `EventTable`, `CitiesTable`, `RegionStats` automatically.
+
+## No migration, no new tests


### PR DESCRIPTION
## Summary
- Adds `cancelledAt: null` to the three `/api/underboss/:region` list/stats/paginated-events handlers, mirroring `/api/sponsor/events` (porchetta-81402).
- Cancelled events drop out of the underboss dashboard, region stats, and city rollups.
- Single-event detail endpoint, bulk endpoints, and co-host sync queries deliberately keep cancelled events visible.

## Why
Snax noticed /underboss showed 415 approved events while /partner showed 399 — the 16-event delta was approved-but-cancelled events that /partner already hides. This brings /underboss in line.

## Test plan
- [ ] Sign in as admin, load `/underboss` (all regions), confirm "Events (N)" tab count dropped by ~16
- [ ] Spot-check RegionStats: totalEvents / totalRsvps / totalApproved all decreased
- [ ] Spot-check CitiesTable: cities whose only event was cancelled drop off
- [ ] Direct-load `/underboss/<region>/event/<known-cancelled-id>` — detail page still loads (verifies single-event endpoint carve-out)
- [ ] Open Network tab, confirm `GET /api/underboss/:region/events?page=1` total dropped by same delta as the dashboard count (guards pagination off-by-N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)