### PR TITLE
acciuga-62583: hard $625 per-submission cap on host payout requests

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -46,6 +46,27 @@ const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'fai
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 
 /**
+ * acciuga-62583: hard per-submission ceiling of $625 — same value as
+ * `HARD_PER_TX_CEILING_USD` in usdc-base.service.ts (the USDC-execute ceiling)
+ * but enforced here at SUBMISSION time across all admin create/edit paths
+ * (external POST + PATCH). No override path. Inlined here per task spec —
+ * mirror of the helper in payout.routes.ts so we don't extract a shared module
+ * just for two callsites.
+ */
+const PER_SUBMISSION_MAX_USD = 625;
+
+function assertWithinPerSubmissionCap(amountUsd: number) {
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) return;
+  if (amountUsd > PER_SUBMISSION_MAX_USD) {
+    throw new AppError(
+      `Payment requests are limited to $${PER_SUBMISSION_MAX_USD} per submission. Please reduce the amount or split into multiple submissions.`,
+      400,
+      'PER_SUBMISSION_CAP_EXCEEDED',
+    );
+  }
+}
+
+/**
  * Shared Prisma `select` for the embedded `party` on payout responses.
  *
  * `expectedGuests` is the host's planning number; `_count.guests` is a
@@ -1051,6 +1072,11 @@ router.post(
         throw new AppError('Host user not found', 404, 'HOST_NOT_FOUND');
       }
 
+      // acciuga-62583: hard per-submission $625 ceiling (no override).
+      // Enforced BEFORE the party-cap check so the error message is clearer
+      // even on uncapped events. Out-of-band records still get split.
+      assertWithinPerSubmissionCap(finalAmountUsd);
+
       // tiramisu-49102: hard cap — block external records that would push the
       // cumulative paid+pending+approved past the party's effective cap.
       await assertWithinPartyCap(partyId, finalAmountUsd);
@@ -1427,6 +1453,9 @@ router.patch(
         if (oldAmount !== newAmount) {
           amountChanged = true;
           data.finalAmountUsd = parsed;
+          // acciuga-62583: hard per-submission $625 ceiling. Applies even to
+          // admin amount edits — there's no override path.
+          assertWithinPerSubmissionCap(parsed);
           // tiramisu-49102: re-check per-party cap when admin edits amount.
           // Exclude THIS row from the existing-total so the edit doesn't
           // count against itself.

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -289,6 +289,27 @@ async function assertMercuryAllowed(
 }
 
 /**
+ * acciuga-62583: hard per-submission ceiling of $625. Independent of the
+ * per-party cap (tiramisu-49102): even on uncapped parties, no single payout
+ * row can exceed $625. Same numeric value as `HARD_PER_TX_CEILING_USD` in
+ * usdc-base.service.ts (the USDC-execute ceiling) but enforced here at
+ * SUBMISSION time across all methods — no override path. Hosts split larger
+ * expenses across multiple submissions.
+ */
+const PER_SUBMISSION_MAX_USD = 625;
+
+function assertWithinPerSubmissionCap(amountUsd: number) {
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) return;
+  if (amountUsd > PER_SUBMISSION_MAX_USD) {
+    throw new AppError(
+      `Payment requests are limited to $${PER_SUBMISSION_MAX_USD} per submission. Please reduce the amount or split into multiple submissions.`,
+      400,
+      'PER_SUBMISSION_CAP_EXCEEDED',
+    );
+  }
+}
+
+/**
  * tiramisu-49102: hard per-party cap enforcement.
  *
  * Sums every existing payout for the party that is `pending | approved | paid`
@@ -643,6 +664,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       );
     }
 
+    // acciuga-62583: hard per-submission ceiling of $625 (no override).
+    // Enforced BEFORE the party-cap check so the host gets the clearer
+    // "split your submission" guidance even on uncapped events.
+    assertWithinPerSubmissionCap(finalUsd);
+
     // tiramisu-49102: hard cap — block creates that would push the cumulative
     // paid+pending+approved total past the party's effective cap. Parties
     // without an effective cap stay uncapped.
@@ -962,6 +988,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       if (!Number.isFinite(n) || n <= 0) {
         throw new AppError('finalAmountUsd must be a positive number', 400, 'INVALID_AMOUNT');
       }
+      // acciuga-62583: hard per-submission $625 ceiling — enforced before the
+      // party-cap check so the message is clearer on uncapped events.
+      assertWithinPerSubmissionCap(n);
       // tiramisu-49102: re-check per-party cap when the host edits the
       // amount. Exclude THIS row from the existing-total so the edit doesn't
       // count against itself.
@@ -1169,6 +1198,12 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ? Number((data.finalAmountUsd as Decimal).toString())
       : (recomputedAmount != null ? Number(recomputedAmount.toString()) : oldAmount);
     const amountChanged = newAmount !== oldAmount;
+
+    // acciuga-62583: hard per-submission $625 ceiling on the recomputed amount
+    // (explicit-amount edits are checked above next to the validation).
+    if (amountChanged && !explicitAmount) {
+      assertWithinPerSubmissionCap(newAmount);
+    }
 
     // tiramisu-49102: re-check per-party cap when a receipt-edit causes the
     // amount to be recomputed (explicit-amount edits are checked above).

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -16,6 +16,13 @@ function stripGppPrefix(name: string): string {
   return name.replace(/^Global Pizza Party\s+/i, '');
 }
 
+/**
+ * acciuga-62583: hard per-submission ceiling of $625. Matches backend
+ * `PER_SUBMISSION_CAP_EXCEEDED` (400). No override path — admin must split
+ * larger prepayments across multiple submissions.
+ */
+const PER_SUBMISSION_MAX_USD = 625;
+
 interface CreatePrepaymentModalProps {
   row: PrepayQueueRow;
   onClose: () => void;
@@ -56,9 +63,12 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
   // decimals round-trip through the backend without loss.
   // tiramisu-49102: clamp the default to whatever's actually left under the
   // cap (so a paid-down event doesn't pre-fill an over-cap default).
+  // acciuga-62583: also clamp to the hard $625 per-submission ceiling so the
+  // pre-filled default never trips the backend limit.
   const rawDefault = cap > 0 ? cap / 2 : 1;
-  const defaultAmount =
-    remainingUsd != null ? Math.min(rawDefault, remainingUsd).toFixed(2) : rawDefault.toFixed(2);
+  const clampedDefault =
+    remainingUsd != null ? Math.min(rawDefault, remainingUsd) : rawDefault;
+  const defaultAmount = Math.min(clampedDefault, PER_SUBMISSION_MAX_USD).toFixed(2);
 
   const mercuryBlocked = isMercuryBlocked(party.country);
 
@@ -99,12 +109,17 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
   const exceedsRemaining =
     remainingUsd != null && Number.isFinite(amountNum) && amountNum > remainingUsd + 1e-9;
 
+  // acciuga-62583: hard per-submission $625 ceiling, no override. Backend
+  // also enforces with 400 PER_SUBMISSION_CAP_EXCEEDED.
+  const exceedsPerSubmission = Number.isFinite(amountNum) && amountNum > PER_SUBMISSION_MAX_USD;
+
   const canSubmit =
     !!selectedCandidate &&
     !(selectedCandidate.method === 'mercury_card' && mercuryBlocked) &&
     Number.isFinite(amountNum) &&
     amountNum > 0 &&
     !exceedsRemaining &&
+    !exceedsPerSubmission &&
     !submitting;
 
   async function handleSubmit(e: React.FormEvent) {
@@ -274,6 +289,12 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
             {exceedsRemaining && remainingUsd != null && (
               <p className="text-xs text-red-500 mt-1">
                 Exceeds cap: ${remainingUsd.toFixed(2)} remaining
+              </p>
+            )}
+            {/* acciuga-62583: per-submission $625 ceiling */}
+            {exceedsPerSubmission && (
+              <p className="text-xs text-red-500 mt-1">
+                Single payments capped at ${PER_SUBMISSION_MAX_USD}
               </p>
             )}
           </div>

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -11,6 +11,13 @@ import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { PayoutAmountSummary } from './PayoutAmountSummary';
 import { AppealCapModal } from './AppealCapModal';
 
+/**
+ * acciuga-62583: hard per-submission ceiling of $625. Matches backend
+ * `PER_SUBMISSION_CAP_EXCEEDED` (400) — UI disables submit + shows inline
+ * error so the host can split the request before posting. No override path.
+ */
+const PER_SUBMISSION_MAX_USD = 625;
+
 interface NewPayoutFormProps {
   partyId: string;
   onCreated: (payout: Payout) => void;
@@ -138,10 +145,15 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const attendanceValid = !askForAttendance
     || (estimatedAttendance != null && estimatedAttendance > 0);
 
+  // acciuga-62583: hard $625 per-submission cap. Hosts split larger expenses
+  // into multiple submissions. Matches backend `PER_SUBMISSION_CAP_EXCEEDED`.
+  const exceedsPerSubmissionCap = finalAmount > PER_SUBMISSION_MAX_USD;
+
   // arugula-38633 v3 follow-up: payment details + receipts are no longer
   // required for submission. The submit button stays active whenever the
   // host has entered a positive amount and nothing async is in flight.
   const canSubmit = finalAmount > 0
+    && finalAmount <= PER_SUBMISSION_MAX_USD
     && attendanceValid
     && !isProcessing
     && !submitting;
@@ -348,6 +360,15 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       {submitError && (
         <div className="card p-4 border-red-500/40 bg-red-500/10 text-sm text-red-300">
           {submitError}
+        </div>
+      )}
+
+      {/* acciuga-62583: per-submission $625 ceiling. Same visual treatment as
+          submitError so the host sees the gate before clicking Submit. */}
+      {exceedsPerSubmissionCap && (
+        <div className="card p-4 border-red-500/40 bg-red-500/10 text-sm text-red-300">
+          Payment requests are limited to ${PER_SUBMISSION_MAX_USD} per submission.
+          Reduce the amount or split into multiple submissions.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Enforces a hard `$625` USD ceiling on every payout submission, with no override path. Hosts split larger expenses across multiple submissions.

- **Backend create paths gated** (returns `400 PER_SUBMISSION_CAP_EXCEEDED`):
  - `POST /api/parties/:partyId/payouts` (host create)
  - `PATCH /api/parties/:partyId/payouts/:payoutId` (host edit, both explicit `finalAmountUsd` and OCR-recomputed amount paths)
  - `POST /api/admin/payouts/external` (admin out-of-band record)
  - `PATCH /api/admin/payouts/:id` (admin amount edit)
- **Frontend gates submit + shows inline error**:
  - `NewPayoutForm` disables Submit when `finalAmount > $625` and renders the inline notice next to the existing error card.
  - `CreatePrepaymentModal` adds the cap to its `canSubmit` predicate, clamps the prefilled default amount, and renders an inline "Single payments capped at $625" hint.
- **Layered consistency**: same numeric value as `HARD_PER_TX_CEILING_USD` in `backend/src/services/usdc-base.service.ts` (the existing USDC-execute ceiling). Both kept in place — execute-time check stays as defense in depth at a different layer.

## Notes

- Independent of the per-party `effectiveReimbursementCapUsd` rule (tiramisu-49102) and the per-wallet $626 soft warning (bianco-89172). Both are unchanged.
- Does not retroactively edit existing payouts that already exceed $625 — that's a separate cleanup task. Only blocks new creates/edits.
- Backend redeploy from `master` is required for the API to enforce the new check; the UI gate ships on the preview branch immediately.

## Test plan

- [ ] On the Vercel preview, host submits a single payout with override > $625 → submit button stays disabled and inline notice visible.
- [ ] Host submits a payout at exactly $625.00 → succeeds.
- [ ] Admin opens `CreatePrepaymentModal` on an event with cap $5000 → default amount clamps to $625.00 (not $2500).
- [ ] After backend redeploy: direct API POST with `finalAmountUsd: 700` → 400 `PER_SUBMISSION_CAP_EXCEEDED`.