### PR TITLE
tiramisu-49102: pay-again button + per-party cap hard-enforce

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -206,6 +206,59 @@ async function fetchPaidTotalsByParty(
   return m;
 }
 
+/**
+ * tiramisu-49102: hard per-party cap enforcement. Sums every payout for the
+ * party that is `pending | approved | paid` and throws 409 PARTY_CAP_EXCEEDED
+ * if `usedUsd + proposedUsd` exceeds the party's `effectiveReimbursementCapUsd`
+ * (validated cap OR max numeric event tag). Parties without an effective cap
+ * stay uncapped.
+ *
+ * `ignorePayoutId` excludes a row from the existing-total — used by PATCH so a
+ * row being edited doesn't count against itself.
+ */
+async function assertWithinPartyCap(
+  partyId: string,
+  proposedUsd: number,
+  ignorePayoutId?: string,
+): Promise<void> {
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: { reimbursementCapUsd: true, eventTags: true },
+  });
+  if (!party) {
+    throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+  }
+  const effectiveCap = computeEffectiveCapUsd({
+    reimbursementCapUsd: party.reimbursementCapUsd,
+    eventTags: party.eventTags,
+  });
+  if (effectiveCap == null) return;
+
+  const where: any = {
+    partyId,
+    status: { in: ['paid', 'pending', 'approved'] },
+  };
+  if (ignorePayoutId) {
+    where.id = { not: ignorePayoutId };
+  }
+  const existingTotal = await prisma.payout.aggregate({
+    where,
+    _sum: { finalAmountUsd: true },
+  });
+  const usedUsd = existingTotal._sum.finalAmountUsd
+    ? Number(existingTotal._sum.finalAmountUsd.toString())
+    : 0;
+  const remainingUsd = Math.max(0, effectiveCap - usedUsd);
+
+  if (usedUsd + proposedUsd > effectiveCap + 1e-9) {
+    throw new AppError(
+      `This payment would exceed the party's $${effectiveCap.toFixed(2)} cap. $${remainingUsd.toFixed(2)} remaining.`,
+      409,
+      'PARTY_CAP_EXCEEDED',
+    );
+  }
+}
+
 /** Build a Prisma `where` clause from query-string filters. */
 function buildPayoutWhere(query: Request['query']): any {
   const where: any = {};
@@ -998,6 +1051,10 @@ router.post(
         throw new AppError('Host user not found', 404, 'HOST_NOT_FOUND');
       }
 
+      // tiramisu-49102: hard cap — block external records that would push the
+      // cumulative paid+pending+approved past the party's effective cap.
+      await assertWithinPartyCap(partyId, finalAmountUsd);
+
       const paidAt = body.paidAt ? new Date(body.paidAt) : new Date();
       if (Number.isNaN(paidAt.getTime())) {
         throw new AppError('paidAt must be a valid ISO date', 400, 'VALIDATION_ERROR');
@@ -1297,7 +1354,18 @@ router.get(
         throw new AppError('Payout not found', 404, 'NOT_FOUND');
       }
 
-      res.json({ payout: serializePayout(row) });
+      const serialized = serializePayout(row);
+      // tiramisu-49102: attach per-party "already paid" totals to the detail
+      // response too so the Pay-again button on PayoutReviewModal can populate
+      // the synthetic PrepayQueueRow with `partyPaidUsd` for the CreatePrepayment
+      // modal's remaining-cap clamp. Cheap one-row aggregate.
+      if (serialized.party?.id) {
+        const totals = await fetchPaidTotalsByParty([serialized.party.id]);
+        const t = totals.get(serialized.party.id);
+        serialized.party.paidTotalUsd = t?.paidUsd ?? 0;
+        serialized.party.paidTotalCount = t?.paidCount ?? 0;
+      }
+      res.json({ payout: serialized });
     } catch (error) {
       next(error);
     }
@@ -1359,6 +1427,10 @@ router.patch(
         if (oldAmount !== newAmount) {
           amountChanged = true;
           data.finalAmountUsd = parsed;
+          // tiramisu-49102: re-check per-party cap when admin edits amount.
+          // Exclude THIS row from the existing-total so the edit doesn't
+          // count against itself.
+          await assertWithinPartyCap(existing.partyId, parsed, existing.id);
         }
       }
 

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -24,6 +24,7 @@ import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
 import { looksLikeEnsName, resolveWalletInput } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
+import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 
 const router = Router();
 
@@ -283,6 +284,62 @@ async function assertMercuryAllowed(
       `Mercury virtual cards are unavailable in ${party?.country ?? 'this country'} due to compliance restrictions. Please pick another payout method.`,
       400,
       'MERCURY_COUNTRY_BLOCKED',
+    );
+  }
+}
+
+/**
+ * tiramisu-49102: hard per-party cap enforcement.
+ *
+ * Sums every existing payout for the party that is `pending | approved | paid`
+ * and rejects with 409 PARTY_CAP_EXCEEDED if `usedUsd + proposedUsd` would
+ * exceed the party's `effectiveReimbursementCapUsd` (validated cap OR max
+ * numeric event tag). Parties without an effective cap stay uncapped.
+ *
+ * Skips a row when `ignorePayoutId` is supplied — used by PATCH edits so the
+ * row being edited doesn't count against itself.
+ */
+async function assertWithinPartyCap(
+  partyId: string,
+  proposedUsd: number,
+  ignorePayoutId?: string,
+): Promise<void> {
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: { reimbursementCapUsd: true, eventTags: true },
+  });
+  if (!party) {
+    // Defensive — callers above already verified the party exists.
+    throw new AppError('Party not found', 404, 'NOT_FOUND');
+  }
+
+  const effectiveCap = computeEffectiveCapUsd({
+    reimbursementCapUsd: party.reimbursementCapUsd,
+    eventTags: party.eventTags,
+  });
+  if (effectiveCap == null) return;
+
+  const where: any = {
+    partyId,
+    status: { in: ['paid', 'pending', 'approved'] },
+  };
+  if (ignorePayoutId) {
+    where.id = { not: ignorePayoutId };
+  }
+  const existingTotal = await prisma.payout.aggregate({
+    where,
+    _sum: { finalAmountUsd: true },
+  });
+  const usedUsd = existingTotal._sum.finalAmountUsd
+    ? Number(existingTotal._sum.finalAmountUsd.toString())
+    : 0;
+  const remainingUsd = Math.max(0, effectiveCap - usedUsd);
+
+  if (usedUsd + proposedUsd > effectiveCap + 1e-9) {
+    throw new AppError(
+      `This payment would exceed the party's $${effectiveCap.toFixed(2)} cap. $${remainingUsd.toFixed(2)} remaining.`,
+      409,
+      'PARTY_CAP_EXCEEDED',
     );
   }
 }
@@ -585,6 +642,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         'INVALID_AMOUNT'
       );
     }
+
+    // tiramisu-49102: hard cap — block creates that would push the cumulative
+    // paid+pending+approved total past the party's effective cap. Parties
+    // without an effective cap stay uncapped.
+    await assertWithinPartyCap(partyId, finalUsd);
 
     // arugula-38633 v3 follow-up: zero-receipts path — default the FX fields
     // to USD passthrough using finalUsd. (extractedUsdSum stays 0; we surface
@@ -900,6 +962,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       if (!Number.isFinite(n) || n <= 0) {
         throw new AppError('finalAmountUsd must be a positive number', 400, 'INVALID_AMOUNT');
       }
+      // tiramisu-49102: re-check per-party cap when the host edits the
+      // amount. Exclude THIS row from the existing-total so the edit doesn't
+      // count against itself.
+      await assertWithinPartyCap(partyId, n, payoutId);
       data.finalAmountUsd = new Decimal(n);
     }
 
@@ -1103,6 +1169,13 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ? Number((data.finalAmountUsd as Decimal).toString())
       : (recomputedAmount != null ? Number(recomputedAmount.toString()) : oldAmount);
     const amountChanged = newAmount !== oldAmount;
+
+    // tiramisu-49102: re-check per-party cap when a receipt-edit causes the
+    // amount to be recomputed (explicit-amount edits are checked above).
+    // Exclude THIS row from the existing-total so it doesn't count against itself.
+    if (amountChanged && !explicitAmount) {
+      await assertWithinPartyCap(partyId, newAmount, payoutId);
+    }
 
     // Single transaction: delete removed docs, insert new docs, update payout,
     // write the audit row(s).

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -45,10 +45,20 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
 }) => {
   const { party, candidates } = row;
   const cap = party.effectiveReimbursementCapUsd ?? 0;
+  // tiramisu-49102: cap-remaining = cap minus what's already been paid for
+  // this party. `partyPaidUsd` is what BISMARCK-92103 attached to PrepayQueueRow
+  // from the prepay-queue endpoint; the synthetic row built by the Pay-again
+  // path uses the same field. null = no cap configured (uncapped event).
+  const paidSoFar = row.partyPaidUsd ?? 0;
+  const remainingUsd: number | null = cap > 0 ? Math.max(0, cap - paidSoFar) : null;
   // bianco-89172: keep the cents — `Math.round(0.5 * 625)` gave 313, off by
   // 50¢ from the actual half. payouts.final_amount_usd is numeric(12,2) so
   // decimals round-trip through the backend without loss.
-  const defaultAmount = cap > 0 ? (cap / 2).toFixed(2) : '1.00';
+  // tiramisu-49102: clamp the default to whatever's actually left under the
+  // cap (so a paid-down event doesn't pre-fill an over-cap default).
+  const rawDefault = cap > 0 ? cap / 2 : 1;
+  const defaultAmount =
+    remainingUsd != null ? Math.min(rawDefault, remainingUsd).toFixed(2) : rawDefault.toFixed(2);
 
   const mercuryBlocked = isMercuryBlocked(party.country);
 
@@ -83,11 +93,18 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
 
   const amountNum = useMemo(() => Number(amountStr), [amountStr]);
 
+  // tiramisu-49102: client-side cap-remaining clamp. Disables submit when the
+  // typed amount exceeds the remaining cap; backend also enforces with 409
+  // PARTY_CAP_EXCEEDED if this slips through (e.g. concurrent admin sends).
+  const exceedsRemaining =
+    remainingUsd != null && Number.isFinite(amountNum) && amountNum > remainingUsd + 1e-9;
+
   const canSubmit =
     !!selectedCandidate &&
     !(selectedCandidate.method === 'mercury_card' && mercuryBlocked) &&
     Number.isFinite(amountNum) &&
     amountNum > 0 &&
+    !exceedsRemaining &&
     !submitting;
 
   async function handleSubmit(e: React.FormEvent) {
@@ -238,6 +255,27 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
             <p className="text-xs text-theme-text-muted mt-1">
               Default is 50% of the event's reimbursement cap. Edit if needed.
             </p>
+            {/* tiramisu-49102: cap-remaining hint. Shown when an effective cap
+                exists. paidSoFar > 0 means there's already a payout against
+                this party (the Pay-again path) so the admin sees exactly how
+                much headroom is left. */}
+            {remainingUsd != null && (
+              <p
+                className={`text-xs mt-1 ${
+                  exceedsRemaining ? 'text-red-500' : 'text-theme-text-muted'
+                }`}
+              >
+                Remaining: ${remainingUsd.toFixed(2)}
+                {paidSoFar > 0 && (
+                  <> &middot; Already paid: ${paidSoFar.toFixed(2)} of ${cap.toFixed(2)} cap</>
+                )}
+              </p>
+            )}
+            {exceedsRemaining && remainingUsd != null && (
+              <p className="text-xs text-red-500 mt-1">
+                Exceeds cap: ${remainingUsd.toFixed(2)} remaining
+              </p>
+            )}
           </div>
 
           {/* Internal note (optional) */}

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -65,6 +65,13 @@ interface PayoutReviewModalProps {
   fetchWalletPaidTotal?: (address: string, amount: number) => Promise<WalletPaidTotal | null>;
   /** Re-open (clear rejected/failed) — uses mark-paid plumbing or a future endpoint. */
   onReopen?: () => Promise<void> | void;
+  /**
+   * tiramisu-49102: "Pay again to this wallet" — only surfaced when this
+   * payout is already `paid`. Parent opens CreatePrepaymentModal pre-filled
+   * with the same party + host + method/destination so the admin can issue a
+   * follow-up payment without leaving the modal.
+   */
+  onPayAgain?: (payout: AdminPayoutDetail) => void;
   busy?: boolean;
 }
 
@@ -81,6 +88,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   fetchUsdcCapRemaining,
   fetchWalletPaidTotal,
   onReopen,
+  onPayAgain,
   busy = false,
 }) => {
   const [editingAmount, setEditingAmount] = useState(false);
@@ -910,6 +918,38 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               Re-open
             </button>
           )}
+          {/* tiramisu-49102: Pay-again button. Surfaced only when status is
+              paid AND we have enough to pre-fill the CreatePrepaymentModal —
+              i.e. a method is set, and (for USDC) a wallet, or (for wire) a
+              bank email. Mercury-card replays only need the host + party.
+              Parent handler builds a synthetic PrepayQueueRow and opens the
+              modal. */}
+          {isPaid && onPayAgain && payout.host?.id && payout.host?.email && payout.payoutMethod && (() => {
+            const m = payout.payoutMethod;
+            const eligible =
+              (m === 'usdc_base' && !!payout.payoutWalletAddress) ||
+              (m === 'wire' &&
+                payout.payoutBankDetails &&
+                typeof (payout.payoutBankDetails as any).email === 'string' &&
+                ((payout.payoutBankDetails as any).email as string).trim().length > 0) ||
+              m === 'mercury_card';
+            if (!eligible) return null;
+            const label =
+              m === 'usdc_base'
+                ? 'Pay again to this wallet'
+                : 'Send another payment';
+            return (
+              <button
+                type="button"
+                onClick={() => onPayAgain(payout)}
+                disabled={busy || selfPayoutBlocked}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
+              >
+                <Repeat2 size={14} />
+                {label}
+              </button>
+            );
+          })()}
           <button
             type="button"
             onClick={onClose}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -23,6 +23,7 @@ import type {
   AdminPayoutFilters,
   AdminPayoutTotals,
   PrepayQueueRow,
+  PrepayCandidate,
 } from '../types';
 import { formatUsd } from '../components/payments-shared';
 import {
@@ -327,6 +328,61 @@ export function PaymentsAdminPage() {
         'success',
       );
     }
+  }
+
+  /**
+   * tiramisu-49102: "Pay again to this wallet" from PayoutReviewModal.
+   * Closes the review modal and opens CreatePrepaymentModal pre-filled with
+   * the same party + host + payout-method/destination as the existing payout.
+   * The synthetic PrepayQueueRow mirrors the shape the prepay-queue endpoint
+   * normally emits — a single PrepayCandidate derived from the paid payout's
+   * host + method + walletAddress/bankEmail. CreatePrepaymentModal handles the
+   * cap-remaining clamp + the existing 50%-of-cap default.
+   */
+  function handlePayAgain(payout: AdminPayoutDetail) {
+    if (!payout.host?.id || !payout.payoutMethod || !payout.host.email) return;
+
+    const bankEmail =
+      payout.payoutMethod === 'wire' &&
+      payout.payoutBankDetails &&
+      typeof (payout.payoutBankDetails as any).email === 'string'
+        ? ((payout.payoutBankDetails as any).email as string).trim() || null
+        : null;
+
+    const candidate: PrepayCandidate = {
+      userId: payout.host.id,
+      name: payout.host.name ?? null,
+      email: payout.host.email,
+      method: payout.payoutMethod,
+      walletAddress:
+        payout.payoutMethod === 'usdc_base' ? payout.payoutWalletAddress ?? null : null,
+      bankEmail,
+      // We don't carry primary/cohost role here — the modal only uses it for
+      // a star icon. Default to false; the admin already knows who they're
+      // paying because the modal came from a specific payout row.
+      isPrimaryHost: false,
+    };
+
+    const syntheticRow: PrepayQueueRow = {
+      party: {
+        id: payout.party.id,
+        name: payout.party.name,
+        customUrl: payout.party.customUrl,
+        country: payout.party.country,
+        effectiveReimbursementCapUsd: payout.party.effectiveReimbursementCapUsd,
+        // We don't carry eventTags on AdminPayout.party; the modal only reads
+        // it for the cap-fallback display, and `effectiveReimbursementCapUsd`
+        // is already resolved upstream.
+        eventTags: [],
+      },
+      candidates: [candidate],
+      hasMultipleCandidates: false,
+      partyPaidUsd: payout.party.paidTotalUsd ?? 0,
+      partyPaidCount: payout.party.paidTotalCount ?? 0,
+    };
+
+    setDetail(null);
+    setPrepayModalRow(syntheticRow);
   }
 
   async function openDetail(p: AdminPayout) {
@@ -765,6 +821,7 @@ export function PaymentsAdminPage() {
                 return null;
               }
             }}
+            onPayAgain={handlePayAgain}
           />
         )}
         {showExternalModal && (


### PR DESCRIPTION
## Summary

Two related improvements to the admin /payments dashboard:

**A. Pay-again button on PayoutReviewModal.** Adds a "Pay again to this wallet" (USDC) / "Send another payment" (wire / mercury_card) button that's surfaced when the payout is `paid` AND we have enough to pre-fill the CreatePrepaymentModal — i.e. USDC needs a wallet, wire needs a bank email, mercury_card just needs the host. Click opens the existing CreatePrepaymentModal with a synthetic PrepayQueueRow holding the same party + host + method/destination, so the admin can issue a follow-up payment without leaving the modal.

**B. Hard per-party cap enforcement.** Until now the per-party `effectiveReimbursementCapUsd` was advisory — admins could exceed it by accident (Snax flagged a single $125 Paid payout against a party with a $500 cap that had no UI guardrail when adding more). Backend now rejects with `409 PARTY_CAP_EXCEEDED` when cumulative `paid+pending+approved` + the new amount would exceed the party's cap. Frontend shows remaining headroom inline, clamps the default amount to `min(cap/2, remaining)`, disables the submit button when over, and shows an inline "Exceeds cap" error.

Enforcement applies to:
- `POST /api/parties/:partyId/payouts` (host create + admin prepayment-create path)
- `PATCH /api/parties/:partyId/payouts/:payoutId` (amount edits, both explicit + recomputed-from-receipts)
- `POST /api/admin/payouts/external` (record external payment)
- `PATCH /api/admin/payouts/:id` (admin amount edits)

PATCH paths exclude the row being edited from the existing-total so a row doesn't count against itself. Parties without an effective cap stay uncapped.

`GET /api/admin/payouts/:id` now attaches `paidTotalUsd`/`paidTotalCount` to the response so the Pay-again path can populate the synthetic PrepayQueueRow with the per-party paid total for the cap-remaining clamp.

The bianco-89172 per-wallet $626 soft warning is untouched — that's a different rule (per-address GPP cap with admin acknowledgement override), and stays alongside the hard per-party cap.

## Deploy notes

- **Backend redeploy from master required** for cap enforcement to take effect (preview frontends talk to the production backend).
- Pay-again UI works on the Vercel preview immediately.

## Test plan

- [ ] On a `paid` USDC payout: PayoutReviewModal shows "Pay again to this wallet"; click opens CreatePrepaymentModal pre-filled with the same wallet + amount default
- [ ] On a `paid` wire payout: button reads "Send another payment"; modal pre-fills the bank email
- [ ] On a `paid` mercury_card payout: button reads "Send another payment"; modal pre-fills the host
- [ ] CreatePrepaymentModal: when remaining < cap/2, default amount clamps to remaining
- [ ] CreatePrepaymentModal: typing an amount over remaining shows "Exceeds cap: \$X remaining" and disables Create
- [ ] CreatePrepaymentModal: submitting at exactly remaining succeeds; over remaining is rejected by backend with 409
- [ ] Edit existing payout amount via PATCH past cap: backend returns 409 with remaining headroom message
- [ ] Record External Payment over cap: backend returns 409
- [ ] Party with no `reimbursementCapUsd` and no numeric event_tag: unconstrained (no cap message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)