### PR TITLE
fix(napoletana-58199): force white outline on vote icon

### DIFF
--- a/frontend/src/components/photos/PhotoCard.tsx
+++ b/frontend/src/components/photos/PhotoCard.tsx
@@ -240,7 +240,7 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
           className={`absolute bottom-2 left-2 z-10 cursor-pointer text-white hover:scale-110 transition-transform ${voting ? 'opacity-70' : ''}`}
           style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.8))' }}
         >
-          <ThumbsUp size={22} fill="currentColor" strokeWidth={2.25} />
+          <ThumbsUp size={22} fill="none" stroke="white" strokeWidth={2.25} />
         </button>
       )}
     </div>

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -630,7 +630,7 @@ function FeedTile({
           className={`absolute bottom-2 right-2 cursor-pointer text-white hover:scale-110 transition-transform ${voting ? 'opacity-70' : ''}`}
           style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.8))' }}
         >
-          <ThumbsUp size={22} fill="currentColor" strokeWidth={2.25} />
+          <ThumbsUp size={22} fill="none" stroke="white" strokeWidth={2.25} />
         </span>
       </div>
       {(displayCity || photo.party.name) && (


### PR DESCRIPTION
## Summary
- Vote icon was rendering dark/black instead of white because .gpp-theme remaps text-white -> #1a1a1a !important
- Switch to explicit `stroke=\"white\"` SVG attr (bypasses CSS cascade) + `fill=\"none\"` (outline only per Snax)

## Test plan
- [ ] /photos: thumbs-up icon is a white outline against any photo background
- [ ] Drop-shadow still gives visibility
- [ ] Vercel preview: https://rsvpizza-git-napoletana-58199-vote-outline-white-pizza-dao.vercel.app/photos

Generated with Claude Code