### PR TITLE
pizzetta-58924: /underboss stats card — approved + not-cancelled lens

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -68,14 +68,19 @@ function computeProgress(party: any, underbossEmails: string[] = []) {
 
 // Helper: compute stats from events
 function computeStats(events: any[], underbossEmails: string[] = []) {
-  const totalEvents = events.length;
+  // pizzetta-58924: per-event counters use approved + not-cancelled lens;
+  // per-guest sums stay across all events.
+  const approvedEvents = events.filter(
+    (e: any) => e.underbossStatus === 'approved' && !e.cancelledAt
+  );
+
+  const totalEvents = approvedEvents.length;
   let totalRsvps = 0;
   let totalApproved = 0;
+  let totalInvited = 0;
   let eventsWithVenue = 0;
   let eventsWithBudget = 0;
   let eventsWithKit = 0;
-
-  let totalInvited = 0;
 
   for (const event of events) {
     const invited = event.guests?.filter((g: any) => g.status === 'INVITED').length || 0;
@@ -85,7 +90,9 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
     totalInvited += invited;
     totalRsvps += guestCount;
     totalApproved += approvedCount;
+  }
 
+  for (const event of approvedEvents) {
     const progress = computeProgress(event, underbossEmails);
     if (progress.hasVenue) eventsWithVenue++;
     if (progress.hasBudget) eventsWithBudget++;

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -16,7 +16,13 @@ import { GPP_REGIONS } from '../types';
 import type { UnderbossDashboardData, UnderbossStats, UnderbossEvent } from '../types';
 
 function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStats {
-  const totalEvents = events.length;
+  // pizzetta-58924: per-event counters use approved + not-cancelled lens;
+  // per-guest sums stay across all events.
+  const approvedEvents = events.filter(
+    e => e.underbossStatus === 'approved' && !e.cancelledAt
+  );
+
+  const totalEvents = approvedEvents.length;
   let totalRsvps = 0;
   let totalInvited = 0;
   let totalApproved = 0;
@@ -27,6 +33,9 @@ function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStat
     totalRsvps += e.guestCount;
     totalInvited += e.invitedCount || 0;
     totalApproved += e.approvedCount;
+  }
+
+  for (const e of approvedEvents) {
     if (e.progress.hasVenue) eventsWithVenue++;
     if (e.progress.hasBudget) eventsWithBudget++;
   }


### PR DESCRIPTION
## Summary
- Events / With Venue / With Budget / completion-rate / avg-RSVPs stat cards on /underboss now count only events with `underbossStatus = 'approved'` AND `cancelledAt IS NULL` (instead of all GPP events).
- Mirrored in both the backend `computeStats` and the frontend `recomputeStats` so the count stays consistent whether the dashboard uses server stats (all regions selected) or recomputes locally (admin de-selects a region).
- Per-guest totals (Total RSVPs, Invited, Approved guests) unchanged.

## Expected impact (prod baseline 2026-05-26)
- Events card: ~1056 → **400**
- Other approved-only cards shrink proportionally; completion %s stay ≤100.

## Test plan
- [ ] Open /underboss as admin on preview; Events ≈ 400
- [ ] Completion-rate %s look reasonable (≤100)
- [ ] Total RSVPs / Invited / Approved unchanged vs prod
- [ ] De-select a region → stats recompute consistently (proves frontend mirror)
- [ ] Events tab badge below still reflects full event count for selected regions