### PR TITLE
feat(pecorino-64118): derive industry RSVP org domain from attendee link

### DIFF
--- a/frontend/src/components/report/reportShared.tsx
+++ b/frontend/src/components/report/reportShared.tsx
@@ -57,13 +57,27 @@ export function KPICard({ label, value, icon: Icon, color, url, onAction, action
   return content;
 }
 
-// Group attendees by org domain
+// Derive a registrable domain from a URL (the attendee's `link`).
+function domainFromUrl(url?: string | null): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`);
+    return u.hostname.replace(/^www\./i, '').toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+// Group attendees by org domain. The org domain is the corporate email domain
+// if present, otherwise the domain derived from the attendee's link. Attendees
+// with neither (personal-registrar email only, or no email and no link) are
+// grouped as "independent".
 export function groupAttendeesByOrg(attendees: NotableAttendee[]) {
   const map = new Map<string, NotableAttendee[]>();
   const independent: NotableAttendee[] = [];
 
   for (const a of attendees) {
-    const domain = a.email ? extractEmailDomain(a.email, true) : null;
+    const domain = (a.email ? extractEmailDomain(a.email, true) : null) || domainFromUrl(a.link);
     if (domain) {
       const list = map.get(domain) || [];
       list.push(a);
@@ -122,7 +136,8 @@ export function ReportOrgCard({ group }: { group: { domain: string | null; atten
             href={`https://${domain}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
+            title={domain}
+            className="text-sm text-theme-text-secondary hover:text-theme-text transition-colors truncate max-w-[180px]"
           >
             {domain}
           </a>


### PR DESCRIPTION
Industry RSVPs now derive the org domain from the attendee's link (not just email), so they render as truncated domain chips like /ethdenver; shared by ReportPreview + ConsolidatedReportPreview; frontend-only, works on preview immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)