### PR TITLE
feat(parmigiano-71294): show event photos to non-RSVP'd visitors

### DIFF
--- a/frontend/src/components/photos/PhotoGallery.tsx
+++ b/frontend/src/components/photos/PhotoGallery.tsx
@@ -15,6 +15,13 @@ interface PhotoGalleryProps {
   guestId?: string;
   photoModeration?: boolean;
   /**
+   * Whether the current viewer can upload. Defaults to true to keep existing
+   * call sites working. When false, the Upload buttons (header + empty state)
+   * and the programmatic triggerUploadRef are hidden so non-confirmed visitors
+   * don't see a broken click → upload-fail flow. parmigiano-71294.
+   */
+  canUpload?: boolean;
+  /**
    * Optional ref the gallery populates on mount with a function that opens
    * the upload picker. Callers (e.g. EventPage) can call this to programmatically
    * trigger an upload flow without restructuring the gallery internals.
@@ -32,6 +39,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
   uploaderEmail,
   guestId,
   photoModeration = false,
+  canUpload = true,
   triggerUploadRef,
 }) => {
   const [photos, setPhotos] = useState<Photo[]>([]);
@@ -50,15 +58,17 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
 
   // Expose an imperative trigger so callers can programmatically open the upload picker.
   // Populated/cleared in an effect to avoid mutating refs during render.
+  // parmigiano-71294: skip the trigger entirely when canUpload is false so
+  // non-confirmed visitors can't open the picker programmatically.
   useEffect(() => {
-    if (!triggerUploadRef) return;
+    if (!triggerUploadRef || !canUpload) return;
     triggerUploadRef.current = () => setShowUpload(true);
     return () => {
       if (triggerUploadRef.current) {
         triggerUploadRef.current = null;
       }
     };
-  }, [triggerUploadRef]);
+  }, [triggerUploadRef, canUpload]);
 
   // Split photos into images and videos for tab filtering
   const imagePhotos = useMemo(() => photos.filter(p => !p.mimeType?.startsWith('video/')), [photos]);
@@ -341,14 +351,16 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
             )}
           </div>}
 
-          {/* Upload Button */}
-          <button
-            onClick={() => setShowUpload(true)}
-            className="flex items-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-4 py-2 rounded-lg transition-colors"
-          >
-            <Upload size={16} />
-            <span className="hidden sm:inline">Upload</span>
-          </button>
+          {/* Upload Button — hidden when viewer can't upload (parmigiano-71294) */}
+          {canUpload && (
+            <button
+              onClick={() => setShowUpload(true)}
+              className="flex items-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-4 py-2 rounded-lg transition-colors"
+            >
+              <Upload size={16} />
+              <span className="hidden sm:inline">Upload</span>
+            </button>
+          )}
         </div>
       </div>
 
@@ -475,7 +487,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
               ? 'No videos yet'
               : 'No photos yet'}
           </p>
-          {filter === 'all' && (
+          {filter === 'all' && canUpload && (
             <button
               onClick={() => setShowUpload(true)}
               className="inline-flex items-center gap-2 bg-[#ff393a] hover:bg-[#ff5a5b] text-white font-medium px-4 py-2 rounded-lg transition-colors"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -593,6 +593,8 @@ export interface PublicEvent {
   shareToUnlock?: boolean;
   shareTweetText?: string | null;
   photoModeration?: boolean;
+  photosEnabled?: boolean;
+  photosPublic?: boolean;
   nftEnabled?: boolean;
   nftChain?: string | null;
   hiddenGppPhotos?: string[];

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1535,8 +1535,13 @@ export function EventPage() {
                   />
                 )}
 
-                {/* Photo Gallery Section - only for confirmed guests */}
-                {photoStats?.photosEnabled && existingGuestData?.status === 'CONFIRMED' && (
+                {/* Photo Gallery Section
+                    parmigiano-71294: Drop the CONFIRMED gate so non-RSVP'd visitors see
+                    the same photos that already appear on the /photos public feed.
+                    Private galleries (photosPublic=false) remain gated to confirmed
+                    guests + hosts. Upload UI is hidden for non-confirmed visitors via
+                    the canUpload prop to avoid a broken click → fail flow. */}
+                {photoStats?.photosEnabled && (event.photosPublic || existingGuestData?.status === 'CONFIRMED' || isHostUser) && (
                   <div ref={photoGalleryRef} className="border-t border-theme-stroke pt-6 mt-6">
                     {showPhotos ? (
                       <PhotoGallery
@@ -1546,6 +1551,7 @@ export function EventPage() {
                         uploaderName={existingGuestData?.name || user?.name || undefined}
                         uploaderEmail={existingGuestData?.email || user?.email}
                         guestId={existingGuestData?.id}
+                        canUpload={existingGuestData?.status === 'CONFIRMED'}
                         triggerUploadRef={photoGalleryTriggerRef}
                       />
                     ) : (

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -228,6 +228,11 @@ export function EventPage() {
           const stats = await getPhotoStats(foundEvent.id);
           if (stats) {
             setPhotoStats(stats);
+            // Auto-expand the gallery if there are existing photos — visitors expect
+            // photos inline, not behind a "View N photos" button (parmigiano-71294).
+            if (stats.totalPhotos && stats.totalPhotos > 0) {
+              setShowPhotos(true);
+            }
           }
         } else {
           setError('Event not found. The link may be invalid or expired.');


### PR DESCRIPTION
## Summary
- Drops the `existingGuestData?.status === 'CONFIRMED'` gate on EventPage's PhotoGallery so non-RSVP'd visitors see the same photos that already appear on /photos
- Respects `photosPublic` for private galleries (kept gated to confirmed guests + hosts via `event.photosPublic || existingGuestData?.status === 'CONFIRMED' || isHostUser`)
- New `canUpload` prop on PhotoGallery hides the Upload buttons (header + empty state) and the programmatic `triggerUploadRef` for visitors who can't actually upload — no broken click → fail flow

## Implementation notes
- Used `event.photosPublic` (already returned by `/api/events/:slug` backend response, just missing from the `PublicEvent` TypeScript interface — added). Cleaner than extending `photoStats`; no backend change.
- Also added `photosEnabled` to `PublicEvent` for consistency (also already returned, just untyped).
- `canUpload` defaults to `true` on PhotoGallery so existing call sites (host dashboards etc.) are unchanged.

## Test plan
- [ ] As anon, visit a public-photos event with starred approved photos -> see the photos (was 0)
- [ ] As anon, no Upload buttons visible (header or empty-state)
- [ ] As confirmed guest, full experience unchanged (gallery + upload)
- [ ] As host, full experience unchanged
- [ ] Event with `photosPublic=false` -> still hidden from non-RSVP'd visitors (gate falls through to CONFIRMED || isHostUser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)