### PR TITLE
fix(aglio-62584): admin per-submission cap override + surface save errors

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1072,10 +1072,21 @@ router.post(
         throw new AppError('Host user not found', 404, 'HOST_NOT_FOUND');
       }
 
-      // acciuga-62583: hard per-submission $625 ceiling (no override).
-      // Enforced BEFORE the party-cap check so the error message is clearer
-      // even on uncapped events. Out-of-band records still get split.
-      assertWithinPerSubmissionCap(finalAmountUsd);
+      // acciuga-62583: hard per-submission $625 ceiling — enforced BEFORE the
+      // party-cap check so the error message is clearer even on uncapped
+      // events. Out-of-band records still get split by default.
+      // aglio-62584: admin override available here too — when the admin is
+      // recording an out-of-band payment that intentionally exceeds the cap
+      // (e.g. backfilling a pre-cap historical wire) they can pass
+      // `allowOverSubmissionCap: true`.
+      if (
+        finalAmountUsd > PER_SUBMISSION_MAX_USD &&
+        body.allowOverSubmissionCap === true
+      ) {
+        // admin acknowledged — proceed
+      } else {
+        assertWithinPerSubmissionCap(finalAmountUsd);
+      }
 
       // tiramisu-49102: hard cap — block external records that would push the
       // cumulative paid+pending+approved past the party's effective cap.
@@ -1453,9 +1464,20 @@ router.patch(
         if (oldAmount !== newAmount) {
           amountChanged = true;
           data.finalAmountUsd = parsed;
-          // acciuga-62583: hard per-submission $625 ceiling. Applies even to
-          // admin amount edits — there's no override path.
-          assertWithinPerSubmissionCap(parsed);
+          // aglio-62584: admin override for the acciuga-62583 per-submission
+          // cap. When the admin is intentionally setting an over-cap amount
+          // (e.g. editing a grandfathered $750 row, or splitting on their own),
+          // they can pass `allowOverSubmissionCap: true` to bypass. The modal
+          // surfaces an amber warning + ack Checkbox before forwarding the
+          // flag. Host-side PATCH (payout.routes.ts) still has no override.
+          if (
+            parsed > PER_SUBMISSION_MAX_USD &&
+            req.body?.allowOverSubmissionCap === true
+          ) {
+            // admin acknowledged — proceed
+          } else {
+            assertWithinPerSubmissionCap(parsed);
+          }
           // tiramisu-49102: re-check per-party cap when admin edits amount.
           // Exclude THIS row from the existing-total so the edit doesn't
           // count against itself.

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -21,6 +21,16 @@ function stripGppPrefix(name: string): string {
   return name.replace(/^Global Pizza Party\s+/i, '');
 }
 
+/**
+ * aglio-62584: client-side mirror of backend `PER_SUBMISSION_MAX_USD` (see
+ * admin-payout.routes.ts). Inlined here so the modal can render an amber
+ * warning + ack Checkbox BEFORE submitting an over-cap edit. The server is
+ * still the source of truth — if this constant drifts, the backend will
+ * 400 with PER_SUBMISSION_CAP_EXCEEDED and the inline error panel
+ * surfaces the message.
+ */
+const PER_SUBMISSION_MAX_USD = 625;
+
 interface PayoutReviewModalProps {
   payout: AdminPayoutDetail;
   /** When set, indicates the actor would be paying themselves — disables mutate buttons. */
@@ -28,7 +38,20 @@ interface PayoutReviewModalProps {
   onClose: () => void;
   onApprove: (note?: string) => Promise<void> | void;
   onReject: (reason: string) => Promise<void> | void;
-  onSaveAmount: (newAmount: number, note?: string) => Promise<void> | void;
+  /**
+   * aglio-62584: `allowOverSubmissionCap` is forwarded when the admin has
+   * acknowledged the amber $625 cap warning by ticking the override
+   * Checkbox below the amount input. Parent should forward to
+   * `updateAdminPayout`'s `allowOverSubmissionCap` field.
+   *
+   * Returns a string error message (NOT throws) when the save fails — the
+   * modal renders it inline below the Save button so the failure isn't
+   * silent. Returning `void` (or resolving to `undefined`) means success.
+   */
+  onSaveAmount: (
+    newAmount: number,
+    opts?: { note?: string; allowOverSubmissionCap?: boolean },
+  ) => Promise<string | void> | string | void;
   onSaveAdminNotes: (notes: string) => Promise<void> | void;
   onMarkPaid: (refs: {
     wireReference?: string;
@@ -95,6 +118,13 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const [draftAmount, setDraftAmount] = useState(String(payout.finalAmountUsd));
   const [adminNotes, setAdminNotes] = useState(payout.adminNotes ?? '');
   const [adminNotesDirty, setAdminNotesDirty] = useState(false);
+
+  // aglio-62584: per-submission $625 cap override + inline error surface.
+  // `ackOverSubmissionCap` is required before Save enables when the draft
+  // amount exceeds the cap; `saveAmountError` renders inline below the
+  // Save button when the backend (or any other failure path) rejects.
+  const [ackOverSubmissionCap, setAckOverSubmissionCap] = useState(false);
+  const [saveAmountError, setSaveAmountError] = useState<string | null>(null);
 
   const [showRejectForm, setShowRejectForm] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
@@ -313,6 +343,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     onClick={() => {
                       setDraftAmount(String(payout.finalAmountUsd));
                       setEditingAmount(true);
+                      // aglio-62584: clear any stale cap-ack / error state
+                      // from a prior open so the warning behaviour is fresh.
+                      setAckOverSubmissionCap(false);
+                      setSaveAmountError(null);
                     }}
                     disabled={selfPayoutBlocked || busy}
                     className="inline-flex items-center gap-1 text-xs text-theme-text-secondary hover:text-theme-text disabled:opacity-50"
@@ -323,37 +357,122 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 )}
               </div>
               {editingAmount ? (
-                <div className="flex items-center gap-2">
-                  <IconInput
-                    icon={DollarSign}
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    placeholder="Final USD amount"
-                    value={draftAmount}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDraftAmount(e.target.value)}
-                  />
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      const n = Number(draftAmount);
-                      if (!Number.isFinite(n) || n < 0) return;
-                      await onSaveAmount(n);
-                      setEditingAmount(false);
-                    }}
-                    disabled={busy}
-                    className="px-3 py-2 rounded-lg bg-[#E52828] text-white text-sm disabled:opacity-50"
-                  >
-                    {busy ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setEditingAmount(false)}
-                    className="px-3 py-2 rounded-lg text-sm text-theme-text-secondary hover:bg-theme-surface-hover"
-                  >
-                    Cancel
-                  </button>
-                </div>
+                (() => {
+                  // aglio-62584: per-submission cap warning + ack. Recompute
+                  // on every render so the warning toggles as the admin types.
+                  const draftNum = Number(draftAmount);
+                  const draftIsValid = Number.isFinite(draftNum) && draftNum >= 0;
+                  const exceedsCap = draftIsValid && draftNum > PER_SUBMISSION_MAX_USD;
+                  const saveDisabled =
+                    busy || !draftIsValid || (exceedsCap && !ackOverSubmissionCap);
+                  return (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <IconInput
+                          icon={DollarSign}
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          placeholder="Final USD amount"
+                          value={draftAmount}
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                            setDraftAmount(e.target.value);
+                            // Clear stale error once the admin starts typing again.
+                            if (saveAmountError) setSaveAmountError(null);
+                          }}
+                        />
+                        <button
+                          type="button"
+                          onClick={async () => {
+                            if (!draftIsValid) return;
+                            if (exceedsCap && !ackOverSubmissionCap) return;
+                            setSaveAmountError(null);
+                            try {
+                              const result = await onSaveAmount(draftNum, {
+                                allowOverSubmissionCap: exceedsCap
+                                  ? ackOverSubmissionCap
+                                  : undefined,
+                              });
+                              // aglio-62584: parent may return a string instead
+                              // of throwing — surface it inline.
+                              if (typeof result === 'string' && result.length > 0) {
+                                setSaveAmountError(result);
+                                return;
+                              }
+                              setEditingAmount(false);
+                              setAckOverSubmissionCap(false);
+                            } catch (err: any) {
+                              setSaveAmountError(
+                                (err && (err.message || String(err))) ||
+                                  'Save failed — please try again.',
+                              );
+                            }
+                          }}
+                          disabled={saveDisabled}
+                          className="px-3 py-2 rounded-lg bg-[#E52828] text-white text-sm disabled:opacity-50"
+                        >
+                          {busy ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditingAmount(false);
+                            setAckOverSubmissionCap(false);
+                            setSaveAmountError(null);
+                          }}
+                          className="px-3 py-2 rounded-lg text-sm text-theme-text-secondary hover:bg-theme-surface-hover"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                      {/* aglio-62584: amber warning + ack Checkbox when the
+                          typed value exceeds the per-submission cap. The
+                          backend will reject the save unless the modal
+                          forwards `allowOverSubmissionCap: true`. */}
+                      {exceedsCap && (
+                        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+                          <div className="flex items-start gap-2.5">
+                            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                            <div className="flex-1 text-sm">
+                              <div className="font-medium text-amber-200 mb-1">
+                                Per-submission cap warning
+                              </div>
+                              <div className="text-theme-text-secondary text-xs">
+                                Payments are normally capped at{' '}
+                                <b>${PER_SUBMISSION_MAX_USD}</b> per submission.
+                                Saving <b>${draftNum.toFixed(2)}</b> requires an
+                                explicit override (used for grandfathered or
+                                pre-cap rows).
+                              </div>
+                              <div className="mt-3">
+                                <Checkbox
+                                  checked={ackOverSubmissionCap}
+                                  onChange={() => setAckOverSubmissionCap((v) => !v)}
+                                  label={`I acknowledge — this exceeds the $${PER_SUBMISSION_MAX_USD} per-submission cap`}
+                                  labelClassName="text-sm text-amber-100"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {/* aglio-62584: inline error surface so save failures
+                          aren't silent. Covers backend rejections (bad
+                          wallet, party cap exceeded, etc.) and network
+                          errors. */}
+                      {saveAmountError && (
+                        <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10">
+                          <div className="flex items-start gap-2.5">
+                            <AlertTriangle className="text-red-300 mt-0.5 flex-shrink-0" size={16} />
+                            <div className="flex-1 text-sm text-red-100">
+                              {saveAmountError}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()
               ) : (
                 <div>
                   <div className="text-2xl font-semibold text-theme-text">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3909,6 +3909,12 @@ export async function updateAdminPayout(
     payoutWalletAddress?: string | null;
     payoutBankDetails?: BankDetails | null;
     note?: string;
+    /**
+     * aglio-62584: admin override for the acciuga-62583 per-submission
+     * $625 cap. Forwarded only when the admin has ticked the ack Checkbox
+     * in PayoutReviewModal's amount-edit form (or recordExternalPayment).
+     */
+    allowOverSubmissionCap?: boolean;
   },
 ): Promise<AdminPayout> {
   const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}`, {

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -750,15 +750,26 @@ export function PaymentsAdminPage() {
                 setModalBusy(false);
               }
             }}
-            onSaveAmount={async (newAmount, note) => {
+            onSaveAmount={async (newAmount, opts) => {
               setModalBusy(true);
               try {
-                await updateAdminPayout(detail.id, { finalAmountUsd: newAmount, note });
+                await updateAdminPayout(detail.id, {
+                  finalAmountUsd: newAmount,
+                  note: opts?.note,
+                  // aglio-62584: forward the admin's per-submission cap
+                  // acknowledgement so the backend bypasses the 400.
+                  allowOverSubmissionCap: opts?.allowOverSubmissionCap,
+                });
                 const fresh = await getAdminPayout(detail.id);
                 setDetail(fresh);
                 await refresh();
+                return;
               } catch (err: any) {
-                setErrorMsg(err.message || 'Save failed');
+                // aglio-62584: return the message instead of swallowing it
+                // into the page-level error so PayoutReviewModal can render
+                // it inline (was previously silent — clicking Save on a
+                // grandfathered $750 row just did nothing visible).
+                return err?.message || 'Save failed';
               } finally {
                 setModalBusy(false);
               }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1589,6 +1589,13 @@ export interface ExternalPaymentInput {
   mercuryCardLast4?: string;  // for mercury_card
   externalProofUrl?: string;
   adminNotes: string;         // REQUIRED — must explain why this is being recorded
+  /**
+   * aglio-62584: admin override for the acciuga-62583 per-submission $625
+   * cap. Set to `true` when backfilling a pre-cap historical out-of-band
+   * payment that legitimately exceeded $625. Without this, finalAmountUsd
+   * > $625 is rejected with PER_SUBMISSION_CAP_EXCEEDED.
+   */
+  allowOverSubmissionCap?: boolean;
 }
 
 // Admin-list payout: includes embedded party + host info


### PR DESCRIPTION
## Summary
- Admin PATCH no longer enforces per-submission cap when `finalAmountUsd` isn't in the body.
- New `allowOverSubmissionCap: true` override admin can pass to deliberately exceed $625 (modal surfaces an amber warning + ack Checkbox).
- PayoutReviewModal surfaces save errors inline instead of silently swallowing them.
- Host-side hard cap unchanged.

## Test plan
- [ ] Edit a $750 grandfathered row → Save notes/wallet without changing amount → succeeds.
- [ ] Change amount to $700 → amber warning + Checkbox → check → Save succeeds.
- [ ] Change amount to $700, don't check → Save disabled.
- [ ] Change amount to $500 → no warning, Save works.
- [ ] Host submits $700 receipt → still 400 (host gate unchanged).