### PR TITLE
feat(pecorino-64118): partner report access + consolidated cross-event report

### DIFF
--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -30,10 +30,16 @@ async function canUserViewReport(partyId: string, userId?: string, userEmail?: s
       const sponsorTags = sponsorUsers.map(s => s.tag);
       const party = await prisma.party.findUnique({
         where: { id: partyId },
-        select: { eventTags: true },
+        select: { eventTags: true, eventType: true },
       });
-      if (party && party.eventTags && Array.isArray(party.eventTags) && (party.eventTags as string[]).some(t => sponsorTags.includes(t))) {
-        return true;
+      if (party) {
+        // pecorino-64118: pizzadao partners can view any GPP event report
+        // (GPP events carry eventType='gpp', not a literal `pizzadao` tag).
+        const isPizzaDao = sponsorTags.includes('pizzadao');
+        const tagged = Array.isArray(party.eventTags) && (party.eventTags as string[]).some(t => sponsorTags.includes(t));
+        if (tagged || (isPizzaDao && party.eventType === 'gpp')) {
+          return true;
+        }
       }
     }
   }
@@ -359,7 +365,12 @@ async function isSponsorForReport(slug: string, userEmail?: string): Promise<boo
   if (sponsorUsers.length === 0) return false;
   const sponsorTags = sponsorUsers.map(s => s.tag);
   const party = await findPartyBySlug(slug);
-  return !!(party?.eventTags && Array.isArray(party.eventTags) && (party.eventTags as string[]).some(t => sponsorTags.includes(t)));
+  if (!party) return false;
+  // pecorino-64118: GPP events are NOT literally tagged `pizzadao` — they carry
+  // eventType='gpp'. A pizzadao partner should be able to view any GPP report.
+  const isPizzaDao = sponsorTags.includes('pizzadao');
+  const tagged = Array.isArray(party.eventTags) && (party.eventTags as string[]).some(t => sponsorTags.includes(t));
+  return tagged || (isPizzaDao && party.eventType === 'gpp');
 }
 
 // GET /api/reports/:publicSlug/check - Check if report requires password (public, optionalAuth)

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -803,6 +803,11 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         name: event.name,
         slug: event.customUrl || event.inviteCode,
         reportPublicSlug: event.reportPublished ? (event.reportPublicSlug || event.customUrl || event.inviteCode) : null,
+        // pecorino-64118: always-resolvable report slug (even for unpublished/draft
+        // reports) so partners can open every event's report from the dashboard.
+        // The partner login bypasses the publish + password gates server-side.
+        reportSlug: event.reportPublicSlug || event.customUrl || event.inviteCode,
+        reportPublished: event.reportPublished,
         date: event.date,
         createdAt: event.createdAt,
         timezone: event.timezone,
@@ -1081,6 +1086,344 @@ sponsorDashboardRouter.get('/events/timeseries', requireAuth, requireSponsorAuth
       bucket: 'hour' as const,
       since: sinceDate.toISOString(),
       points,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/sponsor/report - Consolidated cross-event report (private, full rollup)
+// pecorino-64118: rolls up ALL report data across every event the partner can
+// access into one view. Private (partner login only) — no public slug/password.
+// Same tag-resolution rules as GET /events (pizzadao -> eventType='gpp', admin-all).
+sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (req: SponsorRequest, res: Response, next: NextFunction) => {
+  try {
+    const queryTag = req.query.tag as string | undefined;
+    const tag = req.isAdminViewing
+      ? (queryTag?.trim().toLowerCase() || undefined)
+      : (queryTag?.trim().toLowerCase() || req.sponsorUser?.tag);
+
+    // Build where clause — identical to GET /events
+    const where: any = {};
+    if (tag && tag !== 'pizzadao') {
+      where.eventTags = { has: tag };
+    } else if (tag === 'pizzadao') {
+      where.eventType = 'gpp';
+    } else if (req.isAdminViewing) {
+      where.eventType = 'gpp';
+      where.NOT = { eventTags: { equals: [] } };
+    }
+
+    // Non-admin partners only see approved events.
+    if (!req.isAdminViewing) {
+      where.underbossStatus = 'approved';
+    }
+    // Exclude cancelled events (consistent with GET /events).
+    where.cancelledAt = null;
+
+    // Non-admin with no resolvable tag (shouldn't happen): early-return empty.
+    if (!tag && !req.isAdminViewing) {
+      return res.json({
+        partnerName: req.sponsorUser?.name || null,
+        tag: null,
+        eventCount: 0,
+        dateRange: null,
+        stats: {
+          totalRsvps: 0, approvedGuests: 0, mailingListSignups: 0, walletAddresses: 0,
+          roleBreakdown: {}, poapMints: 0, poapMoments: 0, socialPostViews: 0, socialPostCount: 0,
+        },
+        impressions: { totalViews: 0, uniqueVisitors: 0 },
+        clickStats: { totalClicks: 0, uniqueClickers: 0, byLink: [] },
+        notableAttendees: [],
+        socialPosts: [],
+        featuredPhotos: [],
+        walletAddressList: [],
+        events: [],
+      });
+    }
+
+    // Load all matching parties with report-relevant includes (mirrors report.routes.ts GET).
+    const parties = await prisma.party.findMany({
+      where,
+      include: {
+        socialPosts: { orderBy: { sortOrder: 'asc' } },
+        notableAttendees: {
+          orderBy: { sortOrder: 'asc' },
+          include: { guest: { select: { email: true } } },
+        },
+        photos: {
+          where: { starred: true },
+          orderBy: { starredAt: 'desc' },
+          take: 10,
+        },
+        user: { select: { name: true, profilePictureUrl: true } },
+        guests: {
+          select: {
+            id: true,
+            mailingListOptIn: true,
+            ethereumAddress: true,
+            approved: true,
+            status: true,
+          },
+        },
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    const eventIds = parties.map(p => p.id);
+
+    // Aggregate per-event stats + the rollup.
+    let totalRsvps = 0;
+    let approvedGuests = 0;
+    let mailingListSignups = 0;
+    let walletAddresses = 0;
+    let poapMints = 0;
+    let poapMoments = 0;
+    let socialPostViews = 0;
+    let socialPostCount = 0;
+
+    const walletSet = new Set<string>();
+    const combinedSocialPosts: any[] = [];
+    const combinedNotable: any[] = [];
+    const combinedPhotos: any[] = [];
+
+    // roleBreakdown computed via $queryRaw to avoid loading every guest's roles into Node.
+    const roleBreakdown: Record<string, number> = {};
+    if (eventIds.length > 0) {
+      const roleRows = await prisma.$queryRaw<{ role: string; count: bigint }[]>`
+        SELECT role, COUNT(*)::bigint AS count
+        FROM (
+          SELECT COALESCE(NULLIF(unnest(
+            CASE WHEN array_length(roles, 1) IS NULL OR array_length(roles, 1) = 0
+                 THEN ARRAY[COALESCE(role, 'Other')]
+                 ELSE roles END
+          ), ''), 'Other') AS role
+          FROM guests
+          WHERE party_id::text IN (${Prisma.join(eventIds)})
+            AND status != 'INVITED'
+        ) sub
+        GROUP BY role
+      `;
+      for (const r of roleRows) {
+        roleBreakdown[r.role] = (roleBreakdown[r.role] || 0) + Number(r.count);
+      }
+    }
+
+    // Page-view (impression) aggregation — total + TRUE cross-event distinct visitors.
+    const viewStats = eventIds.length > 0
+      ? await prisma.pageView.groupBy({
+          by: ['partyId'],
+          where: { partyId: { in: eventIds } },
+          _count: true,
+        })
+      : [];
+    const viewCountMap = new Map(viewStats.map(r => [r.partyId, r._count]));
+    let totalViews = 0;
+    for (const v of viewStats) totalViews += v._count;
+
+    let uniqueVisitors = 0;
+    if (eventIds.length > 0) {
+      const uniqRows = await prisma.$queryRaw<{ unique_count: bigint }[]>`
+        SELECT COUNT(DISTINCT visitor_hash) AS unique_count
+        FROM page_views
+        WHERE party_id::text IN (${Prisma.join(eventIds)})
+          AND visitor_hash IS NOT NULL
+      `;
+      uniqueVisitors = Number(uniqRows[0]?.unique_count || 0);
+    }
+
+    // Per-event unique visitors (for the per-event table rows).
+    const perEventUniqueViewMap = new Map<string, number>();
+    if (eventIds.length > 0) {
+      const perEventUniq = await prisma.$queryRaw<{ party_id: string; unique_count: bigint }[]>`
+        SELECT party_id::text, COUNT(DISTINCT visitor_hash) AS unique_count
+        FROM page_views
+        WHERE party_id::text IN (${Prisma.join(eventIds)})
+        GROUP BY party_id
+      `;
+      for (const r of perEventUniq) perEventUniqueViewMap.set(r.party_id, Number(r.unique_count));
+    }
+
+    // Determine partner names to filter link clicks by (same logic as GET /events).
+    let partnerNames: string[] = [];
+    if (!req.isAdminViewing && req.sponsorUser) {
+      const partnerRecord = await prisma.sponsorUser.findUnique({
+        where: { id: req.sponsorUser.id },
+        select: { coHostName: true, name: true, email: true },
+      });
+      const displayName = partnerRecord?.coHostName || partnerRecord?.name || partnerRecord?.email || '';
+      if (displayName) partnerNames = [displayName];
+    } else if (req.isAdminViewing) {
+      const tagPartners = await prisma.sponsorUser.findMany({
+        where: { ...(tag ? { tag } : {}), isActive: true },
+        select: { coHostName: true, name: true, email: true },
+      });
+      partnerNames = tagPartners
+        .map(p => p.coHostName || p.name || p.email)
+        .filter(Boolean) as string[];
+    }
+
+    let labelFilter = Prisma.empty;
+    if (partnerNames.length === 1) {
+      labelFilter = Prisma.sql`AND (link_label = ${partnerNames[0]} OR link_label LIKE ${partnerNames[0] + '_%'})`;
+    } else if (partnerNames.length > 1) {
+      const conditions = partnerNames.map(n =>
+        Prisma.sql`link_label = ${n} OR link_label LIKE ${n + '_%'}`
+      );
+      labelFilter = Prisma.sql`AND (${Prisma.join(conditions, ' OR ')})`;
+    }
+
+    // Link-click aggregation: per-link rollup + per-event totals.
+    const clicksByLink = eventIds.length > 0
+      ? await prisma.$queryRaw<{ party_id: string; url: string; link_type: string; link_label: string | null; total_clicks: bigint; unique_clicks: bigint }[]>`
+        SELECT
+          party_id::text,
+          url,
+          link_type,
+          MAX(link_label) as link_label,
+          COUNT(*) as total_clicks,
+          COUNT(DISTINCT visitor_hash) as unique_clicks
+        FROM link_clicks
+        WHERE party_id::text IN (${Prisma.join(eventIds)})
+        AND link_type IN ('sponsor', 'host_social')
+        ${labelFilter}
+        GROUP BY party_id, url, link_type
+        ORDER BY total_clicks DESC
+      `
+      : [];
+
+    const perEventClickCount = new Map<string, number>();
+    const byLinkAgg = new Map<string, { url: string; linkType: string; linkLabel: string | null; clicks: number; uniqueClickers: number }>();
+    let totalClicks = 0;
+    for (const row of clicksByLink) {
+      perEventClickCount.set(row.party_id, (perEventClickCount.get(row.party_id) || 0) + Number(row.total_clicks));
+      totalClicks += Number(row.total_clicks);
+      // Aggregate per-link across events by url+type.
+      const key = `${row.link_type}::${row.url}`;
+      const existing = byLinkAgg.get(key);
+      if (existing) {
+        existing.clicks += Number(row.total_clicks);
+        existing.uniqueClickers += Number(row.unique_clicks);
+      } else {
+        byLinkAgg.set(key, {
+          url: row.url,
+          linkType: row.link_type,
+          linkLabel: row.link_label,
+          clicks: Number(row.total_clicks),
+          uniqueClickers: Number(row.unique_clicks),
+        });
+      }
+    }
+    const byLink = Array.from(byLinkAgg.values()).sort((a, b) => b.clicks - a.clicks);
+
+    // TRUE cross-event distinct clickers (don't sum per-event uniques).
+    let uniqueClickers = 0;
+    if (eventIds.length > 0) {
+      const labelFilterClause = labelFilter === Prisma.empty ? Prisma.empty : labelFilter;
+      const uniqClickRows = await prisma.$queryRaw<{ unique_count: bigint }[]>`
+        SELECT COUNT(DISTINCT visitor_hash) AS unique_count
+        FROM link_clicks
+        WHERE party_id::text IN (${Prisma.join(eventIds)})
+          AND link_type IN ('sponsor', 'host_social')
+          AND visitor_hash IS NOT NULL
+          ${labelFilterClause}
+      `;
+      uniqueClickers = Number(uniqClickRows[0]?.unique_count || 0);
+    }
+
+    // Per-event rows + scalar rollups from the loaded parties.
+    const events = parties.map(party => {
+      const submitted = party.guests.filter(g => g.status !== 'INVITED');
+      const rsvpCount = submitted.length;
+      const approvedCount = submitted.filter(g => g.approved !== false).length;
+      totalRsvps += rsvpCount;
+      approvedGuests += approvedCount;
+      mailingListSignups += submitted.filter(g => g.mailingListOptIn).length;
+
+      for (const g of submitted) {
+        if (g.ethereumAddress) {
+          walletAddresses += 1;
+          walletSet.add(g.ethereumAddress);
+        }
+      }
+
+      poapMints += party.poapMints || 0;
+      poapMoments += party.poapMoments || 0;
+
+      socialPostCount += party.socialPosts.length;
+      for (const sp of party.socialPosts) {
+        socialPostViews += sp.views || 0;
+        combinedSocialPosts.push({ ...sp, eventName: party.name });
+      }
+
+      // Notable attendees — mask email to @domain (mirrors published public report).
+      for (const a of party.notableAttendees) {
+        const { guest, ...attendee } = a as any;
+        const fullEmail = guest?.email as string | undefined;
+        const domain = fullEmail?.split('@')[1] || null;
+        combinedNotable.push({
+          ...attendee,
+          email: domain ? `@${domain}` : null,
+          eventName: party.name,
+        });
+      }
+
+      for (const ph of party.photos) {
+        combinedPhotos.push(ph);
+      }
+
+      const reportSlug = party.reportPublicSlug || party.customUrl || party.inviteCode;
+      return {
+        id: party.id,
+        name: party.name,
+        date: party.date,
+        slug: party.customUrl || party.inviteCode,
+        reportSlug,
+        rsvpCount,
+        approvedCount,
+        impressions: {
+          totalViews: viewCountMap.get(party.id) || 0,
+          uniqueVisitors: perEventUniqueViewMap.get(party.id) || 0,
+        },
+        clicks: perEventClickCount.get(party.id) || 0,
+      };
+    });
+
+    // Cap combined starred photos at 60 total.
+    const featuredPhotos = combinedPhotos.slice(0, 60);
+
+    // Deduped wallet address list.
+    const walletAddressList = Array.from(walletSet);
+
+    // Date range.
+    const dates = parties.map(p => p.date).filter((d): d is Date => !!d).map(d => new Date(d).getTime());
+    const dateRange = dates.length > 0
+      ? { start: new Date(Math.min(...dates)).toISOString(), end: new Date(Math.max(...dates)).toISOString() }
+      : null;
+
+    res.json({
+      partnerName: req.sponsorUser?.name || (req.isAdminViewing ? (tag || 'All Partners') : null),
+      tag: tag || null,
+      eventCount: parties.length,
+      dateRange,
+      stats: {
+        totalRsvps,
+        approvedGuests,
+        mailingListSignups,
+        walletAddresses,
+        roleBreakdown,
+        poapMints,
+        poapMoments,
+        socialPostViews,
+        socialPostCount,
+      },
+      impressions: { totalViews, uniqueVisitors },
+      clickStats: { totalClicks, uniqueClickers, byLink },
+      notableAttendees: combinedNotable,
+      socialPosts: combinedSocialPosts,
+      featuredPhotos,
+      walletAddressList,
+      events,
     });
   } catch (error) {
     next(error);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { AdminPage } from './pages/AdminPage';
 import { PaymentsAdminPage } from './pages/PaymentsAdminPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
+import { ConsolidatedReportPage } from './pages/ConsolidatedReportPage';
 import { PostComposerPage } from './pages/PostComposerPage';
 import { OneSheetPage } from './pages/OneSheetPage';
 import { GPPPizzeriasPage } from './pages/GPPPizzeriasPage';
@@ -96,6 +97,7 @@ function App() {
             <Route path="/admin" element={<AdminPage />} />
             <Route path="/admin/logo-cleanup" element={<AdminLogoCleanup />} />
             <Route path="/partner" element={<PartnerDashboardPage />} />
+            <Route path="/partner/report" element={<ConsolidatedReportPage />} />
             <Route path="/partner-dashboard" element={<Navigate to="/partner" replace />} />
             <Route path="/sponsor-dashboard" element={<Navigate to="/partner" replace />} />
             <Route path="/partner-intake/:token" element={<PartnerIntakePage />} />

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -1,0 +1,287 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Calendar, Users, Mail, Wallet, Award, Video, Eye, MousePointerClick,
+  FileText, Download, X, ChevronLeft, ChevronRight, ExternalLink,
+} from 'lucide-react';
+import { ConsolidatedReport, Photo } from '../../types';
+import { ReportRoleChart } from './ReportRoleChart';
+import { SocialPostsList } from './SocialPostsList';
+import { KPICard, groupAttendeesByOrg, ReportOrgCard } from './reportShared';
+
+interface ConsolidatedReportPreviewProps {
+  report: ConsolidatedReport;
+}
+
+// pecorino-64118: cross-event consolidated report. Mirrors ReportPreview's layout
+// (KPI cards, industry RSVPs, role chart, social posts) but with a consolidated
+// header (no per-event image hero) and a per-event breakdown table.
+export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewProps) {
+  const { t } = useTranslation('host');
+  const { t: tp } = useTranslation('partner');
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const headerTitle = report.partnerName
+    ? tp('consolidated.title', { name: report.partnerName })
+    : tp('consolidated.titleGeneric');
+
+  const downloadWallets = report.walletAddressList && report.walletAddressList.length > 0 ? () => {
+    const csv = 'wallet_address\n' + report.walletAddressList.join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const namePart = (report.partnerName || report.tag || 'partner').replace(/[^a-zA-Z0-9]/g, '_');
+    a.href = url;
+    a.download = `${namePart}_all_events_wallet_addresses.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  } : undefined;
+
+  const statsDefs: { key: string; label: string; value: number | null | undefined; icon: React.ElementType; color: string; onAction?: () => void; actionIcon?: React.ElementType }[] = [
+    { key: 'pageViews', label: t('report.pageViews'), value: report.impressions.totalViews || null, icon: MousePointerClick, color: 'text-[#ff393a]' },
+    { key: 'uniqueVisitors', label: t('report.uniqueVisitors'), value: report.impressions.uniqueVisitors || null, icon: Eye, color: 'text-[#ff393a]' },
+    { key: 'linkClicks', label: t('report.linkClicks'), value: report.clickStats.totalClicks || null, icon: MousePointerClick, color: 'text-purple-400' },
+    { key: 'socialPostViews', label: t('report.socialPostViews'), value: report.stats.socialPostViews || null, icon: Eye, color: 'text-blue-400' },
+    { key: 'socialPosts', label: t('report.socialPosts'), value: report.stats.socialPostCount || null, icon: FileText, color: 'text-blue-400' },
+    { key: 'totalRsvps', label: t('report.totalRsvps'), value: report.stats.totalRsvps || null, icon: Users, color: 'text-green-400' },
+    { key: 'attendees', label: t('report.attendees'), value: report.stats.approvedGuests || null, icon: Users, color: 'text-emerald-400' },
+    { key: 'newsletterSignups', label: t('report.newsletterSignups'), value: report.stats.mailingListSignups || null, icon: Mail, color: 'text-orange-400' },
+    { key: 'walletAddresses', label: t('report.walletAddresses'), value: report.stats.walletAddresses || null, icon: Wallet, color: 'text-cyan-400', onAction: downloadWallets, actionIcon: Download },
+    { key: 'poapMints', label: t('report.poapMints'), value: report.stats.poapMints || null, icon: Award, color: 'text-yellow-400' },
+    { key: 'poapMoments', label: t('report.poapMoments'), value: report.stats.poapMoments || null, icon: Video, color: 'text-yellow-400' },
+  ];
+
+  const visibleStats = statsDefs.filter(s => s.value != null);
+  const hasKPIs = visibleStats.length > 0;
+
+  const formatDate = (iso: string | null) => iso
+    ? new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    : '—';
+
+  return (
+    <div className="space-y-6">
+      {/* Consolidated header */}
+      <div className="card p-6">
+        <h1 className="text-2xl font-bold text-theme-text mb-2">{headerTitle}</h1>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-theme-text-secondary text-sm">
+          <span className="inline-flex items-center gap-2">
+            <Calendar size={16} />
+            {tp('consolidated.eventCount', { count: report.eventCount })}
+          </span>
+          {report.dateRange && (
+            <span>
+              {formatDate(report.dateRange.start)} – {formatDate(report.dateRange.end)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Stats */}
+      {hasKPIs && (
+        <div className="card p-6">
+          <h2 className="text-lg font-semibold text-theme-text mb-4">{t('report.stats')}</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {visibleStats.map((stat) => (
+              <KPICard
+                key={stat.key}
+                label={stat.label}
+                value={stat.value!}
+                icon={stat.icon}
+                color={stat.color}
+                onAction={stat.onAction}
+                actionIcon={stat.actionIcon}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Per-event breakdown table */}
+      {report.events.length > 0 && (
+        <div className="card p-6">
+          <h2 className="text-lg font-semibold text-theme-text mb-4">{tp('consolidated.perEventBreakdown')}</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-theme-text-muted border-b border-theme-stroke">
+                  <th className="py-2 pr-4 font-medium">{tp('consolidated.table.event')}</th>
+                  <th className="py-2 pr-4 font-medium">{tp('consolidated.table.date')}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{tp('consolidated.table.rsvps')}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{tp('consolidated.table.attendees')}</th>
+                  <th className="py-2 pr-4 font-medium text-right">{tp('consolidated.table.impressions')}</th>
+                  <th className="py-2 font-medium text-right">{tp('consolidated.table.clicks')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.events.map((ev) => (
+                  <tr key={ev.id} className="border-b border-theme-stroke/50 hover:bg-theme-surface-hover/40 transition-colors">
+                    <td className="py-2 pr-4">
+                      <a
+                        href={`/report/${ev.reportSlug}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-theme-text hover:text-theme-text-secondary transition-colors"
+                      >
+                        {ev.name}
+                        <ExternalLink size={12} className="text-theme-text-muted flex-shrink-0" />
+                      </a>
+                    </td>
+                    <td className="py-2 pr-4 text-theme-text-secondary whitespace-nowrap">{formatDate(ev.date)}</td>
+                    <td className="py-2 pr-4 text-right text-theme-text">{ev.rsvpCount.toLocaleString()}</td>
+                    <td className="py-2 pr-4 text-right text-theme-text">{ev.approvedCount.toLocaleString()}</td>
+                    <td className="py-2 pr-4 text-right text-theme-text">{ev.impressions.totalViews.toLocaleString()}</td>
+                    <td className="py-2 text-right text-theme-text">{ev.clicks.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Media — combined starred photos */}
+      {report.featuredPhotos.length > 0 && (
+        <div className="card p-6">
+          <h2 className="text-lg font-semibold text-theme-text mb-4">{t('report.media')}</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+            {report.featuredPhotos.map((photo, i) => (
+              <button
+                key={photo.id}
+                onClick={() => setLightboxIndex(i)}
+                className="w-full aspect-square overflow-hidden rounded-lg cursor-pointer hover:opacity-80 transition-opacity"
+              >
+                <img
+                  src={photo.thumbnailUrl || photo.url}
+                  alt={photo.caption || 'Event photo'}
+                  className="w-full h-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Photo Lightbox */}
+      {lightboxIndex !== null && report.featuredPhotos.length > 0 && (
+        <PhotoLightbox
+          photos={report.featuredPhotos}
+          index={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+          onNavigate={setLightboxIndex}
+        />
+      )}
+
+      {/* Industry RSVPs (combined notable attendees) */}
+      {report.notableAttendees.length > 0 && (
+        <div className="card p-6">
+          <h2 className="text-lg font-semibold text-theme-text mb-3">{t('report.industryRsvps')}</h2>
+          <div className="flex flex-wrap gap-2">
+            {groupAttendeesByOrg(report.notableAttendees).map((group) => (
+              <ReportOrgCard key={group.domain || '_independent'} group={group} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Role Breakdown */}
+      {Object.keys(report.stats.roleBreakdown).length > 0 && (
+        <div className="card p-6">
+          <ReportRoleChart roleBreakdown={report.stats.roleBreakdown} totalRsvps={report.stats.totalRsvps} />
+        </div>
+      )}
+
+      {/* Social Posts (combined) */}
+      {report.socialPosts.length > 0 && (
+        <div className="card p-6">
+          <SocialPostsList
+            posts={report.socialPosts}
+            onAdd={async () => {}}
+            onDelete={async () => {}}
+            editable={false}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PhotoLightbox({
+  photos,
+  index,
+  onClose,
+  onNavigate,
+}: {
+  photos: Photo[];
+  index: number;
+  onClose: () => void;
+  onNavigate: (index: number) => void;
+}) {
+  const photo = photos[index];
+  const hasPrev = index > 0;
+  const hasNext = index < photos.length - 1;
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+    else if (e.key === 'ArrowLeft' && hasPrev) onNavigate(index - 1);
+    else if (e.key === 'ArrowRight' && hasNext) onNavigate(index + 1);
+  }, [index, hasPrev, hasNext, onClose, onNavigate]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-black/95 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 p-2 text-theme-text-secondary hover:text-theme-text transition-colors z-10"
+      >
+        <X size={24} />
+      </button>
+
+      {photos.length > 1 && (
+        <div className="absolute top-4 left-4 text-sm text-theme-text-muted z-10">
+          {index + 1} / {photos.length}
+        </div>
+      )}
+
+      {hasPrev && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onNavigate(index - 1); }}
+          className="absolute left-4 top-1/2 -translate-y-1/2 p-2 text-theme-text-muted hover:text-theme-text transition-colors z-10"
+        >
+          <ChevronLeft size={32} />
+        </button>
+      )}
+
+      <img
+        src={photo.url}
+        alt={photo.caption || 'Event photo'}
+        className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+        onClick={(e) => e.stopPropagation()}
+      />
+
+      {photo.caption && (
+        <div
+          className="absolute bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 bg-black/70 rounded-lg text-sm text-theme-text max-w-lg text-center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {photo.caption}
+        </div>
+      )}
+
+      {hasNext && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onNavigate(index + 1); }}
+          className="absolute right-4 top-1/2 -translate-y-1/2 p-2 text-theme-text-muted hover:text-theme-text transition-colors z-10"
+        >
+          <ChevronRight size={32} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/report/ReportPreview.tsx
+++ b/frontend/src/components/report/ReportPreview.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Calendar, MapPin, Users, Mail, Wallet, Award, Video, Eye, ExternalLink, X, MousePointerClick, FileText, Download, Building2, ChevronLeft, ChevronRight } from 'lucide-react';
-import { EventReport, PageViewStats, NotableAttendee, Photo } from '../../types';
+import { Calendar, MapPin, Users, Mail, Wallet, Award, Video, Eye, ExternalLink, X, MousePointerClick, FileText, Download, ChevronLeft, ChevronRight } from 'lucide-react';
+import { EventReport, PageViewStats, Photo } from '../../types';
 import { ReportRoleChart } from './ReportRoleChart';
 import { SocialPostsList } from './SocialPostsList';
-import { extractEmailDomain, getDomainFaviconUrl } from '../../utils/emailUtils';
+import { KPICard, groupAttendeesByOrg, ReportOrgCard } from './reportShared';
 
 interface ReportPreviewProps {
   report: EventReport;
@@ -254,108 +254,6 @@ export function ReportPreview({ report, onClose, pageViewStats }: ReportPreviewP
   );
 }
 
-// Helper components
-interface KPICardProps {
-  label: string;
-  value: number;
-  icon: React.ElementType;
-  color: string;
-  url?: string | null;
-  onAction?: () => void;
-  actionIcon?: React.ElementType;
-}
-
-function KPICard({ label, value, icon: Icon, color, url, onAction, actionIcon: ActionIcon }: KPICardProps) {
-  const content = (
-    <div className="bg-theme-surface rounded-xl p-4 border border-theme-stroke">
-      <div className="flex items-center gap-2 mb-2">
-        <Icon size={16} className={color} />
-        <span className="text-xs text-theme-text-secondary flex-1">{label}</span>
-        {onAction && ActionIcon && (
-          <button
-            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onAction(); }}
-            className="p-1 rounded hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            title={`Download ${label}`}
-          >
-            <ActionIcon size={14} />
-          </button>
-        )}
-      </div>
-      <div className="text-2xl font-bold text-theme-text">
-        {value.toLocaleString()}
-      </div>
-      {url && (
-        <span className="text-xs text-theme-text-muted hover:text-theme-text-secondary underline mt-1 block truncate">
-          {t('report.viewPost')}
-        </span>
-      )}
-    </div>
-  );
-
-  if (url) {
-    return (
-      <a href={url} target="_blank" rel="noopener noreferrer">
-        {content}
-      </a>
-    );
-  }
-
-  return content;
-}
-
-// Group attendees by org domain
-function groupAttendeesByOrg(attendees: NotableAttendee[]) {
-  const map = new Map<string, NotableAttendee[]>();
-  const independent: NotableAttendee[] = [];
-
-  for (const a of attendees) {
-    const domain = a.email ? extractEmailDomain(a.email, true) : null;
-    if (domain) {
-      const list = map.get(domain) || [];
-      list.push(a);
-      map.set(domain, list);
-    } else {
-      independent.push(a);
-    }
-  }
-
-  const groups = [...map.entries()]
-    .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
-    .map(([domain, members]) => ({ domain, attendees: members }));
-
-  if (independent.length > 0) {
-    groups.push({ domain: null as string | null, attendees: independent });
-  }
-
-  return groups;
-}
-
-function ReportOrgFavicon({ domain, size = 20 }: { domain: string; size?: number }) {
-  const [failed, setFailed] = useState(false);
-
-  if (failed) {
-    return (
-      <div
-        className="rounded bg-theme-surface-hover flex items-center justify-center flex-shrink-0"
-        style={{ width: size, height: size }}
-      >
-        <span className="text-[10px] font-bold text-theme-text-secondary uppercase">{domain.charAt(0)}</span>
-      </div>
-    );
-  }
-
-  return (
-    <img
-      src={getDomainFaviconUrl(domain, size * 2)}
-      alt={domain}
-      width={size}
-      height={size}
-      className="rounded flex-shrink-0"
-      onError={() => setFailed(true)}
-    />
-  );
-}
-
 function PhotoLightbox({
   photos,
   index,
@@ -438,38 +336,6 @@ function PhotoLightbox({
         >
           <ChevronRight size={32} />
         </button>
-      )}
-    </div>
-  );
-}
-
-function ReportOrgCard({ group }: { group: { domain: string | null; attendees: NotableAttendee[] } }) {
-  const { domain, attendees } = group;
-
-  return (
-    <div className="inline-flex items-center gap-2 bg-theme-surface rounded-lg px-3 py-2 border border-theme-stroke">
-      {domain ? (
-        <>
-          <ReportOrgFavicon domain={domain} size={16} />
-          <a
-            href={`https://${domain}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
-          >
-            {domain}
-          </a>
-          {attendees.length > 1 && (
-            <span className="text-xs text-theme-text-muted">({attendees.length})</span>
-          )}
-        </>
-      ) : (
-        <>
-          <Building2 size={14} className="text-theme-text-muted" />
-          {attendees.map((a) => (
-            <span key={a.id} className="text-sm text-theme-text-secondary">{a.name}</span>
-          ))}
-        </>
       )}
     </div>
   );

--- a/frontend/src/components/report/reportShared.tsx
+++ b/frontend/src/components/report/reportShared.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Building2 } from 'lucide-react';
+import { NotableAttendee } from '../../types';
+import { extractEmailDomain, getDomainFaviconUrl } from '../../utils/emailUtils';
+
+// pecorino-64118: shared report building blocks, extracted from ReportPreview so
+// both ReportPreview and ConsolidatedReportPreview render identical KPI cards,
+// org favicons, and the org-grouped notable-attendee chips.
+
+export interface KPICardProps {
+  label: string;
+  value: number;
+  icon: React.ElementType;
+  color: string;
+  url?: string | null;
+  onAction?: () => void;
+  actionIcon?: React.ElementType;
+}
+
+export function KPICard({ label, value, icon: Icon, color, url, onAction, actionIcon: ActionIcon }: KPICardProps) {
+  const { t } = useTranslation('host');
+  const content = (
+    <div className="bg-theme-surface rounded-xl p-4 border border-theme-stroke">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon size={16} className={color} />
+        <span className="text-xs text-theme-text-secondary flex-1">{label}</span>
+        {onAction && ActionIcon && (
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onAction(); }}
+            className="p-1 rounded hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
+            title={`Download ${label}`}
+          >
+            <ActionIcon size={14} />
+          </button>
+        )}
+      </div>
+      <div className="text-2xl font-bold text-theme-text">
+        {value.toLocaleString()}
+      </div>
+      {url && (
+        <span className="text-xs text-theme-text-muted hover:text-theme-text-secondary underline mt-1 block truncate">
+          {t('report.viewPost')}
+        </span>
+      )}
+    </div>
+  );
+
+  if (url) {
+    return (
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+}
+
+// Group attendees by org domain
+export function groupAttendeesByOrg(attendees: NotableAttendee[]) {
+  const map = new Map<string, NotableAttendee[]>();
+  const independent: NotableAttendee[] = [];
+
+  for (const a of attendees) {
+    const domain = a.email ? extractEmailDomain(a.email, true) : null;
+    if (domain) {
+      const list = map.get(domain) || [];
+      list.push(a);
+      map.set(domain, list);
+    } else {
+      independent.push(a);
+    }
+  }
+
+  const groups: { domain: string | null; attendees: NotableAttendee[] }[] = [...map.entries()]
+    .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+    .map(([domain, members]) => ({ domain, attendees: members }));
+
+  if (independent.length > 0) {
+    groups.push({ domain: null, attendees: independent });
+  }
+
+  return groups;
+}
+
+export function ReportOrgFavicon({ domain, size = 20 }: { domain: string; size?: number }) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div
+        className="rounded bg-theme-surface-hover flex items-center justify-center flex-shrink-0"
+        style={{ width: size, height: size }}
+      >
+        <span className="text-[10px] font-bold text-theme-text-secondary uppercase">{domain.charAt(0)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={getDomainFaviconUrl(domain, size * 2)}
+      alt={domain}
+      width={size}
+      height={size}
+      className="rounded flex-shrink-0"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+export function ReportOrgCard({ group }: { group: { domain: string | null; attendees: NotableAttendee[] } }) {
+  const { domain, attendees } = group;
+
+  return (
+    <div className="inline-flex items-center gap-2 bg-theme-surface rounded-lg px-3 py-2 border border-theme-stroke">
+      {domain ? (
+        <>
+          <ReportOrgFavicon domain={domain} size={16} />
+          <a
+            href={`https://${domain}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
+          >
+            {domain}
+          </a>
+          {attendees.length > 1 && (
+            <span className="text-xs text-theme-text-muted">({attendees.length})</span>
+          )}
+        </>
+      ) : (
+        <>
+          <Building2 size={14} className="text-theme-text-muted" />
+          {attendees.map((a) => (
+            <span key={a.id} className="text-sm text-theme-text-secondary">{a.name}</span>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "Eventseite ansehen",
     "joinTelegram": "Stadt-Telegram-Gruppe beitreten",
     "viewEventReport": "Event-Bericht ansehen",
+    "viewReportDraft": "Berichtsentwurf ansehen (noch nicht veröffentlicht)",
+    "draft": "Entwurf",
+    "consolidatedReport": "Gesamtbericht",
     "reportNotPublished": "Bericht noch nicht veröffentlicht",
     "copyOneSheetLink": "One-Sheet-Link kopieren",
     "copied": "Kopiert!",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "Gesamtbericht",
+    "title": "{{name}} — Alle Events",
+    "titleGeneric": "Gesamtbericht — Alle Events",
+    "eventCount": "{{count}} Event",
+    "eventCount_other": "{{count}} Events",
+    "perEventBreakdown": "Aufschlüsselung pro Event",
+    "backToDashboard": "Zurück zum Dashboard",
+    "notAvailableTitle": "Bericht noch nicht verfügbar",
+    "notAvailableDesc": "Der Gesamtbericht ist noch nicht verfügbar. Bitte schauen Sie bald wieder vorbei.",
+    "table": {
+      "event": "Event",
+      "date": "Datum",
+      "rsvps": "RSVPs",
+      "attendees": "Teilnehmer",
+      "impressions": "Impressionen",
+      "clicks": "Klicks"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "View event page",
     "joinTelegram": "Join city Telegram group",
     "viewEventReport": "View event report",
+    "viewReportDraft": "View draft report (not yet published)",
+    "draft": "Draft",
+    "consolidatedReport": "Consolidated report",
     "reportNotPublished": "Report not published yet",
     "copyOneSheetLink": "Copy One Sheet link",
     "copied": "Copied!",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "Consolidated Report",
+    "title": "{{name}} — All Events",
+    "titleGeneric": "Consolidated Report — All Events",
+    "eventCount": "{{count}} event",
+    "eventCount_other": "{{count}} events",
+    "perEventBreakdown": "Per-Event Breakdown",
+    "backToDashboard": "Back to dashboard",
+    "notAvailableTitle": "Report not available yet",
+    "notAvailableDesc": "The consolidated report is not available yet. Please check back soon.",
+    "table": {
+      "event": "Event",
+      "date": "Date",
+      "rsvps": "RSVPs",
+      "attendees": "Attendees",
+      "impressions": "Impressions",
+      "clicks": "Clicks"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "Ver página del evento",
     "joinTelegram": "Unirse al grupo de Telegram de la ciudad",
     "viewEventReport": "Ver reporte del evento",
+    "viewReportDraft": "Ver borrador del reporte (aún no publicado)",
+    "draft": "Borrador",
+    "consolidatedReport": "Reporte consolidado",
     "reportNotPublished": "Reporte aún no publicado",
     "copyOneSheetLink": "Copiar enlace de One Sheet",
     "copied": "¡Copiado!",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "Reporte consolidado",
+    "title": "{{name}} — Todos los eventos",
+    "titleGeneric": "Reporte consolidado — Todos los eventos",
+    "eventCount": "{{count}} evento",
+    "eventCount_other": "{{count}} eventos",
+    "perEventBreakdown": "Desglose por evento",
+    "backToDashboard": "Volver al panel",
+    "notAvailableTitle": "Reporte aún no disponible",
+    "notAvailableDesc": "El reporte consolidado aún no está disponible. Vuelve a consultar pronto.",
+    "table": {
+      "event": "Evento",
+      "date": "Fecha",
+      "rsvps": "RSVPs",
+      "attendees": "Asistentes",
+      "impressions": "Impresiones",
+      "clicks": "Clics"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "Voir la page de l'événement",
     "joinTelegram": "Rejoindre le groupe Telegram de la ville",
     "viewEventReport": "Voir le rapport de l'événement",
+    "viewReportDraft": "Voir le brouillon du rapport (pas encore publié)",
+    "draft": "Brouillon",
+    "consolidatedReport": "Rapport consolidé",
     "reportNotPublished": "Rapport pas encore publié",
     "copyOneSheetLink": "Copier le lien du One Sheet",
     "copied": "Copié !",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "Rapport consolidé",
+    "title": "{{name}} — Tous les événements",
+    "titleGeneric": "Rapport consolidé — Tous les événements",
+    "eventCount": "{{count}} événement",
+    "eventCount_other": "{{count}} événements",
+    "perEventBreakdown": "Détail par événement",
+    "backToDashboard": "Retour au tableau de bord",
+    "notAvailableTitle": "Rapport pas encore disponible",
+    "notAvailableDesc": "Le rapport consolidé n'est pas encore disponible. Veuillez revenir bientôt.",
+    "table": {
+      "event": "Événement",
+      "date": "Date",
+      "rsvps": "RSVPs",
+      "attendees": "Participants",
+      "impressions": "Impressions",
+      "clicks": "Clics"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "イベントページを表示",
     "joinTelegram": "都市のTelegramグループに参加",
     "viewEventReport": "イベントレポートを表示",
+    "viewReportDraft": "下書きレポートを表示（未公開）",
+    "draft": "下書き",
+    "consolidatedReport": "統合レポート",
     "reportNotPublished": "レポートはまだ公開されていません",
     "copyOneSheetLink": "ワンシートリンクをコピー",
     "copied": "コピーしました！",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "統合レポート",
+    "title": "{{name}} — すべてのイベント",
+    "titleGeneric": "統合レポート — すべてのイベント",
+    "eventCount": "{{count}}件のイベント",
+    "eventCount_other": "{{count}}件のイベント",
+    "perEventBreakdown": "イベント別内訳",
+    "backToDashboard": "ダッシュボードに戻る",
+    "notAvailableTitle": "レポートはまだ利用できません",
+    "notAvailableDesc": "統合レポートはまだ利用できません。しばらくしてからもう一度ご確認ください。",
+    "table": {
+      "event": "イベント",
+      "date": "日付",
+      "rsvps": "RSVP",
+      "attendees": "参加者",
+      "impressions": "インプレッション",
+      "clicks": "クリック"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "이벤트 페이지 보기",
     "joinTelegram": "도시 텔레그램 그룹 참여",
     "viewEventReport": "이벤트 리포트 보기",
+    "viewReportDraft": "초안 리포트 보기 (아직 게시되지 않음)",
+    "draft": "초안",
+    "consolidatedReport": "통합 리포트",
     "reportNotPublished": "리포트가 아직 게시되지 않았습니다",
     "copyOneSheetLink": "원시트 링크 복사",
     "copied": "복사됨!",
@@ -233,6 +236,25 @@
       "europe": "유럽",
       "uk": "영국",
       "brazil": "브라질"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "통합 리포트",
+    "title": "{{name}} — 모든 이벤트",
+    "titleGeneric": "통합 리포트 — 모든 이벤트",
+    "eventCount": "이벤트 {{count}}개",
+    "eventCount_other": "이벤트 {{count}}개",
+    "perEventBreakdown": "이벤트별 분석",
+    "backToDashboard": "대시보드로 돌아가기",
+    "notAvailableTitle": "리포트를 아직 사용할 수 없습니다",
+    "notAvailableDesc": "통합 리포트를 아직 사용할 수 없습니다. 잠시 후 다시 확인해 주세요.",
+    "table": {
+      "event": "이벤트",
+      "date": "날짜",
+      "rsvps": "RSVP",
+      "attendees": "참석자",
+      "impressions": "노출수",
+      "clicks": "클릭수"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "Ver página do evento",
     "joinTelegram": "Entrar no grupo de Telegram da cidade",
     "viewEventReport": "Ver relatório do evento",
+    "viewReportDraft": "Ver rascunho do relatório (ainda não publicado)",
+    "draft": "Rascunho",
+    "consolidatedReport": "Relatório consolidado",
     "reportNotPublished": "Relatório ainda não publicado",
     "copyOneSheetLink": "Copiar link do One Sheet",
     "copied": "Copiado!",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "Relatório consolidado",
+    "title": "{{name}} — Todos os eventos",
+    "titleGeneric": "Relatório consolidado — Todos os eventos",
+    "eventCount": "{{count}} evento",
+    "eventCount_other": "{{count}} eventos",
+    "perEventBreakdown": "Detalhamento por evento",
+    "backToDashboard": "Voltar ao painel",
+    "notAvailableTitle": "Relatório ainda não disponível",
+    "notAvailableDesc": "O relatório consolidado ainda não está disponível. Volte em breve.",
+    "table": {
+      "event": "Evento",
+      "date": "Data",
+      "rsvps": "RSVPs",
+      "attendees": "Participantes",
+      "impressions": "Impressões",
+      "clicks": "Cliques"
     }
   },
   "cities": {

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -212,6 +212,9 @@
     "viewEventPage": "查看活动页面",
     "joinTelegram": "加入城市Telegram群组",
     "viewEventReport": "查看活动报告",
+    "viewReportDraft": "查看报告草稿（尚未发布）",
+    "draft": "草稿",
+    "consolidatedReport": "汇总报告",
     "reportNotPublished": "报告尚未发布",
     "copyOneSheetLink": "复制单页链接",
     "copied": "已复制！",
@@ -233,6 +236,25 @@
       "europe": "Europe",
       "uk": "UK",
       "brazil": "Brazil"
+    }
+  },
+  "consolidated": {
+    "pageTitle": "汇总报告",
+    "title": "{{name}} — 所有活动",
+    "titleGeneric": "汇总报告 — 所有活动",
+    "eventCount": "{{count}} 个活动",
+    "eventCount_other": "{{count}} 个活动",
+    "perEventBreakdown": "各活动明细",
+    "backToDashboard": "返回仪表板",
+    "notAvailableTitle": "报告尚不可用",
+    "notAvailableDesc": "汇总报告尚不可用，请稍后再查看。",
+    "table": {
+      "event": "活动",
+      "date": "日期",
+      "rsvps": "RSVP",
+      "attendees": "参加者",
+      "impressions": "曝光量",
+      "clicks": "点击量"
     }
   },
   "cities": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -3296,6 +3296,12 @@ export async function fetchSponsorMe(): Promise<SponsorMeResponse> {
 export async function fetchSponsorEvents(tag?: string): Promise<SponsorDashboardData> {
   const params = tag ? `?tag=${encodeURIComponent(tag)}` : '';
   return apiRequest<SponsorDashboardData>(`/api/sponsor/events${params}`);
+}
+
+// pecorino-64118: consolidated cross-event partner report (private, full rollup).
+export async function fetchSponsorConsolidatedReport(tag?: string): Promise<ConsolidatedReport> {
+  const params = tag ? `?tag=${encodeURIComponent(tag)}` : '';
+  return apiRequest<ConsolidatedReport>(`/api/sponsor/report${params}`);
 }
 
 // Admin-only time-series for partner dashboard chart

--- a/frontend/src/pages/ConsolidatedReportPage.tsx
+++ b/frontend/src/pages/ConsolidatedReportPage.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
+import { useSearchParams, Link } from 'react-router-dom';
+import { Loader2, Shield, FileText, ArrowLeft } from 'lucide-react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+import { LoginModal } from '../components/LoginModal';
+import { useAuth } from '../contexts/AuthContext';
+import { fetchSponsorMe, fetchSponsorConsolidatedReport } from '../lib/api';
+import { ConsolidatedReportPreview } from '../components/report/ConsolidatedReportPreview';
+import type { SponsorMeResponse, ConsolidatedReport } from '../types';
+
+const themeClass = 'gpp-theme';
+const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)' } as React.CSSProperties;
+
+// pecorino-64118: private consolidated cross-event report at /partner/report.
+// Partner-login-only — no public slug/password. Rolls up everything the partner
+// can access into one view.
+export function ConsolidatedReportPage() {
+  const { t } = useTranslation('partner');
+  const { user, loading: authLoading } = useAuth();
+  const [searchParams] = useSearchParams();
+  const tagParam = searchParams.get('tag') || undefined;
+
+  // Set body class for elements outside React tree
+  useEffect(() => {
+    document.body.classList.add('gpp-theme-active');
+    return () => { document.body.classList.remove('gpp-theme-active'); };
+  }, []);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notAvailable, setNotAvailable] = useState(false);
+  const [meData, setMeData] = useState<SponsorMeResponse | null>(null);
+  const [report, setReport] = useState<ConsolidatedReport | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    async function load() {
+      try {
+        const me = await fetchSponsorMe();
+        setMeData(me);
+
+        if (!me.isSponsor) {
+          setLoading(false);
+          return;
+        }
+
+        // Resolve tag: explicit ?tag= wins; else for a single-tag partner use their tag.
+        const resolvedTag = tagParam
+          || (!me.isAdmin && me.sponsor?.tag)
+          || undefined;
+
+        try {
+          const data = await fetchSponsorConsolidatedReport(resolvedTag);
+          setReport(data);
+        } catch (err: any) {
+          // Backend not deployed yet (preview talks to prod backend) → friendly state.
+          const msg = String(err?.message || '');
+          if (msg.includes('404') || msg.toLowerCase().includes('not found')) {
+            setNotAvailable(true);
+          } else {
+            throw err;
+          }
+        }
+      } catch (err: any) {
+        setError(err.message || 'Failed to load consolidated report');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+  }, [user, authLoading, tagParam]);
+
+  // Loading state
+  if (authLoading || loading) {
+    return (
+      <div className={`min-h-screen ${themeClass}`} style={backgroundStyle}>
+        <Header />
+        <div className="flex items-center justify-center py-32">
+          <Loader2 size={32} className="animate-spin text-theme-text-muted" />
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  // Not logged in
+  if (!user) {
+    return (
+      <div className={`min-h-screen ${themeClass}`} style={backgroundStyle}>
+        <Header />
+        <div className="flex flex-col items-center justify-center px-4 py-32">
+          <Shield size={48} className="text-theme-text-faint mb-4" />
+          <h1 className="text-2xl font-bold text-theme-text mb-2">{t('consolidated.title', { name: '' }).trim() || t('title')}</h1>
+          <p className="text-theme-text-muted text-center max-w-md mb-6">{t('loginPrompt')}</p>
+          <button
+            onClick={() => setShowLoginModal(true)}
+            className="px-6 py-2 bg-[#E52828] text-white rounded-xl text-sm font-medium hover:bg-[#CC2020] transition-colors"
+          >
+            {t('logIn')}
+          </button>
+        </div>
+        <Footer />
+        <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className={`min-h-screen ${themeClass}`} style={backgroundStyle}>
+        <Header />
+        <div className="flex flex-col items-center justify-center px-4 py-32">
+          <Shield size={48} className="text-red-400/60 mb-4" />
+          <h1 className="text-2xl font-bold text-theme-text mb-2">{t('error')}</h1>
+          <p className="text-theme-text-muted text-center max-w-md">{error}</p>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  // Not a partner
+  if (!meData?.isSponsor) {
+    return (
+      <div className={`min-h-screen ${themeClass}`} style={backgroundStyle}>
+        <Header />
+        <div className="flex flex-col items-center justify-center px-4 py-32">
+          <Shield size={48} className="text-theme-text-faint mb-4" />
+          <h1 className="text-2xl font-bold text-theme-text mb-2">{t('accessDenied')}</h1>
+          <p className="text-theme-text-muted text-center max-w-md">{t('accessDeniedDesc')}</p>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-screen ${themeClass} relative overflow-hidden`} style={backgroundStyle}>
+      <Helmet>
+        <title>{t('consolidated.pageTitle')} | RSV.Pizza</title>
+      </Helmet>
+
+      <Header />
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8 relative z-10">
+        <div className="rounded-2xl p-6 sm:p-8" style={{ background: 'rgba(240, 240, 240, 0.95)' }}>
+          <Link
+            to={tagParam ? `/partner?tag=${encodeURIComponent(tagParam)}` : '/partner'}
+            className="inline-flex items-center gap-1.5 text-sm text-theme-text-muted hover:text-theme-text-secondary transition-colors mb-6"
+          >
+            <ArrowLeft size={14} />
+            {t('consolidated.backToDashboard')}
+          </Link>
+
+          {notAvailable ? (
+            <div className="text-center py-16">
+              <FileText size={48} className="text-theme-text-faint mx-auto mb-4" />
+              <h1 className="text-xl font-semibold text-theme-text mb-2">{t('consolidated.notAvailableTitle')}</h1>
+              <p className="text-theme-text-muted max-w-md mx-auto">{t('consolidated.notAvailableDesc')}</p>
+            </div>
+          ) : report ? (
+            <ConsolidatedReportPreview report={report} />
+          ) : (
+            <div className="text-center py-16">
+              <FileText size={48} className="text-theme-text-faint mx-auto mb-4" />
+              <p className="text-theme-text-muted">{t('consolidated.notAvailableDesc')}</p>
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -534,16 +534,27 @@ export function PartnerDashboardPage() {
         <div className="rounded-2xl p-6 sm:p-8" style={{ background: 'rgba(240, 240, 240, 0.95)' }}>
         {/* Header */}
         <div className="mb-8">
-          <div className="mb-2">
-            <h1 className="text-2xl font-bold text-theme-text">
-              {dashboardData?.isAdmin ? t('title') : `${sponsor?.name || t('title')}`}
-            </h1>
-            <p className="text-sm text-theme-text-muted">
-              {events.length !== allEvents.length
-                ? t('dashboard.showingCountOfTotal', { count: events.length, total: allEvents.length })
-                : t('dashboard.showingCount', { count: events.length })}
-              {dashboardData?.tag ? t('dashboard.taggedSuffix', { tag: dashboardData.tag }) : ''}
-            </p>
+          <div className="mb-2 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-bold text-theme-text">
+                {dashboardData?.isAdmin ? t('title') : `${sponsor?.name || t('title')}`}
+              </h1>
+              <p className="text-sm text-theme-text-muted">
+                {events.length !== allEvents.length
+                  ? t('dashboard.showingCountOfTotal', { count: events.length, total: allEvents.length })
+                  : t('dashboard.showingCount', { count: events.length })}
+                {dashboardData?.tag ? t('dashboard.taggedSuffix', { tag: dashboardData.tag }) : ''}
+              </p>
+            </div>
+            {/* pecorino-64118: consolidated cross-event report (carries ?tag= when filtered) */}
+            <a
+              href={dashboardData?.tag ? `/partner/report?tag=${encodeURIComponent(dashboardData.tag)}` : '/partner/report'}
+              className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-[#E52828] rounded-lg hover:bg-[#CC2020] transition-colors"
+              title={t('dashboard.consolidatedReport')}
+            >
+              <BarChart3 size={14} />
+              {t('dashboard.consolidatedReport')}
+            </a>
           </div>
 
           {/* Admin tag filter */}
@@ -1108,26 +1119,30 @@ function EventCard({ event, onToggleChecklist, cityChats, isAdmin = false }: Eve
                 </a>
               ) : null;
             })()}
-            {event.reportPublicSlug ? (
-              <a
-                href={`/report/${event.reportPublicSlug}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-theme-text-muted hover:text-theme-text-secondary border border-theme-stroke hover:border-theme-stroke-hover rounded-md transition-colors"
-                title={t('dashboard.viewEventReport')}
-              >
-                <BarChart3 size={12} />
-                {t('dashboard.report')}
-              </a>
-            ) : (
-              <span
-                className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-theme-text-faint border border-theme-surface rounded-md cursor-default"
-                title={t('dashboard.reportNotPublished')}
-              >
-                <BarChart3 size={12} />
-                {t('dashboard.report')}
-              </span>
-            )}
+            {(() => {
+              // pecorino-64118: always link to the report (drafts included). The
+              // partner login bypasses the publish/password gate server-side.
+              // `reportSlug` may be absent before the backend ships — fall back to
+              // `reportPublicSlug` so it degrades gracefully.
+              const slug = event.reportSlug || event.reportPublicSlug;
+              if (!slug) return null;
+              const isDraft = event.reportPublished === false;
+              return (
+                <a
+                  href={`/report/${slug}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-theme-text-muted hover:text-theme-text-secondary border border-theme-stroke hover:border-theme-stroke-hover rounded-md transition-colors"
+                  title={isDraft ? t('dashboard.viewReportDraft') : t('dashboard.viewEventReport')}
+                >
+                  <BarChart3 size={12} />
+                  {t('dashboard.report')}
+                  {isDraft && (
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-400" title={t('dashboard.draft')} />
+                  )}
+                </a>
+              );
+            })()}
             <button
               onClick={() => {
                 navigator.clipboard.writeText(`https://rsv.pizza/onesheet/${event.slug}`);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1364,6 +1364,11 @@ export interface SponsorDashboardEvent {
   name: string;
   slug: string;
   reportPublicSlug: string | null;
+  // pecorino-64118: always-resolvable report slug (works for draft/unpublished
+  // reports too — the partner login bypasses the publish/password gate). Optional
+  // for backward-compat with cached payloads before the backend ships.
+  reportSlug?: string;
+  reportPublished?: boolean;
   date: string | null;
   createdAt: string;
   timezone: string | null;
@@ -1461,6 +1466,57 @@ export interface SponsorDashboardData {
   isAdmin: boolean;
   tag: string | null;
   events: SponsorDashboardEvent[];
+}
+
+// pecorino-64118: consolidated cross-event partner report (GET /api/sponsor/report).
+// Full rollup of every report the partner can access into one private view.
+export interface ConsolidatedReportEvent {
+  id: string;
+  name: string;
+  date: string | null;
+  slug: string;
+  reportSlug: string;
+  rsvpCount: number;
+  approvedCount: number;
+  impressions: { totalViews: number; uniqueVisitors: number };
+  clicks: number;
+}
+
+export interface ConsolidatedReport {
+  partnerName: string | null;
+  tag: string | null;
+  eventCount: number;
+  dateRange: { start: string; end: string } | null;
+  stats: {
+    totalRsvps: number;
+    approvedGuests: number;
+    mailingListSignups: number;
+    walletAddresses: number;
+    roleBreakdown: Record<string, number>;
+    poapMints: number;
+    poapMoments: number;
+    socialPostViews: number;
+    socialPostCount: number;
+  };
+  impressions: { totalViews: number; uniqueVisitors: number };
+  clickStats: {
+    totalClicks: number;
+    uniqueClickers: number;
+    byLink: {
+      url: string;
+      linkType: string;
+      linkLabel: string | null;
+      clicks: number;
+      uniqueClickers: number;
+    }[];
+  };
+  // Notable attendees with email masked to @domain, annotated with event name.
+  notableAttendees: (NotableAttendee & { eventName?: string })[];
+  // Social posts annotated with their event name.
+  socialPosts: (SocialPost & { eventName?: string })[];
+  featuredPhotos: Photo[];
+  walletAddressList: string[];
+  events: ConsolidatedReportEvent[];
 }
 
 // Unified partner (merges event-level Sponsor with underboss SponsorUser)


### PR DESCRIPTION
## Summary

Two capabilities for the Partner Dashboard (`/partner`).

### Part 1 — surface individual report links (incl. drafts)
- **`GET /api/sponsor/events`** now returns `reportSlug` (always resolvable) + `reportPublished` for every event carrying the partner's tag — including unpublished/draft reports. The logged-in partner already bypasses the publish + password gate server-side.
- **`report.routes.ts`**: made the partner bypass consistent for `pizzadao`. GPP events carry `eventType='gpp'` (they are *not* literally tagged `pizzadao`), so a pizzadao partner can now view any GPP report (fixed in both `isSponsorForReport` and `canUserViewReport`).
- **PartnerDashboard `EventCard`**: the report pill always deep-links to `/report/{reportSlug}` now; when the report is a draft it stays active and shows a subtle amber "Draft" dot. Falls back to `reportPublicSlug` so it degrades gracefully before the backend ships.

### Part 2 — consolidated report (private, full rollup)
- **`GET /api/sponsor/report`** (private, partner-login only — no public slug/password): rolls up ALL data from every report the partner can access into one view. Same tag-resolution rules as `/events` (`pizzadao → eventType='gpp'`, admin-all).
  - Summed `stats` (RSVPs, attendees, newsletter, wallets, POAP mints/moments, social post views/count), merged `roleBreakdown`.
  - `impressions.uniqueVisitors` and `clickStats.uniqueClickers` are TRUE cross-event distinct `visitor_hash` counts via a single `$queryRaw` (not summed per-event uniques).
  - Per-link click breakdown, masked notable attendees (`@domain`), combined social posts (annotated with event name), starred photos **capped at 60 total**, **deduped** wallet list, and per-event rows.
  - `roleBreakdown` computed via `unnest()` `$queryRaw` (group-by scoped to `party_id IN (...)`) to avoid loading every guest row into Node.
- New **`/partner/report`** page (`ConsolidatedReportPage`) + `ConsolidatedReportPreview` mirroring `ReportPreview` (KPI cards, role chart, social posts) with a consolidated header, no per-event hero, and a per-event breakdown table (rows link to `/report/{reportSlug}`).
- Extracted `KPICard` + org-grouping helpers into **`report/reportShared.tsx`**, reused by both `ReportPreview` and the new consolidated view (behavior identical).
- "Consolidated report" button in the dashboard header (carries `?tag=` when filtered).
- New i18n keys added to **all 8** `partner.json` locales (de, en, es, fr, ja, ko, pt, zh).

## Deploy ordering ⚠️
**Preview frontends talk to the PRODUCTION backend.** `reportSlug` and `GET /api/sponsor/report` will NOT work on the preview until the backend is deployed from master:
```
cd backend && vercel --prod --scope pizza-dao
```
The frontend is written to degrade gracefully until then: the report pill falls back to `reportPublicSlug`, and `/partner/report` shows a friendly "report not available yet" state on a 404.

No DB migration required.

## Verification
- Backend: `npx tsc --noEmit` — passes (only the pre-existing `auth.test.ts` error, present on master).
- Frontend: `npm run build` — passes. i18n key guardrail test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)