### PR TITLE
feat(pecorino-64118): Industry RSVPs from approved guests' email org domains

### DIFF
--- a/backend/src/lib/emailDomains.ts
+++ b/backend/src/lib/emailDomains.ts
@@ -12,17 +12,45 @@ export const PERSONAL_EMAIL_PROVIDERS: Set<string> = new Set([
   'hey.com', 'pm.me', 'inbox.com', 'mail.ru', 'qq.com', '163.com',
   'comcast.net', 'verizon.net', 'att.net', 'sbcglobal.net', 'cox.net',
   'charter.net', 'earthlink.net', 'optonline.net', 'frontier.com',
+  // pecorino-64118 cleanup: personal providers / relays / international
+  // variants seen in real avax data but missing from the original list.
+  'duck.com', 'mozmail.com', 'passinbox.com', '126.com', '139.com',
+  '189.cn', 'sina.com', 'sina.cn', 'foxmail.com', 'web.de', 't-online.de',
+  'orange.fr', 'free.fr', 'laposte.net', 'libero.it', 'naver.com',
+  'daum.net', 'hanmail.net', 'seznam.cz', 'wp.pl', 'o2.pl', 'bluewin.ch',
+  'rediffmail.com', 'live.fr', 'live.it', 'live.de', 'live.ca',
+  'live.com.mx', 'live.com.ar', 'live.com.pt', 'live.co.uk',
+  'outlook.es', 'outlook.fr', 'outlook.de', 'outlook.com.br',
 ]);
 
+// Internal / host domains that should never surface as "industry orgs"
+// (e.g. the PizzaDAO host's own domain). Excluded the same as personal
+// providers. pecorino-64118 cleanup.
+export const INTERNAL_DOMAINS: Set<string> = new Set([
+  'rarepizzas.com',
+]);
+
+// Brand stems for major personal email providers. If a domain CONTAINS any
+// of these as a substring, treat it as personal — this cleanly catches typos
+// (gmail.con, 35gmail.com) and international variants (hotmail.it, yahoo.fr,
+// outlook.de) that won't be in the exact set. These brand names don't appear
+// in real company domains. pecorino-64118 cleanup.
+export const PERSONAL_BRAND_STEMS: string[] = [
+  'gmail', 'googlemail', 'hotmail', 'outlook', 'yahoo', 'ymail', 'protonmail',
+];
+
 // Returns the lowercased email domain if it is NOT a personal provider,
-// otherwise null. Also returns null for missing / malformed emails.
+// internal/host domain, or personal-brand variant; otherwise null. Also
+// returns null for missing / malformed emails.
 export function orgDomainFromEmail(email: string | null | undefined): string | null {
   if (!email) return null;
   const parts = email.split('@');
   if (parts.length !== 2) return null;
   const domain = parts[1].trim().toLowerCase();
   if (!domain) return null;
+  if (INTERNAL_DOMAINS.has(domain)) return null;
   if (PERSONAL_EMAIL_PROVIDERS.has(domain)) return null;
+  if (PERSONAL_BRAND_STEMS.some((stem) => domain.includes(stem))) return null;
   return domain;
 }
 

--- a/backend/src/lib/emailDomains.ts
+++ b/backend/src/lib/emailDomains.ts
@@ -1,0 +1,44 @@
+// pecorino-64118: shared server-side helper for deriving organization email
+// domains (TLDs) from guest email addresses for the "Industry RSVPs" report
+// section. Personal email providers are excluded so only org domains surface.
+// Port of the frontend EMAIL_PROVIDERS set from frontend/src/utils/emailUtils.ts.
+
+export const PERSONAL_EMAIL_PROVIDERS: Set<string> = new Set([
+  'gmail.com', 'googlemail.com', 'yahoo.com', 'yahoo.co.uk', 'yahoo.co.in',
+  'hotmail.com', 'hotmail.co.uk', 'outlook.com', 'live.com', 'msn.com',
+  'aol.com', 'icloud.com', 'me.com', 'mac.com', 'mail.com', 'email.com',
+  'protonmail.com', 'proton.me', 'zoho.com', 'yandex.com', 'yandex.ru',
+  'gmx.com', 'gmx.net', 'fastmail.com', 'tutanota.com', 'tuta.com',
+  'hey.com', 'pm.me', 'inbox.com', 'mail.ru', 'qq.com', '163.com',
+  'comcast.net', 'verizon.net', 'att.net', 'sbcglobal.net', 'cox.net',
+  'charter.net', 'earthlink.net', 'optonline.net', 'frontier.com',
+]);
+
+// Returns the lowercased email domain if it is NOT a personal provider,
+// otherwise null. Also returns null for missing / malformed emails.
+export function orgDomainFromEmail(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const parts = email.split('@');
+  if (parts.length !== 2) return null;
+  const domain = parts[1].trim().toLowerCase();
+  if (!domain) return null;
+  if (PERSONAL_EMAIL_PROVIDERS.has(domain)) return null;
+  return domain;
+}
+
+// Maps a list of emails to org domains, counts occurrences per domain, and
+// returns them sorted by count desc then domain asc. Personal providers and
+// malformed/empty emails are dropped.
+export function buildIndustryOrgs(
+  emails: (string | null | undefined)[],
+): { domain: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const email of emails) {
+    const domain = orgDomainFromEmail(email);
+    if (!domain) continue;
+    counts.set(domain, (counts.get(domain) || 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([domain, count]) => ({ domain, count }))
+    .sort((a, b) => b.count - a.count || a.domain.localeCompare(b.domain));
+}

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -4,6 +4,7 @@ import { requireAuth, optionalAuth, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import crypto from 'crypto';
 import { canUserEditParty, canUserAccessTab, isSuperAdmin } from '../helpers/partyAccess.js';
+import { buildIndustryOrgs } from '../lib/emailDomains.js';
 
 // Helper: extends canUserEditParty to also allow sponsors tagged on the event (read-only access)
 //
@@ -83,6 +84,7 @@ router.get('/:partyId/report', requireAuth, async (req: AuthRequest, res: Respon
             role: true,
             mailingListOptIn: true,
             approved: true,
+            status: true,
           },
         },
         photos: {
@@ -108,6 +110,15 @@ router.get('/:partyId/report', requireAuth, async (req: AuthRequest, res: Respon
     const approvedGuests = party.guests.filter(g => g.approved !== false).length;
     const mailingListSignups = party.guests.filter(g => g.mailingListOptIn).length;
     const walletAddresses = party.guests.filter(g => g.ethereumAddress).length;
+
+    // pecorino-64118: Industry RSVPs — org domains derived from ALL approved
+    // guests' emails (personal providers excluded). Only { domain, count } is
+    // returned; raw guest emails are never leaked to the report.
+    const industryOrgs = buildIndustryOrgs(
+      party.guests
+        .filter(g => g.approved !== false && g.status !== 'INVITED')
+        .map(g => g.email),
+    );
 
     // Calculate role breakdown — count ALL roles per guest (guests can have multiple)
     const roleBreakdown: Record<string, number> = {};
@@ -166,6 +177,7 @@ router.get('/:partyId/report', requireAuth, async (req: AuthRequest, res: Respon
           email: (a as any).guest?.email || null,
           guest: undefined,
         })),
+        industryOrgs,
         featuredPhotos: party.photos,
 
         // Wallet address list for CSV export
@@ -422,11 +434,13 @@ router.get('/public/:publicSlug', optionalAuth, async (req: AuthRequest, res: Re
         guests: {
           select: {
             id: true,
+            email: true,
             roles: true,
             role: true,
             mailingListOptIn: true,
             ethereumAddress: true,
             approved: true,
+            status: true,
           },
         },
         photos: {
@@ -456,6 +470,15 @@ router.get('/public/:publicSlug', optionalAuth, async (req: AuthRequest, res: Re
     const approvedGuests = party.guests.filter(g => g.approved !== false).length;
     const mailingListSignups = party.guests.filter(g => g.mailingListOptIn).length;
     const walletAddresses = party.guests.filter(g => g.ethereumAddress).length;
+
+    // pecorino-64118: Industry RSVPs — org domains from ALL approved guests'
+    // emails (personal providers excluded). Only { domain, count } is returned;
+    // raw guest emails are NOT included in the public response.
+    const industryOrgs = buildIndustryOrgs(
+      party.guests
+        .filter(g => g.approved !== false && g.status !== 'INVITED')
+        .map(g => g.email),
+    );
 
     // Calculate role breakdown — count ALL roles per guest (guests can have multiple)
     const roleBreakdown: Record<string, number> = {};
@@ -515,6 +538,7 @@ router.get('/public/:publicSlug', optionalAuth, async (req: AuthRequest, res: Re
             email: domain ? `@${domain}` : null,
           };
         }),
+        industryOrgs,
         featuredPhotos: party.photos,
 
         // Wallet address list for CSV export

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -5,6 +5,7 @@ import { requireAuth, AuthRequest, isAdmin, isUnderboss } from '../middleware/au
 import { requireSponsorAuth, SponsorRequest } from '../middleware/sponsorAuth.js';
 import { AppError } from '../middleware/error.js';
 import { syncPartnerToAllEvents, syncAutoSponsorsToAllEvents, removePartnerFromAllEvents, removeAutoSponsorsFromAllEvents } from '../helpers/partnerSync.js';
+import { buildIndustryOrgs } from '../lib/emailDomains.js';
 
 // Admin management routes (mounted at /api/sponsor-users)
 
@@ -1135,6 +1136,7 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
         impressions: { totalViews: 0, uniqueVisitors: 0 },
         clickStats: { totalClicks: 0, uniqueClickers: 0, byLink: [] },
         notableAttendees: [],
+        industryOrgs: [],
         socialPosts: [],
         featuredPhotos: [],
         walletAddressList: [],
@@ -1160,6 +1162,7 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
         guests: {
           select: {
             id: true,
+            email: true,
             mailingListOptIn: true,
             ethereumAddress: true,
             approved: true,
@@ -1171,6 +1174,11 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
     });
 
     const eventIds = parties.map(p => p.id);
+
+    // pecorino-64118: collect approved guest emails across ALL loaded events for
+    // one combined Industry RSVPs rollup (org domains only, personal providers
+    // excluded). Raw emails are never returned — only { domain, count }.
+    const industryOrgEmails: (string | null | undefined)[] = [];
 
     // Aggregate per-event stats + the rollup.
     let totalRsvps = 0;
@@ -1318,6 +1326,11 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       approvedGuests += approvedCount;
       mailingListSignups += submitted.filter(g => g.mailingListOptIn).length;
 
+      // pecorino-64118: gather approved guest emails for the combined Industry RSVPs.
+      for (const g of submitted) {
+        if (g.approved !== false) industryOrgEmails.push(g.email);
+      }
+
       for (const g of submitted) {
         if (g.ethereumAddress) {
           walletAddresses += 1;
@@ -1386,6 +1399,9 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       ? { start: new Date(Math.min(...dates)).toISOString(), end: new Date(Math.max(...dates)).toISOString() }
       : null;
 
+    // pecorino-64118: combined Industry RSVPs across all events.
+    const industryOrgs = buildIndustryOrgs(industryOrgEmails);
+
     res.json({
       partnerName: req.sponsorUser?.name || (req.isAdminViewing ? (tag || 'All Partners') : null),
       tag: tag || null,
@@ -1404,6 +1420,7 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       impressions: { totalViews, uniqueVisitors },
       clickStats: { totalClicks, uniqueClickers, byLink },
       notableAttendees: combinedNotable,
+      industryOrgs,
       socialPosts: combinedSocialPosts,
       featuredPhotos,
       walletAddressList,

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -5,7 +5,7 @@ import {
   FileText, Download, X, ChevronLeft, ChevronRight, ExternalLink, Play,
 } from 'lucide-react';
 import { ConsolidatedReport, ConsolidatedReportPhoto, ConsolidatedReportSocialPost } from '../../types';
-import { KPICard, groupAttendeesByOrg, ReportOrgCard } from './reportShared';
+import { KPICard, OrgDomainChip } from './reportShared';
 import { CircleFlag } from '../CircleFlag';
 import { PlatformIcon, detectPlatform } from './platformIcon';
 import { countryNameToAlpha2 } from '../../utils/countryFlag';
@@ -229,13 +229,13 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
         />
       )}
 
-      {/* Industry RSVPs (combined notable attendees) */}
-      {report.notableAttendees.length > 0 && (
+      {/* Industry RSVPs — combined org domains from approved guests' emails (pecorino-64118) */}
+      {report.industryOrgs && report.industryOrgs.length > 0 && (
         <div className="card p-6">
           <h2 className="text-lg font-semibold text-theme-text mb-3">{t('report.industryRsvps')}</h2>
           <div className="flex flex-wrap gap-2">
-            {groupAttendeesByOrg(report.notableAttendees).map((group) => (
-              <ReportOrgCard key={group.domain || '_independent'} group={group} />
+            {report.industryOrgs.map((org) => (
+              <OrgDomainChip key={org.domain} domain={org.domain} count={org.count} />
             ))}
           </div>
         </div>

--- a/frontend/src/components/report/ReportPreview.tsx
+++ b/frontend/src/components/report/ReportPreview.tsx
@@ -4,7 +4,7 @@ import { Calendar, MapPin, Users, Mail, Wallet, Award, Video, Eye, ExternalLink,
 import { EventReport, PageViewStats, Photo } from '../../types';
 import { ReportRoleChart } from './ReportRoleChart';
 import { SocialPostsList } from './SocialPostsList';
-import { KPICard, groupAttendeesByOrg, ReportOrgCard } from './reportShared';
+import { KPICard, OrgDomainChip } from './reportShared';
 
 interface ReportPreviewProps {
   report: EventReport;
@@ -220,13 +220,13 @@ export function ReportPreview({ report, onClose, pageViewStats }: ReportPreviewP
         </div>
       )}
 
-      {/* Industry RSVPs */}
-      {report.notableAttendees.length > 0 && (
+      {/* Industry RSVPs — org domains derived from approved guests' emails (pecorino-64118) */}
+      {report.industryOrgs && report.industryOrgs.length > 0 && (
         <div className="card p-6">
           <h2 className="text-lg font-semibold text-theme-text mb-3">{t('report.industryRsvps')}</h2>
           <div className="flex flex-wrap gap-2">
-            {groupAttendeesByOrg(report.notableAttendees).map((group) => (
-              <ReportOrgCard key={group.domain || '_independent'} group={group} />
+            {report.industryOrgs.map((org) => (
+              <OrgDomainChip key={org.domain} domain={org.domain} count={org.count} />
             ))}
           </div>
         </div>

--- a/frontend/src/components/report/reportShared.tsx
+++ b/frontend/src/components/report/reportShared.tsx
@@ -124,6 +124,28 @@ export function ReportOrgFavicon({ domain, size = 20 }: { domain: string; size?:
   );
 }
 
+// pecorino-64118: chip for an org domain (TLD) derived from approved guests'
+// emails, with a count when more than one guest shares the domain.
+export function OrgDomainChip({ domain, count }: { domain: string; count: number }) {
+  return (
+    <div className="inline-flex items-center gap-2 bg-theme-surface rounded-lg px-3 py-2 border border-theme-stroke">
+      <ReportOrgFavicon domain={domain} size={16} />
+      <a
+        href={`https://${domain}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={domain}
+        className="text-sm text-theme-text-secondary hover:text-theme-text transition-colors truncate max-w-[180px]"
+      >
+        {domain}
+      </a>
+      {count > 1 && (
+        <span className="text-xs text-theme-text-muted">({count})</span>
+      )}
+    </div>
+  );
+}
+
 export function ReportOrgCard({ group }: { group: { domain: string | null; attendees: NotableAttendee[] } }) {
   const { domain, attendees } = group;
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -726,6 +726,8 @@ export interface EventReport {
   // Related data
   socialPosts: SocialPost[];
   notableAttendees: NotableAttendee[];
+  // pecorino-64118: org domains derived from approved guests' emails (server-side).
+  industryOrgs?: { domain: string; count: number }[];
   featuredPhotos: Photo[];
 
   // Wallet addresses for CSV export
@@ -1548,6 +1550,8 @@ export interface ConsolidatedReport {
   };
   // Notable attendees with email masked to @domain, annotated with event name.
   notableAttendees: (NotableAttendee & { eventName?: string })[];
+  // pecorino-64118: combined org domains from approved guests' emails (server-side).
+  industryOrgs?: { domain: string; count: number }[];
   // Social posts annotated with their event name + optional party context.
   socialPosts: ConsolidatedReportSocialPost[];
   featuredPhotos: ConsolidatedReportPhoto[];


### PR DESCRIPTION
Industry RSVPs now derive org domains/TLDs from all approved guests' emails (personal providers hidden), computed server-side ({domain,count}, no raw emails leaked), replacing the curated notable-attendee display in ReportPreview + ConsolidatedReportPreview; needs backend redeploy from master to take effect;

🤖 Generated with [Claude Code](https://claude.com/claude-code)