### PR TITLE
fix(romana-58291): pin circle-flags to real version (2.8.3)

### DIFF
--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -7,7 +7,7 @@ import { cdnUrl } from '../lib/supabase';
 import { getPhotosFeed, FeedPhoto } from '../lib/api';
 import { countryNameToAlpha2 } from '../utils/countryFlag';
 
-const FLAG_BASE = 'https://cdn.jsdelivr.net/npm/circle-flags@3.3.0/flags';
+const FLAG_BASE = 'https://cdn.jsdelivr.net/npm/circle-flags@2.8.3/flags';
 
 function CircleFlag({ country, size = 14 }: { country: string | null; size?: number }) {
   const code = countryNameToAlpha2(country);


### PR DESCRIPTION
## Summary
- Previous pin `circle-flags@3.3.0` doesn't exist on npm (latest is 2.8.3)
- Every flag SVG on /photos has been 404ing since merge

## Verified
- `curl -sI "https://cdn.jsdelivr.net/npm/circle-flags@2.8.3/flags/us.svg"` -> 200 OK
- `npm view circle-flags version` -> 2.8.3

## Test plan
- [ ] /photos tiles show round flag SVGs instead of broken-image icons
- [ ] Vercel preview: https://rsvpizza-git-romana-58291-circle-flags-v283-pizza-dao.vercel.app/photos

Generated with [Claude Code](https://claude.com/claude-code)