### PR TITLE
feat(romana-71839): country flags on /photos tiles

### DIFF
--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -5,6 +5,12 @@ import { Loader2, Play, MapPin } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import { cdnUrl } from '../lib/supabase';
 import { getPhotosFeed, FeedPhoto } from '../lib/api';
+import { countryNameToFlag } from '../utils/countryFlag';
+
+// Sentinel returned by countryNameToFlag when the country name doesn't map
+// to an ISO-3166 alpha-2 code. When we see this, we fall back to the MapPin
+// icon so we don't show the world-map emoji here.
+const MAP_EMOJI_FALLBACK = '\u{1F5FA}\u{FE0F}';
 
 export function PhotosFeedPage() {
   const [photos, setPhotos] = useState<FeedPhoto[]>([]);
@@ -132,7 +138,12 @@ function FeedTile({ photo, onOpen }: { photo: FeedPhoto; onOpen: () => void }) {
       </div>
       {(photo.party.city || photo.party.name) && (
         <div className="px-2 py-1.5 text-xs text-theme-text-muted flex items-center gap-1">
-          <MapPin size={11} />
+          {(() => {
+            const flag = countryNameToFlag(photo.party.country);
+            return flag && flag !== MAP_EMOJI_FALLBACK
+              ? <span className="text-sm leading-none" aria-label={photo.party.country || ''}>{flag}</span>
+              : <MapPin size={11} />;
+          })()}
           <span className="truncate">{photo.party.city || photo.party.name}</span>
         </div>
       )}
@@ -155,7 +166,12 @@ function FeedLightbox({ photo, onClose }: { photo: FeedPhoto; onClose: () => voi
         <div className="p-4 border-t border-theme-stroke">
           {photo.caption && <p className="text-theme-text mb-2">{photo.caption}</p>}
           <p className="text-theme-text-muted text-sm flex items-center gap-2">
-            <MapPin size={12} />
+            {(() => {
+              const flag = countryNameToFlag(photo.party.country);
+              return flag && flag !== MAP_EMOJI_FALLBACK
+                ? <span className="text-base leading-none" aria-label={photo.party.country || ''}>{flag}</span>
+                : <MapPin size={12} />;
+            })()}
             <Link to={`/${photo.party.slug}`} className="hover:underline text-theme-text">{photo.party.name}</Link>
             {photo.party.city && <span>· {photo.party.city}{photo.party.country ? `, ${photo.party.country}` : ''}</span>}
           </p>


### PR DESCRIPTION
## Summary
- Reuses the existing `countryNameToFlag(name)` helper at `frontend/src/utils/countryFlag.ts` (an existing helper was already in place — used by promo/share flows)
- /photos tiles + lightbox caption now render the country flag emoji in place of the MapPin icon when the party country maps to a known ISO-3166 alpha-2; fall back to MapPin when the helper returns its world-map sentinel
- Frontend-only, no backend or DB changes

## Test plan
- [ ] Tiles for US, India, Philippines, Nigeria, Canada, Brazil show correct flags
- [ ] Unknown / null country falls back to MapPin icon (no broken layout, no stray world-map emoji)
- [ ] Lightbox caption shows the same flag prefix
- [ ] Vercel preview: https://rsvpizza-git-romana-71839-photos-flags-pizza-dao.vercel.app/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)