### PR TITLE
salami-58119: allow HEIC/HEIF/AVIF photo uploads

### DIFF
--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -273,11 +273,11 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
     }
 
     // Validate MIME type (images + videos)
-    const allowedImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    const allowedImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif', 'image/avif'];
     const allowedVideoTypes = ['video/mp4', 'video/webm', 'video/quicktime'];
     const allowedMimeTypes = [...allowedImageTypes, ...allowedVideoTypes];
     if (!allowedMimeTypes.includes(mimeType)) {
-      throw new AppError('Invalid file type. Allowed: jpeg, png, webp, gif, mp4, webm, mov', 400, 'INVALID_FILE_TYPE');
+      throw new AppError('Invalid file type. Allowed: jpeg, png, webp, gif, heic, heif, avif, mp4, webm, mov', 400, 'INVALID_FILE_TYPE');
     }
 
     const isVideo = allowedVideoTypes.includes(mimeType);

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -400,7 +400,7 @@ export async function uploadEventPhoto(
 } | null> {
   try {
     // Validate file type
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif', 'image/avif'];
     if (!allowedTypes.includes(file.type)) {
       console.error('Invalid file type:', file.type);
       return null;
@@ -483,7 +483,7 @@ export async function uploadVenuePhoto(
 } | null> {
   try {
     // Validate file type
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif', 'image/avif'];
     if (!allowedTypes.includes(file.type)) {
       console.error('Invalid file type:', file.type);
       return null;

--- a/plans/salami-58119-heic-heif-avif-photos.md
+++ b/plans/salami-58119-heic-heif-avif-photos.md
@@ -1,0 +1,31 @@
+# salami-58119: Allow HEIC/HEIF/AVIF photo uploads
+
+## Goal
+iPhone users upload directly from their photo library (HEIC by default) and modern Android users (AVIF) currently get silently rejected by the event-photos upload path. Expand the MIME allowlist on the photo-only path so library uploads work.
+
+## Scope (photo path only)
+- `frontend/src/lib/supabase.ts` → `uploadEventPhoto` allowlist
+- `frontend/src/lib/supabase.ts` → `uploadVenuePhoto` allowlist (same bucket)
+- `backend/src/routes/photo.routes.ts` → `allowedImageTypes` + error-message copy
+- `supabase/migrations/20260525_salami_58119_expand_event_photos_mime_types.sql` → bucket `allowed_mime_types`
+
+## MIMEs added
+- `image/heic`
+- `image/heif`
+- `image/avif`
+
+## Explicitly out of scope
+- `uploadEventImage` (event-images bucket — sponsor logos, event covers, description embeds; rendered via `<img>`, HEIC support too patchy for decorative slots)
+- `uploadEventVideo` / `event-videos` bucket
+- `PhotoUpload.tsx` / `PhotoGallery.tsx` (no UX change)
+- Constraint-hint copy (intentionally silent — HEIC/AVIF are an additive allowance)
+
+## Risks
+- HEIC `<img>` rendering: Safari handles natively, Chrome/Firefox degrade gracefully (broken thumbnail). Most galleries here are server-thumbnailed (PhotoGallery renders the stored Supabase URL via `<img>`), so non-Safari viewers may see a broken thumbnail until we add server-side transcode. Acceptable trade-off vs. silent reject.
+- HEIC playback via `<video>` is far worse, but HEIC is image-only; not in play here.
+
+## Verification
+- `npx tsc --noEmit` in frontend — clean.
+- `npm run build` in backend — clean.
+- Manual: upload HEIC from iPhone Safari → succeeds; AVIF from Chrome → succeeds; JPEG regression → still works; oversized file → still rejected with 10MB error.
+- Migration applied via Supabase MCP before merging frontend/backend code (else bucket-level reject overrides app-level allow).

--- a/supabase/migrations/20260525_salami_58119_expand_event_photos_mime_types.sql
+++ b/supabase/migrations/20260525_salami_58119_expand_event_photos_mime_types.sql
@@ -1,0 +1,14 @@
+-- salami-58119: expand event-photos bucket MIME allowlist to include HEIC/HEIF/AVIF
+-- so iPhone (HEIC) and modern Android (AVIF) users can upload library photos.
+-- Mirrors existing list (jpeg/png/webp/gif); videos live in the separate event-videos bucket.
+update storage.buckets
+set allowed_mime_types = array[
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+  'image/avif'
+]
+where id = 'event-photos';


### PR DESCRIPTION
## Problem
iPhone users uploading from their photo library (HEIC by default) and modern Android users (AVIF) were silently rejected by the event-photos upload path — the file picker accepted them, but the validator dropped them with no UX feedback.

## Fix
Add `image/heic`, `image/heif`, `image/avif` to the photo-only allowlist in 4 places: `uploadEventPhoto` + `uploadVenuePhoto` (frontend), `allowedImageTypes` in the photo route (backend), and the `event-photos` Supabase bucket via a new migration.

## MIME additions
- `image/heic`
- `image/heif`
- `image/avif`

Scope is photo-only. `uploadEventImage` (sponsor logos / event covers / description embeds, rendered as `<img>`) is intentionally untouched — HEIC `<img>` rendering outside Safari is too patchy for decorative slots. Video path also untouched.

## Test plan
- [ ] Upload HEIC from iPhone Safari → succeeds
- [ ] Upload AVIF from modern Chrome → succeeds
- [ ] Regression: JPEG upload still works
- [ ] Regression: >10MB upload still rejected with the size error
- [ ] Migration applied to prod bucket before frontend hits the path (else bucket rejects even though app accepts)

## Preview
https://rsvpizza-git-salami-58119-heic-allowlist-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)