### PR TITLE
fix(napoletana-58194): show country after city on /photos tiles

### DIFF
--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -658,7 +658,9 @@ function FeedTile({
           {countryNameToAlpha2(displayCountry)
             ? <CircleFlag country={displayCountry} size={14} />
             : <MapPin size={11} />}
-          <span className="truncate">{displayCity}</span>
+          <span className="truncate">
+            {displayCity && displayCountry ? `${displayCity}, ${displayCountry}` : (displayCity || displayCountry || photo.party.name)}
+          </span>
         </div>
       )}
     </button>


### PR DESCRIPTION
## Summary
- /photos tile footer now reads 'City, Country' (was just 'City')
- Uses the same displayCity/displayCountry derivation from the GPP cityManifest

## Test plan
- [ ] Brussels tile shows Brussels, Belgium with flag
- [ ] Madrid tile shows Madrid, Spain with flag
- [ ] Vercel preview: https://rsvpizza-git-napoletana-58194-tile-country-pizza-dao.vercel.app/photos

Generated with [Claude Code](https://claude.com/claude-code)