### PR TITLE
feat(regina-89172): mobile-optimize /payments + collapsible filter bar

### DIFF
--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -39,9 +39,9 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
 }) => {
   if (selectedCount === 0) return null;
   return (
-    <div className="sticky top-[7rem] z-10 bg-theme-text/95 text-white rounded-xl px-4 py-3 mb-3 shadow-lg flex items-center gap-3 flex-wrap">
+    <div className="sticky top-[4rem] sm:top-[7rem] z-10 bg-theme-text/95 text-white rounded-xl px-3 py-2 sm:px-4 sm:py-3 mb-3 shadow-lg flex items-center gap-2 sm:gap-3 flex-wrap">
       <span className="text-sm font-medium">{selectedCount} selected</span>
-      <div className="ml-auto flex items-center gap-2 flex-wrap">
+      <div className="sm:ml-auto flex items-center gap-2 flex-wrap">
         <button
           type="button"
           onClick={onApprove}

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -204,7 +204,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
       }}
     >
       <div
-        className="card p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke"
+        className="card p-4 sm:p-6 w-full max-w-[95vw] sm:max-w-lg max-h-[90vh] overflow-y-auto bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start gap-3 mb-4">

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -165,7 +165,7 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
     >
       <form
         onSubmit={handleSubmit}
-        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-lg max-h-[95vh] overflow-hidden flex flex-col"
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-[95vw] sm:max-w-lg max-h-[95vh] overflow-hidden flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/payments-admin/ExportSafeJsonModal.tsx
+++ b/frontend/src/components/payments-admin/ExportSafeJsonModal.tsx
@@ -68,7 +68,7 @@ export const ExportSafeJsonModal: React.FC<ExportSafeJsonModalProps> = ({
     >
       <form
         onSubmit={handleSubmit}
-        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-md max-h-[90vh] overflow-y-auto"
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-[95vw] sm:max-w-md max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -234,7 +234,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     >
       <form
         onSubmit={handleSubmit}
-        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-2xl max-h-[95vh] overflow-hidden flex flex-col"
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-[95vw] sm:max-w-2xl max-h-[95vh] overflow-hidden flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/payments-admin/HostPaymentDetailsModal.tsx
+++ b/frontend/src/components/payments-admin/HostPaymentDetailsModal.tsx
@@ -74,7 +74,7 @@ export const HostPaymentDetailsModal: React.FC<HostPaymentDetailsModalProps> = (
       onClick={onClose}
     >
       <div
-        className="card p-6 w-full max-w-md max-h-[90vh] overflow-y-auto bg-theme-surface border border-theme-stroke rounded-2xl shadow-2xl"
+        className="card p-4 sm:p-6 w-full max-w-[95vw] sm:max-w-md max-h-[90vh] overflow-y-auto bg-theme-surface border border-theme-stroke rounded-2xl shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 mb-4">

--- a/frontend/src/components/payments-admin/HotWalletCard.tsx
+++ b/frontend/src/components/payments-admin/HotWalletCard.tsx
@@ -125,7 +125,7 @@ export const HotWalletCard: React.FC = () => {
       ) : loading && !info ? (
         <div className="space-y-3">
           <div className="h-8 rounded-md bg-theme-surface-hover animate-pulse" />
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="h-16 rounded-md bg-theme-surface-hover animate-pulse" />
             <div className="h-16 rounded-md bg-theme-surface-hover animate-pulse" />
           </div>
@@ -149,7 +149,7 @@ export const HotWalletCard: React.FC = () => {
             </button>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="rounded-md border border-theme-stroke bg-theme-surface p-3">
               <div className="text-xs uppercase tracking-wide text-theme-text-secondary mb-1">
                 ETH for gas

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -26,7 +26,7 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, tone = 'default
         {icon}
         <span>{label}</span>
       </div>
-      <div className="text-xl font-semibold text-theme-text">{value}</div>
+      <div className="text-base sm:text-xl font-semibold text-theme-text break-words">{value}</div>
     </div>
   );
 };

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -238,7 +238,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       onClick={onClose}
     >
       <div
-        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-6xl max-h-[95vh] overflow-hidden flex flex-col"
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-[95vw] sm:max-w-6xl max-h-[95vh] overflow-hidden flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Search, X } from 'lucide-react';
+import React, { useState } from 'react';
+import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type { AdminPayoutFilters, PayoutMethod, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
@@ -34,11 +34,34 @@ const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [
 ];
 
 /**
+ * regina-89172: count active (non-default) filter fields. Status tab strip is
+ * NOT counted here — it's always visible above the collapsible section, so
+ * counting it would double-render the signal. Cursor/limit are pagination
+ * plumbing, not user-facing filters.
+ */
+function countActiveFilters(filters: AdminPayoutFilters): number {
+  let n = 0;
+  if (filters.search && filters.search.trim()) n += 1;
+  if (filters.partyId && filters.partyId.trim()) n += 1;
+  if (filters.payoutMethod && filters.payoutMethod !== 'all') n += 1;
+  if (filters.currency && filters.currency !== 'all') n += 1;
+  if (filters.country && filters.country !== 'all') n += 1;
+  if (filters.dateFrom) n += 1;
+  if (filters.dateTo) n += 1;
+  return n;
+}
+
+/**
  * Sticky filter bar at the top of the admin payouts dashboard. All updates are
  * pushed via `onChange` so the parent can refire `listAdminPayouts(filters)`.
  *
  * Cursor is intentionally NOT a prop here — when filters change the parent
  * should reset cursor to undefined.
+ *
+ * regina-89172: on mobile (<640px) the filter controls collapse behind a
+ * "Filters (N)" toggle button so the payouts table stays above the fold.
+ * The status tab strip stays visible at all times. On `sm:` and up the
+ * controls are always expanded (existing desktop behavior).
  */
 export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   filters,
@@ -47,13 +70,16 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   availableCurrencies,
   availableCountries,
 }) => {
+  const [expanded, setExpanded] = useState(false);
+  const activeCount = countActiveFilters(filters);
+
   const update = (patch: Partial<AdminPayoutFilters>) => {
     onChange({ ...filters, ...patch, cursor: undefined });
   };
 
   return (
     <div className="sticky top-0 z-20 bg-theme-surface/95 backdrop-blur-sm border border-theme-stroke rounded-xl p-4 mb-4 shadow-sm">
-      {/* Status tab strip */}
+      {/* Status tab strip — always visible (mobile + desktop). */}
       <div className="flex flex-wrap gap-1.5 mb-3">
         {STATUS_TABS.map((tab) => {
           const active = (filters.status ?? 'all') === tab.value;
@@ -74,103 +100,126 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         })}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-6 gap-2 items-start">
-        {/* salame-83472: unified search — host email|name OR party name. */}
-        <div className="md:col-span-2">
-          <IconInput
-            icon={Search}
-            type="search"
-            placeholder="Search hosts and parties"
-            value={filters.search || ''}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ search: e.target.value })}
-          />
-        </div>
-
-        {/* Party ID search */}
-        <div>
-          <IconInput
-            icon={Search}
-            type="search"
-            placeholder="Party ID"
-            value={filters.partyId || ''}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ partyId: e.target.value })}
-          />
-        </div>
-
-        {/* Method dropdown */}
-        <div>
-          <select
-            value={filters.payoutMethod ?? 'all'}
-            onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
-            className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Filter by payment method"
-          >
-            {METHOD_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
-          </select>
-        </div>
-
-        {/* Currency dropdown */}
-        <div>
-          <select
-            value={filters.currency ?? 'all'}
-            onChange={(e) => update({ currency: e.target.value })}
-            className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Filter by currency"
-          >
-            <option value="all">All currencies</option>
-            {availableCurrencies.map((c) => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
-        </div>
-
-        {/* bruschetta-58291: Country dropdown — populated from the loaded
-            payout set (parallels availableCurrencies). Backend filters by
-            exact `parties.country` match. */}
-        <div>
-          <select
-            value={filters.country ?? 'all'}
-            onChange={(e) => update({ country: e.target.value })}
-            className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Filter by country"
-          >
-            <option value="all">All countries</option>
-            {availableCountries.map((c) => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <div className="flex flex-col md:flex-row md:items-end gap-2 mt-3">
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-theme-text-muted">From</label>
-          <input
-            type="date"
-            value={filters.dateFrom || ''}
-            onChange={(e) => update({ dateFrom: e.target.value })}
-            className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Date from"
-          />
-          <label className="text-xs text-theme-text-muted">To</label>
-          <input
-            type="date"
-            value={filters.dateTo || ''}
-            onChange={(e) => update({ dateTo: e.target.value })}
-            className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-            aria-label="Date to"
-          />
-        </div>
+      {/* regina-89172: mobile-only collapse toggle. Hidden on sm:+ via `sm:hidden`. */}
+      <div className="sm:hidden mb-3">
         <button
           type="button"
-          onClick={onReset}
-          className="ml-auto inline-flex items-center gap-1 text-sm text-theme-text-muted hover:text-theme-text px-3 py-2 rounded-lg hover:bg-theme-surface-hover"
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full inline-flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-theme-stroke bg-theme-surface-hover text-sm font-medium text-theme-text"
+          aria-expanded={expanded}
+          aria-controls="payouts-filter-controls"
         >
-          <X size={14} />
-          Reset filters
+          <span className="inline-flex items-center gap-2">
+            <SlidersHorizontal size={14} />
+            Filters{activeCount > 0 ? ` (${activeCount})` : ''}
+          </span>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
         </button>
+      </div>
+
+      {/* Controls. Hidden on mobile when collapsed; force-visible on sm:+. */}
+      <div
+        id="payouts-filter-controls"
+        className={`${expanded ? 'block' : 'hidden'} sm:block`}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-6 gap-2 items-start">
+          {/* salame-83472: unified search — host email|name OR party name. */}
+          <div className="md:col-span-2">
+            <IconInput
+              icon={Search}
+              type="search"
+              placeholder="Search hosts and parties"
+              value={filters.search || ''}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ search: e.target.value })}
+            />
+          </div>
+
+          {/* Party ID search */}
+          <div>
+            <IconInput
+              icon={Search}
+              type="search"
+              placeholder="Party ID"
+              value={filters.partyId || ''}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ partyId: e.target.value })}
+            />
+          </div>
+
+          {/* Method dropdown */}
+          <div>
+            <select
+              value={filters.payoutMethod ?? 'all'}
+              onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Filter by payment method"
+            >
+              {METHOD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Currency dropdown */}
+          <div>
+            <select
+              value={filters.currency ?? 'all'}
+              onChange={(e) => update({ currency: e.target.value })}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Filter by currency"
+            >
+              <option value="all">All currencies</option>
+              {availableCurrencies.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* bruschetta-58291: Country dropdown — populated from the loaded
+              payout set (parallels availableCurrencies). Backend filters by
+              exact `parties.country` match. */}
+          <div>
+            <select
+              value={filters.country ?? 'all'}
+              onChange={(e) => update({ country: e.target.value })}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Filter by country"
+            >
+              <option value="all">All countries</option>
+              {availableCountries.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex flex-col md:flex-row md:items-end gap-2 mt-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="text-xs text-theme-text-muted">From</label>
+            <input
+              type="date"
+              value={filters.dateFrom || ''}
+              onChange={(e) => update({ dateFrom: e.target.value })}
+              className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Date from"
+            />
+            <label className="text-xs text-theme-text-muted">To</label>
+            <input
+              type="date"
+              value={filters.dateTo || ''}
+              onChange={(e) => update({ dateTo: e.target.value })}
+              className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Date to"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={onReset}
+            className="md:ml-auto inline-flex items-center gap-1 text-sm text-theme-text-muted hover:text-theme-text px-3 py-2 rounded-lg hover:bg-theme-surface-hover"
+          >
+            <X size={14} />
+            Reset filters
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -144,8 +144,10 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
 
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
+      {/* regina-89172: horizontal scroll wrapper with min-w on the table so
+          columns stay legible at mobile widths instead of squishing. */}
       <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+        <table className="w-full min-w-[640px] text-sm">
           <thead>
             <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
               <th className="px-3 py-3 w-10">

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -94,6 +94,24 @@ const HostChip: React.FC<{
   );
 };
 
+/**
+ * regina-89172: shared "already paid" caption — rendered in both the desktop
+ * table cell and the mobile card so behavior stays in lockstep.
+ */
+const AlreadyPaidCaption: React.FC<{ row: PrepayQueueRow }> = ({ row }) => {
+  if (row.partyPaidCount <= 0) return null;
+  const overCap =
+    row.party.effectiveReimbursementCapUsd != null &&
+    row.partyPaidUsd >= row.party.effectiveReimbursementCapUsd;
+  return (
+    <div
+      className={`text-[11px] mt-0.5 ${overCap ? 'text-amber-300' : 'text-theme-text-muted'}`}
+    >
+      Already paid: ${row.partyPaidUsd.toFixed(2)} ({row.partyPaidCount})
+    </div>
+  );
+};
+
 export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
   rows,
   onCreatePrepayment,
@@ -102,7 +120,80 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
 }) => {
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
-      <div className="overflow-x-auto">
+      {/* regina-89172: mobile card list (<640px). Each row becomes a stacked
+          block so 4–5 fields lay out cleanly without horizontal scroll. */}
+      <ul className="sm:hidden divide-y divide-theme-stroke">
+        {rows.map((row) => {
+          const eventSlug = row.party.customUrl ?? row.party.id;
+          return (
+            <li key={row.party.id} className="p-3 space-y-2">
+              <div>
+                <div className="flex items-start gap-2">
+                  <Link
+                    to={`/host/${eventSlug}/details`}
+                    className="font-medium text-theme-text hover:text-[#E52828] hover:underline break-words flex-1 min-w-0"
+                  >
+                    {stripGppPrefix(row.party.name)}
+                  </Link>
+                  {row.hasMultipleCandidates && (
+                    <span
+                      className="inline-flex items-center text-amber-500 shrink-0 mt-0.5"
+                      title="Multiple hosts have payment methods — pick one when creating the prepayment"
+                    >
+                      <AlertTriangle size={14} />
+                    </span>
+                  )}
+                </div>
+                {row.party.country && (
+                  <div className="text-xs text-theme-text-muted mt-0.5">
+                    {row.party.country}
+                  </div>
+                )}
+                <AlreadyPaidCaption row={row} />
+              </div>
+
+              <div>
+                <div className="text-[11px] uppercase tracking-wide text-theme-text-muted mb-1">
+                  Host(s)
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {row.candidates.map((c) => (
+                    <HostChip
+                      key={c.userId}
+                      candidate={c}
+                      invisiblePrimaryHost={row.party.primaryHostInCohosts === false}
+                      onClick={onHostClick ? () => onHostClick(c.userId) : undefined}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm text-theme-text inline-flex items-center gap-1">
+                  <span className="text-[11px] uppercase tracking-wide text-theme-text-muted">
+                    Cap
+                  </span>
+                  <CapInlineEditor
+                    partyId={row.party.id}
+                    currentCapUsd={row.party.effectiveReimbursementCapUsd ?? null}
+                    onUpdated={() => onPartyUpdated?.(row.party.id)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onCreatePrepayment(row)}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium shrink-0"
+                >
+                  Create prepayment
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Desktop table (≥640px). */}
+      <div className="hidden sm:block overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
@@ -150,18 +241,7 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                         admin sees prior payouts to this party before clicking
                         Create prepayment again. Amber when the paid total has
                         reached or exceeded the effective cap. */}
-                    {row.partyPaidCount > 0 && (
-                      <div
-                        className={`text-[11px] mt-0.5 ${
-                          row.party.effectiveReimbursementCapUsd != null &&
-                          row.partyPaidUsd >= row.party.effectiveReimbursementCapUsd
-                            ? 'text-amber-300'
-                            : 'text-theme-text-muted'
-                        }`}
-                      >
-                        Already paid: ${row.partyPaidUsd.toFixed(2)} ({row.partyPaidCount})
-                      </div>
-                    )}
+                    <AlreadyPaidCaption row={row} />
                   </td>
                   <td className="px-3 py-3 align-top">
                     <div className="flex flex-wrap gap-1.5">

--- a/frontend/src/components/payments-admin/RejectReasonModal.tsx
+++ b/frontend/src/components/payments-admin/RejectReasonModal.tsx
@@ -94,7 +94,7 @@ export const RejectReasonModal: React.FC<RejectReasonModalProps> = ({
       }}
     >
       <div
-        className="card p-6 w-full max-w-md max-h-[90vh] overflow-y-auto bg-theme-surface border border-theme-stroke rounded-2xl shadow-2xl"
+        className="card p-4 sm:p-6 w-full max-w-[95vw] sm:max-w-md max-h-[90vh] overflow-y-auto bg-theme-surface border border-theme-stroke rounded-2xl shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 mb-4">

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -102,8 +102,8 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       </td>
 
       {showAdminColumns && admin.host && (
-        <td className="px-3 py-3 text-sm" onClick={(e) => e.stopPropagation()}>
-          <div className="flex items-center gap-1.5">
+        <td className="px-3 py-3 text-sm min-w-[10rem]" onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center gap-1.5 flex-wrap">
             {/* siciliana-69183: when `onHostClick` is wired, the host name becomes
                 a button that opens the read-only HostPaymentDetailsModal. Falls
                 back to plain text for any callsite that doesn't want the modal. */}
@@ -114,10 +114,10 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
                 className="font-medium text-theme-text hover:text-[#E52828] hover:underline text-left"
                 title="View saved payment details"
               >
-                {admin.host.name || admin.host.email || '—'}
+                <span className="break-words">{admin.host.name || admin.host.email || '—'}</span>
               </button>
             ) : (
-              <div className="font-medium text-theme-text">{admin.host.name || '—'}</div>
+              <div className="font-medium text-theme-text break-words">{admin.host.name || '—'}</div>
             )}
             {/* paesana-89172: amber warning when the payout's recipient IS the
                 party's primary host (parties.userId) but the primary host
@@ -146,7 +146,7 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       )}
 
       {showAdminColumns && admin.party && (
-        <td className="px-3 py-3 text-sm">
+        <td className="px-3 py-3 text-sm min-w-[10rem]">
           {/* siciliana-69183: link to the host dashboard's Settings tab. Slug is
               customUrl ?? inviteCode to match user-facing URLs. Tab id 'details'
               is the canonical Settings tab id (see tabPermissions.ts). */}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -616,8 +616,8 @@ export function PaymentsAdminPage() {
                 ? `Prepay queue (${sortedPrepayQueue.length} of ${prepayQueue.length} events)`
                 : `Prepay queue (${prepayQueue.length} event${prepayQueue.length === 1 ? '' : 's'})`}
             </h2>
-            <div className="flex items-center gap-3 mb-3">
-              <div className="max-w-md flex-1">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 mb-3">
+              <div className="sm:max-w-md sm:flex-1">
                 <IconInput
                   icon={Search}
                   type="text"
@@ -626,7 +626,7 @@ export function PaymentsAdminPage() {
                   placeholder="Search city, country, or host…"
                 />
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-xs uppercase tracking-wide text-theme-text-muted">
                   Sort:
                 </span>


### PR DESCRIPTION
## Summary
- PayoutsFilterBar collapses on mobile; default state collapsed; toggle button shows active-filter count.
- Stat cards 2-col on mobile.
- HotWalletCard address breaks correctly; balance tiles stack.
- PrepayQueueTable becomes a vertical card list on mobile; table on sm:+.
- PayoutsTable wrapped in horizontal scroll.
- All modals capped at max-w-[95vw] on mobile.
- BulkActionsBar wraps buttons on mobile.
- PayoutRow stacks metadata vertically on mobile.

## Test plan
- [ ] Resize to ~375px -> /payments has no unintended horizontal scroll.
- [ ] Filter bar starts collapsed -> tap -> expands -> all filters work as before.
- [ ] Prepay queue + payouts list usable at mobile width.
- [ ] All modals visible without clipping.
- [ ] Desktop layout unchanged.