### PR TITLE
feat(formaggi-89172): structured line items + pizza price analytics

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1709,6 +1709,12 @@ model PayoutDocument {
   ocrCurrency   String?  @map("ocr_currency")
   ocrConfidence Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
   ocrRaw        Json?    @map("ocr_raw")
+  // formaggi-89172: structured per-line items extracted from the receipt OCR.
+  // Schema is OcrLineItem[] (see backend/src/services/ocr.service.ts) — each
+  // entry has name, qty, unitPrice, subtotal, category. Stored as JSONB with a
+  // GIN index (`idx_payout_documents_ocr_line_items`) to support future
+  // analytics queries (e.g. average pizza prices by country/city).
+  ocrLineItems  Json?    @map("ocr_line_items")
   ocrError      String?  @map("ocr_error")
   // pancetta-37195: per-receipt uploader attribution. Both nullable so
   // historical rows are valid. uploadedByEmail caches the email at upload

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2752,6 +2752,196 @@ router.patch(
   },
 );
 
+// ============================================
+// GET /api/admin/payouts/pizza-prices
+//
+// formaggi-89172: returns per-row pizza items extracted from payout-document
+// OCR (`payout_documents.ocr_line_items`) plus a simple by-country aggregate,
+// converted to USD via each payout's recorded `exchangeRate`. Backs future
+// analytics; no frontend UI in this PR — admins can `curl` it for spot data.
+//
+// Optional query params:
+//   - country?: string  — filter to a single Party.country (case-sensitive,
+//     matches how the column is stored).
+//   - currency?: string — filter to a single Payout.originalCurrency
+//     (post-fetch, since the FX field lives on the payout, not the doc).
+//   - since?: ISO date  — only payouts created on/after this timestamp.
+// ============================================
+router.get(
+  '/pizza-prices',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const country = typeof req.query.country === 'string' && req.query.country.trim()
+        ? req.query.country.trim()
+        : null;
+      const currency = typeof req.query.currency === 'string' && req.query.currency.trim()
+        ? req.query.currency.trim().toUpperCase()
+        : null;
+      const sinceRaw = typeof req.query.since === 'string' && req.query.since.trim()
+        ? req.query.since.trim()
+        : null;
+
+      let since: Date | null = null;
+      if (sinceRaw) {
+        const parsed = new Date(sinceRaw);
+        if (Number.isNaN(parsed.getTime())) {
+          throw new AppError(`Invalid \`since\` parameter: ${sinceRaw}`, 400, 'BAD_SINCE');
+        }
+        since = parsed;
+      }
+
+      // Build the payout filter — country lives on `payout.party.country`,
+      // since on `payout.createdAt`. We can't filter `originalCurrency` at the
+      // payout-document level (it's on the parent Payout), so we do that
+      // post-fetch in-app.
+      const payoutFilter: Prisma.PayoutWhereInput = {};
+      if (country) payoutFilter.party = { country };
+      if (since) payoutFilter.createdAt = { gte: since };
+
+      const rows = await prisma.payoutDocument.findMany({
+        where: {
+          // Only receipts with a non-null line-items JSONB. `Prisma.DbNull` is
+          // the SQL-NULL marker for JSON columns; without this filter we'd
+          // pull every payout document ever inserted.
+          ocrLineItems: { not: Prisma.DbNull },
+          // Receipts without a parent payout (orphaned via Payout delete +
+          // SetNull) can't be priced — skip them.
+          payout: { is: payoutFilter },
+        },
+        select: {
+          id: true,
+          ocrLineItems: true,
+          ocrCurrency: true,
+          payout: {
+            select: {
+              originalCurrency: true,
+              exchangeRate: true,
+              createdAt: true,
+              party: { select: { id: true, name: true, country: true, city: true } },
+            },
+          },
+        },
+      });
+
+      type PizzaPriceRow = {
+        documentId: string;
+        partyId: string;
+        partyName: string;
+        country: string | null;
+        city: string | null;
+        itemName: string;
+        qty: number;
+        unitPriceOriginal: number;
+        subtotalOriginal: number;
+        currency: string;
+        // formaggi-89172: exchangeRate on `payouts` is stored as
+        // (USD amount) / (original amount). So multiplying an original-currency
+        // unit price by exchangeRate yields USD.
+        unitPriceUsd: number;
+        subtotalUsd: number;
+        payoutCreatedAt: string;
+      };
+
+      const pizzaPrices: PizzaPriceRow[] = [];
+      for (const r of rows) {
+        // `payout` is `is: payoutFilter`-narrowed but still typed nullable —
+        // guard so TS knows we have a payout below.
+        if (!r.payout) continue;
+
+        const items = Array.isArray(r.ocrLineItems) ? (r.ocrLineItems as any[]) : [];
+        if (items.length === 0) continue;
+
+        const payoutCurrency = r.payout.originalCurrency ?? r.ocrCurrency ?? 'USD';
+        if (currency && payoutCurrency.toUpperCase() !== currency) continue;
+
+        const fx = Number(r.payout.exchangeRate?.toString() ?? '1');
+        const safeFx = Number.isFinite(fx) && fx > 0 ? fx : 1;
+
+        for (const it of items) {
+          if (!it || typeof it !== 'object') continue;
+          if (it.category !== 'pizza') continue;
+
+          const qty = Number.isFinite(Number(it.qty)) && Number(it.qty) >= 0 ? Number(it.qty) : 1;
+          const unitOrig = Number.isFinite(Number(it.unitPrice)) && Number(it.unitPrice) >= 0
+            ? Number(it.unitPrice)
+            : 0;
+          const subOrig = Number.isFinite(Number(it.subtotal)) && Number(it.subtotal) >= 0
+            ? Number(it.subtotal)
+            : qty * unitOrig;
+
+          pizzaPrices.push({
+            documentId: r.id,
+            partyId: r.payout.party.id,
+            partyName: r.payout.party.name,
+            country: r.payout.party.country,
+            city: r.payout.party.city,
+            itemName: typeof it.name === 'string' ? it.name : '',
+            qty,
+            unitPriceOriginal: unitOrig,
+            subtotalOriginal: subOrig,
+            currency: payoutCurrency,
+            unitPriceUsd: unitOrig * safeFx,
+            subtotalUsd: subOrig * safeFx,
+            payoutCreatedAt: r.payout.createdAt.toISOString(),
+          });
+        }
+      }
+
+      // Group by country, compute count + USD min/avg/max on unit price.
+      // Zero-priced rows ([illegible] lines etc.) are excluded from the
+      // aggregate so they don't drag the average down; the raw row is still
+      // returned in `pizzaPrices` for completeness.
+      type CountryAgg = {
+        country: string;
+        count: number;
+        avgUnitPriceUsd: number;
+        minUnitPriceUsd: number;
+        maxUnitPriceUsd: number;
+      };
+      const byCountryMap = new Map<string, { sum: number; n: number; min: number; max: number }>();
+      for (const p of pizzaPrices) {
+        if (!p.country) continue;
+        if (p.unitPriceUsd <= 0) continue;
+        const key = p.country;
+        const cur = byCountryMap.get(key);
+        if (cur) {
+          cur.sum += p.unitPriceUsd;
+          cur.n += 1;
+          if (p.unitPriceUsd < cur.min) cur.min = p.unitPriceUsd;
+          if (p.unitPriceUsd > cur.max) cur.max = p.unitPriceUsd;
+        } else {
+          byCountryMap.set(key, {
+            sum: p.unitPriceUsd,
+            n: 1,
+            min: p.unitPriceUsd,
+            max: p.unitPriceUsd,
+          });
+        }
+      }
+      const byCountry: CountryAgg[] = Array.from(byCountryMap.entries())
+        .map(([country, agg]) => ({
+          country,
+          count: agg.n,
+          avgUnitPriceUsd: agg.sum / agg.n,
+          minUnitPriceUsd: agg.min,
+          maxUnitPriceUsd: agg.max,
+        }))
+        .sort((a, b) => b.count - a.count);
+
+      res.json({
+        filters: { country, currency, since: since?.toISOString() ?? null },
+        totalRows: pizzaPrices.length,
+        pizzaPrices,
+        byCountry,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // Re-export the helper so other backend code (e.g. PR 5 execute route) can
 // reuse the composed guard without re-deriving it.
 export { requireAnyAdminOrPaymentAdmin, isFullAdmin };

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -752,6 +752,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       ocrCurrency: string | null;
       ocrConfidence: Decimal | null;
       ocrRaw: any;
+      // formaggi-89172: per-line structured items extracted from the receipt.
+      // null for pizza-photo rows + receipts whose OCR errored.
+      ocrLineItems: any;
       ocrError: string | null;
       sortOrder: number;
     }> = [];
@@ -781,6 +784,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           ocrCurrency: fx.originalCurrency,
           ocrConfidence: new Decimal(ocr.confidence),
           ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
+          // formaggi-89172: structured per-line items for pizza-price analytics.
+          ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
           ocrError: null,
           sortOrder: idx,
         });
@@ -796,6 +801,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           ocrCurrency: null,
           ocrConfidence: null,
           ocrRaw: null,
+          ocrLineItems: null,
           ocrError: err,
           sortOrder: idx,
         });
@@ -815,6 +821,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         ocrCurrency: null,
         ocrConfidence: null,
         ocrRaw: null,
+        ocrLineItems: null,
         ocrError: null,
         sortOrder: i,
       });
@@ -1349,6 +1356,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrCurrency: string | null;
       ocrConfidence: Decimal | null;
       ocrRaw: any;
+      // formaggi-89172: per-line structured items extracted from the receipt.
+      ocrLineItems: any;
       ocrError: string | null;
       sortOrder: number;
     }> = [];
@@ -1385,6 +1394,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrCurrency: fx.originalCurrency,
           ocrConfidence: new Decimal(ocr.confidence),
           ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
+          // formaggi-89172: structured per-line items for pizza-price analytics.
+          ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
           ocrError: null,
           sortOrder: i,
         });
@@ -1400,6 +1411,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrCurrency: null,
           ocrConfidence: null,
           ocrRaw: null,
+          ocrLineItems: null,
           ocrError: err,
           sortOrder: i,
         });
@@ -1416,6 +1428,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrCurrency: null,
       ocrConfidence: null,
       ocrRaw: null,
+      ocrLineItems: null,
       ocrError: null,
       sortOrder: i,
     }));
@@ -1506,6 +1519,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
             uploadedByUserId: uploaderUserId,
             uploadedByEmail: uploaderEmail,
             ocrRaw: d.ocrRaw === null ? Prisma.JsonNull : (d.ocrRaw as Prisma.InputJsonValue),
+            // formaggi-89172: same JsonNull handling as ocrRaw — Prisma needs
+            // an explicit JsonNull marker (not JS null) to insert a SQL NULL
+            // into a JSONB column via createMany.
+            ocrLineItems: d.ocrLineItems == null ? Prisma.JsonNull : (d.ocrLineItems as Prisma.InputJsonValue),
           })),
         });
       }

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -8,26 +8,69 @@
  *
  * Returns BOTH the parsed result AND the raw JSON string so callers can
  * persist it on `payout_documents.ocr_raw` for debugging low-confidence rows.
+ *
+ * formaggi-89172: also extracts per-line structured items (name, qty,
+ * unitPrice, subtotal, category) so we can later aggregate average pizza
+ * prices by country/city. Stored on `payout_documents.ocr_line_items` JSONB.
  */
 
 import { getOpenAI } from '../lib/openai.js';
+
+// formaggi-89172: allowed categories. Keep in sync with the system prompt
+// and the sanitizer below. `other` is the safe fallback for anything else.
+const ALLOWED_CATEGORIES = [
+  'pizza',
+  'drink',
+  'side',
+  'dessert',
+  'tax',
+  'tip',
+  'fee',
+  'other',
+] as const;
+export type OcrLineItemCategory = (typeof ALLOWED_CATEGORIES)[number];
+
+export interface OcrLineItem {
+  name: string;
+  qty: number;
+  unitPrice: number;
+  subtotal: number;
+  category: OcrLineItemCategory;
+}
 
 export interface OcrResult {
   amount: number;
   currency: string;
   confidence: number;
   items?: string[];
+  // formaggi-89172: new — structured line items + merchant/date for analytics.
+  lineItems?: OcrLineItem[];
+  merchant?: string | null;
+  receiptDate?: string | null;
   raw: unknown;
 }
 
-const SYSTEM_PROMPT = `You are a receipt analysis assistant. Extract the total amount from the receipt image.
+const SYSTEM_PROMPT = `You are a receipt analysis assistant. Extract the total amount and per-line items from the receipt image.
 Return ONLY a JSON object with these fields:
 - amount: number (the total amount paid, as a decimal number)
-- currency: string (USD, EUR, etc. - default to USD if unclear)
-- confidence: number (0-1, your confidence in the extraction)
-- items: string[] (optional list of food items if visible)
+- currency: string (USD, EUR, INR, etc. - default to USD if unclear)
+- confidence: number (0-1, your confidence in the total extraction)
+- merchant: string (restaurant/store name if visible, else null)
+- receiptDate: string (YYYY-MM-DD if visible, else null)
+- lineItems: Array<{
+    name: string,            // the item as printed on the receipt
+    qty: number,             // quantity (default 1 if not visible)
+    unitPrice: number,       // price per unit in the receipt's currency (use amount field's currency)
+    subtotal: number,        // total for this line (qty * unitPrice, or what's printed)
+    category: "pizza" | "drink" | "side" | "dessert" | "tax" | "tip" | "fee" | "other"
+  }>
+- items: string[] (legacy fallback — flat list of item names; will be deprecated)
 
-If you cannot determine the total, estimate from visible items. Always return valid JSON.`;
+Be exhaustive with lineItems — extract every line on the receipt. If a line is illegible, set name to "[illegible]" and other numeric fields to 0.
+Use your best judgment for category. Default "other".
+If the receipt is unreadable, return lineItems: [] and confidence: 0.
+
+Always return valid JSON.`;
 
 /**
  * Fetch an image from a public URL and convert to a base64 data URL.
@@ -42,6 +85,47 @@ async function imageUrlToBase64DataUrl(imageUrl: string): Promise<string> {
   const base64 = Buffer.from(arrayBuf).toString('base64');
   const contentType = response.headers.get('content-type') || 'image/jpeg';
   return `data:${contentType};base64,${base64}`;
+}
+
+/**
+ * formaggi-89172: defensively sanitize the model's `lineItems` array.
+ * Drops rows that don't have at least a name; clamps numeric fields to
+ * non-negative finite numbers; coerces category into the allowed enum.
+ */
+function sanitizeLineItems(raw: unknown): OcrLineItem[] {
+  if (!Array.isArray(raw)) return [];
+  const out: OcrLineItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+
+    // Name is required; coerce non-strings, fall back to placeholder.
+    const rawName = e.name;
+    const name = typeof rawName === 'string' && rawName.trim().length > 0
+      ? rawName.trim()
+      : '[illegible]';
+
+    const qtyNum = Number(e.qty);
+    const qty = Number.isFinite(qtyNum) && qtyNum >= 0 ? qtyNum : 1;
+
+    const unitNum = Number(e.unitPrice);
+    const unitPrice = Number.isFinite(unitNum) && unitNum >= 0 ? unitNum : 0;
+
+    const subNum = Number(e.subtotal);
+    const subtotal = Number.isFinite(subNum) && subNum >= 0
+      ? subNum
+      : qty * unitPrice;
+
+    const rawCategory = typeof e.category === 'string'
+      ? e.category.toLowerCase().trim()
+      : 'other';
+    const category: OcrLineItemCategory = (ALLOWED_CATEGORIES as readonly string[]).includes(rawCategory)
+      ? (rawCategory as OcrLineItemCategory)
+      : 'other';
+
+    out.push({ name, qty, unitPrice, subtotal, category });
+  }
+  return out;
 }
 
 /**
@@ -61,12 +145,14 @@ export async function analyzeReceipt(imageUrl: string): Promise<OcrResult> {
       {
         role: 'user',
         content: [
-          { type: 'text', text: 'Extract the total amount from this receipt.' },
+          { type: 'text', text: 'Extract the total amount and per-line items from this receipt.' },
           { type: 'image_url', image_url: { url: base64Image } },
         ],
       },
     ],
-    max_tokens: 500,
+    // formaggi-89172: bumped from 500 → 1500 to fit the per-line items array.
+    // Receipts with 10–20 lines were getting truncated mid-JSON otherwise.
+    max_tokens: 1500,
     response_format: { type: 'json_object' },
   });
 
@@ -95,11 +181,23 @@ export async function analyzeReceipt(imageUrl: string): Promise<OcrResult> {
     throw new Error(`OpenAI returned non-numeric amount: ${JSON.stringify(parsed)}`);
   }
 
+  // formaggi-89172: merchant + receiptDate are best-effort. Coerce missing/
+  // empty strings to null so the JSONB row has consistent shape.
+  const merchant = typeof parsed.merchant === 'string' && parsed.merchant.trim().length > 0
+    ? parsed.merchant.trim()
+    : null;
+  const receiptDate = typeof parsed.receiptDate === 'string' && parsed.receiptDate.trim().length > 0
+    ? parsed.receiptDate.trim()
+    : null;
+
   return {
     amount,
     currency,
     confidence,
     items: Array.isArray(parsed.items) ? parsed.items.filter((s: unknown) => typeof s === 'string') : undefined,
+    lineItems: sanitizeLineItems(parsed.lineItems),
+    merchant,
+    receiptDate,
     raw: parsed,
   };
 }


### PR DESCRIPTION
## Summary
- `payout_documents.ocr_line_items jsonb` + GIN index (migration applied to prod).
- OCR prompt expanded to extract per-line items with categories (pizza, drink, side, dessert, tax, tip, fee, other) + merchant + receiptDate.
- New admin endpoint `GET /api/admin/payouts/pizza-prices?country=&since=` returns per-row pizza items + by-country aggregate, in USD via payout-level FX.
- Existing total-amount extraction unchanged.
- No frontend UI in this PR.

## Test plan
- [ ] Upload a multi-pizza receipt → `ocr_line_items` populated.
- [ ] `curl /api/admin/payouts/pizza-prices` returns rows + aggregate.
- [ ] Existing payouts without line items return null for the column — no regression.