### PR TITLE
feat(salame-58195): thumbs-up voting on photos

### DIFF
--- a/backend/prisma/migrations/20260526000000_add_photo_votes/migration.sql
+++ b/backend/prisma/migrations/20260526000000_add_photo_votes/migration.sql
@@ -1,0 +1,25 @@
+-- salame-58195: thumbs-up voting on photos.
+--
+-- New table photo_votes records one vote per (photo_id, user_id) and a
+-- denormalized vote_count on the photos table is maintained by the backend
+-- toggle endpoint (no DB trigger). Logged-in users only — anonymous visitors
+-- can read counts but cannot vote.
+--
+-- The User FK references the "User" table (PascalCase, singular) because the
+-- Prisma User model has no @@map directive.
+
+CREATE TABLE "photo_votes" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "photo_id" UUID NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "photo_votes_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "photo_votes_photo_id_fkey" FOREIGN KEY ("photo_id") REFERENCES "photos"("id") ON DELETE CASCADE,
+  CONSTRAINT "photo_votes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE,
+  CONSTRAINT "photo_votes_photo_id_user_id_key" UNIQUE ("photo_id", "user_id")
+);
+
+CREATE INDEX "photo_votes_photo_id_idx" ON "photo_votes" ("photo_id");
+CREATE INDEX "photo_votes_user_id_idx" ON "photo_votes" ("user_id");
+
+ALTER TABLE "photos" ADD COLUMN "vote_count" INT NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -718,6 +718,10 @@ model Photo {
   // Video metadata
   duration Float? // Video duration in seconds (null for images)
 
+  // salame-58195: thumbs-up voting (denormalized counter, maintained by toggle endpoint)
+  voteCount Int         @default(0) @map("vote_count")
+  votes     PhotoVote[]
+
   // Metadata
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -728,6 +732,23 @@ model Photo {
   // margherita-43821: composite index supporting GET /api/photos/feed
   @@index([starred, status, createdAt(sort: Desc), id(sort: Desc)])
   @@map("photos")
+}
+
+// salame-58195: thumbs-up votes on photos. One vote per (photo, user); toggle
+// to unvote. The User FK is one-way (no back-relation on User to avoid Prisma
+// churn) and references the "User" table (PascalCase singular — no @@map on
+// the User model).
+model PhotoVote {
+  id        String   @id @default(uuid()) @db.Uuid
+  photoId   String   @map("photo_id") @db.Uuid
+  photo     Photo    @relation(fields: [photoId], references: [id], onDelete: Cascade)
+  userId    String   @map("user_id")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@unique([photoId, userId])
+  @@index([photoId])
+  @@index([userId])
+  @@map("photo_votes")
 }
 
 // ============================================

--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -52,7 +52,7 @@ function buildPartyFilter(opts: { regions: string[]; countries: string[]; partne
   return partyFilter;
 }
 
-router.get('/feed', async (req: Request, res: Response, next: NextFunction) => {
+router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const limit = Math.min(
       Math.max(parseInt((req.query.limit as string) || String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT, 1),
@@ -96,6 +96,11 @@ router.get('/feed', async (req: Request, res: Response, next: NextFunction) => {
         width: true,
         height: true,
         createdAt: true,
+        // salame-58195
+        voteCount: true,
+        votes: req.userId
+          ? { where: { userId: req.userId }, select: { id: true } }
+          : false,
         party: {
           select: {
             id: true,
@@ -116,23 +121,31 @@ router.get('/feed', async (req: Request, res: Response, next: NextFunction) => {
       : null;
 
     res.json({
-      photos: page.map((p) => ({
-        id: p.id,
-        url: p.url,
-        thumbnailUrl: p.thumbnailUrl,
-        caption: p.caption,
-        mimeType: p.mimeType,
-        duration: p.duration,
-        width: p.width,
-        height: p.height,
-        createdAt: p.createdAt,
-        party: {
-          slug: p.party.customUrl || p.party.inviteCode,
-          name: p.party.name,
-          city: p.party.city,
-          country: p.party.country,
-        },
-      })),
+      photos: page.map((p) => {
+        const votes = (p as typeof p & { votes?: { id: string }[] }).votes;
+        return {
+          id: p.id,
+          url: p.url,
+          thumbnailUrl: p.thumbnailUrl,
+          caption: p.caption,
+          mimeType: p.mimeType,
+          duration: p.duration,
+          width: p.width,
+          height: p.height,
+          createdAt: p.createdAt,
+          // salame-58195
+          voteCount: p.voteCount,
+          votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+          party: {
+            // Include id so the client can hit the per-party vote endpoint.
+            id: p.party.id,
+            slug: p.party.customUrl || p.party.inviteCode,
+            name: p.party.name,
+            city: p.party.city,
+            country: p.party.country,
+          },
+        };
+      }),
       nextCursor,
     });
   } catch (error) {

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -78,13 +78,28 @@ router.get('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Respo
       skip: parseInt(offset as string, 10),
       include: {
         guest: { select: { id: true, name: true } },
+        // salame-58195: include current user's vote (if any) so the client can
+        // render votedByMe without an extra round-trip.
+        votes: req.userId
+          ? { where: { userId: req.userId }, select: { id: true } }
+          : false,
       },
     });
 
     const total = await prisma.photo.count({ where });
 
+    // salame-58195: shape response with votedByMe (boolean). voteCount is
+    // already a column on Photo so it comes through automatically.
+    const photosWithVote = photos.map((p) => {
+      const { votes, ...rest } = p as typeof p & { votes?: { id: string }[] };
+      return {
+        ...rest,
+        votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+      };
+    });
+
     res.json({
-      photos,
+      photos: photosWithVote,
       total,
       limit: parseInt(limit as string, 10),
       offset: parseInt(offset as string, 10),
@@ -377,7 +392,7 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
 });
 
 // GET /api/parties/:partyId/photos/:photoId - Get single photo details
-router.get('/:partyId/photos/:photoId', async (req: AuthRequest, res: Response, next: NextFunction) => {
+router.get('/:partyId/photos/:photoId', optionalAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId, photoId } = req.params;
 
@@ -407,6 +422,10 @@ router.get('/:partyId/photos/:photoId', async (req: AuthRequest, res: Response, 
       where: { id: photoId, partyId },
       include: {
         guest: { select: { id: true, name: true } },
+        // salame-58195
+        votes: req.userId
+          ? { where: { userId: req.userId }, select: { id: true } }
+          : false,
       },
     });
 
@@ -414,7 +433,13 @@ router.get('/:partyId/photos/:photoId', async (req: AuthRequest, res: Response, 
       throw new AppError('Photo not found', 404, 'NOT_FOUND');
     }
 
-    res.json({ photo });
+    const { votes, ...rest } = photo as typeof photo & { votes?: { id: string }[] };
+    const photoWithVote = {
+      ...rest,
+      votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+    };
+
+    res.json({ photo: photoWithVote });
   } catch (error) {
     next(error);
   }
@@ -522,6 +547,65 @@ router.delete('/:partyId/photos/:photoId', requireAuth, async (req: AuthRequest,
     });
 
     res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// salame-58195: POST /api/parties/:partyId/photos/:photoId/vote
+// Toggle the current user's thumbs-up on a photo. Requires auth.
+// Returns { voted: boolean, voteCount: number }.
+router.post('/:partyId/photos/:photoId/vote', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId, photoId } = req.params;
+    const userId = req.userId;
+    if (!userId) {
+      throw new AppError('Auth required', 401, 'UNAUTHORIZED');
+    }
+
+    // Verify the photo exists and belongs to this party.
+    const photo = await prisma.photo.findFirst({
+      where: { id: photoId, partyId },
+      select: { id: true },
+    });
+    if (!photo) {
+      throw new AppError('Photo not found', 404, 'NOT_FOUND');
+    }
+
+    const existing = await prisma.photoVote.findUnique({
+      where: { photoId_userId: { photoId, userId } },
+      select: { id: true },
+    });
+
+    if (existing) {
+      // Toggle off
+      const [, updated] = await prisma.$transaction([
+        prisma.photoVote.delete({
+          where: { photoId_userId: { photoId, userId } },
+        }),
+        prisma.photo.update({
+          where: { id: photoId },
+          data: { voteCount: { decrement: 1 } },
+          select: { voteCount: true },
+        }),
+      ]);
+      // Guard against negative drift (shouldn't happen, but safe).
+      const voteCount = Math.max(0, updated.voteCount);
+      return res.json({ voted: false, voteCount });
+    }
+
+    // Toggle on
+    const [, updated] = await prisma.$transaction([
+      prisma.photoVote.create({
+        data: { photoId, userId },
+      }),
+      prisma.photo.update({
+        where: { id: photoId },
+        data: { voteCount: { increment: 1 } },
+        select: { voteCount: true },
+      }),
+    ]);
+    return res.json({ voted: true, voteCount: updated.voteCount });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/photos/PhotoCard.tsx
+++ b/frontend/src/components/photos/PhotoCard.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
-import { Star, Trash2, User, CheckCircle2, XCircle, Clock, Play } from 'lucide-react';
+import React, { useState } from 'react';
+import { Star, Trash2, User, CheckCircle2, XCircle, Clock, Play, ThumbsUp } from 'lucide-react';
 import { Photo } from '../../types';
+import { useAuth } from '../../contexts/AuthContext';
+import { togglePhotoVote } from '../../lib/api';
 
 interface PhotoCardProps {
   photo: Photo;
@@ -10,6 +12,8 @@ interface PhotoCardProps {
   onDelete?: (photoId: string) => void;
   onApprove?: (photoId: string) => void;
   onReject?: (photoId: string) => void;
+  // salame-58195: thumbs-up vote toggled — parent updates local list.
+  onVoteChange?: (photoId: string, next: { voteCount: number; votedByMe: boolean }) => void;
 }
 
 /** Format duration in seconds to "M:SS" display */
@@ -27,11 +31,31 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
   onDelete,
   onApprove,
   onReject,
+  onVoteChange,
 }) => {
   const uploaderDisplayName = photo.guest?.name || photo.uploaderName || 'Anonymous';
   const isPending = photo.status === 'pending';
   const isRejected = photo.status === 'rejected';
   const isVideo = photo.mimeType?.startsWith('video/');
+
+  // salame-58195: thumbs-up voting
+  const { user } = useAuth();
+  const [voting, setVoting] = useState(false);
+  const handleVote = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!user) {
+      // Anon: fall through to opening the modal (login prompt deferred).
+      onClick?.();
+      return;
+    }
+    if (voting) return;
+    setVoting(true);
+    const res = await togglePhotoVote(photo.partyId, photo.id);
+    setVoting(false);
+    if (res && onVoteChange) {
+      onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
+    }
+  };
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -204,6 +228,24 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
             </span>
           )}
         </div>
+      )}
+
+      {/* salame-58195: thumbs-up vote (approved photos only) */}
+      {!isPending && !isRejected && (
+        <button
+          type="button"
+          onClick={handleVote}
+          aria-label={photo.votedByMe ? 'Remove vote' : 'Thumbs up'}
+          title={user ? (photo.votedByMe ? 'Remove vote' : 'Thumbs up') : 'Log in to vote'}
+          className={`absolute bottom-2 left-2 z-10 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors ${
+            photo.votedByMe
+              ? 'bg-red-500 text-white hover:bg-red-600'
+              : 'bg-black/60 text-white hover:bg-black/80'
+          } ${voting ? 'opacity-70' : ''}`}
+        >
+          <ThumbsUp size={12} fill={photo.votedByMe ? 'currentColor' : 'none'} />
+          {photo.voteCount > 0 && <span>{photo.voteCount}</span>}
+        </button>
       )}
     </div>
   );

--- a/frontend/src/components/photos/PhotoGallery.tsx
+++ b/frontend/src/components/photos/PhotoGallery.tsx
@@ -248,6 +248,16 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     }
   };
 
+  // salame-58195: propagate thumbs-up vote changes back into the local list
+  // (and the open modal if it's the same photo) so counts/state stay in sync.
+  const handleVoteChange = useCallback(
+    (photoId: string, next: { voteCount: number; votedByMe: boolean }) => {
+      setPhotos((prev) => prev.map((p) => (p.id === photoId ? { ...p, ...next } : p)));
+      setSelectedPhoto((cur) => (cur && cur.id === photoId ? { ...cur, ...next } : cur));
+    },
+    []
+  );
+
   const handleApproveAll = async () => {
     if (!stats || stats.pendingPhotos === 0) return;
     setBatchLoading(true);
@@ -510,6 +520,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
                 onDelete={handleDelete}
                 onApprove={isHost && photo.status === 'pending' ? handleApprove : undefined}
                 onReject={isHost && photo.status === 'pending' ? handleReject : undefined}
+                onVoteChange={handleVoteChange}
               />
             ))}
           </div>
@@ -552,6 +563,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
           onUpdateYear={handleUpdateYear}
           onApprove={isHost ? handleApprove : undefined}
           onReject={isHost ? handleReject : undefined}
+          onVoteChange={handleVoteChange}
         />
       )}
     </div>

--- a/frontend/src/components/photos/PhotoModal.tsx
+++ b/frontend/src/components/photos/PhotoModal.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { X, ChevronLeft, ChevronRight, Star, Download, Trash2, User, Calendar, Tag, CheckCircle2, XCircle, Clock, MessageSquare } from 'lucide-react';
+import { X, ChevronLeft, ChevronRight, Star, Download, Trash2, User, Calendar, Tag, CheckCircle2, XCircle, Clock, MessageSquare, ThumbsUp } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Photo } from '../../types';
+import { useAuth } from '../../contexts/AuthContext';
+import { togglePhotoVote } from '../../lib/api';
 
 interface PhotoModalProps {
   photo: Photo;
@@ -18,6 +20,8 @@ interface PhotoModalProps {
   onUpdateYear?: (photoId: string, year: number | null) => void;
   onApprove?: (photoId: string) => void;
   onReject?: (photoId: string) => void;
+  // salame-58195: thumbs-up vote toggled — parent updates local list.
+  onVoteChange?: (photoId: string, next: { voteCount: number; votedByMe: boolean }) => void;
 }
 
 export const PhotoModal: React.FC<PhotoModalProps> = ({
@@ -34,7 +38,21 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
   onUpdateYear,
   onApprove,
   onReject,
+  onVoteChange,
 }) => {
+  // salame-58195: thumbs-up voting
+  const { user } = useAuth();
+  const [voting, setVoting] = useState(false);
+  const handleVote = async () => {
+    if (!user || voting) return;
+    setVoting(true);
+    const res = await togglePhotoVote(photo.partyId, photo.id);
+    setVoting(false);
+    if (res && onVoteChange) {
+      onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
+    }
+  };
+
   const [editingCaption, setEditingCaption] = useState(false);
   const [captionValue, setCaptionValue] = useState(photo.caption || '');
   const [editingTags, setEditingTags] = useState(false);
@@ -477,6 +495,23 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
 
           {/* Actions */}
           <div className="space-y-2 border-t border-theme-stroke pt-4">
+            {/* salame-58195: thumbs-up vote (approved photos only) */}
+            {photo.status === 'approved' && (
+              <button
+                onClick={handleVote}
+                disabled={!user || voting}
+                title={user ? (photo.votedByMe ? 'Remove vote' : 'Thumbs up') : 'Log in to vote'}
+                className={`w-full flex items-center justify-center gap-2 font-medium py-2.5 rounded-lg transition-colors ${
+                  photo.votedByMe
+                    ? 'bg-red-500 text-white hover:bg-red-600'
+                    : 'bg-theme-surface-hover text-theme-text hover:bg-white/15'
+                } ${!user || voting ? 'opacity-60 cursor-not-allowed' : ''}`}
+              >
+                <ThumbsUp size={18} fill={photo.votedByMe ? 'currentColor' : 'none'} />
+                {photo.voteCount > 0 ? `${photo.voteCount}` : ''} {photo.votedByMe ? 'Voted' : 'Thumbs up'}
+              </button>
+            )}
+
             <button
               onClick={handleDownload}
               className="w-full flex items-center justify-center gap-2 bg-theme-surface-hover hover:bg-theme-surface-hover text-theme-text font-medium py-2.5 rounded-lg transition-colors"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -926,6 +926,26 @@ export async function batchReviewPhotos(
   }
 }
 
+// salame-58195: toggle the current user's thumbs-up vote on a photo.
+// Logged-in users only. Returns { voted, voteCount } on success, null on error.
+export async function togglePhotoVote(
+  partyId: string,
+  photoId: string,
+): Promise<{ voted: boolean; voteCount: number } | null> {
+  try {
+    return await apiRequest<{ voted: boolean; voteCount: number }>(
+      `/api/parties/${partyId}/photos/${photoId}/vote`,
+      {
+        method: 'POST',
+        requireAuth: true,
+      }
+    );
+  } catch (error) {
+    console.error('Error toggling photo vote:', error);
+    return null;
+  }
+}
+
 // Get available photo tags for a party (defaults + confirmed sponsor names)
 export async function getPhotoTags(partyId: string): Promise<{ tags: string[]; defaultTags: string[]; sponsorTags: string[] } | null> {
   try {
@@ -4772,7 +4792,10 @@ export interface FeedPhoto {
   width: number | null;
   height: number | null;
   createdAt: string;
-  party: { slug: string; name: string; city: string | null; country: string | null };
+  // salame-58195: thumbs-up voting state
+  voteCount: number;
+  votedByMe: boolean;
+  party: { id: string; slug: string; name: string; city: string | null; country: string | null };
 }
 
 export interface PhotosFeedResponse {

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { Loader2, Play, MapPin, ChevronLeft, ChevronRight, ChevronDown, Check, Search, X } from 'lucide-react';
+import { Loader2, Play, MapPin, ChevronLeft, ChevronRight, ChevronDown, Check, Search, X, ThumbsUp } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import { ThemeProvider } from '../contexts/ThemeContext';
+import { useAuth } from '../contexts/AuthContext';
 import { cdnUrl } from '../lib/supabase';
 import {
   getPhotosFeed,
   getPhotosFeedFacets,
   getMyPartnerTags,
+  togglePhotoVote,
   FeedPhoto,
 } from '../lib/api';
 import { countryNameToAlpha2, alpha2ToCountryNames, alpha2ToCanonicalName } from '../utils/countryFlag';
@@ -227,6 +229,16 @@ export function PhotosFeedPage() {
     setActivePartnerTag(null);
   };
 
+  // salame-58195: propagate vote changes back into the photos array so the
+  // count + filled icon update immediately on click (and stay in sync across
+  // tile <-> lightbox).
+  const handleVoteChange = useCallback(
+    (photoId: string, next: { voteCount: number; votedByMe: boolean }) => {
+      setPhotos((prev) => prev.map((p) => (p.id === photoId ? { ...p, ...next } : p)));
+    },
+    []
+  );
+
   const anyFiltersActive = activeCountries.length > 0 || activeRegions.length > 0 || !!activePartnerTag;
 
   return (
@@ -283,7 +295,14 @@ export function PhotosFeedPage() {
           <EmptyState anyFiltersActive={anyFiltersActive} onClear={clearAllFilters} />
         ) : (
           <div className="columns-2 sm:columns-3 lg:columns-4 xl:columns-5 gap-3">
-            {photos.map((p, idx) => <FeedTile key={p.id} photo={p} onOpen={() => setSelectedIdx(idx)} />)}
+            {photos.map((p, idx) => (
+              <FeedTile
+                key={p.id}
+                photo={p}
+                onOpen={() => setSelectedIdx(idx)}
+                onVoteChange={handleVoteChange}
+              />
+            ))}
           </div>
         )}
 
@@ -309,6 +328,7 @@ export function PhotosFeedPage() {
           onPrev={() => setSelectedIdx((i) => (i !== null && i > 0 ? i - 1 : i))}
           onNext={() => setSelectedIdx((i) => (i !== null && i < photos.length - 1 ? i + 1 : i))}
           onClose={() => setSelectedIdx(null)}
+          onVoteChange={handleVoteChange}
         />
       )}
     </Layout>
@@ -564,7 +584,15 @@ function PartnerFilterButton({
 
 // --- Tiles + lightbox (unchanged from pre-sicilian-58129) --------------------
 
-function FeedTile({ photo, onOpen }: { photo: FeedPhoto; onOpen: () => void }) {
+function FeedTile({
+  photo,
+  onOpen,
+  onVoteChange,
+}: {
+  photo: FeedPhoto;
+  onOpen: () => void;
+  onVoteChange: (photoId: string, next: { voteCount: number; votedByMe: boolean }) => void;
+}) {
   const isVideo = photo.mimeType?.startsWith('video/');
   const src = cdnUrl(photo.url);
   const aspectRatio = photo.width && photo.height
@@ -575,6 +603,26 @@ function FeedTile({ photo, onOpen }: { photo: FeedPhoto; onOpen: () => void }) {
   const gpp = gppCityBySlug(photo.party.slug);
   const displayCity = gpp?.name ?? photo.party.city ?? photo.party.name;
   const displayCountry = gpp?.country ?? photo.party.country;
+
+  // salame-58195
+  const { user } = useAuth();
+  const [voting, setVoting] = useState(false);
+  const handleVote = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (!user) {
+      // Anon: defer login prompt — fall through to lightbox.
+      onOpen();
+      return;
+    }
+    if (voting) return;
+    setVoting(true);
+    const res = await togglePhotoVote(photo.party.id, photo.id);
+    setVoting(false);
+    if (res) {
+      onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
+    }
+  };
 
   return (
     <button onClick={onOpen} className="mb-3 block w-full break-inside-avoid rounded-lg overflow-hidden bg-theme-surface hover:opacity-90 transition-opacity">
@@ -591,6 +639,19 @@ function FeedTile({ photo, onOpen }: { photo: FeedPhoto; onOpen: () => void }) {
         ) : (
           <img src={src} alt={photo.caption || ''} loading="lazy" className="w-full h-full object-cover block" />
         )}
+        {/* salame-58195: thumbs-up overlay */}
+        <span
+          onClick={handleVote}
+          aria-label={photo.votedByMe ? 'Remove vote' : 'Thumbs up'}
+          className={`absolute bottom-2 right-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+            photo.votedByMe
+              ? 'bg-red-500 text-white hover:bg-red-600'
+              : 'bg-black/60 text-white hover:bg-black/80'
+          } ${voting ? 'opacity-70' : ''}`}
+        >
+          <ThumbsUp size={12} fill={photo.votedByMe ? 'currentColor' : 'none'} />
+          {photo.voteCount > 0 && <span>{photo.voteCount}</span>}
+        </span>
       </div>
       {(displayCity || photo.party.name) && (
         <div className="px-2 py-1.5 text-xs text-theme-text-muted flex items-center gap-1.5">
@@ -605,7 +666,7 @@ function FeedTile({ photo, onOpen }: { photo: FeedPhoto; onOpen: () => void }) {
 }
 
 function FeedLightbox({
-  photo, onClose, onPrev, onNext, hasPrev, hasNext,
+  photo, onClose, onPrev, onNext, hasPrev, hasNext, onVoteChange,
 }: {
   photo: FeedPhoto;
   onClose: () => void;
@@ -613,6 +674,7 @@ function FeedLightbox({
   onNext: () => void;
   hasPrev: boolean;
   hasNext: boolean;
+  onVoteChange: (photoId: string, next: { voteCount: number; votedByMe: boolean }) => void;
 }) {
   const isVideo = photo.mimeType?.startsWith('video/');
 
@@ -620,6 +682,20 @@ function FeedLightbox({
   const gpp = gppCityBySlug(photo.party.slug);
   const displayCity = gpp?.name ?? photo.party.city;
   const displayCountry = gpp?.country ?? photo.party.country;
+
+  // salame-58195
+  const { user } = useAuth();
+  const [voting, setVoting] = useState(false);
+  const handleVote = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!user || voting) return;
+    setVoting(true);
+    const res = await togglePhotoVote(photo.party.id, photo.id);
+    setVoting(false);
+    if (res) {
+      onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
+    }
+  };
 
   return (
     <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4" onClick={onClose}>
@@ -649,15 +725,32 @@ function FeedLightbox({
         </div>
         <div className="p-4 border-t border-theme-stroke">
           {photo.caption && <p className="text-theme-text mb-2">{photo.caption}</p>}
-          <p className="text-theme-text-muted text-sm flex items-center gap-2">
-            {countryNameToAlpha2(displayCountry)
-              ? <CircleFlag country={displayCountry} size={18} />
-              : <MapPin size={12} />}
-            <Link to={`/${photo.party.slug}`} className="hover:underline text-theme-text">
-              {photo.party.name}
-            </Link>
-            {displayCity && <span>· {displayCity}{displayCountry ? `, ${displayCountry}` : ''}</span>}
-          </p>
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <p className="text-theme-text-muted text-sm flex items-center gap-2">
+              {countryNameToAlpha2(displayCountry)
+                ? <CircleFlag country={displayCountry} size={18} />
+                : <MapPin size={12} />}
+              <Link to={`/${photo.party.slug}`} className="hover:underline text-theme-text">
+                {photo.party.name}
+              </Link>
+              {displayCity && <span>· {displayCity}{displayCountry ? `, ${displayCountry}` : ''}</span>}
+            </p>
+            {/* salame-58195: vote button (logged-in users only; anon sees count) */}
+            <button
+              onClick={handleVote}
+              disabled={!user || voting}
+              aria-label={photo.votedByMe ? 'Remove vote' : 'Thumbs up'}
+              title={user ? (photo.votedByMe ? 'Remove vote' : 'Thumbs up') : 'Log in to vote'}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                photo.votedByMe
+                  ? 'bg-red-500 text-white hover:bg-red-600'
+                  : 'bg-white/10 text-theme-text hover:bg-white/20'
+              } ${!user || voting ? 'opacity-60 cursor-not-allowed' : ''}`}
+            >
+              <ThumbsUp size={18} fill={photo.votedByMe ? 'currentColor' : 'none'} />
+              <span>{photo.voteCount}</span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -495,6 +495,9 @@ export interface Photo {
   reviewedAt: string | null;
   reviewedBy: string | null;
   duration: number | null; // Video duration in seconds (null for images)
+  // salame-58195: thumbs-up voting
+  voteCount: number;
+  votedByMe: boolean;
   createdAt: string;
   updatedAt: string;
   guest?: {


### PR DESCRIPTION
## Summary
- Logged-in users can thumb-up photos (1 vote per user per photo, toggle to unvote)
- Vote count + per-user voted state surfaces on /photos tiles + lightbox AND event-page PhotoGallery (PhotoCard + PhotoModal)
- New photo_votes table + denormalized voteCount counter on photos
- POST /api/parties/:partyId/photos/:photoId/vote toggle endpoint

## Deploy order
1. Apply migration to prod via Supabase MCP (creates photo_votes table + adds vote_count column on photos)
2. Merge -> backend deploys with toggle endpoint + extended feed/list response
3. Frontend deploys with vote buttons

## Migration
- File: backend/prisma/migrations/20260526000000_add_photo_votes/migration.sql
- Creates table photo_votes with FK to "User"(id) (PascalCase singular - User model has no @@map) and FK to photos(id) ON DELETE CASCADE
- Adds vote_count INT NOT NULL DEFAULT 0 on photos

## Test plan
- [ ] As anon, /photos tile click goes to lightbox (no error)
- [ ] As logged-in user, /photos tile thumb-up click increments count + fills icon
- [ ] Second click toggles off
- [ ] Vote persists across page refresh
- [ ] Event-page PhotoCard shows same vote count + state; PhotoModal vote button toggles
- [ ] DB: photo_votes row exists for (photoId, userId); photos.vote_count matches
- [ ] Vercel preview: https://rsvpizza-git-salame-58195-photo-votes-pizza-dao.vercel.app/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)