### PR TITLE
provolone-41882: fix Browse Organizations modal rendering under RSVP Roles

### DIFF
--- a/frontend/src/components/report/BrowseGuestsModal.tsx
+++ b/frontend/src/components/report/BrowseGuestsModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { X, Search, Loader2, Check } from 'lucide-react';
 import { Guest } from '../../types';
@@ -149,7 +150,7 @@ export function BrowseGuestsModal({ isOpen, onClose, guests, partyId, onChanged 
 
   if (!isOpen) return null;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[100] flex items-center justify-center p-4"
       onClick={(e) => {
@@ -243,6 +244,7 @@ export function BrowseGuestsModal({ isOpen, onClose, guests, partyId, onChanged 
           </span>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Problem
In the event report editor, the **Browse Organizations** modal rendered underneath the later **RSVP Roles** card — the bottom rows were covered/unclickable.

## Root cause
`.card` in `index.css` uses `transform: translateZ(0)` + `z-index: 1`, making every report card its own stacking context. `BrowseGuestsModal` returned its `fixed inset-0 z-[100]` overlay inline inside the "Industry RSVPs" card, so the `z-[100]` was scoped to that card and a later card painted over it.

## Fix
Render the overlay via `createPortal(..., document.body)` so it escapes all card stacking contexts — matching the existing pattern in `RSVPModal` and `PhotoModal`. One file, no behavior change.

## Verify
Open a report editor, click "Browse All" in Industry RSVPs, confirm the modal fully overlays the page with nothing from RSVP Roles bleeding through. Search / toggle / close all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)