### PR TITLE
feat(fontina-91827): admin tool to transfer event ownership

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -51,6 +51,7 @@ import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
 import adminPayoutRoutes, { payoutWalletRouter } from './routes/admin-payout.routes.js';
+import adminPartyRoutes from './routes/admin-party.routes.js';
 import graphicsAdminRoutes from './routes/graphics-admin.routes.js';
 import logoAuditRoutes from './routes/logoAudit.routes.js';
 import { sponsorUserAdminRouter, sponsorDashboardRouter } from './routes/sponsor-user.routes.js';
@@ -136,6 +137,7 @@ app.use('/api/rsvp', rsvpLimiter);
 app.use('/api/admin/logo-bg-audit', logoAuditRoutes); // Graphics-admin logo cleanup (before /api/admin catch-all)
 app.use('/api/admin/payouts', adminPayoutRoutes); // Host payouts admin dashboard (before /api/admin catch-all)
 app.use('/api/admin/payout-wallet', payoutWalletRouter); // coppa-91827: hot wallet address + balances (before /api/admin catch-all)
+app.use('/api/admin/parties', adminPartyRoutes); // fontina-91827: admin party-management routes (transfer ownership) — before /api/admin catch-all
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/telegram/webhook', telegramWebhookRoutes); // Telegram inbound webhook (no auth — secret-token header gate)

--- a/backend/src/routes/admin-party.routes.ts
+++ b/backend/src/routes/admin-party.routes.ts
@@ -1,0 +1,333 @@
+/**
+ * Admin party-management routes (fontina-91827).
+ *
+ * Mounted at `/api/admin/parties` (see backend/src/index.ts — registered
+ * BEFORE the generic `/api/admin` catch-all so it isn't shadowed).
+ *
+ * Auth model:
+ *  - All endpoints require `requireAuth` + admin/super_admin/payment_admin
+ *    via `isPaymentAdmin` (mirrors admin-payout.routes.ts gate).
+ *
+ * Today's endpoints:
+ *  - POST /:partyId/transfer-ownership — atomically reassign `parties.user_id`
+ *    from one User to another, scrub the old owner from `co_hosts`, delete
+ *    their `party_payment_opt_ins` row, and canonicalize the new owner in the
+ *    cohost array. Audit row written to `deletion_log` when that table's
+ *    Prisma model is available; otherwise the same payload is `console.warn`-ed
+ *    for log retention.
+ */
+import { Router, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { prisma } from '../config/database.js';
+import {
+  requireAuth,
+  AuthRequest,
+  isPaymentAdmin,
+} from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+
+const router = Router();
+
+/**
+ * Middleware: allow admin / super_admin / payment_admin only.
+ * Mirrors the gate in admin-payout.routes.ts. payment_admin qualifies because
+ * they manage payment-routing concerns (the new owner inherits the prepay
+ * candidate / payment-opt-in surface).
+ */
+async function requireAnyAdminOrPaymentAdmin(
+  req: AuthRequest,
+  _res: Response,
+  next: NextFunction
+) {
+  try {
+    if (!(await isPaymentAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/admin/parties/:partyId/owner
+ *
+ * Lightweight admin lookup that returns the current primary-host email + name
+ * for a party. Used by TransferOwnershipModal so the admin UI can render
+ * "Currently owned by X (email)" without requiring the host-side cohosts/full
+ * endpoint (which is gated by canUserEditParty — an admin who is not also the
+ * host wouldn't qualify on every party).
+ */
+router.get(
+  '/:partyId/owner',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: {
+          id: true,
+          userId: true,
+          user: { select: { id: true, email: true, name: true } },
+        },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+      res.json({
+        partyId: party.id,
+        ownerId: party.userId,
+        ownerEmail: party.user?.email ?? null,
+        ownerName: party.user?.name ?? null,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+interface TransferOwnershipBody {
+  newOwnerEmail?: unknown;
+  removeOldFromCoHosts?: unknown;
+  deleteOldOptIn?: unknown;
+  note?: unknown;
+}
+
+interface CoHostEntry {
+  id?: string;
+  name?: string | null;
+  email?: string | null;
+  canEdit?: boolean;
+  showOnEvent?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * POST /api/admin/parties/:partyId/transfer-ownership
+ *
+ * Body:
+ *   {
+ *     newOwnerEmail: string;
+ *     removeOldFromCoHosts?: boolean (default true);
+ *     deleteOldOptIn?: boolean (default true);
+ *     note?: string;
+ *   }
+ *
+ * Behavior (all in a single $transaction so partial failures roll back):
+ *   1. Look up party → 404 if missing.
+ *   2. Lookup new owner User by email (case-insensitive) → 400 NEW_OWNER_NOT_FOUND.
+ *   3. Reject same-owner no-op → 400 SAME_OWNER.
+ *   4. Update parties.user_id = newOwner.id.
+ *   5. Mutate parties.co_hosts JSONB:
+ *        - filter out old-owner entries by email (case-insensitive) when
+ *          removeOldFromCoHosts (default true);
+ *        - ensure the new owner has an entry with canEdit:true,
+ *          showOnEvent:true (append if missing, force flags if present).
+ *   6. Delete party_payment_opt_ins row for {partyId, oldOwnerId} when
+ *      deleteOldOptIn (default true).
+ *   7. Write an audit row to deletion_log (raw SQL — Prisma model is not
+ *      exposed in schema.prisma) with table_name='parties.user_id',
+ *      record_id=partyId, record_data={old,new owner ids+emails},
+ *      deleted_by=actorEmail, context='Ownership transfer[: <note>]'.
+ *      On audit failure we console.warn but do NOT roll back the transfer —
+ *      audit-best-effort matches how the rest of the codebase treats
+ *      deletion_log writes.
+ */
+router.post(
+  '/:partyId/transfer-ownership',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const body = (req.body ?? {}) as TransferOwnershipBody;
+
+      // Validate body.newOwnerEmail
+      const rawEmail = typeof body.newOwnerEmail === 'string' ? body.newOwnerEmail.trim() : '';
+      if (!rawEmail) {
+        throw new AppError('newOwnerEmail is required', 400, 'INVALID_INPUT');
+      }
+      const newOwnerEmailLower = rawEmail.toLowerCase();
+
+      const removeOldFromCoHosts =
+        body.removeOldFromCoHosts === undefined ? true : body.removeOldFromCoHosts !== false;
+      const deleteOldOptIn =
+        body.deleteOldOptIn === undefined ? true : body.deleteOldOptIn !== false;
+      const note =
+        typeof body.note === 'string' && body.note.trim() ? body.note.trim() : null;
+
+      const actorEmail = req.userEmail?.toLowerCase() ?? 'unknown';
+
+      const result = await prisma.$transaction(async (tx) => {
+        // 1. Look up the party
+        const party = await tx.party.findUnique({
+          where: { id: partyId },
+          select: {
+            id: true,
+            userId: true,
+            coHosts: true,
+          },
+        });
+        if (!party) {
+          throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+        }
+
+        const oldOwnerId = party.userId; // may be null for orphan parties
+
+        // 2. Capture old owner email for cohost-scrub + audit context
+        const oldOwner = oldOwnerId
+          ? await tx.user.findUnique({
+              where: { id: oldOwnerId },
+              select: { id: true, email: true, name: true },
+            })
+          : null;
+        const oldOwnerEmailLower = oldOwner?.email?.toLowerCase() ?? null;
+
+        // 3. Look up new owner User (case-insensitive via findFirst+insensitive mode).
+        //    Emails are stored lowercase on writes throughout the codebase, but
+        //    historical rows are not guaranteed normalized — use the
+        //    insensitive matcher to catch both cases.
+        const newOwner = await tx.user.findFirst({
+          where: { email: { equals: newOwnerEmailLower, mode: 'insensitive' } },
+          select: { id: true, email: true, name: true },
+        });
+        if (!newOwner) {
+          throw new AppError(
+            `User ${rawEmail} doesn't exist on rsv.pizza yet — they need to log in once before they can be made owner.`,
+            400,
+            'NEW_OWNER_NOT_FOUND',
+          );
+        }
+
+        // 4. Same-owner guard
+        if (newOwner.id === oldOwnerId) {
+          throw new AppError(
+            'New owner is the same as the current owner.',
+            400,
+            'SAME_OWNER',
+          );
+        }
+
+        // 5. Build new co_hosts array
+        const existingCoHostsRaw = Array.isArray(party.coHosts) ? party.coHosts : [];
+        const newOwnerEmailNormalized = newOwner.email.toLowerCase();
+
+        let nextCoHosts: CoHostEntry[] = (existingCoHostsRaw as unknown as CoHostEntry[]).map(
+          (entry) => ({ ...entry }),
+        );
+
+        // Optionally scrub the old owner from the cohost list (by email)
+        if (removeOldFromCoHosts && oldOwnerEmailLower) {
+          nextCoHosts = nextCoHosts.filter((h) => {
+            const e = typeof h?.email === 'string' ? h.email.toLowerCase() : '';
+            return e !== oldOwnerEmailLower;
+          });
+        }
+
+        // Canonicalize the new owner entry: if present, force canEdit/showOnEvent
+        // ON; if absent, append a fresh entry. This mirrors what a host would
+        // see after the transfer (Primary host + persistent editor permissions).
+        const newOwnerExistingIdx = nextCoHosts.findIndex((h) => {
+          const e = typeof h?.email === 'string' ? h.email.toLowerCase() : '';
+          return e === newOwnerEmailNormalized;
+        });
+        if (newOwnerExistingIdx >= 0) {
+          nextCoHosts[newOwnerExistingIdx] = {
+            ...nextCoHosts[newOwnerExistingIdx],
+            canEdit: true,
+            showOnEvent: true,
+          };
+        } else {
+          nextCoHosts.push({
+            id: randomUUID(),
+            name: newOwner.name ?? newOwner.email,
+            email: newOwner.email,
+            canEdit: true,
+            showOnEvent: true,
+          });
+        }
+
+        // 6. Update party row (user_id + co_hosts)
+        const updatedParty = await tx.party.update({
+          where: { id: partyId },
+          data: {
+            userId: newOwner.id,
+            coHosts: nextCoHosts as unknown as Prisma.InputJsonValue,
+          },
+          select: {
+            id: true,
+            userId: true,
+            name: true,
+            inviteCode: true,
+            customUrl: true,
+          },
+        });
+
+        // 7. Delete old owner's payment opt-in row for this party (if known)
+        if (deleteOldOptIn && oldOwnerId) {
+          await tx.partyPaymentOptIn.deleteMany({
+            where: { partyId, userId: oldOwnerId },
+          });
+        }
+
+        // 8. Audit — write to deletion_log via raw SQL because the model isn't
+        //    exposed in Prisma. We don't want to introduce a Prisma model just
+        //    for this single insert. On failure (e.g. table renamed, columns
+        //    drifted) we console.warn the same payload so the trail still lands
+        //    in Vercel logs and we don't fail the transfer.
+        const auditPayload = {
+          oldOwnerId,
+          oldOwnerEmail: oldOwner?.email ?? null,
+          newOwnerId: newOwner.id,
+          newOwnerEmail: newOwner.email,
+        };
+        const auditContext = `Ownership transfer${note ? ': ' + note : ''}`;
+        try {
+          await tx.$executeRaw`
+            INSERT INTO deletion_log (table_name, record_id, record_data, deleted_by, deleted_at, context)
+            VALUES (
+              'parties.user_id',
+              ${partyId}::text,
+              ${JSON.stringify(auditPayload)}::jsonb,
+              ${actorEmail}::text,
+              NOW(),
+              ${auditContext}::text
+            )
+          `;
+        } catch (auditErr) {
+          // Audit-best-effort: don't roll back the transfer if logging fails.
+          console.warn(
+            '[fontina-91827] deletion_log audit insert failed; transfer still applied',
+            {
+              partyId,
+              auditPayload,
+              auditContext,
+              actorEmail,
+              error: auditErr instanceof Error ? auditErr.message : String(auditErr),
+            },
+          );
+        }
+
+        return {
+          updatedParty,
+          newOwner,
+        };
+      });
+
+      res.json({
+        ok: true,
+        partyId: result.updatedParty.id,
+        newOwnerId: result.newOwner.id,
+        newOwnerEmail: result.newOwner.email,
+        party: result.updatedParty,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/frontend/src/components/HostsManager.tsx
+++ b/frontend/src/components/HostsManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp, Send } from 'lucide-react';
+import { User, UserPlus, X, Globe, Instagram, GripVertical, ChevronDown, ChevronUp, Send, ArrowRightLeft } from 'lucide-react';
 import { CoHost } from '../types';
 import { Checkbox } from './Checkbox';
 import HostFormModal from './HostFormModal';
@@ -8,7 +8,9 @@ import { fetchXAvatarToSupabase, isAutoFilledXAvatar } from '../utils/avatarUtil
 import { uuid, normalizeUrl, stripToHandle } from '../lib/utils';
 import { ALL_HOST_TABS } from '../lib/tabPermissions';
 import { usePizza } from '../contexts/PizzaContext';
-import { apiRequest } from '../lib/api';
+import { apiRequest, fetchPartyOwner } from '../lib/api';
+import { useIsAdminOrUnderboss } from '../hooks/useIsAdminOrUnderboss';
+import TransferOwnershipModal from './admin/TransferOwnershipModal';
 
 interface HostsManagerProps {
   partyId: string;
@@ -162,6 +164,45 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
     })();
     return () => { cancelled = true; };
   }, [partyId]);
+
+  // fontina-91827: admin-only "Transfer ownership" affordance under the
+  // primary host row. The hook resolves to null while loading, then true/false.
+  // The owner-info lookup is deferred until the admin actually opens the modal
+  // so we don't hit the backend on every host page render.
+  const isAdminCaller = useIsAdminOrUnderboss();
+  const [showTransferModal, setShowTransferModal] = useState(false);
+  const [primaryOwner, setPrimaryOwner] = useState<{ email: string; name: string | null } | null>(null);
+  const [primaryOwnerError, setPrimaryOwnerError] = useState<string | null>(null);
+  const [loadingPrimaryOwner, setLoadingPrimaryOwner] = useState(false);
+
+  const openTransferModal = async () => {
+    setPrimaryOwnerError(null);
+    if (primaryOwner) {
+      setShowTransferModal(true);
+      return;
+    }
+    // paesana-89172 already fetches the primary host into `primaryHost`; if
+    // that's populated we don't need a second network call.
+    if (primaryHost?.email) {
+      setPrimaryOwner({ email: primaryHost.email, name: primaryHost.name });
+      setShowTransferModal(true);
+      return;
+    }
+    setLoadingPrimaryOwner(true);
+    try {
+      const data = await fetchPartyOwner(partyId);
+      if (!data.ownerEmail) {
+        setPrimaryOwnerError('This event has no primary owner on record.');
+        return;
+      }
+      setPrimaryOwner({ email: data.ownerEmail, name: data.ownerName });
+      setShowTransferModal(true);
+    } catch (e) {
+      setPrimaryOwnerError(e instanceof Error ? e.message : 'Failed to load owner');
+    } finally {
+      setLoadingPrimaryOwner(false);
+    }
+  };
 
   const [newCoHostName, setNewCoHostName] = useState('');
   const [newCoHostEmail, setNewCoHostEmail] = useState('');
@@ -521,18 +562,39 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
             haven't yet loaded the primaryHost data (network fallback)
             AND the owner isn't already in the cohosts array. */}
         {hostName && !primaryHost && !ownerCoHost && (
-          <div className="flex items-center justify-between p-3 bg-white/5 rounded-xl border border-[#ff393a]/30 transition-all">
-            <div className="flex items-center gap-3 flex-1">
-              <div className="w-10 h-10 rounded-full bg-[#ff393a]/20 flex items-center justify-center">
-                <User className="w-5 h-5 text-[#ff393a]" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <p className="text-white font-medium truncate">{hostName}</p>
-                  <span className="text-xs bg-[#ff393a]/20 text-[#ff393a] px-2 py-0.5 rounded-full">Primary</span>
+          <div className="p-3 bg-white/5 rounded-xl border border-[#ff393a]/30 transition-all">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3 flex-1">
+                <div className="w-10 h-10 rounded-full bg-[#ff393a]/20 flex items-center justify-center">
+                  <User className="w-5 h-5 text-[#ff393a]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-white font-medium truncate">{hostName}</p>
+                    <span className="text-xs bg-[#ff393a]/20 text-[#ff393a] px-2 py-0.5 rounded-full">Primary</span>
+                  </div>
                 </div>
               </div>
             </div>
+            {/* fontina-91827: admin-only Transfer ownership affordance even in
+                the legacy/network-fallback render path. */}
+            {isAdminCaller && (
+              <div className="mt-2 pl-[52px] flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={openTransferModal}
+                  disabled={loadingPrimaryOwner}
+                  className="text-xs text-white/50 hover:text-[#ff393a] transition-colors flex items-center gap-1 disabled:opacity-50"
+                  title="Admin only — reassign event ownership to another registered user"
+                >
+                  <ArrowRightLeft size={12} />
+                  {loadingPrimaryOwner ? 'Loading…' : 'Transfer ownership →'}
+                </button>
+                {primaryOwnerError && (
+                  <span className="text-xs text-[#ff393a]">{primaryOwnerError}</span>
+                )}
+              </div>
+            )}
           </div>
         )}
 
@@ -656,7 +718,25 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
               >
                 Edit
               </button>
+              {/* fontina-91827: admin-only Transfer-ownership affordance,
+                  rendered next to Edit on the Owner row. Hidden for
+                  non-admin callers and non-owner rows. */}
+              {isOwnerRow && isAdminCaller && (
+                <button
+                  type="button"
+                  onClick={openTransferModal}
+                  disabled={loadingPrimaryOwner}
+                  className="text-white/50 hover:text-[#ff393a] text-xs font-medium flex items-center gap-1 disabled:opacity-50"
+                  title="Admin only — reassign event ownership to another registered user"
+                >
+                  <ArrowRightLeft size={12} />
+                  {loadingPrimaryOwner ? 'Loading…' : 'Transfer ownership →'}
+                </button>
+              )}
             </div>
+            {isOwnerRow && primaryOwnerError && (
+              <div className="mt-1 pl-9 text-xs text-[#ff393a]">{primaryOwnerError}</div>
+            )}
 
             {/* Tab permissions expander (only when canEdit is true) */}
             {coHost.canEdit && (
@@ -839,6 +919,27 @@ export const HostsManager: React.FC<HostsManagerProps> = ({
         onSubmit={addCoHost}
         submitting={savingHost}
       />
+
+      {/* fontina-91827: admin-only ownership transfer modal */}
+      {primaryOwner && (
+        <TransferOwnershipModal
+          isOpen={showTransferModal}
+          partyId={partyId}
+          currentOwnerName={primaryOwner.name}
+          currentOwnerEmail={primaryOwner.email}
+          candidateCoHosts={coHosts
+            .filter(h => !!h.email)
+            .map(h => ({ name: h.name, email: h.email as string }))}
+          onClose={() => setShowTransferModal(false)}
+          onTransferred={() => {
+            // Hard reload — ownership change fundamentally rewires the host
+            // session (the calling admin may have just lost edit power on
+            // this party; the new owner needs the full host UI). Letting
+            // the existing party context settle without a reload is risky.
+            window.location.reload();
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/admin/TransferOwnershipModal.tsx
+++ b/frontend/src/components/admin/TransferOwnershipModal.tsx
@@ -1,0 +1,230 @@
+/**
+ * TransferOwnershipModal (fontina-91827)
+ *
+ * Admin-only modal that hits POST /api/admin/parties/:partyId/transfer-ownership
+ * to atomically swap parties.user_id, scrub the old owner from co_hosts, drop
+ * their payment opt-in row, and canonicalize the new owner.
+ *
+ * Mounted from HostsManager under the primary host row when the caller is an
+ * admin or underboss.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Mail, AlertCircle, ArrowRightLeft, Loader2, X } from 'lucide-react';
+import { Checkbox } from '../Checkbox';
+import { IconInput } from '../IconInput';
+import { transferEventOwnership } from '../../lib/api';
+
+export interface TransferOwnershipModalProps {
+  isOpen: boolean;
+  partyId: string;
+  currentOwnerName: string | null;
+  currentOwnerEmail: string;
+  candidateCoHosts: Array<{ name: string | null; email: string }>;
+  onClose: () => void;
+  onTransferred: () => void;
+}
+
+const TransferOwnershipModal: React.FC<TransferOwnershipModalProps> = ({
+  isOpen,
+  partyId,
+  currentOwnerName,
+  currentOwnerEmail,
+  candidateCoHosts,
+  onClose,
+  onTransferred,
+}) => {
+  const [newOwnerEmail, setNewOwnerEmail] = useState('');
+  const [removeOldFromCoHosts, setRemoveOldFromCoHosts] = useState(true);
+  const [deleteOldOptIn, setDeleteOldOptIn] = useState(true);
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset on open/close so a re-open doesn't reveal the previous attempt
+  useEffect(() => {
+    if (isOpen) {
+      setNewOwnerEmail('');
+      setRemoveOldFromCoHosts(true);
+      setDeleteOldOptIn(true);
+      setNote('');
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  // De-duplicate candidates (case-insensitive) and drop the current owner so
+  // the suggestion dropdown never offers the no-op.
+  const dedupedCandidates = useMemo(() => {
+    const currentLower = currentOwnerEmail.toLowerCase();
+    const seen = new Set<string>();
+    const out: Array<{ name: string | null; email: string }> = [];
+    for (const c of candidateCoHosts) {
+      const e = (c.email || '').toLowerCase().trim();
+      if (!e) continue;
+      if (e === currentLower) continue;
+      if (seen.has(e)) continue;
+      seen.add(e);
+      out.push({ name: c.name ?? null, email: c.email });
+    }
+    return out;
+  }, [candidateCoHosts, currentOwnerEmail]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async () => {
+    const trimmed = newOwnerEmail.trim();
+    if (!trimmed) {
+      setError('Enter the new owner email.');
+      return;
+    }
+    if (trimmed.toLowerCase() === currentOwnerEmail.toLowerCase()) {
+      setError('New owner is the same as the current owner.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await transferEventOwnership(partyId, {
+        newOwnerEmail: trimmed,
+        removeOldFromCoHosts,
+        deleteOldOptIn,
+        note: note.trim() || undefined,
+      });
+      onTransferred();
+      onClose();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Transfer failed';
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const displayName = currentOwnerName ?? currentOwnerEmail;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="card p-6 max-w-md w-full"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-theme-text flex items-center gap-2">
+            <ArrowRightLeft size={18} className="text-[#ff393a]" />
+            Transfer ownership
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-white/50 hover:text-white"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <p className="text-sm text-white/60 mb-4">
+          Currently owned by <span className="text-white font-medium">{displayName}</span>{' '}
+          <span className="text-white/40">({currentOwnerEmail})</span>.
+        </p>
+
+        <div className="space-y-3">
+          <div>
+            <IconInput
+              icon={Mail}
+              type="email"
+              value={newOwnerEmail}
+              onChange={(e) => setNewOwnerEmail(e.target.value)}
+              placeholder="New owner email"
+              autoComplete="off"
+            />
+            <p className="text-xs text-white/40 mt-1">
+              Must be an existing rsv.pizza user — they need to have logged in at least once.
+            </p>
+          </div>
+
+          {dedupedCandidates.length > 0 && (
+            <div className="rounded-lg border border-white/10 bg-white/5 p-2">
+              <p className="text-xs text-white/50 mb-1.5 px-1">Pick from cohosts:</p>
+              <div className="flex flex-wrap gap-1.5">
+                {dedupedCandidates.map((c) => (
+                  <button
+                    key={c.email}
+                    type="button"
+                    onClick={() => setNewOwnerEmail(c.email)}
+                    className={`text-xs px-2 py-1 rounded-md transition-colors ${
+                      newOwnerEmail.trim().toLowerCase() === c.email.toLowerCase()
+                        ? 'bg-[#ff393a]/20 text-[#ff393a] border border-[#ff393a]/40'
+                        : 'bg-white/5 text-white/70 hover:bg-white/10 border border-white/10'
+                    }`}
+                  >
+                    {c.name ? `${c.name} (${c.email})` : c.email}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2 pt-1">
+            <Checkbox
+              checked={removeOldFromCoHosts}
+              onChange={() => setRemoveOldFromCoHosts((v) => !v)}
+              label="Remove old owner from the cohost list"
+              size={16}
+              labelClassName="text-sm text-white/70"
+            />
+            <Checkbox
+              checked={deleteOldOptIn}
+              onChange={() => setDeleteOldOptIn((v) => !v)}
+              label="Delete old owner's payment opt-in for this event"
+              size={16}
+              labelClassName="text-sm text-white/70"
+            />
+          </div>
+
+          <IconInput
+            multiline
+            rows={2}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Reason / notes (optional)"
+          />
+
+          {error && (
+            <div className="flex items-start gap-2 text-sm text-[#ff393a] bg-[#ff393a]/10 border border-[#ff393a]/30 rounded-lg p-3">
+              <AlertCircle size={16} className="shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3 mt-5">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="flex-1 bg-theme-surface-hover hover:bg-theme-surface-hover text-theme-text font-medium py-2.5 rounded-lg transition-colors text-sm disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !newOwnerEmail.trim()}
+            className="flex-1 bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"
+          >
+            {submitting ? <Loader2 size={16} className="animate-spin" /> : <ArrowRightLeft size={16} />}
+            {submitting ? 'Transferring...' : 'Transfer'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default TransferOwnershipModal;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2628,6 +2628,37 @@ export async function removeAdmin(id: string): Promise<void> {
   await apiRequest(`/api/admin/${id}`, { method: 'DELETE' });
 }
 
+// fontina-91827: admin-only lookup for a party's current owner email + name.
+// Used by TransferOwnershipModal so the admin UI can render "Currently owned
+// by X (email)" without depending on the host-gated cohosts/full endpoint.
+export async function fetchPartyOwner(partyId: string): Promise<{
+  partyId: string;
+  ownerId: string | null;
+  ownerEmail: string | null;
+  ownerName: string | null;
+}> {
+  return apiRequest(`/api/admin/parties/${partyId}/owner`);
+}
+
+// fontina-91827: admin-only event ownership transfer. Atomically updates
+// parties.user_id, removes the old owner from co_hosts, deletes their
+// party_payment_opt_ins row, and canonicalizes the new owner with
+// canEdit:true + showOnEvent:true in the cohost array.
+export async function transferEventOwnership(
+  partyId: string,
+  body: {
+    newOwnerEmail: string;
+    removeOldFromCoHosts?: boolean;
+    deleteOldOptIn?: boolean;
+    note?: string;
+  },
+): Promise<{ ok: true; partyId: string; newOwnerId: string; newOwnerEmail: string }> {
+  return apiRequest(`/api/admin/parties/${partyId}/transfer-ownership`, {
+    method: 'POST',
+    body,
+  });
+}
+
 // Underboss Admin API (management)
 
 export async function fetchUnderbossList(): Promise<UnderbossAdmin[]> {


### PR DESCRIPTION
## Summary
- New admin-only `POST /api/admin/parties/:partyId/transfer-ownership` -- atomic transaction that updates `parties.user_id`, scrubs the old owner from `co_hosts`, deletes their `party_payment_opt_ins` row, and canonicalizes the new owner.
- New `TransferOwnershipModal` rendered under the primary host row in the Hosts settings panel (admin-only).
- Audit row written to `deletion_log` with old + new owner ids/emails for traceability.
- No schema changes.

## Test plan
- [ ] Admin transfers ownership of an event with a cohost candidate -> new primary host correctly stamped, old removed.
- [ ] Old owner can no longer access /host/:slug after transfer.
- [ ] Old owner's opt-in row gone.
- [ ] Non-existing email -> 400 NEW_OWNER_NOT_FOUND.
- [ ] Same-owner transfer -> 400 SAME_OWNER.
- [ ] Non-admin caller -> 403.