### PR TITLE
fix(provolone-39042): allow hosts to add receipts on approved payouts

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -925,13 +925,43 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     if (!existing) {
       throw new AppError('Payment not found', 404, 'NOT_FOUND');
     }
-    if (existing.status !== 'pending') {
+
+    // provolone-39042: split doc-only edits from amount/method/wallet edits so
+    // hosts can attach receipts to already-approved payouts (Adama incident:
+    // host couldn't add a receipt to their $200 approved wire). The admin
+    // PATCH route stays unrestricted — this is host-side only.
+    const hasAmountOrMethodChanges =
+      payoutMethod !== undefined ||
+      payoutWalletAddress !== undefined ||
+      payoutBankDetails !== undefined ||
+      finalAmountUsd !== undefined ||
+      mercuryCardLast4 !== undefined ||
+      hostNotes !== undefined;
+
+    // Paid/failed/rejected payouts are frozen entirely on the host side.
+    if (
+      existing.status === 'paid' ||
+      existing.status === 'rejected' ||
+      existing.status === 'failed'
+    ) {
       throw new AppError(
-        'Payments can only be edited while pending; this one is ' + existing.status,
+        `Payments cannot be edited once ${existing.status}.`,
         400,
         'NOT_EDITABLE'
       );
     }
+
+    // Approved payouts: doc-only edits allowed, but amount/method/wallet/notes
+    // are frozen so the admin-approved amount can't be silently changed.
+    if (existing.status === 'approved' && hasAmountOrMethodChanges) {
+      throw new AppError(
+        'Approved payments cannot have amount, method, wallet, or notes changed. Ask an admin to revert to pending first.',
+        400,
+        'APPROVED_NOT_EDITABLE'
+      );
+    }
+
+    // Pending payouts fall through unchanged — anything goes.
 
     // gouda-83912: only the cohost who submitted the payout (or any admin)
     // may edit it. Other cohosts on the same party can see the row but
@@ -1164,7 +1194,13 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       id => existing.documents.find(d => d.id === id)?.kind === 'receipt'
     );
 
-    if (receiptsChanged) {
+    // provolone-39042: only pending payouts auto-recompute finalAmountUsd from
+    // the OCR sum when receipts change. Approved payouts keep their
+    // admin-approved amount even if new receipts are attached — the OCR sum
+    // becomes informational only.
+    const allowRecompute = existing.status === 'pending';
+
+    if (receiptsChanged && allowRecompute) {
       const removedSet = new Set(removeIds);
       const survivingReceipts = existing.documents.filter(
         d => d.kind === 'receipt' && !removedSet.has(d.id)

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -131,6 +131,14 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     payout && (isAdmin || (user?.id != null && user.id === payout.hostUserId))
   );
 
+  // provolone-39042: hosts can edit pending or approved payouts. On approved
+  // rows the editable surface is narrowed to receipts/photos only — amount,
+  // method, notes are locked (the backend enforces APPROVED_NOT_EDITABLE).
+  // paid/rejected/failed remain fully frozen on the host side.
+  const isEditableStatus =
+    payout?.status === 'pending' || payout?.status === 'approved';
+  const isApproved = payout?.status === 'approved';
+
   const handleSave = async () => {
     if (!payout || saving) return;
     setSaving(true);
@@ -139,22 +147,31 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
       // Build the patch payload. Only include fields that actually changed.
       const patch: Parameters<typeof updatePayout>[2] = {};
 
+      // provolone-39042: on approved payouts the notes + amount inputs are
+      // hidden; never include them in the patch (backend would reject with
+      // APPROVED_NOT_EDITABLE).
+      const approvedLocked = payout.status === 'approved';
+
       // Notes (treat empty string as a clear).
-      const trimmedNotes = editNotes.trim();
-      const originalNotes = (payout.hostNotes ?? '').trim();
-      if (trimmedNotes !== originalNotes) {
-        patch.hostNotes = trimmedNotes.length > 0 ? trimmedNotes : null;
+      if (!approvedLocked) {
+        const trimmedNotes = editNotes.trim();
+        const originalNotes = (payout.hostNotes ?? '').trim();
+        if (trimmedNotes !== originalNotes) {
+          patch.hostNotes = trimmedNotes.length > 0 ? trimmedNotes : null;
+        }
       }
 
       // Amount override.
-      const amountStr = editOverrideAmount.trim();
-      if (amountStr !== '') {
-        const parsed = Number(amountStr);
-        if (!Number.isFinite(parsed) || parsed <= 0) {
-          throw new Error('Amount must be a positive number');
-        }
-        if (parsed !== payout.finalAmountUsd) {
-          patch.finalAmountUsd = parsed;
+      if (!approvedLocked) {
+        const amountStr = editOverrideAmount.trim();
+        if (amountStr !== '') {
+          const parsed = Number(amountStr);
+          if (!Number.isFinite(parsed) || parsed <= 0) {
+            throw new Error('Amount must be a positive number');
+          }
+          if (parsed !== payout.finalAmountUsd) {
+            patch.finalAmountUsd = parsed;
+          }
         }
       }
 
@@ -228,7 +245,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {payout && !editing && payout.status === 'pending' && canModify && (
+            {payout && !editing && isEditableStatus && canModify && (
               <button
                 type="button"
                 onClick={enterEdit}
@@ -286,9 +303,11 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 </span>
               </div>
 
-              {/* gouda-83912: ownership notice for non-owners on pending payouts.
-                  Explains why Edit/Cancel buttons aren't shown. */}
-              {payout.status === 'pending' && !canModify && (
+              {/* gouda-83912: ownership notice for non-owners on editable payouts.
+                  Explains why Edit/Cancel buttons aren't shown. provolone-39042
+                  extends this to approved rows (which are also host-editable
+                  for receipts now). */}
+              {isEditableStatus && !canModify && (
                 <p className="text-xs text-theme-text-muted">
                   Only {payout.hostName ?? payout.hostEmail ?? 'the submitter'} can modify this.
                 </p>
@@ -446,8 +465,9 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
           {payout && editing && (
             <>
               <p className="text-xs text-theme-text-muted">
-                You can edit this payment until an admin reviews it. Removed
-                photos are deleted on save.
+                {isApproved
+                  ? 'This payment is approved. You can still add or remove receipts and pizza photos for record-keeping. Amount and method are locked after approval — contact an admin to change.'
+                  : 'You can edit this payment until an admin reviews it. Removed photos are deleted on save.'}
               </p>
 
               {/* Existing receipts — host can click X to mark for removal */}
@@ -529,37 +549,41 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 />
               </div>
 
-              {/* Notes */}
-              <div>
-                <p className="text-xs text-theme-text-muted mb-2">Notes</p>
-                <IconInput
-                  icon={StickyNote}
-                  multiline
-                  rows={3}
-                  placeholder="What was this for? Pizza + venue, etc."
-                  value={editNotes}
-                  onChange={e => setEditNotes(e.target.value)}
-                  maxLength={500}
-                />
-                <p className="text-xs text-theme-text-muted mt-1">{editNotes.length}/500</p>
-              </div>
+              {/* Notes — locked on approved payouts (provolone-39042). */}
+              {!isApproved && (
+                <div>
+                  <p className="text-xs text-theme-text-muted mb-2">Notes</p>
+                  <IconInput
+                    icon={StickyNote}
+                    multiline
+                    rows={3}
+                    placeholder="What was this for? Pizza + venue, etc."
+                    value={editNotes}
+                    onChange={e => setEditNotes(e.target.value)}
+                    maxLength={500}
+                  />
+                  <p className="text-xs text-theme-text-muted mt-1">{editNotes.length}/500</p>
+                </div>
+              )}
 
-              {/* Amount override */}
-              <div>
-                <p className="text-xs text-theme-text-muted mb-2">Amount (USD)</p>
-                <IconInput
-                  icon={DollarSign}
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  placeholder="Override amount (USD) — leave blank to recompute from receipts"
-                  value={editOverrideAmount}
-                  onChange={e => setEditOverrideAmount(e.target.value)}
-                />
-                <p className="text-xs text-theme-text-muted mt-1">
-                  If you change receipts, we'll re-add the totals automatically unless you set a value here.
-                </p>
-              </div>
+              {/* Amount override — locked on approved payouts (provolone-39042). */}
+              {!isApproved && (
+                <div>
+                  <p className="text-xs text-theme-text-muted mb-2">Amount (USD)</p>
+                  <IconInput
+                    icon={DollarSign}
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    placeholder="Override amount (USD) — leave blank to recompute from receipts"
+                    value={editOverrideAmount}
+                    onChange={e => setEditOverrideAmount(e.target.value)}
+                  />
+                  <p className="text-xs text-theme-text-muted mt-1">
+                    If you change receipts, we'll re-add the totals automatically unless you set a value here.
+                  </p>
+                </div>
+              )}
 
               {saveError && (
                 <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-300 inline-flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Host-side PATCH gate split: doc-only edits OK on approved, amount/method changes still blocked.
- Approved payouts' amount no longer auto-recomputes from new receipts.
- PayoutDetailModal disables amount/method edits on approved rows.
- Paid/rejected/failed remain fully frozen.

## Test plan
- [ ] Approved payout host → add receipt → succeeds, amount unchanged.
- [ ] Approved payout host → try edit amount → 400 APPROVED_NOT_EDITABLE.
- [ ] Paid payout host → no edit possible.
- [ ] Pending payout host → all edits work (regression).