### PR TITLE
pecorino-64118: show all approved photos in /photos feed + report sample with View all

### DIFF
--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -68,7 +68,6 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
       : null;
 
     const where: any = {
-      starred: true,
       status: 'approved',
       party: {
         is: buildPartyFilter({ regions, countries, partnerTag }),
@@ -154,14 +153,13 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
 });
 
 // sicilian-58129: facets endpoint — returns distinct country values among
-// feed-eligible photos (starred + approved + party-eligible) with photo counts.
+// feed-eligible photos (approved + party-eligible) with photo counts.
 // Used by the /photos filter bar to populate the country dropdown.
 router.get('/feed/facets', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const grouped = await prisma.photo.groupBy({
       by: ['partyId'],
       where: {
-        starred: true,
         status: 'approved',
         party: {
           is: {

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1154,8 +1154,8 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
           include: { guest: { select: { email: true } } },
         },
         photos: {
-          where: { starred: true },
-          orderBy: { starredAt: 'desc' },
+          where: { status: 'approved' },
+          orderBy: [{ starred: 'desc' }, { createdAt: 'desc' }],
           take: 10,
         },
         user: { select: { name: true, profilePictureUrl: true } },
@@ -1387,8 +1387,9 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       };
     });
 
-    // Cap combined starred photos at 60 total.
-    const featuredPhotos = combinedPhotos.slice(0, 60);
+    // pecorino-64118: report shows a representative SAMPLE (starred/best first,
+    // then recent); the "View all photos" link covers the rest via /photos.
+    const featuredPhotos = combinedPhotos.slice(0, 24);
 
     // Deduped wallet address list.
     const walletAddressList = Array.from(walletSet);

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -216,6 +216,17 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
               );
             })}
           </div>
+          {report.tag && (
+            <div className="mt-4">
+              <a
+                href={`/photos?partnerTag=${encodeURIComponent(report.tag)}`}
+                className="inline-flex items-center gap-1 text-sm text-theme-text hover:text-theme-text-secondary transition-colors"
+              >
+                {tp('consolidated.viewAllPhotos')}
+                <ExternalLink size={14} className="text-theme-text-muted flex-shrink-0" />
+              </a>
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}} Event",
     "eventCount_other": "{{count}} Events",
     "perEventBreakdown": "Aufschlüsselung pro Event",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "Zurück zum Dashboard",
     "notAvailableTitle": "Bericht noch nicht verfügbar",
     "notAvailableDesc": "Der Gesamtbericht ist noch nicht verfügbar. Bitte schauen Sie bald wieder vorbei.",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}} event",
     "eventCount_other": "{{count}} events",
     "perEventBreakdown": "Per-Event Breakdown",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "Back to dashboard",
     "notAvailableTitle": "Report not available yet",
     "notAvailableDesc": "The consolidated report is not available yet. Please check back soon.",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}} evento",
     "eventCount_other": "{{count}} eventos",
     "perEventBreakdown": "Desglose por evento",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "Volver al panel",
     "notAvailableTitle": "Reporte aún no disponible",
     "notAvailableDesc": "El reporte consolidado aún no está disponible. Vuelve a consultar pronto.",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}} événement",
     "eventCount_other": "{{count}} événements",
     "perEventBreakdown": "Détail par événement",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "Retour au tableau de bord",
     "notAvailableTitle": "Rapport pas encore disponible",
     "notAvailableDesc": "Le rapport consolidé n'est pas encore disponible. Veuillez revenir bientôt.",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}}件のイベント",
     "eventCount_other": "{{count}}件のイベント",
     "perEventBreakdown": "イベント別内訳",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "ダッシュボードに戻る",
     "notAvailableTitle": "レポートはまだ利用できません",
     "notAvailableDesc": "統合レポートはまだ利用できません。しばらくしてからもう一度ご確認ください。",

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "이벤트 {{count}}개",
     "eventCount_other": "이벤트 {{count}}개",
     "perEventBreakdown": "이벤트별 분석",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "대시보드로 돌아가기",
     "notAvailableTitle": "리포트를 아직 사용할 수 없습니다",
     "notAvailableDesc": "통합 리포트를 아직 사용할 수 없습니다. 잠시 후 다시 확인해 주세요.",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}} evento",
     "eventCount_other": "{{count}} eventos",
     "perEventBreakdown": "Detalhamento por evento",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "Voltar ao painel",
     "notAvailableTitle": "Relatório ainda não disponível",
     "notAvailableDesc": "O relatório consolidado ainda não está disponível. Volte em breve.",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -245,6 +245,7 @@
     "eventCount": "{{count}} 个活动",
     "eventCount_other": "{{count}} 个活动",
     "perEventBreakdown": "各活动明细",
+    "viewAllPhotos": "View all photos →",
     "backToDashboard": "返回仪表板",
     "notAvailableTitle": "报告尚不可用",
     "notAvailableDesc": "汇总报告尚不可用，请稍后再查看。",


### PR DESCRIPTION
Follow-up to **pecorino-64118**. Two changes so the consolidated report's photos aren't truncated/starred-limited.

## (A) `/photos` feed shows ALL approved photos
- `backend/src/routes/photo-feed.routes.ts`: removed `starred: true` from both `GET /feed` and `GET /feed/facets` `where` clauses. Now shows all **approved** photos (moderation status + party `underbossStatus:'approved'` / `photosPublic:true` / `photosEnabled:true` host opt-in still gate it). Pagination/ordering/response shape unchanged.
- **Note: this changes the public `/photos` page globally** (no longer starred-only), not just the report path.

## (B) Consolidated report = sample + "View all photos →"
- `backend/src/routes/sponsor-user.routes.ts` `GET /report`: photos query `where` changed to `{ status: 'approved' }`, `orderBy` to `[{ starred: 'desc' }, { createdAt: 'desc' }]` (starred/best first, then recent), `take: 10` per event kept. Final cap changed from `slice(0, 60)` → `slice(0, 24)` (report shows a *sample* now).
- `frontend/src/components/report/ConsolidatedReportPreview.tsx`: renders the ≤24 sample grid, plus a **"View all photos →"** link below it (only when `report.tag` is truthy) to `/photos?partnerTag={tag}` (the `/photos` page already reads `partnerTag` from the query string and filters by it).
- i18n: added `consolidated.viewAllPhotos` to all 8 `partner.json` locales (English real value, English placeholder for the rest).

## Deploy note
Backend change needs a **redeploy from master** to take effect — previews hit the prod backend.

## Verify
- `cd backend && npx tsc --noEmit` — only the pre-existing `src/middleware/auth.test.ts(38,14)` error (confirmed on origin/master) plus `sharp`/`openai` module-not-found (missing worktree deps). No errors in the two edited route files.
- `cd frontend && npm run build` — passes.
- i18n key-parity guardrail test (`src/i18n/__tests__/i18n-keys.test.ts`) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code).