### PR TITLE
feat(napoletana-58211): unify photo storage - payouts mirror into photos table

### DIFF
--- a/backend/prisma/migrations/20260528000000_payout_documents_photo_id/migration.sql
+++ b/backend/prisma/migrations/20260528000000_payout_documents_photo_id/migration.sql
@@ -1,0 +1,9 @@
+-- napoletana-58211: link payout_documents.photo_id to photos.id for kind='pizza'.
+-- Receipts (kind='receipt') keep photo_id NULL.
+-- ON DELETE SET NULL so deleting the photos row doesn't cascade and lose the payout record.
+
+ALTER TABLE "payout_documents"
+  ADD COLUMN "photo_id" UUID NULL
+    REFERENCES "photos"("id") ON DELETE SET NULL;
+
+CREATE INDEX "payout_documents_photo_id_idx" ON "payout_documents" ("photo_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -737,6 +737,12 @@ model Photo {
   voteCount Int         @default(0) @map("vote_count")
   votes     PhotoVote[]
 
+  // napoletana-58211: reverse relation for payout_documents.photo_id. A photo
+  // can have at most one linked pizza payout-doc, but Prisma models this as a
+  // collection because the FK on the other side isn't unique. Empty for all
+  // photos that weren't created via the payout-pizza flow.
+  payoutDocuments PayoutDocument[]
+
   // Metadata
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -1731,9 +1737,18 @@ model PayoutDocument {
   voteCount Int                  @default(0) @map("vote_count")
   votes     PayoutDocumentVote[]
 
+  // napoletana-58211: when kind='pizza', this links to the canonical row in
+  // the `photos` table. Receipts (kind='receipt') keep photoId NULL. ON
+  // DELETE SET NULL so deleting the photo row doesn't cascade and lose the
+  // payout record — we want the payout to survive a moderator removing the
+  // photo from the feed.
+  photoId String? @map("photo_id") @db.Uuid
+  photo   Photo?  @relation(fields: [photoId], references: [id], onDelete: SetNull)
+
   @@index([partyId])
   @@index([payoutId])
   @@index([uploadedByUserId])
+  @@index([photoId])
   @@map("payout_documents")
 }
 

--- a/backend/scripts/backfill-payout-pizzas-to-photos.cjs
+++ b/backend/scripts/backfill-payout-pizzas-to-photos.cjs
@@ -1,0 +1,151 @@
+// napoletana-58211: link existing payout_documents (kind='pizza', photo_id IS NULL)
+// to the canonical `photos` table. For each candidate doc:
+//   1. If a photos row already exists in the same party with matching url OR
+//      matching (file_name, file_size), link the doc to it (UPDATE photo_id).
+//   2. Otherwise, INSERT a new photos row (auto-starred + auto-approved so it
+//      mirrors the in-place new-upload flow), then link the doc.
+//   3. Transfer any payout_document_votes for the linked doc into photo_votes
+//      (deduping on (photo_id, user_id)) and refresh photos.vote_count.
+//      Original payout_document_votes rows are left intact for audit.
+//
+// Run AFTER the 20260528000000_payout_documents_photo_id migration is applied
+// to production. Idempotent on re-run — already-linked docs are skipped because
+// the SELECT filters on photo_id IS NULL.
+
+const { Client } = require('pg');
+require('dotenv').config();
+
+async function main() {
+  const c = new Client({ connectionString: process.env.DATABASE_URL });
+  await c.connect();
+  console.log('Backfilling payout pizzas to photos...');
+
+  // Get all unlinked payout pizzas.
+  const docs = await c.query(`
+    SELECT pd.id AS pd_id,
+           pd.party_id,
+           pd.url,
+           pd.file_name,
+           pd.file_size,
+           pd.mime_type,
+           pd.uploaded_by_user_id,
+           pd.uploaded_by_email,
+           pd.created_at AS uploaded_at
+    FROM payout_documents pd
+    LEFT JOIN payouts p ON p.id = pd.payout_id
+    WHERE pd.kind = 'pizza'
+      AND pd.photo_id IS NULL
+      AND (p.id IS NULL OR p.status <> 'rejected')
+    ORDER BY pd.created_at ASC
+  `);
+  console.log(`Candidates: ${docs.rowCount}`);
+
+  let linked = 0;
+  let inserted = 0;
+  let votesTransferred = 0;
+  let skipped = 0;
+
+  for (const d of docs.rows) {
+    // Dedup: does a photo exist in the same party with the same url OR same
+    // (file_name, file_size)? URL match takes precedence — same Supabase URL
+    // is the strongest signal. file_name+file_size catches the Cape Town
+    // pattern where the host uploaded the same file twice from different
+    // pages (different Supabase paths but identical file metadata).
+    const dupQ = await c.query(
+      `
+      SELECT id FROM photos
+      WHERE party_id = $1
+        AND (
+          url = $2
+          OR (file_name = $3 AND file_size = $4)
+        )
+      ORDER BY created_at ASC
+      LIMIT 1
+    `,
+      [d.party_id, d.url, d.file_name, d.file_size],
+    );
+
+    let photoIdToLink;
+    if (dupQ.rowCount > 0) {
+      photoIdToLink = dupQ.rows[0].id;
+      linked++;
+    } else {
+      // Insert a new photo row with auto-star + auto-approve so it surfaces
+      // immediately on the event gallery + /photos feed. Schema mirrors the
+      // new-upload path in payout.routes.ts:
+      //   - status='approved', starred=true, starred_at=uploaded_at
+      //   - reviewed_at=uploaded_at, reviewed_by=uploaded_by_user_id
+      //   - uploaded_by is the Guest FK — payouts come from Users, so null
+      //   - uploader_email is the User's email at upload time
+      const newPhoto = await c.query(
+        `
+        INSERT INTO photos (
+          id, party_id, url, file_name, file_size, mime_type,
+          status, starred, starred_at, reviewed_at, reviewed_by,
+          uploader_email, created_at, updated_at
+        ) VALUES (
+          gen_random_uuid(), $1, $2, $3, $4, $5,
+          'approved', true, $6, $6, $7,
+          $8, $6, $6
+        ) RETURNING id
+      `,
+        [
+          d.party_id,
+          d.url,
+          d.file_name,
+          d.file_size,
+          d.mime_type,
+          d.uploaded_at,
+          d.uploaded_by_user_id,
+          d.uploaded_by_email,
+        ],
+      );
+      photoIdToLink = newPhoto.rows[0].id;
+      inserted++;
+    }
+
+    // Stamp photo_id on the payout doc.
+    await c.query(`UPDATE payout_documents SET photo_id = $1 WHERE id = $2`, [
+      photoIdToLink,
+      d.pd_id,
+    ]);
+
+    // Transfer payout_document_votes -> photo_votes (idempotent via
+    // ON CONFLICT). Keep the original payout_document_votes rows as an audit
+    // trail; the toggle endpoints still write to their respective vote tables
+    // for new votes, but the feed/gallery only reads vote_count from photos
+    // for linked rows (because they're excluded from the payout-side UNION).
+    const voteTransfer = await c.query(
+      `
+      INSERT INTO photo_votes (photo_id, user_id, created_at)
+      SELECT $1, user_id, created_at
+      FROM payout_document_votes
+      WHERE payout_document_id = $2
+      ON CONFLICT (photo_id, user_id) DO NOTHING
+      RETURNING id
+    `,
+      [photoIdToLink, d.pd_id],
+    );
+    votesTransferred += voteTransfer.rowCount;
+
+    // Refresh the denormalized counter on photos.
+    await c.query(
+      `
+      UPDATE photos SET vote_count = (
+        SELECT COUNT(*) FROM photo_votes WHERE photo_id = $1
+      ) WHERE id = $1
+    `,
+      [photoIdToLink],
+    );
+  }
+
+  console.log(
+    `Done. linked=${linked} inserted=${inserted} votesTransferred=${votesTransferred} skipped=${skipped}`,
+  );
+  await c.end();
+}
+
+main().catch((e) => {
+  console.error('ERROR:', e.message);
+  process.exit(1);
+});

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -757,6 +757,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       ocrLineItems: any;
       ocrError: string | null;
       sortOrder: number;
+      // napoletana-58211: filled in below for kind='pizza' docs after we
+      // insert the canonical photos row. Receipts keep this null.
+      photoId: string | null;
     }> = [];
 
     let idx = 0;
@@ -788,6 +791,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
           ocrError: null,
           sortOrder: idx,
+          photoId: null,
         });
       } else {
         const err = result && !result.ok ? result.error : 'Unexpected OCR result';
@@ -804,6 +808,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           ocrLineItems: null,
           ocrError: err,
           sortOrder: idx,
+          photoId: null,
         });
       }
       idx++;
@@ -824,6 +829,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         ocrLineItems: null,
         ocrError: null,
         sortOrder: i,
+        // napoletana-58211: filled in inside the transaction below — we
+        // create the canonical photos row first, then attach its id here.
+        photoId: null,
       });
     });
 
@@ -911,57 +919,97 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     // explicitly since it's a sibling FK, not a back-relation.
     const uploaderUserId = req.userId ?? null;
     const uploaderEmail = req.userEmail ?? null;
-    const docsToCreateStamped = docsToCreate.map(d => ({
-      ...d,
-      partyId,
-      uploadedByUserId: uploaderUserId,
-      uploadedByEmail: uploaderEmail,
-    }));
 
-    // Create the payout + its documents atomically.
-    const payout = await prisma.payout.create({
-      data: {
-        partyId,
-        // bismarck-92103: when admins create prepayments on behalf of a
-        // cohost, `effectiveHostUserId` is the cohost; otherwise it's the
-        // authenticated submitter (req.userId).
-        hostUserId: effectiveHostUserId,
-        // salumi-89172: persist purpose + tied kit. Defaults to 'event' /
-        // null when the body didn't supply them, matching pre-feature
-        // behavior.
-        purpose,
-        partyKitId: partyKitIdInput,
-        originalAmount: new Decimal(effectiveOriginalAmount),
-        originalCurrency: effectiveOriginalCurrency,
-        exchangeRate: new Decimal(effectiveExchangeRate),
-        extractedAmountUsd: new Decimal(effectiveExtractedUsd),
-        finalAmountUsd: new Decimal(finalUsd),
-        status: 'pending',
-        // arugula-38633 v3 follow-up: payoutMethod is optional. Persist null
-        // when the host hasn't set their payment details yet.
-        payoutMethod: hasMethod ? payoutMethod : null,
-        payoutWalletAddress: resolvedWallet,
-        ...(hasMethod && payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
-          ? { payoutBankDetails: payoutBankDetails as Prisma.InputJsonValue }
-          : {}),
-        mercuryCardLast4: hasMethod && payoutMethod === 'mercury_card' && typeof mercuryCardLast4 === 'string'
-          ? mercuryCardLast4.slice(-4)
-          : null,
-        hostNotes: typeof hostNotes === 'string' && hostNotes.trim().length > 0
-          ? hostNotes.trim()
-          : null,
-        // bismarck-92103: admin-supplied adminNotes (e.g. "Prepayment for X")
-        // when an admin creates a prepayment on behalf of a cohost.
-        adminNotes: initialAdminNotes,
-        documents: { create: docsToCreateStamped },
-      },
-      include: {
-        host: { select: { id: true, name: true, email: true } },
-        documents: {
-          orderBy: { sortOrder: 'asc' },
-          include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+    // napoletana-58211: the `photos` table is the canonical store for ALL
+    // party photos. For each kind='pizza' payout doc, insert the photos row
+    // FIRST (auto-approved + auto-starred so it surfaces immediately on the
+    // event gallery + /photos feed), then create the payout_documents row
+    // with `photoId` pointing at it. Receipts (kind='receipt') stay
+    // payout-only — photoId remains null. Wrapped in a transaction so a
+    // photos-insert failure aborts the whole submission and we never leave
+    // an orphan payout_documents row.
+    const payout = await prisma.$transaction(async (tx) => {
+      const now = new Date();
+      const docsToCreateStamped = await Promise.all(
+        docsToCreate.map(async (d) => {
+          let photoId: string | null = d.photoId;
+          if (d.kind === 'pizza') {
+            const photo = await tx.photo.create({
+              data: {
+                partyId,
+                url: d.url,
+                fileName: d.fileName,
+                fileSize: d.fileSize,
+                mimeType: d.mimeType,
+                // uploadedBy is a Guest FK; payout submitters are Users.
+                // Leave null and rely on uploaderEmail for attribution.
+                uploadedBy: null,
+                uploaderName: null,
+                uploaderEmail: uploaderEmail,
+                status: 'approved',
+                starred: true,
+                starredAt: now,
+                reviewedAt: now,
+                reviewedBy: uploaderUserId,
+              },
+              select: { id: true },
+            });
+            photoId = photo.id;
+          }
+          return {
+            ...d,
+            partyId,
+            uploadedByUserId: uploaderUserId,
+            uploadedByEmail: uploaderEmail,
+            photoId,
+          };
+        }),
+      );
+
+      return tx.payout.create({
+        data: {
+          partyId,
+          // bismarck-92103: when admins create prepayments on behalf of a
+          // cohost, `effectiveHostUserId` is the cohost; otherwise it's the
+          // authenticated submitter (req.userId).
+          hostUserId: effectiveHostUserId,
+          // salumi-89172: persist purpose + tied kit. Defaults to 'event' /
+          // null when the body didn't supply them, matching pre-feature
+          // behavior.
+          purpose,
+          partyKitId: partyKitIdInput,
+          originalAmount: new Decimal(effectiveOriginalAmount),
+          originalCurrency: effectiveOriginalCurrency,
+          exchangeRate: new Decimal(effectiveExchangeRate),
+          extractedAmountUsd: new Decimal(effectiveExtractedUsd),
+          finalAmountUsd: new Decimal(finalUsd),
+          status: 'pending',
+          // arugula-38633 v3 follow-up: payoutMethod is optional. Persist null
+          // when the host hasn't set their payment details yet.
+          payoutMethod: hasMethod ? payoutMethod : null,
+          payoutWalletAddress: resolvedWallet,
+          ...(hasMethod && payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
+            ? { payoutBankDetails: payoutBankDetails as Prisma.InputJsonValue }
+            : {}),
+          mercuryCardLast4: hasMethod && payoutMethod === 'mercury_card' && typeof mercuryCardLast4 === 'string'
+            ? mercuryCardLast4.slice(-4)
+            : null,
+          hostNotes: typeof hostNotes === 'string' && hostNotes.trim().length > 0
+            ? hostNotes.trim()
+            : null,
+          // bismarck-92103: admin-supplied adminNotes (e.g. "Prepayment for X")
+          // when an admin creates a prepayment on behalf of a cohost.
+          adminNotes: initialAdminNotes,
+          documents: { create: docsToCreateStamped },
         },
-      },
+        include: {
+          host: { select: { id: true, name: true, email: true } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
+        },
+      });
     });
 
     // One-shot: persist the host's attendance estimate to the party, but only
@@ -1360,6 +1408,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrLineItems: any;
       ocrError: string | null;
       sortOrder: number;
+      // napoletana-58211: kept here for shape parity with newPizzaDocs so the
+      // combined createMany call below has a uniform input type. Receipts
+      // always carry null.
+      photoId: string | null;
     }> = [];
     let newOcrSum = 0;
     interface FxHeadline {
@@ -1398,6 +1450,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
           ocrError: null,
           sortOrder: i,
+          photoId: null,
         });
       } else {
         const err = result && !result.ok ? result.error : 'Unexpected OCR result';
@@ -1414,6 +1467,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrLineItems: null,
           ocrError: err,
           sortOrder: i,
+          photoId: null,
         });
       }
     });
@@ -1431,6 +1485,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrLineItems: null,
       ocrError: null,
       sortOrder: i,
+      // napoletana-58211: filled in inside the transaction below — we
+      // insert the canonical photos row first, then attach its id.
+      photoId: null as string | null,
     }));
 
     const documentsChanged = newReceiptDocs.length > 0 || newPizzaDocs.length > 0 || removeIds.length > 0;
@@ -1509,6 +1566,35 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         // not the original payout submitter.
         const uploaderUserId = req.userId ?? null;
         const uploaderEmail = req.userEmail ?? null;
+
+        // napoletana-58211: insert photos rows for each new pizza doc FIRST
+        // (auto-approved + auto-starred) and stamp photoId so the
+        // payout_documents row links to the canonical photos record. If any
+        // photos.create fails, the surrounding transaction aborts and the
+        // patch is rolled back. Receipts skip this step (photoId stays null).
+        const now = new Date();
+        for (const d of newPizzaDocs) {
+          const photo = await tx.photo.create({
+            data: {
+              partyId,
+              url: d.url,
+              fileName: d.fileName,
+              fileSize: d.fileSize,
+              mimeType: d.mimeType,
+              uploadedBy: null,
+              uploaderName: null,
+              uploaderEmail: uploaderEmail,
+              status: 'approved',
+              starred: true,
+              starredAt: now,
+              reviewedAt: now,
+              reviewedBy: uploaderUserId,
+            },
+            select: { id: true },
+          });
+          d.photoId = photo.id;
+        }
+
         await tx.payoutDocument.createMany({
           data: [...newReceiptDocs, ...newPizzaDocs].map(d => ({
             ...d,

--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -156,6 +156,12 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
     // -- payout pizza photos source ---------------------------------------
     const payoutDocWhere: any = {
       kind: 'pizza',
+      // napoletana-58211: rows already mirrored into the `photos` table are
+      // represented on the photo side of the union — exclude them here to
+      // avoid double-display. New uploads always create both rows
+      // atomically (see POST /:partyId/payouts), and the backfill script
+      // links existing pizza docs to a canonical photos row.
+      photoId: null,
       // exclude docs whose payout was rejected. payout_id is nullable on the
       // schema but in practice always set for pizza docs (verified during
       // implementation). The nested `payout: { isNot: { status: 'rejected' } }`

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -149,6 +149,11 @@ router.get('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Respo
         where: {
           partyId,
           kind: 'pizza',
+          // napoletana-58211: exclude docs already mirrored into the
+          // `photos` table — they're returned on the photo side of this
+          // UNION. New uploads create both rows atomically; backfill links
+          // existing rows.
+          photoId: null,
           OR: [
             { payoutId: null },
             { payout: { isNot: { status: 'rejected' } } },
@@ -176,6 +181,11 @@ router.get('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Respo
         where: {
           partyId,
           kind: 'pizza',
+          // napoletana-58211: exclude docs already mirrored into the
+          // `photos` table — they're returned on the photo side of this
+          // UNION. New uploads create both rows atomically; backfill links
+          // existing rows.
+          photoId: null,
           OR: [
             { payoutId: null },
             { payout: { isNot: { status: 'rejected' } } },


### PR DESCRIPTION
## Summary
- photos table is canonical for ALL party photos (event-page + payout-flow pizza uploads)
- New photo_id FK on payout_documents links kind='pizza' rows to a photos row
- Receipts unchanged (stay payout-only, photo_id null)
- New payout pizza uploads write to photos first, then create payout_documents with photo_id
- Feed UNION excludes payout_documents WHERE photo_id IS NOT NULL (no double-display)
- Backfill script links existing 1,022 payout pizzas, deduping by (party_id, url) or (party_id, file_name, file_size); inserts new photos rows for unmatched

## Deploy order
1. Apply migration to prod via Supabase MCP (adds photo_id column + FK + index)
2. Merge -> backend deploys (new uploads mirror to photos; feed excludes linked payout docs)
3. Run backfill script from main session: `node backend/scripts/backfill-payout-pizzas-to-photos.cjs`
4. Verify: zero payout_documents WHERE kind='pizza' AND photo_id IS NULL AND payout.status <> 'rejected'

## Test plan
- [ ] As host, upload a pizza via payouts flow -> both a photos row AND a payout_documents row created, FK linked
- [ ] /photos shows the photo (from photos source), no duplicate
- [ ] Cape Town: no more duplicate pizza photos on /photos after backfill
- [ ] Existing votes survive the backfill (vote counts preserved on the unified photos row)

Generated with [Claude Code](https://claude.com/claude-code)