### PR TITLE
fix(napoletana-58197): vote button = icon-only, white, drop-shadow

### DIFF
--- a/frontend/src/components/photos/PhotoCard.tsx
+++ b/frontend/src/components/photos/PhotoCard.tsx
@@ -230,21 +230,17 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
         </div>
       )}
 
-      {/* salame-58195: thumbs-up vote (approved photos only) */}
+      {/* salame-58195: thumbs-up vote (approved photos only) — napoletana-58197: icon-only, white, drop-shadow */}
       {!isPending && !isRejected && (
         <button
           type="button"
           onClick={handleVote}
-          aria-label={photo.votedByMe ? 'Remove vote' : 'Thumbs up'}
-          title={user ? (photo.votedByMe ? 'Remove vote' : 'Thumbs up') : 'Log in to vote'}
-          className={`absolute bottom-2 left-2 z-10 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors ${
-            photo.votedByMe
-              ? 'bg-red-500 text-white hover:bg-red-600'
-              : 'bg-black/60 text-white hover:bg-black/80'
-          } ${voting ? 'opacity-70' : ''}`}
+          aria-label={photo.votedByMe ? 'Remove vote' : 'Vote'}
+          title={user ? (photo.votedByMe ? 'Remove vote' : 'Vote') : 'Log in to vote'}
+          className={`absolute bottom-2 left-2 z-10 cursor-pointer text-white hover:scale-110 transition-transform ${voting ? 'opacity-70' : ''}`}
+          style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.8))' }}
         >
-          <ThumbsUp size={12} fill={photo.votedByMe ? 'currentColor' : 'none'} />
-          {photo.voteCount > 0 && <span>{photo.voteCount}</span>}
+          <ThumbsUp size={22} fill={photo.votedByMe ? 'currentColor' : 'none'} strokeWidth={2.25} />
         </button>
       )}
     </div>

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -639,18 +639,15 @@ function FeedTile({
         ) : (
           <img src={src} alt={photo.caption || ''} loading="lazy" className="w-full h-full object-cover block" />
         )}
-        {/* salame-58195: thumbs-up overlay */}
+        {/* salame-58195: thumbs-up overlay (napoletana-58197: icon-only, white, drop-shadow) */}
         <span
           onClick={handleVote}
-          aria-label={photo.votedByMe ? 'Remove vote' : 'Thumbs up'}
-          className={`absolute bottom-2 right-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
-            photo.votedByMe
-              ? 'bg-red-500 text-white hover:bg-red-600'
-              : 'bg-black/60 text-white hover:bg-black/80'
-          } ${voting ? 'opacity-70' : ''}`}
+          role="button"
+          aria-label={photo.votedByMe ? 'Remove vote' : 'Vote'}
+          className={`absolute bottom-2 right-2 cursor-pointer text-white hover:scale-110 transition-transform ${voting ? 'opacity-70' : ''}`}
+          style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.8))' }}
         >
-          <ThumbsUp size={12} fill={photo.votedByMe ? 'currentColor' : 'none'} />
-          {photo.voteCount > 0 && <span>{photo.voteCount}</span>}
+          <ThumbsUp size={22} fill={photo.votedByMe ? 'currentColor' : 'none'} strokeWidth={2.25} />
         </span>
       </div>
       {(displayCity || photo.party.name) && (


### PR DESCRIPTION
## Summary
- On-photo vote overlays (FeedTile + PhotoCard) now render as just a white thumbs-up icon with a CSS drop-shadow (was a dark pill with icon + count)
- Lightbox + modal keep the count visible (they're in text areas, not over photos)
- Icon size bumped to 22 for tappability

## Test plan
- [ ] /photos tile: white thumbs-up icon, visible on light AND dark photos
- [ ] Click toggles votedByMe (icon fills/unfills)
- [ ] Click doesn't open lightbox (stopPropagation still works)
- [ ] Lightbox vote button + count still visible
- [ ] Vercel preview: https://rsvpizza-git-napoletana-58197-vote-icon-only-pizza-dao.vercel.app/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)