### PR TITLE
feat(napoletana-58210): combine payout pizza photos into /photos + event galleries

### DIFF
--- a/backend/prisma/migrations/20260527000000_add_payout_doc_votes/migration.sql
+++ b/backend/prisma/migrations/20260527000000_add_payout_doc_votes/migration.sql
@@ -1,0 +1,27 @@
+-- napoletana-58210: thumbs-up voting on payout-document photos.
+--
+-- The /photos feed and event-page galleries now union photos from two tables:
+-- the existing `photos` table (curated, with star+approve flags) and
+-- `payout_documents` filtered to kind='pizza' (uncurated, auto-approved).
+-- Voting on each source uses its own table to keep the FK clean. This file
+-- introduces `payout_document_votes` (mirror of `photo_votes`) plus a
+-- denormalized `vote_count` column on `payout_documents`.
+--
+-- The User FK references the "User" table (PascalCase, singular) because the
+-- Prisma User model has no @@map directive — matches the photo_votes pattern.
+
+CREATE TABLE "payout_document_votes" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "payout_document_id" UUID NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "payout_document_votes_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "payout_document_votes_payout_document_id_fkey" FOREIGN KEY ("payout_document_id") REFERENCES "payout_documents"("id") ON DELETE CASCADE,
+  CONSTRAINT "payout_document_votes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE,
+  CONSTRAINT "payout_document_votes_unique" UNIQUE ("payout_document_id", "user_id")
+);
+
+CREATE INDEX "payout_document_votes_doc_idx" ON "payout_document_votes" ("payout_document_id");
+CREATE INDEX "payout_document_votes_user_idx" ON "payout_document_votes" ("user_id");
+
+ALTER TABLE "payout_documents" ADD COLUMN "vote_count" INT NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,17 +33,17 @@ model User {
   payoutWalletAddress   String? @map("payout_wallet_address")
   payoutBankDetails     Json?   @map("payout_bank_details")
 
-  createdAt                  DateTime @default(now())
-  updatedAt                  DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  parties      Party[]
-  orders       Order[]
-  magicLinks   MagicLink[]
-  apiKeys      ApiKey[]
-  aiPhoneCalls AIPhoneCall[]
-  payouts      Payout[]
-  paymentOptIns PartyPaymentOptIn[] @relation("PartyPaymentOptIns")
-  uploadedPayoutDocuments PayoutDocument[] @relation("PayoutDocumentUploadedBy")
+  parties                          Party[]
+  orders                           Order[]
+  magicLinks                       MagicLink[]
+  apiKeys                          ApiKey[]
+  aiPhoneCalls                     AIPhoneCall[]
+  payouts                          Payout[]
+  paymentOptIns                    PartyPaymentOptIn[]      @relation("PartyPaymentOptIns")
+  uploadedPayoutDocuments          PayoutDocument[]         @relation("PayoutDocumentUploadedBy")
   reimbursementCapAppealsSubmitted ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsByHost")
   reimbursementCapAppealsReviewed  ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsReviewedBy")
 }
@@ -156,21 +156,21 @@ model Party {
   flyerArtistUrl  String? @map("flyer_artist_url") // Flyer artist link
 
   // KPI tracking
-  xPostUrl         String? @map("x_post_url") // Main X/Twitter post
-  xPostViews       Int?    @map("x_post_views") // X post view count
-  farcasterPostUrl String? @map("farcaster_post_url") // Main Farcaster post
-  farcasterViews   Int?    @map("farcaster_views") // Farcaster view count
-  lumaUrl          String? @map("luma_url") // Luma event URL
-  lumaViews        Int?    @map("luma_views") // Luma page views
-  meetupUrl        String? @map("meetup_url") // Meetup event URL
-  eventbriteUrl    String? @map("eventbrite_url") // Eventbrite event URL
-  externalLinks    Json?   @default("[]") @map("external_links") // Custom external links [{label, url}]
-  telegramGroup    String? @map("telegram_group") @db.VarChar // City Telegram group link
+  xPostUrl              String? @map("x_post_url") // Main X/Twitter post
+  xPostViews            Int?    @map("x_post_views") // X post view count
+  farcasterPostUrl      String? @map("farcaster_post_url") // Main Farcaster post
+  farcasterViews        Int?    @map("farcaster_views") // Farcaster view count
+  lumaUrl               String? @map("luma_url") // Luma event URL
+  lumaViews             Int?    @map("luma_views") // Luma page views
+  meetupUrl             String? @map("meetup_url") // Meetup event URL
+  eventbriteUrl         String? @map("eventbrite_url") // Eventbrite event URL
+  externalLinks         Json?   @default("[]") @map("external_links") // Custom external links [{label, url}]
+  telegramGroup         String? @map("telegram_group") @db.VarChar // City Telegram group link
   hostTelegramChatId    BigInt? @map("host_telegram_chat_id") // Host's private Telegram chat_id (set via /start <token> webhook)
   hostTelegramLinkToken String? @unique @map("host_telegram_link_token") @db.VarChar // nanoid(10) token for host /start deeplink
-  poapEventId      String? @map("poap_event_id") // POAP event ID
-  poapMints        Int?    @map("poap_mints") // POAP mint count
-  poapMoments      Int?    @map("poap_moments") // POAP moments count
+  poapEventId           String? @map("poap_event_id") // POAP event ID
+  poapMints             Int?    @map("poap_mints") // POAP mint count
+  poapMoments           Int?    @map("poap_moments") // POAP moments count
 
   // Report settings
   reportPublished   Boolean @default(false) @map("report_published")
@@ -194,11 +194,11 @@ model Party {
   city    String?
 
   // Underboss dashboard fields
-  hostStatus      String? @map("host_status")
-  underbossStatus String  @default("pending") @map("underboss_status")
+  hostStatus      String?            @map("host_status")
+  underbossStatus String             @default("pending") @map("underboss_status")
   statusAudit     PartyStatusAudit[]
-  hostTags        Json    @default("[]") @map("host_tags")
-  underbossNotes  String? @map("underboss_notes")
+  hostTags        Json               @default("[]") @map("host_tags")
+  underbossNotes  String?            @map("underboss_notes")
 
   // GPP (Global Pizza Party/Previous year) photo management
   hiddenGppPhotos Json @default("[]") @map("hidden_gpp_photos") // Array of hidden app.gpp.day photo src paths
@@ -229,39 +229,39 @@ model Party {
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  guests                Guest[]
-  orders                Order[]
-  photos                Photo[]
-  partyKit              PartyKit?
-  donations             Donation[]
-  raffles               Raffle[]
-  displays              Display[]
-  staff                 Staff[]
-  performers            Performer[]
-  venues                Venue[]
-  sponsors              Sponsor[]
-  budgetItems           BudgetItem[]
-  checklistItems        ChecklistItem[]
-  socialPosts           SocialPost[]
-  notableAttendees      NotableAttendee[]
-  aiPhoneCalls          AIPhoneCall[]
-  pageViews             PageView[]
-  linkClicks            LinkClick[]
-  rsvpFunnelEvents      RsvpFunnelEvent[]
-  sponsorChecklistItems SponsorChecklistItem[]
-  partnerEventNotes     PartnerEventNote[]
-  quizQuestions         QuizQuestion[]
-  slugAliases           SlugAlias[]
-  scorecardItems        GuestScorecardItem[]
-  payouts               Payout[]
+  guests                  Guest[]
+  orders                  Order[]
+  photos                  Photo[]
+  partyKit                PartyKit?
+  donations               Donation[]
+  raffles                 Raffle[]
+  displays                Display[]
+  staff                   Staff[]
+  performers              Performer[]
+  venues                  Venue[]
+  sponsors                Sponsor[]
+  budgetItems             BudgetItem[]
+  checklistItems          ChecklistItem[]
+  socialPosts             SocialPost[]
+  notableAttendees        NotableAttendee[]
+  aiPhoneCalls            AIPhoneCall[]
+  pageViews               PageView[]
+  linkClicks              LinkClick[]
+  rsvpFunnelEvents        RsvpFunnelEvent[]
+  sponsorChecklistItems   SponsorChecklistItem[]
+  partnerEventNotes       PartnerEventNote[]
+  quizQuestions           QuizQuestion[]
+  slugAliases             SlugAlias[]
+  scorecardItems          GuestScorecardItem[]
+  payouts                 Payout[]
   // agnolotti-58291: receipts are now party-level (PayoutDocument.partyId);
   // payout association is optional. Inverse relation lives here so cascading
   // a party delete also removes its receipts.
-  payoutDocuments       PayoutDocument[]
-  paymentOptIns         PartyPaymentOptIn[]
-  outreachAttempts      OutreachAttempt[]
-  announcements         Announcement[]
-  attestations          GuestAttestation[]
+  payoutDocuments         PayoutDocument[]
+  paymentOptIns           PartyPaymentOptIn[]
+  outreachAttempts        OutreachAttempt[]
+  announcements           Announcement[]
+  attestations            GuestAttestation[]
   reimbursementCapAppeals ReimbursementCapAppeal[]
   reimbursementCapAudits  ReimbursementCapAudit[]
 
@@ -274,17 +274,17 @@ model Party {
 // keys off this table so underbosses can mark appeals as reviewed and view
 // the full history of past appeals + resolutions.
 model ReimbursementCapAppeal {
-  id               String   @id @default(uuid()) @db.Uuid
-  partyId          String   @map("party_id") @db.Uuid
-  party            Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  hostUserId       String   @map("host_user_id")
-  host             User     @relation("ReimbursementCapAppealsByHost", fields: [hostUserId], references: [id])
+  id               String    @id @default(uuid()) @db.Uuid
+  partyId          String    @map("party_id") @db.Uuid
+  party            Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  hostUserId       String    @map("host_user_id")
+  host             User      @relation("ReimbursementCapAppealsByHost", fields: [hostUserId], references: [id])
   note             String
-  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
   reviewedAt       DateTime? @map("reviewed_at") @db.Timestamptz
-  reviewedByUserId String?  @map("reviewed_by_user_id")
-  reviewedBy       User?    @relation("ReimbursementCapAppealsReviewedBy", fields: [reviewedByUserId], references: [id])
-  reviewedNote     String?  @map("reviewed_note")
+  reviewedByUserId String?   @map("reviewed_by_user_id")
+  reviewedBy       User?     @relation("ReimbursementCapAppealsReviewedBy", fields: [reviewedByUserId], references: [id])
+  reviewedNote     String?   @map("reviewed_note")
 
   @@index([partyId])
   @@map("reimbursement_cap_appeals")
@@ -332,15 +332,15 @@ model PartyStatusAudit {
 // actor's email and role (admin/super_admin/payment_admin/underboss/host/system).
 // No historical backfill: rows that pre-date this audit have no actor info.
 model ReimbursementCapAudit {
-  id          String   @id @default(uuid()) @db.Uuid
-  partyId     String   @map("party_id") @db.Uuid
-  party       Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  oldCapUsd   Decimal? @map("old_cap_usd") @db.Decimal(10, 2)
-  newCapUsd   Decimal? @map("new_cap_usd") @db.Decimal(10, 2)
-  actorEmail  String   @map("actor_email")
-  actorKind   String   @map("actor_kind")
-  setAt       DateTime @default(now()) @map("set_at") @db.Timestamptz
-  note        String?
+  id         String   @id @default(uuid()) @db.Uuid
+  partyId    String   @map("party_id") @db.Uuid
+  party      Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  oldCapUsd  Decimal? @map("old_cap_usd") @db.Decimal(10, 2)
+  newCapUsd  Decimal? @map("new_cap_usd") @db.Decimal(10, 2)
+  actorEmail String   @map("actor_email")
+  actorKind  String   @map("actor_kind")
+  setAt      DateTime @default(now()) @map("set_at") @db.Timestamptz
+  note       String?
 
   @@index([partyId])
   @@index([setAt(sort: Desc)])
@@ -442,15 +442,15 @@ model Guest {
 // P2002/23505 in the route handler instead. DO NOT add a competing
 // @@unique — the migration would try to drop the COALESCE index.
 model GuestAttestation {
-  id               String   @id @default(uuid()) @db.Uuid
-  guestId          String   @map("guest_id") @db.Uuid
-  partyId          String   @map("party_id") @db.Uuid
-  attesterKind     String   @map("attester_kind") // 'host_admin' | 'peer_guest' | 'self_host'
-  attesterUserId   String?  @map("attester_user_id")
-  attesterGuestId  String?  @map("attester_guest_id") @db.Uuid
-  attesterEmail    String?  @map("attester_email")
-  attesterName     String?  @map("attester_name")
-  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  id              String   @id @default(uuid()) @db.Uuid
+  guestId         String   @map("guest_id") @db.Uuid
+  partyId         String   @map("party_id") @db.Uuid
+  attesterKind    String   @map("attester_kind") // 'host_admin' | 'peer_guest' | 'self_host'
+  attesterUserId  String?  @map("attester_user_id")
+  attesterGuestId String?  @map("attester_guest_id") @db.Uuid
+  attesterEmail   String?  @map("attester_email")
+  attesterName    String?  @map("attester_name")
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
   guest         Guest  @relation("AttestationsOfGuest", fields: [guestId], references: [id], onDelete: Cascade)
   party         Party  @relation(fields: [partyId], references: [id], onDelete: Cascade)
@@ -1294,7 +1294,7 @@ model LinkClick {
 model RsvpFunnelEvent {
   id          String   @id @default(uuid()) @db.Uuid
   partyId     String   @map("party_id") @db.Uuid
-  step        String   // 'rsvp_opened' | 'rsvp_step1_complete'
+  step        String // 'rsvp_opened' | 'rsvp_step1_complete'
   visitorHash String   @map("visitor_hash")
   ipAddress   String?  @map("ip_address")
   userAgent   String?  @map("user_agent")
@@ -1575,11 +1575,11 @@ model SlugAlias {
 
 // Guest scorecard items for gamified engagement tracking
 model GuestScorecardItem {
-  id          String    @id @default(uuid()) @db.Uuid
-  guestId     String    @map("guest_id") @db.Uuid
-  guest       Guest     @relation(fields: [guestId], references: [id], onDelete: Cascade)
-  partyId     String    @map("party_id") @db.Uuid
-  party       Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  id      String @id @default(uuid()) @db.Uuid
+  guestId String @map("guest_id") @db.Uuid
+  guest   Guest  @relation(fields: [guestId], references: [id], onDelete: Cascade)
+  partyId String @map("party_id") @db.Uuid
+  party   Party  @relation(fields: [partyId], references: [id], onDelete: Cascade)
 
   itemKey     String    @map("item_key") @db.VarChar
   completed   Boolean   @default(false)
@@ -1588,8 +1588,8 @@ model GuestScorecardItem {
   proofType   String?   @map("proof_type") @db.VarChar
   metadata    Json      @default("{}")
 
-  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   @@unique([guestId, partyId, itemKey])
   @@index([guestId, partyId])
@@ -1605,56 +1605,56 @@ model GuestScorecardItem {
 // at the DB layer enforce allowed values.
 
 model Payout {
-  id                  String    @id @default(uuid()) @db.Uuid
-  partyId             String    @map("party_id") @db.Uuid
-  party               Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  hostUserId          String    @map("host_user_id")
-  host                User      @relation(fields: [hostUserId], references: [id], onDelete: Restrict)
+  id         String @id @default(uuid()) @db.Uuid
+  partyId    String @map("party_id") @db.Uuid
+  party      Party  @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  hostUserId String @map("host_user_id")
+  host       User   @relation(fields: [hostUserId], references: [id], onDelete: Restrict)
 
   // salumi-89172: distinguishes event-reimbursement payouts ('event') from
   // shipping-coordinator receipt payouts ('shipping'). DB CHECK constraint
   // restricts the value set; default 'event' preserves existing behavior.
-  purpose             String    @default("event")
+  purpose    String    @default("event")
   // salumi-89172: optional kit the shipping receipt is tied to. NULL for
   // event payouts and for shipping receipts that aren't tied to a kit (none
   // in v1 — selection is required on the form). FK ON DELETE SET NULL so
   // archiving a kit doesn't cascade-destroy historical reimbursements.
-  partyKitId          String?   @map("party_kit_id") @db.Uuid
-  partyKit            PartyKit? @relation("PayoutsForKit", fields: [partyKitId], references: [id], onDelete: SetNull)
+  partyKitId String?   @map("party_kit_id") @db.Uuid
+  partyKit   PartyKit? @relation("PayoutsForKit", fields: [partyKitId], references: [id], onDelete: SetNull)
 
-  originalAmount      Decimal   @map("original_amount") @db.Decimal(12, 2)
-  originalCurrency    String    @map("original_currency")
-  exchangeRate        Decimal   @map("exchange_rate") @db.Decimal(18, 6)
-  extractedAmountUsd  Decimal   @map("extracted_amount_usd") @db.Decimal(12, 2)
-  finalAmountUsd      Decimal   @map("final_amount_usd") @db.Decimal(12, 2)
+  originalAmount     Decimal @map("original_amount") @db.Decimal(12, 2)
+  originalCurrency   String  @map("original_currency")
+  exchangeRate       Decimal @map("exchange_rate") @db.Decimal(18, 6)
+  extractedAmountUsd Decimal @map("extracted_amount_usd") @db.Decimal(12, 2)
+  finalAmountUsd     Decimal @map("final_amount_usd") @db.Decimal(12, 2)
 
-  status              String    @default("pending")
+  status       String  @default("pending")
   // arugula-38633 v3 follow-up: optional — hosts can submit a payout with
   // just an amount; admin nags the host for payment details before execute.
-  payoutMethod        String?   @map("payout_method")
+  payoutMethod String? @map("payout_method")
 
-  payoutWalletAddress String?   @map("payout_wallet_address")
-  payoutBankDetails   Json?     @map("payout_bank_details")
-  mercuryCardId       String?   @map("mercury_card_id")
-  mercuryCardLast4    String?   @map("mercury_card_last4")
+  payoutWalletAddress String? @map("payout_wallet_address")
+  payoutBankDetails   Json?   @map("payout_bank_details")
+  mercuryCardId       String? @map("mercury_card_id")
+  mercuryCardLast4    String? @map("mercury_card_last4")
 
-  hostNotes           String?   @map("host_notes")
-  adminNotes          String?   @map("admin_notes")
-  rejectionReason     String?   @map("rejection_reason")
+  hostNotes       String? @map("host_notes")
+  adminNotes      String? @map("admin_notes")
+  rejectionReason String? @map("rejection_reason")
 
-  reviewedBy          String?   @map("reviewed_by")
-  reviewedAt          DateTime? @map("reviewed_at") @db.Timestamptz
-  paidAt              DateTime? @map("paid_at") @db.Timestamptz
+  reviewedBy String?   @map("reviewed_by")
+  reviewedAt DateTime? @map("reviewed_at") @db.Timestamptz
+  paidAt     DateTime? @map("paid_at") @db.Timestamptz
 
-  transactionHash     String?   @map("transaction_hash")
-  wireReference       String?   @map("wire_reference")
-  externalProofUrl    String?   @map("external_proof_url")
+  transactionHash  String? @map("transaction_hash")
+  wireReference    String? @map("wire_reference")
+  externalProofUrl String? @map("external_proof_url")
 
-  createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt           DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
-  documents           PayoutDocument[]
-  audits              PayoutAudit[]
+  documents PayoutDocument[]
+  audits    PayoutAudit[]
 
   @@index([partyId])
   @@index([hostUserId])
@@ -1679,11 +1679,11 @@ model Payout {
 // submitted a real payout for an event keeps appearing as a candidate
 // without re-clicking Submit.
 model PartyPaymentOptIn {
-  partyId    String   @map("party_id") @db.Uuid
-  party      Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  userId     String   @map("user_id")
-  user       User     @relation("PartyPaymentOptIns", fields: [userId], references: [id], onDelete: Cascade)
-  optedInAt  DateTime @default(now()) @map("opted_in_at") @db.Timestamptz
+  partyId   String   @map("party_id") @db.Uuid
+  party     Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  userId    String   @map("user_id")
+  user      User     @relation("PartyPaymentOptIns", fields: [userId], references: [id], onDelete: Cascade)
+  optedInAt DateTime @default(now()) @map("opted_in_at") @db.Timestamptz
 
   @@id([partyId, userId])
   @@index([partyId])
@@ -1691,39 +1691,45 @@ model PartyPaymentOptIn {
 }
 
 model PayoutDocument {
-  id            String   @id @default(uuid()) @db.Uuid
+  id               String   @id @default(uuid()) @db.Uuid
   // agnolotti-58291: receipts are now PARTY-level. `partyId` is the canonical
   // owner (NOT NULL, CASCADE on party delete). `payoutId` is optional and is
   // the submission this receipt was uploaded with; it goes NULL via SET NULL
   // cascade if the payout row is later hard-deleted, so receipts survive.
-  partyId       String   @map("party_id") @db.Uuid
-  party         Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  payoutId      String?  @map("payout_id") @db.Uuid
-  payout        Payout?  @relation(fields: [payoutId], references: [id], onDelete: SetNull)
-  kind          String   // 'pizza' | 'receipt'
-  url           String
-  fileName      String   @map("file_name")
-  fileSize      Int      @map("file_size")
-  mimeType      String   @map("mime_type")
-  ocrAmount     Decimal? @map("ocr_amount") @db.Decimal(12, 2)
-  ocrCurrency   String?  @map("ocr_currency")
-  ocrConfidence Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
-  ocrRaw        Json?    @map("ocr_raw")
+  partyId          String   @map("party_id") @db.Uuid
+  party            Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  payoutId         String?  @map("payout_id") @db.Uuid
+  payout           Payout?  @relation(fields: [payoutId], references: [id], onDelete: SetNull)
+  kind             String // 'pizza' | 'receipt'
+  url              String
+  fileName         String   @map("file_name")
+  fileSize         Int      @map("file_size")
+  mimeType         String   @map("mime_type")
+  ocrAmount        Decimal? @map("ocr_amount") @db.Decimal(12, 2)
+  ocrCurrency      String?  @map("ocr_currency")
+  ocrConfidence    Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
+  ocrRaw           Json?    @map("ocr_raw")
   // formaggi-89172: structured per-line items extracted from the receipt OCR.
   // Schema is OcrLineItem[] (see backend/src/services/ocr.service.ts) — each
   // entry has name, qty, unitPrice, subtotal, category. Stored as JSONB with a
   // GIN index (`idx_payout_documents_ocr_line_items`) to support future
   // analytics queries (e.g. average pizza prices by country/city).
-  ocrLineItems  Json?    @map("ocr_line_items")
-  ocrError      String?  @map("ocr_error")
+  ocrLineItems     Json?    @map("ocr_line_items")
+  ocrError         String?  @map("ocr_error")
   // pancetta-37195: per-receipt uploader attribution. Both nullable so
   // historical rows are valid. uploadedByEmail caches the email at upload
   // time so display still works if the User is later deleted.
-  uploadedByUserId String? @map("uploaded_by_user_id")
-  uploadedByEmail  String? @map("uploaded_by_email")
-  uploadedBy       User?   @relation("PayoutDocumentUploadedBy", fields: [uploadedByUserId], references: [id], onDelete: SetNull)
-  sortOrder     Int      @default(0) @map("sort_order")
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
+  uploadedByUserId String?  @map("uploaded_by_user_id")
+  uploadedByEmail  String?  @map("uploaded_by_email")
+  uploadedBy       User?    @relation("PayoutDocumentUploadedBy", fields: [uploadedByUserId], references: [id], onDelete: SetNull)
+  sortOrder        Int      @default(0) @map("sort_order")
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  // napoletana-58210: thumbs-up voting on payout pizza photos surfaced in
+  // the /photos feed + event galleries. Denormalized counter maintained by
+  // the toggle endpoint (parallel to Photo.voteCount).
+  voteCount Int                  @default(0) @map("vote_count")
+  votes     PayoutDocumentVote[]
 
   @@index([partyId])
   @@index([payoutId])
@@ -1731,19 +1737,36 @@ model PayoutDocument {
   @@map("payout_documents")
 }
 
+// napoletana-58210: thumbs-up votes on payout-document photos. One vote per
+// (payout_document, user); toggle to unvote. Mirrors PhotoVote — User FK is
+// one-way (no back-relation on User) and references the "User" table
+// (PascalCase singular — no @@map on the User model).
+model PayoutDocumentVote {
+  id               String         @id @default(uuid()) @db.Uuid
+  payoutDocumentId String         @map("payout_document_id") @db.Uuid
+  payoutDocument   PayoutDocument @relation(fields: [payoutDocumentId], references: [id], onDelete: Cascade)
+  userId           String         @map("user_id")
+  createdAt        DateTime       @default(now()) @map("created_at") @db.Timestamptz
+
+  @@unique([payoutDocumentId, userId], map: "payout_document_votes_unique")
+  @@index([payoutDocumentId], map: "payout_document_votes_doc_idx")
+  @@index([userId], map: "payout_document_votes_user_idx")
+  @@map("payout_document_votes")
+}
+
 model PayoutAudit {
-  id          String   @id @default(uuid()) @db.Uuid
-  payoutId    String   @map("payout_id") @db.Uuid
-  payout      Payout   @relation(fields: [payoutId], references: [id], onDelete: Cascade)
-  action      String
-  oldStatus   String?  @map("old_status")
-  newStatus   String?  @map("new_status")
-  oldAmount   Decimal? @map("old_amount") @db.Decimal(12, 2)
-  newAmount   Decimal? @map("new_amount") @db.Decimal(12, 2)
-  actorEmail  String   @map("actor_email")
-  actorKind   String   @map("actor_kind")
-  note        String?
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  id         String   @id @default(uuid()) @db.Uuid
+  payoutId   String   @map("payout_id") @db.Uuid
+  payout     Payout   @relation(fields: [payoutId], references: [id], onDelete: Cascade)
+  action     String
+  oldStatus  String?  @map("old_status")
+  newStatus  String?  @map("new_status")
+  oldAmount  Decimal? @map("old_amount") @db.Decimal(12, 2)
+  newAmount  Decimal? @map("new_amount") @db.Decimal(12, 2)
+  actorEmail String   @map("actor_email")
+  actorKind  String   @map("actor_kind")
+  note       String?
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   @@index([payoutId])
   @@index([createdAt(sort: Desc)])
@@ -1758,22 +1781,22 @@ model PayoutAudit {
 // contact list consumed by /underboss/outreach (marinara-67583).
 
 model OutreachCommunity {
-  id             String    @id @default(cuid())
-  city           String
-  country        String?
-  communityName  String    @map("community_name")
-  source         String    // 'luma' | 'meetup' | 'curated' | 'twitter'
-  contactHandle  String?   @map("contact_handle")
-  contactUrl     String    @map("contact_url")
-  contactEmail   String?   @map("contact_email")
-  followerCount  Int?      @map("follower_count")
-  activityScore  Decimal?  @map("activity_score") @db.Decimal(10, 4)
-  priority       String?   // 'high' | 'medium' | 'low'
-  notes          String?
+  id            String   @id @default(cuid())
+  city          String
+  country       String?
+  communityName String   @map("community_name")
+  source        String // 'luma' | 'meetup' | 'curated' | 'twitter'
+  contactHandle String?  @map("contact_handle")
+  contactUrl    String   @map("contact_url")
+  contactEmail  String?  @map("contact_email")
+  followerCount Int?     @map("follower_count")
+  activityScore Decimal? @map("activity_score") @db.Decimal(10, 4)
+  priority      String? // 'high' | 'medium' | 'low'
+  notes         String?
 
-  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz
-  attempts       OutreachAttempt[]
+  createdAt DateTime          @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime          @updatedAt @map("updated_at") @db.Timestamptz
+  attempts  OutreachAttempt[]
 
   @@unique([source, contactUrl])
   @@index([city])
@@ -1782,19 +1805,19 @@ model OutreachCommunity {
 }
 
 model OutreachAttempt {
-  id                String   @id @default(cuid())
-  communityId       String   @map("community_id")
-  community         OutreachCommunity @relation(fields: [communityId], references: [id], onDelete: Cascade)
-  channel           String   // 'twitter_dm' | 'email' | 'telegram'
-  templateId        String   @map("template_id") // 'v1_twitter' | 'v1_email' | 'v1_telegram'
-  sentAt            DateTime @default(now()) @map("sent_at") @db.Timestamptz
-  sentBy            String   @map("sent_by") // admin email from req.userEmail
-  status            String   @default("sent") // 'sent' | 'replied' | 'declined' | 'converted' | 'bounced'
-  convertedPartyId  String?  @map("converted_party_id") @db.Uuid
-  convertedParty    Party?   @relation(fields: [convertedPartyId], references: [id], onDelete: SetNull)
-  notes             String?
-  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt         DateTime @updatedAt @map("updated_at") @db.Timestamptz
+  id               String            @id @default(cuid())
+  communityId      String            @map("community_id")
+  community        OutreachCommunity @relation(fields: [communityId], references: [id], onDelete: Cascade)
+  channel          String // 'twitter_dm' | 'email' | 'telegram'
+  templateId       String            @map("template_id") // 'v1_twitter' | 'v1_email' | 'v1_telegram'
+  sentAt           DateTime          @default(now()) @map("sent_at") @db.Timestamptz
+  sentBy           String            @map("sent_by") // admin email from req.userEmail
+  status           String            @default("sent") // 'sent' | 'replied' | 'declined' | 'converted' | 'bounced'
+  convertedPartyId String?           @map("converted_party_id") @db.Uuid
+  convertedParty   Party?            @relation(fields: [convertedPartyId], references: [id], onDelete: SetNull)
+  notes            String?
+  createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz
 
   @@index([communityId])
   @@index([status])

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -35,6 +35,7 @@ import sponsorRoutes from './routes/sponsor.routes.js';
 import partnerIntakeRoutes from './routes/partner-intake.routes.js';
 import budgetRoutes from './routes/budget.routes.js';
 import payoutRoutes from './routes/payout.routes.js';
+import payoutDocumentVoteRoutes from './routes/payout-document-vote.routes.js';
 import checklistRoutes from './routes/checklist.routes.js';
 import reportRoutes from './routes/report.routes.js';
 import leaderboardRoutes from './routes/leaderboard.routes.js';
@@ -151,6 +152,7 @@ app.use('/api/sponsor', sponsorDashboardRouter); // Sponsor dashboard (login-bas
 app.use('/api/shipping', shippingRoutes); // Shipping coordinator dashboard
 app.use('/api/auth', authRoutes);
 app.use('/api/photos', photoFeedRoutes); // margherita-43821: public global photos feed
+app.use('/api/payouts', payoutDocumentVoteRoutes); // napoletana-58210: vote on payout-sourced pizza photos
 app.use('/api/parties', photoRoutes); // Photo routes first (some are public)
 app.use('/api/parties', hostTelegramRoutes); // Host Telegram connect/disconnect routes (host only)
 app.use('/api/parties', kitRoutes);   // Kit routes for party kit requests

--- a/backend/src/routes/payout-document-vote.routes.ts
+++ b/backend/src/routes/payout-document-vote.routes.ts
@@ -1,0 +1,86 @@
+/**
+ * napoletana-58210: thumbs-up voting on payout-sourced pizza photos.
+ *
+ * The /photos feed and event-page galleries now union the photos table and
+ * payout_documents (kind='pizza'). Voting on payout-sourced items uses its
+ * own table (`payout_document_votes`) parallel to `photo_votes`, so this
+ * router exposes the toggle endpoint:
+ *
+ *   POST /api/payouts/:payoutId/documents/:docId/vote
+ *
+ * Mirrors the photo vote endpoint:
+ *   - requires auth
+ *   - verifies the doc exists, is kind='pizza', and belongs to the payout
+ *   - toggles (insert / delete) the (docId, userId) row
+ *   - maintains the denormalized vote_count column transactionally
+ *   - returns { voted, voteCount }
+ */
+
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+
+const router = Router();
+
+router.post(
+  '/:payoutId/documents/:docId/vote',
+  requireAuth,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { payoutId, docId } = req.params;
+      const userId = req.userId;
+      if (!userId) {
+        throw new AppError('Auth required', 401, 'UNAUTHORIZED');
+      }
+
+      // Verify the doc exists, is kind='pizza', and belongs to that payout.
+      // Anything else (receipts, mismatched payout) → 404.
+      const doc = await prisma.payoutDocument.findFirst({
+        where: { id: docId, payoutId, kind: 'pizza' },
+        select: { id: true },
+      });
+      if (!doc) {
+        throw new AppError('Payout pizza photo not found', 404, 'NOT_FOUND');
+      }
+
+      const existing = await prisma.payoutDocumentVote.findUnique({
+        where: { payoutDocumentId_userId: { payoutDocumentId: docId, userId } },
+        select: { id: true },
+      });
+
+      if (existing) {
+        // Toggle off.
+        const [, updated] = await prisma.$transaction([
+          prisma.payoutDocumentVote.delete({
+            where: { payoutDocumentId_userId: { payoutDocumentId: docId, userId } },
+          }),
+          prisma.payoutDocument.update({
+            where: { id: docId },
+            data: { voteCount: { decrement: 1 } },
+            select: { voteCount: true },
+          }),
+        ]);
+        const voteCount = Math.max(0, updated.voteCount);
+        return res.json({ voted: false, voteCount });
+      }
+
+      // Toggle on.
+      const [, updated] = await prisma.$transaction([
+        prisma.payoutDocumentVote.create({
+          data: { payoutDocumentId: docId, userId },
+        }),
+        prisma.payoutDocument.update({
+          where: { id: docId },
+          data: { voteCount: { increment: 1 } },
+          select: { voteCount: true },
+        }),
+      ]);
+      return res.json({ voted: true, voteCount: updated.voteCount });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -7,14 +7,40 @@ const DEFAULT_LIMIT = 24;
 const MAX_LIMIT = 50;
 const MAX_FILTER_ITEMS = 50;
 
-function parseCursor(raw: unknown): { createdAt: Date; id: string } | null {
+type FeedSource = 'photo' | 'payout';
+
+// napoletana-58210: cursor format extended to include the source discriminator
+// so the (createdAt, id) tuple is unambiguous when merging two tables. Format:
+// `<iso>_<source>_<id>`. Legacy cursors (`<iso>_<id>`) are still accepted and
+// default to `photo` source — important because the feed shipped without the
+// source segment historically and clients may have stale cursors in their URL
+// or localStorage.
+function parseCursor(raw: unknown): { createdAt: Date; source: FeedSource | null; id: string } | null {
   if (typeof raw !== 'string' || !raw.includes('_')) return null;
+  const parts = raw.split('_');
+  // <iso>_<source>_<id> => at least 3 parts (iso may itself contain underscores? no — ISO 8601 doesn't)
+  // Strip trailing pieces from the right: last segment is id, prior is source candidate, rest is iso.
+  if (parts.length >= 3) {
+    const id = parts[parts.length - 1];
+    const sourceCandidate = parts[parts.length - 2];
+    if (sourceCandidate === 'photo' || sourceCandidate === 'payout') {
+      const ts = parts.slice(0, parts.length - 2).join('_');
+      const d = new Date(ts);
+      if (Number.isNaN(d.getTime()) || !id) return null;
+      return { createdAt: d, source: sourceCandidate, id };
+    }
+  }
+  // Legacy: `<iso>_<id>`
   const sepIdx = raw.lastIndexOf('_');
   const ts = raw.slice(0, sepIdx);
   const id = raw.slice(sepIdx + 1);
   const d = new Date(ts);
   if (Number.isNaN(d.getTime()) || !id) return null;
-  return { createdAt: d, id };
+  return { createdAt: d, source: null, id };
+}
+
+function buildCursorString(createdAt: Date, source: FeedSource, id: string): string {
+  return `${createdAt.toISOString()}_${source}_${id}`;
 }
 
 // sicilian-58129: parse comma-separated query param, dedupe, trim, cap length.
@@ -52,6 +78,33 @@ function buildPartyFilter(opts: { regions: string[]; countries: string[]; partne
   return partyFilter;
 }
 
+// napoletana-58210: shape returned per feed item. `source` discriminates
+// between the curated `photos` table and the uncurated `payout_documents`
+// (kind='pizza') source. Payout-sourced items always have payoutId populated;
+// photo-sourced items have payoutId=null.
+interface FeedItem {
+  id: string;
+  source: FeedSource;
+  url: string;
+  thumbnailUrl: string | null;
+  caption: string | null;
+  mimeType: string;
+  duration: number | null;
+  width: number | null;
+  height: number | null;
+  createdAt: Date;
+  voteCount: number;
+  votedByMe: boolean;
+  payoutId: string | null;
+  party: {
+    id: string;
+    slug: string;
+    name: string;
+    city: string | null;
+    country: string | null;
+  };
+}
+
 router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const limit = Math.min(
@@ -67,63 +120,141 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
       ? partnerTagRaw.trim()
       : null;
 
-    const where: any = {
-      status: 'approved',
-      party: {
-        is: buildPartyFilter({ regions, countries, partnerTag }),
-      },
-    };
+    const partyFilter = buildPartyFilter({ regions, countries, partnerTag });
 
+    // napoletana-58210: each source queries `limit + 1` rows so we can detect
+    // hasMore deterministically after the merge. We over-fetch slightly (each
+    // side gets `limit + 1`) rather than `limit*2` because the merge picks at
+    // most `limit + 1` from the combined pool; pulling `limit*2` per side would
+    // waste rows. The trade-off: if one source dominates the time window the
+    // cursor straddles, the next page may need a follow-up query — fine for an
+    // infinite-scroll UX.
+    const fetchSize = limit + 1;
+
+    // -- photos source ----------------------------------------------------
+    const photoWhere: any = {
+      status: 'approved',
+      starred: true,
+      party: { is: partyFilter },
+    };
     if (cursor) {
-      where.OR = [
-        { createdAt: { lt: cursor.createdAt } },
-        { AND: [{ createdAt: cursor.createdAt }, { id: { lt: cursor.id } }] },
-      ];
+      // When cursor source is explicit, only paginate within that source for
+      // strict tuple ordering. When legacy (source=null), apply the cursor to
+      // both sides so behavior is backwards-compatible.
+      if (cursor.source === 'photo' || cursor.source === null) {
+        photoWhere.OR = [
+          { createdAt: { lt: cursor.createdAt } },
+          { AND: [{ createdAt: cursor.createdAt }, { id: { lt: cursor.id } }] },
+        ];
+      } else {
+        // Cursor is in the other source — pull photos strictly older than the
+        // cursor timestamp (id tiebreak doesn't apply across sources).
+        photoWhere.createdAt = { lte: cursor.createdAt };
+      }
     }
 
-    const rows = await prisma.photo.findMany({
-      where,
-      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-      take: limit + 1,
-      select: {
-        id: true,
-        url: true,
-        thumbnailUrl: true,
-        caption: true,
-        mimeType: true,
-        duration: true,
-        width: true,
-        height: true,
-        createdAt: true,
-        // salame-58195
-        voteCount: true,
-        votes: req.userId
-          ? { where: { userId: req.userId }, select: { id: true } }
-          : false,
-        party: {
-          select: {
-            id: true,
-            name: true,
-            customUrl: true,
-            inviteCode: true,
-            city: true,
-            country: true,
+    // -- payout pizza photos source ---------------------------------------
+    const payoutDocWhere: any = {
+      kind: 'pizza',
+      // exclude docs whose payout was rejected. payout_id is nullable on the
+      // schema but in practice always set for pizza docs (verified during
+      // implementation). The nested `payout: { isNot: { status: 'rejected' } }`
+      // handles both states.
+      OR: [
+        { payoutId: null },
+        { payout: { isNot: { status: 'rejected' } } },
+      ],
+      party: { is: partyFilter },
+    };
+    if (cursor) {
+      if (cursor.source === 'payout' || cursor.source === null) {
+        // Strict tuple ordering within the payout source.
+        const tupleClause = [
+          { createdAt: { lt: cursor.createdAt } },
+          { AND: [{ createdAt: cursor.createdAt }, { id: { lt: cursor.id } }] },
+        ];
+        payoutDocWhere.AND = [
+          { OR: payoutDocWhere.OR },
+          { OR: tupleClause },
+        ];
+        delete payoutDocWhere.OR;
+      } else {
+        // Cursor is in the photo source — pull payouts at-or-older than the
+        // cursor timestamp; id tiebreak doesn't cross sources.
+        payoutDocWhere.AND = [
+          { OR: payoutDocWhere.OR },
+          { createdAt: { lte: cursor.createdAt } },
+        ];
+        delete payoutDocWhere.OR;
+      }
+    }
+
+    const [photoRows, payoutRows] = await Promise.all([
+      prisma.photo.findMany({
+        where: photoWhere,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: fetchSize,
+        select: {
+          id: true,
+          url: true,
+          thumbnailUrl: true,
+          caption: true,
+          mimeType: true,
+          duration: true,
+          width: true,
+          height: true,
+          createdAt: true,
+          voteCount: true,
+          votes: req.userId
+            ? { where: { userId: req.userId }, select: { id: true } }
+            : false,
+          party: {
+            select: {
+              id: true,
+              name: true,
+              customUrl: true,
+              inviteCode: true,
+              city: true,
+              country: true,
+            },
           },
         },
-      },
-    });
+      }),
+      prisma.payoutDocument.findMany({
+        where: payoutDocWhere,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: fetchSize,
+        select: {
+          id: true,
+          url: true,
+          mimeType: true,
+          createdAt: true,
+          payoutId: true,
+          voteCount: true,
+          votes: req.userId
+            ? { where: { userId: req.userId }, select: { id: true } }
+            : false,
+          party: {
+            select: {
+              id: true,
+              name: true,
+              customUrl: true,
+              inviteCode: true,
+              city: true,
+              country: true,
+            },
+          },
+        },
+      }),
+    ]);
 
-    const hasMore = rows.length > limit;
-    const page = hasMore ? rows.slice(0, limit) : rows;
-    const nextCursor = hasMore
-      ? `${page[page.length - 1].createdAt.toISOString()}_${page[page.length - 1].id}`
-      : null;
-
-    res.json({
-      photos: page.map((p) => {
+    // Merge into a single list, sorted by (createdAt desc, id desc) tiebreak.
+    const merged: FeedItem[] = [
+      ...photoRows.map((p): FeedItem => {
         const votes = (p as typeof p & { votes?: { id: string }[] }).votes;
         return {
           id: p.id,
+          source: 'photo',
           url: p.url,
           thumbnailUrl: p.thumbnailUrl,
           caption: p.caption,
@@ -132,11 +263,10 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
           width: p.width,
           height: p.height,
           createdAt: p.createdAt,
-          // salame-58195
           voteCount: p.voteCount,
           votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+          payoutId: null,
           party: {
-            // Include id so the client can hit the per-party vote endpoint.
             id: p.party.id,
             slug: p.party.customUrl || p.party.inviteCode,
             name: p.party.name,
@@ -145,6 +275,65 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
           },
         };
       }),
+      ...payoutRows.map((pd): FeedItem => {
+        const votes = (pd as typeof pd & { votes?: { id: string }[] }).votes;
+        return {
+          id: pd.id,
+          source: 'payout',
+          url: pd.url,
+          // Payout docs don't have thumbnails / captions / dimensions.
+          thumbnailUrl: null,
+          caption: null,
+          mimeType: pd.mimeType,
+          duration: null,
+          width: null,
+          height: null,
+          createdAt: pd.createdAt,
+          voteCount: pd.voteCount,
+          votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+          payoutId: pd.payoutId,
+          party: {
+            id: pd.party.id,
+            slug: pd.party.customUrl || pd.party.inviteCode,
+            name: pd.party.name,
+            city: pd.party.city,
+            country: pd.party.country,
+          },
+        };
+      }),
+    ];
+
+    merged.sort((a, b) => {
+      const tDiff = b.createdAt.getTime() - a.createdAt.getTime();
+      if (tDiff !== 0) return tDiff;
+      // Tiebreak by id desc to match the per-table orderBy.
+      return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+    });
+
+    const hasMore = merged.length > limit;
+    const page = hasMore ? merged.slice(0, limit) : merged;
+    const last = page.length > 0 ? page[page.length - 1] : null;
+    const nextCursor = hasMore && last
+      ? buildCursorString(last.createdAt, last.source, last.id)
+      : null;
+
+    res.json({
+      photos: page.map((p) => ({
+        id: p.id,
+        source: p.source,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        mimeType: p.mimeType,
+        duration: p.duration,
+        width: p.width,
+        height: p.height,
+        createdAt: p.createdAt,
+        voteCount: p.voteCount,
+        votedByMe: p.votedByMe,
+        payoutId: p.payoutId,
+        party: p.party,
+      })),
       nextCursor,
     });
   } catch (error) {
@@ -155,6 +344,12 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
 // sicilian-58129: facets endpoint — returns distinct country values among
 // feed-eligible photos (approved + party-eligible) with photo counts.
 // Used by the /photos filter bar to populate the country dropdown.
+//
+// napoletana-58210 v1 LIMITATION: this endpoint still only counts the
+// `photos` table — countries that have ONLY payout pizza photos won't appear
+// in the country dropdown. Acceptable for v1 because (a) the feed itself
+// shows payout photos regardless of dropdown choice, and (b) most cities with
+// payout photos also have photos-table entries.
 router.get('/feed/facets', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const grouped = await prisma.photo.groupBy({

--- a/backend/src/routes/photo.routes.test.ts
+++ b/backend/src/routes/photo.routes.test.ts
@@ -11,6 +11,14 @@ const mockPrisma = vi.hoisted(() => ({
     create: vi.fn(), update: vi.fn(), updateMany: vi.fn(),
     groupBy: vi.fn(), delete: vi.fn(),
   },
+  // napoletana-58210: the GET /:partyId/photos handler now unions payout
+  // pizza photos when no source-incompatible filter is set. Default mocks
+  // return empty arrays so the existing test assertions about photo.findMany
+  // continue to hold.
+  payoutDocument: {
+    findMany: vi.fn(() => Promise.resolve([])),
+    count: vi.fn(() => Promise.resolve(0)),
+  },
   guest: { findFirst: vi.fn() },
 }));
 

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -8,6 +8,15 @@ import { autoCompleteScorecardItem } from './scorecard.routes.js';
 const router = Router();
 
 // GET /api/parties/:partyId/photos - List all photos for a party (public if photosPublic is true)
+//
+// napoletana-58210: the response is a UNION of two sources — the curated
+// `photos` table (existing behaviour) and uncurated payout pizza photos
+// (`payout_documents` where kind='pizza' and the parent payout is not
+// 'rejected'). Each item carries a `source` discriminator + `payoutId` so the
+// frontend can dispatch vote calls to the right endpoint. Source-incompatible
+// filters (starred, tag, uploadedBy, non-default status) collapse the
+// response to the photos table for v1 — payout docs have no analog for
+// any of those concepts.
 router.get('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId } = req.params;
@@ -71,38 +80,211 @@ router.get('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Respo
       where.status = 'approved';
     }
 
-    const photos = await prisma.photo.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      take: Math.min(parseInt(limit as string, 10), 100),
-      skip: parseInt(offset as string, 10),
-      include: {
-        guest: { select: { id: true, name: true } },
-        // salame-58195: include current user's vote (if any) so the client can
-        // render votedByMe without an extra round-trip.
-        votes: req.userId
-          ? { where: { userId: req.userId }, select: { id: true } }
-          : false,
-      },
+    // napoletana-58210: payout pizza photos are included ONLY when the request
+    // has no filters that would otherwise exclude them (starred/tag/uploadedBy
+    // don't exist on payout docs; non-default status filters target moderation
+    // states that don't apply either). Default unfiltered = both sources.
+    const includePayoutDocs =
+      !starred &&
+      !tag &&
+      !uploadedBy &&
+      (!statusFilter || statusFilter === 'approved');
+
+    const photoLimit = Math.min(parseInt(limit as string, 10), 100);
+    const photoOffset = parseInt(offset as string, 10);
+
+    const photoSelect = {
+      guest: { select: { id: true, name: true } },
+      // salame-58195: include current user's vote (if any) so the client can
+      // render votedByMe without an extra round-trip.
+      votes: req.userId
+        ? { where: { userId: req.userId }, select: { id: true } }
+        : false,
+    } as const;
+
+    if (!includePayoutDocs) {
+      // Original behaviour — single-source response.
+      const photos = await prisma.photo.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: photoLimit,
+        skip: photoOffset,
+        include: photoSelect,
+      });
+
+      const total = await prisma.photo.count({ where });
+
+      const photosWithVote = photos.map((p) => {
+        const { votes, ...rest } = p as typeof p & { votes?: { id: string }[] };
+        return {
+          ...rest,
+          source: 'photo' as const,
+          payoutId: null,
+          votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+        };
+      });
+
+      return res.json({
+        photos: photosWithVote,
+        total,
+        limit: photoLimit,
+        offset: photoOffset,
+      });
+    }
+
+    // UNION mode: pull both sources, merge, sort, then paginate.
+    // We fetch up to (limit + offset) from each source (capped) so the merged
+    // window can serve the requested page deterministically; counts come from
+    // separate count queries.
+    const fetchCap = Math.min(photoLimit + photoOffset, 200);
+
+    const [photos, payoutDocs, photoTotal, payoutTotal] = await Promise.all([
+      prisma.photo.findMany({
+        where,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: fetchCap,
+        include: photoSelect,
+      }),
+      prisma.payoutDocument.findMany({
+        where: {
+          partyId,
+          kind: 'pizza',
+          OR: [
+            { payoutId: null },
+            { payout: { isNot: { status: 'rejected' } } },
+          ],
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: fetchCap,
+        select: {
+          id: true,
+          partyId: true,
+          url: true,
+          fileName: true,
+          fileSize: true,
+          mimeType: true,
+          payoutId: true,
+          createdAt: true,
+          voteCount: true,
+          votes: req.userId
+            ? { where: { userId: req.userId }, select: { id: true } }
+            : false,
+        },
+      }),
+      prisma.photo.count({ where }),
+      prisma.payoutDocument.count({
+        where: {
+          partyId,
+          kind: 'pizza',
+          OR: [
+            { payoutId: null },
+            { payout: { isNot: { status: 'rejected' } } },
+          ],
+        },
+      }),
+    ]);
+
+    // Shape both into a common payload. Photo-sourced rows preserve the
+    // existing shape (so the frontend Photo type still applies); payout-sourced
+    // rows fill in null/defaults for the photo-only fields.
+    type Merged = {
+      id: string;
+      partyId: string;
+      url: string;
+      thumbnailUrl: string | null;
+      fileName: string;
+      fileSize: number;
+      mimeType: string;
+      width: number | null;
+      height: number | null;
+      uploadedBy: string | null;
+      uploaderName: string | null;
+      uploaderEmail: string | null;
+      caption: string | null;
+      tags: string[];
+      photoYear: number | null;
+      starred: boolean;
+      starredAt: Date | null;
+      status: string;
+      reviewedAt: Date | null;
+      reviewedBy: string | null;
+      duration: number | null;
+      voteCount: number;
+      votedByMe: boolean;
+      createdAt: Date;
+      updatedAt: Date;
+      guest: { id: string; name: string | null } | null;
+      source: 'photo' | 'payout';
+      payoutId: string | null;
+    };
+
+    const merged: Merged[] = [
+      ...photos.map((p): Merged => {
+        const { votes, guest, ...rest } = p as typeof p & {
+          votes?: { id: string }[];
+          guest?: { id: string; name: string | null } | null;
+        };
+        return {
+          ...rest,
+          guest: guest ?? null,
+          source: 'photo',
+          payoutId: null,
+          votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+        };
+      }),
+      ...payoutDocs.map((pd): Merged => {
+        const votes = (pd as typeof pd & { votes?: { id: string }[] }).votes;
+        return {
+          id: pd.id,
+          partyId: pd.partyId,
+          url: pd.url,
+          thumbnailUrl: null,
+          fileName: pd.fileName,
+          fileSize: pd.fileSize,
+          mimeType: pd.mimeType,
+          width: null,
+          height: null,
+          uploadedBy: null,
+          uploaderName: null,
+          uploaderEmail: null,
+          caption: null,
+          tags: [],
+          photoYear: null,
+          // Payout pizza photos are auto-approved + auto-starred so they look
+          // like the host curated them.
+          starred: true,
+          starredAt: pd.createdAt,
+          status: 'approved',
+          reviewedAt: null,
+          reviewedBy: null,
+          duration: null,
+          voteCount: pd.voteCount,
+          votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+          createdAt: pd.createdAt,
+          // PayoutDocument has no updatedAt — fall back to createdAt for shape parity.
+          updatedAt: pd.createdAt,
+          guest: null,
+          source: 'payout',
+          payoutId: pd.payoutId,
+        };
+      }),
+    ];
+
+    merged.sort((a, b) => {
+      const tDiff = b.createdAt.getTime() - a.createdAt.getTime();
+      if (tDiff !== 0) return tDiff;
+      return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
     });
 
-    const total = await prisma.photo.count({ where });
-
-    // salame-58195: shape response with votedByMe (boolean). voteCount is
-    // already a column on Photo so it comes through automatically.
-    const photosWithVote = photos.map((p) => {
-      const { votes, ...rest } = p as typeof p & { votes?: { id: string }[] };
-      return {
-        ...rest,
-        votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
-      };
-    });
+    const pageStart = photoOffset;
+    const pageEnd = pageStart + photoLimit;
+    const page = merged.slice(pageStart, pageEnd);
 
     res.json({
-      photos: photosWithVote,
-      total,
-      limit: parseInt(limit as string, 10),
-      offset: parseInt(offset as string, 10),
+      photos: page,
+      total: photoTotal + payoutTotal,
+      limit: photoLimit,
+      offset: photoOffset,
     });
   } catch (error) {
     next(error);

--- a/frontend/src/components/photos/PhotoCard.tsx
+++ b/frontend/src/components/photos/PhotoCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Star, Trash2, User, CheckCircle2, XCircle, Clock, Play, ThumbsUp } from 'lucide-react';
 import { Photo } from '../../types';
 import { useAuth } from '../../contexts/AuthContext';
-import { togglePhotoVote } from '../../lib/api';
+import { togglePhotoVote, togglePayoutPhotoVote } from '../../lib/api';
 
 interface PhotoCardProps {
   photo: Photo;
@@ -37,6 +37,9 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
   const isPending = photo.status === 'pending';
   const isRejected = photo.status === 'rejected';
   const isVideo = photo.mimeType?.startsWith('video/');
+  // napoletana-58210: payout-sourced rows are uncurated — hide star / delete /
+  // tag-edit affordances. The source field is optional for back-compat.
+  const isPayoutSource = photo.source === 'payout';
 
   // salame-58195: thumbs-up voting
   const { user } = useAuth();
@@ -50,7 +53,10 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
     }
     if (voting) return;
     setVoting(true);
-    const res = await togglePhotoVote(photo.partyId, photo.id);
+    // napoletana-58210: route to the source-specific vote endpoint.
+    const res = isPayoutSource && photo.payoutId
+      ? await togglePayoutPhotoVote(photo.payoutId, photo.id)
+      : await togglePhotoVote(photo.partyId, photo.id);
     setVoting(false);
     if (res && onVoteChange) {
       onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
@@ -132,8 +138,10 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
         </div>
       )}
 
-      {/* Star Badge (if starred and not pending/rejected) */}
-      {photo.starred && !isPending && !isRejected && (
+      {/* Star Badge (if starred and not pending/rejected) — napoletana-58210:
+          hidden for payout-sourced rows because we set starred=true
+          synthetically and don't want to imply host curation. */}
+      {photo.starred && !isPending && !isRejected && !isPayoutSource && (
         <div className="absolute top-2 left-2">
           <Star className="w-5 h-5 text-yellow-400 fill-yellow-400 drop-shadow-lg" />
         </div>
@@ -165,8 +173,9 @@ export const PhotoCard: React.FC<PhotoCardProps> = ({
         </div>
       )}
 
-      {/* Host Controls (for approved photos) */}
-      {isHost && !isPending && (
+      {/* Host Controls (for approved photos) — napoletana-58210: hidden for
+          payout-sourced photos because star/delete don't apply to payout docs. */}
+      {isHost && !isPending && !isPayoutSource && (
         <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
           <button
             onClick={(e) => {

--- a/frontend/src/components/photos/PhotoModal.tsx
+++ b/frontend/src/components/photos/PhotoModal.tsx
@@ -4,7 +4,7 @@ import { X, ChevronLeft, ChevronRight, Star, Download, Trash2, User, Calendar, T
 import { IconInput } from '../IconInput';
 import { Photo } from '../../types';
 import { useAuth } from '../../contexts/AuthContext';
-import { togglePhotoVote } from '../../lib/api';
+import { togglePhotoVote, togglePayoutPhotoVote } from '../../lib/api';
 import { MediaThumb } from './MediaThumb';
 
 interface PhotoModalProps {
@@ -41,13 +41,20 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
   onReject,
   onVoteChange,
 }) => {
+  // napoletana-58210: payout-sourced rows hide star/delete/tag-edit
+  // affordances and route vote toggles to a different endpoint.
+  const isPayoutSource = photo.source === 'payout';
+
   // salame-58195: thumbs-up voting
   const { user } = useAuth();
   const [voting, setVoting] = useState(false);
   const handleVote = async () => {
     if (!user || voting) return;
     setVoting(true);
-    const res = await togglePhotoVote(photo.partyId, photo.id);
+    // napoletana-58210: route to the source-specific vote endpoint.
+    const res = isPayoutSource && photo.payoutId
+      ? await togglePayoutPhotoVote(photo.payoutId, photo.id)
+      : await togglePhotoVote(photo.partyId, photo.id);
     setVoting(false);
     if (res && onVoteChange) {
       onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
@@ -313,7 +320,7 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
               <div>
                 {photo.caption ? (
                   <p className="text-theme-text">{photo.caption}</p>
-                ) : isHost ? (
+                ) : isHost && !isPayoutSource ? (
                   <button
                     onClick={() => setEditingCaption(true)}
                     className="text-theme-text-muted hover:text-theme-text-secondary text-sm"
@@ -321,7 +328,7 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
                     Add a caption...
                   </button>
                 ) : null}
-                {isHost && photo.caption && (
+                {isHost && !isPayoutSource && photo.caption && (
                   <button
                     onClick={() => setEditingCaption(true)}
                     className="text-theme-text-muted hover:text-theme-text-secondary text-xs mt-1"
@@ -395,7 +402,7 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
                       </span>
                     ))}
                   </div>
-                  {isHost && onUpdateTags && availableTags.length > 0 && (
+                  {isHost && !isPayoutSource && onUpdateTags && availableTags.length > 0 && (
                     <button
                       onClick={() => setEditingTags(true)}
                       className="text-theme-text-muted hover:text-theme-text-secondary text-xs mt-1"
@@ -404,7 +411,7 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
                     </button>
                   )}
                 </>
-              ) : isHost && onUpdateTags && availableTags.length > 0 ? (
+              ) : isHost && !isPayoutSource && onUpdateTags && availableTags.length > 0 ? (
                 <button
                   onClick={() => setEditingTags(true)}
                   className="text-theme-text-muted hover:text-theme-text-secondary text-sm flex items-center gap-1"
@@ -453,7 +460,7 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
                 </button>
               </div>
             </div>
-          ) : isHost && onUpdateYear ? (
+          ) : isHost && !isPayoutSource && onUpdateYear ? (
             <div className="mb-4">
               {photo.photoYear ? (
                 <div>
@@ -514,7 +521,9 @@ export const PhotoModal: React.FC<PhotoModalProps> = ({
               Download
             </button>
 
-            {isHost && (
+            {/* napoletana-58210: host star/delete affordances don't apply to
+                payout-sourced rows — hide them to avoid 404s + confusion. */}
+            {isHost && !isPayoutSource && (
               <>
                 <button
                   onClick={() => onStar?.(photo.id, !photo.starred)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -949,6 +949,29 @@ export async function togglePhotoVote(
   }
 }
 
+// napoletana-58210: toggle the current user's thumbs-up vote on a
+// payout-sourced photo. The /photos feed + event-page galleries union the
+// `photos` table with payout-document pizza photos; voting on the payout
+// side uses a separate table so we need a separate endpoint. Callers should
+// dispatch on `photo.source` and pass `photo.payoutId`.
+export async function togglePayoutPhotoVote(
+  payoutId: string,
+  docId: string,
+): Promise<{ voted: boolean; voteCount: number } | null> {
+  try {
+    return await apiRequest<{ voted: boolean; voteCount: number }>(
+      `/api/payouts/${payoutId}/documents/${docId}/vote`,
+      {
+        method: 'POST',
+        requireAuth: true,
+      }
+    );
+  } catch (error) {
+    console.error('Error toggling payout photo vote:', error);
+    return null;
+  }
+}
+
 // Get available photo tags for a party (defaults + confirmed sponsor names)
 export async function getPhotoTags(partyId: string): Promise<{ tags: string[]; defaultTags: string[]; sponsorTags: string[] } | null> {
   try {
@@ -4881,6 +4904,13 @@ export interface FeedPhoto {
   // salame-58195: thumbs-up voting state
   voteCount: number;
   votedByMe: boolean;
+  // napoletana-58210: the feed now unions the photos table with payout
+  // pizza photos. `source` discriminates; `payoutId` is non-null when the
+  // item came from the payouts side so the client can build the correct
+  // vote-toggle URL. Older backends won't return these fields — keep the
+  // type tolerant by defaulting to 'photo' / null at the call site.
+  source?: 'photo' | 'payout';
+  payoutId?: string | null;
   party: { id: string; slug: string; name: string; city: string | null; country: string | null };
 }
 

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -11,6 +11,7 @@ import {
   getPhotosFeedFacets,
   getMyPartnerTags,
   togglePhotoVote,
+  togglePayoutPhotoVote,
   FeedPhoto,
 } from '../lib/api';
 import { countryNameToAlpha2, alpha2ToCountryNames, alpha2ToCanonicalName } from '../utils/countryFlag';
@@ -601,7 +602,10 @@ function FeedTile({
     }
     if (voting) return;
     setVoting(true);
-    const res = await togglePhotoVote(photo.party.id, photo.id);
+    // napoletana-58210: route to the source-specific vote endpoint.
+    const res = photo.source === 'payout' && photo.payoutId
+      ? await togglePayoutPhotoVote(photo.payoutId, photo.id)
+      : await togglePhotoVote(photo.party.id, photo.id);
     setVoting(false);
     if (res) {
       onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });
@@ -673,7 +677,10 @@ function FeedLightbox({
     e.stopPropagation();
     if (!user || voting) return;
     setVoting(true);
-    const res = await togglePhotoVote(photo.party.id, photo.id);
+    // napoletana-58210: route to the source-specific vote endpoint.
+    const res = photo.source === 'payout' && photo.payoutId
+      ? await togglePayoutPhotoVote(photo.payoutId, photo.id)
+      : await togglePhotoVote(photo.party.id, photo.id);
     setVoting(false);
     if (res) {
       onVoteChange(photo.id, { voteCount: res.voteCount, votedByMe: res.voted });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -506,6 +506,14 @@ export interface Photo {
     id: string;
     name: string;
   } | null;
+  // napoletana-58210: per-party photo lists now union the photos table with
+  // payout-document pizza photos. `source` discriminates; `payoutId` is
+  // present on payout-sourced rows so the vote toggle can route to the
+  // correct endpoint. Photos table rows default to source='photo' /
+  // payoutId=null. Star / delete / tag-edit affordances should be hidden on
+  // payout-sourced rows in the v1 gallery.
+  source?: 'photo' | 'payout';
+  payoutId?: string | null;
 }
 
 export interface PhotoStats {


### PR DESCRIPTION
## Summary
- /photos feed + event-page PhotoGallery now UNION photos + payout_documents (kind='pizza', non-rejected payouts)
- Payout photos auto-approved + auto-starred (no curation)
- New `payout_document_votes` table; vote toggle routes to source-specific endpoint
- FeedPhoto + Photo types gain `source: 'photo' | 'payout'` + `payoutId` discriminator
- Star/delete/tag-edit affordances hidden for payout-sourced photos in event-page gallery

## Deploy order
1. Apply migration to prod via Supabase MCP (creates payout_document_votes table + vote_count column on payout_documents)
2. Merge => backend deploys with UNION queries + new vote endpoint
3. Frontend deploys

## Test plan
- [ ] Cape Town tiles appear on /photos (zero in photos table, 10 in payout_documents kind='pizza')
- [ ] Country filter 'South Africa' includes Cape Town payout photos
- [ ] As logged-in user: click vote on a payout-sourced photo => vote count increments, persists across refresh
- [ ] Click vote on a regular photos-table photo => still works (no regression)
- [ ] DB: payout_document_votes row exists for (docId, userId); payout_documents.vote_count matches
- [ ] PhotoGallery on event page also shows payout pizza photos
- [ ] Star/delete buttons hidden on payout-sourced photos
- [ ] Receipts (kind='receipt') do NOT appear anywhere on /photos
- [ ] Vercel preview: https://rsvpizza-git-napoletana-58210-combine-payout-photos-pizza-dao.vercel.app/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)