### PR TITLE
feat(salumi-89172): shipping coordinator payments on /shipping

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -770,6 +770,10 @@ model PartyKit {
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
+  // salumi-89172: shipping-coordinator reimbursement payouts that are tied
+  // to this kit. Mirrors Payout.partyKit (relation name "PayoutsForKit").
+  reimbursementPayouts Payout[] @relation("PayoutsForKit")
+
   @@map("party_kits")
 }
 
@@ -1570,6 +1574,17 @@ model Payout {
   party               Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
   hostUserId          String    @map("host_user_id")
   host                User      @relation(fields: [hostUserId], references: [id], onDelete: Restrict)
+
+  // salumi-89172: distinguishes event-reimbursement payouts ('event') from
+  // shipping-coordinator receipt payouts ('shipping'). DB CHECK constraint
+  // restricts the value set; default 'event' preserves existing behavior.
+  purpose             String    @default("event")
+  // salumi-89172: optional kit the shipping receipt is tied to. NULL for
+  // event payouts and for shipping receipts that aren't tied to a kit (none
+  // in v1 — selection is required on the form). FK ON DELETE SET NULL so
+  // archiving a kit doesn't cascade-destroy historical reimbursements.
+  partyKitId          String?   @map("party_kit_id") @db.Uuid
+  partyKit            PartyKit? @relation("PayoutsForKit", fields: [partyKitId], references: [id], onDelete: SetNull)
 
   originalAmount      Decimal   @map("original_amount") @db.Decimal(12, 2)
   originalCurrency    String    @map("original_currency")

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -300,6 +300,14 @@ function buildPayoutWhere(query: Request['query']): any {
     where.payoutMethod = method;
   }
 
+  // salumi-89172: Purpose filter — 'event' | 'shipping' | 'all' (default).
+  // When unset, both purposes are returned (existing behavior — pre-feature
+  // all rows were implicitly 'event').
+  const purpose = query.purpose;
+  if (typeof purpose === 'string' && purpose !== 'all' && (purpose === 'event' || purpose === 'shipping')) {
+    where.purpose = purpose;
+  }
+
   const partyId = query.partyId;
   if (typeof partyId === 'string' && partyId.trim().length > 0) {
     where.partyId = partyId.trim();
@@ -385,6 +393,10 @@ function serializePayout(row: any): any {
     id: row.id,
     partyId: row.partyId,
     hostUserId: row.hostUserId,
+    // salumi-89172: shipping coordinator payouts can be filtered out of the
+    // normal queue + show a "Shipping" pill in the admin UI.
+    purpose: row.purpose ?? 'event',
+    partyKitId: row.partyKitId ?? null,
     originalAmount: Number(row.originalAmount),
     originalCurrency: row.originalCurrency,
     exchangeRate: Number(row.exchangeRate),

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -73,6 +73,11 @@ function serializePayout(p: any) {
     id: p.id,
     partyId: p.partyId,
     hostUserId: p.hostUserId,
+    // salumi-89172: surface the payout purpose + the optional kit it's tied
+    // to so the host-side list can distinguish event reimbursements from
+    // shipping-coordinator receipts.
+    purpose: p.purpose ?? 'event',
+    partyKitId: p.partyKitId ?? null,
     // pancetta-37195: surface the submitter so cohosts can tell who created
     // the payout. host is included via the prisma findUnique/findMany below.
     hostName: p.host?.name ?? null,
@@ -526,7 +531,47 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       // default `req.userId` for `hostUserId`. Preserves pancetta-37195
       // attribution — "Submitted by X" reads correctly.
       recipientHostUserId,
+      // salumi-89172: optional payout purpose + tied kit. Shipping
+      // coordinators submit `purpose='shipping'` with `partyKitId` set to
+      // the kit the receipt belongs to. Event-reimbursement flows leave
+      // both unset; the column defaults to 'event'.
+      purpose: bodyPurpose,
+      partyKitId: bodyPartyKitId,
     } = req.body || {};
+
+    // salumi-89172: validate purpose. Default 'event' preserves all existing
+    // flows. 'shipping' is only allowed when `partyKitId` is also supplied
+    // AND the kit actually belongs to this party (checked below after the
+    // party-edit gate).
+    const purpose: 'event' | 'shipping' =
+      bodyPurpose === 'shipping' ? 'shipping' : 'event';
+    const partyKitIdInput =
+      typeof bodyPartyKitId === 'string' && bodyPartyKitId.trim().length > 0
+        ? bodyPartyKitId.trim()
+        : null;
+    if (purpose === 'shipping' && !partyKitIdInput) {
+      throw new AppError(
+        'partyKitId is required for shipping receipts',
+        400,
+        'PARTY_KIT_ID_REQUIRED',
+      );
+    }
+    if (purpose !== 'shipping' && partyKitIdInput) {
+      // Refuse to silently drop a kit id on a non-shipping payout — it almost
+      // certainly indicates a frontend bug rather than intent.
+      throw new AppError(
+        'partyKitId may only be set when purpose="shipping"',
+        400,
+        'INVALID_PARTY_KIT_ID',
+      );
+    }
+
+    // salumi-89172: shipping receipts are submitted by shipping coordinators
+    // who don't necessarily have edit access on the party — they manage
+    // logistics, not the event itself. When `purpose='shipping'`, swap the
+    // canUserEditParty gate for a shipping-coordinator / admin check that
+    // mirrors the auth used by `/api/shipping/*`.
+    const isShippingPurpose = purpose === 'shipping';
 
     // bismarck-92103: admins creating prepayments on behalf of a cohost don't
     // need party edit access — they're operating from the /payments admin
@@ -536,7 +581,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     const recipientOverrideRequested =
       typeof recipientHostUserId === 'string' && recipientHostUserId.trim().length > 0;
     const skipPartyEditCheck =
-      recipientOverrideRequested && (await isAnyAdmin(req.userEmail));
+      (recipientOverrideRequested && (await isAnyAdmin(req.userEmail))) ||
+      isShippingPurpose;
     if (!skipPartyEditCheck) {
       const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
       if (!canEdit) {
@@ -548,6 +594,46 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           );
         }
         throw new AppError('Party not found', 404, 'NOT_FOUND');
+      }
+    }
+
+    // salumi-89172: for shipping receipts, require the caller to be an admin
+    // OR an active shipping coordinator. Also enforce that the kit belongs
+    // to the party in the URL — submitters can't cross parties.
+    if (isShippingPurpose) {
+      const email = req.userEmail?.toLowerCase() || '';
+      const callerIsAdmin = await isAnyAdmin(req.userEmail);
+      let allowed = callerIsAdmin;
+      if (!allowed && email) {
+        const coord = await prisma.shippingCoordinator.findFirst({
+          where: { email, isActive: true },
+          select: { id: true },
+        });
+        allowed = !!coord;
+      }
+      if (!allowed) {
+        throw new AppError(
+          'Shipping receipts require admin or shipping-coordinator access.',
+          403,
+          'FORBIDDEN_SHIPPING_PAYOUT',
+        );
+      }
+      // Verify the kit exists AND belongs to this party. Cross-party submits
+      // would otherwise let a coordinator file a receipt under a kit they
+      // don't actually handle.
+      const kit = await prisma.partyKit.findUnique({
+        where: { id: partyKitIdInput! },
+        select: { id: true, partyId: true },
+      });
+      if (!kit) {
+        throw new AppError('Kit not found', 404, 'KIT_NOT_FOUND');
+      }
+      if (kit.partyId !== partyId) {
+        throw new AppError(
+          'Kit does not belong to this party',
+          400,
+          'KIT_PARTY_MISMATCH',
+        );
       }
     }
 
@@ -827,6 +913,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         // cohost, `effectiveHostUserId` is the cohost; otherwise it's the
         // authenticated submitter (req.userId).
         hostUserId: effectiveHostUserId,
+        // salumi-89172: persist purpose + tied kit. Defaults to 'event' /
+        // null when the body didn't supply them, matching pre-feature
+        // behavior.
+        purpose,
+        partyKitId: partyKitIdInput,
         originalAmount: new Decimal(effectiveOriginalAmount),
         originalCurrency: effectiveOriginalCurrency,
         exchangeRate: new Decimal(effectiveExchangeRate),

--- a/backend/src/routes/shipping.routes.ts
+++ b/backend/src/routes/shipping.routes.ts
@@ -986,6 +986,114 @@ router.delete('/admin/coordinators/:id', requireAuth, requireShippingAuth, async
   }
 });
 
+// ============================================
+// GET /api/shipping/my-payouts - salumi-89172
+//
+// Returns the current shipping coordinator's (or admin's) shipping-purpose
+// payouts. Reuses the existing payouts pipeline (OCR, FX, methods,
+// notifications) — the row shape mirrors `serializePayout` from
+// payout.routes.ts so the host PayoutListRow component renders without
+// modification.
+// ============================================
+router.get('/my-payouts', requireAuth, requireShippingAuth, async (req: ShippingRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.userId) {
+      throw new AppError('Authenticated user has no userId', 500, 'NO_USER_ID');
+    }
+
+    const rows = await prisma.payout.findMany({
+      where: {
+        hostUserId: req.userId,
+        purpose: 'shipping',
+      },
+      include: {
+        host: { select: { id: true, name: true, email: true } },
+        documents: {
+          orderBy: { sortOrder: 'asc' },
+          include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+        },
+        party: { select: { id: true, name: true, customUrl: true, inviteCode: true } },
+        partyKit: {
+          select: { id: true, requestedTier: true, allocatedTier: true, recipientName: true, city: true, country: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    function serialize(p: any) {
+      return {
+        id: p.id,
+        partyId: p.partyId,
+        hostUserId: p.hostUserId,
+        purpose: p.purpose ?? 'event',
+        partyKitId: p.partyKitId ?? null,
+        hostName: p.host?.name ?? null,
+        hostEmail: p.host?.email ?? null,
+        originalAmount: Number(p.originalAmount),
+        originalCurrency: p.originalCurrency,
+        exchangeRate: Number(p.exchangeRate),
+        extractedAmountUsd: Number(p.extractedAmountUsd),
+        finalAmountUsd: Number(p.finalAmountUsd),
+        status: p.status,
+        payoutMethod: p.payoutMethod,
+        payoutWalletAddress: p.payoutWalletAddress ?? null,
+        payoutBankDetails: p.payoutBankDetails ?? null,
+        mercuryCardId: p.mercuryCardId ?? null,
+        mercuryCardLast4: p.mercuryCardLast4 ?? null,
+        hostNotes: p.hostNotes ?? null,
+        adminNotes: p.adminNotes ?? null,
+        rejectionReason: p.rejectionReason ?? null,
+        reviewedBy: p.reviewedBy ?? null,
+        reviewedAt: p.reviewedAt ? p.reviewedAt.toISOString() : null,
+        paidAt: p.paidAt ? p.paidAt.toISOString() : null,
+        transactionHash: p.transactionHash ?? null,
+        wireReference: p.wireReference ?? null,
+        externalProofUrl: p.externalProofUrl ?? null,
+        createdAt: p.createdAt.toISOString(),
+        updatedAt: p.updatedAt.toISOString(),
+        documents: (p.documents || []).map((d: any) => ({
+          id: d.id,
+          kind: d.kind,
+          url: d.url,
+          fileName: d.fileName,
+          fileSize: d.fileSize,
+          mimeType: d.mimeType,
+          ocrAmount: d.ocrAmount != null ? Number(d.ocrAmount) : null,
+          ocrCurrency: d.ocrCurrency ?? null,
+          ocrConfidence: d.ocrConfidence != null ? Number(d.ocrConfidence) : null,
+          ocrError: d.ocrError ?? null,
+          sortOrder: d.sortOrder,
+          uploadedByUserId: d.uploadedByUserId ?? null,
+          uploadedByName: d.uploadedBy?.name ?? null,
+          uploadedByEmail: d.uploadedByEmail ?? d.uploadedBy?.email ?? null,
+        })),
+        party: p.party
+          ? {
+              id: p.party.id,
+              name: p.party.name,
+              customUrl: p.party.customUrl,
+              inviteCode: p.party.inviteCode,
+            }
+          : null,
+        partyKit: p.partyKit
+          ? {
+              id: p.partyKit.id,
+              requestedTier: p.partyKit.requestedTier,
+              allocatedTier: p.partyKit.allocatedTier,
+              recipientName: p.partyKit.recipientName,
+              city: p.partyKit.city,
+              country: p.partyKit.country,
+            }
+          : null,
+      };
+    }
+
+    res.json({ payouts: rows.map(serialize) });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // Helper: escape CSV field
 function escapeCSV(value: string): string {
   if (value.includes(',') || value.includes('"') || value.includes('\n')) {

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
 import { IconInput } from '../IconInput';
-import type { AdminPayoutFilters, PayoutMethod, PayoutStatus } from '../../types';
+import type { AdminPayoutFilters, PayoutMethod, PayoutPurpose, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
 
 interface PayoutsFilterBarProps {
@@ -33,6 +33,13 @@ const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [
   { value: 'wire', label: PAYOUT_METHOD_LABELS.wire },
 ];
 
+// salumi-89172: Purpose filter — event reimbursements vs shipping receipts.
+const PURPOSE_OPTIONS: Array<{ value: PayoutPurpose | 'all'; label: string }> = [
+  { value: 'all', label: 'All purposes' },
+  { value: 'event', label: 'Event' },
+  { value: 'shipping', label: 'Shipping' },
+];
+
 /**
  * regina-89172: count active (non-default) filter fields. Status tab strip is
  * NOT counted here — it's always visible above the collapsible section, so
@@ -46,6 +53,7 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.payoutMethod && filters.payoutMethod !== 'all') n += 1;
   if (filters.currency && filters.currency !== 'all') n += 1;
   if (filters.country && filters.country !== 'all') n += 1;
+  if (filters.purpose && filters.purpose !== 'all') n += 1;
   if (filters.dateFrom) n += 1;
   if (filters.dateTo) n += 1;
   return n;
@@ -122,7 +130,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         id="payouts-filter-controls"
         className={`${expanded ? 'block' : 'hidden'} sm:block`}
       >
-        <div className="grid grid-cols-1 md:grid-cols-6 gap-2 items-start">
+        <div className="grid grid-cols-1 md:grid-cols-7 gap-2 items-start">
           {/* salame-83472: unified search — host email|name OR party name. */}
           <div className="md:col-span-2">
             <IconInput
@@ -187,6 +195,21 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               <option value="all">All countries</option>
               {availableCountries.map((c) => (
                 <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* salumi-89172: Purpose dropdown — Event reimbursements vs
+              Shipping coordinator receipts. Default 'all' shows both. */}
+          <div>
+            <select
+              value={filters.purpose ?? 'all'}
+              onChange={(e) => update({ purpose: e.target.value as PayoutPurpose | 'all' })}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Filter by purpose"
+            >
+              {PURPOSE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
           </div>

--- a/frontend/src/components/shipping/NewShippingReceiptModal.tsx
+++ b/frontend/src/components/shipping/NewShippingReceiptModal.tsx
@@ -1,0 +1,294 @@
+import React, { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Loader2, X, StickyNote, Truck, AlertTriangle } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { useAuth } from '../../contexts/AuthContext';
+import { createPayout } from '../../lib/api';
+import { ReceiptUpload, ReceiptItem } from '../payouts/ReceiptUpload';
+import { PayoutAmountSummary } from '../payouts/PayoutAmountSummary';
+import type { ShippingKit, ShippingPayout } from '../../types';
+
+interface NewShippingReceiptModalProps {
+  /**
+   * Kits the coordinator can attach the receipt to. Filtered by the parent
+   * to those in the coordinator's region; v1 requires a kit selection so we
+   * can route the POST to a real partyId.
+   */
+  kits: ShippingKit[];
+  onClose: () => void;
+  onCreated: (payout: ShippingPayout) => void;
+}
+
+/**
+ * salumi-89172: shipping coordinator submits a reimbursement receipt for
+ * postage / packing / supplies they paid out of pocket.
+ *
+ * Reuses the host-side `createPayout` flow (OCR + FX + currency override +
+ * notifications) by passing `purpose='shipping'` and the selected kit's id.
+ * The POST routes to `/api/parties/{kit.partyId}/payouts` — the kit's
+ * parent party is the canonical owner for routing purposes; the backend
+ * validates kit ⇄ party correspondence before persisting.
+ *
+ * Kit selection is required for v1. Untied/general-supplies receipts are
+ * deliberately out of scope here.
+ */
+export const NewShippingReceiptModal: React.FC<NewShippingReceiptModalProps> = ({
+  kits,
+  onClose,
+  onCreated,
+}) => {
+  const { user } = useAuth();
+
+  // Form state
+  const [selectedKitId, setSelectedKitId] = useState<string>('');
+  const [receipts, setReceipts] = useState<ReceiptItem[]>([]);
+  const [notes, setNotes] = useState('');
+  const [overrideAmount, setOverrideAmount] = useState<number | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Reuse the same temp-id grouping NewPayoutForm uses — scoped to a single
+  // in-flight submission so uploads sort cleanly under payouts/<partyId>/.
+  const [payoutTempId] = useState(
+    () => `tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+
+  const selectedKit = useMemo(
+    () => kits.find(k => k.id === selectedKitId) ?? null,
+    [kits, selectedKitId],
+  );
+
+  // Filter out placeholder rows (events with no kit request) since they have
+  // no real party_kits.id to reference.
+  const selectableKits = useMemo(
+    () => kits.filter(k => !k.isPlaceholder),
+    [kits],
+  );
+
+  const ocrSum = useMemo(
+    () => receipts
+      .filter(r => r.status === 'done' && r.ocr)
+      .reduce((sum, r) => sum + (r.ocr?.amount ?? 0), 0),
+    [receipts],
+  );
+  const finalAmount = overrideAmount != null ? overrideAmount : ocrSum;
+  const isProcessing = receipts.some(r => r.status === 'uploading' || r.status === 'ocring');
+
+  // Saved payout method (same logic as host NewPayoutForm — coordinator
+  // configures their method via /payments PaymentDetailsCard, or admin sets
+  // it for them).
+  const savedMethod = user?.preferredPayoutMethod ?? null;
+  const savedWallet = user?.payoutWalletAddress ?? null;
+  const savedBank = user?.payoutBankDetails ?? null;
+  const savedMethodValid = useMemo(() => {
+    if (savedMethod == null) return false;
+    if (savedMethod === 'usdc_base') {
+      return !!savedWallet && /^0x[0-9a-fA-F]{40}$/.test(savedWallet.trim());
+    }
+    if (savedMethod === 'wire') {
+      if (!savedBank) return false;
+      const email = savedBank.email?.trim() ?? '';
+      if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return true;
+      if (!savedBank.accountHolderName?.trim() || !savedBank.bankName?.trim()) return false;
+      const hasUs = !!savedBank.routingNumber?.trim() && !!savedBank.accountNumber?.trim();
+      const hasIntl = !!savedBank.iban?.trim() || !!savedBank.swift?.trim();
+      return hasUs || hasIntl;
+    }
+    return true;
+  }, [savedMethod, savedWallet, savedBank]);
+
+  const canSubmit =
+    !!selectedKit &&
+    finalAmount > 0 &&
+    !isProcessing &&
+    !submitting;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit || !selectedKit) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const forwardMethod = savedMethod && savedMethodValid;
+      const created = (await createPayout(selectedKit.partyId, {
+        receiptPhotos: receipts
+          .filter(r => r.status === 'done' && r.url)
+          .map(r => ({
+            url: r.url!,
+            fileName: r.fileName,
+            fileSize: r.fileSize,
+            mimeType: r.mimeType,
+          })),
+        // Shipping receipts don't carry pizza/event proof photos.
+        pizzaPhotos: [],
+        hostNotes: notes.trim() || undefined,
+        purpose: 'shipping',
+        partyKitId: selectedKit.id,
+        ...(forwardMethod
+          ? {
+              payoutMethod: savedMethod!,
+              ...(savedMethod === 'usdc_base' && savedWallet
+                ? { payoutWalletAddress: savedWallet.trim() }
+                : {}),
+              ...(savedMethod === 'wire' && savedBank
+                ? { payoutBankDetails: savedBank }
+                : {}),
+              saveAsDefault: true,
+            }
+          : {}),
+        ...(overrideAmount != null ? { finalAmountUsd: overrideAmount } : {}),
+      })) as unknown as ShippingPayout;
+      onCreated(created);
+    } catch (err: any) {
+      setSubmitError(err?.message || 'Failed to submit receipt');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm overflow-y-auto p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-theme-card border border-theme-stroke rounded-2xl p-6 w-full max-w-2xl my-8"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-theme-text inline-flex items-center gap-2">
+            <Truck size={20} />
+            New shipping receipt
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-theme-text-faint hover:text-theme-text-secondary transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* 1. Kit selection (required) */}
+          <div>
+            <div className="mb-2">
+              <h4 className="text-sm font-semibold text-theme-text">Tied to event</h4>
+              <p className="text-xs text-theme-text-muted mt-0.5">
+                Pick the kit this receipt belongs to. (Required for v1.)
+              </p>
+            </div>
+            <select
+              value={selectedKitId}
+              onChange={(e) => setSelectedKitId(e.target.value)}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              required
+              aria-label="Pick the kit this receipt is tied to"
+            >
+              <option value="">Select a kit…</option>
+              {selectableKits.map((k) => (
+                <option key={k.id} value={k.id}>
+                  {k.partyName} — {k.recipientName}, {k.city}
+                  {k.country ? `, ${k.country}` : ''}
+                </option>
+              ))}
+            </select>
+            {selectableKits.length === 0 && (
+              <p className="text-xs text-amber-300 mt-1.5 inline-flex items-start gap-1">
+                <AlertTriangle size={12} className="mt-0.5" />
+                No kits in your region yet.
+              </p>
+            )}
+          </div>
+
+          {/* 2. Receipts (OCR + FX) */}
+          {selectedKit && (
+            <div>
+              <div className="mb-2">
+                <h4 className="text-sm font-semibold text-theme-text">Receipts</h4>
+                <p className="text-xs text-theme-text-muted mt-0.5">
+                  Upload your postage / packing / supply receipts. We'll add them up.
+                </p>
+              </div>
+              <ReceiptUpload
+                partyId={selectedKit.partyId}
+                payoutTempId={payoutTempId}
+                items={receipts}
+                onChange={setReceipts}
+              />
+            </div>
+          )}
+
+          {/* 3. Notes */}
+          <div>
+            <div className="mb-2">
+              <h4 className="text-sm font-semibold text-theme-text">Notes</h4>
+            </div>
+            <IconInput
+              icon={StickyNote}
+              multiline
+              rows={3}
+              placeholder="What was this for? Postage, packing, etc."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              maxLength={500}
+            />
+            <p className="text-xs text-theme-text-muted mt-1">{notes.length}/500</p>
+          </div>
+
+          {/* 4. Amount summary */}
+          <div>
+            <div className="mb-2">
+              <h4 className="text-sm font-semibold text-theme-text">Amount</h4>
+            </div>
+            <PayoutAmountSummary
+              receipts={receipts}
+              overrideAmount={overrideAmount}
+              onOverrideChange={setOverrideAmount}
+            />
+          </div>
+
+          {submitError && (
+            <div className="card p-3 border-red-500/40 bg-red-500/10 text-sm text-red-300">
+              {submitError}
+            </div>
+          )}
+
+          {/* No-method warning (informational) */}
+          {!savedMethodValid && (
+            <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 text-sm text-amber-100 inline-flex items-start gap-2">
+              <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
+              <span>
+                Your payment method isn't set yet. You can still submit — admin will
+                request it before paying.
+              </span>
+            </div>
+          )}
+
+          <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="btn-secondary"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="btn-primary inline-flex items-center gap-2 justify-center"
+            >
+              {submitting && <Loader2 size={16} className="animate-spin" />}
+              {isProcessing
+                ? 'Waiting for uploads…'
+                : submitting
+                ? 'Submitting…'
+                : `Submit $${finalAmount.toFixed(2)} receipt`}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/frontend/src/components/shipping/ShippingPaymentsSection.tsx
+++ b/frontend/src/components/shipping/ShippingPaymentsSection.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Plus, Loader2, AlertCircle, RefreshCw, Receipt as ReceiptIcon, BadgeDollarSign } from 'lucide-react';
+import { fetchMyShippingPayouts } from '../../lib/api';
+import type { ShippingKit, ShippingPayout, PayoutMethod, PayoutStatus } from '../../types';
+import { NewShippingReceiptModal } from './NewShippingReceiptModal';
+
+interface ShippingPaymentsSectionProps {
+  /**
+   * Kits the coordinator can attach receipts to. Filtered upstream by region
+   * so the dropdown only shows kits they actually handle.
+   */
+  kits: ShippingKit[];
+}
+
+const METHOD_LABEL: Record<PayoutMethod, string> = {
+  mercury_card: 'Mercury card',
+  wire: 'Wire transfer',
+  usdc_base: 'USDC on Base',
+};
+
+const STATUS_STYLES: Record<PayoutStatus, string> = {
+  pending: 'bg-amber-500/20 text-amber-800',
+  approved: 'bg-sky-500/20 text-sky-800',
+  rejected: 'bg-red-500/20 text-red-800',
+  paid: 'bg-emerald-500/20 text-emerald-800',
+  failed: 'bg-red-600/30 text-red-900',
+};
+
+const STATUS_LABEL: Record<PayoutStatus, string> = {
+  pending: 'Pending review',
+  approved: 'Approved',
+  rejected: 'Rejected',
+  paid: 'Paid',
+  failed: 'Failed',
+};
+
+/**
+ * salumi-89172: "My Payments" section on the /shipping dashboard.
+ *
+ * Shows the current coordinator's submitted shipping receipts and provides
+ * a "+ New shipping receipt" CTA that opens NewShippingReceiptModal. Reuses
+ * the host PayoutListRow visual treatment but inline so the dashboard's
+ * GPP theme reads cleanly against the light background.
+ */
+export const ShippingPaymentsSection: React.FC<ShippingPaymentsSectionProps> = ({ kits }) => {
+  const [payouts, setPayouts] = useState<ShippingPayout[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchMyShippingPayouts();
+      setPayouts(data);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load your payments');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleCreated = (created: ShippingPayout) => {
+    setPayouts((prev) => [created, ...prev]);
+    setShowModal(false);
+  };
+
+  const totalPaidUsd = payouts
+    .filter((p) => p.status === 'paid')
+    .reduce((s, p) => s + Number(p.finalAmountUsd || 0), 0);
+
+  return (
+    <section className="mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-semibold text-theme-text inline-flex items-center gap-2">
+            <ReceiptIcon size={18} />
+            My Payments
+          </h2>
+          <p className="text-xs text-theme-text-muted mt-0.5">
+            Submit receipts for shipping costs you've paid (postage, packing, supplies).
+          </p>
+        </div>
+        <button
+          onClick={() => setShowModal(true)}
+          className="inline-flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-xl font-medium text-sm transition-colors"
+        >
+          <Plus size={16} />
+          New shipping receipt
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="bg-white/60 border border-theme-stroke rounded-xl p-8 flex items-center justify-center">
+          <Loader2 className="w-6 h-6 animate-spin text-theme-text-muted" />
+        </div>
+      ) : error ? (
+        <div className="bg-white/60 border border-theme-stroke rounded-xl p-6 text-center">
+          <AlertCircle className="w-10 h-10 text-red-400 mx-auto mb-2" />
+          <p className="text-sm text-theme-text-secondary mb-3">{error}</p>
+          <button
+            onClick={load}
+            className="inline-flex items-center gap-2 text-sm text-theme-text-secondary hover:text-theme-text"
+          >
+            <RefreshCw size={14} />
+            Try again
+          </button>
+        </div>
+      ) : payouts.length === 0 ? (
+        <div className="bg-white/60 border border-theme-stroke rounded-xl p-8 text-center">
+          <ReceiptIcon className="w-10 h-10 text-theme-text-muted mx-auto mb-2" />
+          <p className="text-sm font-medium text-theme-text mb-1">No receipts yet</p>
+          <p className="text-xs text-theme-text-muted">
+            Submit your first shipping receipt to get reimbursed.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {totalPaidUsd > 0 && (
+            <div className="bg-white/60 border border-theme-stroke rounded-xl p-3 sm:p-4 flex items-center gap-3">
+              <BadgeDollarSign size={18} className="text-emerald-600 flex-shrink-0" />
+              <div className="text-sm font-medium text-theme-text">
+                Total paid to date: ${totalPaidUsd.toFixed(2)}
+              </div>
+            </div>
+          )}
+          <div className="bg-white/60 border border-theme-stroke rounded-xl p-3 sm:p-4 space-y-2">
+            {payouts.map((p) => (
+              <ShippingPayoutRow key={p.id} payout={p} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {showModal && (
+        <NewShippingReceiptModal
+          kits={kits}
+          onClose={() => setShowModal(false)}
+          onCreated={handleCreated}
+        />
+      )}
+    </section>
+  );
+};
+
+interface ShippingPayoutRowProps {
+  payout: ShippingPayout;
+}
+
+const ShippingPayoutRow: React.FC<ShippingPayoutRowProps> = ({ payout }) => {
+  const kit = payout.partyKit;
+  const party = payout.party;
+
+  return (
+    <div className="flex items-center gap-3 p-3 rounded-xl bg-white hover:bg-white/80 transition-colors border border-theme-stroke">
+      {/* Amount + tied-to */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-theme-text font-semibold">
+          <span>${Number(payout.finalAmountUsd).toFixed(2)} USD</span>
+          {payout.originalCurrency && payout.originalCurrency !== 'USD' && (
+            <span className="text-xs text-theme-text-muted font-normal">
+              ({Number(payout.originalAmount).toLocaleString()} {payout.originalCurrency})
+            </span>
+          )}
+        </div>
+        <div className="text-xs text-theme-text-muted mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+          {party && (
+            <span className="truncate max-w-[200px]" title={party.name}>
+              {party.name}
+            </span>
+          )}
+          {kit && (
+            <>
+              <span aria-hidden>•</span>
+              <span>
+                Kit → {kit.recipientName}, {kit.city}
+              </span>
+            </>
+          )}
+          <span aria-hidden>•</span>
+          <span>{payout.payoutMethod ? METHOD_LABEL[payout.payoutMethod] : 'No method set'}</span>
+          <span aria-hidden>•</span>
+          <span>
+            {new Date(payout.createdAt).toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })}
+          </span>
+        </div>
+      </div>
+
+      {/* Status pill */}
+      <span
+        className={`text-[11px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap ${STATUS_STYLES[payout.status]}`}
+      >
+        {STATUS_LABEL[payout.status]}
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/components/shipping/index.ts
+++ b/frontend/src/components/shipping/index.ts
@@ -7,3 +7,5 @@ export { KitContentsModal } from './KitContentsModal';
 export { CsvImportModal } from './CsvImportModal';
 export { CoordinatorManager } from './CoordinatorManager';
 export { CoordinatorModal } from './CoordinatorModal';
+export { ShippingPaymentsSection } from './ShippingPaymentsSection';
+export { NewShippingReceiptModal } from './NewShippingReceiptModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2957,6 +2957,16 @@ export async function exportShippingKitsCsv(filters?: ShippingKitFilters): Promi
   return response.blob();
 }
 
+// salumi-89172: shipping coordinator's own shipping-purpose payouts (uploaded
+// receipts for postage / packing / supplies they paid out of pocket).
+export async function fetchMyShippingPayouts(): Promise<import('../types').ShippingPayout[]> {
+  const res = await apiRequest<{ payouts: import('../types').ShippingPayout[] }>(
+    '/api/shipping/my-payouts',
+    { requireAuth: true },
+  );
+  return res.payouts;
+}
+
 // Coordinator management (admin only)
 export async function fetchShippingCoordinators(): Promise<{ coordinators: ShippingCoordinator[] }> {
   return apiRequest<{ coordinators: ShippingCoordinator[] }>('/api/shipping/admin/coordinators');
@@ -3981,6 +3991,8 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   // bruschetta-58291: country filter — exact-match `parties.country`.
   if (filters.country && filters.country !== 'all') params.set('country', filters.country);
   if (filters.currency && filters.currency !== 'all') params.set('currency', filters.currency);
+  // salumi-89172: purpose filter — 'event' | 'shipping' | 'all'. Omitted = show both.
+  if (filters.purpose && filters.purpose !== 'all') params.set('purpose', filters.purpose);
   if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
   if (filters.dateTo) params.set('dateTo', filters.dateTo);
   if (filters.cursor) params.set('cursor', filters.cursor);
@@ -4338,6 +4350,16 @@ export interface CreatePayoutData {
   recipientHostUserId?: string;
   /** Optional admin-supplied note stored on the new payout. */
   adminNotes?: string;
+  /**
+   * salumi-89172: 'event' (default) or 'shipping'. Shipping coordinators
+   * submit `purpose='shipping'` with `partyKitId` set.
+   */
+  purpose?: 'event' | 'shipping';
+  /**
+   * salumi-89172: UUID of the `party_kits` row the receipt is tied to.
+   * Required when `purpose==='shipping'`; rejected for event payouts.
+   */
+  partyKitId?: string;
 }
 
 export async function createPayout(

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -54,6 +54,9 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   currency: 'all',
   // bruschetta-58291: country filter default — 'all' means no filter.
   country: 'all',
+  // salumi-89172: purpose filter default — 'all' shows both event and
+  // shipping payouts so the existing admin queue is unchanged out of box.
+  purpose: 'all',
 };
 
 // lardo-58294: substring filter shared between the search input and the

--- a/frontend/src/pages/ShippingDashboard.tsx
+++ b/frontend/src/pages/ShippingDashboard.tsx
@@ -5,7 +5,7 @@ import { Loader2, Shield, AlertCircle, Truck, ChevronDown, LogIn, Check, Printer
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { KitStats, KitFilters, KitTable, KitDetailModal, CsvImportModal, CoordinatorManager, KitContentsModal } from '../components/shipping';
+import { KitStats, KitFilters, KitTable, KitDetailModal, CsvImportModal, CoordinatorManager, KitContentsModal, ShippingPaymentsSection } from '../components/shipping';
 import { PrintMaterials } from '../components/print';
 import {
   fetchShippingMe,
@@ -457,6 +457,12 @@ export function ShippingDashboard() {
 
           {activeTab === 'kits' && (
             <>
+              {/* salumi-89172: My Payments section — coordinator uploads
+                  reimbursement receipts for shipping costs they paid out of
+                  pocket (postage, packing, supplies). Reuses the host
+                  payouts pipeline via `purpose='shipping'`. */}
+              <ShippingPaymentsSection kits={kits} />
+
               {/* Stats */}
               {stats && (
                 <section className="mb-6">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1536,10 +1536,29 @@ export interface PayoutAuditEntry {
 }
 
 
+/**
+ * salumi-89172: distinguishes event-reimbursement payouts ('event') from
+ * shipping-coordinator receipt payouts ('shipping'). Existing event payouts
+ * default to 'event' on the wire when the column was unset.
+ */
+export type PayoutPurpose = 'event' | 'shipping';
+
 export interface Payout {
   id: string;
   partyId: string;
   hostUserId: string;
+  /**
+   * salumi-89172: 'event' (host reimbursement, the original flow) or
+   * 'shipping' (shipping-coordinator receipt). Defaults to 'event' on
+   * historical rows when the column was unset.
+   */
+  purpose: PayoutPurpose;
+  /**
+   * salumi-89172: optional UUID of the `party_kits` row the receipt is tied
+   * to. NULL for all event-purpose payouts and (later) any general-supplies
+   * shipping receipts. Required for shipping receipts in v1.
+   */
+  partyKitId: string | null;
   // pancetta-37195: submitter name/email so cohosts see "Submitted by X".
   hostName?: string | null;
   hostEmail?: string | null;
@@ -1596,6 +1615,30 @@ export interface ExternalPaymentInput {
    * > $625 is rejected with PER_SUBMISSION_CAP_EXCEEDED.
    */
   allowOverSubmissionCap?: boolean;
+}
+
+/**
+ * salumi-89172: payouts returned by `GET /api/shipping/my-payouts`. Mirrors
+ * the host-side `Payout` shape with embedded `party` + `partyKit` so the
+ * /shipping dashboard can render "Receipt tied to <event> — <kit
+ * recipient>". Re-uses the same documents array so PayoutListRow renders
+ * without changes.
+ */
+export interface ShippingPayout extends Payout {
+  party: {
+    id: string;
+    name: string;
+    customUrl: string | null;
+    inviteCode: string;
+  } | null;
+  partyKit: {
+    id: string;
+    requestedTier: string;
+    allocatedTier: string | null;
+    recipientName: string;
+    city: string;
+    country: string;
+  } | null;
 }
 
 // Admin-list payout: includes embedded party + host info
@@ -1694,6 +1737,12 @@ export interface AdminPayoutFilters {
   /** bruschetta-58291: country filter — exact-match `parties.country`. `'all'` / undefined = no filter. */
   country?: string;
   currency?: string;
+  /**
+   * salumi-89172: Purpose filter — 'event' (host reimbursements) or
+   * 'shipping' (shipping-coordinator receipts) or 'all' / undefined to show
+   * both.
+   */
+  purpose?: PayoutPurpose | 'all';
   dateFrom?: string;
   dateTo?: string;
   cursor?: string;


### PR DESCRIPTION
## Summary
- New `payouts.purpose` ('event'|'shipping', default 'event') + `payouts.party_kit_id` (uuid, FK to party_kits).
- New "My Payments" section on /shipping dashboard for the current coordinator's shipping receipts.
- Reuses existing payout submission flow (OCR, FX, currency override, method picker).
- Kit selection is required for v1 (no untied receipts).
- Admin /payments gets a Purpose filter.

## Test plan
- [ ] Migration applied; existing payouts have purpose='event'.
- [ ] Coordinator submits shipping receipt tied to a kit → succeeds, appears in My Payments.
- [ ] Admin filters /payments by Purpose:Shipping → only shipping rows.
- [ ] Host /host/:slug/payments unchanged (event-purpose only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)