### PR TITLE
mascarpone-49102: tag filter on /payments queue

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -354,14 +354,26 @@ function buildPayoutWhere(query: Request['query']): any {
       ? { country: country.trim() }
       : {};
 
+  // mascarpone-49102: optional tag filter — single tag, "contains" semantic
+  // on the party.event_tags String[] column. Prisma's `{ has: string }`
+  // operator emits `event_tags @> ARRAY[$1]`. Folds into `where.party` below
+  // alongside the approval gate + country clause; do NOT overwrite either.
+  const tag = query.tag;
+  const tagClause =
+    typeof tag === 'string' && tag !== 'all' && tag.trim().length > 0
+      ? { eventTags: { has: tag.trim() } }
+      : {};
+
   // tartufo-58291: hide payouts from unapproved parties from the admin queue
   // + CSV export. Existing rows from before the bresaola-49185 backend gate
   // shouldn't surface in routine review. Stats/totals reuse this same `where`
   // so they stay consistent. bruschetta-58291: merged with optional country
-  // filter so both apply.
+  // filter so both apply. mascarpone-49102: merged with optional tag filter
+  // (single event_tag "has" match) so the queue can be sliced by tag.
   where.party = {
     underbossStatus: 'approved',
     ...countryClause,
+    ...tagClause,
   };
 
   return where;

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -15,6 +15,13 @@ interface PayoutsFilterBarProps {
    * derived in `PaymentsAdminPage` from the loaded set. Sorted ascending.
    */
   availableCountries: string[];
+  /**
+   * mascarpone-49102: distinct event-tag values across the currently-loaded
+   * payouts (flattened from each `party.eventTags` array). Mirrors the
+   * `availableCountries` pattern — derived in `PaymentsAdminPage`. Sorted
+   * ascending.
+   */
+  availableTags: string[];
 }
 
 const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
@@ -53,6 +60,7 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.payoutMethod && filters.payoutMethod !== 'all') n += 1;
   if (filters.currency && filters.currency !== 'all') n += 1;
   if (filters.country && filters.country !== 'all') n += 1;
+  if (filters.tag && filters.tag !== 'all') n += 1;
   if (filters.purpose && filters.purpose !== 'all') n += 1;
   if (filters.dateFrom) n += 1;
   if (filters.dateTo) n += 1;
@@ -77,6 +85,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   onReset,
   availableCurrencies,
   availableCountries,
+  availableTags,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const activeCount = countActiveFilters(filters);
@@ -130,7 +139,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         id="payouts-filter-controls"
         className={`${expanded ? 'block' : 'hidden'} sm:block`}
       >
-        <div className="grid grid-cols-1 md:grid-cols-7 gap-2 items-start">
+        <div className="grid grid-cols-1 md:grid-cols-8 gap-2 items-start">
           {/* salame-83472: unified search — host email|name OR party name. */}
           <div className="md:col-span-2">
             <IconInput
@@ -195,6 +204,24 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               <option value="all">All countries</option>
               {availableCountries.map((c) => (
                 <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* mascarpone-49102: Tag dropdown — populated from event_tags
+              flattened across the loaded payout set (parallels
+              availableCurrencies/availableCountries). Backend filters
+              `party.eventTags` via Prisma `{ has: tag }`. */}
+          <div>
+            <select
+              value={filters.tag ?? 'all'}
+              onChange={(e) => update({ tag: e.target.value })}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Filter by tag"
+            >
+              <option value="all">All tags</option>
+              {availableTags.map((t) => (
+                <option key={t} value={t}>{t}</option>
               ))}
             </select>
           </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3996,6 +3996,8 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.search) params.set('search', filters.search);
   // bruschetta-58291: country filter — exact-match `parties.country`.
   if (filters.country && filters.country !== 'all') params.set('country', filters.country);
+  // mascarpone-49102: tag filter — single event_tag "has" match.
+  if (filters.tag && filters.tag !== 'all') params.set('tag', filters.tag);
   if (filters.currency && filters.currency !== 'all') params.set('currency', filters.currency);
   // salumi-89172: purpose filter — 'event' | 'shipping' | 'all'. Omitted = show both.
   if (filters.purpose && filters.purpose !== 'all') params.set('purpose', filters.purpose);

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -54,6 +54,8 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   currency: 'all',
   // bruschetta-58291: country filter default — 'all' means no filter.
   country: 'all',
+  // mascarpone-49102: tag filter default — 'all' means no filter.
+  tag: 'all',
   // salumi-89172: purpose filter default — 'all' shows both event and
   // shipping payouts so the existing admin queue is unchanged out of box.
   purpose: 'all',
@@ -237,6 +239,21 @@ export function PaymentsAdminPage() {
     const set = new Set<string>();
     for (const p of payouts) {
       if (p.party.country) set.add(p.party.country);
+    }
+    return Array.from(set).sort();
+  }, [payouts]);
+
+  // mascarpone-49102: derive the tag dropdown set from `party.eventTags`
+  // (added to PAYOUT_PARTY_SELECT in tagliatelle-49102). Flattens the arrays
+  // and dedupes; sorted ascending. Mirrors the country / currency pattern.
+  const availableTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of payouts) {
+      if (Array.isArray(p.party.eventTags)) {
+        for (const t of p.party.eventTags) {
+          if (t && typeof t === 'string') set.add(t);
+        }
+      }
     }
     return Array.from(set).sort();
   }, [payouts]);
@@ -667,6 +684,7 @@ export function PaymentsAdminPage() {
           onReset={() => setFilters(DEFAULT_FILTERS)}
           availableCurrencies={availableCurrencies}
           availableCountries={availableCountries}
+          availableTags={availableTags}
         />
 
         <BulkActionsBar

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1792,6 +1792,8 @@ export interface AdminPayoutFilters {
   search?: string;
   /** bruschetta-58291: country filter — exact-match `parties.country`. `'all'` / undefined = no filter. */
   country?: string;
+  /** mascarpone-49102: event-tag filter — single tag "has" match on `parties.event_tags`. `'all'` / undefined = no filter. */
+  tag?: string;
   currency?: string;
   /**
    * salumi-89172: Purpose filter — 'event' (host reimbursements) or


### PR DESCRIPTION
## Summary

Extends the admin payouts FilterBar with a Tag dropdown populated from the currently-loaded set of `party.eventTags`. Backend merges `eventTags: { has: tag }` into `where.party` alongside the existing approval + country constraints. No multi-tag, no AND/OR, no negative filter — single-tag slice.

- **Backend redeploy required** for the filter to take effect (preview frontends call prod backend).
- Dropdown render works on preview immediately (no schema/DB changes).

## Changes

- `backend/src/routes/admin-payout.routes.ts` — `buildPayoutWhere` now folds an optional `tag` clause into the single `where.party` object alongside the tartufo-58291 approval gate and bruschetta-58291 country clause. Uses Prisma's `{ has: tag }` (emits `event_tags @> ARRAY[$1]`).
- `frontend/src/types.ts` — `AdminPayoutFilters.tag?: string`.
- `frontend/src/lib/api.ts` — `buildPayoutQuery` serializes `tag` (skips when falsy or `'all'`).
- `frontend/src/components/payments-admin/PayoutsFilterBar.tsx` — new Tag dropdown after Country; grid bumped from `md:grid-cols-7` to `md:grid-cols-8`; `availableTags` prop; `tag` counted by `countActiveFilters`.
- `frontend/src/pages/PaymentsAdminPage.tsx` — `availableTags` derived via `useMemo` by flattening `party.eventTags` across loaded payouts (mirrors `availableCountries`); `tag: 'all'` added to `DEFAULT_FILTERS`.

## Test plan

- [ ] Backend deploys to prod
- [ ] Open `/payments`, confirm Tag dropdown populates from `event_tags` values present in the loaded set (e.g. `prepay`)
- [ ] Selecting a tag refetches and filters the queue to payouts whose party has that tag
- [ ] Selecting `All tags` clears the filter
- [ ] Reset filters button restores `'all'` state
- [ ] No regression to existing Country / Currency / Method / Status / Purpose filters
- [ ] Active filter count badge on mobile collapse toggle includes tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)