### PR TITLE
salsiccia-29304: GPP-style the scorecard URL-input panel

### DIFF
--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -145,7 +145,7 @@ export function ScorecardItem({
 
       {/* URL Input (for post item) - appears below the row */}
       {showInput && !completed && (
-        <div className="ml-11 p-3 bg-[#1a1a2e] border border-white/10 rounded-lg">
+        <div className="ml-11 p-3 bg-white/10 border border-white/10 rounded-lg backdrop-blur-sm">
           <p className="text-xs text-white/60 mb-2">Paste the link to your post:</p>
           <div className="flex gap-2">
             <IconInput


### PR DESCRIPTION
## Summary
- The scorecard "Paste the link to your post" reveal panel was hardcoded `bg-[#1a1a2e]` (dark indigo), which looked jarring on `.gpp-theme` event pages (cloud-blue/yellow/white)
- Switched to `bg-white/10` so the `.gpp-theme` override automatically translates it to a subtle light surface on GPP pages while keeping it usable on non-GPP events
- Added `backdrop-blur-sm` for a softer feel against the GPP cloud background
- Submit button already uses `text-[#ffffff]` (from mortadella-58492) so it dodges the `.gpp-theme .text-white` override; helper text `text-white/60` maps cleanly to `#555` on GPP per `index.css:447`

## Test plan
- [ ] https://rsvpizza-git-salsiccia-29304-gpp-tweet-panel-pizza-dao.vercel.app/scorecard-test as hello@rarepizzas.com -> tap Share on the scorecard -> panel surface blends with GPP cloud page, Submit reads as red+white pill, helper text legible
- [ ] Visit a non-GPP event with the scorecard surfaced -- panel still looks reasonable on dark contexts (no regression)

Generated with [Claude Code](https://claude.com/claude-code)