### PR TITLE
feat(calzone-93001): two-person payout approval with pre_approved status

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1591,6 +1591,8 @@ model Payout {
   adminNotes          String?   @map("admin_notes")
   rejectionReason     String?   @map("rejection_reason")
 
+  firstApprovedBy     String?   @map("first_approved_by")
+  firstApprovedAt     DateTime? @map("first_approved_at") @db.Timestamptz
   reviewedBy          String?   @map("reviewed_by")
   reviewedAt          DateTime? @map("reviewed_at") @db.Timestamptz
   paidAt              DateTime? @map("paid_at") @db.Timestamptz

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -42,7 +42,7 @@ import { emailHostOfPaymentExecution } from '../services/payoutEmailNotify.js';
 
 const router = Router();
 
-const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed'] as const;
+const ALLOWED_PAYOUT_STATUSES = ['pending', 'pre_approved', 'approved', 'rejected', 'paid', 'failed'] as const;
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 
 /**
@@ -399,6 +399,8 @@ function serializePayout(row: any): any {
     hostNotes: row.hostNotes,
     adminNotes: row.adminNotes,
     rejectionReason: row.rejectionReason,
+    firstApprovedBy: row.firstApprovedBy ?? null,
+    firstApprovedAt: row.firstApprovedAt ? row.firstApprovedAt.toISOString() : null,
     reviewedBy: row.reviewedBy,
     reviewedAt: row.reviewedAt ? row.reviewedAt.toISOString() : null,
     paidAt: row.paidAt ? row.paidAt.toISOString() : null,
@@ -1307,6 +1309,7 @@ router.get(
       let totalUsdThisMonth = 0;
       let sumUsd = 0;
       let awaitingReview = 0;
+      let preApprovedCount = 0;
 
       // parmigiana-58291: per-party rollup over `status === 'paid'` rows.
       // Keyed by party.id; we accumulate sum + count and resolve to a sorted
@@ -1327,9 +1330,10 @@ router.get(
         byMethod[methodKey] = (byMethod[methodKey] || 0) + 1;
         const usd = Number(r.finalAmountUsd);
         sumUsd += usd;
-        if (r.status === 'pending') {
+        if (r.status === 'pending' || r.status === 'pre_approved') {
           totalUsdPending += usd;
           awaitingReview += 1;
+          if (r.status === 'pre_approved') preApprovedCount += 1;
         } else if (r.status === 'paid') {
           totalUsdPaid += usd;
           if (r.paidAt && r.paidAt >= startOfMonth) {
@@ -1400,6 +1404,7 @@ router.get(
           totalUsdThisMonth,
           avgUsd,
           awaitingReview,
+          preApprovedCount,
         },
       });
     } catch (error) {
@@ -1624,6 +1629,9 @@ router.patch(
 // ============================================
 // POST /api/admin/payouts/:id/approve
 // ============================================
+// Two-person approval: pending → pre_approved → approved.
+// First approve sets firstApprovedBy; second approve (by a different admin)
+// sets reviewedBy and flips to approved (executable).
 router.post(
   '/:id/approve',
   requireAuth,
@@ -1639,21 +1647,34 @@ router.post(
           hostUserId: true,
           partyId: true,
           finalAmountUsd: true,
+          firstApprovedBy: true,
         },
       });
 
       if (!existing) {
         throw new AppError('Payout not found', 404, 'NOT_FOUND');
       }
-      if (existing.status !== 'pending') {
+      if (existing.status !== 'pending' && existing.status !== 'pre_approved') {
         throw new AppError(
-          `Can only approve a pending payout (current status: ${existing.status})`,
+          `Can only approve a pending or pre-approved payout (current status: ${existing.status})`,
           400,
           'INVALID_STATE',
         );
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      if (
+        existing.status === 'pre_approved' &&
+        existing.firstApprovedBy &&
+        existing.firstApprovedBy.toLowerCase() === actor.email.toLowerCase()
+      ) {
+        throw new AppError(
+          'You already pre-approved this payout. A different admin must give final approval.',
+          400,
+          'SAME_APPROVER_FORBIDDEN',
+        );
+      }
 
       // bocconcini-49102: re-run the per-submission + per-party cap checks at
       // approve time so rows created/edited BEFORE the cap rules landed (or
@@ -1668,15 +1689,23 @@ router.post(
       );
 
       const { note, autoExecute } = req.body || {};
+      const isFirstApproval = existing.status === 'pending';
+      const nextStatus = isFirstApproval ? 'pre_approved' : 'approved';
+      const auditAction = isFirstApproval ? 'first_approve' : 'second_approve';
 
       const updated = await prisma.$transaction(async (tx) => {
+        const data: any = { status: nextStatus };
+        if (isFirstApproval) {
+          data.firstApprovedBy = actor.email;
+          data.firstApprovedAt = new Date();
+        } else {
+          data.reviewedBy = actor.email;
+          data.reviewedAt = new Date();
+        }
+
         const row = await tx.payout.update({
           where: { id: existing.id },
-          data: {
-            status: 'approved',
-            reviewedBy: actor.email,
-            reviewedAt: new Date(),
-          },
+          data,
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
             host: { select: { id: true, name: true, email: true } },
@@ -1691,9 +1720,9 @@ router.post(
         await tx.payoutAudit.create({
           data: {
             payoutId: existing.id,
-            action: 'approve',
-            oldStatus: 'pending',
-            newStatus: 'approved',
+            action: auditAction,
+            oldStatus: existing.status,
+            newStatus: nextStatus,
             actorEmail: actor.email,
             actorKind: actor.actorKind,
             note: typeof note === 'string' ? note : null,
@@ -1704,14 +1733,14 @@ router.post(
       });
 
       // autoExecute (PR 5): synchronously execute after approval — only for
-      // usdc_base, since wire + mercury_card require body refs (wireReference,
-      // mercuryCardLast4) which the approve call doesn't carry. For those two,
-      // we log + no-op (the admin will hit execute separately with refs).
+      // usdc_base and only on the second (final) approval step, since wire +
+      // mercury_card require body refs and first-approval doesn't produce an
+      // executable state.
       let autoExecuted = false;
       let autoExecuteSkippedReason: string | null = null;
       let result = updated;
 
-      if (autoExecute) {
+      if (autoExecute && !isFirstApproval) {
         if (updated.payoutMethod === 'usdc_base') {
           try {
             result = await executePayout({
@@ -1721,14 +1750,10 @@ router.post(
             });
             autoExecuted = true;
           } catch (err: any) {
-            // Execution failed but approval already happened — surface the
-            // error to the client. executePayout already wrote audit + flipped
-            // status to failed for usdc_base.
             console.error(
               `[admin-payout] autoExecute after approve failed for ${existing.id}: ` +
                 (err?.message || err),
             );
-            // Re-fetch so client sees the failed state.
             const refreshed = await prisma.payout.findUnique({
               where: { id: existing.id },
               include: {
@@ -1753,6 +1778,8 @@ router.post(
               `method=${updated.payoutMethod}: ${autoExecuteSkippedReason}`,
           );
         }
+      } else if (autoExecute && isFirstApproval) {
+        autoExecuteSkippedReason = 'autoExecute deferred — payout needs a second approval first';
       }
 
       res.json({

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -60,7 +60,7 @@ type PayoutMethod = (typeof PAYOUT_METHODS)[number];
 // host's only out when the admin approved a non-compliant amount (e.g.
 // post-bocconcini-49102 cap recheck would now reject the row at execute time).
 // `paid`, `rejected`, and `failed` remain terminal from the host side.
-const WITHDRAWABLE_STATUSES = ['pending', 'approved'] as const;
+const WITHDRAWABLE_STATUSES = ['pending', 'pre_approved', 'approved'] as const;
 
 // ---------- helpers ----------
 
@@ -91,6 +91,8 @@ function serializePayout(p: any) {
     hostNotes: p.hostNotes ?? null,
     adminNotes: p.adminNotes ?? null,
     rejectionReason: p.rejectionReason ?? null,
+    firstApprovedBy: p.firstApprovedBy ?? null,
+    firstApprovedAt: p.firstApprovedAt ? p.firstApprovedAt.toISOString() : null,
     reviewedBy: p.reviewedBy ?? null,
     reviewedAt: p.reviewedAt ? p.reviewedAt.toISOString() : null,
     paidAt: p.paidAt ? p.paidAt.toISOString() : null,
@@ -351,7 +353,7 @@ async function assertWithinPartyCap(
 
   const where: any = {
     partyId,
-    status: { in: ['paid', 'pending', 'approved'] },
+    status: { in: ['paid', 'pending', 'pre_approved', 'approved'] },
   };
   if (ignorePayoutId) {
     where.id = { not: ignorePayoutId };
@@ -1032,7 +1034,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
 
     // Approved payouts: doc-only edits allowed, but amount/method/wallet/notes
     // are frozen so the admin-approved amount can't be silently changed.
-    if (existing.status === 'approved' && hasAmountOrMethodChanges) {
+    if ((existing.status === 'approved' || existing.status === 'pre_approved') && hasAmountOrMethodChanges) {
       throw new AppError(
         'Approved payments cannot have amount, method, wallet, or notes changed. Ask an admin to revert to pending first.',
         400,

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DollarSign, Calendar, TrendingUp, Inbox } from 'lucide-react';
+import { DollarSign, Calendar, TrendingUp, Inbox, ShieldCheck } from 'lucide-react';
 import type { AdminPayoutTotals } from '../../types';
 import { formatUsd } from '../payments-shared';
 
@@ -34,8 +34,8 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, tone = 'default
 export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, loading }) => {
   if (loading || !totals) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-        {[0, 1, 2, 3].map((i) => (
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+        {[0, 1, 2, 3, 4].map((i) => (
           <div key={i} className="rounded-xl border border-theme-stroke bg-theme-surface p-4 animate-pulse h-20" />
         ))}
       </div>
@@ -43,12 +43,18 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
   }
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
       <StatCard
         icon={<DollarSign size={14} />}
         label="Pending"
         value={formatUsd(totals.totalUsdPending)}
         tone="amber"
+      />
+      <StatCard
+        icon={<ShieldCheck size={14} />}
+        label="Pre-Approved"
+        value={String(totals.preApprovedCount)}
+        tone="default"
       />
       <StatCard
         icon={<Calendar size={14} />}

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2 } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, ShieldCheck } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -95,6 +95,8 @@ interface PayoutReviewModalProps {
    * follow-up payment without leaving the modal.
    */
   onPayAgain?: (payout: AdminPayoutDetail) => void;
+  /** Current admin email — used to block self-second-approve on pre_approved rows. */
+  adminEmail?: string;
   busy?: boolean;
 }
 
@@ -112,6 +114,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   fetchWalletPaidTotal,
   onReopen,
   onPayAgain,
+  adminEmail,
   busy = false,
 }) => {
   const [editingAmount, setEditingAmount] = useState(false);
@@ -176,6 +179,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const ocrSum = receipts.reduce((sum, r) => sum + (Number(r.ocrAmount) || 0), 0);
 
   const isPending = payout.status === 'pending';
+  const isPreApproved = payout.status === 'pre_approved';
   const isFailed = payout.status === 'failed';
   // passata-49102: failed payouts are now re-executable, so treat them like
   // 'approved' for the Execute affordance (button + form).
@@ -184,6 +188,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // 'failed' is no longer "closed" — it has the Execute (Retry) button instead
   // of Re-open. Only 'rejected' remains terminal-until-reopened.
   const isClosed = payout.status === 'rejected';
+
+  const isSameApprover =
+    isPreApproved &&
+    payout.firstApprovedBy != null &&
+    adminEmail != null &&
+    payout.firstApprovedBy.toLowerCase() === adminEmail.toLowerCase();
 
   // For Mercury, last4 must be exactly 4 digits before the button enables.
   const execMercuryValid = /^\d{4}$/.test(execCardLast4.trim());
@@ -996,16 +1006,23 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
         {/* Footer actions */}
         <div className="border-t border-theme-stroke px-5 py-3 flex items-center gap-2 flex-wrap bg-theme-surface">
-          {isPending && (
+          {isPreApproved && payout.firstApprovedBy && (
+            <div className="flex items-center gap-1.5 text-xs text-purple-500 mr-auto">
+              <ShieldCheck size={14} />
+              <span>Pre-approved by {payout.firstApprovedBy}</span>
+            </div>
+          )}
+          {(isPending || isPreApproved) && (
             <>
               <button
                 type="button"
                 onClick={() => onApprove()}
-                disabled={busy || selfPayoutBlocked}
+                disabled={busy || selfPayoutBlocked || isSameApprover}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
+                title={isSameApprover ? 'You pre-approved this — another admin must approve' : undefined}
               >
                 {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
-                Approve
+                {isPending ? 'Pre-Approve' : 'Final Approve'}
               </button>
               <button
                 type="button"
@@ -1016,6 +1033,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 <X size={14} />
                 Reject
               </button>
+              {isSameApprover && (
+                <span className="text-xs text-amber-500">
+                  You already pre-approved this payout.
+                </span>
+              )}
             </>
           )}
           {isApproved && (

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -20,6 +20,7 @@ interface PayoutsFilterBarProps {
 const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'pending', label: 'Pending' },
+  { value: 'pre_approved', label: 'Pre-Approved' },
   { value: 'approved', label: 'Approved' },
   { value: 'paid', label: 'Paid' },
   { value: 'rejected', label: 'Rejected' },

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -25,6 +25,8 @@ interface PayoutsTableProps {
    * edit so the row reflects the new value.
    */
   onCapUpdated?: (partyId: string) => void;
+  /** Current admin email — used to block self-second-approve on pre_approved rows. */
+  adminEmail?: string;
   busyRowId?: string | null;
   loading?: boolean;
   loadingMore?: boolean;
@@ -36,6 +38,7 @@ interface PayoutsTableProps {
 function ActionsCell({
   payout,
   busy,
+  adminEmail,
   onApprove,
   onReject,
   onEdit,
@@ -44,6 +47,7 @@ function ActionsCell({
 }: {
   payout: AdminPayout;
   busy: boolean;
+  adminEmail?: string;
   onApprove: (id: string) => void;
   onReject: (id: string) => void;
   onEdit: (payout: AdminPayout) => void;
@@ -51,6 +55,12 @@ function ActionsCell({
   onExecute: (payout: AdminPayout) => void;
 }) {
   const status: PayoutStatus = payout.status;
+  const isSameApprover =
+    status === 'pre_approved' &&
+    payout.firstApprovedBy != null &&
+    adminEmail != null &&
+    payout.firstApprovedBy.toLowerCase() === adminEmail.toLowerCase();
+
   return (
     <div className="inline-flex items-center gap-1">
       <button
@@ -63,14 +73,20 @@ function ActionsCell({
         <Eye size={15} />
       </button>
 
-      {status === 'pending' && (
+      {(status === 'pending' || status === 'pre_approved') && (
         <>
           <button
             type="button"
             onClick={() => onApprove(payout.id)}
-            disabled={busy}
+            disabled={busy || isSameApprover}
             className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
-            title="Approve"
+            title={
+              isSameApprover
+                ? 'You pre-approved this — another admin must approve'
+                : status === 'pending'
+                  ? 'Pre-approve'
+                  : 'Final approve'
+            }
           >
             {busy ? <Loader2 size={15} className="animate-spin" /> : <Check size={15} />}
           </button>
@@ -83,15 +99,17 @@ function ActionsCell({
           >
             <X size={15} />
           </button>
-          <button
-            type="button"
-            onClick={() => onEdit(payout)}
-            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-secondary"
-            title="Edit amount"
-            disabled={busy}
-          >
-            <Pencil size={15} />
-          </button>
+          {status === 'pending' && (
+            <button
+              type="button"
+              onClick={() => onEdit(payout)}
+              className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-secondary"
+              title="Edit amount"
+              disabled={busy}
+            >
+              <Pencil size={15} />
+            </button>
+          )}
         </>
       )}
 
@@ -134,6 +152,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
   onExecute,
   onHostClick,
   onCapUpdated,
+  adminEmail,
   busyRowId,
   loading,
   loadingMore,
@@ -200,6 +219,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
                   <ActionsCell
                     payout={p}
                     busy={busyRowId === p.id}
+                    adminEmail={adminEmail}
                     onApprove={onApprove}
                     onReject={onReject}
                     onEdit={onEdit}

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, StickyNote } from 'lucide-react';
 import type { AdminPayout, Payout } from '../../types';
 import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
@@ -250,7 +250,23 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       </td>
 
       <td className="px-3 py-3">
-        <PayoutStatusPill status={payout.status} />
+        <div className="flex items-center gap-1.5">
+          <PayoutStatusPill status={payout.status} />
+          <StickyNote
+            size={13}
+            className={`shrink-0 transition-colors ${
+              payout.adminNotes
+                ? 'text-amber-400'
+                : 'text-theme-text-faint'
+            }`}
+            title={payout.adminNotes ?? 'No admin notes'}
+          />
+        </div>
+        {showAdminColumns && payout.status === 'pre_approved' && payout.firstApprovedBy && (
+          <div className="text-[11px] text-purple-400 mt-0.5">
+            by {payout.firstApprovedBy}
+          </div>
+        )}
       </td>
 
       {actions && (

--- a/frontend/src/components/payments-shared/PayoutStatusPill.tsx
+++ b/frontend/src/components/payments-shared/PayoutStatusPill.tsx
@@ -18,6 +18,12 @@ const STATUS_STYLES: Record<PayoutStatus, { bg: string; text: string; border: st
     border: 'border-amber-300',
     label: 'Pending',
   },
+  pre_approved: {
+    bg: 'bg-purple-100',
+    text: 'text-purple-800',
+    border: 'border-purple-300',
+    label: 'Pre-Approved',
+  },
   approved: {
     bg: 'bg-blue-100',
     text: 'text-blue-800',

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -28,6 +28,7 @@ interface PayoutDetailModalProps {
 
 const STATUS_STYLES: Record<PayoutStatus, string> = {
   pending: 'bg-amber-500/20 text-amber-300',
+  pre_approved: 'bg-purple-500/20 text-purple-300',
   approved: 'bg-sky-500/20 text-sky-300',
   rejected: 'bg-red-500/20 text-red-300',
   paid: 'bg-emerald-500/20 text-emerald-300',
@@ -36,6 +37,7 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
   pending: 'Pending review',
+  pre_approved: 'Pre-Approved',
   approved: 'Approved — payment pending',
   rejected: 'Rejected',
   paid: 'Paid',

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -697,6 +697,7 @@ export function PaymentsAdminPage() {
           onExecute={openDetail}
           onHostClick={(userId) => setHostDetailUserId(userId)}
           onCapUpdated={() => refresh()}
+          adminEmail={role.kind === 'allowed' ? role.email : undefined}
           busyRowId={rowBusyId}
           loading={loading}
           loadingMore={loadingMore}
@@ -722,6 +723,7 @@ export function PaymentsAdminPage() {
               !!detail.host.email &&
               detail.host.email.toLowerCase() === role.email.toLowerCase()
             }
+            adminEmail={role.kind === 'allowed' ? role.email : undefined}
             busy={modalBusy}
             onClose={closeDetail}
             onApprove={async (note) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1480,7 +1480,7 @@ export interface UnifiedPartner {
 // ============================================
 // Host Payouts (arugula-38633)
 // ============================================
-export type PayoutStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'failed';
+export type PayoutStatus = 'pending' | 'pre_approved' | 'approved' | 'rejected' | 'paid' | 'failed';
 export type PayoutMethod = 'mercury_card' | 'wire' | 'usdc_base';
 
 export interface PayoutDocument {
@@ -1560,6 +1560,8 @@ export interface Payout {
   hostNotes: string | null;
   adminNotes: string | null;
   rejectionReason: string | null;
+  firstApprovedBy: string | null;
+  firstApprovedAt: string | null;
   reviewedBy: string | null;
   reviewedAt: string | null;
   paidAt: string | null;
@@ -1700,6 +1702,7 @@ export interface AdminPayoutTotals {
   totalUsdThisMonth: number;
   avgUsd: number;
   awaitingReview: number;
+  preApprovedCount: number;
 }
 
 export interface AdminPayoutsResponse {

--- a/supabase/migrations/20260522_two_person_payout_approval.sql
+++ b/supabase/migrations/20260522_two_person_payout_approval.sql
@@ -1,0 +1,18 @@
+-- Two-person payout approval: add pre_approved intermediate status.
+-- First admin approves → pre_approved (sets first_approved_by/first_approved_at).
+-- Second (different) admin approves → approved (ready for execution).
+
+-- Add first-approver tracking columns
+ALTER TABLE payouts
+  ADD COLUMN IF NOT EXISTS first_approved_by TEXT,
+  ADD COLUMN IF NOT EXISTS first_approved_at TIMESTAMPTZ;
+
+-- Expand status CHECK to include 'pre_approved'
+ALTER TABLE payouts DROP CONSTRAINT IF EXISTS payouts_status_check;
+ALTER TABLE payouts ADD CONSTRAINT payouts_status_check
+  CHECK (status IN ('pending','pre_approved','approved','rejected','paid','failed'));
+
+-- Expand audit action CHECK to include 'first_approve' and 'second_approve'
+ALTER TABLE payout_audit DROP CONSTRAINT IF EXISTS payout_audit_action_check;
+ALTER TABLE payout_audit ADD CONSTRAINT payout_audit_action_check
+  CHECK (action IN ('create','approve','first_approve','second_approve','reject','edit_amount','mark_paid','mark_failed','retry','cancel','bulk_execute'));


### PR DESCRIPTION
Add intermediate pre_approved status to payout flow, requiring two different admins to approve before a payout becomes executable. First admin approves (pending → pre_approved), second different admin gives final approval (pre_approved → approved). Includes admin notes notifier (StickyNote icon) on payout rows.