### PR TITLE
feat(pecorino-64118): reroute Previous Years uploads to photos table

### DIFF
--- a/frontend/src/components/PreviousYearPhotos.tsx
+++ b/frontend/src/components/PreviousYearPhotos.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { usePizza } from '../contexts/PizzaContext';
 import { updateParty, uploadEventPhoto } from '../lib/supabase';
+import { uploadPhoto } from '../lib/api';
 
 const GPP_PHOTOS_URL = 'https://app.gpp.day/api/photos.json';
 const GPP_BASE_URL = 'https://app.gpp.day';
@@ -222,13 +223,14 @@ export function PreviousYearPhotos() {
     [party, extraPhotos, hiddenSrcs, loadParty]
   );
 
-  // Upload handler
+  // Upload handler — uploads go to the photos table (consolidated), not extra_gpp_photos
   const handleUploadFiles = useCallback(
     async (files: FileList | File[]) => {
       if (!party) return;
 
       setUploading(true);
-      const newUrls: string[] = [];
+
+      const eventYear = party.date ? new Date(party.date).getUTCFullYear() : undefined;
 
       for (const file of Array.from(files)) {
         if (!file.type.startsWith('image/')) continue;
@@ -236,30 +238,22 @@ export function PreviousYearPhotos() {
 
         const result = await uploadEventPhoto(file, party.id);
         if (result) {
-          newUrls.push(result.url);
-        }
-      }
-
-      if (newUrls.length > 0) {
-        const updatedExtras = [...extraPhotos, ...newUrls];
-        setExtraPhotos(updatedExtras);
-
-        const success = await updateParty(party.id, {
-          extra_gpp_photos: updatedExtras,
-        });
-
-        if (!success) {
-          setExtraPhotos(extraPhotos);
-          if (party.inviteCode) {
-            loadParty(party.inviteCode);
-          }
+          await uploadPhoto(party.id, {
+            url: result.url,
+            fileName: result.fileName,
+            fileSize: result.fileSize,
+            mimeType: result.mimeType,
+            width: result.width,
+            height: result.height,
+            photoYear: eventYear,
+          });
         }
       }
 
       setUploading(false);
       setShowUploadArea(false);
     },
-    [party, extraPhotos, loadParty]
+    [party]
   );
 
   // Lightbox navigation
@@ -596,8 +590,8 @@ function UploadModal({
         </div>
 
         <p className="text-theme-text-muted text-xs mb-4">
-          Upload your own photos from previous years. These will appear alongside the
-          app.gpp.day photos on your public event page.
+          Upload your own photos from previous years. They're added to your event photo
+          gallery and, if photo moderation is on, appear once you approve them.
         </p>
 
         <div


### PR DESCRIPTION
Host "Previous Years" photo uploads now go to the `photos` table (consolidated) instead of the party's `extra_gpp_photos` JSON array, preventing re-fragmentation after the migration of existing extras.

## Changes
- `PreviousYearPhotos.tsx` `handleUploadFiles`: for each uploaded image, after `uploadEventPhoto(file, party.id)` succeeds, calls `uploadPhoto(party.id, { url, fileName, fileSize, mimeType, width, height, photoYear })` to create a photos-table row.
- `photoYear` is set from the event year (`party.date` → `getUTCFullYear()`), for consistency with the migrated photos.
- Removed the `extra_gpp_photos` append + `updateParty(...)` write from this handler.
- Updated the upload-modal copy: uploads go to the event photo gallery and (if moderation is on) appear once approved.

## Notes
- Frontend-only; works on preview immediately (no DB migration / backend change).
- Uploads follow normal photo moderation (`uploadPhoto` rows default to `status: 'pending'`).
- GPP-archive hide/show logic and manifest fetch left intact. The now-dead `extraPhotos`/`removeExtraPhoto`/`isExtra` rendering is left as-is (renders nothing going forward) to avoid touching the GPP-archive code.
- `cd frontend && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)