### PR TITLE
gelato-72831: let hosts withdraw approved payment requests

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -6,7 +6,7 @@
  *   GET    /:partyId/payouts                List payouts for a party (host view)
  *   GET    /:partyId/payouts/:payoutId      Detail (host or any admin)
  *   PATCH  /:partyId/payouts/:payoutId      Update (host, while status='pending' only)
- *   DELETE /:partyId/payouts/:payoutId      Cancel (host, while status='pending' only)
+ *   DELETE /:partyId/payouts/:payoutId      Withdraw (host, while status IN 'pending'|'approved')
  *   POST   /:partyId/payouts/ocr-preview    OCR a single uploaded image without saving
  *
  * Admin execution + approval/rejection endpoints land in PR 4 / PR 5.
@@ -52,6 +52,15 @@ const ocrPreviewLimiter = rateLimit({
 // Valid payout methods (mirrors the CHECK constraint in the DB)
 const PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 type PayoutMethod = (typeof PAYOUT_METHODS)[number];
+
+// gelato-72831: hosts can withdraw their own payment requests while the row is
+// still in a non-terminal state. `pending` is the initial state; `approved`
+// means an admin OK'd it but no money has moved yet (Mercury card not issued,
+// USDC not sent, wire not initiated). Withdrawing an approved row is the
+// host's only out when the admin approved a non-compliant amount (e.g.
+// post-bocconcini-49102 cap recheck would now reject the row at execute time).
+// `paid`, `rejected`, and `failed` remain terminal from the host side.
+const WITHDRAWABLE_STATUSES = ['pending', 'approved'] as const;
 
 // ---------- helpers ----------
 
@@ -243,7 +252,7 @@ async function isAnyAdmin(email?: string): Promise<boolean> {
  * mutate Payout rows and we don't want them piling up before underboss review.
  *
  * GET and DELETE are NOT gated: hosts must still be able to see existing
- * payouts and cancel pending ones even if approval is later revoked.
+ * payouts and withdraw pending/approved ones even if approval is later revoked.
  *
  * Throws 403 PARTY_NOT_APPROVED when the party isn't approved (or doesn't
  * exist — we don't leak the existence distinction since the action is gated
@@ -1330,11 +1339,11 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
     if (!existing) {
       throw new AppError('Payment not found', 404, 'NOT_FOUND');
     }
-    if (existing.status !== 'pending') {
+    if (!WITHDRAWABLE_STATUSES.includes(existing.status as (typeof WITHDRAWABLE_STATUSES)[number])) {
       throw new AppError(
-        'Only pending payments can be cancelled',
+        'This payment can no longer be withdrawn',
         400,
-        'PAYOUT_NOT_PENDING'
+        'PAYOUT_NOT_WITHDRAWABLE'
       );
     }
 
@@ -1344,7 +1353,7 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
     const isAdminCaller = await isAnyAdmin(req.userEmail);
     if (!isAdminCaller && existing.hostUserId !== req.userId) {
       throw new AppError(
-        'Only the cohost who submitted this payment can cancel it.',
+        'Only the cohost who submitted this payment can withdraw it.',
         403,
         'FORBIDDEN_NOT_OWNER',
       );

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign } from 'lucide-react';
+import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign, Trash2 } from 'lucide-react';
 import { Payout, PayoutStatus } from '../../types';
-import { getPayout, updatePayout, fetchAdminMe } from '../../lib/api';
+import { cancelPayout, getPayout, updatePayout, fetchAdminMe } from '../../lib/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { methodIcon, methodLabel } from './PayoutListRow';
 import { IconInput } from '../IconInput';
@@ -17,6 +17,12 @@ interface PayoutDetailModalProps {
    * (PayoutsTab) refresh its list so totals / OCR sums stay in sync.
    */
   onUpdated?: () => void;
+  /**
+   * gelato-72831: optional callback fired after a successful withdraw so the
+   * parent list can drop the row. If provided, the modal will close itself
+   * after invoking it.
+   */
+  onWithdrawn?: (payoutId: string) => void;
 }
 
 const STATUS_STYLES: Record<PayoutStatus, string> = {
@@ -45,6 +51,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   payoutId,
   onClose,
   onUpdated,
+  onWithdrawn,
 }) => {
   const { user } = useAuth();
   const [payout, setPayout] = useState<Payout | null>(null);
@@ -67,6 +74,10 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // ---- withdraw state (gelato-72831) ----
+  const [withdrawing, setWithdrawing] = useState(false);
+  const [withdrawError, setWithdrawError] = useState<string | null>(null);
 
   // New uploads since edit-mode was opened (existing docs aren't re-uploaded).
   const [newReceipts, setNewReceipts] = useState<ReceiptItem[]>([]);
@@ -207,6 +218,38 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     }
   };
 
+  // gelato-72831: withdraw both pending and approved payouts. Hard-deletes
+  // the row server-side (deletion_log trigger keeps audit trail). For approved
+  // rows the confirm copy makes clear that resubmitting is the next step.
+  const handleWithdraw = async () => {
+    if (!payout || withdrawing) return;
+    const message = payout.status === 'approved'
+      ? 'Withdraw this request? You can submit a new one afterward.'
+      : 'Withdraw this payment request? This cannot be undone.';
+    if (!confirm(message)) return;
+    setWithdrawing(true);
+    setWithdrawError(null);
+    try {
+      const ok = await cancelPayout(partyId, payout.id);
+      if (ok) {
+        onWithdrawn?.(payout.id);
+        onClose();
+      }
+    } catch (err: any) {
+      setWithdrawError(err?.message || 'Failed to withdraw payment');
+    } finally {
+      setWithdrawing(false);
+    }
+  };
+
+  // Status-gated withdraw availability. canModify already enforces
+  // submitter-or-admin ownership.
+  const canWithdraw = Boolean(
+    payout &&
+    (payout.status === 'pending' || payout.status === 'approved') &&
+    canModify
+  );
+
   return (
     <div
       className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
@@ -238,6 +281,22 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 Edit
               </button>
             )}
+            {/* gelato-72831: Withdraw is available for pending AND approved
+                rows. Approved means an admin OK'd it but no money has moved;
+                hard-deleting still leaves a deletion_log audit trail. */}
+            {payout && !editing && canWithdraw && (
+              <button
+                type="button"
+                onClick={handleWithdraw}
+                disabled={withdrawing}
+                className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md text-theme-text-secondary hover:text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+                title="Withdraw"
+                aria-label="Withdraw payment request"
+              >
+                {withdrawing ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+                Withdraw
+              </button>
+            )}
             <button
               onClick={onClose}
               className="p-1.5 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover transition-colors"
@@ -258,6 +317,12 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
           {error && (
             <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300 inline-flex items-center gap-2">
               <AlertCircle size={16} /> {error}
+            </div>
+          )}
+
+          {withdrawError && (
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300 inline-flex items-center gap-2">
+              <AlertCircle size={16} /> {withdrawError}
             </div>
           )}
 

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -8,6 +8,9 @@ interface PayoutListRowProps {
   payout: Payout;
   partyId: string;
   onOpen: () => void;
+  // Renamed conceptually to "withdrawn" in gelato-72831, but the prop name
+  // stays the same to keep the diff small — it's just a notification that
+  // the row was removed (whether the prior status was pending or approved).
   onCancelled: (payoutId: string) => void;
 }
 
@@ -54,9 +57,9 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
   onCancelled,
 }) => {
   const { user } = useAuth();
-  const [cancelling, setCancelling] = useState(false);
+  const [withdrawing, setWithdrawing] = useState(false);
 
-  // gouda-83912: only the submitter (or any admin) may cancel a payout from
+  // gouda-83912: only the submitter (or any admin) may withdraw a payout from
   // the host-side list. Other cohosts can still see and open the row, but
   // the inline X button is hidden so they don't get a 403 on click.
   const [isAdmin, setIsAdmin] = useState(false);
@@ -70,21 +73,32 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
   const canModify =
     isAdmin || (user?.id != null && user.id === payout.hostUserId);
 
+  // gelato-72831: hosts can withdraw both pending and approved payouts.
+  // Approved means an admin OK'd it but no payment has been issued yet, so
+  // hard-deleting is still safe (the deletion_log trigger keeps an audit
+  // record). `paid`, `rejected`, `failed` remain terminal.
+  const canWithdraw = payout.status === 'pending' || payout.status === 'approved';
+
   // First pizza photo, or first receipt as a fallback thumbnail
   const thumb = payout.documents.find(d => d.kind === 'pizza')
     ?? payout.documents.find(d => d.kind === 'receipt');
 
-  const handleCancel = async (e: React.MouseEvent) => {
+  const handleWithdraw = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!confirm('Cancel this payment request? This cannot be undone.')) return;
-    setCancelling(true);
+    // Hard-delete is not reversible, so we keep a confirm step. For approved
+    // rows the copy makes clear that resubmitting is the next step.
+    const message = payout.status === 'approved'
+      ? 'Withdraw this request? You can submit a new one afterward.'
+      : 'Withdraw this payment request? This cannot be undone.';
+    if (!confirm(message)) return;
+    setWithdrawing(true);
     try {
       const ok = await cancelPayout(partyId, payout.id);
       if (ok) {
         onCancelled(payout.id);
       }
     } finally {
-      setCancelling(false);
+      setWithdrawing(false);
     }
   };
 
@@ -152,15 +166,17 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
         {STATUS_LABEL[payout.status]}
       </span>
 
-      {/* Cancel button (only while pending, and only for the submitter/admin) */}
-      {payout.status === 'pending' && canModify && (
+      {/* Withdraw button (pending or approved; only for the submitter/admin).
+          gelato-72831: extended from pending-only to pending+approved. */}
+      {canWithdraw && canModify && (
         <button
-          onClick={handleCancel}
-          disabled={cancelling}
+          onClick={handleWithdraw}
+          disabled={withdrawing}
           className="p-1.5 rounded-md text-theme-text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
-          title="Cancel"
+          title="Withdraw"
+          aria-label="Withdraw payment request"
         >
-          {cancelling ? <Loader2 size={16} className="animate-spin" /> : <X size={16} />}
+          {withdrawing ? <Loader2 size={16} className="animate-spin" /> : <X size={16} />}
         </button>
       )}
 

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -285,6 +285,9 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           payoutId={detailPayoutId}
           onClose={() => setDetailPayoutId(null)}
           onUpdated={loadPayouts}
+          // gelato-72831: refresh the list when a withdraw happens from inside
+          // the modal so the row disappears immediately.
+          onWithdrawn={() => loadPayouts()}
         />
       )}
 


### PR DESCRIPTION
## Summary

- Extends the host-side `DELETE /api/parties/:partyId/payouts/:payoutId` endpoint from `pending`-only to `pending` + `approved`. `paid`, `rejected`, and `failed` remain terminal from the host side.
- New backend error code `PAYOUT_NOT_WITHDRAWABLE` replaces `PAYOUT_NOT_PENDING`.
- Frontend renames the inline X control from "Cancel" to "Withdraw" (PayoutListRow), and adds a Withdraw button in PayoutDetailModal that surfaces for both statuses.
- Approved-row confirm copy: "Withdraw this request? You can submit a new one afterward." Pending-row confirm copy unchanged.
- gouda-83912 submitter-only rule and the `deletion_log` audit trigger are untouched. Withdrawal still hard-deletes; the trigger keeps traceability.
- No change to admin reject/edit endpoints. No change to cap-check logic (bocconcini-49102).

## Why

bocconcini-49102 added cap rechecks at approve/execute/mark-paid time. An admin-approved row that exceeds the cap (e.g. the Ouagadougou \$750 case) now fails at execute, but the host previously had no way to remove it. This task gives them that escape hatch so they can resubmit at a compliant amount via the existing `NewPayoutForm`.

## Test plan

- [ ] As a host on a pending payout, click Withdraw in the list — row disappears.
- [ ] As a host on an approved payout (Ouagadougou \$750), click Withdraw — confirm dialog mentions resubmission; row disappears after confirm.
- [ ] As a host on a paid/rejected/failed payout, no Withdraw control is visible.
- [ ] As a non-submitter cohost, no Withdraw control on either pending or approved rows.
- [ ] DELETE on `paid`/`rejected`/`failed` from a curl/Postman returns 400 `PAYOUT_NOT_WITHDRAWABLE`.
- [ ] `deletion_log` table contains a row for the withdrawn payout.
- [ ] Withdraw button in PayoutDetailModal closes the modal and refreshes the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)