### PR TITLE
feat(bresaola-89172): receipt thumbnail lightbox on /payments

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Check, AlertTriangle, ChevronLeft, ChevronRight, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -11,6 +11,7 @@ import {
   PAYOUT_METHOD_LABELS,
   formatUsd,
   formatOriginalCurrency,
+  ReceiptLightbox,
 } from '../payments-shared';
 
 /**
@@ -337,33 +338,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     }
   }
 
-  // taralli-58291: keyboard navigation for the lightbox + Escape passthrough
-  // to the parent close. When the lightbox is open, Escape closes it (and
-  // ArrowLeft / ArrowRight cycle); when closed, Escape closes the modal.
-  // Only one window listener is attached to keep the order deterministic.
+  // bresaola-89172: keyboard nav for the lightbox now lives inside the
+  // ReceiptLightbox component itself (Esc to close, arrows to cycle). The
+  // parent modal still listens for Esc here to close the review modal —
+  // when the lightbox is open it stops Esc propagation, so only one of
+  // these handlers fires per keypress.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (lightboxIndex != null) {
-        if (e.key === 'Escape') {
-          setLightboxIndex(null);
-        } else if (e.key === 'ArrowLeft') {
-          if (allPhotos.length === 0) return;
-          setLightboxIndex((i) =>
-            i == null ? null : (i - 1 + allPhotos.length) % allPhotos.length,
-          );
-        } else if (e.key === 'ArrowRight') {
-          if (allPhotos.length === 0) return;
-          setLightboxIndex((i) =>
-            i == null ? null : (i + 1) % allPhotos.length,
-          );
-        }
-      } else if (e.key === 'Escape') {
+      if (lightboxIndex == null && e.key === 'Escape') {
         onClose();
       }
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onClose, lightboxIndex, allPhotos.length]);
+  }, [onClose, lightboxIndex]);
 
   const ocrSum = receipts.reduce((sum, r) => sum + (Number(r.ocrAmount) || 0), 0);
 
@@ -1431,83 +1419,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         </div>
       </div>
 
-      {/* Lightbox — taralli-58291: ArrowLeft / ArrowRight cycle through
-          receipts + pizza photos, Escape closes. Keyboard handlers live in
-          the useEffect at the top of the component so they remain bound
-          regardless of focus. */}
-      {lightboxIndex != null && allPhotos[lightboxIndex] && (
-        <div
-          className="fixed inset-0 z-[60] bg-black/80 backdrop-blur-sm flex items-center justify-center p-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            setLightboxIndex(null);
-          }}
-        >
-          <img
-            src={allPhotos[lightboxIndex].url}
-            alt={allPhotos[lightboxIndex].fileName}
-            className="max-w-[90vw] max-h-[90vh] object-contain"
-            onClick={(e) => e.stopPropagation()}
-          />
-          {allPhotos.length > 1 && (
-            <>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setLightboxIndex((i) =>
-                    i == null
-                      ? null
-                      : (i - 1 + allPhotos.length) % allPhotos.length,
-                  );
-                }}
-                className="absolute left-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60"
-                aria-label="Previous photo"
-              >
-                <ChevronLeft size={32} />
-              </button>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setLightboxIndex((i) =>
-                    i == null ? null : (i + 1) % allPhotos.length,
-                  );
-                }}
-                className="absolute right-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60"
-                aria-label="Next photo"
-              >
-                <ChevronRight size={32} />
-              </button>
-            </>
-          )}
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setLightboxIndex(null);
-            }}
-            className="absolute top-4 right-4 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60"
-            aria-label="Close lightbox"
-          >
-            <X size={20} />
-          </button>
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/90 text-xs sm:text-sm flex items-center gap-2 bg-black/40 rounded-full px-3 py-1.5 max-w-[90vw]">
-            <span
-              className={`text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
-                allPhotos[lightboxIndex].kind === 'receipt'
-                  ? 'bg-amber-500 text-white'
-                  : 'bg-emerald-500 text-white'
-              }`}
-            >
-              {allPhotos[lightboxIndex].kind}
-            </span>
-            <span className="truncate">
-              {lightboxIndex + 1} / {allPhotos.length} · {allPhotos[lightboxIndex].fileName}
-            </span>
-          </div>
-        </div>
-      )}
+      {/* bresaola-89172: shared ReceiptLightbox renders into document.body
+          via createPortal, so it isn't clipped by the modal's overflow. It
+          owns its own Esc + arrow-key handlers and the HEIC fallback. */}
+      <ReceiptLightbox
+        isOpen={lightboxIndex != null}
+        images={allPhotos.map((d) => ({
+          url: d.url,
+          fileName: d.fileName,
+          mimeType: d.mimeType,
+        }))}
+        initialIndex={lightboxIndex ?? 0}
+        onClose={() => setLightboxIndex(null)}
+      />
     </div>
   );
 };

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
+
+/**
+ * bresaola-89172: focused full-screen overlay for receipt / pizza-photo
+ * thumbnails on the /payments dashboards (admin + host). Clicking a
+ * thumbnail opens this lightbox instead of doing nothing or popping a raw
+ * URL into a new tab.
+ *
+ * Behaviour:
+ * - Black backdrop, click backdrop OR press Esc to close.
+ * - Image centered, contained to 90vw / 90vh.
+ * - Multi-image: left/right arrows + footer "N of M" counter; ArrowLeft /
+ *   ArrowRight keys also navigate.
+ * - HEIC files can't be previewed natively in browsers — show a fallback
+ *   link to open the raw URL in a new tab.
+ */
+export interface ReceiptLightboxImage {
+  url: string;
+  fileName: string;
+  mimeType?: string;
+}
+
+interface ReceiptLightboxProps {
+  isOpen: boolean;
+  images: ReceiptLightboxImage[];
+  /** Index into `images` to display on open. Defaults to 0. */
+  initialIndex?: number;
+  onClose: () => void;
+}
+
+/** Some HEIC files come through with non-image/heic MIME types or no MIME at
+ *  all (the browser leaves it blank for unrecognised types). Match both the
+ *  MIME and the file-name extension. */
+function isHeic(image: ReceiptLightboxImage | undefined): boolean {
+  if (!image) return false;
+  const mime = (image.mimeType || '').toLowerCase();
+  if (mime === 'image/heic' || mime === 'image/heif') return true;
+  const name = (image.fileName || '').toLowerCase();
+  return name.endsWith('.heic') || name.endsWith('.heif');
+}
+
+export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
+  isOpen,
+  images,
+  initialIndex = 0,
+  onClose,
+}) => {
+  // Index lives in this component so callers only need to pass the starting
+  // image. Reset whenever the lightbox is (re-)opened so each open starts
+  // from `initialIndex`.
+  const [index, setIndex] = React.useState(initialIndex);
+  useEffect(() => {
+    if (isOpen) {
+      // Clamp to valid range — `initialIndex` from the caller might be stale
+      // by the time the lightbox opens.
+      const safe = Math.max(0, Math.min(initialIndex, Math.max(0, images.length - 1)));
+      setIndex(safe);
+    }
+  }, [isOpen, initialIndex, images.length]);
+
+  const count = images.length;
+  const hasMultiple = count > 1;
+
+  const goPrev = useCallback(() => {
+    if (count === 0) return;
+    setIndex((i) => (i - 1 + count) % count);
+  }, [count]);
+  const goNext = useCallback(() => {
+    if (count === 0) return;
+    setIndex((i) => (i + 1) % count);
+  }, [count]);
+
+  // Keyboard nav — Esc closes, arrows cycle (when more than one image).
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      } else if (e.key === 'ArrowLeft' && hasMultiple) {
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === 'ArrowRight' && hasMultiple) {
+        e.preventDefault();
+        goNext();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose, goPrev, goNext, hasMultiple]);
+
+  if (!isOpen || count === 0) return null;
+
+  const current = images[index];
+  if (!current) return null;
+  const heic = isHeic(current);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4"
+      onClick={(e) => {
+        // React event propagation follows the React tree, not the DOM tree.
+        // Even though this div is portalled into document.body, click events
+        // still bubble up to parent components (e.g. an enclosing modal whose
+        // own backdrop closes it). Stop the bubble so closing the lightbox
+        // doesn't also close the parent modal.
+        e.stopPropagation();
+        onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Receipt preview"
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        className="absolute top-4 right-4 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60 z-10"
+        aria-label="Close preview"
+      >
+        <X size={20} />
+      </button>
+
+      {hasMultiple && (
+        <>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              goPrev();
+            }}
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60 z-10"
+            aria-label="Previous image"
+          >
+            <ChevronLeft size={32} />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              goNext();
+            }}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60 z-10"
+            aria-label="Next image"
+          >
+            <ChevronRight size={32} />
+          </button>
+        </>
+      )}
+
+      {/* Main content — image OR HEIC fallback. Stop click propagation so the
+          centered image isn't a click-through dead zone that triggers close. */}
+      <div
+        className="max-w-[90vw] max-h-[90vh] flex items-center justify-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {heic ? (
+          <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
+            <p className="text-sm font-semibold">Can't preview HEIC files</p>
+            <p className="text-xs text-theme-text-muted">
+              Your browser doesn't render <span className="font-mono">.heic</span>{' '}
+              images natively. Open the file in a new tab to download or view it.
+            </p>
+            <a
+              href={current.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
+            >
+              Open in new tab <ExternalLink size={14} />
+            </a>
+            <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
+          </div>
+        ) : (
+          <img
+            src={current.url}
+            alt={current.fileName}
+            className="max-h-[90vh] max-w-[90vw] object-contain"
+          />
+        )}
+      </div>
+
+      {/* Footer — counter + file name. Only show counter when more than one. */}
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/90 text-xs sm:text-sm flex items-center gap-2 bg-black/40 rounded-full px-3 py-1.5 max-w-[90vw]">
+        {hasMultiple && (
+          <span className="font-medium">
+            {index + 1} of {count}
+          </span>
+        )}
+        <span className="truncate">{current.fileName}</span>
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -3,3 +3,5 @@ export { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from './PayoutMethodIcon';
 export { PayoutRow } from './PayoutRow';
 export { CapInlineEditor } from './CapInlineEditor';
 export { formatPayoutAmount, formatUsd, formatOriginalCurrency } from './formatPayoutAmount';
+export { ReceiptLightbox } from './ReceiptLightbox';
+export type { ReceiptLightboxImage } from './ReceiptLightbox';

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -8,6 +8,7 @@ import { IconInput } from '../IconInput';
 import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { CurrencyOverrideSelect } from './CurrencyOverrideSelect';
+import { ReceiptLightbox } from '../payments-shared';
 
 interface PayoutDetailModalProps {
   partyId: string;
@@ -83,6 +84,13 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   const [withdrawing, setWithdrawing] = useState(false);
   const [withdrawError, setWithdrawError] = useState<string | null>(null);
 
+  // bresaola-89172: lightbox state for receipt + pizza-photo thumbnails.
+  // The carousel combines both kinds so arrow-key nav walks the whole set.
+  const [lightboxState, setLightboxState] = useState<{ open: boolean; initialIndex: number }>({
+    open: false,
+    initialIndex: 0,
+  });
+
   // New uploads since edit-mode was opened (existing docs aren't re-uploaded).
   const [newReceipts, setNewReceipts] = useState<ReceiptItem[]>([]);
   const [newPizzaPhotos, setNewPizzaPhotos] = useState<PizzaPhotoItem[]>([]);
@@ -147,6 +155,29 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     () => (payout?.documents ?? []).filter(d => d.kind === 'pizza' && !removedDocIds.has(d.id)),
     [payout, removedDocIds]
   );
+
+  // bresaola-89172: unified lightbox list across receipts + pizza photos so
+  // arrow-key nav walks the whole set. Receipts listed first (matches the
+  // top-down DOM order in read-only mode).
+  const viewReceipts = useMemo(
+    () => (payout?.documents ?? []).filter(d => d.kind === 'receipt'),
+    [payout]
+  );
+  const viewPizzaPhotos = useMemo(
+    () => (payout?.documents ?? []).filter(d => d.kind === 'pizza'),
+    [payout]
+  );
+  const lightboxImages = useMemo(
+    () =>
+      [...viewReceipts, ...viewPizzaPhotos].map(d => ({
+        url: d.url,
+        fileName: d.fileName,
+        mimeType: d.mimeType,
+      })),
+    [viewReceipts, viewPizzaPhotos]
+  );
+  const receiptsLightboxOffset = 0;
+  const pizzasLightboxOffset = viewReceipts.length;
 
   const isProcessingUploads =
     newReceipts.some(r => r.status === 'uploading' || r.status === 'ocring') ||
@@ -440,15 +471,23 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
               )}
 
               {/* Receipts (with OCR breakdown) */}
-              {payout.documents.some(d => d.kind === 'receipt') && (
+              {viewReceipts.length > 0 && (
                 <div>
                   <p className="text-xs text-theme-text-muted mb-2">Receipts</p>
                   <ul className="space-y-2">
-                    {payout.documents.filter(d => d.kind === 'receipt').map(d => (
+                    {viewReceipts.map((d, idx) => (
                       <li key={d.id} className="flex items-center gap-3 p-2 rounded-lg bg-theme-surface-hover">
-                        <a href={d.url} target="_blank" rel="noreferrer" className="flex-shrink-0">
-                          <img src={d.url} alt="" className="w-14 h-14 rounded object-cover" />
-                        </a>
+                        {/* bresaola-89172: thumbnail opens the shared lightbox
+                            instead of popping the raw URL in a new tab. */}
+                        <button
+                          type="button"
+                          onClick={() => setLightboxState({ open: true, initialIndex: receiptsLightboxOffset + idx })}
+                          className="flex-shrink-0 rounded overflow-hidden hover:opacity-80 transition-opacity"
+                          aria-label={`Open ${d.fileName}`}
+                          title={d.fileName}
+                        >
+                          <img src={d.url} alt={d.fileName} className="w-14 h-14 object-cover block" />
+                        </button>
                         <div className="flex-1 min-w-0">
                           <p className="text-sm text-theme-text truncate">{d.fileName}</p>
                           {d.ocrAmount != null ? (
@@ -469,7 +508,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                             </p>
                           )}
                         </div>
-                        <a href={d.url} target="_blank" rel="noreferrer" className="p-1 text-theme-text-muted hover:text-theme-text">
+                        <a href={d.url} target="_blank" rel="noreferrer" className="p-1 text-theme-text-muted hover:text-theme-text" title="Open raw file">
                           <ExternalLink size={14} />
                         </a>
                       </li>
@@ -479,20 +518,23 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
               )}
 
               {/* Pizza photos */}
-              {payout.documents.some(d => d.kind === 'pizza') && (
+              {viewPizzaPhotos.length > 0 && (
                 <div>
                   <p className="text-xs text-theme-text-muted mb-2">Pizza / event photos</p>
                   <div className="grid grid-cols-4 sm:grid-cols-5 gap-2">
-                    {payout.documents.filter(d => d.kind === 'pizza').map(d => (
+                    {viewPizzaPhotos.map((d, idx) => (
                       <div key={d.id} className="space-y-1">
-                        <a
-                          href={d.url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="block aspect-square rounded-lg overflow-hidden bg-theme-surface"
+                        {/* bresaola-89172: same lightbox treatment — combined
+                            carousel walks receipts then pizza photos. */}
+                        <button
+                          type="button"
+                          onClick={() => setLightboxState({ open: true, initialIndex: pizzasLightboxOffset + idx })}
+                          className="block w-full aspect-square rounded-lg overflow-hidden bg-theme-surface hover:opacity-90 transition-opacity"
+                          aria-label={`Open ${d.fileName}`}
+                          title={d.fileName}
                         >
-                          <img src={d.url} alt="" className="w-full h-full object-cover hover:opacity-90 transition-opacity" />
-                        </a>
+                          <img src={d.url} alt={d.fileName} className="w-full h-full object-cover" />
+                        </button>
                         {/* pancetta-37195: per-photo uploader attribution.
                             Hidden for historical rows (null uploadedByUserId). */}
                         {d.uploadedByUserId && (
@@ -743,6 +785,13 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
           )}
         </div>
       </div>
+
+      <ReceiptLightbox
+        isOpen={lightboxState.open}
+        images={lightboxImages}
+        initialIndex={lightboxState.initialIndex}
+        onClose={() => setLightboxState({ open: false, initialIndex: 0 })}
+      />
     </div>
   );
 };

--- a/frontend/src/components/payouts/ReceiptsLibrary.tsx
+++ b/frontend/src/components/payouts/ReceiptsLibrary.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Loader2, AlertCircle, RefreshCw, FileText, ExternalLink } from 'lucide-react';
 import { fetchReceiptsLibrary } from '../../lib/api';
 import type { ReceiptLibraryEntry } from '../../types';
 import { PayoutStatusPill } from '../payments-shared/PayoutStatusPill';
+import { ReceiptLightbox } from '../payments-shared';
 
 interface ReceiptsLibraryProps {
   partyId: string;
@@ -25,6 +26,26 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
   const [receipts, setReceipts] = useState<ReceiptLibraryEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // bresaola-89172: lightbox state — store the initial index so clicking a
+  // specific row opens that image first and the carousel can step through
+  // every receipt in the library.
+  const [lightboxState, setLightboxState] = useState<{ open: boolean; initialIndex: number }>({
+    open: false,
+    initialIndex: 0,
+  });
+
+  // Build the carousel list once per receipts array. Includes every entry —
+  // non-image rows still get a fallback render inside the lightbox via the
+  // HEIC pathway, and unknown formats degrade gracefully.
+  const lightboxImages = useMemo(
+    () =>
+      receipts.map((r) => ({
+        url: r.url,
+        fileName: r.fileName,
+        mimeType: r.mimeType,
+      })),
+    [receipts],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -93,7 +114,7 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
 
       {!loading && !error && receipts.length > 0 && (
         <ul className="divide-y divide-theme-stroke">
-          {receipts.map((r) => {
+          {receipts.map((r, idx) => {
             const isImage = (r.mimeType || '').startsWith('image/');
             const formattedDate = new Date(r.createdAt).toLocaleDateString(undefined, {
               year: 'numeric',
@@ -106,18 +127,30 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
             const uploader = r.uploadedByName || r.uploadedByEmail || null;
             return (
               <li key={r.id} className="flex items-center gap-3 py-3">
-                {isImage ? (
-                  <img
-                    src={r.url}
-                    alt={r.fileName}
-                    className="w-12 h-12 object-cover rounded border border-theme-stroke flex-shrink-0"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="w-12 h-12 rounded border border-theme-stroke bg-theme-surface-hover flex items-center justify-center flex-shrink-0">
-                    <FileText size={20} className="text-theme-text-secondary" />
-                  </div>
-                )}
+                {/* bresaola-89172: thumbnail wrapped in a button so clicking
+                    opens the shared lightbox carousel scrolled to this row.
+                    Non-image rows (PDFs etc.) still open in a new tab via
+                    the lightbox's HEIC-style fallback. */}
+                <button
+                  type="button"
+                  onClick={() => setLightboxState({ open: true, initialIndex: idx })}
+                  className="flex-shrink-0 rounded border border-theme-stroke overflow-hidden hover:opacity-80 transition-opacity"
+                  aria-label={`Open ${r.fileName}`}
+                  title={r.fileName}
+                >
+                  {isImage ? (
+                    <img
+                      src={r.url}
+                      alt={r.fileName}
+                      className="w-12 h-12 object-cover block"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 bg-theme-surface-hover flex items-center justify-center">
+                      <FileText size={20} className="text-theme-text-secondary" />
+                    </div>
+                  )}
+                </button>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-sm font-medium text-theme-text truncate">
@@ -147,6 +180,13 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
           })}
         </ul>
       )}
+
+      <ReceiptLightbox
+        isOpen={lightboxState.open}
+        images={lightboxImages}
+        initialIndex={lightboxState.initialIndex}
+        onClose={() => setLightboxState({ open: false, initialIndex: 0 })}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- New `ReceiptLightbox` (createPortal, full-screen, Esc to close, arrow-key nav).
- Wired into PayoutReviewModal, PayoutDetailModal, ReceiptsLibrary.
- Combines receipts + pizza photos into one carousel.
- HEIC fallback links to raw URL.
- No backend/schema changes.

## Test plan
- [ ] Click receipt thumbnail on /payments → lightbox opens with that image.
- [ ] Esc + backdrop click both close.
- [ ] Arrow keys navigate across all docs.
- [ ] HEIC file shows fallback link.