### PR TITLE
feat(parmigiana-71820): Stream + Broadcast move under Music

### DIFF
--- a/frontend/src/components/day-of/DayOfDashboard.tsx
+++ b/frontend/src/components/day-of/DayOfDashboard.tsx
@@ -82,6 +82,22 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
           hideOpenTabLink={isMobile}
         />
       </CollapsibleCard>
+      <CollapsibleCard
+        id="stream-on-screen"
+        partyId={party.id}
+        title="Put the stream on screen"
+      >
+        <StreamOnScreenCard />
+      </CollapsibleCard>
+      {isGpp && (
+        <CollapsibleCard
+          id="broadcast"
+          partyId={party.id}
+          title="Join the global PizzaDAO broadcast"
+        >
+          <BroadcastJoinCard partyId={party.id} layout={layout} />
+        </CollapsibleCard>
+      )}
       {/* StandWithCryptoCard self-gates on party.eventTags containing 'swc' */}
       <CollapsibleCard id="swc" partyId={party.id} title="Stand With Crypto">
         <StandWithCryptoCard party={party} />
@@ -104,22 +120,6 @@ export const DayOfDashboard: React.FC<DayOfDashboardProps> = ({ party, layout })
 
   const rightColumn = (
     <>
-      <CollapsibleCard
-        id="stream-on-screen"
-        partyId={party.id}
-        title="Put the stream on screen"
-      >
-        <StreamOnScreenCard />
-      </CollapsibleCard>
-      {isGpp && (
-        <CollapsibleCard
-          id="broadcast"
-          partyId={party.id}
-          title="Join the global PizzaDAO broadcast"
-        >
-          <BroadcastJoinCard partyId={party.id} layout={layout} />
-        </CollapsibleCard>
-      )}
       {isGpp && !briefingFirst && (
         <CollapsibleCard
           id="briefing"


### PR DESCRIPTION
## Summary
Stream-on-Screen and Broadcast move from the right column into the left column, after Music and before SWC.

## New left column
Pizza · Music · **Stream-on-Screen** · **Broadcast (GPP)** · SWC · Announce · Sent today

## New right column
Briefing (GPP, non-promoted) · Photo · SignedBox (GPP) · BoxTower (GPP)

## Mobile order
Briefing pulse (if active) · Status · Pizza · Music · Stream · Broadcast · SWC · Announce · Sent today · Briefing (non-promoted) · Photo · SignedBox · BoxTower

🤖 Generated with [Claude Code](https://claude.com/claude-code)