### PR TITLE
paneer-37591: scorecard self-report items open destination URL on tap

### DIFF
--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -14,6 +14,8 @@ interface GuestScorecardProps {
   eventUrl?: string;
   /** Sponsor Twitter handles (no `@`, deduped, excluding `pizza_dao`). */
   partnerHandles?: string[];
+  /** Per-event Telegram URL (normalized). Falls back to https://t.me/pizzadao when absent. */
+  telegramUrl?: string | null;
 }
 
 const ITEM_ORDER: ScorecardItemKey[] = [
@@ -35,6 +37,7 @@ export function GuestScorecard({
   refreshSignal,
   eventUrl,
   partnerHandles,
+  telegramUrl,
 }: GuestScorecardProps) {
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
@@ -154,6 +157,7 @@ export function GuestScorecard({
                 onTakeSelfie={onTakeSelfie}
                 eventUrl={eventUrl}
                 partnerHandles={partnerHandles}
+                telegramUrl={telegramUrl}
               />
             </div>
           );

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -27,6 +27,8 @@ interface ScorecardItemProps {
   eventUrl?: string;
   /** Sponsor Twitter handles (no `@` prefix, deduped, excluding `pizza_dao`). */
   partnerHandles?: string[];
+  /** Per-event Telegram URL (normalized). Falls back to https://t.me/pizzadao when absent. */
+  telegramUrl?: string | null;
 }
 
 const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = {
@@ -50,6 +52,7 @@ export function ScorecardItem({
   onTakeSelfie,
   eventUrl,
   partnerHandles,
+  telegramUrl,
 }: ScorecardItemProps) {
   const [showInput, setShowInput] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -87,6 +90,18 @@ export function ScorecardItem({
     } else if (itemKey === 'pizza_selfie') {
       // Backend auto-completes when photo tagged "pizza-selfie".
       onTakeSelfie?.();
+    } else if (itemKey === 'join_telegram') {
+      const url = telegramUrl || 'https://t.me/pizzadao';
+      window.open(url, '_blank', 'noopener,noreferrer');
+      onComplete(itemKey, url, 'self_report');
+    } else if (itemKey === 'follow_pizzadao') {
+      const url = 'https://twitter.com/pizza_dao';
+      window.open(url, '_blank', 'noopener,noreferrer');
+      onComplete(itemKey, url, 'self_report');
+    } else if (itemKey === 'signup_pizzadao') {
+      const url = 'https://pizzadao.org';
+      window.open(url, '_blank', 'noopener,noreferrer');
+      onComplete(itemKey, url, 'self_report');
     } else if (isSelfReport) {
       onComplete(itemKey, undefined, 'self_report');
     }
@@ -105,9 +120,9 @@ export function ScorecardItem({
     if (itemKey === 'vouch') return 'Scan';
     if (itemKey === 'pizza_selfie') return 'Selfie';
     if (itemKey === 'sign_pizza_box') return 'I signed it!';
-    if (itemKey === 'join_telegram') return 'I joined!';
-    if (itemKey === 'follow_pizzadao') return 'I followed!';
-    if (itemKey === 'signup_pizzadao') return 'I signed up!';
+    if (itemKey === 'join_telegram') return 'Join';
+    if (itemKey === 'follow_pizzadao') return 'Follow';
+    if (itemKey === 'signup_pizzadao') return 'Sign up';
     return '';
   };
 

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1304,6 +1304,7 @@ export function EventPage() {
                     refreshSignal={scorecardRefresh}
                     eventUrl={eventUrl}
                     partnerHandles={partnerHandles}
+                    telegramUrl={telegramLink}
                   />
                 )}
 


### PR DESCRIPTION
## Summary
- `join_telegram` button now opens `event.telegramGroup` (fallback `t.me/pizzadao`) in a new tab and marks complete
- `follow_pizzadao` button opens `twitter.com/pizza_dao` in a new tab and marks complete
- `signup_pizzadao` button opens `pizzadao.org` in a new tab and marks complete
- `sign_pizza_box` unchanged (no destination)
- Button labels switched from past tense ("I joined!") to imperative ("Join") since the button now actually performs the action

No backend changes — `telegramGroup` is already on the `PublicEvent` response shape. Per-event Telegram URL is run through the existing `normalizeTelegramUrl` helper in `EventPage.tsx`, so invalid/empty values transparently fall back to `t.me/pizzadao`.

## Test plan
- [ ] https://rsvpizza-git-paneer-37591-selfreport-linkout-pizza-dao.vercel.app/scorecard-test as hello@rarepizzas.com
- [ ] Tap Join → opens telegram in new tab, row turns done
- [ ] Tap Follow → opens twitter in new tab, row turns done
- [ ] Tap Sign up → opens pizzadao.org in new tab, row turns done
- [ ] Tap I signed it! → row turns done, no new tab (unchanged behavior)

Generated with Claude Code