### PR TITLE
feat(focaccia-89172): currency override dropdown on OCR'd receipts

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -414,6 +414,80 @@ router.post(
   }
 );
 
+// ---------- POST /:partyId/payouts/convert-fx ----------
+
+/**
+ * focaccia-89172: host-side currency override. OCR sometimes misreads a
+ * currency symbol (e.g. `₹` as `$`) and the resulting USD conversion is
+ * wildly off. This endpoint wraps `convertToUSD` so the host can pick the
+ * correct currency from a dropdown on each receipt row; the row's locked
+ * FX fields are then replaced in-place client-side.
+ *
+ * Pure FX lookup — no OCR. Same auth + rate-limit shape as ocr-preview.
+ */
+router.post(
+  '/:partyId/payouts/convert-fx',
+  ocrPreviewLimiter,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const { originalAmount, originalCurrency } = req.body || {};
+
+      const amt = Number(originalAmount);
+      if (!Number.isFinite(amt) || amt <= 0) {
+        throw new AppError(
+          'originalAmount must be a positive number',
+          400,
+          'INVALID_AMOUNT'
+        );
+      }
+      if (typeof originalCurrency !== 'string' || originalCurrency.trim().length === 0) {
+        throw new AppError(
+          'originalCurrency is required',
+          400,
+          'INVALID_CURRENCY'
+        );
+      }
+
+      const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+      if (!canEdit) {
+        throw new AppError('Party not found', 404, 'NOT_FOUND');
+      }
+
+      // bresaola-49185: same approval gate as ocr-preview — no FX lookups
+      // (which can touch external APIs) on unapproved parties.
+      await assertPartyApproved(partyId);
+
+      const fx = await convertToUSD(amt, originalCurrency.trim());
+
+      // convertToUSD never throws — it returns source='unknown' with rate=1
+      // when no provider can serve the currency. Reject that case so the
+      // host gets explicit feedback (and so the dropdown reverts client-side).
+      if (fx.source === 'unknown') {
+        throw new AppError(
+          `Could not look up exchange rate for currency "${originalCurrency.trim().toUpperCase()}".`,
+          400,
+          'UNKNOWN_CURRENCY'
+        );
+      }
+
+      res.json({
+        usdAmount: fx.usdAmount,
+        originalAmount: fx.originalAmount,
+        originalCurrency: fx.originalCurrency,
+        exchangeRate: fx.exchangeRate,
+        source: fx.source,
+        conversionNote:
+          fx.originalCurrency !== 'USD'
+            ? `Converted from ${fx.originalAmount.toLocaleString()} ${fx.originalCurrency} → $${fx.usdAmount.toFixed(2)} USD (1 ${fx.originalCurrency} = $${fx.exchangeRate.toFixed(6)} USD)`
+            : undefined,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
 // ---------- POST /:partyId/payouts ----------
 
 interface IncomingDocument {

--- a/frontend/src/components/payouts/CurrencyOverrideSelect.tsx
+++ b/frontend/src/components/payouts/CurrencyOverrideSelect.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  COMMON_CURRENCIES,
+  COMMON_CURRENCY_CODES,
+  COMMON_CURRENCY_CODE_SET,
+} from '../../lib/currencies';
+import { convertFx, ConvertFxResult } from '../../lib/api';
+
+interface CurrencyOverrideSelectProps {
+  /** Party id — required for the authed convert-fx call. */
+  partyId: string;
+  /** The amount in the currently-selected currency. */
+  originalAmount: number;
+  /** The currently-selected currency code (3-letter ISO). */
+  currentCurrency: string;
+  /** Fired with the new FX result after a successful convert-fx call. */
+  onConverted: (result: ConvertFxResult) => void;
+}
+
+/**
+ * focaccia-89172: native `<select>` for overriding the OCR-detected currency
+ * on a receipt row. On change, calls `convertFx` and forwards the new USD
+ * amount + rate to `onConverted`. On error, surfaces an inline message and
+ * reverts the dropdown to its previous selection.
+ *
+ * Native (not IconInput / a custom popover) because mobile UX for a 40-item
+ * currency list is best handled by the OS picker.
+ */
+export const CurrencyOverrideSelect: React.FC<CurrencyOverrideSelectProps> = ({
+  partyId,
+  originalAmount,
+  currentCurrency,
+  onConverted,
+}) => {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // If the current code isn't in our pre-populated list, surface it as an
+  // extra option so we don't lose the OCR-detected value when rendering.
+  const extraCurrent = useMemo(() => {
+    const upper = (currentCurrency || '').toUpperCase();
+    if (!upper) return null;
+    const known = COMMON_CURRENCIES.some(c => c.code === upper);
+    return known ? null : upper;
+  }, [currentCurrency]);
+
+  const allSorted = useMemo(
+    () =>
+      [...COMMON_CURRENCIES]
+        .filter(c => !COMMON_CURRENCY_CODE_SET.has(c.code))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    []
+  );
+
+  const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = e.target.value;
+    const previous = currentCurrency;
+    if (!next || next === previous) return;
+
+    setError(null);
+    setBusy(true);
+    try {
+      const result = await convertFx(partyId, {
+        originalAmount,
+        originalCurrency: next,
+      });
+      onConverted(result);
+    } catch (err: any) {
+      setError(err?.message || 'Could not look up exchange rate');
+      // Revert: react-controlled <select>'s `value` prop is `currentCurrency`
+      // which we haven't changed yet, so React snaps the DOM back on re-render.
+      // Force a re-render via state so the user sees the revert immediately.
+      // No-op: setBusy(false) below already triggers a render.
+      void previous;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <select
+        value={currentCurrency.toUpperCase()}
+        onChange={handleChange}
+        disabled={busy}
+        // Keep the visual treatment minimal — this lives inline inside a
+        // receipt row's existing details strip, so it should feel like a
+        // small adjustment widget, not a form field.
+        className="text-xs bg-theme-surface border border-theme-stroke rounded px-1.5 py-0.5 text-theme-text hover:border-[#ff393a]/40 focus:border-[#ff393a] focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+        aria-label="Override currency"
+        onClick={e => e.stopPropagation()}
+      >
+        {extraCurrent && (
+          <option value={extraCurrent}>
+            {extraCurrent} (detected)
+          </option>
+        )}
+        <optgroup label="Common">
+          {COMMON_CURRENCY_CODES.map(code => {
+            const c = COMMON_CURRENCIES.find(x => x.code === code);
+            return c ? (
+              <option key={c.code} value={c.code}>
+                {c.label}
+              </option>
+            ) : null;
+          })}
+        </optgroup>
+        <optgroup label="All">
+          {allSorted.map(c => (
+            <option key={c.code} value={c.code}>
+              {c.label}
+            </option>
+          ))}
+        </optgroup>
+      </select>
+      {busy && <Loader2 size={12} className="animate-spin text-theme-text-muted" />}
+      {error && (
+        <span className="text-xs text-red-300" role="alert">
+          {error}
+        </span>
+      )}
+    </span>
+  );
+};

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -7,6 +7,7 @@ import { methodIcon, methodLabel } from './PayoutListRow';
 import { IconInput } from '../IconInput';
 import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
+import { CurrencyOverrideSelect } from './CurrencyOverrideSelect';
 
 interface PayoutDetailModalProps {
   partyId: string;
@@ -76,6 +77,17 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   const [editNotes, setEditNotes] = useState('');
   const [editOverrideAmount, setEditOverrideAmount] = useState<string>('');
 
+  // focaccia-89172: per-existing-document FX overrides keyed by document id.
+  // The on-disk `ocrAmount`/`ocrCurrency` columns aren't currently mutable via
+  // the host PATCH, so we apply the corrected USD via `editOverrideAmount`
+  // when the host saves — the per-doc values stay informational.
+  interface DocFxOverride {
+    usdAmount: number;
+    originalAmount: number;
+    originalCurrency: string;
+  }
+  const [docFxOverrides, setDocFxOverrides] = useState<Record<string, DocFxOverride>>({});
+
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -95,6 +107,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     setNewReceipts([]);
     setNewPizzaPhotos([]);
     setRemovedDocIds(new Set());
+    setDocFxOverrides({});
     setEditNotes(payout.hostNotes ?? '');
     setEditOverrideAmount(
       payout.finalAmountUsd != null ? String(payout.finalAmountUsd) : ''
@@ -107,6 +120,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     setNewReceipts([]);
     setNewPizzaPhotos([]);
     setRemovedDocIds(new Set());
+    setDocFxOverrides({});
   };
 
   // Surviving existing documents (not marked for removal) — drives the
@@ -475,30 +489,79 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 <div>
                   <p className="text-xs text-theme-text-muted mb-2">Existing receipts</p>
                   <ul className="space-y-2">
-                    {survivingReceipts.map(d => (
-                      <li key={d.id} className="flex items-center gap-3 p-2 rounded-lg bg-theme-surface-hover">
-                        <a href={d.url} target="_blank" rel="noreferrer" className="flex-shrink-0">
-                          <img src={d.url} alt="" className="w-14 h-14 rounded object-cover" />
-                        </a>
-                        <div className="flex-1 min-w-0">
-                          <p className="text-sm text-theme-text truncate">{d.fileName}</p>
-                          {d.ocrAmount != null && (
-                            <p className="text-xs text-theme-text-muted">
-                              ${d.ocrAmount.toFixed(2)} USD
-                              {d.ocrCurrency && d.ocrCurrency !== 'USD' && ` (from ${d.ocrCurrency})`}
-                            </p>
-                          )}
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => setRemovedDocIds(prev => new Set(prev).add(d.id))}
-                          className="p-1.5 rounded-md text-theme-text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                          aria-label="Remove receipt"
-                        >
-                          <X size={16} />
-                        </button>
-                      </li>
-                    ))}
+                    {survivingReceipts.map(d => {
+                      // focaccia-89172: apply local FX override (if any) on top
+                      // of the stored OCR values so the host sees the corrected
+                      // USD inline. The corrected total flows into the amount
+                      // override field on save (see onConverted below).
+                      const ov = docFxOverrides[d.id];
+                      const displayedUsd = ov ? ov.usdAmount : d.ocrAmount;
+                      const displayedOriginal = ov ? ov.originalAmount : d.ocrAmount;
+                      const displayedCurrency = ov ? ov.originalCurrency : (d.ocrCurrency || 'USD');
+                      return (
+                        <li key={d.id} className="flex items-center gap-3 p-2 rounded-lg bg-theme-surface-hover">
+                          <a href={d.url} target="_blank" rel="noreferrer" className="flex-shrink-0">
+                            <img src={d.url} alt="" className="w-14 h-14 rounded object-cover" />
+                          </a>
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm text-theme-text truncate">{d.fileName}</p>
+                            {displayedUsd != null && (
+                              <div className="text-xs text-theme-text-muted mt-0.5 inline-flex items-center gap-2 flex-wrap">
+                                <span>${displayedUsd.toFixed(2)} USD</span>
+                                {displayedCurrency !== 'USD' && (
+                                  <span>(from {(displayedOriginal ?? 0).toLocaleString()})</span>
+                                )}
+                                {/* On approved payouts the amount is locked,
+                                    so the dropdown wouldn't change anything.
+                                    Hide it there. */}
+                                {!isApproved && d.ocrAmount != null && (
+                                  <CurrencyOverrideSelect
+                                    partyId={partyId}
+                                    originalAmount={displayedOriginal ?? d.ocrAmount}
+                                    currentCurrency={displayedCurrency}
+                                    onConverted={result => {
+                                      // 1) Remember the override locally so
+                                      //    the row re-renders with new values.
+                                      setDocFxOverrides(prev => {
+                                        const nextOverrides = {
+                                          ...prev,
+                                          [d.id]: {
+                                            usdAmount: result.usdAmount,
+                                            originalAmount: result.originalAmount,
+                                            originalCurrency: result.originalCurrency,
+                                          },
+                                        };
+                                        // 2) Recompute the total across surviving
+                                        //    receipts with overrides applied and
+                                        //    push that into the amount-override
+                                        //    field so save persists the new sum.
+                                        const newTotal = survivingReceipts.reduce((sum, sr) => {
+                                          const o = nextOverrides[sr.id];
+                                          const usd = o ? o.usdAmount : (sr.ocrAmount ?? 0);
+                                          return sum + usd;
+                                        }, 0);
+                                        if (newTotal > 0) {
+                                          setEditOverrideAmount(newTotal.toFixed(2));
+                                        }
+                                        return nextOverrides;
+                                      });
+                                    }}
+                                  />
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => setRemovedDocIds(prev => new Set(prev).add(d.id))}
+                            className="p-1.5 rounded-md text-theme-text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                            aria-label="Remove receipt"
+                          >
+                            <X size={16} />
+                          </button>
+                        </li>
+                      );
+                    })}
                   </ul>
                 </div>
               )}

--- a/frontend/src/components/payouts/ReceiptUpload.tsx
+++ b/frontend/src/components/payouts/ReceiptUpload.tsx
@@ -3,6 +3,7 @@ import { Loader2, X, Upload, Receipt as ReceiptIcon, AlertCircle, CheckCircle2 }
 import { uploadPayoutPhoto } from '../../lib/supabase';
 import { previewReceiptOCR } from '../../lib/api';
 import { OcrPreviewResult } from '../../types';
+import { CurrencyOverrideSelect } from './CurrencyOverrideSelect';
 
 export interface ReceiptItem {
   /** Stable client-side id for React keys. */
@@ -167,18 +168,40 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
                     </span>
                   )}
                   {item.status === 'done' && item.ocr && (
-                    <span className="inline-flex items-center gap-2">
+                    <span className="inline-flex items-center gap-2 flex-wrap">
                       <span className="inline-flex items-center gap-1">
                         {item.ocr.confidence >= 0.8
                           ? <CheckCircle2 size={12} className="text-emerald-400" />
                           : <AlertCircle size={12} className="text-amber-400" />}
                         ${item.ocr.amount.toFixed(2)} USD
                       </span>
-                      {item.ocr.conversionNote && (
-                        <span className="text-theme-text-muted">
-                          (from {item.ocr.originalAmount.toLocaleString()} {item.ocr.originalCurrency})
-                        </span>
-                      )}
+                      <span className="text-theme-text-muted">
+                        (from {item.ocr.originalAmount.toLocaleString()})
+                      </span>
+                      {/* focaccia-89172: native currency override dropdown.
+                          OCR misreads `₹` as `$` etc.; host picks the correct
+                          ISO code and we re-convert in-place. */}
+                      <CurrencyOverrideSelect
+                        partyId={partyId}
+                        originalAmount={item.ocr.originalAmount}
+                        currentCurrency={item.ocr.originalCurrency}
+                        onConverted={result => {
+                          const next = updateItem(items, item.id, {
+                            ocr: {
+                              ...item.ocr!,
+                              amount: result.usdAmount,
+                              originalAmount: result.originalAmount,
+                              originalCurrency: result.originalCurrency,
+                              exchangeRate: result.exchangeRate,
+                              conversionNote: result.conversionNote,
+                              fxSource:
+                                (result.source as OcrPreviewResult['fxSource']) ||
+                                item.ocr!.fxSource,
+                            },
+                          });
+                          onChange(next);
+                        }}
+                      />
                       <span className={item.ocr.confidence >= 0.8 ? 'text-emerald-300' : 'text-amber-300'}>
                         {Math.round(item.ocr.confidence * 100)}% confidence
                       </span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4419,6 +4419,28 @@ export async function previewReceiptOCR(
   );
 }
 
+// focaccia-89172: re-run the FX cascade for a host-supplied currency override.
+// OCR sometimes misreads `₹` as `$` (etc.) — the host picks the correct code
+// from a dropdown and we replace the row's USD amount + exchange rate in-place.
+export interface ConvertFxResult {
+  usdAmount: number;
+  originalAmount: number;
+  originalCurrency: string;
+  exchangeRate: number;
+  source: string;
+  conversionNote?: string;
+}
+
+export async function convertFx(
+  partyId: string,
+  body: { originalAmount: number; originalCurrency: string }
+): Promise<ConvertFxResult> {
+  return apiRequest<ConvertFxResult>(
+    `/api/parties/${partyId}/payouts/convert-fx`,
+    { method: 'POST', body, requireAuth: true }
+  );
+}
+
 // ============================================================
 // Outreach (marinara-67583) — admin-only outreach tracker
 // ============================================================

--- a/frontend/src/lib/currencies.ts
+++ b/frontend/src/lib/currencies.ts
@@ -1,0 +1,97 @@
+/**
+ * focaccia-89172: ISO 4217 currency options for the receipt-row currency
+ * override dropdown. OCR sometimes misreads `₹` as `$` (or similar) and the
+ * FX conversion is then off by ~80x — hosts pick the correct code from this
+ * list to re-trigger the conversion.
+ *
+ * The list is intentionally finite (~40 codes) — covers the major fiat
+ * currencies + the ones we see most in GPP receipts (Africa, LATAM, MENA,
+ * APAC). All five "Common" entries are popular OCR-misread targets.
+ */
+
+export interface CurrencyOption {
+  code: string;
+  label: string;
+  symbol?: string;
+}
+
+/**
+ * The handful of codes hosts most commonly need to swap to. Rendered above
+ * the long alphabetical list in an `<optgroup>` for quick access.
+ */
+export const COMMON_CURRENCY_CODES: readonly string[] = [
+  'USD',
+  'EUR',
+  'GBP',
+  'INR',
+  'NGN',
+];
+
+/**
+ * Full ~40-code list. Sorted alphabetically by label for the "All" optgroup.
+ * Symbols are informational only — the FX lookup uses the ISO code.
+ */
+export const COMMON_CURRENCIES: CurrencyOption[] = [
+  { code: 'AED', label: 'AED — UAE Dirham', symbol: 'د.إ' },
+  { code: 'ARS', label: 'ARS — Argentine Peso', symbol: '$' },
+  { code: 'AUD', label: 'AUD — Australian Dollar', symbol: 'A$' },
+  { code: 'BRL', label: 'BRL — Brazilian Real', symbol: 'R$' },
+  { code: 'CAD', label: 'CAD — Canadian Dollar', symbol: 'C$' },
+  { code: 'CHF', label: 'CHF — Swiss Franc', symbol: 'CHF' },
+  { code: 'CLP', label: 'CLP — Chilean Peso', symbol: '$' },
+  { code: 'CNY', label: 'CNY — Chinese Yuan', symbol: '¥' },
+  { code: 'COP', label: 'COP — Colombian Peso', symbol: '$' },
+  { code: 'CZK', label: 'CZK — Czech Koruna', symbol: 'Kč' },
+  { code: 'DKK', label: 'DKK — Danish Krone', symbol: 'kr' },
+  { code: 'EGP', label: 'EGP — Egyptian Pound', symbol: 'E£' },
+  { code: 'EUR', label: 'EUR — Euro', symbol: '€' },
+  { code: 'GBP', label: 'GBP — British Pound', symbol: '£' },
+  { code: 'GHS', label: 'GHS — Ghanaian Cedi', symbol: '₵' },
+  { code: 'HKD', label: 'HKD — Hong Kong Dollar', symbol: 'HK$' },
+  { code: 'HUF', label: 'HUF — Hungarian Forint', symbol: 'Ft' },
+  { code: 'IDR', label: 'IDR — Indonesian Rupiah', symbol: 'Rp' },
+  { code: 'ILS', label: 'ILS — Israeli Shekel', symbol: '₪' },
+  { code: 'INR', label: 'INR — Indian Rupee', symbol: '₹' },
+  { code: 'JPY', label: 'JPY — Japanese Yen', symbol: '¥' },
+  { code: 'KES', label: 'KES — Kenyan Shilling', symbol: 'KSh' },
+  { code: 'KRW', label: 'KRW — South Korean Won', symbol: '₩' },
+  { code: 'MAD', label: 'MAD — Moroccan Dirham', symbol: 'د.م.' },
+  { code: 'MXN', label: 'MXN — Mexican Peso', symbol: '$' },
+  { code: 'MYR', label: 'MYR — Malaysian Ringgit', symbol: 'RM' },
+  { code: 'NGN', label: 'NGN — Nigerian Naira', symbol: '₦' },
+  { code: 'NOK', label: 'NOK — Norwegian Krone', symbol: 'kr' },
+  { code: 'NZD', label: 'NZD — New Zealand Dollar', symbol: 'NZ$' },
+  { code: 'PEN', label: 'PEN — Peruvian Sol', symbol: 'S/' },
+  { code: 'PHP', label: 'PHP — Philippine Peso', symbol: '₱' },
+  { code: 'PLN', label: 'PLN — Polish Złoty', symbol: 'zł' },
+  { code: 'QAR', label: 'QAR — Qatari Riyal', symbol: 'ر.ق' },
+  { code: 'RON', label: 'RON — Romanian Leu', symbol: 'lei' },
+  { code: 'RUB', label: 'RUB — Russian Ruble', symbol: '₽' },
+  { code: 'SAR', label: 'SAR — Saudi Riyal', symbol: 'ر.س' },
+  { code: 'SEK', label: 'SEK — Swedish Krona', symbol: 'kr' },
+  { code: 'SGD', label: 'SGD — Singapore Dollar', symbol: 'S$' },
+  { code: 'THB', label: 'THB — Thai Baht', symbol: '฿' },
+  { code: 'TRY', label: 'TRY — Turkish Lira', symbol: '₺' },
+  { code: 'TWD', label: 'TWD — Taiwan Dollar', symbol: 'NT$' },
+  { code: 'USD', label: 'USD — US Dollar', symbol: '$' },
+  { code: 'VND', label: 'VND — Vietnamese Dong', symbol: '₫' },
+  { code: 'ZAR', label: 'ZAR — South African Rand', symbol: 'R' },
+];
+
+/**
+ * The set of codes that count as "common" — used by the dropdown to render
+ * a top optgroup separately from the long alphabetical list.
+ */
+export const COMMON_CURRENCY_CODE_SET: ReadonlySet<string> = new Set(COMMON_CURRENCY_CODES);
+
+/**
+ * Look up a CurrencyOption by code (case-insensitive). Returns undefined when
+ * the code isn't in our pre-populated list (which is fine — the dropdown
+ * still renders the unknown code as a fallback option so the OCR-detected
+ * value isn't lost).
+ */
+export function findCurrency(code: string | null | undefined): CurrencyOption | undefined {
+  if (!code) return undefined;
+  const upper = code.toUpperCase();
+  return COMMON_CURRENCIES.find(c => c.code === upper);
+}


### PR DESCRIPTION
## Summary
- New backend `POST /api/parties/:partyId/payouts/convert-fx` wraps `convertToUSD`.
- New `<select>` currency dropdown on NewPayoutForm receipt rows; on change re-converts and updates the row's USD amount.
- New `frontend/src/lib/currencies.ts` with 40 ISO 4217 options + optgroups.
- PayoutDetailModal receipt rows get the same dropdown when editing.

## Test plan
- [ ] Upload a receipt OCR'd as USD; drop to INR; row reflects new USD amount.
- [ ] Submit goes through with corrected values.
- [ ] Bad currency → inline error, dropdown reverts.