### PR TITLE
feat(stracchino-22301): cap EventPage 'On the Menu' to top-3 pizzerias

### DIFF
--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -1,43 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import { addGuestToParty, getUserPreferences, saveUserPreferences, ExistingGuestData, getExperimentFlag } from '../lib/supabase';
 import { getExcludedToppingIds } from '../constants/options';
-import { searchPizzerias, geocodeAddress, calculateDistanceMiles } from '../lib/ordering';
+import { searchPizzerias, geocodeAddress } from '../lib/ordering';
 import { Pizzeria } from '../types';
 import { PublicEvent, trackRsvpFunnel } from '../lib/api';
 import { DbParty } from '../lib/supabase';
 import { uuid } from '../lib/utils';
 import { findActiveRegion } from '../lib/optinAbRegions';
 import { getOrCreateVisitorSessionId } from '../lib/visitorSession';
-
-// ---- Ranking helpers (vesuvio-58492) ----
-
-// Cap the RSVP "Favorite Pizzerias" list to the top N entries ranked by a
-// weighted score combining rating and distance from the venue. Istanbul GPP
-// had ~15+ host-selected pizzerias which overwhelmed the form.
-const TOP_PIZZERIA_LIMIT = 3;
-const DISTANCE_WEIGHT_PER_MILE = 0.3;
-
-function rankPizzerias(
-  list: Pizzeria[],
-  venue: { lat: number; lng: number } | null,
-): Pizzeria[] {
-  return [...list]
-    .map(p => {
-      const rating = p.rating ?? 3.5;
-      const hasDistance =
-        !!venue &&
-        !!p.location &&
-        p.location.lat !== 0 &&
-        p.location.lng !== 0;
-      const distance = hasDistance
-        ? calculateDistanceMiles(venue.lat, venue.lng, p.location.lat, p.location.lng)
-        : 0;
-      return { p, score: rating - distance * DISTANCE_WEIGHT_PER_MILE };
-    })
-    .sort((a, b) => b.score - a.score)
-    .slice(0, TOP_PIZZERIA_LIMIT)
-    .map(x => x.p);
-}
+import { rankPizzerias } from '../lib/pizzeriaRank';
 
 // ---- Types ----
 

--- a/frontend/src/lib/pizzeriaRank.ts
+++ b/frontend/src/lib/pizzeriaRank.ts
@@ -1,0 +1,32 @@
+import { Pizzeria } from '../types';
+import { calculateDistanceMiles } from './ordering';
+
+// ---- Ranking helpers (vesuvio-58492) ----
+
+// Cap the RSVP "Favorite Pizzerias" list to the top N entries ranked by a
+// weighted score combining rating and distance from the venue. Istanbul GPP
+// had ~15+ host-selected pizzerias which overwhelmed the form.
+export const TOP_PIZZERIA_LIMIT = 3;
+export const DISTANCE_WEIGHT_PER_MILE = 0.3;
+
+export function rankPizzerias(
+  list: Pizzeria[],
+  venue: { lat: number; lng: number } | null,
+): Pizzeria[] {
+  return [...list]
+    .map(p => {
+      const rating = p.rating ?? 3.5;
+      const hasDistance =
+        !!venue &&
+        !!p.location &&
+        p.location.lat !== 0 &&
+        p.location.lng !== 0;
+      const distance = hasDistance
+        ? calculateDistanceMiles(venue.lat, venue.lng, p.location.lat, p.location.lng)
+        : 0;
+      return { p, score: rating - distance * DISTANCE_WEIGHT_PER_MILE };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, TOP_PIZZERIA_LIMIT)
+    .map(x => x.p);
+}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
@@ -31,6 +31,7 @@ import { formatTimezoneDisplay } from '../utils/dateUtils';
 import { useConfetti } from '../hooks/useConfetti';
 import { AddToCalendarPopup } from '../components/AddToCalendarPopup';
 import { ParticipatingPizzerias } from '../components/ParticipatingPizzerias';
+import { rankPizzerias } from '../lib/pizzeriaRank';
 import { LastYearPhotos } from '../components/LastYearPhotos';
 import VenueMap from '../components/VenueMap';
 import { CheckInButton } from '../components/CheckInButton';
@@ -318,6 +319,18 @@ export function EventPage() {
       setEditPasswordInput('');
     }
   };
+
+  // Cap "On the Menu" to top-3 pizzerias by the shared ranking helper
+  // (stracchino-22301). Must be declared above the early returns below.
+  const topPizzerias = useMemo(
+    () => rankPizzerias(
+      event?.selectedPizzerias ?? [],
+      event?.latitude != null && event?.longitude != null
+        ? { lat: event.latitude, lng: event.longitude }
+        : null,
+    ),
+    [event?.selectedPizzerias, event?.latitude, event?.longitude],
+  );
 
   if (loading) {
     return (
@@ -1404,9 +1417,9 @@ export function EventPage() {
                 <MusicWidget isHost={false} partyId={event.id} className="border-t border-theme-stroke pt-6 mt-6" />
 
                 {/* Participating Pizzerias Section */}
-                {event.selectedPizzerias && event.selectedPizzerias.length > 0 && (
+                {topPizzerias.length > 0 && (
                   <ParticipatingPizzerias
-                    pizzerias={event.selectedPizzerias}
+                    pizzerias={topPizzerias}
                     venueAddress={event.address}
                     eventSlug={slug}
                   />


### PR DESCRIPTION
## Summary
- Lifts rankPizzerias() from useRSVPForm.ts into frontend/src/lib/pizzeriaRank.ts so EventPage and the RSVP form share the same top-3 ranking
- Applies it to EventPage's "On the Menu" section, which previously rendered the full selectedPizzerias array uncapped (some events had 15+)

## Test plan
- [ ] Open an event with >3 stored pizzerias on Vercel preview — "On the Menu" shows exactly 3
- [ ] Same event's RSVP form shows the same 3 in the same order
- [ ] Event with <=3 pizzerias renders unchanged

Generated with Claude Code