### PR TITLE
mortadella-58492: scorecard tweet tags partners + adds URL; fix Checked In button text

### DIFF
--- a/frontend/src/components/CheckInButton.tsx
+++ b/frontend/src/components/CheckInButton.tsx
@@ -128,7 +128,7 @@ export function CheckInButton({
         <button
           onClick={handleOpenScanner}
           className="flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-semibold text-sm
-            bg-green-600 hover:bg-green-700 text-white transition-colors"
+            bg-green-600 hover:bg-green-700 text-[#ffffff] transition-colors"
         >
           Checked In
         </button>

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -10,6 +10,10 @@ interface GuestScorecardProps {
   onTakeSelfie?: () => void;
   /** When this number changes, the scorecard refetches its items. */
   refreshSignal?: number;
+  /** Public event URL, used as the second line in the share tweet. */
+  eventUrl?: string;
+  /** Sponsor Twitter handles (no `@`, deduped, excluding `pizza_dao`). */
+  partnerHandles?: string[];
 }
 
 const ITEM_ORDER: ScorecardItemKey[] = [
@@ -29,6 +33,8 @@ export function GuestScorecard({
   onScanGuest,
   onTakeSelfie,
   refreshSignal,
+  eventUrl,
+  partnerHandles,
 }: GuestScorecardProps) {
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
@@ -146,6 +152,8 @@ export function GuestScorecard({
                 onUploadPhoto={onUploadPhoto}
                 onScanGuest={onScanGuest}
                 onTakeSelfie={onTakeSelfie}
+                eventUrl={eventUrl}
+                partnerHandles={partnerHandles}
               />
             </div>
           );

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -23,6 +23,10 @@ interface ScorecardItemProps {
   onUploadPhoto?: () => void;
   onScanGuest?: () => void;
   onTakeSelfie?: () => void;
+  /** Public URL of the event, included as a second line in the share tweet. */
+  eventUrl?: string;
+  /** Sponsor Twitter handles (no `@` prefix, deduped, excluding `pizza_dao`). */
+  partnerHandles?: string[];
 }
 
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
@@ -44,6 +48,8 @@ export function ScorecardItem({
   onUploadPhoto,
   onScanGuest,
   onTakeSelfie,
+  eventUrl,
+  partnerHandles,
 }: ScorecardItemProps) {
   const [showInput, setShowInput] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -58,8 +64,18 @@ export function ScorecardItem({
     if (completed) return;
 
     if (needsUrlProof) {
-      // Open Twitter intent first, then show input for URL
-      const tweetText = encodeURIComponent("Having a great time at the pizza party! @pizza_dao #PizzaDAO");
+      // Open Twitter intent first, then show input for URL.
+      // Build tweet body: tag @pizza_dao + all sponsor handles, then event URL on a second line.
+      // Falls back to the original hardcoded text if either input is missing.
+      let tweetBody: string;
+      if (partnerHandles && eventUrl) {
+        const handles = partnerHandles.map(h => `@${h}`).join(' ');
+        const firstLine = `Having a great time at the pizza party! @pizza_dao${handles ? ' ' + handles : ''} #PizzaDAO`;
+        tweetBody = [firstLine, eventUrl].filter(Boolean).join('\n');
+      } else {
+        tweetBody = "Having a great time at the pizza party! @pizza_dao #PizzaDAO";
+      }
+      const tweetText = encodeURIComponent(tweetBody);
       window.open(`https://twitter.com/intent/tweet?text=${tweetText}`, '_blank');
       setShowInput(true);
     } else if (itemKey === 'photo') {
@@ -120,7 +136,7 @@ export function ScorecardItem({
         ) : (
           <button
             onClick={handleAction}
-            className="text-xs font-medium px-3 py-1.5 rounded-full bg-[#ff393a] hover:bg-[#ff5a5b] text-white transition-colors"
+            className="text-xs font-medium px-3 py-1.5 rounded-full bg-[#ff393a] hover:bg-[#ff5a5b] text-[#ffffff] transition-colors"
           >
             {getActionLabel()}
           </button>
@@ -142,7 +158,7 @@ export function ScorecardItem({
             <button
               onClick={handleSubmitUrl}
               disabled={!inputValue.trim()}
-              className="px-3 py-1.5 rounded bg-[#ff393a] hover:bg-[#ff5a5b] text-white text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-3 py-1.5 rounded bg-[#ff393a] hover:bg-[#ff5a5b] text-[#ffffff] text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Submit
             </button>

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -343,6 +343,24 @@ export function EventPage() {
     [event?.selectedPizzerias, event?.latitude, event?.longitude],
   );
 
+  // Normalize sponsor twitter handles for the scorecard share tweet
+  // (mortadella-58492). Must be declared above the early returns below.
+  const partnerHandles = useMemo(() => {
+    if (!event?.sponsors) return [];
+    const handles = event.sponsors
+      .map(s => (s.brandTwitter || '').trim().replace(/^@/, ''))
+      .filter(Boolean)
+      .filter(h => h.toLowerCase() !== 'pizza_dao');
+    const seen = new Set<string>();
+    return handles.filter(h => {
+      const k = h.toLowerCase();
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+  }, [event?.sponsors]);
+  const eventUrl = event ? `https://rsv.pizza/${event.customUrl || event.inviteCode || ''}` : '';
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -1279,6 +1297,8 @@ export function EventPage() {
                     onScanGuest={handleScorecardScanGuest}
                     onTakeSelfie={handleScorecardTakeSelfie}
                     refreshSignal={scorecardRefresh}
+                    eventUrl={eventUrl}
+                    partnerHandles={partnerHandles}
                   />
                 )}
 


### PR DESCRIPTION
## Summary
- Scorecard "Share" tweet now tags every sponsor with a brandTwitter handle and links the event URL (`https://rsv.pizza/<slug>`)
- "Checked In" button text was rendering dark-on-green on GPP pages due to the `.gpp-theme .text-white` global override; switched to `text-[#ffffff]` to dodge the selector
- Same fix applied to the new red scorecard action buttons (Upload/Scan/Selfie/Share) so they read crisp white on GPP pages

## Test plan
- [ ] Visit https://rsvpizza-git-mortadella-58492-tweet-and-button-color-pizza-dao.vercel.app/scorecard-test as hello@rarepizzas.com
- [ ] Tap "Share" - Twitter intent opens with `@pizza_dao` plus event sponsor handles + event URL appended
- [ ] "Checked In" button text reads as clean white
- [ ] All red scorecard action buttons read as clean white text

Generated with [Claude Code](https://claude.com/claude-code)