### PR TITLE
salame-83472: unified search on payouts queue (host name + email + party name)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -192,11 +192,19 @@ function buildPayoutWhere(query: Request['query']): any {
     where.partyId = partyId.trim();
   }
 
-  const hostEmail = query.hostEmail;
-  if (typeof hostEmail === 'string' && hostEmail.trim().length > 0) {
-    where.host = {
-      email: { contains: hostEmail.trim().toLowerCase(), mode: 'insensitive' as const },
-    };
+  // salame-83472: unified search — matches host.email, host.name, OR party.name
+  // (case-insensitive contains). Replaces the previous `hostEmail`-only filter.
+  // The implicit AND with the existing top-level `where.party` (underbossStatus
+  // 'approved' from tartufo-58291 + optional country from bruschetta-58291) is
+  // preserved by Prisma because top-level OR is AND'd with other top-level keys.
+  const search = query.search;
+  if (typeof search === 'string' && search.trim().length > 0) {
+    const needle = search.trim();
+    where.OR = [
+      { host: { email: { contains: needle, mode: 'insensitive' as const } } },
+      { host: { name: { contains: needle, mode: 'insensitive' as const } } },
+      { party: { name: { contains: needle, mode: 'insensitive' as const } } },
+    ];
   }
 
   const currency = query.currency;

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Search, Mail, X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type { AdminPayoutFilters, PayoutMethod, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
@@ -75,14 +75,14 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-6 gap-2 items-start">
-        {/* Host search */}
+        {/* salame-83472: unified search — host email|name OR party name. */}
         <div className="md:col-span-2">
           <IconInput
-            icon={Mail}
+            icon={Search}
             type="search"
-            placeholder="Filter by host email"
-            value={filters.hostEmail || ''}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ hostEmail: e.target.value })}
+            placeholder="Search hosts and parties"
+            value={filters.search || ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ search: e.target.value })}
           />
         </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3878,7 +3878,8 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.status && filters.status !== 'all') params.set('status', filters.status);
   if (filters.payoutMethod && filters.payoutMethod !== 'all') params.set('payoutMethod', filters.payoutMethod);
   if (filters.partyId) params.set('partyId', filters.partyId);
-  if (filters.hostEmail) params.set('hostEmail', filters.hostEmail);
+  // salame-83472: unified search — host email|name OR party name.
+  if (filters.search) params.set('search', filters.search);
   // bruschetta-58291: country filter — exact-match `parties.country`.
   if (filters.country && filters.country !== 'all') params.set('country', filters.country);
   if (filters.currency && filters.currency !== 'all') params.set('currency', filters.currency);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1633,7 +1633,8 @@ export interface AdminPayoutFilters {
   status?: PayoutStatus | 'all';
   payoutMethod?: PayoutMethod | 'all';
   partyId?: string;
-  hostEmail?: string;
+  /** salame-83472: unified search — host email|name OR party name (case-insensitive contains). */
+  search?: string;
   /** bruschetta-58291: country filter — exact-match `parties.country`. `'all'` / undefined = no filter. */
   country?: string;
   currency?: string;


### PR DESCRIPTION
## Summary

Expands the host-email-only filter on the admin `/payments` PayoutsFilterBar into a single unified search input that matches `host.email`, `host.name`, **or** `party.name` (case-insensitive contains). The separate Party ID exact-match input is preserved for UUID lookups.

## Changes

- **Backend** `backend/src/routes/admin-payout.routes.ts` (`buildPayoutWhere`): replaces the `hostEmail` clause with a top-level `where.OR` covering the three fields. The existing top-level `where.party = { underbossStatus: 'approved', ...countryClause }` (tartufo-58291 + bruschetta-58291) is untouched and Prisma AND's the two top-level keys.
- **Frontend types** `frontend/src/types.ts`: renames `AdminPayoutFilters.hostEmail` -> `search`.
- **Frontend API client** `frontend/src/lib/api.ts` (`buildPayoutQuery`): serializes `filters.search` -> `?search=...` query param.
- **Frontend FilterBar** `frontend/src/components/payments-admin/PayoutsFilterBar.tsx`: icon Mail -> Search, placeholder "Search hosts and parties", removed unused `Mail` import.

## Param rename

The legacy `?hostEmail=` query param on `GET /api/admin/payouts` is replaced by `?search=`. This endpoint is admin-only and has no external consumers, so no compatibility shim is needed.

## Deploy caveat

Backend must be deployed from `master` before the new param takes effect on the frontend preview. Preview previews talk to production backend, so until backend redeploys, `?search=` is a no-op (returns all unfiltered) but does not error.

## Test plan

- [ ] Vercel preview loads `/payments` for an admin user
- [ ] Typing a host name in the search input filters the table to that host's payouts
- [ ] Typing a host email filters as before
- [ ] Typing a party name filters to payouts attached to that party
- [ ] Party ID exact-match input still works independently
- [ ] Reset filters clears the search input
- [ ] `cd backend && npx tsc --noEmit` shows no new errors in `admin-payout.routes.ts`
- [ ] `cd frontend && npx tsc --noEmit` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)