### PR TITLE
feat(bianco-89172): per-address $626 cap warning + 312.50 prepay default

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -29,6 +29,8 @@ import {
   getUsdcDailyCapStatus,
   getPayoutWalletAddress,
   getPayoutWalletBalanceUsd,
+  getPerAddressPaidTotals,
+  PER_ADDRESS_HARD_CAP_USD,
 } from '../services/usdc-base.service.js';
 import { createPublicClient, http, formatUnits, erc20Abi } from 'viem';
 import { base } from 'viem/chains';
@@ -1761,6 +1763,67 @@ router.get(
   },
 );
 
+// ============================================
+// bianco-89172: GET /api/admin/payouts/wallet-paid-total
+//
+// Returns cumulative paid USDC for a single recipient wallet, optionally with
+// a `wouldExceed` flag for a proposed additional amount. Backs the warning
+// panels in PayoutReviewModal + BulkSendModal so admins can see "wallet X has
+// already received $Y; sending $Z more would push past the $626 per-address
+// cap" before they fire off a duplicate payment.
+//
+// Query params:
+//   address (required): 0x...40 hex chars (case-insensitive)
+//   amount  (optional): proposed additional USD. When set, response includes
+//                       wouldExceed = (paidUsd + amount > capUsd). When
+//                       omitted, wouldExceed = null.
+//
+// Admin-only (isPaymentAdmin via requireAnyAdminOrPaymentAdmin).
+// ============================================
+router.get(
+  '/wallet-paid-total',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const addressRaw = typeof req.query.address === 'string' ? req.query.address.trim() : '';
+      if (!addressRaw || !/^0x[0-9a-fA-F]{40}$/.test(addressRaw)) {
+        throw new AppError(
+          'address query param must be a valid 0x-prefixed 40-char hex wallet',
+          400,
+          'VALIDATION_ERROR',
+        );
+      }
+
+      let amount: number | null = null;
+      if (req.query.amount != null && req.query.amount !== '') {
+        const parsed = Number(req.query.amount);
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          throw new AppError(
+            'amount query param must be a non-negative number',
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        amount = parsed;
+      }
+
+      const { paidUsd, paidCount } = await getPerAddressPaidTotals(addressRaw);
+      const wouldExceed = amount == null ? null : paidUsd + amount > PER_ADDRESS_HARD_CAP_USD;
+
+      res.json({
+        address: addressRaw,
+        paidUsd,
+        paidCount,
+        capUsd: PER_ADDRESS_HARD_CAP_USD,
+        wouldExceed,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
 /**
  * Shared executor used by both the explicit POST /:id/execute route and the
  * `autoExecute: true` branch of POST /:id/approve. Branches on payoutMethod
@@ -1784,8 +1847,14 @@ async function executePayout(params: {
     actorKind: AdminActorKind;
   };
   body: any;
+  /**
+   * bianco-89172: when true, skip the per-address $626 cumulative cap
+   * pre-flight inside `sendUsdcPayment`. The admin UI sets this only when
+   * the warning's acknowledgement checkbox has been ticked.
+   */
+  allowOverPerAddressCap?: boolean;
 }) {
-  const { payoutId, actor, body } = params;
+  const { payoutId, actor, body, allowOverPerAddressCap } = params;
 
   const existing = await prisma.payout.findUnique({
     where: { id: payoutId },
@@ -1834,7 +1903,9 @@ async function executePayout(params: {
     }
 
     try {
-      const result = await sendUsdcPayment(existing.payoutWalletAddress, finalAmountUsd);
+      const result = await sendUsdcPayment(existing.payoutWalletAddress, finalAmountUsd, {
+        allowOverPerAddressCap: !!allowOverPerAddressCap,
+      });
 
       const updated = await prisma.$transaction(async (tx) => {
         const row = await tx.payout.update({
@@ -2056,6 +2127,10 @@ router.post(
         payoutId: existing.id,
         actor: { email: actor.email, actorKind: actor.actorKind },
         body: req.body || {},
+        // bianco-89172: admin can acknowledge the per-address $626 cap
+        // warning via the PayoutReviewModal checkbox; the frontend forwards
+        // the flag here.
+        allowOverPerAddressCap: !!(req.body && req.body.allowOverPerAddressCap),
       });
 
       res.json({ payout: serializePayout(updated) });
@@ -2204,6 +2279,11 @@ router.post(
         );
       }
 
+      // bianco-89172: a single batch-level acknowledgement covers every row.
+      // BulkSendModal disables Send when any selected wallet would exceed the
+      // per-address cap unless the admin ticks "Allow over-cap sends".
+      const allowOverPerAddressCap = !!(req.body && req.body.allowOverPerAddressCap);
+
       // SEQUENTIAL execution — nonce safety. Do NOT switch to Promise.all.
       const results: BulkSendResult[] = [];
       for (const row of eligible) {
@@ -2213,6 +2293,7 @@ router.post(
             payoutId: row.id,
             actor: { email: actor.email, actorKind: actor.actorKind },
             body: {},
+            allowOverPerAddressCap,
           });
           // Record a batch-context audit alongside the mark_paid audit that
           // executePayout already wrote.

--- a/backend/src/services/usdc-base.service.ts
+++ b/backend/src/services/usdc-base.service.ts
@@ -40,6 +40,16 @@ const DEFAULT_PER_TX_CAP_USD = 200;
 const DEFAULT_DAILY_CAP_USD = 2000;
 const TX_RECEIPT_TIMEOUT_MS = 90_000;
 
+/**
+ * bianco-89172: per-address cumulative cap. No single 0x address should ever
+ * receive more than $626 USDC across all parties without explicit admin
+ * acknowledgement. Matches HARD_PER_TX_CEILING_USD + $1 cushion (so a single
+ * at-the-ceiling tx doesn't accidentally trip this) while still catching the
+ * double-payment scenarios observed in Osogbo ($626) and Seropédica ($600).
+ * Override via `sendUsdcPayment(addr, amt, { allowOverPerAddressCap: true })`.
+ */
+export const PER_ADDRESS_HARD_CAP_USD = 626;
+
 const ERC20_TRANSFER_ABI = [
   {
     inputs: [
@@ -155,11 +165,64 @@ export async function getUsdcDailyCapStatus(): Promise<UsdcDailyCapStatus> {
 }
 
 /**
+ * bianco-89172: cumulative USDC paid to a single recipient wallet across all
+ * parties + payouts. Used by the per-address hard cap pre-flight (below) and
+ * by the admin warning endpoint that surfaces the same number in the UI.
+ *
+ * Sums `payouts.finalAmountUsd` where status='paid' AND payoutMethod='usdc_base'
+ * AND payoutWalletAddress matches `toAddress` case-insensitively (wallets are
+ * hex; mixed-case checksum addresses shouldn't slip through this check).
+ */
+export async function getPerAddressPaidTotalUsd(toAddress: string): Promise<number> {
+  if (!toAddress) return 0;
+  const sum = await prisma.payout.aggregate({
+    where: {
+      status: 'paid',
+      payoutMethod: 'usdc_base',
+      payoutWalletAddress: { equals: toAddress, mode: 'insensitive' },
+    },
+    _sum: { finalAmountUsd: true },
+  });
+  return sum._sum.finalAmountUsd ? Number(sum._sum.finalAmountUsd.toString()) : 0;
+}
+
+/**
+ * bianco-89172: same shape as `getPerAddressPaidTotalUsd` but also returns the
+ * count of contributing rows so the admin UI can show "$X across N payouts".
+ */
+export async function getPerAddressPaidTotals(
+  toAddress: string,
+): Promise<{ paidUsd: number; paidCount: number }> {
+  if (!toAddress) return { paidUsd: 0, paidCount: 0 };
+  const agg = await prisma.payout.aggregate({
+    where: {
+      status: 'paid',
+      payoutMethod: 'usdc_base',
+      payoutWalletAddress: { equals: toAddress, mode: 'insensitive' },
+    },
+    _sum: { finalAmountUsd: true },
+    _count: { _all: true },
+  });
+  return {
+    paidUsd: agg._sum.finalAmountUsd ? Number(agg._sum.finalAmountUsd.toString()) : 0,
+    paidCount: agg._count?._all ?? 0,
+  };
+}
+
+/**
  * Send `amountUsd` USDC from the payout wallet to `toAddress` on Base.
  * Throws on any pre-flight failure or onchain revert. Caller must persist the
  * resulting `txHash` on the payout row.
+ *
+ * `opts.allowOverPerAddressCap` (bianco-89172): bypass the per-address $626
+ * cumulative-paid pre-flight. Required when the admin has acknowledged the
+ * warning in PayoutReviewModal / BulkSendModal. Default false.
  */
-export async function sendUsdcPayment(toAddress: string, amountUsd: number): Promise<SendUsdcResult> {
+export async function sendUsdcPayment(
+  toAddress: string,
+  amountUsd: number,
+  opts?: { allowOverPerAddressCap?: boolean },
+): Promise<SendUsdcResult> {
   // 1. Address validation
   if (!toAddress || !isAddress(toAddress)) {
     throw new Error(`Invalid recipient address: ${toAddress}`);
@@ -201,6 +264,21 @@ export async function sendUsdcPayment(toAddress: string, amountUsd: number): Pro
       `Daily USDC cap exceeded: $${usedUsd.toFixed(2)} already paid in last 24h + $${amountUsd.toFixed(2)} > ` +
         `$${dailyCapUsd.toFixed(2)} cap (USDC_PAYOUT_DAILY_CAP_USD)`,
     );
+  }
+
+  // 6. Per-address cumulative cap (bianco-89172). Prevents double-paying the
+  // same wallet across parties without an explicit admin ack. The override
+  // path is gated by `opts.allowOverPerAddressCap` — the admin UI sets this
+  // only when an admin has ticked the acknowledgement checkbox.
+  if (!opts?.allowOverPerAddressCap) {
+    const perAddressTotal = await getPerAddressPaidTotalUsd(recipient);
+    if (perAddressTotal + amountUsd > PER_ADDRESS_HARD_CAP_USD) {
+      throw new Error(
+        `This wallet has already received $${perAddressTotal.toFixed(2)} USDC. ` +
+          `Sending $${amountUsd.toFixed(2)} more would exceed the $${PER_ADDRESS_HARD_CAP_USD} per-address cap. ` +
+          `Set allowOverPerAddressCap=true to acknowledge and proceed.`,
+      );
+    }
   }
 
   // Encode ERC-20 transfer calldata via viem

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Send, Loader2, CheckCircle2, XCircle, ExternalLink, AlertTriangle } from 'lucide-react';
-import type { AdminPayout } from '../../types';
-import { bulkExecutePayouts, type BulkSendResult } from '../../lib/api';
+import { Checkbox } from '../Checkbox';
+import type { AdminPayout, WalletPaidTotal } from '../../types';
+import { bulkExecutePayouts, fetchWalletPaidTotal, type BulkSendResult } from '../../lib/api';
 
 interface BulkSendModalProps {
   isOpen: boolean;
@@ -35,6 +36,14 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
   const [phase, setPhase] = useState<Phase>('idle');
   const [results, setResults] = useState<BulkSendResult[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // bianco-89172: per-wallet prior-paid totals (lowercased addr → WalletPaidTotal).
+  // Fetched once per modal-open, then locally combined with the in-batch
+  // amounts to determine which wallets would push past the $626 cap. The
+  // admin must tick `overrideCap` to enable Send when any wallet would exceed.
+  const [walletTotals, setWalletTotals] = useState<Map<string, WalletPaidTotal>>(new Map());
+  const [walletTotalsLoading, setWalletTotalsLoading] = useState(false);
+  const [overrideCap, setOverrideCap] = useState(false);
 
   // Eligibility filter — keep in sync with backend bulk-execute filter
   // (USDC + approved-or-failed + valid 0x wallet). passata-49102 added
@@ -71,8 +80,81 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
       setPhase('idle');
       setResults([]);
       setErrorMsg(null);
+      setWalletTotals(new Map());
+      setOverrideCap(false);
     }
   }, [isOpen]);
+
+  // bianco-89172: fetch prior-paid totals for every distinct recipient wallet
+  // in the selection. Skipped when modal isn't open or no eligible rows.
+  // Failures fall back to an empty entry per address so the rest of the UI
+  // still renders — the server-side pre-flight will still catch issues.
+  useEffect(() => {
+    if (!isOpen || eligible.length === 0) return;
+    let cancelled = false;
+    const distinctAddrs = Array.from(
+      new Set(eligible.map((p) => (p.payoutWalletAddress || '').toLowerCase()).filter(Boolean)),
+    );
+    if (distinctAddrs.length === 0) return;
+    setWalletTotalsLoading(true);
+    Promise.all(
+      distinctAddrs.map(async (addr) => {
+        try {
+          const total = await fetchWalletPaidTotal(addr);
+          return [addr, total] as const;
+        } catch {
+          return [
+            addr,
+            { address: addr, paidUsd: 0, paidCount: 0, capUsd: 626, wouldExceed: null },
+          ] as const;
+        }
+      }),
+    ).then((entries) => {
+      if (cancelled) return;
+      setWalletTotals(new Map(entries));
+      setWalletTotalsLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // `eligible` is derived from `selectedPayouts` and is stable per modal open
+    // (the parent re-renders the modal closed/open on selection change), so
+    // this re-runs only when the modal opens or the selection changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, selectedPayouts]);
+
+  // bianco-89172: combine prior-paid + in-batch amounts per wallet to figure
+  // out which selected rows would push the recipient past the cap. Returns
+  // {overCapRowIds, overCapWalletCount, capUsd} — used for the disabled state
+  // on Send + the warning panel.
+  const capAnalysis = useMemo(() => {
+    if (walletTotals.size === 0 || eligible.length === 0) {
+      return { overCapRowIds: new Set<string>(), overCapWalletCount: 0, capUsd: 626 };
+    }
+    // First, sum up each wallet's in-batch total.
+    const inBatchByWallet = new Map<string, number>();
+    for (const p of eligible) {
+      const addr = (p.payoutWalletAddress || '').toLowerCase();
+      if (!addr) continue;
+      inBatchByWallet.set(addr, (inBatchByWallet.get(addr) || 0) + Number(p.finalAmountUsd || 0));
+    }
+    let capUsd = 626;
+    const overCapWallets = new Set<string>();
+    for (const [addr, batchTotal] of inBatchByWallet.entries()) {
+      const wt = walletTotals.get(addr);
+      if (!wt) continue;
+      capUsd = wt.capUsd; // server is the source of truth — same for every row
+      if (wt.paidUsd + batchTotal > wt.capUsd) {
+        overCapWallets.add(addr);
+      }
+    }
+    const overCapRowIds = new Set<string>();
+    for (const p of eligible) {
+      const addr = (p.payoutWalletAddress || '').toLowerCase();
+      if (overCapWallets.has(addr)) overCapRowIds.add(p.id);
+    }
+    return { overCapRowIds, overCapWalletCount: overCapWallets.size, capUsd };
+  }, [walletTotals, eligible]);
 
   // Close on Escape (only when not sending — never cancel an in-flight batch)
   useEffect(() => {
@@ -92,11 +174,16 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
 
   async function handleSend() {
     if (eligible.length === 0) return;
+    // bianco-89172: block submit if any row is over-cap and the admin hasn't
+    // ticked the override checkbox.
+    if (capAnalysis.overCapWalletCount > 0 && !overrideCap) return;
     setPhase('sending');
     setErrorMsg(null);
     try {
       const ids = eligible.map((p) => p.id);
-      const res = await bulkExecutePayouts(ids);
+      const res = await bulkExecutePayouts(ids, {
+        allowOverPerAddressCap: capAnalysis.overCapWalletCount > 0 ? overrideCap : false,
+      });
       setResults(res);
       setPhase('done');
       onComplete(res);
@@ -178,6 +265,84 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
               </div>
             )}
 
+            {/* bianco-89172: per-address cap warning. Surfaces a count of
+                wallets in this selection whose prior-paid + in-batch total
+                would exceed the $626 cap, and requires an explicit override
+                checkbox to enable Send. The server-side pre-flight is the
+                ultimate gate; this is just defense-in-depth for admins. */}
+            {walletTotalsLoading && eligible.length > 0 && (
+              <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface-hover border border-theme-stroke text-xs text-theme-text-muted mb-4">
+                <Loader2 size={12} className="animate-spin" />
+                Checking per-address cap…
+              </div>
+            )}
+            {!walletTotalsLoading && capAnalysis.overCapWalletCount > 0 && (
+              <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mb-4">
+                <div className="flex items-start gap-2.5">
+                  <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                  <div className="flex-1 text-sm">
+                    <div className="font-medium text-amber-200 mb-1">
+                      Per-address cap warning
+                    </div>
+                    <div className="text-theme-text-secondary text-xs">
+                      {capAnalysis.overCapWalletCount} selected wallet
+                      {capAnalysis.overCapWalletCount === 1 ? '' : 's'} would exceed the
+                      ${capAnalysis.capUsd} per-address cap once this batch sends
+                      ({capAnalysis.overCapRowIds.size} row
+                      {capAnalysis.overCapRowIds.size === 1 ? '' : 's'} in this batch).
+                    </div>
+                    <div className="mt-3">
+                      <Checkbox
+                        checked={overrideCap}
+                        onChange={() => setOverrideCap((v) => !v)}
+                        label="Allow over-cap sends — I acknowledge"
+                        labelClassName="text-sm text-amber-100"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* bianco-89172: per-row indicator so admins can see WHICH wallets
+                in their selection would exceed. Folded into the existing
+                eligibility list (kept concise — first 8 rows). */}
+            {capAnalysis.overCapRowIds.size > 0 && (
+              <ul className="space-y-1 mb-4 max-h-[20vh] overflow-y-auto text-xs">
+                {eligible
+                  .filter((p) => capAnalysis.overCapRowIds.has(p.id))
+                  .slice(0, 8)
+                  .map((p) => {
+                    const addr = p.payoutWalletAddress || '';
+                    const shortAddr =
+                      addr.length >= 10 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+                    const wt = walletTotals.get(addr.toLowerCase());
+                    return (
+                      <li
+                        key={p.id}
+                        className="flex items-baseline gap-2 px-2 py-1 rounded bg-amber-500/5 border border-amber-500/20"
+                      >
+                        <AlertTriangle size={10} className="text-amber-400 shrink-0 self-center" />
+                        <span className="font-mono text-[11px] text-amber-100">{shortAddr}</span>
+                        <span className="text-theme-text-muted">
+                          ${Number(p.finalAmountUsd).toFixed(2)}
+                        </span>
+                        {wt && (
+                          <span className="text-amber-300/80">
+                            prior ${wt.paidUsd.toFixed(2)}
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })}
+                {capAnalysis.overCapRowIds.size > 8 && (
+                  <li className="text-theme-text-muted text-[11px] px-2">
+                    …and {capAnalysis.overCapRowIds.size - 8} more.
+                  </li>
+                )}
+              </ul>
+            )}
+
             <div className="flex items-center justify-end gap-2 pt-2 border-t border-theme-stroke">
               <button
                 type="button"
@@ -189,7 +354,12 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
               <button
                 type="button"
                 onClick={handleSend}
-                disabled={eligible.length === 0}
+                disabled={
+                  eligible.length === 0 ||
+                  walletTotalsLoading ||
+                  // bianco-89172: block Send when over-cap and admin hasn't ack'd
+                  (capAnalysis.overCapWalletCount > 0 && !overrideCap)
+                }
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Send size={14} />

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -45,7 +45,10 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
 }) => {
   const { party, candidates } = row;
   const cap = party.effectiveReimbursementCapUsd ?? 0;
-  const defaultAmount = Math.max(1, Math.round(0.5 * cap));
+  // bianco-89172: keep the cents — `Math.round(0.5 * 625)` gave 313, off by
+  // 50¢ from the actual half. payouts.final_amount_usd is numeric(12,2) so
+  // decimals round-trip through the backend without loss.
+  const defaultAmount = cap > 0 ? (cap / 2).toFixed(2) : '1.00';
 
   const mercuryBlocked = isMercuryBlocked(party.country);
 
@@ -59,7 +62,7 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
   }, [candidates, mercuryBlocked]);
 
   const [selectedUserId, setSelectedUserId] = useState<string>(initialCandidateId);
-  const [amountStr, setAmountStr] = useState(String(defaultAmount));
+  const [amountStr, setAmountStr] = useState(defaultAmount);
   const [notes, setNotes] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw } from 'lucide-react';
 import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
-import type { AdminPayoutDetail, PayoutAuditEntry } from '../../types';
+import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal } from '../../types';
 import {
   PayoutStatusPill,
   PayoutMethodIcon,
@@ -39,18 +40,29 @@ interface PayoutReviewModalProps {
   /**
    * Execute payout (PR 5). For USDC → no body, server sends via Privy.
    * For wire / mercury_card → admin-supplied refs.
+   *
+   * `allowOverPerAddressCap` (bianco-89172): forwarded when the admin has
+   * acknowledged the per-address $626 cap warning by ticking the override
+   * checkbox in the execute form.
    */
   onExecute: (body: {
     wireReference?: string;
     mercuryCardLast4?: string;
     mercuryCardId?: string;
     note?: string;
+    allowOverPerAddressCap?: boolean;
   }) => Promise<void> | void;
   /**
    * Optional fetcher for the USDC daily-cap-remaining hint. Only called when
    * the admin opens the USDC execute confirmation. Returns null if unavailable.
    */
   fetchUsdcCapRemaining?: () => Promise<{ usedUsd: number; capUsd: number; remainingUsd: number } | null>;
+  /**
+   * bianco-89172: optional fetcher for the per-address paid total + would-exceed
+   * check. Called when a USDC execute form opens so we can render the cap
+   * warning panel before the admin clicks Send. Returns null if unavailable.
+   */
+  fetchWalletPaidTotal?: (address: string, amount: number) => Promise<WalletPaidTotal | null>;
   /** Re-open (clear rejected/failed) — uses mark-paid plumbing or a future endpoint. */
   onReopen?: () => Promise<void> | void;
   busy?: boolean;
@@ -67,6 +79,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onMarkPaid,
   onExecute,
   fetchUsdcCapRemaining,
+  fetchWalletPaidTotal,
   onReopen,
   busy = false,
 }) => {
@@ -95,6 +108,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     { usedUsd: number; capUsd: number; remainingUsd: number } | null
   >(null);
   const [usdcCapLoading, setUsdcCapLoading] = useState(false);
+
+  // bianco-89172: per-address $626 cap warning state. `walletPaidTotal` is
+  // null until the USDC execute form opens; `overrideCap` is the admin's
+  // acknowledgement of the warning (required to enable Execute when
+  // `wouldExceed === true`).
+  const [walletPaidTotal, setWalletPaidTotal] = useState<WalletPaidTotal | null>(null);
+  const [walletPaidLoading, setWalletPaidLoading] = useState(false);
+  const [overrideCap, setOverrideCap] = useState(false);
 
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
 
@@ -136,6 +157,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     setExecCardLast4('');
     setExecCardId('');
     setExecNote('');
+    // bianco-89172: clear the per-address cap state on every open so the
+    // ack checkbox doesn't carry over from a previous Execute attempt.
+    setWalletPaidTotal(null);
+    setOverrideCap(false);
     if (payout.payoutMethod === 'usdc_base' && fetchUsdcCapRemaining) {
       setUsdcCapLoading(true);
       try {
@@ -145,6 +170,26 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         setUsdcCap(null);
       } finally {
         setUsdcCapLoading(false);
+      }
+    }
+    // bianco-89172: fetch the per-address paid-total for the recipient wallet
+    // so we can warn the admin if this payout would push past the $626 cap.
+    if (
+      payout.payoutMethod === 'usdc_base' &&
+      payout.payoutWalletAddress &&
+      fetchWalletPaidTotal
+    ) {
+      setWalletPaidLoading(true);
+      try {
+        const total = await fetchWalletPaidTotal(
+          payout.payoutWalletAddress,
+          Number(payout.finalAmountUsd),
+        );
+        setWalletPaidTotal(total);
+      } catch {
+        setWalletPaidTotal(null);
+      } finally {
+        setWalletPaidLoading(false);
       }
     }
   }
@@ -573,6 +618,51 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         <span className="text-emerald-800/70">Daily cap status unavailable.</span>
                       )}
                     </div>
+                    {/* bianco-89172: per-address $626 cap warning. Only shown
+                        when the proposed send would push the recipient's
+                        cumulative paid total past the cap. The admin must
+                        explicitly tick the override checkbox; until they do,
+                        the Send button below is disabled. */}
+                    {walletPaidLoading && (
+                      <div className="text-xs text-emerald-800/80 inline-flex items-center gap-1">
+                        <Loader2 size={10} className="animate-spin" /> Checking per-address total…
+                      </div>
+                    )}
+                    {!walletPaidLoading && walletPaidTotal?.wouldExceed && payout.payoutWalletAddress && (
+                      <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+                        <div className="flex items-start gap-2.5">
+                          <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                          <div className="flex-1 text-sm">
+                            <div className="font-medium text-amber-200 mb-1">
+                              Per-address cap warning
+                            </div>
+                            <div className="text-theme-text-secondary text-xs">
+                              Wallet{' '}
+                              <code className="font-mono text-[11px]">
+                                {payout.payoutWalletAddress.slice(0, 6)}…{payout.payoutWalletAddress.slice(-4)}
+                              </code>{' '}
+                              has already received{' '}
+                              <b>${walletPaidTotal.paidUsd.toFixed(2)}</b>{' '}
+                              across {walletPaidTotal.paidCount} payout
+                              {walletPaidTotal.paidCount === 1 ? '' : 's'}. Sending{' '}
+                              <b>${Number(payout.finalAmountUsd).toFixed(2)}</b> would push the total to{' '}
+                              <b>
+                                ${(walletPaidTotal.paidUsd + Number(payout.finalAmountUsd)).toFixed(2)}
+                              </b>
+                              , exceeding the ${walletPaidTotal.capUsd} per-address cap.
+                            </div>
+                            <div className="mt-3">
+                              <Checkbox
+                                checked={overrideCap}
+                                onChange={() => setOverrideCap((v) => !v)}
+                                label="I acknowledge — proceed anyway"
+                                labelClassName="text-sm text-amber-100"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
 
@@ -632,6 +722,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       if (payout.payoutMethod === 'wire' && !execWireValid) return;
                       if (payout.payoutMethod === 'mercury_card' && !execMercuryValid) return;
                       if (payout.payoutMethod === 'usdc_base' && !payout.payoutWalletAddress) return;
+                      // bianco-89172: block submit if the per-address cap would
+                      // exceed and the admin hasn't ticked the override.
+                      if (
+                        payout.payoutMethod === 'usdc_base' &&
+                        walletPaidTotal?.wouldExceed &&
+                        !overrideCap
+                      ) {
+                        return;
+                      }
                       await onExecute({
                         wireReference: payout.payoutMethod === 'wire' ? execWireRef.trim() : undefined,
                         mercuryCardLast4:
@@ -641,6 +740,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                             ? execCardId.trim()
                             : undefined,
                         note: execNote.trim() || undefined,
+                        // bianco-89172: forward the admin's acknowledgement so
+                        // the server bypasses its own per-address cap check.
+                        allowOverPerAddressCap:
+                          payout.payoutMethod === 'usdc_base' && walletPaidTotal?.wouldExceed
+                            ? overrideCap
+                            : undefined,
                       });
                       setShowExecuteForm(false);
                     }}
@@ -649,7 +754,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       payout.payoutMethod == null ||
                       (payout.payoutMethod === 'wire' && !execWireValid) ||
                       (payout.payoutMethod === 'mercury_card' && !execMercuryValid) ||
-                      (payout.payoutMethod === 'usdc_base' && !payout.payoutWalletAddress)
+                      (payout.payoutMethod === 'usdc_base' && !payout.payoutWalletAddress) ||
+                      // bianco-89172: disabled until ack when the cap would exceed.
+                      (payout.payoutMethod === 'usdc_base' &&
+                        !!walletPaidTotal?.wouldExceed &&
+                        !overrideCap)
                     }
                     className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
                   >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -3958,6 +3958,11 @@ export async function markAdminPayoutPaid(
  *   - usdc_base    → no body required; server sends via Privy server-wallet
  *   - wire         → { wireReference: string } REQUIRED
  *   - mercury_card → { mercuryCardLast4: 'NNNN', mercuryCardId?: string, note?: string } REQUIRED
+ *
+ * `allowOverPerAddressCap` (bianco-89172): forwarded to the server to bypass
+ * the per-address $626 cumulative cap when the admin has acknowledged the
+ * warning in PayoutReviewModal.
+ *
  * Returns the updated payout. Throws on any server-side validation/execution failure.
  */
 export async function executeAdminPayout(
@@ -3967,6 +3972,7 @@ export async function executeAdminPayout(
     mercuryCardLast4?: string;
     mercuryCardId?: string;
     note?: string;
+    allowOverPerAddressCap?: boolean;
   } = {},
 ): Promise<AdminPayout> {
   const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/execute`, {
@@ -3996,12 +4002,38 @@ export interface BulkSendResult {
   error?: string;
 }
 
-export async function bulkExecutePayouts(ids: string[]): Promise<BulkSendResult[]> {
+export async function bulkExecutePayouts(
+  ids: string[],
+  opts?: { allowOverPerAddressCap?: boolean },
+): Promise<BulkSendResult[]> {
+  const body: { ids: string[]; allowOverPerAddressCap?: boolean } = { ids };
+  if (opts?.allowOverPerAddressCap) body.allowOverPerAddressCap = true;
   const res = await apiRequest<{ results: BulkSendResult[] }>(`/api/admin/payouts/bulk-execute`, {
     method: 'POST',
-    body: { ids },
+    body,
   });
   return res.results;
+}
+
+/**
+ * bianco-89172: fetch the cumulative paid-USDC total for a single recipient
+ * wallet, optionally with a "wouldExceed" check for a proposed additional
+ * amount. Backs the per-address $626 cap warning in PayoutReviewModal +
+ * BulkSendModal. Returns `wouldExceed: null` when `amount` is omitted.
+ *
+ * Admin-only — throws via `apiRequest` if the caller is not a payment admin.
+ */
+export async function fetchWalletPaidTotal(
+  address: string,
+  amount?: number,
+): Promise<WalletPaidTotal> {
+  const params = new URLSearchParams({ address });
+  if (amount != null && Number.isFinite(amount)) {
+    params.set('amount', String(amount));
+  }
+  return apiRequest<WalletPaidTotal>(
+    `/api/admin/payouts/wallet-paid-total?${params.toString()}`,
+  );
 }
 
 /**

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -13,6 +13,7 @@ import {
   markAdminPayoutPaid,
   executeAdminPayout,
   getUsdcDailyCapRemaining,
+  fetchWalletPaidTotal,
   exportAdminPayoutsCsv,
   fetchPrepayQueue,
 } from '../lib/api';
@@ -762,6 +763,13 @@ export function PaymentsAdminPage() {
             fetchUsdcCapRemaining={async () => {
               try {
                 return await getUsdcDailyCapRemaining();
+              } catch {
+                return null;
+              }
+            }}
+            fetchWalletPaidTotal={async (address, amount) => {
+              try {
+                return await fetchWalletPaidTotal(address, amount);
               } catch {
                 return null;
               }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1641,6 +1641,20 @@ export interface AdminPayoutDetail extends AdminPayout {
   audits: PayoutAuditEntry[];
 }
 
+/**
+ * bianco-89172: cumulative paid-USDC summary for a single recipient wallet.
+ * Backs the per-address $626 cap warning in PayoutReviewModal + BulkSendModal.
+ * `wouldExceed` is null when no proposed `amount` was supplied to the
+ * `/wallet-paid-total` endpoint; true / false when one was.
+ */
+export interface WalletPaidTotal {
+  address: string;
+  paidUsd: number;
+  paidCount: number;
+  capUsd: number;
+  wouldExceed: boolean | null;
+}
+
 export interface AdminPayoutFilters {
   status?: PayoutStatus | 'all';
   payoutMethod?: PayoutMethod | 'all';


### PR DESCRIPTION
## Summary
- New per-address $626 cumulative-paid cap on USDC sends. Sums status='paid' final_amount_usd by wallet.
- Throws unless `allowOverPerAddressCap: true` is in the request body.
- PayoutReviewModal warning + acknowledgement Checkbox.
- BulkSendModal batch-level warning + single Checkbox override.
- New admin endpoint `GET /api/admin/payouts/wallet-paid-total` backs the warnings.
- CreatePrepaymentModal default fixed to $312.50 (was rounded to $313).

## Test plan
- [ ] Wallet at $313 paid → Execute $313 more → warning panel + disabled Execute → check ack → Execute proceeds (total $626 → on edge but allowed).
- [ ] Wallet at $326 paid → Execute $300 more → warning shows projected $626.xx total → ack → proceeds.
- [ ] Wallet at $626 paid → any new send shows warning → still proceeds with ack.
- [ ] Bulk Send with 3 OK + 1 over-cap → batch warning surfaces, Send disabled, ack enables → batch sends per-row.
- [ ] Create Prepayment on cap=$625 party → default amount `312.50`.