### PR TITLE
fix(napoletana-58201): country-search input padding fix

### DIFF
--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -407,7 +407,7 @@ function CountryFilterButton({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search countries..."
-            className="w-full pl-7 pr-2 py-1.5 text-sm bg-white border border-black/10 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:border-red-500/40"
+            className="w-full pl-9 pr-2 py-1.5 text-sm bg-white border border-black/10 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:border-red-500/40"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Country filter dropdown's search input had pl-7 (28px); the absolutely-positioned magnifying-glass icon overlapped the typed text
- Bump to pl-9 (36px)

## Test plan
- [ ] /photos -> Country dropdown -> click search -> type "spain" -> icon and text don't overlap
- [ ] Vercel preview: https://rsvpizza-git-napoletana-58201-search-icon-overlap-pizza-dao.vercel.app/photos

Generated with [Claude Code](https://claude.com/claude-code)