### PR TITLE
fix(romana-58291): drop end-of-feed message on /photos

### DIFF
--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -127,9 +127,6 @@ export function PhotosFeedPage() {
             <button onClick={() => { hasMoreRef.current = true; setHasMore(true); loadPage(false); }} className="mt-2 underline text-theme-text">Try again</button>
           </div>
         )}
-        {!hasMore && photos.length > 0 && !error && (
-          <p className="text-center text-theme-text-muted py-6 text-sm">You've reached the end.</p>
-        )}
       </div>
 
       {selectedIdx !== null && photos[selectedIdx] && (


### PR DESCRIPTION
## Summary
- Remove \`You've reached the end.\` footer on /photos
- Feed silently ends when all photos are loaded; real network errors still surface

## Test plan
- [ ] /photos, scroll to bottom of 502-photo feed → no footer text visible
- [ ] Vercel preview: https://rsvpizza-git-romana-58291-drop-end-message-pizza-dao.vercel.app/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)