### PR TITLE
[margherita-58471] hotfix: rename sendReminder.tsx -> .ts

### DIFF
--- a/backend/src/lib/sendReminder.ts
+++ b/backend/src/lib/sendReminder.ts
@@ -1,6 +1,6 @@
 import { render } from '@react-email/render';
 import { Resend } from 'resend';
-import * as React from 'react';
+import { createElement } from 'react';
 import EventReminder, {
   renderPlainText,
   type EventReminderProps,
@@ -92,7 +92,7 @@ export async function buildReminderPayload(
     hours,
     publicOrigin: opts?.publicOrigin,
   };
-  const html = await render(<EventReminder {...props} />);
+  const html = await render(createElement(EventReminder, props));
   const text = renderPlainText(props);
   const timeOnly = shortLocalTime(ctx.partyDate, ctx.partyTimezone);
   return {


### PR DESCRIPTION
Production is currently 500ing on all routes — `ERR_MODULE_NOT_FOUND` for `/var/task/src/lib/sendReminder.js`. @vercel/node isn't producing output for the .tsx source. Switching the file to .ts (with createElement instead of JSX) restores the build.

Merge ASAP.