### PR TITLE
pecorino-64118: report media (videos+flags), platform icons, industry RSVP links

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1130,7 +1130,7 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
         dateRange: null,
         stats: {
           totalRsvps: 0, approvedGuests: 0, mailingListSignups: 0, walletAddresses: 0,
-          roleBreakdown: {}, poapMints: 0, poapMoments: 0, socialPostViews: 0, socialPostCount: 0,
+          poapMints: 0, poapMoments: 0, socialPostViews: 0, socialPostCount: 0,
         },
         impressions: { totalViews: 0, uniqueVisitors: 0 },
         clickStats: { totalClicks: 0, uniqueClickers: 0, byLink: [] },
@@ -1186,31 +1186,6 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
     const combinedSocialPosts: any[] = [];
     const combinedNotable: any[] = [];
     const combinedPhotos: any[] = [];
-
-    // roleBreakdown computed via $queryRaw to avoid loading every guest's roles into Node.
-    const roleBreakdown: Record<string, number> = {};
-    if (eventIds.length > 0) {
-      const roleRows = await prisma.$queryRaw<{ role: string; count: bigint }[]>`
-        SELECT role, COUNT(*)::bigint AS count
-        FROM (
-          SELECT COALESCE(NULLIF(r, ''), 'Other') AS role
-          FROM (
-            SELECT unnest(
-              CASE WHEN array_length(roles, 1) IS NULL OR array_length(roles, 1) = 0
-                   THEN ARRAY[COALESCE(role, 'Other')]
-                   ELSE roles END
-            ) AS r
-            FROM guests
-            WHERE party_id::text IN (${Prisma.join(eventIds)})
-              AND status != 'INVITED'
-          ) u
-        ) sub
-        GROUP BY role
-      `;
-      for (const r of roleRows) {
-        roleBreakdown[r.role] = (roleBreakdown[r.role] || 0) + Number(r.count);
-      }
-    }
 
     // Page-view (impression) aggregation — total + TRUE cross-event distinct visitors.
     const viewStats = eventIds.length > 0
@@ -1353,10 +1328,17 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       poapMints += party.poapMints || 0;
       poapMoments += party.poapMoments || 0;
 
+      const partyContext = {
+        slug: party.customUrl || party.inviteCode,
+        name: party.name,
+        city: party.city,
+        country: party.country,
+      };
+
       socialPostCount += party.socialPosts.length;
       for (const sp of party.socialPosts) {
         socialPostViews += sp.views || 0;
-        combinedSocialPosts.push({ ...sp, eventName: party.name });
+        combinedSocialPosts.push({ ...sp, eventName: party.name, party: partyContext });
       }
 
       // Notable attendees — mask email to @domain (mirrors published public report).
@@ -1372,7 +1354,7 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       }
 
       for (const ph of party.photos) {
-        combinedPhotos.push(ph);
+        combinedPhotos.push({ ...ph, party: partyContext });
       }
 
       const reportSlug = party.reportPublicSlug || party.customUrl || party.inviteCode;
@@ -1414,7 +1396,6 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
         approvedGuests,
         mailingListSignups,
         walletAddresses,
-        roleBreakdown,
         poapMints,
         poapMoments,
         socialPostViews,

--- a/frontend/src/components/CircleFlag.tsx
+++ b/frontend/src/components/CircleFlag.tsx
@@ -1,0 +1,19 @@
+import { countryNameToAlpha2 } from '../utils/countryFlag';
+
+export const FLAG_BASE = 'https://cdn.jsdelivr.net/npm/circle-flags@2.8.3/flags';
+
+export function CircleFlag({ country, code, size = 14 }: { country?: string | null; code?: string | null; size?: number }) {
+  const c = code ?? countryNameToAlpha2(country ?? null);
+  if (!c) return null;
+  return (
+    <img
+      src={`${FLAG_BASE}/${c}.svg`}
+      alt={country || c}
+      width={size}
+      height={size}
+      loading="lazy"
+      className="rounded-full inline-block shrink-0"
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -2,12 +2,49 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Calendar, Users, Mail, Wallet, Award, Video, Eye, MousePointerClick,
-  FileText, Download, X, ChevronLeft, ChevronRight, ExternalLink,
+  FileText, Download, X, ChevronLeft, ChevronRight, ExternalLink, Play,
 } from 'lucide-react';
-import { ConsolidatedReport, Photo } from '../../types';
-import { ReportRoleChart } from './ReportRoleChart';
-import { SocialPostsList } from './SocialPostsList';
+import { ConsolidatedReport, ConsolidatedReportPhoto, ConsolidatedReportSocialPost } from '../../types';
 import { KPICard, groupAttendeesByOrg, ReportOrgCard } from './reportShared';
+import { CircleFlag } from '../CircleFlag';
+import { PlatformIcon, detectPlatform } from './platformIcon';
+import { countryNameToAlpha2 } from '../../utils/countryFlag';
+import { gppCityBySlug } from '../../utils/gppCity';
+
+const isVideoMime = (m: string | null | undefined) => !!m && m.startsWith('video/');
+
+// Resolve a flag + "City, Country" label from the per-item party context,
+// preferring the GPP city manifest (same treatment as /photos).
+function resolvePartyLocation(party?: { slug: string; name: string; city: string | null; country: string | null }) {
+  if (!party) return null;
+  const gpp = gppCityBySlug(party.slug);
+  const city = gpp?.name ?? party.city ?? party.name;
+  const country = gpp?.country ?? party.country;
+  if (!city && !country) return null;
+  const label = city && country ? `${city}, ${country}` : (city || country || '');
+  return { city, country, label };
+}
+
+// Small flag + city/country chip overlaid on media tiles / shown inline on posts.
+function LocationChip({ party, overlay = false }: { party?: { slug: string; name: string; city: string | null; country: string | null }; overlay?: boolean }) {
+  const loc = resolvePartyLocation(party);
+  if (!loc) return null;
+  const flag = countryNameToAlpha2(loc.country) ? <CircleFlag country={loc.country} size={14} /> : null;
+  if (overlay) {
+    return (
+      <div className="absolute bottom-0 inset-x-0 px-2 py-1 bg-gradient-to-t from-black/70 to-transparent flex items-center gap-1.5 text-[11px] text-white pointer-events-none">
+        {flag}
+        <span className="truncate">{loc.label}</span>
+      </div>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-theme-text-muted">
+      {flag}
+      <span className="truncate">{loc.label}</span>
+    </span>
+  );
+}
 
 interface ConsolidatedReportPreviewProps {
   report: ConsolidatedReport;
@@ -144,19 +181,40 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
         <div className="card p-6">
           <h2 className="text-lg font-semibold text-theme-text mb-4">{t('report.media')}</h2>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
-            {report.featuredPhotos.map((photo, i) => (
-              <button
-                key={photo.id}
-                onClick={() => setLightboxIndex(i)}
-                className="w-full aspect-square overflow-hidden rounded-lg cursor-pointer hover:opacity-80 transition-opacity"
-              >
-                <img
-                  src={photo.thumbnailUrl || photo.url}
-                  alt={photo.caption || 'Event photo'}
-                  className="w-full h-full object-cover"
-                />
-              </button>
-            ))}
+            {report.featuredPhotos.map((photo, i) => {
+              const video = isVideoMime(photo.mimeType);
+              return (
+                <button
+                  key={photo.id}
+                  onClick={() => setLightboxIndex(i)}
+                  className="relative w-full aspect-square overflow-hidden rounded-lg cursor-pointer hover:opacity-80 transition-opacity"
+                >
+                  {video ? (
+                    <>
+                      <video
+                        src={photo.url}
+                        muted
+                        playsInline
+                        preload="metadata"
+                        className="w-full h-full object-cover"
+                      />
+                      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                        <div className="bg-black/50 rounded-full p-2">
+                          <Play size={20} className="text-white fill-white" />
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <img
+                      src={photo.thumbnailUrl || photo.url}
+                      alt={photo.caption || 'Event photo'}
+                      className="w-full h-full object-cover"
+                    />
+                  )}
+                  <LocationChip party={photo.party} overlay />
+                </button>
+              );
+            })}
           </div>
         </div>
       )}
@@ -183,25 +241,64 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
         </div>
       )}
 
-      {/* Role Breakdown */}
-      {Object.keys(report.stats.roleBreakdown).length > 0 && (
-        <div className="card p-6">
-          <ReportRoleChart roleBreakdown={report.stats.roleBreakdown} totalRsvps={report.stats.totalRsvps} />
-        </div>
-      )}
-
-      {/* Social Posts (combined) */}
+      {/* Social Posts (combined) — compact platform-icon cards */}
       {report.socialPosts.length > 0 && (
         <div className="card p-6">
-          <SocialPostsList
-            posts={report.socialPosts}
-            onAdd={async () => {}}
-            onDelete={async () => {}}
-            editable={false}
-          />
+          <h2 className="text-lg font-semibold text-theme-text mb-4">{t('report.socialPosts')}</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {report.socialPosts.map((post) => (
+              <SocialPostCard key={post.id} post={post} />
+            ))}
+          </div>
         </div>
       )}
     </div>
+  );
+}
+
+// Compact social-post card: platform icon, title/handle/url, views, location chip, link.
+function SocialPostCard({ post }: { post: ConsolidatedReportSocialPost }) {
+  const { t } = useTranslation('host');
+  // Map the stored platform value to the shared PlatformIcon's labels; fall back
+  // to URL detection so every post gets a recognizable real-logo icon.
+  const platformMap: Record<string, string> = {
+    twitter: 'X',
+    farcaster: 'Farcaster',
+    instagram: 'Instagram',
+    facebook: 'Facebook',
+    linkedin: 'LinkedIn',
+    youtube: 'YouTube',
+    tiktok: 'TikTok',
+  };
+  const platform = platformMap[(post.platform || '').toLowerCase()] || detectPlatform(post.url);
+  const label = post.title || post.authorHandle || post.url;
+
+  return (
+    <a
+      href={post.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="bg-theme-surface rounded-xl p-3 border border-theme-stroke flex items-start gap-3 hover:border-theme-text-muted transition-colors group"
+    >
+      <div className="text-theme-text-secondary mt-0.5 flex-shrink-0">
+        <PlatformIcon platform={platform} size={18} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm text-theme-text truncate flex-1">{label}</span>
+          <ExternalLink size={12} className="text-theme-text-muted flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        </div>
+        <div className="flex items-center gap-x-3 gap-y-1 flex-wrap mt-1">
+          {post.views != null && post.views > 0 && (
+            <span className="inline-flex items-center gap-1 text-xs text-theme-text-muted">
+              <Eye size={12} />
+              {post.views.toLocaleString()} {t('report.socialPostViews')}
+            </span>
+          )}
+          <LocationChip party={post.party} />
+        </div>
+      </div>
+    </a>
   );
 }
 
@@ -211,7 +308,7 @@ function PhotoLightbox({
   onClose,
   onNavigate,
 }: {
-  photos: Photo[];
+  photos: ConsolidatedReportPhoto[];
   index: number;
   onClose: () => void;
   onNavigate: (index: number) => void;
@@ -219,6 +316,7 @@ function PhotoLightbox({
   const photo = photos[index];
   const hasPrev = index > 0;
   const hasNext = index < photos.length - 1;
+  const video = isVideoMime(photo.mimeType);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') onClose();
@@ -258,12 +356,23 @@ function PhotoLightbox({
         </button>
       )}
 
-      <img
-        src={photo.url}
-        alt={photo.caption || 'Event photo'}
-        className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
-        onClick={(e) => e.stopPropagation()}
-      />
+      {video ? (
+        <video
+          src={photo.url}
+          controls
+          autoPlay
+          playsInline
+          className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <img
+          src={photo.url}
+          alt={photo.caption || 'Event photo'}
+          className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
 
       {photo.caption && (
         <div

--- a/frontend/src/components/report/platformIcon.tsx
+++ b/frontend/src/components/report/platformIcon.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Instagram, Youtube, Linkedin, Globe, Facebook } from 'lucide-react';
+
+// pecorino-64118: shared platform-icon helpers, extracted from PartnerDashboardPage
+// so both the dashboard and the consolidated report render the same real-logo SVGs.
+
+// Detect platform from URL domain
+export function detectPlatform(url: string): string {
+  try {
+    const host = new URL(url).hostname.replace('www.', '');
+    if (host.includes('instagram.com')) return 'Instagram';
+    if (host.includes('twitter.com') || host.includes('x.com')) return 'X';
+    if (host.includes('youtube.com') || host.includes('youtu.be')) return 'YouTube';
+    if (host.includes('tiktok.com')) return 'TikTok';
+    if (host.includes('linkedin.com')) return 'LinkedIn';
+    if (host.includes('facebook.com') || host.includes('fb.com')) return 'Facebook';
+    if (host.includes('farcaster') || host.includes('warpcast.com')) return 'Farcaster';
+    return 'Website';
+  } catch {
+    return 'Website';
+  }
+}
+
+// X (Twitter) icon
+const XIcon: React.FC<{ size: number }> = ({ size }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+// TikTok icon
+const TikTokIcon: React.FC<{ size: number }> = ({ size }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M19.59 6.69a4.83 4.83 0 01-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 01-5.2 1.74 2.89 2.89 0 012.31-4.64 2.93 2.93 0 01.88.13V9.4a6.84 6.84 0 00-1-.05A6.33 6.33 0 005 20.1a6.34 6.34 0 0010.86-4.43v-7a8.16 8.16 0 004.77 1.52v-3.4a4.85 4.85 0 01-1-.1z" />
+  </svg>
+);
+
+// Farcaster icon
+const FarcasterIcon: React.FC<{ size: number }> = ({ size }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M5.315 3.401h13.37v17.198h-1.689V7.68H6.998v12.919H5.315V3.401zm3.371 7.674h6.628v1.414h-6.628v-1.414z" />
+  </svg>
+);
+
+export function PlatformIcon({ platform, size = 12 }: { platform: string; size?: number }) {
+  switch (platform) {
+    case 'Instagram': return <Instagram size={size} />;
+    case 'X': return <XIcon size={size} />;
+    case 'YouTube': return <Youtube size={size} />;
+    case 'TikTok': return <TikTokIcon size={size} />;
+    case 'LinkedIn': return <Linkedin size={size} />;
+    case 'Facebook': return <Facebook size={size} />;
+    case 'Farcaster': return <FarcasterIcon size={size} />;
+    default: return <Globe size={size} />;
+  }
+}

--- a/frontend/src/components/report/reportShared.tsx
+++ b/frontend/src/components/report/reportShared.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Building2 } from 'lucide-react';
+import { Building2, Globe } from 'lucide-react';
 import { NotableAttendee } from '../../types';
 import { extractEmailDomain, getDomainFaviconUrl } from '../../utils/emailUtils';
 
@@ -133,9 +133,22 @@ export function ReportOrgCard({ group }: { group: { domain: string | null; atten
       ) : (
         <>
           <Building2 size={14} className="text-theme-text-muted" />
-          {attendees.map((a) => (
-            <span key={a.id} className="text-sm text-theme-text-secondary">{a.name}</span>
-          ))}
+          {attendees.map((a) =>
+            a.link ? (
+              <a
+                key={a.id}
+                href={a.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
+              >
+                {a.name}
+                <Globe size={12} className="text-theme-text-muted flex-shrink-0" />
+              </a>
+            ) : (
+              <span key={a.id} className="text-sm text-theme-text-secondary">{a.name}</span>
+            )
+          )}
         </>
       )}
     </div>

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -13,10 +13,10 @@ import {
   Loader2, Shield, Tag, Users,
   Search, BarChart3, Calendar, MapPin,
   Wallet, TrendingUp, StickyNote, MessageCircle, MousePointerClick, Eye,
-  Instagram, Youtube, Linkedin, Globe, Facebook,
   Camera, ChevronLeft, ChevronRight, X, Link2, Download,
   Mail, Send, DollarSign,
 } from 'lucide-react';
+import { PlatformIcon, detectPlatform } from '../components/report/platformIcon';
 import { cdnUrl } from '../lib/supabase';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../lib/gppPhotos';
 import { fetchSheetCities } from '../lib/cities';
@@ -118,57 +118,6 @@ function PhotoLightbox({
 
 const themeClass = 'gpp-theme';
 const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)' } as React.CSSProperties;
-
-// Detect platform from URL domain
-function detectPlatform(url: string): string {
-  try {
-    const host = new URL(url).hostname.replace('www.', '');
-    if (host.includes('instagram.com')) return 'Instagram';
-    if (host.includes('twitter.com') || host.includes('x.com')) return 'X';
-    if (host.includes('youtube.com') || host.includes('youtu.be')) return 'YouTube';
-    if (host.includes('tiktok.com')) return 'TikTok';
-    if (host.includes('linkedin.com')) return 'LinkedIn';
-    if (host.includes('facebook.com') || host.includes('fb.com')) return 'Facebook';
-    if (host.includes('farcaster') || host.includes('warpcast.com')) return 'Farcaster';
-    return 'Website';
-  } catch {
-    return 'Website';
-  }
-}
-
-// X (Twitter) icon
-const XIcon: React.FC<{ size: number }> = ({ size }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
-    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-  </svg>
-);
-
-// TikTok icon
-const TikTokIcon: React.FC<{ size: number }> = ({ size }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
-    <path d="M19.59 6.69a4.83 4.83 0 01-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 01-5.2 1.74 2.89 2.89 0 012.31-4.64 2.93 2.93 0 01.88.13V9.4a6.84 6.84 0 00-1-.05A6.33 6.33 0 005 20.1a6.34 6.34 0 0010.86-4.43v-7a8.16 8.16 0 004.77 1.52v-3.4a4.85 4.85 0 01-1-.1z" />
-  </svg>
-);
-
-// Farcaster icon
-const FarcasterIcon: React.FC<{ size: number }> = ({ size }) => (
-  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
-    <path d="M5.315 3.401h13.37v17.198h-1.689V7.68H6.998v12.919H5.315V3.401zm3.371 7.674h6.628v1.414h-6.628v-1.414z" />
-  </svg>
-);
-
-function PlatformIcon({ platform, size = 12 }: { platform: string; size?: number }) {
-  switch (platform) {
-    case 'Instagram': return <Instagram size={size} />;
-    case 'X': return <XIcon size={size} />;
-    case 'YouTube': return <Youtube size={size} />;
-    case 'TikTok': return <TikTokIcon size={size} />;
-    case 'LinkedIn': return <Linkedin size={size} />;
-    case 'Facebook': return <Facebook size={size} />;
-    case 'Farcaster': return <FarcasterIcon size={size} />;
-    default: return <Globe size={size} />;
-  }
-}
 
 function resolveCityChat(eventName: string, chats: Map<string, string>): string | undefined {
   // Event names are like "Global Pizza Party City Name" — strip the prefix

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -16,24 +16,7 @@ import {
 import { countryNameToAlpha2, alpha2ToCountryNames, alpha2ToCanonicalName } from '../utils/countryFlag';
 import { gppCityBySlug } from '../utils/gppCity';
 import { GPP_REGIONS, GPPRegion } from '../types';
-
-const FLAG_BASE = 'https://cdn.jsdelivr.net/npm/circle-flags@2.8.3/flags';
-
-function CircleFlag({ country, code, size = 14 }: { country?: string | null; code?: string | null; size?: number }) {
-  const c = code ?? countryNameToAlpha2(country ?? null);
-  if (!c) return null;
-  return (
-    <img
-      src={`${FLAG_BASE}/${c}.svg`}
-      alt={country || c}
-      width={size}
-      height={size}
-      loading="lazy"
-      className="rounded-full inline-block shrink-0"
-      style={{ width: size, height: size }}
-    />
-  );
-}
+import { CircleFlag } from '../components/CircleFlag';
 
 // --- URL <-> state helpers (sicilian-58129) ----------------------------------
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1485,6 +1485,40 @@ export interface ConsolidatedReportEvent {
   clicks: number;
 }
 
+// pecorino-64118: per-item event context attached to consolidated photos/posts so
+// the report can render a flag + city/country chip. Optional so the frontend
+// degrades gracefully before the backend redeploy lands.
+export interface ConsolidatedReportPartyContext {
+  slug: string;
+  name: string;
+  city: string | null;
+  country: string | null;
+}
+
+// Combined starred photo for the consolidated media grid — the subset of Photo
+// fields the grid + lightbox actually use, plus optional party context.
+export interface ConsolidatedReportPhoto {
+  id: string;
+  url: string;
+  thumbnailUrl: string | null;
+  caption: string | null;
+  mimeType: string | null;
+  duration: number | null;
+  party?: ConsolidatedReportPartyContext;
+}
+
+// Combined social post annotated with its event name + optional party context.
+export interface ConsolidatedReportSocialPost {
+  id: string;
+  platform: string;
+  url: string;
+  authorHandle: string | null;
+  title: string | null;
+  views: number | null;
+  eventName?: string;
+  party?: ConsolidatedReportPartyContext;
+}
+
 export interface ConsolidatedReport {
   partnerName: string | null;
   tag: string | null;
@@ -1495,7 +1529,6 @@ export interface ConsolidatedReport {
     approvedGuests: number;
     mailingListSignups: number;
     walletAddresses: number;
-    roleBreakdown: Record<string, number>;
     poapMints: number;
     poapMoments: number;
     socialPostViews: number;
@@ -1515,9 +1548,9 @@ export interface ConsolidatedReport {
   };
   // Notable attendees with email masked to @domain, annotated with event name.
   notableAttendees: (NotableAttendee & { eventName?: string })[];
-  // Social posts annotated with their event name.
-  socialPosts: (SocialPost & { eventName?: string })[];
-  featuredPhotos: Photo[];
+  // Social posts annotated with their event name + optional party context.
+  socialPosts: ConsolidatedReportSocialPost[];
+  featuredPhotos: ConsolidatedReportPhoto[];
   walletAddressList: string[];
   events: ConsolidatedReportEvent[];
 }


### PR DESCRIPTION
Follow-up to **pecorino-64118**: five fixes/enhancements to the partner consolidated report (`/partner/report`, rendered by `ConsolidatedReportPreview`, served by `GET /api/sponsor/report`).

## Changes

1. **Backend `GET /api/sponsor/report`** — attach per-item party context (`{ slug, name, city, country }`) to combined photos + social posts (photos already return `mimeType`/`duration` via the no-`select` include). **Removed the roles breakdown entirely** (the `roleBreakdown` `$queryRaw` block + the `stats.roleBreakdown` response field — this also retires the previously-crash-prone SRF query).
2. **Shared `CircleFlag`** — extracted from `PhotosFeedPage.tsx` into `frontend/src/components/CircleFlag.tsx` (behavior identical; `PhotosFeedPage` now imports it).
3. **Shared `PlatformIcon` + `detectPlatform`** — extracted from `PartnerDashboardPage.tsx` into `frontend/src/components/report/platformIcon.tsx` (behavior identical; dashboard now imports them).
4. **Frontend types** — added `ConsolidatedReportPhoto` / `ConsolidatedReportSocialPost` (with **optional** `party` context so the frontend degrades gracefully before the backend deploys); dropped `roleBreakdown` from the `ConsolidatedReport` stats type.
5. **`ConsolidatedReportPreview`** — media grid now renders `<video>` for `video/*` items (grid tile with play overlay + lightbox `<video controls>`), fixing the 19 starred avax videos that were broken `<img>` placeholders; flag + city/country chip overlaid on each media tile; social posts now render as compact platform-icon cards (icon + title/handle/url + views + flag/city chip + external link), no Twitter embed; the RSVP role breakdown card is hidden (the `ReportRoleChart` component file is kept — `ReportPreview` still uses it).
6. **`reportShared.tsx` `ReportOrgCard`** — "independent" attendees (no email domain) with a `link` now render as a clickable `<a>` with a globe icon (matches the individual `/ethdenver` report; shared component, so `ReportPreview` benefits too).

## Deploy / preview notes
- The photo/post **`party` context needs a backend redeploy from master** (preview frontends hit the prod backend), so **flags + city/country chips won't show on the preview** until the backend ships. The frontend degrades gracefully meanwhile (chip is skipped when `party` is absent).
- The **video-rendering fix** and the **industry-RSVP link change** are frontend-only and work on the preview immediately.

## Verify
- `cd backend && npx tsc --noEmit` — only pre-existing errors remain (`auth.test.ts(38,14)`, plus `sharp`/`openai` missing-module + `payout.routes.ts` schema mismatches that all pre-exist on origin/master and are untouched here). My edited file `sponsor-user.routes.ts` is clean.
- `cd frontend && npm run build` passes; `tsc --noEmit` clean; i18n guardrail test passes (no new keys — reused `host:report.*`).
- UI/data-shape change only; no DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)