### PR TITLE
fix(salame-58198): shared MediaThumb component - kills broken video thumbnails site-wide

### DIFF
--- a/frontend/src/components/photos/MediaThumb.tsx
+++ b/frontend/src/components/photos/MediaThumb.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Play } from 'lucide-react';
+
+interface MediaThumbProps {
+  src: string;
+  mimeType?: string | null;
+  alt?: string;
+  /** "thumb" = no autoplay, muted, play icon overlay (default). "full" = video has controls + autoPlay. */
+  mode?: 'thumb' | 'full';
+  className?: string;
+  /** Force play-icon overlay size for thumb mode. */
+  playIconSize?: number;
+}
+
+/**
+ * Renders a media URL as <img> or <video> based on mimeType.
+ * - mode="thumb": video shows poster frame + centered play-icon overlay (no controls).
+ * - mode="full":  video shows controls + autoPlay (suitable for lightbox / modal).
+ *
+ * For non-video mimeTypes (or when mimeType is missing), renders <img>.
+ *
+ * salame-58198: shared component fixes broken video thumbnails site-wide. The
+ * `photos` table holds both images and videos; surfaces that rendered raw
+ * <img src={photo.url}> without checking mimeType produced the broken-image
+ * placeholder for video rows (browsers can't decode an MP4 inside an <img>).
+ */
+export function MediaThumb({
+  src, mimeType, alt = '', mode = 'thumb', className = '', playIconSize = 24,
+}: MediaThumbProps) {
+  const isVideo = mimeType?.startsWith('video/');
+
+  if (isVideo) {
+    if (mode === 'full') {
+      return (
+        <video src={src} controls autoPlay className={className} />
+      );
+    }
+    // thumb mode: poster frame + play overlay
+    return (
+      <div className="relative w-full h-full">
+        <video src={src} preload="metadata" muted className={className} />
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="bg-black/50 rounded-full p-3">
+            <Play size={playIconSize} className="text-white fill-white" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <img src={src} alt={alt} loading="lazy" className={className} />;
+}

--- a/frontend/src/components/photos/PhotoModal.tsx
+++ b/frontend/src/components/photos/PhotoModal.tsx
@@ -5,6 +5,7 @@ import { IconInput } from '../IconInput';
 import { Photo } from '../../types';
 import { useAuth } from '../../contexts/AuthContext';
 import { togglePhotoVote } from '../../lib/api';
+import { MediaThumb } from './MediaThumb';
 
 interface PhotoModalProps {
   photo: Photo;
@@ -202,21 +203,14 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
       >
         {/* Photo/Video */}
         <div className="flex-1 flex items-center justify-center min-h-0">
-          {isVideo ? (
-            <video
-              key={photo.id}
-              src={photo.url}
-              controls
-              autoPlay
-              className="max-w-full max-h-[70vh] md:max-h-[85vh] object-contain rounded-lg"
-            />
-          ) : (
-            <img
-              src={photo.url}
-              alt={photo.caption || 'Event photo'}
-              className="max-w-full max-h-[70vh] md:max-h-[85vh] object-contain rounded-lg"
-            />
-          )}
+          <MediaThumb
+            key={photo.id}
+            src={photo.url}
+            mimeType={photo.mimeType}
+            alt={photo.caption || 'Event photo'}
+            mode="full"
+            className="max-w-full max-h-[70vh] md:max-h-[85vh] object-contain rounded-lg"
+          />
         </div>
 
         {/* Info Panel */}

--- a/frontend/src/components/report/ReportPreview.tsx
+++ b/frontend/src/components/report/ReportPreview.tsx
@@ -5,6 +5,7 @@ import { EventReport, PageViewStats, Photo } from '../../types';
 import { ReportRoleChart } from './ReportRoleChart';
 import { SocialPostsList } from './SocialPostsList';
 import { KPICard, OrgDomainChip } from './reportShared';
+import { MediaThumb } from '../photos/MediaThumb';
 
 interface ReportPreviewProps {
   report: EventReport;
@@ -165,9 +166,11 @@ export function ReportPreview({ report, onClose, pageViewStats }: ReportPreviewP
                   onClick={() => setLightboxIndex(i)}
                   className="w-full aspect-square overflow-hidden rounded-lg cursor-pointer hover:opacity-80 transition-opacity"
                 >
-                  <img
+                  <MediaThumb
                     src={photo.thumbnailUrl || photo.url}
+                    mimeType={photo.mimeType}
                     alt={photo.caption || 'Event photo'}
+                    mode="thumb"
                     className="w-full h-full object-cover"
                   />
                 </button>
@@ -310,13 +313,16 @@ function PhotoLightbox({
         </button>
       )}
 
-      {/* Image */}
-      <img
-        src={photo.url}
-        alt={photo.caption || 'Event photo'}
-        className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
-        onClick={(e) => e.stopPropagation()}
-      />
+      {/* Image or Video */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <MediaThumb
+          src={photo.url}
+          mimeType={photo.mimeType}
+          alt={photo.caption || 'Event photo'}
+          mode="full"
+          className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+        />
+      </div>
 
       {/* Caption */}
       {photo.caption && (

--- a/frontend/src/components/report/ReportWidget.tsx
+++ b/frontend/src/components/report/ReportWidget.tsx
@@ -11,6 +11,7 @@ import { ReportPreview } from './ReportPreview';
 import { IconInput } from '../IconInput';
 import { PageViewStats } from './PageViewStats';
 import { LinkClickStats } from './LinkClickStats';
+import { MediaThumb } from '../photos/MediaThumb';
 import {
   getReport,
   updateReport,
@@ -555,12 +556,15 @@ export function ReportWidget({ partyId }: ReportWidgetProps) {
           <p className="text-theme-text-muted text-xs mb-3">{t('report.starredPhotosHint')}</p>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
             {report.featuredPhotos.map((photo) => (
-              <img
-                key={photo.id}
-                src={photo.thumbnailUrl || photo.url}
-                alt={photo.caption || 'Event photo'}
-                className="w-full aspect-square object-cover rounded-lg"
-              />
+              <div key={photo.id} className="w-full aspect-square">
+                <MediaThumb
+                  src={photo.thumbnailUrl || photo.url}
+                  mimeType={photo.mimeType}
+                  alt={photo.caption || 'Event photo'}
+                  mode="thumb"
+                  className="w-full h-full object-cover rounded-lg"
+                />
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Root cause
photos table holds both images and videos. Surfaces that render <img src={photo.url}> without checking mimeType show the broken-image placeholder for video rows. Medellin's report 'Medios' section had 5 broken thumbnails because the top 5 starred items are MP4s.

## Fix
New <MediaThumb src mimeType alt mode className /> in frontend/src/components/photos/MediaThumb.tsx. Branches on mimeType: img for images, video for videos. `mode='thumb'` adds a play-icon overlay over the video poster frame. `mode='full'` shows controls + autoPlay (lightbox/modal).

Replaced raw <img> usages in:
- ReportPreview.tsx (grid + lightbox)
- ReportWidget.tsx (featured photos)
- PhotoModal.tsx

PhotoCard.tsx already had its own inline video branching (poster + play overlay + duration badge + custom hover styling) - left alone since plan said "if it does, leave it alone and skip this file". PhotosFeedPage.tsx also already handles video - left alone per plan.

## Test plan
- [ ] /report/medellin: 'Medios' section now shows playable video thumbnails (was broken-image icons)
- [ ] Event-page PhotoGallery PhotoModal: video items render with controls + autoPlay on open
- [ ] Clicking a video thumbnail in featured photos opens the lightbox with playback controls
- [ ] No image regressions (jpg/png/webp still render normally)
- [ ] Vercel preview: https://rsvpizza-git-salame-58198-photo-video-component-pizza-dao.vercel.app/report/medellin

Generated with [Claude Code](https://claude.com/claude-code)