### PR TITLE
basil-72184: scorecard action buttons for photo/vouch/selfie

### DIFF
--- a/frontend/src/components/photos/PhotoGallery.tsx
+++ b/frontend/src/components/photos/PhotoGallery.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Camera, Star, Loader2, Upload, Filter, Clock, CheckCircle2, XCircle, CheckCheck, Tag, Video } from 'lucide-react';
 import { Photo, PhotoStats } from '../../types';
@@ -14,6 +14,12 @@ interface PhotoGalleryProps {
   uploaderEmail?: string;
   guestId?: string;
   photoModeration?: boolean;
+  /**
+   * Optional ref the gallery populates on mount with a function that opens
+   * the upload picker. Callers (e.g. EventPage) can call this to programmatically
+   * trigger an upload flow without restructuring the gallery internals.
+   */
+  triggerUploadRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 type FilterOption = 'all' | 'starred' | 'pending';
@@ -26,6 +32,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   uploaderEmail,
   guestId,
   photoModeration = false,
+  triggerUploadRef,
 }) => {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [stats, setStats] = useState<PhotoStats | null>(null);
@@ -40,6 +47,18 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [batchLoading, setBatchLoading] = useState(false);
+
+  // Expose an imperative trigger so callers can programmatically open the upload picker.
+  // Populated/cleared in an effect to avoid mutating refs during render.
+  useEffect(() => {
+    if (!triggerUploadRef) return;
+    triggerUploadRef.current = () => setShowUpload(true);
+    return () => {
+      if (triggerUploadRef.current) {
+        triggerUploadRef.current = null;
+      }
+    };
+  }, [triggerUploadRef]);
 
   // Split photos into images and videos for tab filtering
   const imagePhotos = useMemo(() => photos.filter(p => !p.mimeType?.startsWith('video/')), [photos]);

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -5,6 +5,11 @@ import { ScorecardItem, ScorecardItemKey } from './ScorecardItem';
 
 interface GuestScorecardProps {
   inviteCode: string;
+  onUploadPhoto?: () => void;
+  onScanGuest?: () => void;
+  onTakeSelfie?: () => void;
+  /** When this number changes, the scorecard refetches its items. */
+  refreshSignal?: number;
 }
 
 const ITEM_ORDER: ScorecardItemKey[] = [
@@ -18,7 +23,13 @@ const ITEM_ORDER: ScorecardItemKey[] = [
   'signup_pizzadao',
 ];
 
-export function GuestScorecard({ inviteCode }: GuestScorecardProps) {
+export function GuestScorecard({
+  inviteCode,
+  onUploadPhoto,
+  onScanGuest,
+  onTakeSelfie,
+  refreshSignal,
+}: GuestScorecardProps) {
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
   const [totalItems, setTotalItems] = useState(8);
@@ -48,6 +59,14 @@ export function GuestScorecard({ inviteCode }: GuestScorecardProps) {
   useEffect(() => {
     fetchScorecard();
   }, [fetchScorecard]);
+
+  // Refetch when the parent bumps `refreshSignal` (e.g. after a photo upload,
+  // a successful vouch, or a selfie upload — all of which auto-complete a
+  // scorecard item on the backend).
+  useEffect(() => {
+    if (refreshSignal === undefined) return;
+    fetchScorecard();
+  }, [refreshSignal, fetchScorecard]);
 
   const handleComplete = async (itemKey: ScorecardItemKey, proofUrl?: string, proofType?: string) => {
     setCompletingItem(itemKey);
@@ -124,6 +143,9 @@ export function GuestScorecard({ inviteCode }: GuestScorecardProps) {
                 completed={item.completed}
                 loading={completingItem === key}
                 onComplete={handleComplete}
+                onUploadPhoto={onUploadPhoto}
+                onScanGuest={onScanGuest}
+                onTakeSelfie={onTakeSelfie}
               />
             </div>
           );

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -20,6 +20,9 @@ interface ScorecardItemProps {
   completed: boolean;
   loading?: boolean;
   onComplete: (itemKey: ScorecardItemKey, proofUrl?: string, proofType?: string) => void;
+  onUploadPhoto?: () => void;
+  onScanGuest?: () => void;
+  onTakeSelfie?: () => void;
 }
 
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
@@ -33,15 +36,21 @@ const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = 
   signup_pizzadao: { label: 'Sign up on pizzadao.org', emoji: '🌐' },
 };
 
-export function ScorecardItem({ itemKey, completed, loading, onComplete }: ScorecardItemProps) {
+export function ScorecardItem({
+  itemKey,
+  completed,
+  loading,
+  onComplete,
+  onUploadPhoto,
+  onScanGuest,
+  onTakeSelfie,
+}: ScorecardItemProps) {
   const [showInput, setShowInput] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const config = ITEM_CONFIG[itemKey];
 
   // Items that need URL proof
   const needsUrlProof = itemKey === 'post';
-  // Auto-complete items (no user action needed from this UI)
-  const isAutoItem = itemKey === 'photo' || itemKey === 'vouch' || itemKey === 'pizza_selfie';
   // Self-report items
   const isSelfReport = itemKey === 'sign_pizza_box' || itemKey === 'join_telegram' || itemKey === 'follow_pizzadao' || itemKey === 'signup_pizzadao';
 
@@ -53,6 +62,15 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
       const tweetText = encodeURIComponent("Having a great time at the pizza party! @pizza_dao #PizzaDAO");
       window.open(`https://twitter.com/intent/tweet?text=${tweetText}`, '_blank');
       setShowInput(true);
+    } else if (itemKey === 'photo') {
+      // Backend auto-completes via photo upload side effect.
+      onUploadPhoto?.();
+    } else if (itemKey === 'vouch') {
+      // Backend auto-completes via vouch endpoint side effect.
+      onScanGuest?.();
+    } else if (itemKey === 'pizza_selfie') {
+      // Backend auto-completes when photo tagged "pizza-selfie".
+      onTakeSelfie?.();
     } else if (isSelfReport) {
       onComplete(itemKey, undefined, 'self_report');
     }
@@ -67,6 +85,9 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
 
   const getActionLabel = (): string => {
     if (itemKey === 'post') return 'Share';
+    if (itemKey === 'photo') return 'Upload';
+    if (itemKey === 'vouch') return 'Scan';
+    if (itemKey === 'pizza_selfie') return 'Selfie';
     if (itemKey === 'sign_pizza_box') return 'I signed it!';
     if (itemKey === 'join_telegram') return 'I joined!';
     if (itemKey === 'follow_pizzadao') return 'I followed!';
@@ -96,8 +117,6 @@ export function ScorecardItem({ itemKey, completed, loading, onComplete }: Score
           <Loader2 className="w-4 h-4 animate-spin text-white/50" />
         ) : completed ? (
           <span className="text-xs text-green-400 font-medium">Done</span>
-        ) : isAutoItem ? (
-          <span className="text-xs text-white/40">Auto</span>
         ) : (
           <button
             onClick={handleAction}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -34,7 +34,10 @@ import { ParticipatingPizzerias } from '../components/ParticipatingPizzerias';
 import { LastYearPhotos } from '../components/LastYearPhotos';
 import VenueMap from '../components/VenueMap';
 import { CheckInButton } from '../components/CheckInButton';
+import { CheckInScanner } from '../components/CheckInScanner';
 import { GuestScorecard } from '../components/scorecard';
+import { uploadPhoto } from '../lib/api';
+import { uploadEventPhoto } from '../lib/supabase';
 
 function normalizeTelegramUrl(raw: string | null | undefined): string | null {
   if (!raw) return null;
@@ -100,6 +103,14 @@ export function EventPage() {
   const { fire: fireConfetti, ConfettiOverlay } = useConfetti();
   const [showCalendarPopup, setShowCalendarPopup] = useState(false);
   const calendarAnchorRef = useRef<HTMLDivElement>(null);
+
+  // Scorecard action wiring (basil-72184).
+  const photoGalleryRef = useRef<HTMLDivElement>(null);
+  const photoGalleryTriggerRef = useRef<(() => void) | null>(null);
+  const selfieInputRef = useRef<HTMLInputElement>(null);
+  const [vouchScannerOpen, setVouchScannerOpen] = useState(false);
+  const [scorecardRefresh, setScorecardRefresh] = useState(0);
+  const [selfieUploading, setSelfieUploading] = useState(false);
 
   // Sticky RSVP button on mobile: show when inline button is scrolled above the viewport.
   // Uses a scroll listener instead of IntersectionObserver because IO won't fire when an
@@ -534,6 +545,70 @@ export function EventPage() {
     setExistingGuestData((prev) =>
       prev ? { ...prev, checkedInAt } : prev
     );
+  };
+
+  // Scorecard action handlers (basil-72184). Backend auto-completes the
+  // photo/vouch/pizza_selfie scorecard items as side effects, so these only
+  // trigger the user-visible action and bump `scorecardRefresh` so the
+  // scorecard refetches afterward.
+  const handleScorecardUploadPhoto = () => {
+    // Scroll to the gallery so the upload modal appears in context.
+    photoGalleryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // Open the picker if the gallery has registered a trigger.
+    if (photoGalleryTriggerRef.current) {
+      photoGalleryTriggerRef.current();
+    } else {
+      // Gallery not mounted yet (button is collapsed). Expand it; the trigger
+      // will register on the next render and we don't auto-open in that case.
+      setShowPhotos(true);
+    }
+  };
+
+  const handleScorecardScanGuest = () => {
+    setVouchScannerOpen(true);
+  };
+
+  const handleScorecardTakeSelfie = () => {
+    selfieInputRef.current?.click();
+  };
+
+  const handleSelfieFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset the input so picking the same file twice still triggers onChange.
+    e.target.value = '';
+    if (!file || !event) return;
+
+    setSelfieUploading(true);
+    try {
+      const uploadResult = await uploadEventPhoto(file, event.id);
+      if (!uploadResult) {
+        console.error('Selfie storage upload failed');
+        return;
+      }
+      const result = await uploadPhoto(event.id, {
+        url: uploadResult.url,
+        fileName: uploadResult.fileName,
+        fileSize: uploadResult.fileSize,
+        mimeType: uploadResult.mimeType,
+        width: uploadResult.width,
+        height: uploadResult.height,
+        uploaderName: existingGuestData?.name || user?.name || undefined,
+        uploaderEmail: existingGuestData?.email || user?.email,
+        guestId: existingGuestData?.id,
+        tags: ['pizza-selfie'],
+      });
+      if (!result) {
+        console.error('Selfie record creation failed');
+        return;
+      }
+      // Both `photo` (any upload) and `pizza_selfie` (pizza-selfie tag) get
+      // auto-completed by the backend; refetch to reflect the new state.
+      setScorecardRefresh((n) => n + 1);
+    } catch (err) {
+      console.error('Selfie upload error:', err);
+    } finally {
+      setSelfieUploading(false);
+    }
   };
 
   // Interactive Google Maps JS SDK venue thumbnail (see VenueMap component).
@@ -1185,7 +1260,13 @@ export function EventPage() {
 
                 {/* Guest Scorecard - shown after check-in on event day */}
                 {isEventDay && existingGuestData?.checkedInAt && (
-                  <GuestScorecard inviteCode={event.customUrl || event.inviteCode} />
+                  <GuestScorecard
+                    inviteCode={event.customUrl || event.inviteCode}
+                    onUploadPhoto={handleScorecardUploadPhoto}
+                    onScanGuest={handleScorecardScanGuest}
+                    onTakeSelfie={handleScorecardTakeSelfie}
+                    refreshSignal={scorecardRefresh}
+                  />
                 )}
 
                 {/* Guest Count - Mobile */}
@@ -1423,7 +1504,7 @@ export function EventPage() {
 
                 {/* Photo Gallery Section - only for confirmed guests */}
                 {photoStats?.photosEnabled && existingGuestData?.status === 'CONFIRMED' && (
-                  <div className="border-t border-theme-stroke pt-6 mt-6">
+                  <div ref={photoGalleryRef} className="border-t border-theme-stroke pt-6 mt-6">
                     {showPhotos ? (
                       <PhotoGallery
                         partyId={event.id}
@@ -1432,6 +1513,7 @@ export function EventPage() {
                         uploaderName={existingGuestData?.name || user?.name || undefined}
                         uploaderEmail={existingGuestData?.email || user?.email}
                         guestId={existingGuestData?.id}
+                        triggerUploadRef={photoGalleryTriggerRef}
                       />
                     ) : (
                       <button
@@ -1517,6 +1599,31 @@ export function EventPage() {
           )}
         </div>
       )}
+
+      {/* Vouch / check-in QR scanner (scorecard "Scan" action — basil-72184).
+          CheckInScanner self-portals via createPortal. */}
+      {vouchScannerOpen && (
+        <CheckInScanner
+          inviteCode={event.customUrl || event.inviteCode}
+          currentGuestId={existingGuestData?.id}
+          onVouchSuccess={() => {
+            setVouchScannerOpen(false);
+            setScorecardRefresh((n) => n + 1);
+          }}
+          onClose={() => setVouchScannerOpen(false)}
+        />
+      )}
+
+      {/* Hidden file input for scorecard "Selfie" action — opens front camera on mobile. */}
+      <input
+        ref={selfieInputRef}
+        type="file"
+        accept="image/*"
+        capture="user"
+        style={{ display: 'none' }}
+        onChange={handleSelfieFile}
+        disabled={selfieUploading}
+      />
 
       <CornerLinks />
 


### PR DESCRIPTION
## Summary
- Replaces the inert "Auto" badge on 3 scorecard items with tappable red-pill buttons
- **Upload a photo** -> smooth-scrolls to the PhotoGallery section and opens its upload picker
- **Check someone in** -> opens the existing CheckInScanner QR scanner as a fullscreen modal
- **Pizza selfie** -> opens device front camera and uploads as a photo tagged `pizza-selfie`
- No backend changes - backend already auto-completes all 3 keys via existing side-effect hooks (photo.routes.ts, checkin.routes.ts)

## Implementation notes
- `ScorecardItem`: new `onUploadPhoto`/`onScanGuest`/`onTakeSelfie` optional callbacks + action labels ("Upload"/"Scan"/"Selfie")
- `GuestScorecard`: forwards the callbacks, accepts `refreshSignal` and refetches when it changes
- `PhotoGallery`: exposes optional `triggerUploadRef` that callers populate with an open-picker fn (minimum-viable, no internal restructure)
- `EventPage`: state + refs added above early returns; CheckInScanner self-portals via createPortal; hidden file input with `capture="user"` for selfie

## Test plan
- [ ] Visit the preview URL logged in as a confirmed guest on event day
- [ ] All 8 scorecard items show interactive controls (no "Auto" badges)
- [ ] Tap **Upload** -> page scrolls to PhotoGallery + upload picker opens
- [ ] Tap **Scan** -> fullscreen QR scanner appears; X closes
- [ ] Tap **Selfie** -> front camera launches; capturing + uploading flips both Pizza selfie + Upload a photo to Done

[Generated with Claude Code](https://claude.com/claude-code)