### PR TITLE
feat(speck-89172): hosts can submit receipts regardless of cap

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -664,15 +664,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       );
     }
 
-    // acciuga-62583: hard per-submission ceiling of $625 (no override).
-    // Enforced BEFORE the party-cap check so the host gets the clearer
-    // "split your submission" guidance even on uncapped events.
-    assertWithinPerSubmissionCap(finalUsd);
-
-    // tiramisu-49102: hard cap — block creates that would push the cumulative
-    // paid+pending+approved total past the party's effective cap. Parties
-    // without an effective cap stay uncapped.
-    await assertWithinPartyCap(partyId, finalUsd);
+    // speck-89172: host POST is no longer cap-enforced. Hosts can submit any
+    // positive amount; admin moderates over-cap rows from /payments (which
+    // surfaces an amber flag on rows that exceed the party's effective cap).
+    // The acciuga-62583 / tiramisu-49102 helpers remain in this file because
+    // admin PATCH (aglio-62584) still uses the per-submission ceiling.
 
     // arugula-38633 v3 follow-up: zero-receipts path — default the FX fields
     // to USD passthrough using finalUsd. (extractedUsdSum stays 0; we surface
@@ -1018,13 +1014,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       if (!Number.isFinite(n) || n <= 0) {
         throw new AppError('finalAmountUsd must be a positive number', 400, 'INVALID_AMOUNT');
       }
-      // acciuga-62583: hard per-submission $625 ceiling — enforced before the
-      // party-cap check so the message is clearer on uncapped events.
-      assertWithinPerSubmissionCap(n);
-      // tiramisu-49102: re-check per-party cap when the host edits the
-      // amount. Exclude THIS row from the existing-total so the edit doesn't
-      // count against itself.
-      await assertWithinPartyCap(partyId, n, payoutId);
+      // speck-89172: host PATCH is no longer cap-enforced. The amber flag on
+      // /payments rows surfaces over-cap edits for admin moderation; admin
+      // PATCH (aglio-62584) retains the per-submission ceiling via the
+      // override checkbox.
       data.finalAmountUsd = new Decimal(n);
     }
 
@@ -1235,18 +1228,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       : (recomputedAmount != null ? Number(recomputedAmount.toString()) : oldAmount);
     const amountChanged = newAmount !== oldAmount;
 
-    // acciuga-62583: hard per-submission $625 ceiling on the recomputed amount
-    // (explicit-amount edits are checked above next to the validation).
-    if (amountChanged && !explicitAmount) {
-      assertWithinPerSubmissionCap(newAmount);
-    }
-
-    // tiramisu-49102: re-check per-party cap when a receipt-edit causes the
-    // amount to be recomputed (explicit-amount edits are checked above).
-    // Exclude THIS row from the existing-total so it doesn't count against itself.
-    if (amountChanged && !explicitAmount) {
-      await assertWithinPartyCap(partyId, newAmount, payoutId);
-    }
+    // speck-89172: cap enforcement on receipt-edit recompute removed — the
+    // amber flag on /payments rows surfaces over-cap edits for admin
+    // moderation. Admin PATCH (aglio-62584) retains the per-submission
+    // ceiling via its override checkbox.
 
     // Single transaction: delete removed docs, insert new docs, update payout,
     // write the audit row(s).

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -475,8 +475,22 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 })()
               ) : (
                 <div>
-                  <div className="text-2xl font-semibold text-theme-text">
+                  <div className="text-2xl font-semibold text-theme-text inline-flex items-center gap-2">
                     {formatUsd(Number(payout.finalAmountUsd))}
+                    {/* speck-89172: amber AlertTriangle when the payout's
+                        final amount exceeds the party's effective cap. Hosts
+                        can now submit any amount; admin moderates over-cap
+                        rows from /payments. */}
+                    {payout.party?.effectiveReimbursementCapUsd != null &&
+                      Number(payout.finalAmountUsd) > payout.party.effectiveReimbursementCapUsd && (
+                        <span
+                          className="inline-flex items-center text-amber-500 shrink-0"
+                          title={`Submitted amount $${Number(payout.finalAmountUsd).toFixed(2)} exceeds the party's $${Number(payout.party.effectiveReimbursementCapUsd).toFixed(2)} cap.`}
+                          aria-label="Amount exceeds party cap"
+                        >
+                          <AlertTriangle size={18} />
+                        </span>
+                      )}
                   </div>
                   {payout.originalCurrency && payout.originalCurrency.toUpperCase() !== 'USD' && (
                     <div className="text-xs text-theme-text-muted mt-0.5">

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -221,12 +221,27 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       </td>
 
       <td className="px-3 py-3 text-sm text-theme-text">
-        <div className="font-medium">
+        <div className="font-medium inline-flex items-center gap-1.5">
           {formatPayoutAmount(
             Number(payout.finalAmountUsd),
             Number(payout.originalAmount),
             payout.originalCurrency,
           )}
+          {/* speck-89172: amber AlertTriangle when the payout's final amount
+              exceeds the party's effective reimbursement cap. Additive to
+              the parmigiana-89172 "Already paid" caption — this flags the
+              individual row, that flags the cumulative paid total. */}
+          {showAdminColumns &&
+            admin.party?.effectiveReimbursementCapUsd != null &&
+            Number(payout.finalAmountUsd) > admin.party.effectiveReimbursementCapUsd && (
+              <span
+                className="inline-flex items-center text-amber-500 shrink-0"
+                title={`Submitted amount $${Number(payout.finalAmountUsd).toFixed(2)} exceeds the party's $${admin.party.effectiveReimbursementCapUsd.toFixed(2)} cap.`}
+                aria-label="Amount exceeds party cap"
+              >
+                <AlertTriangle size={14} />
+              </span>
+            )}
         </div>
       </td>
 

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Loader2, StickyNote, BadgeDollarSign, Users } from 'lucide-react';
+import { Loader2, StickyNote, BadgeDollarSign, Users, AlertTriangle } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePizza } from '../../contexts/PizzaContext';
@@ -12,11 +12,13 @@ import { PayoutAmountSummary } from './PayoutAmountSummary';
 import { AppealCapModal } from './AppealCapModal';
 
 /**
- * acciuga-62583: hard per-submission ceiling of $625. Matches backend
- * `PER_SUBMISSION_CAP_EXCEEDED` (400) — UI disables submit + shows inline
- * error so the host can split the request before posting. No override path.
+ * speck-89172: the $625 per-payment hard ceiling is still informative — USDC
+ * execute still caps at $625 per tx, so a single oversize submission may
+ * require admin to split into multiple sends. Host submission is no longer
+ * blocked; instead we render an amber warning so the host knows what to
+ * expect on the admin side.
  */
-const PER_SUBMISSION_MAX_USD = 625;
+const PER_PAYMENT_HARD_CEILING_USD = 625;
 
 interface NewPayoutFormProps {
   partyId: string;
@@ -145,15 +147,18 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const attendanceValid = !askForAttendance
     || (estimatedAttendance != null && estimatedAttendance > 0);
 
-  // acciuga-62583: hard $625 per-submission cap. Hosts split larger expenses
-  // into multiple submissions. Matches backend `PER_SUBMISSION_CAP_EXCEEDED`.
-  const exceedsPerSubmissionCap = finalAmount > PER_SUBMISSION_MAX_USD;
+  // speck-89172: hosts can now submit any positive amount. The party-cap and
+  // $625 hard-ceiling checks are surfaced as non-blocking amber warnings
+  // instead. Admin moderates over-cap rows from /payments.
+  const effectiveCapUsd = party?.effectiveReimbursementCapUsd ?? null;
+  const exceedsPartyCap =
+    effectiveCapUsd != null && effectiveCapUsd > 0 && finalAmount > effectiveCapUsd;
+  const exceedsHardCeiling = finalAmount > PER_PAYMENT_HARD_CEILING_USD;
 
   // arugula-38633 v3 follow-up: payment details + receipts are no longer
   // required for submission. The submit button stays active whenever the
   // host has entered a positive amount and nothing async is in flight.
   const canSubmit = finalAmount > 0
-    && finalAmount <= PER_SUBMISSION_MAX_USD
     && attendanceValid
     && !isProcessing
     && !submitting;
@@ -363,12 +368,30 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         </div>
       )}
 
-      {/* acciuga-62583: per-submission $625 ceiling. Same visual treatment as
-          submitError so the host sees the gate before clicking Submit. */}
-      {exceedsPerSubmissionCap && (
-        <div className="card p-4 border-red-500/40 bg-red-500/10 text-sm text-red-300">
-          Payment requests are limited to ${PER_SUBMISSION_MAX_USD} per submission.
-          Reduce the amount or split into multiple submissions.
+      {/* speck-89172: party-cap amber warning. Non-blocking — submit stays
+          enabled, admin reviews from /payments. Only renders when the party
+          has an effective cap AND the typed amount exceeds it. */}
+      {exceedsPartyCap && (
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-100">
+              Heads up: ${finalAmount.toFixed(2)} exceeds your ${effectiveCapUsd!.toFixed(2)} reimbursement cap. Admin will review.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* speck-89172: $625 hard-ceiling amber warning. USDC execute caps at
+          $625 per tx, so admin may need to split this into multiple sends. */}
+      {exceedsHardCeiling && (
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-100">
+              Heads up: ${finalAmount.toFixed(2)} exceeds the ${PER_PAYMENT_HARD_CEILING_USD} per-payment maximum. Admin may need to split into multiple sends.
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Removes host-side per-submission cap (acciuga) and per-party cap (tiramisu) enforcement on POST + PATCH.
- NewPayoutForm replaces hard error block with two amber warnings (party cap + $625 ceiling). Submit always enabled.
- Admin /payments rows + Prepay queue + Review modal show amber AlertTriangle on amounts that exceed the party cap.
- Admin-side enforcement + USDC execute ceiling + per-address cap unchanged.

## Test plan
- [ ] Host submits $1000 on $250-cap party → no rejection, amber warning visible, payout created.
- [ ] Admin sees amber icon on the row.
- [ ] Host submits within cap → no warning, normal flow.
- [ ] Admin edit on the $1000 row → still gated by admin cap until override checkbox ticked.