### PR TITLE
fix(pecorino-64118): hotfix SRF-in-COALESCE crash in sponsor report role breakdown

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1193,14 +1193,17 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       const roleRows = await prisma.$queryRaw<{ role: string; count: bigint }[]>`
         SELECT role, COUNT(*)::bigint AS count
         FROM (
-          SELECT COALESCE(NULLIF(unnest(
-            CASE WHEN array_length(roles, 1) IS NULL OR array_length(roles, 1) = 0
-                 THEN ARRAY[COALESCE(role, 'Other')]
-                 ELSE roles END
-          ), ''), 'Other') AS role
-          FROM guests
-          WHERE party_id::text IN (${Prisma.join(eventIds)})
-            AND status != 'INVITED'
+          SELECT COALESCE(NULLIF(r, ''), 'Other') AS role
+          FROM (
+            SELECT unnest(
+              CASE WHEN array_length(roles, 1) IS NULL OR array_length(roles, 1) = 0
+                   THEN ARRAY[COALESCE(role, 'Other')]
+                   ELSE roles END
+            ) AS r
+            FROM guests
+            WHERE party_id::text IN (${Prisma.join(eventIds)})
+              AND status != 'INVITED'
+          ) u
         ) sub
         GROUP BY role
       `;


### PR DESCRIPTION
## Hotfix: `GET /api/sponsor/report` 500s in production (pecorino-64118)

### The bug
The role-breakdown `$queryRaw` in the `/report` handler nested the set-returning function `unnest()` inside `COALESCE(NULLIF(...))`:

```sql
SELECT COALESCE(NULLIF(unnest( CASE WHEN ... THEN ARRAY[...] ELSE roles END ), ''), 'Other') AS role
```

`NULLIF(a, b)` expands to a `CASE` expression, and PostgreSQL forbids set-returning functions (SRFs) inside `CASE`/`COALESCE`. So every call to the endpoint threw:

```
set-returning functions are not allowed in COALESCE
```

This was confirmed against production.

### The fix
Restructure the query so `unnest()` runs in its own inner subquery **first** (producing column `r`), and apply `COALESCE(NULLIF(r, ''), 'Other')` in an **outer** query that never wraps the SRF:

```sql
SELECT role, COUNT(*)::bigint AS count
FROM (
  SELECT COALESCE(NULLIF(r, ''), 'Other') AS role
  FROM (
    SELECT unnest(
      CASE WHEN array_length(roles, 1) IS NULL OR array_length(roles, 1) = 0
           THEN ARRAY[COALESCE(role, 'Other')]
           ELSE roles END
    ) AS r
    FROM guests
    WHERE party_id::text IN (...)
      AND status != 'INVITED'
  ) u
) sub
GROUP BY role
```

The result set is identical — the SRF is simply no longer nested inside a `CASE`/`COALESCE`. No other query or file was touched.

### Deploy note
The backend is a separate Vercel project that only deploys from `master`. **This fix will not take effect on production until the backend is redeployed from `master`** after merge.

### Verification
- `cd backend && npx tsc --noEmit` passes with only the pre-existing `auth.test.ts(38,14)` error (confirmed identical on `origin/master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
