### PR TITLE
feat(paesana-89172): primary-host visibility + suspicious-payment flag

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -90,6 +90,12 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   // `computeEffectiveCapUsd` helper (validated cap OR max numeric tag).
   reimbursementCapUsd: true,
   eventTags: true,
+  // paesana-89172: needed to derive `primaryHostInCohosts` — admin warning
+  // when a payout's recipient is the primary host but they're not in the
+  // co_hosts JSONB (= invisible on the event UI).
+  userId: true,
+  coHosts: true,
+  user: { select: { email: true } },
   _count: {
     select: {
       guests: {
@@ -353,6 +359,26 @@ function buildPayoutWhere(query: Request['query']): any {
   return where;
 }
 
+/**
+ * paesana-89172: returns true when the party's primary host (party.user.email)
+ * is present in the co_hosts JSONB array (case-insensitive email match), OR
+ * the party doesn't have a User joined (rare). Returns false ONLY when we know
+ * the primary host's email AND it's missing from co_hosts — that's the
+ * suspicious-payment signal: the recipient is the event owner but they're
+ * invisible in the Hosts UI / public page.
+ */
+function isPrimaryHostInCohosts(party: any): boolean {
+  if (!party || typeof party !== 'object') return true;
+  const ownerEmail = party.user?.email ? String(party.user.email).toLowerCase() : null;
+  if (!ownerEmail) return true; // can't determine — don't flag
+  const list = Array.isArray(party.coHosts) ? party.coHosts : [];
+  return list.some((ch: any) =>
+    ch && typeof ch === 'object'
+    && typeof ch.email === 'string'
+    && ch.email.toLowerCase() === ownerEmail
+  );
+}
+
 /** Shape a Prisma payout row for the API response. */
 function serializePayout(row: any): any {
   return {
@@ -421,6 +447,13 @@ function serializePayout(row: any): any {
             reimbursementCapUsd: row.party.reimbursementCapUsd,
             eventTags: row.party.eventTags,
           }),
+          // paesana-89172: surface the owner's id + a flag for whether they
+          // appear in the co_hosts array. Frontend pairs this with
+          // `payout.hostUserId` to flag suspicious admin-created prepayments
+          // whose recipient is the primary host but isn't visible on the
+          // event UI.
+          userId: row.party.userId ?? null,
+          primaryHostInCohosts: isPrimaryHostInCohosts(row.party),
         }
       : undefined,
     host: row.host
@@ -817,6 +850,11 @@ router.get(
           country: string | null;
           effectiveReimbursementCapUsd: number | null;
           eventTags: string[];
+          // paesana-89172: primary host (parties.userId) + whether they
+          // appear in co_hosts. Frontend flags amber when a candidate's
+          // userId matches but the primary host isn't visible.
+          userId: string | null;
+          primaryHostInCohosts: boolean;
         };
         candidates: CandidateInternal[];
       };
@@ -870,6 +908,11 @@ router.get(
             country: p.country,
             effectiveReimbursementCapUsd: cap,
             eventTags: p.eventTags,
+            // paesana-89172: shape this party for the warning helper. The
+            // prepay-queue select already pulls `userId`, `coHosts`, and
+            // `user.email` — reuse them via `isPrimaryHostInCohosts`.
+            userId: p.userId ?? null,
+            primaryHostInCohosts: isPrimaryHostInCohosts(p),
           },
           candidates,
         });

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -275,11 +275,30 @@ router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => 
       select: { name: true },
     });
 
-    // Build coHosts array with host email if provided
-    const hostCoHosts = req.userEmail
-      ? [{ id: crypto.randomUUID(), name: user?.name || '', email: req.userEmail, showOnEvent: false }]
-      : [];
-    const finalCoHosts = coHosts || hostCoHosts;
+    // paesana-89172: ALWAYS ensure the primary host (req.userEmail) appears in
+    // the co_hosts array — otherwise the Hosts UI hides them and the prepay
+    // queue treats them as an invisible recipient. Merge the client-supplied
+    // coHosts with a synthesized entry for the creator (case-insensitive email
+    // match) when missing. showOnEvent + canEdit default true so the owner is
+    // visible on the event page and can manage it.
+    const baseCoHosts: any[] = Array.isArray(coHosts) ? [...coHosts] : [];
+    if (req.userEmail) {
+      const creatorEmail = req.userEmail.toLowerCase();
+      const alreadyPresent = baseCoHosts.some(
+        (h: any) => h && typeof h === 'object' && typeof h.email === 'string'
+          && h.email.toLowerCase() === creatorEmail
+      );
+      if (!alreadyPresent) {
+        baseCoHosts.push({
+          id: crypto.randomUUID(),
+          name: user?.name || req.userEmail,
+          email: req.userEmail,
+          showOnEvent: true,
+          canEdit: true,
+        });
+      }
+    }
+    const finalCoHosts = baseCoHosts;
 
     const party = await prisma.party.create({
       data: {
@@ -982,7 +1001,21 @@ router.get('/:partyId/cohosts/full', async (req: AuthRequest, res: Response, nex
 
     const party = await prisma.party.findUnique({
       where: { id: partyId },
-      select: { coHosts: true },
+      // paesana-89172: also return the primary host (parties.userId) so the
+      // HostsManager can render an "Owner" row even when the owner's email
+      // isn't in co_hosts yet. Without this, owners created via the v1 API
+      // or older code paths vanish from the Hosts UI.
+      select: {
+        coHosts: true,
+        userId: true,
+        user: {
+          select: {
+            name: true,
+            email: true,
+            profilePictureUrl: true,
+          },
+        },
+      },
     });
 
     if (!party) {
@@ -994,7 +1027,17 @@ router.get('/:partyId/cohosts/full', async (req: AuthRequest, res: Response, nex
       return res.status(403).json({ error: 'not authorized' });
     }
 
-    return res.json({ coHosts: party.coHosts ?? [] });
+    return res.json({
+      coHosts: party.coHosts ?? [],
+      primaryHost: party.user
+        ? {
+            userId: party.userId,
+            name: party.user.name,
+            email: party.user.email,
+            avatar_url: party.user.profilePictureUrl,
+          }
+        : null,
+    });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/v1/parties.ts
+++ b/backend/src/routes/v1/parties.ts
@@ -1,4 +1,5 @@
 import { Router, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import { prisma } from '../../config/database.js';
 import { requireApiKey, ApiKeyRequest, SCOPES } from '../../middleware/apiKey.js';
 import { AppError } from '../../middleware/error.js';
@@ -141,6 +142,23 @@ router.post('/', requireApiKey(SCOPES.PARTIES_WRITE), async (req: ApiKeyRequest,
       }
     }
 
+    // paesana-89172: auto-add the API key's owner User as the primary host
+    // in co_hosts. Without this, parties created via the public API would
+    // never show their owner in the Hosts UI / prepay queue.
+    const owner = await prisma.user.findUnique({
+      where: { id: req.apiKey!.userId },
+      select: { name: true, email: true },
+    });
+    const ownerCoHosts: any[] = owner?.email
+      ? [{
+          id: crypto.randomUUID(),
+          name: owner.name || owner.email,
+          email: owner.email,
+          showOnEvent: true,
+          canEdit: true,
+        }]
+      : [];
+
     const party = await prisma.party.create({
       data: {
         name: name.trim(),
@@ -160,7 +178,7 @@ router.post('/', requireApiKey(SCOPES.PARTIES_WRITE), async (req: ApiKeyRequest,
         eventImageUrl: eventImageUrl || null,
         description: description || null,
         customUrl: customUrl || null,
-        coHosts: [],
+        coHosts: ownerCoHosts,
         userId: req.apiKey!.userId,
       },
     });

--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -45,6 +45,18 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   // (see arugula-38633 incident in MEMORY).
   const [fullCoHosts, setFullCoHosts] = useState<CoHost[] | null>(null);
 
+  // paesana-89172: primary host (parties.userId) info fetched from the same
+  // endpoint. Used to render a synthetic "Owner" row when the owner's email
+  // isn't in co_hosts yet — and to canonicalize them into co_hosts on first
+  // save (toggle/edit/remove of any sibling). 37+ existing parties had their
+  // owner invisible from this UI before the paesana-89172 backfill landed.
+  const [primaryHost, setPrimaryHost] = useState<{
+    userId: string | null;
+    name: string | null;
+    email: string;
+    avatar_url: string | null;
+  } | null>(null);
+
   // Co-hosts state — includes ALL co-hosts (manual + protected).
   // Prefer the unsanitized fetch when available; fall back to props otherwise.
   const [coHosts, setCoHosts] = useState<CoHost[]>(initialCoHosts);
@@ -54,6 +66,61 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   const visibleCoHosts = React.useMemo(
     () => coHosts.filter(h => !isProtected(h)),
     [coHosts]
+  );
+
+  // paesana-89172: case-insensitive lookup of the primary host inside the
+  // current cohosts array.
+  const ownerEmail = primaryHost?.email?.toLowerCase() ?? null;
+  const ownerCoHost = React.useMemo<CoHost | null>(() => {
+    if (!ownerEmail) return null;
+    return visibleCoHosts.find(h => (h.email ?? '').toLowerCase() === ownerEmail) ?? null;
+  }, [visibleCoHosts, ownerEmail]);
+
+  // paesana-89172: when the primary host is NOT yet in co_hosts (legacy
+  // parties pre-backfill or any new path that forgets to auto-add), build a
+  // synthetic row so they still render. Any change to the synthetic row
+  // canonicalizes them into co_hosts via `canonicalizeOwnerIntoCoHosts`.
+  const syntheticOwnerRow = React.useMemo<CoHost | null>(() => {
+    if (!primaryHost || ownerCoHost) return null;
+    return {
+      id: `__owner_synthetic_${primaryHost.userId ?? primaryHost.email}`,
+      name: primaryHost.name ?? primaryHost.email,
+      email: primaryHost.email,
+      avatar_url: primaryHost.avatar_url ?? undefined,
+      showOnEvent: true,
+      canEdit: true,
+    };
+  }, [primaryHost, ownerCoHost]);
+
+  // The row id of "the owner" — synthetic or real — used to flag the Owner
+  // badge + hide the X (remove) button on that row.
+  const ownerRowId = syntheticOwnerRow?.id ?? ownerCoHost?.id ?? null;
+
+  // Cohosts list as actually rendered: prepend the synthetic owner when one
+  // exists; otherwise leave the list alone. The owner appears once either way.
+  const renderedCoHosts = React.useMemo<CoHost[]>(() => {
+    if (syntheticOwnerRow) return [syntheticOwnerRow, ...visibleCoHosts];
+    return visibleCoHosts;
+  }, [syntheticOwnerRow, visibleCoHosts]);
+
+  /**
+   * paesana-89172: if the owner row is synthetic (not yet in coHosts), inject
+   * them into the array so the rest of the toggle/edit handlers can operate
+   * on a real entry. Returns the updated array + the id the rest of the
+   * handler should target (synthetic id is replaced with a real uuid).
+   */
+  const canonicalizeOwnerIntoCoHosts = React.useCallback(
+    (current: CoHost[], targetId: string): { next: CoHost[]; resolvedId: string } => {
+      if (!syntheticOwnerRow || targetId !== syntheticOwnerRow.id) {
+        return { next: current, resolvedId: targetId };
+      }
+      const realEntry: CoHost = {
+        ...syntheticOwnerRow,
+        id: uuid(),
+      };
+      return { next: [...current, realEntry], resolvedId: realEntry.id };
+    },
+    [syntheticOwnerRow]
   );
 
   // Sync from props when enriched data arrives asynchronously — but only if
@@ -68,18 +135,27 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
 
   // Fetch the unsanitized cohosts (with email) on mount / partyId change.
   // Silent fallback on error — render falls back to sanitized props.
+  // paesana-89172: also captures the primary host so we can render the
+  // synthetic "Owner" row when their email isn't in co_hosts.
   useEffect(() => {
     if (!partyId) return;
     let cancelled = false;
     (async () => {
       try {
-        const data = await apiRequest<{ coHosts: CoHost[] }>(
-          `/api/parties/${partyId}/cohosts/full`
-        );
+        const data = await apiRequest<{
+          coHosts: CoHost[];
+          primaryHost?: {
+            userId: string | null;
+            name: string | null;
+            email: string;
+            avatar_url: string | null;
+          } | null;
+        }>(`/api/parties/${partyId}/cohosts/full`);
         if (cancelled) return;
         const next = Array.isArray(data.coHosts) ? data.coHosts : [];
         setFullCoHosts(next);
         setCoHosts(next);
+        setPrimaryHost(data.primaryHost ?? null);
       } catch {
         // Silent fallback — keep sanitized props as source of truth.
       }
@@ -176,8 +252,10 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   };
 
   const toggleTabPermission = async (coHostId: string, tabId: string) => {
-    const newCoHosts = coHosts.map(h => {
-      if (h.id !== coHostId) return h;
+    // paesana-89172: canonicalize synthetic owner before mutating permissions.
+    const { next: canon, resolvedId } = canonicalizeOwnerIntoCoHosts(coHosts, coHostId);
+    const newCoHosts = canon.map(h => {
+      if (h.id !== resolvedId) return h;
       // If allowedTabs is undefined (all access), start with full list then remove the toggled tab
       const current = Array.isArray(h.allowedTabs) ? h.allowedTabs : permissionTabs.map(t => t.id);
       const updated = current.includes(tabId)
@@ -192,11 +270,14 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   };
 
   const toggleAllTabs = async (coHostId: string) => {
-    const coHost = coHosts.find(h => h.id === coHostId);
+    // Use the rendered list (incl. synthetic owner) for the lookup, then
+    // canonicalize before applying — same pattern as toggleCoHostCanEdit.
+    const coHost = renderedCoHosts.find(h => h.id === coHostId);
     if (!coHost) return;
     const hasAll = !Array.isArray(coHost.allowedTabs);
-    const newCoHosts = coHosts.map(h => {
-      if (h.id !== coHostId) return h;
+    const { next: canon, resolvedId } = canonicalizeOwnerIntoCoHosts(coHosts, coHostId);
+    const newCoHosts = canon.map(h => {
+      if (h.id !== resolvedId) return h;
       // If currently all tabs (undefined), restrict to empty; if restricted, give all (undefined)
       return { ...h, allowedTabs: hasAll ? [] : undefined };
     });
@@ -327,8 +408,15 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
         avatarUrl = await proxyAvatarToStorage(editHostAvatarUrl.trim());
       }
 
-      const newCoHosts = coHosts.map(h =>
-        h.id === editingHostId
+      // paesana-89172: if the editing target is the synthetic owner row,
+      // canonicalize into coHosts first so the field updates land on a real
+      // entry that will persist through subsequent renders.
+      const { next: canon, resolvedId } = canonicalizeOwnerIntoCoHosts(
+        coHosts,
+        editingHostId ?? '',
+      );
+      const newCoHosts = canon.map(h =>
+        h.id === resolvedId
           ? {
             ...h,
             name: editHostName.trim(),
@@ -358,8 +446,11 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   };
 
   const toggleCoHostShowOnEvent = async (id: string) => {
-    const newCoHosts = coHosts.map(h =>
-      h.id === id ? { ...h, showOnEvent: !h.showOnEvent } : h
+    // paesana-89172: canonicalize synthetic owner row → real cohost entry
+    // before applying the toggle, so the change actually persists.
+    const { next: canon, resolvedId } = canonicalizeOwnerIntoCoHosts(coHosts, id);
+    const newCoHosts = canon.map(h =>
+      h.id === resolvedId ? { ...h, showOnEvent: !h.showOnEvent } : h
     );
     setCoHosts(newCoHosts);
     // Auto-save
@@ -367,12 +458,14 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
   };
 
   const toggleCoHostCanEdit = async (id: string) => {
-    const newCoHosts = coHosts.map(h => {
-      if (h.id !== id) return h;
+    // paesana-89172: canonicalize synthetic owner row → real cohost entry.
+    const { next: canon, resolvedId } = canonicalizeOwnerIntoCoHosts(coHosts, id);
+    const newCoHosts = canon.map(h => {
+      if (h.id !== resolvedId) return h;
       const newCanEdit = !h.canEdit;
       // Clear allowedTabs and collapse permissions when turning off Editor
       if (!newCanEdit) {
-        setExpandedPermissionsId(prev => prev === id ? null : prev);
+        setExpandedPermissionsId(prev => prev === resolvedId ? null : prev);
         return { ...h, canEdit: false, allowedTabs: undefined };
       }
       return { ...h, canEdit: true };
@@ -420,8 +513,14 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
 
       {/* Hosts List (Main Host + Co-Hosts) */}
       <div className="space-y-2 mb-3">
-        {/* Main Host (display only - name comes from user account) */}
-        {hostName && (
+        {/* paesana-89172: the standalone "Primary" display row used to
+            render here. The owner is now the first entry in
+            `renderedCoHosts` below (with an "Owner" badge + editable
+            toggles + non-removable), so rendering them here would
+            duplicate them. Only render this legacy display row when we
+            haven't yet loaded the primaryHost data (network fallback)
+            AND the owner isn't already in the cohosts array. */}
+        {hostName && !primaryHost && !ownerCoHost && (
           <div className="flex items-center justify-between p-3 bg-white/5 rounded-xl border border-[#ff393a]/30 transition-all">
             <div className="flex items-center gap-3 flex-1">
               <div className="w-10 h-10 rounded-full bg-[#ff393a]/20 flex items-center justify-center">
@@ -437,24 +536,37 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
           </div>
         )}
 
-        {/* Co-Hosts (visible only — protected/auto-added entries are hidden from host UI) */}
-        {visibleCoHosts.map((coHost) => {
+        {/* Co-Hosts (visible only — protected/auto-added entries are hidden from host UI)
+            paesana-89172: `renderedCoHosts` prepends a synthetic "Owner" row when
+            the primary host isn't yet in co_hosts; on first toggle/edit the
+            synthetic row is canonicalized into a real co_host entry. */}
+        {renderedCoHosts.map((coHost) => {
           const fullIndex = coHosts.findIndex(h => h.id === coHost.id);
+          const isOwnerRow = ownerRowId !== null && coHost.id === ownerRowId;
+          // Owner row can't be dragged or removed (they can't be kicked off
+          // their own event). Synthetic owner has no real index — render
+          // without dnd handlers.
+          const draggable = !isOwnerRow;
           return (
           <div
             key={coHost.id}
-            draggable
-            onDragStart={() => handleDragStart(coHost.id)}
-            onDragOver={(e) => handleDragOver(e, coHost.id)}
-            onDragEnd={handleDragEnd}
-            className={`p-3 bg-white/5 rounded-xl border border-white/10 transition-all cursor-move ${draggedIndex === fullIndex ? 'opacity-50' : 'opacity-100'
+            draggable={draggable}
+            onDragStart={draggable ? () => handleDragStart(coHost.id) : undefined}
+            onDragOver={draggable ? (e) => handleDragOver(e, coHost.id) : undefined}
+            onDragEnd={draggable ? handleDragEnd : undefined}
+            className={`p-3 bg-white/5 rounded-xl border ${isOwnerRow ? 'border-[#ff393a]/30' : 'border-white/10'} transition-all ${draggable ? 'cursor-move' : ''} ${draggedIndex === fullIndex ? 'opacity-50' : 'opacity-100'
               }`}
           >
             {/* Top row: identity + remove button */}
             <div className="flex items-center gap-3">
-              <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0">
-                <GripVertical size={18} />
-              </div>
+              {isOwnerRow ? (
+                // Owner row: no drag handle (can't be reordered before owner).
+                <div className="w-[18px] shrink-0" />
+              ) : (
+                <div className="cursor-grab active:cursor-grabbing text-white/30 hover:text-white/60 shrink-0">
+                  <GripVertical size={18} />
+                </div>
+              )}
               {coHost.avatar_url ? (
                 <img src={coHost.avatar_url} alt={coHost.name} className="w-10 h-10 rounded-full object-cover shrink-0" />
               ) : (
@@ -465,6 +577,14 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <p className="text-white font-medium truncate">{coHost.name}</p>
+                  {/* paesana-89172: "Owner" badge for the primary host row
+                      (synthetic OR real). Mirrors the existing "Primary"
+                      pill style used on the main host row. */}
+                  {isOwnerRow && (
+                    <span className="text-xs bg-[#ff393a]/20 text-[#ff393a] px-2 py-0.5 rounded-full shrink-0">
+                      Owner
+                    </span>
+                  )}
                 </div>
                 {coHost.email && (
                   <p className="text-white/50 text-xs truncate">{coHost.email}</p>
@@ -501,13 +621,17 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
                   )}
                 </div>
               </div>
-              <button
-                type="button"
-                onClick={() => removeCoHost(coHost.id)}
-                className="text-[#ff393a] hover:text-[#ff5a5b] shrink-0"
-              >
-                <X size={18} />
-              </button>
+              {/* paesana-89172: Owner row is non-removable — the primary host
+                  can't be kicked from their own event. */}
+              {!isOwnerRow && (
+                <button
+                  type="button"
+                  onClick={() => removeCoHost(coHost.id)}
+                  className="text-[#ff393a] hover:text-[#ff5a5b] shrink-0"
+                >
+                  <X size={18} />
+                </button>
+              )}
             </div>
             {/* Bottom row: controls */}
             <div className="flex items-center gap-3 mt-2 pl-9">
@@ -606,12 +730,12 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
         avatarFilePreview={editAvatarFilePreview}
         showOnEvent={
           editingHostId
-            ? (coHosts.find(h => h.id === editingHostId)?.showOnEvent !== false)
+            ? (renderedCoHosts.find(h => h.id === editingHostId)?.showOnEvent !== false)
             : true
         }
         canEdit={
           editingHostId
-            ? (coHosts.find(h => h.id === editingHostId)?.canEdit === true)
+            ? (renderedCoHosts.find(h => h.id === editingHostId)?.canEdit === true)
             : false
         }
         xAvatarFetching={editXAvatarFetching}

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -229,6 +229,17 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
                           <Star size={12} className="text-amber-500 shrink-0" />
                         )}
                         <span className="truncate">{label}</span>
+                        {/* paesana-89172: amber warning when this candidate
+                            is the primary host of an event where the primary
+                            host isn't in co_hosts (= invisible on the public
+                            event page). Doesn't block selection. */}
+                        {c.isPrimaryHost && party.primaryHostInCohosts === false && (
+                          <AlertTriangle
+                            size={12}
+                            className="text-amber-500 shrink-0"
+                            aria-label="Primary host is not visible on the event page"
+                          />
+                        )}
                       </div>
                       <div className="text-xs text-theme-text-muted truncate">
                         {c.email}
@@ -239,6 +250,17 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
                           {PAYOUT_METHOD_LABELS[c.method]}
                         </span>
                       </div>
+                      {/* paesana-89172: explainer text under the chosen
+                          recipient when they're the invisible primary host. */}
+                      {c.isPrimaryHost && party.primaryHostInCohosts === false && (
+                        <div className="mt-1.5 flex items-start gap-1 text-xs text-amber-500">
+                          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                          <span>
+                            This host isn't shown on the event page — confirm
+                            they're the active organizer before paying.
+                          </span>
+                        </div>
+                      )}
                       {disabled && (
                         <div className="mt-1.5 flex items-start gap-1 text-xs text-amber-500">
                           <AlertTriangle size={12} className="mt-0.5 shrink-0" />

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -37,14 +37,23 @@ function stripGppPrefix(name: string): string {
  *
  * siciliana-69183: becomes a button when `onClick` is supplied so the admin
  * can drill into the candidate's saved payment details.
+ *
+ * paesana-89172: when the candidate is the primary host AND the primary host
+ * isn't in co_hosts, suffix an amber AlertTriangle. Means "this person
+ * isn't shown on the event page — confirm before paying."
  */
 const HostChip: React.FC<{
   candidate: PrepayCandidate;
+  invisiblePrimaryHost?: boolean;
   onClick?: () => void;
-}> = ({ candidate, onClick }) => {
+}> = ({ candidate, invisiblePrimaryHost = false, onClick }) => {
   const displayName = candidate.name && candidate.name.trim()
     ? candidate.name
     : candidate.email;
+  const showInvisibleWarning = candidate.isPrimaryHost && invisiblePrimaryHost;
+  const titleSuffix = showInvisibleWarning
+    ? ' · NOT VISIBLE on event page — confirm this is the right host'
+    : '';
   const inner = (
     <>
       {candidate.isPrimaryHost && (
@@ -52,6 +61,13 @@ const HostChip: React.FC<{
       )}
       <PayoutMethodIcon method={candidate.method} size={12} />
       <span className="truncate max-w-[12rem]">{displayName}</span>
+      {showInvisibleWarning && (
+        <AlertTriangle
+          size={12}
+          className="text-amber-500 shrink-0"
+          aria-label="Primary host is not visible on the event page"
+        />
+      )}
     </>
   );
   const baseClass =
@@ -62,7 +78,7 @@ const HostChip: React.FC<{
         type="button"
         onClick={onClick}
         className={`${baseClass} hover:border-theme-stroke-hover hover:bg-theme-surface-active cursor-pointer`}
-        title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]} · click for payment details`}
+        title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]} · click for payment details${titleSuffix}`}
       >
         {inner}
       </button>
@@ -71,7 +87,7 @@ const HostChip: React.FC<{
   return (
     <span
       className={baseClass}
-      title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]}`}
+      title={`${displayName} — ${PAYOUT_METHOD_LABELS[candidate.method]}${titleSuffix}`}
     >
       {inner}
     </span>
@@ -153,6 +169,10 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                         <HostChip
                           key={c.userId}
                           candidate={c}
+                          // paesana-89172: pass through the party-level
+                          // "primary host missing from co_hosts" flag so the
+                          // chip can render the amber warning.
+                          invisiblePrimaryHost={row.party.primaryHostInCohosts === false}
                           onClick={onHostClick ? () => onHostClick(c.userId) : undefined}
                         />
                       ))}

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { AlertTriangle } from 'lucide-react';
 import type { AdminPayout, Payout } from '../../types';
 import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
@@ -102,21 +103,40 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
 
       {showAdminColumns && admin.host && (
         <td className="px-3 py-3 text-sm" onClick={(e) => e.stopPropagation()}>
-          {/* siciliana-69183: when `onHostClick` is wired, the host name becomes
-              a button that opens the read-only HostPaymentDetailsModal. Falls
-              back to plain text for any callsite that doesn't want the modal. */}
-          {onHostClick && payout.hostUserId ? (
-            <button
-              type="button"
-              onClick={() => onHostClick(payout.hostUserId)}
-              className="font-medium text-theme-text hover:text-[#E52828] hover:underline text-left"
-              title="View saved payment details"
-            >
-              {admin.host.name || admin.host.email || '—'}
-            </button>
-          ) : (
-            <div className="font-medium text-theme-text">{admin.host.name || '—'}</div>
-          )}
+          <div className="flex items-center gap-1.5">
+            {/* siciliana-69183: when `onHostClick` is wired, the host name becomes
+                a button that opens the read-only HostPaymentDetailsModal. Falls
+                back to plain text for any callsite that doesn't want the modal. */}
+            {onHostClick && payout.hostUserId ? (
+              <button
+                type="button"
+                onClick={() => onHostClick(payout.hostUserId)}
+                className="font-medium text-theme-text hover:text-[#E52828] hover:underline text-left"
+                title="View saved payment details"
+              >
+                {admin.host.name || admin.host.email || '—'}
+              </button>
+            ) : (
+              <div className="font-medium text-theme-text">{admin.host.name || '—'}</div>
+            )}
+            {/* paesana-89172: amber warning when the payout's recipient IS the
+                party's primary host (parties.userId) but the primary host
+                isn't in co_hosts — meaning the recipient is invisible on the
+                event UI. Backfill should make this 0-hit for legacy data;
+                this is the defensive flag for any new occurrences. */}
+            {admin.party
+              && admin.party.primaryHostInCohosts === false
+              && admin.party.userId != null
+              && admin.party.userId === payout.hostUserId && (
+                <span
+                  className="inline-flex items-center text-amber-500 shrink-0"
+                  title="This host isn't shown on the event page — they may not be the active organizer."
+                  aria-label="Primary host not visible in cohost list"
+                >
+                  <AlertTriangle size={14} />
+                </span>
+              )}
+          </div>
           {admin.host.email && (
             <div className="text-xs text-theme-text-muted">
               <ClickableEmail email={admin.host.email} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1629,6 +1629,21 @@ export interface AdminPayout extends Payout {
      * `paidTotalUsd`. Shown in parens, e.g. "Already paid: $470.00 (2)".
      */
     paidTotalCount?: number;
+    /**
+     * paesana-89172: owner User id (parties.userId). Paired with
+     * `primaryHostInCohosts` so the frontend can flag rows where the payout
+     * recipient is the primary host but they aren't visible on the event UI
+     * (= missing from co_hosts). Optional for backward-compat with cached
+     * payloads during rolling deploys.
+     */
+    userId?: string | null;
+    /**
+     * paesana-89172: true when the primary host's email appears in co_hosts.
+     * False means the primary host is invisible on the event page — admins
+     * should double-check before paying out to them. Optional for
+     * backward-compat.
+     */
+    primaryHostInCohosts?: boolean;
   };
   host: {
     id: string;
@@ -1714,6 +1729,19 @@ export interface PrepayQueueRow {
     country: string | null;
     effectiveReimbursementCapUsd: number | null;
     eventTags: string[];
+    /**
+     * paesana-89172: owner User id (parties.userId). Paired with
+     * `primaryHostInCohosts` so the prepay-queue table can flag rows where
+     * the candidate is the primary host but they aren't visible on the
+     * event UI. Optional for backward-compat with cached payloads.
+     */
+    userId?: string | null;
+    /**
+     * paesana-89172: true when the primary host's email appears in
+     * co_hosts. False = invisible owner — flag amber on the candidate
+     * chip. Optional for backward-compat.
+     */
+    primaryHostInCohosts?: boolean;
   };
   candidates: PrepayCandidate[];
   /** True when the admin must disambiguate between ≥2 candidates. */


### PR DESCRIPTION
## Summary
- Frontend Hosts UI (settings + public event page) renders primary host even when missing from co_hosts (Owner badge).
- Backend create handlers audited; any path missing the auto-add is patched.
- Backfill 37+ approved parties where primary host wasn't in co_hosts (already applied to prod).
- /payments rows + prepay candidates carry `primaryHostInCohosts` flag; amber warning shown when payout recipient is primary host but not visible on event.

## Test plan
- [ ] Kisumu settings page → Chris Frank now appears as "Owner".
- [ ] Public event page → primary host visible even on unaffected parties.
- [ ] After backfill, no party has missing primary host in co_hosts.
- [ ] Create a new party via non-GPP path, leave creator out of co_hosts → warning amber flag fires on /payments.