### PR TITLE
arrabbiata-49102: stop leaking admin notes to hosts

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -94,7 +94,6 @@ function serializePayout(p: any) {
     mercuryCardId: p.mercuryCardId ?? null,
     mercuryCardLast4: p.mercuryCardLast4 ?? null,
     hostNotes: p.hostNotes ?? null,
-    adminNotes: p.adminNotes ?? null,
     rejectionReason: p.rejectionReason ?? null,
     reviewedBy: p.reviewedBy ?? null,
     reviewedAt: p.reviewedAt ? p.reviewedAt.toISOString() : null,

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -429,12 +429,6 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                   <p className="text-sm text-theme-text whitespace-pre-wrap">{payout.hostNotes}</p>
                 </div>
               )}
-              {payout.adminNotes && (
-                <div>
-                  <p className="text-xs text-theme-text-muted mb-1">Reviewer notes</p>
-                  <p className="text-sm text-theme-text whitespace-pre-wrap">{payout.adminNotes}</p>
-                </div>
-              )}
               {payout.rejectionReason && (
                 <div>
                   <p className="text-xs text-red-300 mb-1">Rejection reason</p>


### PR DESCRIPTION
## Summary

The admin `/payments` UI labels the notes field **"Internal notes (visible to admins only)"** but the host-facing payout API was returning `adminNotes` on every response, and the host `PayoutDetailModal` rendered it under "Reviewer notes". This leaked internal review comments to every host who opened their own payout.

## The leak

- `backend/src/routes/payout.routes.ts` is the host-facing serializer (mounted on `/api/payouts/...`, auth'd as the host/cohost). It included `adminNotes: p.adminNotes ?? null` in `serializePayout`.
- `frontend/src/components/payouts/PayoutDetailModal.tsx` (the modal hosts see) had a `{payout.adminNotes && ...}` block labeled "Reviewer notes".

## The fix (two lines)

- Drop `adminNotes` from the host-facing `serializePayout` in `payout.routes.ts`.
- Remove the "Reviewer notes" block from `PayoutDetailModal.tsx`. "Your notes" (hostNotes) and "Rejection reason" remain — those are intentionally host-visible.

## Intentionally untouched

- **`backend/src/routes/admin-payout.routes.ts`** has its own separate `serializePayout` and is gated by `requireAnyAdminOrPaymentAdmin`. Admins still need `adminNotes` in the review queue, so that serializer keeps the field.
- **`Payout` TS type** still has `adminNotes?: string | null`. `AdminPayout extends Payout` and admin-side consumers (PaymentsAdminPage, PayoutReviewModal) continue to compile and render the field.
- **`rejectionReason`** is unchanged — it's intentionally host-visible (different field, different intent).

## Test plan

- [ ] Backend: `npx tsc --noEmit` — only pre-existing errors (`sharp`/`openai` imports, JWT test types).
- [ ] Frontend: `npx tsc --noEmit` clean.
- [ ] Vercel preview: open a host payout with non-empty `adminNotes` in the DB — modal should no longer show "Reviewer notes".
- [ ] Vercel preview: `/payments` (admin route) still shows admin notes in the review queue + modal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)