### PR TITLE
feat(margherita-43821): public /photos feed + auto-star host uploads

### DIFF
--- a/backend/prisma/migrations/20260522000000_add_photo_feed_index/migration.sql
+++ b/backend/prisma/migrations/20260522000000_add_photo_feed_index/migration.sql
@@ -1,0 +1,14 @@
+-- margherita-43821: composite index supporting GET /api/photos/feed.
+-- Filters: starred=true AND status='approved' (+ joins into Party for
+-- underbossStatus/photosPublic/photosEnabled), ordered by (created_at DESC,
+-- id DESC) for cursor pagination. The leading (starred, status) columns are
+-- highly selective even before the orderBy kicks in.
+--
+-- NOTE: Prisma wraps migrations in a single transaction, so we use the plain
+-- non-CONCURRENTLY form here. In prod we will apply this via Supabase MCP
+-- using the CONCURRENTLY variant to avoid an exclusive lock on `photos`:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "photos_starred_status_created_at_id_idx"
+--     ON "photos" ("starred", "status", "created_at" DESC, "id" DESC);
+CREATE INDEX IF NOT EXISTS "photos_starred_status_created_at_id_idx"
+  ON "photos" ("starred", "status", "created_at" DESC, "id" DESC);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -725,6 +725,8 @@ model Photo {
   @@index([partyId, createdAt])
   @@index([partyId, starred])
   @@index([partyId, status])
+  // margherita-43821: composite index supporting GET /api/photos/feed
+  @@index([starred, status, createdAt(sort: Desc), id(sort: Desc)])
   @@map("photos")
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import userRoutes from './routes/user.routes.js';
 import eventRoutes from './routes/event.routes.js';
 import nftRoutes from './routes/nft.routes.js';
 import photoRoutes from './routes/photo.routes.js';
+import photoFeedRoutes from './routes/photo-feed.routes.js';
 import kitRoutes from './routes/kit.routes.js';
 import gppRoutes from './routes/gpp.routes.js';
 import donationRoutes from './routes/donation.routes.js';
@@ -145,6 +146,7 @@ app.use('/api/sponsor-users', quizTemplateRoutes); // Quiz template CRUD (admin)
 app.use('/api/sponsor', sponsorDashboardRouter); // Sponsor dashboard (login-based auth)
 app.use('/api/shipping', shippingRoutes); // Shipping coordinator dashboard
 app.use('/api/auth', authRoutes);
+app.use('/api/photos', photoFeedRoutes); // margherita-43821: public global photos feed
 app.use('/api/parties', photoRoutes); // Photo routes first (some are public)
 app.use('/api/parties', hostTelegramRoutes); // Host Telegram connect/disconnect routes (host only)
 app.use('/api/parties', kitRoutes);   // Kit routes for party kit requests

--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -1,0 +1,103 @@
+import { Router, Response, NextFunction, Request } from 'express';
+import { prisma } from '../config/database.js';
+
+const router = Router();
+const DEFAULT_LIMIT = 24;
+const MAX_LIMIT = 50;
+
+function parseCursor(raw: unknown): { createdAt: Date; id: string } | null {
+  if (typeof raw !== 'string' || !raw.includes('_')) return null;
+  const sepIdx = raw.lastIndexOf('_');
+  const ts = raw.slice(0, sepIdx);
+  const id = raw.slice(sepIdx + 1);
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime()) || !id) return null;
+  return { createdAt: d, id };
+}
+
+router.get('/feed', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const limit = Math.min(
+      Math.max(parseInt((req.query.limit as string) || String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT, 1),
+      MAX_LIMIT
+    );
+    const cursor = parseCursor(req.query.cursor);
+
+    const where: any = {
+      starred: true,
+      status: 'approved',
+      party: {
+        is: {
+          underbossStatus: 'approved',
+          photosPublic: true,
+          photosEnabled: true,
+        },
+      },
+    };
+
+    if (cursor) {
+      where.OR = [
+        { createdAt: { lt: cursor.createdAt } },
+        { AND: [{ createdAt: cursor.createdAt }, { id: { lt: cursor.id } }] },
+      ];
+    }
+
+    const rows = await prisma.photo.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        url: true,
+        thumbnailUrl: true,
+        caption: true,
+        mimeType: true,
+        duration: true,
+        width: true,
+        height: true,
+        createdAt: true,
+        party: {
+          select: {
+            id: true,
+            name: true,
+            customUrl: true,
+            inviteCode: true,
+            city: true,
+            country: true,
+          },
+        },
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore
+      ? `${page[page.length - 1].createdAt.toISOString()}_${page[page.length - 1].id}`
+      : null;
+
+    res.json({
+      photos: page.map((p) => ({
+        id: p.id,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        mimeType: p.mimeType,
+        duration: p.duration,
+        width: p.width,
+        height: p.height,
+        createdAt: p.createdAt,
+        party: {
+          slug: p.party.customUrl || p.party.inviteCode,
+          name: p.party.name,
+          city: p.party.city,
+          country: p.party.country,
+        },
+      })),
+      nextCursor,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -228,7 +228,7 @@ router.post('/:partyId/photos/batch-review', requireAuth, async (req: AuthReques
 });
 
 // POST /api/parties/:partyId/photos - Upload a new photo (requires guest identity or auth)
-router.post('/:partyId/photos', async (req: AuthRequest, res: Response, next: NextFunction) => {
+router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId } = req.params;
     const {
@@ -322,8 +322,13 @@ router.post('/:partyId/photos', async (req: AuthRequest, res: Response, next: Ne
       }
     }
 
-    // All photos/videos require approval
-    const initialStatus = 'pending';
+    // margherita-43821: host uploads (owner / co-host w/ canEdit / super-admin /
+    // GPP editor) are auto-approved + auto-starred so they appear in /photos
+    // immediately. Guest uploads still go through pending moderation.
+    const isHostUpload = await canUserEditParty(partyId, req.userId, req.userEmail);
+    const initialStatus = isHostUpload ? 'approved' : 'pending';
+    const initialStarred = isHostUpload ? true : false;
+    const now = new Date();
 
     const photo = await prisma.photo.create({
       data: {
@@ -343,6 +348,10 @@ router.post('/:partyId/photos', async (req: AuthRequest, res: Response, next: Ne
         photoYear: photoYear ? parseInt(photoYear, 10) : null,
         duration: isVideo && duration ? duration : null,
         status: initialStatus,
+        starred: initialStarred,
+        starredAt: initialStarred ? now : null,
+        reviewedAt: isHostUpload ? now : null,
+        reviewedBy: isHostUpload ? (req.userId || null) : null,
       },
       include: {
         guest: { select: { id: true, name: true } },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import { GPPPizzeriasPage } from './pages/GPPPizzeriasPage';
 import { EventsMapPage } from './pages/EventsMapPage';
 import { AdminLogoCleanup } from './pages/AdminLogoCleanup';
 import { PartnersPage } from './pages/PartnersPage';
+import { PhotosFeedPage } from './pages/PhotosFeedPage';
 
 // Legacy redirect: /sponsor-intake/:token → /partner-intake/:token
 // <Navigate> doesn't forward path params, so we wrap useParams().
@@ -65,6 +66,8 @@ function App() {
             <Route path="/partners" element={<PartnersPage />} />
             {/* /payments must come before /:slug */}
             <Route path="/payments" element={<PaymentsAdminPage />} />
+            {/* margherita-43821: /photos public global feed; must come before /:slug */}
+            <Route path="/photos" element={<PhotosFeedPage />} />
             <Route path="/account" element={<AccountPage />} />
             <Route path="/auth/verify" element={<AuthVerifyPage />} />
             <Route path="/report/:slug" element={<PublicReportPage />} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4598,3 +4598,43 @@ export async function resolveEnsName(name: string): Promise<string | null> {
     return null;
   }
 }
+
+// ============================================
+// margherita-43821: public photos feed
+// ============================================
+
+export interface FeedPhoto {
+  id: string;
+  url: string;
+  thumbnailUrl: string | null;
+  caption: string | null;
+  mimeType: string;
+  duration: number | null;
+  width: number | null;
+  height: number | null;
+  createdAt: string;
+  party: { slug: string; name: string; city: string | null; country: string | null };
+}
+
+export interface PhotosFeedResponse {
+  photos: FeedPhoto[];
+  nextCursor: string | null;
+}
+
+export async function getPhotosFeed(
+  cursor: string | null,
+  limit: number = 24
+): Promise<PhotosFeedResponse | null> {
+  try {
+    const params = new URLSearchParams();
+    if (cursor) params.append('cursor', cursor);
+    params.append('limit', String(limit));
+    return await apiRequest<PhotosFeedResponse>(
+      `/api/photos/feed?${params.toString()}`,
+      { method: 'GET', requireAuth: false }
+    );
+  } catch (e) {
+    console.error('Error fetching photos feed:', e);
+    return null;
+  }
+}

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { Loader2, Play, MapPin } from 'lucide-react';
+import { Layout } from '../components/Layout';
+import { cdnUrl } from '../lib/supabase';
+import { getPhotosFeed, FeedPhoto } from '../lib/api';
+
+export function PhotosFeedPage() {
+  const [photos, setPhotos] = useState<FeedPhoto[]>([]);
+  const [, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<FeedPhoto | null>(null);
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const cursorRef = useRef<string | null>(null);
+  const loadingRef = useRef(false);
+  const hasMoreRef = useRef(true);
+
+  const loadPage = useCallback(async (isInitial: boolean) => {
+    if (loadingRef.current || !hasMoreRef.current) return;
+    loadingRef.current = true;
+    if (isInitial) setLoading(true); else setLoadingMore(true);
+    setError(null);
+    try {
+      const res = await getPhotosFeed(cursorRef.current);
+      if (!res) {
+        setError('Could not load photos right now.');
+        hasMoreRef.current = false;
+        setHasMore(false);
+      } else {
+        setPhotos(prev => isInitial ? res.photos : [...prev, ...res.photos]);
+        cursorRef.current = res.nextCursor;
+        setCursor(res.nextCursor);
+        hasMoreRef.current = !!res.nextCursor;
+        setHasMore(!!res.nextCursor);
+      }
+    } catch {
+      setError('Could not load photos right now.');
+    } finally {
+      loadingRef.current = false;
+      if (isInitial) setLoading(false); else setLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => { loadPage(true); }, [loadPage]);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    const obs = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) loadPage(false);
+    }, { rootMargin: '600px 0px' });
+    obs.observe(sentinelRef.current);
+    return () => obs.disconnect();
+  }, [loadPage]);
+
+  useEffect(() => {
+    if (!selected) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setSelected(null); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selected]);
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>Photos from Pizza Parties Around the World | RSV.Pizza</title>
+        <meta name="description" content="A live feed of starred photos from approved pizza parties hosted around the world." />
+        <meta property="og:title" content="Pizza Party Photos" />
+        <meta property="og:description" content="A live feed of starred photos from approved pizza parties hosted around the world." />
+      </Helmet>
+
+      <div className="max-w-[1400px] mx-auto px-4 py-8">
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold text-theme-text">Photos</h1>
+          <p className="text-theme-text-secondary mt-1">Highlights from pizza parties around the world.</p>
+        </header>
+
+        {loading && photos.length === 0 ? (
+          <SkeletonGrid />
+        ) : photos.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="columns-2 sm:columns-3 lg:columns-4 xl:columns-5 gap-3 [column-fill:_balance]">
+            {photos.map(p => <FeedTile key={p.id} photo={p} onOpen={() => setSelected(p)} />)}
+          </div>
+        )}
+
+        <div ref={sentinelRef} className="h-12" />
+        {loadingMore && (
+          <div className="flex justify-center py-6">
+            <Loader2 className="w-6 h-6 text-theme-text-muted animate-spin" />
+          </div>
+        )}
+        {error && (
+          <div className="text-center py-6">
+            <p className="text-amber-400">{error}</p>
+            <button onClick={() => { hasMoreRef.current = true; setHasMore(true); loadPage(false); }} className="mt-2 underline text-theme-text">Try again</button>
+          </div>
+        )}
+        {!hasMore && photos.length > 0 && !error && (
+          <p className="text-center text-theme-text-muted py-6 text-sm">You've reached the end.</p>
+        )}
+      </div>
+
+      {selected && <FeedLightbox photo={selected} onClose={() => setSelected(null)} />}
+    </Layout>
+  );
+}
+
+function FeedTile({ photo, onOpen }: { photo: FeedPhoto; onOpen: () => void }) {
+  const isVideo = photo.mimeType?.startsWith('video/');
+  const src = cdnUrl(photo.url);
+  return (
+    <button onClick={onOpen} className="mb-3 block w-full break-inside-avoid rounded-lg overflow-hidden bg-theme-surface hover:opacity-90 transition-opacity">
+      <div className="relative">
+        {isVideo ? (
+          <>
+            <video src={src} preload="metadata" muted className="w-full h-auto block" />
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <div className="bg-black/50 rounded-full p-3">
+                <Play size={24} className="text-white fill-white" />
+              </div>
+            </div>
+          </>
+        ) : (
+          <img src={src} alt={photo.caption || ''} loading="lazy" className="w-full h-auto block" />
+        )}
+      </div>
+      {(photo.party.city || photo.party.name) && (
+        <div className="px-2 py-1.5 text-xs text-theme-text-muted flex items-center gap-1">
+          <MapPin size={11} />
+          <span className="truncate">{photo.party.city || photo.party.name}</span>
+        </div>
+      )}
+    </button>
+  );
+}
+
+function FeedLightbox({ photo, onClose }: { photo: FeedPhoto; onClose: () => void }) {
+  const isVideo = photo.mimeType?.startsWith('video/');
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4" onClick={onClose}>
+      <div className="max-w-5xl w-full max-h-[90vh] bg-theme-header rounded-xl overflow-hidden flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="flex-1 flex items-center justify-center bg-black min-h-0">
+          {isVideo ? (
+            <video src={cdnUrl(photo.url)} controls autoPlay className="max-w-full max-h-[75vh]" />
+          ) : (
+            <img src={cdnUrl(photo.url)} alt={photo.caption || ''} className="max-w-full max-h-[75vh] object-contain" />
+          )}
+        </div>
+        <div className="p-4 border-t border-theme-stroke">
+          {photo.caption && <p className="text-theme-text mb-2">{photo.caption}</p>}
+          <p className="text-theme-text-muted text-sm flex items-center gap-2">
+            <MapPin size={12} />
+            <Link to={`/${photo.party.slug}`} className="hover:underline text-theme-text">{photo.party.name}</Link>
+            {photo.party.city && <span>· {photo.party.city}{photo.party.country ? `, ${photo.party.country}` : ''}</span>}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonGrid() {
+  return (
+    <div className="columns-2 sm:columns-3 lg:columns-4 xl:columns-5 gap-3">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <div key={i} className="mb-3 w-full rounded-lg bg-theme-surface animate-pulse" style={{ aspectRatio: i % 3 === 0 ? '3 / 4' : i % 3 === 1 ? '1 / 1' : '4 / 5' }} />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="text-center py-20">
+      <p className="text-theme-text text-lg">No starred photos yet.</p>
+      <p className="text-theme-text-muted mt-2">Check back after the next pizza party.</p>
+    </div>
+  );
+}

--- a/plans/margherita-43821-photos-feed.md
+++ b/plans/margherita-43821-photos-feed.md
@@ -1,0 +1,184 @@
+# Plan: Public Photos Feed at `/photos`
+
+**Task ID:** `margherita-43821-photos-feed`
+**Branch:** `margherita-43821-photos-feed` (off `origin/master`)
+
+## 1. Problem & Goal
+
+Today there's no way to browse photos and videos across all approved RSV.Pizza/GPP parties — they're only visible on the individual event page galleries. We need a public `/photos` page that aggregates "best of" media globally, latest first, so visitors can discover events at a glance. Host-uploaded media auto-stars on upload (curation by default); guest uploads still require manual starring by the host, preserving the existing moderation model.
+
+## 2. Approach Summary
+
+Add one new public backend endpoint (`GET /api/photos/feed`) that joins `Photo` and `Party` and returns starred+approved photos from approved parties, cursor-paginated by `(createdAt DESC, id DESC)`. Modify `POST /api/parties/:partyId/photos` so when the uploader is the party owner or a co-host with `canEdit:true`, the photo is created with `status='approved'` and `starred:true`. Frontend adds a `PhotosFeedPage` at `/photos` (above the `/:slug` catch-all), with IntersectionObserver-driven infinite scroll over a CSS-column masonry layout, and a click-to-open lightbox modal. A new composite index supports the feed query at scale.
+
+## 3. Backend Changes
+
+### 3.1 photo.routes.ts — auto-star host uploads
+
+Add `optionalAuth` to the `POST /:partyId/photos` route. Use the existing `canUserEditParty(partyId, req.userId, req.userEmail)` helper to detect host uploads and branch `initialStatus` / `initialStarred`:
+
+```ts
+router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res, next) => {
+  // ...existing validation...
+
+  const isHostUpload = await canUserEditParty(partyId, req.userId, req.userEmail);
+  const initialStatus = isHostUpload ? 'approved' : 'pending';
+  const initialStarred = isHostUpload ? true : false;
+  const now = new Date();
+
+  const photo = await prisma.photo.create({
+    data: {
+      // ...existing fields...
+      status: initialStatus,
+      starred: initialStarred,
+      starredAt: initialStarred ? now : null,
+      reviewedAt: isHostUpload ? now : null,
+      reviewedBy: isHostUpload ? (req.userId || null) : null,
+    },
+    include: { guest: { select: { id: true, name: true } } },
+  });
+  // ...
+});
+```
+
+### 3.2 photo-feed.routes.ts — new file
+
+```ts
+import { Router, Response, NextFunction, Request } from 'express';
+import { prisma } from '../config/database.js';
+
+const router = Router();
+const DEFAULT_LIMIT = 24;
+const MAX_LIMIT = 50;
+
+function parseCursor(raw: unknown): { createdAt: Date; id: string } | null {
+  if (typeof raw !== 'string' || !raw.includes('_')) return null;
+  const sepIdx = raw.lastIndexOf('_');
+  const ts = raw.slice(0, sepIdx);
+  const id = raw.slice(sepIdx + 1);
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime()) || !id) return null;
+  return { createdAt: d, id };
+}
+
+router.get('/feed', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const limit = Math.min(
+      Math.max(parseInt((req.query.limit as string) || String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT, 1),
+      MAX_LIMIT
+    );
+    const cursor = parseCursor(req.query.cursor);
+
+    const where: any = {
+      starred: true,
+      status: 'approved',
+      party: {
+        is: {
+          underbossStatus: 'approved',
+          photosPublic: true,
+          photosEnabled: true,
+        },
+      },
+    };
+
+    if (cursor) {
+      where.OR = [
+        { createdAt: { lt: cursor.createdAt } },
+        { AND: [{ createdAt: cursor.createdAt }, { id: { lt: cursor.id } }] },
+      ];
+    }
+
+    const rows = await prisma.photo.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      select: {
+        id: true, url: true, thumbnailUrl: true, caption: true,
+        mimeType: true, duration: true, width: true, height: true, createdAt: true,
+        party: { select: { id: true, name: true, customUrl: true, inviteCode: true, city: true, country: true } },
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore
+      ? `${page[page.length - 1].createdAt.toISOString()}_${page[page.length - 1].id}`
+      : null;
+
+    res.json({
+      photos: page.map(p => ({
+        id: p.id, url: p.url, thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption, mimeType: p.mimeType, duration: p.duration,
+        width: p.width, height: p.height, createdAt: p.createdAt,
+        party: {
+          slug: p.party.customUrl || p.party.inviteCode,
+          name: p.party.name, city: p.party.city, country: p.party.country,
+        },
+      })),
+      nextCursor,
+    });
+  } catch (error) { next(error); }
+});
+
+export default router;
+```
+
+### 3.3 index.ts — mount router
+
+```ts
+import photoFeedRoutes from './routes/photo-feed.routes.js';
+// ...
+app.use('/api/photos', photoFeedRoutes);
+app.use('/api/parties', photoRoutes);
+```
+
+### 3.4 schema.prisma — index
+
+```prisma
+@@index([starred, status, createdAt(sort: Desc), id(sort: Desc)])
+```
+
+### 3.5 Migration file content
+
+```sql
+CREATE INDEX IF NOT EXISTS "photos_starred_status_created_at_id_idx"
+  ON "photos" ("starred", "status", "created_at" DESC, "id" DESC);
+```
+
+## 4. Frontend Changes
+
+### 4.1 PhotosFeedPage.tsx — new file
+
+Full source per plan: masonry CSS-column grid, IntersectionObserver infinite scroll, lightbox modal, react-helmet-async, cdnUrl wrapping, video poster + play overlay, Esc-to-close, retry on error, empty/loading skeleton states.
+
+### 4.2 api.ts — add helper
+
+```ts
+export interface FeedPhoto {
+  id: string; url: string; thumbnailUrl: string | null; caption: string | null;
+  mimeType: string; duration: number | null; width: number | null; height: number | null;
+  createdAt: string;
+  party: { slug: string; name: string; city: string | null; country: string | null };
+}
+export interface PhotosFeedResponse { photos: FeedPhoto[]; nextCursor: string | null }
+export async function getPhotosFeed(cursor: string | null, limit: number = 24): Promise<PhotosFeedResponse | null> {
+  try {
+    const params = new URLSearchParams();
+    if (cursor) params.append('cursor', cursor);
+    params.append('limit', String(limit));
+    return await apiRequest<PhotosFeedResponse>(`/api/photos/feed?${params.toString()}`, { method: 'GET', requireAuth: false });
+  } catch (e) { console.error('Error fetching photos feed:', e); return null; }
+}
+```
+
+### 4.3 App.tsx — route
+
+```tsx
+import { PhotosFeedPage } from './pages/PhotosFeedPage';
+// ...
+<Route path="/photos" element={<PhotosFeedPage />} />  // MUST be above /:slug catch-all
+```
+
+## 5–10
+
+(Migration applied first via Supabase MCP in prod; then backend ships; then frontend. No backfill. Defer Header nav link. Index, route precedence, body-parser order, co-host canEdit semantics noted as risks.)


### PR DESCRIPTION
## Summary
- New public page at /photos showing a global feed of starred photos from approved parties (masonry grid, infinite scroll, lightbox)
- New endpoint GET /api/photos/feed (public, cursor-paginated, joins Photo + Party with full filter chain)
- Host uploads (owner / co-host w/ canEdit / super-admin / GPP editor) now auto-star + auto-approve on upload — guest uploads unchanged
- New composite index photos_starred_status_created_at_id_idx supporting the feed query

## Deploy order
1. Apply migration to prod via Supabase MCP (CONCURRENTLY) before merge
2. Merge → backend deploys from master
3. Frontend auto-deploys

## Test plan
- [ ] GET /api/photos/feed returns up to 24 photos, all starred+approved, all from approved+photosPublic parties
- [ ] Cursor pagination: page 2 returns strictly older createdAt
- [ ] Unapproved party's starred photos NOT in feed
- [ ] Host upload while logged in → DB row has starred=true, status='approved', reviewed_at populated
- [ ] Guest upload → starred=false, status='pending' (unchanged)
- [ ] /photos renders the feed (not EventPage 404)
- [ ] Lightbox opens on tile click, closes on Esc / backdrop click
- [ ] Vercel preview: https://rsvpizza-git-margherita-43821-photos-feed-pizza-dao.vercel.app/photos

Plan: plans/margherita-43821-photos-feed.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)