### PR TITLE
fix(napoletana-58200): restore voted-state visual on white vote icon

### DIFF
--- a/frontend/src/components/photos/PhotoCard.tsx
+++ b/frontend/src/components/photos/PhotoCard.tsx
@@ -240,7 +240,7 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
           className={`absolute bottom-2 left-2 z-10 cursor-pointer text-white hover:scale-110 transition-transform ${voting ? 'opacity-70' : ''}`}
           style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.8))' }}
         >
-          <ThumbsUp size={22} fill="none" stroke="white" strokeWidth={2.25} />
+          <ThumbsUp size={22} fill={photo.votedByMe ? 'white' : 'none'} stroke="white" strokeWidth={2.25} />
         </button>
       )}
     </div>

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -630,7 +630,7 @@ function FeedTile({
           className={`absolute bottom-2 right-2 cursor-pointer text-white hover:scale-110 transition-transform ${voting ? 'opacity-70' : ''}`}
           style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.8))' }}
         >
-          <ThumbsUp size={22} fill="none" stroke="white" strokeWidth={2.25} />
+          <ThumbsUp size={22} fill={photo.votedByMe ? 'white' : 'none'} stroke="white" strokeWidth={2.25} />
         </span>
       </div>
       {(displayCity || photo.party.name) && (


### PR DESCRIPTION
## Summary
- Vote click was toggling correctly in DB but icon looked identical before/after — felt broken
- Restore votedByMe distinction: outline-only when not voted, solid white when voted (stroke stays white in both states)

## Test plan
- [ ] As logged-in user on /photos: click thumbs-up → icon fills white. Click again → icon goes back to outline
- [ ] Vote persists across refresh
- [ ] Vercel preview: https://rsvpizza-git-napoletana-58200-vote-visual-state-pizza-dao.vercel.app/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)