### PR TITLE
feat(parmigiana-89172): inline 'already paid' total per party on /payments

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -173,6 +173,37 @@ function escapeCSV(value: string): string {
   return value;
 }
 
+/**
+ * parmigiana-89172: aggregate `status === 'paid'` payout totals per party in a
+ * single groupBy query. Used to surface an "Already paid" warning inline on
+ * both the prepay queue rows AND the admin payouts table rows, so admins don't
+ * accidentally double-pay (Osogbo, Seropédica, Dar es Salaam all got two USDC
+ * sends within hours of each other before this landed).
+ *
+ * Returns a Map keyed by partyId so callers can do O(1) lookups. Parties with
+ * no paid payouts are simply absent from the map — callers should default to
+ * `{ paidUsd: 0, paidCount: 0 }` for those.
+ */
+async function fetchPaidTotalsByParty(
+  partyIds: string[],
+): Promise<Map<string, { paidUsd: number; paidCount: number }>> {
+  if (partyIds.length === 0) return new Map();
+  const rows = await prisma.payout.groupBy({
+    by: ['partyId'],
+    where: { partyId: { in: partyIds }, status: 'paid' },
+    _sum: { finalAmountUsd: true },
+    _count: { id: true },
+  });
+  const m = new Map<string, { paidUsd: number; paidCount: number }>();
+  for (const r of rows) {
+    m.set(r.partyId, {
+      paidUsd: r._sum.finalAmountUsd ? Number(r._sum.finalAmountUsd.toString()) : 0,
+      paidCount: r._count.id,
+    });
+  }
+  return m;
+}
+
 /** Build a Prisma `where` clause from query-string filters. */
 function buildPayoutWhere(query: Request['query']): any {
   const where: any = {};
@@ -874,7 +905,22 @@ router.get(
           hasMultipleCandidates: r.candidates.length > 1,
         }));
 
-      res.json({ rows: finalRows });
+      // parmigiana-89172: attach per-party "already paid" totals so the
+      // admin sees inline warning before clicking Create Prepayment again.
+      // Single aggregate query keyed by partyId; default 0/0 for parties
+      // with no prior paid payouts.
+      const finalPartyIds = finalRows.map(r => r.party.id);
+      const paidTotals = await fetchPaidTotalsByParty(finalPartyIds);
+      const rowsWithPaidTotals = finalRows.map(r => {
+        const totals = paidTotals.get(r.party.id);
+        return {
+          ...r,
+          partyPaidUsd: totals?.paidUsd ?? 0,
+          partyPaidCount: totals?.paidCount ?? 0,
+        };
+      });
+
+      res.json({ rows: rowsWithPaidTotals });
     } catch (error) {
       next(error);
     }
@@ -1180,8 +1226,31 @@ router.get(
         (a, b) => b.totalPaidUsd - a.totalPaidUsd,
       );
 
+      // parmigiana-89172: attach a per-party "already paid" rollup to each
+      // row's nested `party` object so the PayoutsTable can render an
+      // inline "Already paid: $X (N)" warning under the event name. Per
+      // PARTY, not per payout — collect the unique partyIds in the page
+      // and run one aggregate query.
+      const pagePartyIds = Array.from(
+        new Set(
+          page
+            .map(p => (p as any).party?.id)
+            .filter((id): id is string => typeof id === 'string' && id.length > 0),
+        ),
+      );
+      const pagePaidTotals = await fetchPaidTotalsByParty(pagePartyIds);
+      const serializedPayouts = page.map(p => {
+        const serialized = serializePayout(p);
+        if (serialized.party?.id) {
+          const totals = pagePaidTotals.get(serialized.party.id);
+          serialized.party.paidTotalUsd = totals?.paidUsd ?? 0;
+          serialized.party.paidTotalCount = totals?.paidCount ?? 0;
+        }
+        return serialized;
+      });
+
       res.json({
-        payouts: page.map(serializePayout),
+        payouts: serializedPayouts,
         nextCursor,
         totals: {
           byStatus,

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -124,6 +124,22 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                         {row.party.country}
                       </div>
                     )}
+                    {/* parmigiana-89172: inline "already paid" total so the
+                        admin sees prior payouts to this party before clicking
+                        Create prepayment again. Amber when the paid total has
+                        reached or exceeded the effective cap. */}
+                    {row.partyPaidCount > 0 && (
+                      <div
+                        className={`text-[11px] mt-0.5 ${
+                          row.party.effectiveReimbursementCapUsd != null &&
+                          row.partyPaidUsd >= row.party.effectiveReimbursementCapUsd
+                            ? 'text-amber-300'
+                            : 'text-theme-text-muted'
+                        }`}
+                      >
+                        Already paid: ${row.partyPaidUsd.toFixed(2)} ({row.partyPaidCount})
+                      </div>
+                    )}
                   </td>
                   <td className="px-3 py-3 align-top">
                     <div className="flex flex-wrap gap-1.5">

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -132,6 +132,27 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
                 visible. Same convention as PrepayQueueTable. */}
             {stripGppPrefix(admin.party.name)}
           </Link>
+          {/* parmigiana-89172: inline "already paid" total per party so admins
+              see prior payouts to this party before clicking Execute again.
+              Includes the current row if its own status is paid — that's the
+              intended behavior ("total sent to this party as of right now").
+              Amber when the paid total has reached or exceeded the effective
+              reimbursement cap. */}
+          {admin.party.paidTotalCount != null &&
+            admin.party.paidTotalCount > 0 && (
+              <div
+                className={`text-[11px] mt-0.5 ${
+                  admin.party.effectiveReimbursementCapUsd != null &&
+                  (admin.party.paidTotalUsd ?? 0) >=
+                    admin.party.effectiveReimbursementCapUsd
+                    ? 'text-amber-300'
+                    : 'text-theme-text-muted'
+                }`}
+              >
+                Already paid: ${(admin.party.paidTotalUsd ?? 0).toFixed(2)} (
+                {admin.party.paidTotalCount})
+              </div>
+            )}
           {/* bruschetta-58291: country subtitle so admins can scan by region
               at a glance. Omitted when null to keep dense rows clean. */}
           {admin.party.country && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1617,6 +1617,18 @@ export interface AdminPayout extends Payout {
      * `event_tags` → null. See backend/src/helpers/reimbursementCap.ts.
      */
     effectiveReimbursementCapUsd: number | null;
+    /**
+     * parmigiana-89172: per-party sum of `status === 'paid'` payouts (all
+     * methods — USDC, wire, Mercury). Surfaced inline on PayoutRow to
+     * warn admins before they accidentally double-pay. Optional so older
+     * cached payloads don't break TS during a rolling deploy.
+     */
+    paidTotalUsd?: number;
+    /**
+     * parmigiana-89172: count of paid payouts that contribute to
+     * `paidTotalUsd`. Shown in parens, e.g. "Already paid: $470.00 (2)".
+     */
+    paidTotalCount?: number;
   };
   host: {
     id: string;
@@ -1704,6 +1716,18 @@ export interface PrepayQueueRow {
   candidates: PrepayCandidate[];
   /** True when the admin must disambiguate between ≥2 candidates. */
   hasMultipleCandidates: boolean;
+  /**
+   * parmigiana-89172: per-party sum of `status === 'paid'` payouts (all
+   * methods). Surfaced as an inline "Already paid: $X (N)" line under the
+   * city name so admins don't accidentally double-pay. Always present from
+   * the backend — defaults to 0 for parties with no prior paid payouts.
+   */
+  partyPaidUsd: number;
+  /**
+   * parmigiana-89172: count of paid payouts that contribute to
+   * `partyPaidUsd`. Shown in parens, e.g. "Already paid: $600.00 (2)".
+   */
+  partyPaidCount: number;
 }
 
 export interface OcrPreviewResult {


### PR DESCRIPTION
## Summary
- New backend helper `fetchPaidTotalsByParty(ids)` — single Prisma groupBy.
- Wired into `GET /prepay-queue` and the main admin payouts list.
- New `partyPaidUsd` / `partyPaidCount` fields exposed on both.
- Frontend renders "Already paid: \$X (N)" under the event name on PrepayQueueTable rows AND PayoutRow rows. Amber when total >= effective cap.
- No schema changes.

## Test plan
- [ ] Seropédica in prepay queue → shows "Already paid: \$600.00 (2)" in amber (assuming cap <= \$600).
- [ ] Same party's payouts in admin payouts table → same inline line on each row.
- [ ] Party with no paid payouts → no line rendered.
- [ ] Party where paid total < cap → muted color, no amber.