### PR TITLE
agnolotti-58291: party-level receipts + per-receipt edit + all-hosts visibility

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -249,6 +249,10 @@ model Party {
   slugAliases           SlugAlias[]
   scorecardItems        GuestScorecardItem[]
   payouts               Payout[]
+  // agnolotti-58291: receipts are now party-level (PayoutDocument.partyId);
+  // payout association is optional. Inverse relation lives here so cascading
+  // a party delete also removes its receipts.
+  payoutDocuments       PayoutDocument[]
   paymentOptIns         PartyPaymentOptIn[]
   outreachAttempts      OutreachAttempt[]
   announcements         Announcement[]
@@ -1677,8 +1681,14 @@ model PartyPaymentOptIn {
 
 model PayoutDocument {
   id            String   @id @default(uuid()) @db.Uuid
-  payoutId      String   @map("payout_id") @db.Uuid
-  payout        Payout   @relation(fields: [payoutId], references: [id], onDelete: Cascade)
+  // agnolotti-58291: receipts are now PARTY-level. `partyId` is the canonical
+  // owner (NOT NULL, CASCADE on party delete). `payoutId` is optional and is
+  // the submission this receipt was uploaded with; it goes NULL via SET NULL
+  // cascade if the payout row is later hard-deleted, so receipts survive.
+  partyId       String   @map("party_id") @db.Uuid
+  party         Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  payoutId      String?  @map("payout_id") @db.Uuid
+  payout        Payout?  @relation(fields: [payoutId], references: [id], onDelete: SetNull)
   kind          String   // 'pizza' | 'receipt'
   url           String
   fileName      String   @map("file_name")
@@ -1698,6 +1708,7 @@ model PayoutDocument {
   sortOrder     Int      @default(0) @map("sort_order")
   createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
 
+  @@index([partyId])
   @@index([payoutId])
   @@index([uploadedByUserId])
   @@map("payout_documents")

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2597,6 +2597,161 @@ router.post(
   },
 );
 
+// ============================================
+// PATCH /api/admin/payouts/documents/:docId — agnolotti-58291
+//
+// Admin per-receipt OCR correction. Updates ONLY the `payout_documents` row's
+// `ocrAmount` and `ocrCurrency` fields. Does NOT recompute the parent payout's
+// `finalAmountUsd` — admins use the existing edit-amount affordance on the
+// payout itself for that. Useful for forensics and for correcting OCR drift
+// when the model misread a receipt amount or currency.
+//
+// Auth: requireAnyAdminOrPaymentAdmin (admin / super_admin / payment_admin).
+// Body: { ocrAmount?: number | null, ocrCurrency?: string | null }
+//   - null clears the field; undefined leaves it untouched.
+//   - ocrAmount must be finite (or null).
+//   - ocrCurrency must be a non-empty string ≤8 chars (or null).
+//
+// Audit: writes a payout_audit row with action='edit_amount' when the document
+// still has a parent payout. Skips audit when payoutId is null (orphaned
+// receipt — parent payout was deleted; nothing to audit against).
+// ============================================
+router.patch(
+  '/documents/:docId',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { docId } = req.params;
+      const body = req.body || {};
+
+      const doc = await prisma.payoutDocument.findUnique({
+        where: { id: docId },
+        select: {
+          id: true,
+          kind: true,
+          payoutId: true,
+          ocrAmount: true,
+          ocrCurrency: true,
+        },
+      });
+      if (!doc) {
+        throw new AppError('Document not found', 404, 'NOT_FOUND');
+      }
+
+      const data: { ocrAmount?: number | null; ocrCurrency?: string | null } = {};
+
+      if (body.ocrAmount !== undefined) {
+        if (body.ocrAmount === null) {
+          data.ocrAmount = null;
+        } else {
+          const n = Number(body.ocrAmount);
+          if (!Number.isFinite(n) || n < 0) {
+            throw new AppError(
+              'ocrAmount must be a non-negative finite number or null',
+              400,
+              'VALIDATION_ERROR',
+            );
+          }
+          data.ocrAmount = n;
+        }
+      }
+
+      if (body.ocrCurrency !== undefined) {
+        if (body.ocrCurrency === null) {
+          data.ocrCurrency = null;
+        } else {
+          const c = String(body.ocrCurrency).trim();
+          if (c.length === 0 || c.length > 8) {
+            throw new AppError(
+              'ocrCurrency must be a non-empty string of 1-8 characters or null',
+              400,
+              'VALIDATION_ERROR',
+            );
+          }
+          data.ocrCurrency = c;
+        }
+      }
+
+      if (Object.keys(data).length === 0) {
+        throw new AppError('No editable fields supplied', 400, 'VALIDATION_ERROR');
+      }
+
+      // Run the update + audit atomically. Audit only fires when there's a
+      // parent payout — orphaned receipts (payoutId IS NULL) have nothing to
+      // audit against, since payout_audit.payout_id is NOT NULL with CASCADE.
+      const oldAmount = doc.ocrAmount == null ? null : Number(doc.ocrAmount.toString());
+      const oldCurrency = doc.ocrCurrency;
+      const actor = await loadActor(req);
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payoutDocument.update({
+          where: { id: docId },
+          data: {
+            ocrAmount: data.ocrAmount === undefined
+              ? undefined
+              : data.ocrAmount === null
+                ? null
+                : (data.ocrAmount as any),
+            ocrCurrency: data.ocrCurrency === undefined
+              ? undefined
+              : data.ocrCurrency,
+          },
+        });
+
+        if (doc.payoutId) {
+          // Use action='edit_amount' (existing enum value) and stash the
+          // before/after in `note` JSON so forensics tools can pick this up
+          // alongside the regular amount edits.
+          const newAmount = data.ocrAmount === undefined
+            ? oldAmount
+            : data.ocrAmount;
+          const newCurrency = data.ocrCurrency === undefined
+            ? oldCurrency
+            : data.ocrCurrency;
+          await tx.payoutAudit.create({
+            data: {
+              payoutId: doc.payoutId,
+              action: 'edit_amount',
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: JSON.stringify({
+                scope: 'receipt',
+                documentId: docId,
+                oldAmount,
+                newAmount,
+                oldCurrency,
+                newCurrency,
+              }),
+            },
+          });
+        }
+
+        return row;
+      });
+
+      res.json({
+        document: {
+          id: updated.id,
+          kind: updated.kind,
+          url: updated.url,
+          fileName: updated.fileName,
+          fileSize: updated.fileSize,
+          mimeType: updated.mimeType,
+          ocrAmount: updated.ocrAmount == null ? null : Number(updated.ocrAmount),
+          ocrCurrency: updated.ocrCurrency,
+          ocrConfidence: updated.ocrConfidence == null ? null : Number(updated.ocrConfidence),
+          ocrError: updated.ocrError,
+          sortOrder: updated.sortOrder,
+          uploadedByUserId: updated.uploadedByUserId ?? null,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
 // Re-export the helper so other backend code (e.g. PR 5 execute route) can
 // reuse the composed guard without re-deriving it.
 export { requireAnyAdminOrPaymentAdmin, isFullAdmin };

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -897,10 +897,16 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     }
 
     // pancetta-37195: stamp each new document with the uploader.
+    // agnolotti-58291: also stamp `partyId` so the document is party-scoped
+    // independent of the payoutId association (which is now SET NULL on
+    // payout delete). The nested `documents: { create: ... }` below uses the
+    // implicit `payoutId` from the parent create; partyId must be set
+    // explicitly since it's a sibling FK, not a back-relation.
     const uploaderUserId = req.userId ?? null;
     const uploaderEmail = req.userEmail ?? null;
     const docsToCreateStamped = docsToCreate.map(d => ({
       ...d,
+      partyId,
       uploadedByUserId: uploaderUserId,
       uploadedByEmail: uploaderEmail,
     }));
@@ -1031,14 +1037,21 @@ router.get('/:partyId/payouts', async (req: AuthRequest, res: Response, next: Ne
 // ---------- GET /:partyId/payouts/receipts-library ----------
 
 /**
- * ravioli-82931: the host's submitted receipts (kind='receipt' documents)
- * across ALL their payouts on this party, including withdrawn. Lets hosts see
- * what they've previously submitted even after they withdrew the request.
+ * ravioli-82931 + agnolotti-58291: party-scoped receipts library.
+ *
+ * Every `kind='receipt'` `payout_documents` row belonging to this party is
+ * returned, regardless of which cohost uploaded it or which payout it was
+ * attached to (or whether the parent payout was later withdrawn / hard-
+ * deleted — receipts now survive payout deletion via `partyId` FK +
+ * `payoutId` SET NULL).
+ *
+ * Auth: `canUserEditParty` only. Any cohost with edit access on the party
+ * sees ALL the party's receipts. The "submitter-only" filter from
+ * `gouda-83912` was removed by agnolotti-58291 so the receipts library is
+ * a shared per-event resource.
  *
  * Mounted BEFORE `/:partyId/payouts/:payoutId` so the literal path wins over
- * the dynamic param. Auth mirrors `gouda-83912`: requires `canUserEditParty`
- * AND the caller must be the submitter (`hostUserId === req.userId`) OR an
- * admin. Other cohosts on the same party can't see each other's receipts.
+ * the dynamic param.
  */
 router.get('/:partyId/payouts/receipts-library', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
@@ -1047,22 +1060,17 @@ router.get('/:partyId/payouts/receipts-library', async (req: AuthRequest, res: R
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
     }
-    const isAdminCaller = await isAnyAdmin(req.userEmail);
 
-    // Pull all receipt documents for payouts on this party where the caller
-    // is the submitter (or admin — admins can see across all submitters).
-    const payoutWhere: any = { partyId };
-    if (!isAdminCaller) {
-      payoutWhere.hostUserId = req.userId;
-    }
-
+    // agnolotti-58291: query payout_documents by partyId directly (no join
+    // through payouts.partyId). payoutId is nullable now — receipts attached
+    // to a since-deleted payout still surface here with `payoutId === null`.
     const docs = await prisma.payoutDocument.findMany({
-      where: {
-        kind: 'receipt',
-        payout: payoutWhere,
-      },
+      where: { partyId, kind: 'receipt' },
       include: {
-        payout: { select: { id: true, status: true } },
+        payout: { select: { id: true, status: true, hostUserId: true } },
+        // agnolotti-58291: surface uploader name/email so the UI can render
+        // "uploaded by X" — useful now that cohosts see each other's receipts.
+        uploadedBy: { select: { id: true, name: true, email: true } },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -1079,6 +1087,11 @@ router.get('/:partyId/payouts/receipts-library', async (req: AuthRequest, res: R
         ocrAmount: d.ocrAmount != null ? numberFromDecimal(d.ocrAmount) : null,
         ocrCurrency: d.ocrCurrency ?? null,
         ocrConfidence: d.ocrConfidence != null ? numberFromDecimal(d.ocrConfidence) : null,
+        // agnolotti-58291: uploader attribution. Falls back to cached email
+        // if the User row is later deleted.
+        uploadedByUserId: d.uploadedByUserId ?? null,
+        uploadedByName: d.uploadedBy?.name ?? null,
+        uploadedByEmail: d.uploadedByEmail ?? d.uploadedBy?.email ?? null,
         createdAt: d.createdAt.toISOString(),
       })),
     });
@@ -1486,6 +1499,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         await tx.payoutDocument.createMany({
           data: [...newReceiptDocs, ...newPizzaDocs].map(d => ({
             ...d,
+            // agnolotti-58291: stamp partyId on every new doc — the FK is now
+            // NOT NULL party-side, optional payout-side.
+            partyId,
             payoutId: existing.id,
             uploadedByUserId: uploaderUserId,
             uploadedByEmail: uploaderEmail,

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -3,7 +3,7 @@ import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSig
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
-import { updatePartyApi } from '../../lib/api';
+import { updatePartyApi, updatePayoutDocument } from '../../lib/api';
 import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal } from '../../types';
 import {
   PayoutStatusPill,
@@ -232,6 +232,88 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
 
+  // agnolotti-58291: per-receipt OCR amount + currency edit state. The modal
+  // ships an inline form per receipt row (gated to full admins + payment_admin)
+  // so admins can correct OCR misreads without recomputing the parent payout.
+  // `receiptOverrides` is a docId -> { ocrAmount, ocrCurrency } map applied on
+  // top of `payout.documents` for rendering, so the row reflects the saved
+  // value immediately without waiting for a parent refresh.
+  type ReceiptOverride = { ocrAmount: number | null; ocrCurrency: string | null };
+  const [receiptOverrides, setReceiptOverrides] = useState<Record<string, ReceiptOverride>>({});
+  // Per-row save state.
+  const [receiptSavingId, setReceiptSavingId] = useState<string | null>(null);
+  const [receiptSaveErrors, setReceiptSaveErrors] = useState<Record<string, string>>({});
+  // Per-row drafts so admins can edit without re-typing on re-render. Drafts
+  // are seeded from the original OCR value on first edit and kept until the
+  // row is saved or the modal closes.
+  type ReceiptDraft = { amount: string; currency: string };
+  const [receiptDrafts, setReceiptDrafts] = useState<Record<string, ReceiptDraft>>({});
+
+  // Hooks must be declared above any early returns. There aren't any early
+  // returns in this component today, but keeping all hooks grouped here makes
+  // the rule-of-hooks invariant easier to verify.
+
+  const canEditReceipts =
+    adminRole === 'admin' || adminRole === 'super_admin' || adminRole === 'payment_admin';
+
+  async function saveReceiptEdit(docId: string) {
+    const draft = receiptDrafts[docId];
+    if (!draft) return;
+    setReceiptSavingId(docId);
+    setReceiptSaveErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    try {
+      // Empty string -> null (clear the field). Otherwise parse as number /
+      // upper-case the currency.
+      const trimmedAmt = draft.amount.trim();
+      const trimmedCur = draft.currency.trim();
+      const patch: { ocrAmount?: number | null; ocrCurrency?: string | null } = {};
+      if (trimmedAmt === '') {
+        patch.ocrAmount = null;
+      } else {
+        const n = Number(trimmedAmt);
+        if (!Number.isFinite(n) || n < 0) {
+          throw new Error('Amount must be a non-negative number');
+        }
+        patch.ocrAmount = n;
+      }
+      if (trimmedCur === '') {
+        patch.ocrCurrency = null;
+      } else if (trimmedCur.length > 8) {
+        throw new Error('Currency must be 8 characters or fewer');
+      } else {
+        patch.ocrCurrency = trimmedCur.toUpperCase();
+      }
+      const updated = await updatePayoutDocument(docId, patch);
+      setReceiptOverrides((m) => ({
+        ...m,
+        [docId]: {
+          ocrAmount: updated.ocrAmount,
+          ocrCurrency: updated.ocrCurrency,
+        },
+      }));
+      // Sync the draft text to the canonical saved value so the inputs match
+      // the rendered row on the next render.
+      setReceiptDrafts((m) => ({
+        ...m,
+        [docId]: {
+          amount: updated.ocrAmount == null ? '' : String(updated.ocrAmount),
+          currency: updated.ocrCurrency ?? '',
+        },
+      }));
+    } catch (err: any) {
+      setReceiptSaveErrors((m) => ({
+        ...m,
+        [docId]: err?.message || 'Failed to save',
+      }));
+    } finally {
+      setReceiptSavingId(null);
+    }
+  }
+
   // Close on Escape
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -244,7 +326,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose, lightboxUrl]);
 
-  const receipts = payout.documents.filter((d) => d.kind === 'receipt');
+  // agnolotti-58291: apply admin-edited receipt overrides on top of the raw
+  // payout.documents so inline-edited rows render the saved values without
+  // waiting for a parent reload.
+  const receipts = payout.documents
+    .filter((d) => d.kind === 'receipt')
+    .map((d) => {
+      const ov = receiptOverrides[d.id];
+      return ov ? { ...d, ocrAmount: ov.ocrAmount, ocrCurrency: ov.ocrCurrency } : d;
+    });
   const pizzas = payout.documents.filter((d) => d.kind === 'pizza');
   const allPhotos = [...pizzas, ...receipts];
 
@@ -649,30 +739,106 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   {receipts.map((r) => {
                     const conf = r.ocrConfidence ?? 0;
                     const lowConf = conf > 0 && conf < 0.8;
+                    // agnolotti-58291: capture the OCR'd values as placeholders
+                    // so admins can see what the model originally returned
+                    // when they're correcting the field. `original*` reflects
+                    // the saved-but-not-yet-overridden value.
+                    const originalAmt = payout.documents.find((d) => d.id === r.id)?.ocrAmount;
+                    const originalCur = payout.documents.find((d) => d.id === r.id)?.ocrCurrency;
+                    const draft = receiptDrafts[r.id];
+                    const draftAmt = draft?.amount ?? (r.ocrAmount == null ? '' : String(r.ocrAmount));
+                    const draftCur = draft?.currency ?? (r.ocrCurrency ?? '');
+                    const dirty =
+                      draftAmt !== (r.ocrAmount == null ? '' : String(r.ocrAmount)) ||
+                      draftCur !== (r.ocrCurrency ?? '');
+                    const saving = receiptSavingId === r.id;
+                    const saveError = receiptSaveErrors[r.id];
                     return (
-                      <li key={r.id} className="flex items-center gap-2 text-sm">
-                        <span
-                          className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                            r.ocrError ? 'bg-red-500' :
-                            lowConf ? 'bg-amber-500' :
-                            conf >= 0.8 ? 'bg-emerald-500' :
-                            'bg-gray-400'
-                          }`}
-                        />
-                        <span className="text-theme-text-muted flex-1 truncate">{r.fileName}</span>
-                        {r.ocrError ? (
-                          <span className="text-xs text-red-600">{r.ocrError}</span>
-                        ) : r.ocrAmount != null && r.ocrCurrency ? (
-                          <>
-                            <span className="text-theme-text font-medium">
-                              {formatOriginalCurrency(Number(r.ocrAmount), r.ocrCurrency)}
-                            </span>
-                            <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
-                              {(conf * 100).toFixed(0)}%
-                            </span>
-                          </>
-                        ) : (
-                          <span className="text-xs text-theme-text-faint">no OCR</span>
+                      <li key={r.id} className="text-sm">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                              r.ocrError ? 'bg-red-500' :
+                              lowConf ? 'bg-amber-500' :
+                              conf >= 0.8 ? 'bg-emerald-500' :
+                              'bg-gray-400'
+                            }`}
+                          />
+                          <span className="text-theme-text-muted flex-1 truncate">{r.fileName}</span>
+                          {canEditReceipts ? (
+                            <>
+                              {/*
+                                agnolotti-58291: tight inline data-grid edits.
+                                IconInput is designed for full-width form
+                                fields with placeholder-as-label semantics and
+                                hardcodes `w-full !pl-14`, which doesn't fit a
+                                per-row 2-input + Save layout. Treating this as
+                                a data-grid cell, not a form field, so raw
+                                inputs are intentional here.
+                              */}
+                              <input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                inputMode="decimal"
+                                value={draftAmt}
+                                placeholder={originalAmt == null ? 'amount' : String(originalAmt)}
+                                onChange={(e) =>
+                                  setReceiptDrafts((m) => ({
+                                    ...m,
+                                    [r.id]: { amount: e.target.value, currency: draftCur },
+                                  }))
+                                }
+                                className="w-24 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                              />
+                              <input
+                                type="text"
+                                maxLength={8}
+                                value={draftCur}
+                                placeholder={originalCur || 'CUR'}
+                                onChange={(e) =>
+                                  setReceiptDrafts((m) => ({
+                                    ...m,
+                                    [r.id]: { amount: draftAmt, currency: e.target.value },
+                                  }))
+                                }
+                                className="w-16 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs uppercase"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => saveReceiptEdit(r.id)}
+                                disabled={!dirty || saving}
+                                className="px-2 py-1 rounded bg-[#E52828] text-white text-xs disabled:opacity-40 inline-flex items-center gap-1"
+                                title="Save OCR override for this receipt"
+                              >
+                                {saving ? <Loader2 size={12} className="animate-spin" /> : 'Save'}
+                              </button>
+                              {conf > 0 && (
+                                <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
+                                  {(conf * 100).toFixed(0)}%
+                                </span>
+                              )}
+                            </>
+                          ) : r.ocrError ? (
+                            <span className="text-xs text-red-600">{r.ocrError}</span>
+                          ) : r.ocrAmount != null && r.ocrCurrency ? (
+                            <>
+                              <span className="text-theme-text font-medium">
+                                {formatOriginalCurrency(Number(r.ocrAmount), r.ocrCurrency)}
+                              </span>
+                              <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
+                                {(conf * 100).toFixed(0)}%
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-xs text-theme-text-faint">no OCR</span>
+                          )}
+                        </div>
+                        {canEditReceipts && r.ocrError && (
+                          <div className="text-xs text-red-600 mt-0.5 ml-4">{r.ocrError}</div>
+                        )}
+                        {saveError && (
+                          <div className="text-xs text-red-600 mt-0.5 ml-4">{saveError}</div>
                         )}
                       </li>
                     );
@@ -680,6 +846,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 </ul>
                 <div className="text-xs text-theme-text-muted mt-2 border-t border-theme-stroke pt-2">
                   Sum of OCR amounts (in their own currencies, not normalized): {ocrSum.toFixed(2)}
+                  {canEditReceipts && (
+                    <span className="block mt-1 text-theme-text-faint">
+                      Editing a receipt's OCR amount or currency here updates the document only —
+                      use the Edit Amount affordance on the payment itself to change the final USD total.
+                    </span>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/components/payouts/ReceiptsLibrary.tsx
+++ b/frontend/src/components/payouts/ReceiptsLibrary.tsx
@@ -9,15 +9,17 @@ interface ReceiptsLibraryProps {
 }
 
 /**
- * ravioli-82931: "Your receipts" section on the host PayoutsTab. Lists every
- * receipt the host has uploaded for THIS party across all of their payouts,
- * including ones on rows they later withdrew. Withdrawal soft-deletes the
- * payout (status='withdrawn') instead of hard-deleting it so the receipts
- * remain reachable here.
+ * ravioli-82931 + agnolotti-58291: "Receipts" section on the host PayoutsTab.
  *
- * Read-only: host can view full image in a new tab but can't delete entries.
- * Receipt rows are tied to past submissions; deletion would require editing
- * the source row, which has its own pending-only edit flow.
+ * After agnolotti-58291 this is a PARTY-scoped library — every receipt
+ * uploaded against the party is listed, regardless of which cohost submitted
+ * it (visibility now matches event-edit access, not the original uploader).
+ * Receipts also survive both soft-withdraw (ravioli-82931) and hard-delete
+ * of the parent payout (FK SET NULL), so historical evidence stays reachable.
+ *
+ * Read-only: hosts can view the full image in a new tab but can't delete
+ * entries here. Receipt removal still goes through the source payout's
+ * pending-only edit flow.
  */
 export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => {
   const [receipts, setReceipts] = useState<ReceiptLibraryEntry[]>([]);
@@ -56,9 +58,9 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
     <div className="card p-6">
       <div className="flex items-center justify-between mb-3">
         <div>
-          <h2 className="text-lg font-semibold text-theme-text">Your receipts</h2>
+          <h2 className="text-lg font-semibold text-theme-text">Receipts</h2>
           <p className="text-xs text-white/40 mt-1">
-            Every receipt you've uploaded for this event, including withdrawn requests.
+            Every receipt uploaded for this event by any host, including withdrawn requests.
           </p>
         </div>
       </div>
@@ -85,7 +87,7 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
 
       {!loading && !error && receipts.length === 0 && (
         <p className="text-sm text-theme-text-secondary py-6 text-center">
-          Receipts you upload will appear here.
+          Receipts uploaded by any host appear here.
         </p>
       )}
 
@@ -98,6 +100,10 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
               month: 'short',
               day: 'numeric',
             });
+            // agnolotti-58291: prefer the uploader's display name, fall back
+            // to the cached email when the User row has been deleted. Empty
+            // when both are missing (historical pre-pancetta receipts).
+            const uploader = r.uploadedByName || r.uploadedByEmail || null;
             return (
               <li key={r.id} className="flex items-center gap-3 py-3">
                 {isImage ? (
@@ -117,10 +123,11 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
                     <span className="text-sm font-medium text-theme-text truncate">
                       {r.fileName}
                     </span>
-                    <PayoutStatusPill status={r.payoutStatus} />
+                    {r.payoutStatus && <PayoutStatusPill status={r.payoutStatus} />}
                   </div>
                   <div className="text-xs text-white/40 mt-0.5">
                     Uploaded {formattedDate}
+                    {uploader && <> by {uploader}</>}
                     {r.ocrAmount != null && r.ocrCurrency && (
                       <> — {r.ocrAmount.toFixed(2)} {r.ocrCurrency}</>
                     )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4062,6 +4062,46 @@ export async function updateAdminPayout(
   return res.payout;
 }
 
+/**
+ * agnolotti-58291: per-receipt admin OCR correction. Updates ONLY the
+ * `ocrAmount` and `ocrCurrency` on a single `payout_documents` row — does NOT
+ * touch the parent payout's `finalAmountUsd`. Use the normal
+ * `updateAdminPayout` edit-amount path when an admin wants to recompute the
+ * payout total.
+ *
+ * Sending `null` clears the field; sending `undefined` (i.e. omitting it from
+ * the object) leaves it untouched.
+ *
+ * Returns the updated document row shape — same fields as
+ * `AdminPayoutDetail.documents[]` minus the uploader join.
+ */
+export async function updatePayoutDocument(
+  docId: string,
+  patch: {
+    ocrAmount?: number | null;
+    ocrCurrency?: string | null;
+  },
+): Promise<{
+  id: string;
+  kind: 'pizza' | 'receipt';
+  url: string;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  ocrAmount: number | null;
+  ocrCurrency: string | null;
+  ocrConfidence: number | null;
+  ocrError: string | null;
+  sortOrder: number;
+  uploadedByUserId: string | null;
+}> {
+  const res = await apiRequest<{ document: any }>(
+    `/api/admin/payouts/documents/${docId}`,
+    { method: 'PATCH', body: patch },
+  );
+  return res.document;
+}
+
 export async function approveAdminPayout(
   id: string,
   opts?: { note?: string; autoExecute?: boolean },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1545,14 +1545,20 @@ export interface UnifiedPartner {
 export type PayoutStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'failed' | 'withdrawn';
 
 /**
- * ravioli-82931: one entry in the host's receipts library — a `kind='receipt'`
- * `payout_documents` row joined to its parent payout's status. Surfaced via
- * `GET /api/parties/:partyId/payouts/receipts-library`.
+ * ravioli-82931 + agnolotti-58291: one entry in the party-scoped receipts
+ * library. After agnolotti, receipts are party-level — every cohost with
+ * edit access on the party sees ALL the party's receipts (not just their own).
+ * The parent payout association (`payoutId` / `payoutStatus`) is optional
+ * because receipts now survive payout hard-delete (FK SET NULL).
+ *
+ * Surfaced via `GET /api/parties/:partyId/payouts/receipts-library`.
  */
 export interface ReceiptLibraryEntry {
   id: string;
-  payoutId: string;
-  payoutStatus: PayoutStatus;
+  /** agnolotti-58291: null when the parent payout has been hard-deleted. */
+  payoutId: string | null;
+  /** agnolotti-58291: null when the parent payout has been hard-deleted. */
+  payoutStatus: PayoutStatus | null;
   url: string;
   fileName: string;
   fileSize: number;
@@ -1560,6 +1566,15 @@ export interface ReceiptLibraryEntry {
   ocrAmount: number | null;
   ocrCurrency: string | null;
   ocrConfidence: number | null;
+  /**
+   * agnolotti-58291: uploader attribution so the UI can show "uploaded by X"
+   * — useful now that cohosts see each other's receipts. `uploadedByName`
+   * comes from the live User join; `uploadedByEmail` falls back to the
+   * cached email if the User row was later deleted.
+   */
+  uploadedByUserId: string | null;
+  uploadedByName: string | null;
+  uploadedByEmail: string | null;
   createdAt: string;
 }
 export type PayoutMethod = 'mercury_card' | 'wire' | 'usdc_base';

--- a/supabase/migrations/20260526_agnolotti_58291_party_level_receipts.sql
+++ b/supabase/migrations/20260526_agnolotti_58291_party_level_receipts.sql
@@ -1,0 +1,30 @@
+-- agnolotti-58291: receipts become party-level. payout_id stays as an optional
+-- association so we know which submission a receipt was uploaded with; party_id
+-- is the canonical owner. With soft-withdraw + SET NULL on payout_id, receipts
+-- survive the payout being removed/withdrawn so they remain available in the
+-- party-scoped receipts library.
+
+ALTER TABLE payout_documents
+  ADD COLUMN party_id UUID;
+
+-- Backfill from payouts.party_id (every existing row has a non-null payout_id).
+UPDATE payout_documents pd
+SET party_id = p.party_id
+FROM payouts p
+WHERE pd.payout_id = p.id;
+
+-- Lock down party_id as NOT NULL and add FK + index.
+ALTER TABLE payout_documents
+  ALTER COLUMN party_id SET NOT NULL,
+  ADD CONSTRAINT payout_documents_party_id_fkey
+    FOREIGN KEY (party_id) REFERENCES parties(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_payout_documents_party_id ON payout_documents (party_id);
+
+-- Loosen payout_id: make nullable AND change cascade -> SET NULL so withdrawn/
+-- deleted payouts don't drop the receipt.
+ALTER TABLE payout_documents
+  DROP CONSTRAINT IF EXISTS payout_documents_payout_id_fkey,
+  ALTER COLUMN payout_id DROP NOT NULL,
+  ADD CONSTRAINT payout_documents_payout_id_fkey
+    FOREIGN KEY (payout_id) REFERENCES payouts(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Three tightly-coupled changes to the payouts surface:

1. **`payout_documents` becomes party-scoped.** Migration adds NOT NULL `party_id` (FK to `parties` with CASCADE on party delete; backfilled from `payouts.party_id` — **1417 rows** updated against prod before this PR was opened). `payout_id` is loosened to nullable with **SET NULL cascade** so receipts survive payout hard-delete (soft-withdraw already preserved them via `status='withdrawn'`).
2. **ReceiptsLibrary all-hosts visibility.** The host-side `GET /api/parties/:partyId/payouts/receipts-library` endpoint drops the submitter-only filter and now scopes by `canUserEditParty` only. Every cohost with edit access sees ALL of the party's receipts. The list surfaces "uploaded by X" so cohosts can tell submissions apart. Section heading and empty-state copy updated.
3. **Per-receipt OCR edit for admins.** New `PATCH /api/admin/payouts/documents/:docId` lets admin / super_admin / payment_admin correct `ocrAmount` + `ocrCurrency` on a single `payout_documents` row. PayoutReviewModal grows an inline edit form per receipt row. Does **not** recompute the parent payout's `finalAmountUsd` — admins use the existing edit-amount affordance for that. Writes a `payout_audit` row with the before/after stashed as JSON in `note`.

## Deployment notes

- Migration was applied to prod via `pg + DATABASE_URL` **before** this commit. The new column is live; backend code referencing `partyId` on `PayoutDocument` is now safe to ship.
- Backend redeploy required (it's not on the master deploy path automatically) — the new PATCH endpoint and the receipts-library scope change ride with master.
- Frontend `ReceiptLibraryEntry` interface widens `payoutId` / `payoutStatus` to nullable + adds `uploadedByUserId` / `uploadedByName` / `uploadedByEmail`.

## Out of scope (intentionally)

- No "delete receipt" affordance outside the existing payout-edit flow.
- No host-side receipt re-use (selecting an existing receipt when filing a new submission).
- No auto-recompute of payout `finalAmountUsd` on per-receipt edit.
- No changes to `kind='pizza'` document handling — receipts only.
- Photo lightbox untouched (separate task).

## Test plan

- [ ] Open `/payments` as a payment_admin, drill into any pending payout — receipts now render with inline amount + currency inputs and a Save button.
- [ ] Edit a receipt's OCR amount + currency, click Save → row reflects the new value without parent reload; `payout_audit` shows an `edit_amount` row with `scope: 'receipt'` in `note` JSON.
- [ ] Submit empty values to clear OCR amount/currency → fields persist as NULL.
- [ ] Try invalid (negative, non-numeric) amount → inline error appears, server returns 400 VALIDATION_ERROR.
- [ ] On `/host/<inviteCode>` Payments tab, the Receipts section now shows receipts from all cohosts on the event, with "by X" attribution.
- [ ] Withdraw a payout — its receipts still appear in the library.
- [ ] (Manual) Confirm the migration: `SELECT party_id IS NULL, COUNT(*) FROM payout_documents GROUP BY 1` returns only `false` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)