### PR TITLE
feat(montasio-49102): inline cap editor on admin /payments rows

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -20,6 +20,11 @@ interface PayoutsTableProps {
    * User.id. Surfaced when the admin clicks the host name in a row.
    */
   onHostClick?: (userId: string) => void;
+  /**
+   * montasio-49102: parent re-fetches the payouts list after an inline cap
+   * edit so the row reflects the new value.
+   */
+  onCapUpdated?: (partyId: string) => void;
   busyRowId?: string | null;
   loading?: boolean;
   loadingMore?: boolean;
@@ -128,6 +133,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
   onMarkPaid,
   onExecute,
   onHostClick,
+  onCapUpdated,
   busyRowId,
   loading,
   loadingMore,
@@ -187,6 +193,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
                 onSelectToggle={() => onToggleSelect(p.id)}
                 onClick={() => onRowClick(p)}
                 onHostClick={onHostClick}
+                onCapUpdated={onCapUpdated}
                 actions={
                   <ActionsCell
                     payout={p}

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { AlertTriangle, Star } from 'lucide-react';
 import type { PrepayCandidate, PrepayQueueRow } from '../../types';
-import { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from '../payments-shared';
+import { PayoutMethodIcon, PAYOUT_METHOD_LABELS, CapInlineEditor } from '../payments-shared';
 
 interface PrepayQueueTableProps {
   rows: PrepayQueueRow[];
@@ -13,6 +13,12 @@ interface PrepayQueueTableProps {
    * surface the click event with the User.id.
    */
   onHostClick?: (userId: string) => void;
+  /**
+   * montasio-49102: parent refreshes the prepay queue after an inline cap
+   * edit so the row reflects the new value (and any downstream "already paid
+   * vs cap" indicators).
+   */
+  onPartyUpdated?: (partyId: string) => void;
 }
 
 /**
@@ -76,6 +82,7 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
   rows,
   onCreatePrepayment,
   onHostClick,
+  onPartyUpdated,
 }) => {
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
@@ -91,7 +98,6 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
           </thead>
           <tbody>
             {rows.map((row) => {
-              const cap = row.party.effectiveReimbursementCapUsd;
               // siciliana-69183: event name links into the host dashboard's
               // Settings tab. Slug is `customUrl ?? id` to match user-facing
               // URLs. Tab id `'details'` is the canonical Settings tab (see
@@ -153,7 +159,13 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                     </div>
                   </td>
                   <td className="px-3 py-3 align-top text-theme-text">
-                    {cap != null ? `$${cap.toLocaleString()}` : '—'}
+                    {/* montasio-49102: inline edit so admins can change the
+                        cap without bouncing to the underboss dashboard. */}
+                    <CapInlineEditor
+                      partyId={row.party.id}
+                      currentCapUsd={row.party.effectiveReimbursementCapUsd ?? null}
+                      onUpdated={() => onPartyUpdated?.(row.party.id)}
+                    />
                   </td>
                   <td className="px-3 py-3 align-top text-right">
                     <button

--- a/frontend/src/components/payments-shared/CapInlineEditor.tsx
+++ b/frontend/src/components/payments-shared/CapInlineEditor.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { Check, X, Pencil, Loader2 } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { updatePartyApi } from '../../lib/api';
+
+interface CapInlineEditorProps {
+  partyId: string;
+  /**
+   * Current effective cap (may be the validated value or a tag-derived one).
+   * The editor saves to the underlying `reimbursementCapUsd` column (the
+   * validated value), not the tag fallback.
+   */
+  currentCapUsd: number | null;
+  /** Called after a successful save so the parent can refresh its data. */
+  onUpdated?: (newCapUsd: number | null) => void;
+}
+
+/**
+ * montasio-49102: shared inline editor for the per-event reimbursement cap,
+ * used on the `/payments` admin dashboard (Prepay queue + payouts table).
+ *
+ * Click the cap value (or the adjacent pencil icon) to enter edit mode.
+ * Enter saves, Escape cancels. An empty input clears the cap (saves `null`).
+ *
+ * The underboss dashboard has its own `ReimbursementCapCell` with extra
+ * "suggested cap" + "validate" logic; this is the stripped-down variant for
+ * admins who already know the value they want.
+ */
+export const CapInlineEditor: React.FC<CapInlineEditorProps> = ({
+  partyId,
+  currentCapUsd,
+  onUpdated,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(
+    currentCapUsd != null ? String(currentCapUsd) : ''
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function startEditing(e: React.MouseEvent) {
+    e.stopPropagation();
+    setDraft(currentCapUsd != null ? String(currentCapUsd) : '');
+    setError(null);
+    setEditing(true);
+  }
+
+  function cancel() {
+    setEditing(false);
+    setError(null);
+    setDraft(currentCapUsd != null ? String(currentCapUsd) : '');
+  }
+
+  async function save() {
+    const trimmed = draft.trim();
+    let value: number | null;
+    if (trimmed === '') {
+      value = null;
+    } else {
+      const n = Number(trimmed);
+      if (!Number.isFinite(n) || n <= 0 || n > 100000) {
+        setError('Enter a positive number ≤ 100000');
+        return;
+      }
+      value = n;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await updatePartyApi(partyId, { reimbursementCapUsd: value });
+      setEditing(false);
+      onUpdated?.(value);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <div
+        className="inline-flex flex-col gap-1"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="inline-flex items-center gap-1">
+          <IconInput
+            type="number"
+            step="0.01"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                save();
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                cancel();
+              }
+            }}
+            disabled={saving}
+            placeholder="$"
+            className="!pl-2 py-1 text-xs w-[70px] bg-theme-surface border border-theme-stroke rounded text-theme-text"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving}
+            className="p-1 rounded text-emerald-500 hover:bg-emerald-500/10 disabled:opacity-40"
+            title="Save"
+          >
+            {saving ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Check size={12} />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={cancel}
+            disabled={saving}
+            className="p-1 rounded text-theme-text-faint hover:text-theme-text-muted hover:bg-theme-surface-hover disabled:opacity-40"
+            title="Cancel"
+          >
+            <X size={12} />
+          </button>
+        </div>
+        {error && (
+          <span className="text-[10px] text-red-400" title={error}>
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  const display =
+    currentCapUsd != null ? `$${Number(currentCapUsd).toLocaleString()}` : '—';
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      className="inline-flex items-center gap-1 text-theme-text hover:text-[#E52828] group"
+      title="Edit reimbursement cap"
+    >
+      <span>{display}</span>
+      <Pencil
+        size={11}
+        className="text-theme-text-faint group-hover:text-[#E52828]"
+      />
+    </button>
+  );
+};

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -5,6 +5,7 @@ import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
 import { PayoutMethodIcon } from './PayoutMethodIcon';
 import { formatPayoutAmount } from './formatPayoutAmount';
+import { CapInlineEditor } from './CapInlineEditor';
 
 /**
  * bruschetta-58291: strip the "Global Pizza Party " prefix from event names so
@@ -39,6 +40,11 @@ interface PayoutRowProps {
    * `payout.hostUserId`. Parent owns the modal state.
    */
   onHostClick?: (userId: string) => void;
+  /**
+   * montasio-49102: parent re-fetches the payouts list after an inline cap
+   * edit so the row reflects the new value.
+   */
+  onCapUpdated?: (partyId: string) => void;
 }
 
 /**
@@ -56,6 +62,7 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
   onClick,
   actions,
   onHostClick,
+  onCapUpdated,
 }) => {
   const admin = payout as AdminPayout;
   const firstPizza = (payout.documents || []).find((d) => d.kind === 'pizza');
@@ -168,16 +175,23 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
             {admin.party.rsvpCount}
             {' RSVPs'}
           </div>
-          {/* arugula-38633 (cap-everywhere): show resolved reimbursement cap
-              when set. Null = omit the line entirely (the row is already dense). */}
-          {admin.party.effectiveReimbursementCapUsd != null && (
-            <div
-              className="text-xs text-theme-text-muted"
-              title="Reimbursement cap (validated value or max numeric event_tag)"
-            >
-              ${Number(admin.party.effectiveReimbursementCapUsd).toLocaleString()} cap
-            </div>
-          )}
+          {/* arugula-38633 (cap-everywhere): show resolved reimbursement cap.
+              montasio-49102: inline editor so admins can change the cap
+              without bouncing to the underboss dashboard. Always rendered in
+              admin mode so admins can set a cap on parties that don't have
+              one yet. */}
+          <div
+            className="text-xs text-theme-text-muted mt-0.5 inline-flex items-center gap-1"
+            title="Reimbursement cap (validated value or max numeric event_tag)"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CapInlineEditor
+              partyId={admin.party.id}
+              currentCapUsd={admin.party.effectiveReimbursementCapUsd ?? null}
+              onUpdated={() => onCapUpdated?.(admin.party.id)}
+            />
+            <span>cap</span>
+          </div>
         </td>
       )}
 

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -1,4 +1,5 @@
 export { PayoutStatusPill } from './PayoutStatusPill';
 export { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from './PayoutMethodIcon';
 export { PayoutRow } from './PayoutRow';
+export { CapInlineEditor } from './CapInlineEditor';
 export { formatPayoutAmount, formatUsd, formatOriginalCurrency } from './formatPayoutAmount';

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -652,6 +652,7 @@ export function PaymentsAdminPage() {
                 rows={sortedPrepayQueue}
                 onCreatePrepayment={(row) => setPrepayModalRow(row)}
                 onHostClick={(userId) => setHostDetailUserId(userId)}
+                onPartyUpdated={() => loadPrepayQueue()}
               />
             )}
           </section>
@@ -695,6 +696,7 @@ export function PaymentsAdminPage() {
           onMarkPaid={handleRowMarkPaid}
           onExecute={openDetail}
           onHostClick={(userId) => setHostDetailUserId(userId)}
+          onCapUpdated={() => refresh()}
           busyRowId={rowBusyId}
           loading={loading}
           loadingMore={loadingMore}


### PR DESCRIPTION
## Summary
- New `CapInlineEditor` shared component (`frontend/src/components/payments-shared/CapInlineEditor.tsx`).
- Wired into `PrepayQueueTable` (Cap column) and `PayoutRow` (cap chip).
- Click to edit, Enter to save, Esc to cancel; empty value clears the cap.
- Uses existing PATCH endpoint + auto-audited via fennel-49102.
- Parent refreshes data after save.

## Test plan
- [ ] Prepay queue row -> click cap -> change -> Save -> row reflects.
- [ ] Payouts table row -> click cap -> change -> Save -> row reflects.
- [ ] Clear input + Save -> cap becomes null, displays "-".
- [ ] Bad input -> inline error, no save.
- [ ] reimbursement_cap_audit table shows the change with actor_email = the admin who clicked.