### PR TITLE
bocconcini-49102: re-check caps on approve/execute/mark-paid/bulk-execute

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1633,7 +1633,13 @@ router.post(
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true },
+        select: {
+          id: true,
+          status: true,
+          hostUserId: true,
+          partyId: true,
+          finalAmountUsd: true,
+        },
       });
 
       if (!existing) {
@@ -1648,6 +1654,18 @@ router.post(
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      // bocconcini-49102: re-run the per-submission + per-party cap checks at
+      // approve time so rows created/edited BEFORE the cap rules landed (or
+      // rows whose party's cap was tightened after creation) can't be pushed
+      // through to `approved` (and from there to `paid`). Helpers are
+      // idempotent — better to over-check than to under-check.
+      assertWithinPerSubmissionCap(Number(existing.finalAmountUsd));
+      await assertWithinPartyCap(
+        existing.partyId,
+        Number(existing.finalAmountUsd),
+        existing.id,
+      );
 
       const { note, autoExecute } = req.body || {};
 
@@ -1834,7 +1852,13 @@ router.post(
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true },
+        select: {
+          id: true,
+          status: true,
+          hostUserId: true,
+          partyId: true,
+          finalAmountUsd: true,
+        },
       });
 
       if (!existing) {
@@ -1845,6 +1869,16 @@ router.post(
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      // bocconcini-49102: re-run the per-submission + per-party cap checks at
+      // mark-paid time too. mark-paid is the manual override that records an
+      // out-of-band payment for an existing row — same gates apply.
+      assertWithinPerSubmissionCap(Number(existing.finalAmountUsd));
+      await assertWithinPartyCap(
+        existing.partyId,
+        Number(existing.finalAmountUsd),
+        existing.id,
+      );
 
       const {
         wireReference,
@@ -2031,6 +2065,7 @@ async function executePayout(params: {
       payoutMethod: true,
       finalAmountUsd: true,
       payoutWalletAddress: true,
+      partyId: true,
     },
   });
   if (!existing) {
@@ -2045,6 +2080,17 @@ async function executePayout(params: {
   }
 
   const finalAmountUsd = Number(existing.finalAmountUsd);
+
+  // bocconcini-49102: re-run the per-submission + per-party cap checks at
+  // execute time so rows approved before the cap rules landed (or rows whose
+  // party cap was tightened after approval) can't be pushed through to
+  // `paid`. Covers BOTH the direct POST /:id/execute route and the
+  // `autoExecute: true` branch of POST /:id/approve, plus per-row checks in
+  // POST /bulk-execute (which serially calls this helper). `assertWithinPartyCap`
+  // re-queries on every call, so successive bulk rows see the freshly-paid
+  // earlier rows in their `usedUsd` totals.
+  assertWithinPerSubmissionCap(finalAmountUsd);
+  await assertWithinPartyCap(existing.partyId, finalAmountUsd, existing.id);
 
   // arugula-38633 v3 follow-up: payout_method can be null when the host
   // submitted before setting their payment details. Block execute with a


### PR DESCRIPTION
## Summary

Closes the loophole where payout rows created or approved **before** the per-submission $625 and per-party cap rules landed (tiramisu-49102 + acciuga-62583) could still be pushed all the way to `paid` because the cap helpers only ran at CREATE + EDIT.

Concrete current blast site this PR blocks: the Ouagadougou **$750** approved row sitting against a **$100** party cap — currently ready to execute without a single cap gate firing.

## Changes

All in `backend/src/routes/admin-payout.routes.ts`. Re-uses the existing helpers — no new helpers, no new error codes.

- **`POST /:id/approve`** — after loading the payout, before the transaction flips it to `approved`:
  - `assertWithinPerSubmissionCap(finalAmountUsd)` (hard $625)
  - `assertWithinPartyCap(partyId, finalAmountUsd, payoutId)`
- **`POST /:id/mark-paid`** (manual out-of-band override) — same two assertions before the status flip.
- **`executePayout()` helper** — same two assertions near the top, after the basic state/method validations. This single change covers:
  - `POST /:id/execute` (direct execute route)
  - `POST /:id/approve` with `autoExecute: true` (the approve route already delegates to this helper)
  - `POST /bulk-execute` (serial `for ... await` loop, one `executePayout` call per row)

The approve-route precheck is belt-and-suspenders alongside the in-`executePayout` check — both are idempotent and cheap.

## Bulk-execute correctness

`bulk-execute` is sequential (`for ... await`), not `Promise.all`. Each row's `executePayout` commits status -> paid before the next row's `assertWithinPartyCap` re-queries, so successive rows see freshly-paid earlier rows in their `usedUsd` totals. Per-row failures continue to land in the existing `BulkSendResult` shape with the cap-error message + code — the batch doesn't abort early.

## Error contract

Existing codes only:
- `PER_SUBMISSION_CAP_EXCEEDED` (400) — `finalAmountUsd > $625`
- `PARTY_CAP_EXCEEDED` (409) — `usedUsd + proposed > effectiveCap`

`AppError`s flow through the existing `next(error)` handler with the unchanged response shape. Admin UI already surfaces these via toast/modal handling.

## Out of scope

- No reject/cancel/restore changes (don't move money).
- No force-execute override (cap is hard).
- No frontend changes.
- No change to the bianco-89172 per-wallet $626 soft warning.

## Test plan

- [ ] Vercel preview build green (`gh pr checks <num>`).
- [ ] Manual: approve Ouagadougou $750 row -> expect 409 PARTY_CAP_EXCEEDED.
- [ ] Manual: execute any row whose party cap was tightened post-approval -> expect 409.
- [ ] Manual: bulk-execute a selection where the 2nd row would push a party over cap -> 1st succeeds, 2nd lands as a per-row failure in the response with `PARTY_CAP_EXCEEDED` message.
- [ ] Manual: mark-paid on the Ouagadougou row -> expect 409.

(Backend redeploys from master only — enforcement lands after merge + `cd backend && vercel --prod --scope pizza-dao`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)