### PR TITLE
ravioli-82931: soft-withdraw + host receipts library

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -42,7 +42,11 @@ import { emailHostOfPaymentExecution } from '../services/payoutEmailNotify.js';
 
 const router = Router();
 
-const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed'] as const;
+// ravioli-82931: 'withdrawn' added — host-soft-deleted rows show in the admin
+// queue for transparency. They are excluded from per-party cap math
+// (`assertWithinPartyCap` only sums paid|pending|approved) and from
+// `partyTotals` (which only sums paid).
+const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed', 'withdrawn'] as const;
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 
 /**

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -2,12 +2,13 @@
  * Host-facing payout routes (arugula-38633, PR 3/5).
  *
  * Mounted at `/api/parties`. Endpoints:
- *   POST   /:partyId/payouts                Create a new payout request (with parallel OCR)
- *   GET    /:partyId/payouts                List payouts for a party (host view)
- *   GET    /:partyId/payouts/:payoutId      Detail (host or any admin)
- *   PATCH  /:partyId/payouts/:payoutId      Update (host, while status='pending' only)
- *   DELETE /:partyId/payouts/:payoutId      Withdraw (host, while status IN 'pending'|'approved')
- *   POST   /:partyId/payouts/ocr-preview    OCR a single uploaded image without saving
+ *   POST   /:partyId/payouts                          Create a new payout request (with parallel OCR)
+ *   GET    /:partyId/payouts                          List active payouts for a party (excludes withdrawn)
+ *   GET    /:partyId/payouts/receipts-library         Submitter's receipts across all statuses incl. withdrawn (ravioli-82931)
+ *   GET    /:partyId/payouts/:payoutId                Detail (host or any admin)
+ *   PATCH  /:partyId/payouts/:payoutId                Update (host, while status='pending' only)
+ *   DELETE /:partyId/payouts/:payoutId                Soft-withdraw — sets status='withdrawn' (ravioli-82931)
+ *   POST   /:partyId/payouts/ocr-preview              OCR a single uploaded image without saving
  *
  * Admin execution + approval/rejection endpoints land in PR 4 / PR 5.
  */
@@ -1007,8 +1008,11 @@ router.get('/:partyId/payouts', async (req: AuthRequest, res: Response, next: Ne
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
 
+    // ravioli-82931: hide withdrawn rows from the active host payouts list.
+    // They remain reachable via the receipts-library endpoint below so hosts
+    // can still see receipts they uploaded on rows they later withdrew.
     const payouts = await prisma.payout.findMany({
-      where: { partyId },
+      where: { partyId, status: { not: 'withdrawn' } },
       include: {
         host: { select: { id: true, name: true, email: true } },
         documents: {
@@ -1020,6 +1024,65 @@ router.get('/:partyId/payouts', async (req: AuthRequest, res: Response, next: Ne
     });
 
     res.json({ payouts: payouts.map(serializePayout) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------- GET /:partyId/payouts/receipts-library ----------
+
+/**
+ * ravioli-82931: the host's submitted receipts (kind='receipt' documents)
+ * across ALL their payouts on this party, including withdrawn. Lets hosts see
+ * what they've previously submitted even after they withdrew the request.
+ *
+ * Mounted BEFORE `/:partyId/payouts/:payoutId` so the literal path wins over
+ * the dynamic param. Auth mirrors `gouda-83912`: requires `canUserEditParty`
+ * AND the caller must be the submitter (`hostUserId === req.userId`) OR an
+ * admin. Other cohosts on the same party can't see each other's receipts.
+ */
+router.get('/:partyId/payouts/receipts-library', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+    if (!canEdit) {
+      throw new AppError('Party not found', 404, 'NOT_FOUND');
+    }
+    const isAdminCaller = await isAnyAdmin(req.userEmail);
+
+    // Pull all receipt documents for payouts on this party where the caller
+    // is the submitter (or admin — admins can see across all submitters).
+    const payoutWhere: any = { partyId };
+    if (!isAdminCaller) {
+      payoutWhere.hostUserId = req.userId;
+    }
+
+    const docs = await prisma.payoutDocument.findMany({
+      where: {
+        kind: 'receipt',
+        payout: payoutWhere,
+      },
+      include: {
+        payout: { select: { id: true, status: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({
+      receipts: docs.map((d) => ({
+        id: d.id,
+        payoutId: d.payoutId,
+        payoutStatus: d.payout?.status ?? null,
+        url: d.url,
+        fileName: d.fileName,
+        fileSize: d.fileSize,
+        mimeType: d.mimeType,
+        ocrAmount: d.ocrAmount != null ? numberFromDecimal(d.ocrAmount) : null,
+        ocrCurrency: d.ocrCurrency ?? null,
+        ocrConfidence: d.ocrConfidence != null ? numberFromDecimal(d.ocrConfidence) : null,
+        createdAt: d.createdAt.toISOString(),
+      })),
+    });
   } catch (error) {
     next(error);
   }
@@ -1510,6 +1573,17 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
 
 // ---------- DELETE /:partyId/payouts/:payoutId ----------
 
+/**
+ * ravioli-82931: soft-withdraw. Replaced the hard-delete from gelato-72831
+ * with `status = 'withdrawn'` so the linked payout_documents (receipts) are
+ * preserved. Withdrawn rows are hidden from the host's active list (see GET
+ * above) and from `assertWithinPartyCap`'s per-party sum (it only counts
+ * `paid|pending|approved`), but remain reachable for the host's receipts
+ * library and visible in the admin queue for transparency.
+ *
+ * The HTTP verb stays DELETE for backward-compat with the cancelPayout API
+ * client; the response shape is unchanged.
+ */
 router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId, payoutId } = req.params;
@@ -1534,7 +1608,7 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
     }
 
     // gouda-83912: only the cohost who submitted the payout (or any admin)
-    // may delete it. Other cohosts on the same party can see the row but
+    // may withdraw it. Other cohosts on the same party can see the row but
     // cannot mutate it.
     const isAdminCaller = await isAnyAdmin(req.userEmail);
     if (!isAdminCaller && existing.hostUserId !== req.userId) {
@@ -1545,7 +1619,26 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
       );
     }
 
-    await prisma.payout.delete({ where: { id: payoutId } });
+    // ravioli-82931: soft-delete via status flip + 'cancel' audit row. Using
+    // 'cancel' (already in the action enum) instead of adding a new
+    // 'withdraw' constraint value to keep this PR DB-migration-scope small.
+    await prisma.$transaction(async (tx) => {
+      await tx.payout.update({
+        where: { id: payoutId },
+        data: { status: 'withdrawn' },
+      });
+      await tx.payoutAudit.create({
+        data: {
+          payoutId,
+          action: 'cancel',
+          oldStatus: existing.status,
+          newStatus: 'withdrawn',
+          actorEmail: (req.userEmail || '').toLowerCase(),
+          actorKind: 'host',
+          note: 'Host withdrew payment request (receipts preserved).',
+        },
+      });
+    });
 
     res.json({ success: true });
   } catch (error) {

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -31,6 +31,8 @@ const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
   { value: 'paid', label: 'Paid' },
   { value: 'rejected', label: 'Rejected' },
   { value: 'failed', label: 'Failed' },
+  // ravioli-82931: surface soft-withdrawn rows in admin for transparency.
+  { value: 'withdrawn', label: 'Withdrawn' },
 ];
 
 const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [

--- a/frontend/src/components/payments-shared/PayoutStatusPill.tsx
+++ b/frontend/src/components/payments-shared/PayoutStatusPill.tsx
@@ -42,6 +42,15 @@ const STATUS_STYLES: Record<PayoutStatus, { bg: string; text: string; border: st
     border: 'border-rose-300',
     label: 'Failed',
   },
+  // ravioli-82931: muted neutral gray for soft-withdrawn rows. Host cancelled
+  // the request; row is preserved so its receipts remain in the host's
+  // receipts library. Same disabled/inactive aesthetic.
+  withdrawn: {
+    bg: 'bg-gray-100',
+    text: 'text-gray-600',
+    border: 'border-gray-300',
+    label: 'Withdrawn',
+  },
 };
 
 export const PayoutStatusPill: React.FC<PayoutStatusPillProps> = ({ status, size = 'sm' }) => {

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -32,6 +32,8 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
   rejected: 'bg-red-500/20 text-red-300',
   paid: 'bg-emerald-500/20 text-emerald-300',
   failed: 'bg-red-600/30 text-red-200',
+  // ravioli-82931: muted neutral for soft-withdrawn rows (matches PayoutStatusPill aesthetic).
+  withdrawn: 'bg-gray-500/20 text-gray-300',
 };
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
@@ -40,6 +42,7 @@ const STATUS_LABEL: Record<PayoutStatus, string> = {
   rejected: 'Rejected',
   paid: 'Paid',
   failed: 'Failed',
+  withdrawn: 'Withdrawn',
 };
 
 /**

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -26,6 +26,10 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
   rejected: 'bg-red-500/20 text-red-300',
   paid: 'bg-emerald-500/20 text-emerald-300',
   failed: 'bg-red-600/30 text-red-200',
+  // ravioli-82931: muted neutral for soft-withdrawn rows. The active-list GET
+  // already filters these out, so this style only kicks in for stale-state
+  // edge cases (e.g. realtime race after withdraw).
+  withdrawn: 'bg-gray-500/20 text-gray-300',
 };
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
@@ -34,6 +38,7 @@ const STATUS_LABEL: Record<PayoutStatus, string> = {
   rejected: 'Rejected',
   paid: 'Paid',
   failed: 'Failed',
+  withdrawn: 'Withdrawn',
 };
 
 // arugula-38633 v3 follow-up: helper to display a method (or "Not set" placeholder).

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -12,6 +12,7 @@ import { ExpectedGuestsCard } from './ExpectedGuestsCard';
 import { PrepayCheckbox } from './PrepayCheckbox';
 import { PaymentDetailsCard } from './PaymentDetailsCard';
 import { AppealCapModal } from './AppealCapModal';
+import { ReceiptsLibrary } from './ReceiptsLibrary';
 
 interface PayoutsTabProps {
   partyId: string;
@@ -254,6 +255,15 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             totalPaidUsd={totalPaidUsd}
             reimbursementCapUsd={effectiveReimbursementCapUsd ?? null}
           />
+
+          {/*
+            ravioli-82931: surfaces every receipt the host has uploaded for
+            THIS party across all of their payouts (any status, including
+            withdrawn). Lets hosts see what they've previously submitted even
+            after withdrawing a request — receipts are no longer hard-deleted
+            with the parent payout. Read-only.
+          */}
+          <ReceiptsLibrary partyId={partyId} />
         </>
       )}
 

--- a/frontend/src/components/payouts/ReceiptsLibrary.tsx
+++ b/frontend/src/components/payouts/ReceiptsLibrary.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, AlertCircle, RefreshCw, FileText, ExternalLink } from 'lucide-react';
+import { fetchReceiptsLibrary } from '../../lib/api';
+import type { ReceiptLibraryEntry } from '../../types';
+import { PayoutStatusPill } from '../payments-shared/PayoutStatusPill';
+
+interface ReceiptsLibraryProps {
+  partyId: string;
+}
+
+/**
+ * ravioli-82931: "Your receipts" section on the host PayoutsTab. Lists every
+ * receipt the host has uploaded for THIS party across all of their payouts,
+ * including ones on rows they later withdrew. Withdrawal soft-deletes the
+ * payout (status='withdrawn') instead of hard-deleting it so the receipts
+ * remain reachable here.
+ *
+ * Read-only: host can view full image in a new tab but can't delete entries.
+ * Receipt rows are tied to past submissions; deletion would require editing
+ * the source row, which has its own pending-only edit flow.
+ */
+export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => {
+  const [receipts, setReceipts] = useState<ReceiptLibraryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchReceiptsLibrary(partyId)
+      .then((rows) => {
+        if (!cancelled) setReceipts(rows);
+      })
+      .catch((err: any) => {
+        if (!cancelled) setError(err?.message || 'Failed to load receipts');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
+  const reload = () => {
+    setLoading(true);
+    setError(null);
+    fetchReceiptsLibrary(partyId)
+      .then(setReceipts)
+      .catch((err: any) => setError(err?.message || 'Failed to load receipts'))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h2 className="text-lg font-semibold text-theme-text">Your receipts</h2>
+          <p className="text-xs text-white/40 mt-1">
+            Every receipt you've uploaded for this event, including withdrawn requests.
+          </p>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-[#ff393a]" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="flex flex-col items-center gap-3 py-8 text-center">
+          <AlertCircle className="w-8 h-8 text-[#ff393a]" />
+          <p className="text-sm text-theme-text-secondary">{error}</p>
+          <button
+            onClick={reload}
+            className="btn-secondary inline-flex items-center gap-2 text-sm"
+          >
+            <RefreshCw size={14} />
+            Try again
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && receipts.length === 0 && (
+        <p className="text-sm text-theme-text-secondary py-6 text-center">
+          Receipts you upload will appear here.
+        </p>
+      )}
+
+      {!loading && !error && receipts.length > 0 && (
+        <ul className="divide-y divide-theme-stroke">
+          {receipts.map((r) => {
+            const isImage = (r.mimeType || '').startsWith('image/');
+            const formattedDate = new Date(r.createdAt).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            });
+            return (
+              <li key={r.id} className="flex items-center gap-3 py-3">
+                {isImage ? (
+                  <img
+                    src={r.url}
+                    alt={r.fileName}
+                    className="w-12 h-12 object-cover rounded border border-theme-stroke flex-shrink-0"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-12 h-12 rounded border border-theme-stroke bg-theme-surface-hover flex items-center justify-center flex-shrink-0">
+                    <FileText size={20} className="text-theme-text-secondary" />
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-sm font-medium text-theme-text truncate">
+                      {r.fileName}
+                    </span>
+                    <PayoutStatusPill status={r.payoutStatus} />
+                  </div>
+                  <div className="text-xs text-white/40 mt-0.5">
+                    Uploaded {formattedDate}
+                    {r.ocrAmount != null && r.ocrCurrency && (
+                      <> — {r.ocrAmount.toFixed(2)} {r.ocrCurrency}</>
+                    )}
+                  </div>
+                </div>
+                <a
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-[#ff393a] hover:underline inline-flex items-center gap-1 flex-shrink-0"
+                >
+                  View full
+                  <ExternalLink size={12} />
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/index.ts
+++ b/frontend/src/components/payouts/index.ts
@@ -11,3 +11,4 @@ export { AppealCapModal } from './AppealCapModal';
 export { ExpectedGuestsCard } from './ExpectedGuestsCard';
 export { PrepayCheckbox } from './PrepayCheckbox';
 export { PaymentDetailsCard } from './PaymentDetailsCard';
+export { ReceiptsLibrary } from './ReceiptsLibrary';

--- a/frontend/src/components/shipping/ShippingPaymentsSection.tsx
+++ b/frontend/src/components/shipping/ShippingPaymentsSection.tsx
@@ -24,6 +24,8 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
   rejected: 'bg-red-500/20 text-red-800',
   paid: 'bg-emerald-500/20 text-emerald-800',
   failed: 'bg-red-600/30 text-red-900',
+  // ravioli-82931: muted neutral for soft-withdrawn rows.
+  withdrawn: 'bg-gray-500/20 text-gray-700',
 };
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
@@ -32,6 +34,7 @@ const STATUS_LABEL: Record<PayoutStatus, string> = {
   rejected: 'Rejected',
   paid: 'Paid',
   failed: 'Failed',
+  withdrawn: 'Withdrawn',
 };
 
 /**

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -4407,6 +4407,19 @@ export async function listPayouts(partyId: string): Promise<Payout[]> {
     { requireAuth: true }
   );
   return res.payouts;
+}
+
+/**
+ * ravioli-82931: returns every receipt the caller has submitted for this
+ * party across ALL their payouts (any status, including withdrawn). Powers
+ * the "Your receipts" section on PayoutsTab.
+ */
+export async function fetchReceiptsLibrary(partyId: string): Promise<ReceiptLibraryEntry[]> {
+  const res = await apiRequest<{ receipts: ReceiptLibraryEntry[] }>(
+    `/api/parties/${partyId}/payouts/receipts-library`,
+    { requireAuth: true }
+  );
+  return res.receipts;
 }
 
 export async function getPayout(partyId: string, payoutId: string): Promise<Payout> {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1539,7 +1539,29 @@ export interface UnifiedPartner {
 // ============================================
 // Host Payouts (arugula-38633)
 // ============================================
-export type PayoutStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'failed';
+// ravioli-82931: 'withdrawn' is the soft-delete state hosts move pending|approved
+// rows into via DELETE /:partyId/payouts/:payoutId. Receipts on the row are
+// retained for the host's receipts-library tab.
+export type PayoutStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'failed' | 'withdrawn';
+
+/**
+ * ravioli-82931: one entry in the host's receipts library — a `kind='receipt'`
+ * `payout_documents` row joined to its parent payout's status. Surfaced via
+ * `GET /api/parties/:partyId/payouts/receipts-library`.
+ */
+export interface ReceiptLibraryEntry {
+  id: string;
+  payoutId: string;
+  payoutStatus: PayoutStatus;
+  url: string;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  ocrAmount: number | null;
+  ocrCurrency: string | null;
+  ocrConfidence: number | null;
+  createdAt: string;
+}
 export type PayoutMethod = 'mercury_card' | 'wire' | 'usdc_base';
 
 export interface PayoutDocument {

--- a/supabase/migrations/20260526_ravioli_82931_add_withdrawn_status.sql
+++ b/supabase/migrations/20260526_ravioli_82931_add_withdrawn_status.sql
@@ -1,0 +1,8 @@
+-- ravioli-82931: add 'withdrawn' to payout status check.
+-- Soft-delete host withdrawals so linked payout_documents (receipts) are
+-- preserved and remain visible in the host's receipts library. Withdrawn rows
+-- are excluded from the host's active payouts list and from the per-party cap
+-- sum (assertWithinPartyCap only sums 'paid'|'pending'|'approved').
+ALTER TABLE payouts DROP CONSTRAINT IF EXISTS payouts_status_check;
+ALTER TABLE payouts ADD CONSTRAINT payouts_status_check
+  CHECK (status IN ('pending','approved','rejected','paid','failed','withdrawn'));


### PR DESCRIPTION
## Summary

- **Soft-delete on host withdraw.** `DELETE /:partyId/payouts/:payoutId` now sets `status='withdrawn'` (was hard-delete from gelato-72831) so the linked `payout_documents` rows are preserved. CHECK constraint on `payouts.status` expanded to include `'withdrawn'` (migration `20260526_ravioli_82931_add_withdrawn_status.sql` applied to prod via pg fallback BEFORE this PR merges). `WITHDRAWABLE_STATUSES = ['pending','approved']` gate from gelato-72831 unchanged. Audit row written with `action='cancel'` (existing enum value — no audit-constraint change needed).
- **Host receipts library.** New `GET /:partyId/payouts/receipts-library` returns every `kind='receipt'` document the submitter has uploaded for this party across ALL their payouts (any status, including withdrawn). Auth: `canUserEditParty` AND caller is submitter (`hostUserId === userId`) or admin — mirrors `gouda-83912` ownership pattern. Mounted BEFORE the `/:partyId/payouts/:payoutId` route so the literal path wins.
- **PayoutsTab UI.** New `ReceiptsLibrary` section renders below `PayoutsList` on the host `/host/:invite/payments` tab — grid of thumbnails with filename, upload date, payout-status pill (so hosts can tell which submission a receipt came from), and a "View full" link. Empty state: "Receipts you upload will appear here." Read-only.
- **Admin transparency.** Withdrawn rows DO show in the admin queue. `ALLOWED_PAYOUT_STATUSES` and `STATUS_TABS` (FilterBar) include `'withdrawn'`. `PayoutStatusPill` styles it as a muted neutral gray. `assertWithinPartyCap` already sums only `paid|pending|approved`, so withdrawn rows are naturally excluded from per-party cap math.

## Out of scope

- No receipt RE-USE flow (selecting prior receipts on a new submission) — Snax said "see", not "re-use".
- No individual-receipt deletion — receipts are tied to past payouts; deletion requires editing the source row via the existing pending-only edit flow.
- No change to prepay-queue eligibility — withdrawn rows aren't in-flight, queue auto-recovers.

## Migration

`supabase/migrations/20260526_ravioli_82931_add_withdrawn_status.sql` — applied to prod via `pg + DATABASE_URL` BEFORE pushing this PR. Dropped `payouts_status_check` and recreated it with `'withdrawn'` added. New code writes 'withdrawn' so the constraint had to land first.

## Test plan

- [ ] Withdraw a pending payout from a host page; row disappears from the list, but its receipts still appear in "Your receipts" with a "Withdrawn" pill.
- [ ] Withdraw an approved payout; same behavior; admin queue (filter=Withdrawn) shows the row.
- [ ] Re-create a new payout after withdrawing; per-party cap math reflects only `paid|pending|approved` (withdrawn doesn't burn cap).
- [ ] Different cohost on the same party loads `/host/:invite/payments`; they see their own receipts, not the other cohost's.
- [ ] Admin queue filter tabs include "Withdrawn"; clicking shows only withdrawn rows.

Generated with [Claude Code](https://claude.com/claude-code)