### PR TITLE
feat(pecorino-64118): group consolidated report Industry RSVPs by city

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1393,12 +1393,20 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
         combinedPhotos.push({ ...ph, party: partyContext });
       }
 
+      // pecorino-64118: per-event Industry RSVPs — org domains from THIS event's
+      // approved guests, so the consolidated report can group industry orgs by city.
+      const eventIndustryOrgs = buildIndustryOrgs(
+        submitted.filter(g => g.approved !== false).map(g => g.email)
+      );
+
       const reportSlug = party.reportPublicSlug || party.customUrl || party.inviteCode;
       return {
         id: party.id,
         name: party.name,
         date: party.date,
         slug: party.customUrl || party.inviteCode,
+        city: party.city,
+        country: party.country,
         reportSlug,
         rsvpCount,
         approvedCount,
@@ -1407,6 +1415,7 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
           uniqueVisitors: perEventUniqueViewMap.get(party.id) || 0,
         },
         clicks: perEventClickCount.get(party.id) || 0,
+        industryOrgs: eventIndustryOrgs,
       };
     });
 

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -237,17 +237,39 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
         />
       )}
 
-      {/* Industry RSVPs — combined org domains from approved guests' emails (pecorino-64118) */}
-      {report.industryOrgs && report.industryOrgs.length > 0 && (
-        <div className="card p-6">
-          <h2 className="text-lg font-semibold text-theme-text mb-3">{t('report.industryRsvps')}</h2>
-          <div className="flex flex-wrap gap-2">
-            {report.industryOrgs.map((org) => (
-              <OrgDomainChip key={org.domain} domain={org.domain} count={org.count} />
-            ))}
+      {/* Industry RSVPs — grouped by city / event (pecorino-64118).
+          Each city sub-group shows a flag + "City, Country" header and that event's
+          org-domain chips. Groups ordered by descending org count. */}
+      {(() => {
+        const cityGroups = report.events
+          .filter((ev) => ev.industryOrgs && ev.industryOrgs.length > 0)
+          .sort((a, b) => (b.industryOrgs?.length || 0) - (a.industryOrgs?.length || 0));
+        if (cityGroups.length === 0) return null;
+        return (
+          <div className="card p-6">
+            <h2 className="text-lg font-semibold text-theme-text mb-3">{t('report.industryRsvps')}</h2>
+            <div className="space-y-5">
+              {cityGroups.map((ev) => {
+                const loc = resolvePartyLocation({ slug: ev.slug, name: ev.name, city: ev.city ?? null, country: ev.country ?? null });
+                const flag = loc && countryNameToAlpha2(loc.country) ? <CircleFlag country={loc.country} size={16} /> : null;
+                return (
+                  <div key={ev.id}>
+                    <div className="flex items-center gap-2 mb-2">
+                      {flag}
+                      <span className="text-sm font-medium text-theme-text-secondary">{loc?.label || ev.name}</span>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {ev.industryOrgs!.map((org) => (
+                        <OrgDomainChip key={org.domain} domain={org.domain} count={org.count} />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Social Posts (combined) — compact platform-icon cards */}
       {report.socialPosts.length > 0 && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1485,6 +1485,11 @@ export interface ConsolidatedReportEvent {
   approvedCount: number;
   impressions: { totalViews: number; uniqueVisitors: number };
   clicks: number;
+  // pecorino-64118: per-event org domains from approved guests' emails, plus city/
+  // country so the consolidated report can group Industry RSVPs by city.
+  industryOrgs?: { domain: string; count: number }[];
+  city?: string | null;
+  country?: string | null;
 }
 
 // pecorino-64118: per-item event context attached to consolidated photos/posts so


### PR DESCRIPTION
Consolidated report Industry RSVPs now grouped by city (per event), each with a flag + city header and that city's org-domain chips. Backend computes per-event `industryOrgs` (from each event's own approved guests) and includes `city`/`country` on each `events[]` entry; the frontend switches from the single combined list to per-city sub-groups ordered by descending org count. Needs backend redeploy from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code).