### PR TITLE
taralli-58291: lightbox keyboard nav for /payments photos

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { X, Check, AlertTriangle, ChevronLeft, ChevronRight, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -230,23 +230,51 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const [walletPaidLoading, setWalletPaidLoading] = useState(false);
   const [overrideCap, setOverrideCap] = useState(false);
 
-  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+  // taralli-58291: lightbox uses an index into `allPhotos` so ArrowLeft /
+  // ArrowRight can cycle through receipts + pizza photos. Hooks must be
+  // declared above any early return — see feedback_hooks_above_early_returns.
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
-  // Close on Escape
+  // Memoize the merged photo list so the keyboard handler's effect doesn't
+  // re-bind on every render (new array identity each time would tear off /
+  // re-attach the listener and lose key events mid-keypress).
+  const receipts = useMemo(
+    () => payout.documents.filter((d) => d.kind === 'receipt'),
+    [payout.documents],
+  );
+  const pizzas = useMemo(
+    () => payout.documents.filter((d) => d.kind === 'pizza'),
+    [payout.documents],
+  );
+  const allPhotos = useMemo(() => [...pizzas, ...receipts], [pizzas, receipts]);
+
+  // taralli-58291: keyboard navigation for the lightbox + Escape passthrough
+  // to the parent close. When the lightbox is open, Escape closes it (and
+  // ArrowLeft / ArrowRight cycle); when closed, Escape closes the modal.
+  // Only one window listener is attached to keep the order deterministic.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        if (lightboxUrl) setLightboxUrl(null);
-        else onClose();
+      if (lightboxIndex != null) {
+        if (e.key === 'Escape') {
+          setLightboxIndex(null);
+        } else if (e.key === 'ArrowLeft') {
+          if (allPhotos.length === 0) return;
+          setLightboxIndex((i) =>
+            i == null ? null : (i - 1 + allPhotos.length) % allPhotos.length,
+          );
+        } else if (e.key === 'ArrowRight') {
+          if (allPhotos.length === 0) return;
+          setLightboxIndex((i) =>
+            i == null ? null : (i + 1) % allPhotos.length,
+          );
+        }
+      } else if (e.key === 'Escape') {
+        onClose();
       }
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, lightboxUrl]);
-
-  const receipts = payout.documents.filter((d) => d.kind === 'receipt');
-  const pizzas = payout.documents.filter((d) => d.kind === 'pizza');
-  const allPhotos = [...pizzas, ...receipts];
+  }, [onClose, lightboxIndex, allPhotos.length]);
 
   const ocrSum = receipts.reduce((sum, r) => sum + (Number(r.ocrAmount) || 0), 0);
 
@@ -385,11 +413,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               <p className="text-sm text-theme-text-faint">No photos attached.</p>
             )}
             <div className="grid grid-cols-3 gap-2">
-              {allPhotos.map((doc) => (
+              {allPhotos.map((doc, idx) => (
                 <button
                   key={doc.id}
                   type="button"
-                  onClick={() => setLightboxUrl(doc.url)}
+                  onClick={() => setLightboxIndex(idx)}
                   className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
                   title={doc.fileName}
                 >
@@ -1232,29 +1260,81 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         </div>
       </div>
 
-      {/* Lightbox */}
-      {lightboxUrl && (
+      {/* Lightbox — taralli-58291: ArrowLeft / ArrowRight cycle through
+          receipts + pizza photos, Escape closes. Keyboard handlers live in
+          the useEffect at the top of the component so they remain bound
+          regardless of focus. */}
+      {lightboxIndex != null && allPhotos[lightboxIndex] && (
         <div
-          className="fixed inset-0 z-[60] bg-black/80 flex items-center justify-center p-4"
+          className="fixed inset-0 z-[60] bg-black/80 backdrop-blur-sm flex items-center justify-center p-4"
           onClick={(e) => {
             e.stopPropagation();
-            setLightboxUrl(null);
+            setLightboxIndex(null);
           }}
         >
           <img
-            src={lightboxUrl}
-            alt=""
-            className="max-w-full max-h-full object-contain"
+            src={allPhotos[lightboxIndex].url}
+            alt={allPhotos[lightboxIndex].fileName}
+            className="max-w-[90vw] max-h-[90vh] object-contain"
             onClick={(e) => e.stopPropagation()}
           />
+          {allPhotos.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLightboxIndex((i) =>
+                    i == null
+                      ? null
+                      : (i - 1 + allPhotos.length) % allPhotos.length,
+                  );
+                }}
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60"
+                aria-label="Previous photo"
+              >
+                <ChevronLeft size={32} />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLightboxIndex((i) =>
+                    i == null ? null : (i + 1) % allPhotos.length,
+                  );
+                }}
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60"
+                aria-label="Next photo"
+              >
+                <ChevronRight size={32} />
+              </button>
+            </>
+          )}
           <button
             type="button"
-            onClick={() => setLightboxUrl(null)}
-            className="absolute top-4 right-4 text-white/80 hover:text-white p-2 rounded-full bg-black/40"
+            onClick={(e) => {
+              e.stopPropagation();
+              setLightboxIndex(null);
+            }}
+            className="absolute top-4 right-4 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60"
             aria-label="Close lightbox"
           >
             <X size={20} />
           </button>
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/90 text-xs sm:text-sm flex items-center gap-2 bg-black/40 rounded-full px-3 py-1.5 max-w-[90vw]">
+            <span
+              className={`text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
+                allPhotos[lightboxIndex].kind === 'receipt'
+                  ? 'bg-amber-500 text-white'
+                  : 'bg-emerald-500 text-white'
+              }`}
+            >
+              {allPhotos[lightboxIndex].kind}
+            </span>
+            <span className="truncate">
+              {lightboxIndex + 1} / {allPhotos.length} · {allPhotos[lightboxIndex].fileName}
+            </span>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Clicking a photo in the admin `PayoutReviewModal` (`/payments`) now opens an in-modal lightbox with full keyboard navigation: `ArrowLeft` / `ArrowRight` cycle through the combined receipt + pizza photo list, `Escape` closes.
- Adds chevron prev / next buttons (only shown when there is more than one photo), a kind badge (receipt / pizza), filename, and a counter (`3 / 7`) along the bottom of the lightbox.
- Admin-only modal — host-side `PayoutDetailModal` is untouched. No URL changes, no zoom / pan, no autoplay.

## Implementation notes

- Replaced `lightboxUrl: string | null` with `lightboxIndex: number | null` so prev / next can be index-based.
- The single window `keydown` handler now branches on whether the lightbox is open: when open it handles `Escape` / `ArrowLeft` / `ArrowRight`; when closed it falls through to `onClose()` on `Escape` (no double-dismiss).
- `receipts`, `pizzas`, and `allPhotos` are memoized so the effect deps stay stable across renders.
- Lightbox sits at `z-[60]` (above the review modal's `z-50`).
- Mirrors the existing `PhotoModal` pattern used on the public photos feed for consistency.

## Test plan

- [ ] Open `/payments`, click a payout that has 2+ photos, click any thumbnail.
- [ ] Press `ArrowRight` repeatedly — confirm it cycles forward through all photos and wraps.
- [ ] Press `ArrowLeft` from the first photo — confirm it wraps to the last.
- [ ] Press `Escape` — lightbox closes, review modal stays open.
- [ ] Press `Escape` again — review modal closes.
- [ ] Open a payout with a single photo — confirm the prev / next arrows don't render, but `Escape` still closes.
- [ ] Click outside the image inside the lightbox — confirm it closes the lightbox (not the parent modal).
- [ ] Confirm receipt / pizza badge + filename + counter render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)