### PR TITLE
feat(sicilian-58195): shuffle option on /photos feed

### DIFF
--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -1,4 +1,5 @@
 import { Router, Response, NextFunction, Request } from 'express';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
 import { optionalAuth, AuthRequest } from '../middleware/auth.js';
 
@@ -8,6 +9,7 @@ const MAX_LIMIT = 50;
 const MAX_FILTER_ITEMS = 50;
 
 type FeedSource = 'photo' | 'payout';
+type FeedSort = 'newest' | 'random';
 
 // napoletana-58210: cursor format extended to include the source discriminator
 // so the (createdAt, id) tuple is unambiguous when merging two tables. Format:
@@ -41,6 +43,22 @@ function parseCursor(raw: unknown): { createdAt: Date; source: FeedSource | null
 
 function buildCursorString(createdAt: Date, source: FeedSource, id: string): string {
   return `${createdAt.toISOString()}_${source}_${id}`;
+}
+
+// sicilian-58195: random-sort cursor format = `<md5hash>_<id>`. The md5 hash is
+// 32 lowercase hex chars (no underscores) and the id is a UUID (no underscores
+// either), so `_` is an unambiguous separator. The hash is the keyset's primary
+// component; id is the tiebreak for the rare md5 collision case.
+function parseRandomCursor(raw: unknown): { hash: string; id: string } | null {
+  if (typeof raw !== 'string') return null;
+  const sepIdx = raw.indexOf('_');
+  if (sepIdx <= 0) return null;
+  const hash = raw.slice(0, sepIdx);
+  const id = raw.slice(sepIdx + 1);
+  // md5 hash must be exactly 32 hex chars; reject otherwise so a malformed/
+  // newest-mode cursor that's accidentally sent doesn't break the query.
+  if (!/^[0-9a-f]{32}$/.test(hash) || !id) return null;
+  return { hash, id };
 }
 
 // sicilian-58129: parse comma-separated query param, dedupe, trim, cap length.
@@ -111,7 +129,6 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
       Math.max(parseInt((req.query.limit as string) || String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT, 1),
       MAX_LIMIT
     );
-    const cursor = parseCursor(req.query.cursor);
 
     const regions = parseCsv(req.query.regions);
     const countries = parseCsv(req.query.countries);
@@ -119,6 +136,23 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
     const partnerTag = typeof partnerTagRaw === 'string' && partnerTagRaw.trim()
       ? partnerTagRaw.trim()
       : null;
+
+    // sicilian-58195: random shuffle sort. When sort=random, the seed deter-
+    // mines the order so cursor pagination + filters stay consistent across
+    // requests. Order is MD5(id::text || seed::text) ASC (tiebreak: id ASC).
+    // We skip the payout-docs UNION in random mode — after napoletana-58211
+    // every kind='pizza' payout doc has photo_id set, so the payout side is
+    // effectively empty in practice. (Documented limitation.)
+    const sort: FeedSort = req.query.sort === 'random' ? 'random' : 'newest';
+    const seed = sort === 'random'
+      ? String(parseInt((req.query.seed as string) || '', 10) || 0)
+      : null;
+
+    if (sort === 'random' && seed !== null) {
+      return await handleRandomFeed(req, res, { limit, regions, countries, partnerTag, seed });
+    }
+
+    const cursor = parseCursor(req.query.cursor);
 
     const partyFilter = buildPartyFilter({ regions, countries, partnerTag });
 
@@ -346,6 +380,138 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
     next(error);
   }
 });
+
+// sicilian-58195: random-shuffle handler. ORDER BY MD5(id::text || seed::text)
+// gives a deterministic shuffle for a given seed; keyset pagination over the
+// (md5_hash, id) tuple keeps subsequent pages aligned with page 1 even as the
+// underlying photo set grows. We fetch ids+hash in one raw query (Prisma's
+// typed builder can't ORDER BY arbitrary SQL expressions), then re-fetch the
+// rows via the normal Prisma select so the response shape matches newest mode.
+async function handleRandomFeed(
+  req: AuthRequest,
+  res: Response,
+  opts: {
+    limit: number;
+    regions: string[];
+    countries: string[];
+    partnerTag: string | null;
+    seed: string;
+  },
+): Promise<void> {
+  const { limit, regions, countries, partnerTag, seed } = opts;
+  const cursor = parseRandomCursor(req.query.cursor);
+  const fetchSize = limit + 1;
+
+  // Build optional WHERE fragments using Prisma.sql so values are parameter-
+  // bound (no SQL-injection surface).
+  const regionFilter = regions.length > 0
+    ? Prisma.sql`AND pa.region = ANY(${regions}::text[])`
+    : Prisma.empty;
+  const countryFilter = countries.length > 0
+    ? Prisma.sql`AND pa.country = ANY(${countries}::text[])`
+    : Prisma.empty;
+  const partnerTagFilter = partnerTag
+    ? Prisma.sql`AND ${partnerTag} = ANY(pa.event_tags)`
+    : Prisma.empty;
+  const cursorFilter = cursor
+    ? Prisma.sql`AND (
+        MD5(p.id::text || ${seed}::text) > ${cursor.hash}
+        OR (MD5(p.id::text || ${seed}::text) = ${cursor.hash} AND p.id::text > ${cursor.id})
+      )`
+    : Prisma.empty;
+
+  const rows = await prisma.$queryRaw<{ id: string; sort_hash: string }[]>(Prisma.sql`
+    SELECT p.id::text AS id, MD5(p.id::text || ${seed}::text) AS sort_hash
+    FROM photos p
+    JOIN parties pa ON pa.id = p.party_id
+    WHERE p.starred = true
+      AND p.status = 'approved'
+      AND pa.underboss_status = 'approved'
+      AND pa.photos_public = true
+      AND pa.photos_enabled = true
+      ${regionFilter}
+      ${countryFilter}
+      ${partnerTagFilter}
+      ${cursorFilter}
+    ORDER BY MD5(p.id::text || ${seed}::text) ASC, p.id::text ASC
+    LIMIT ${fetchSize}
+  `);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const ids = pageRows.map((r) => r.id);
+
+  // Re-fetch the full photo rows (with party + vote relations) using the same
+  // select shape as newest mode so the response is identical apart from order.
+  const photos = ids.length > 0
+    ? await prisma.photo.findMany({
+        where: { id: { in: ids } },
+        select: {
+          id: true,
+          url: true,
+          thumbnailUrl: true,
+          caption: true,
+          mimeType: true,
+          duration: true,
+          width: true,
+          height: true,
+          createdAt: true,
+          voteCount: true,
+          votes: req.userId
+            ? { where: { userId: req.userId }, select: { id: true } }
+            : false,
+          party: {
+            select: {
+              id: true,
+              name: true,
+              customUrl: true,
+              inviteCode: true,
+              city: true,
+              country: true,
+            },
+          },
+        },
+      })
+    : [];
+
+  // Map by id and re-emit in the random sort order from the raw query.
+  const byId = new Map(photos.map((p) => [p.id, p]));
+  const sorted = ids.map((id) => byId.get(id)).filter((p): p is NonNullable<typeof p> => !!p);
+
+  const lastRow = pageRows.length > 0 ? pageRows[pageRows.length - 1] : null;
+  const nextCursor = hasMore && lastRow
+    ? `${lastRow.sort_hash}_${lastRow.id}`
+    : null;
+
+  res.json({
+    photos: sorted.map((p) => {
+      const votes = (p as typeof p & { votes?: { id: string }[] }).votes;
+      return {
+        id: p.id,
+        source: 'photo' as const,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        caption: p.caption,
+        mimeType: p.mimeType,
+        duration: p.duration,
+        width: p.width,
+        height: p.height,
+        createdAt: p.createdAt,
+        voteCount: p.voteCount,
+        votedByMe: req.userId ? (votes?.length ?? 0) > 0 : false,
+        payoutId: null,
+        party: {
+          id: p.party.id,
+          slug: p.party.customUrl || p.party.inviteCode,
+          name: p.party.name,
+          city: p.party.city,
+          country: p.party.country,
+        },
+      };
+    }),
+    nextCursor,
+  });
+}
 
 // sicilian-58129: facets endpoint — returns distinct country values among
 // feed-eligible photos (approved + party-eligible) with photo counts.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4925,6 +4925,10 @@ export interface PhotosFeedFilters {
   countries?: string[];      // raw country names (locale variants) sent to backend
   regions?: string[];        // GPP region ids
   partnerTag?: string | null;
+  // sicilian-58195: shuffle support. When sort='random', backend uses MD5(id
+  // || seed) as the order key so pagination + filters stay consistent.
+  sort?: 'newest' | 'random';
+  seed?: string | null;
 }
 
 export async function getPhotosFeed(
@@ -4944,6 +4948,10 @@ export async function getPhotosFeed(
     }
     if (filters?.partnerTag) {
       params.append('partnerTag', filters.partnerTag);
+    }
+    if (filters?.sort === 'random' && filters.seed) {
+      params.append('sort', 'random');
+      params.append('seed', filters.seed);
     }
     return await apiRequest<PhotosFeedResponse>(
       `/api/photos/feed?${params.toString()}`,

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { Loader2, Play, MapPin, ChevronLeft, ChevronRight, ChevronDown, Check, Search, X, ThumbsUp } from 'lucide-react';
+import { Loader2, Play, MapPin, ChevronLeft, ChevronRight, ChevronDown, Check, Search, X, ThumbsUp, Shuffle } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import { ThemeProvider } from '../contexts/ThemeContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -36,6 +36,16 @@ export function PhotosFeedPage() {
   const [activeRegions, setActiveRegions] = useState<string[]>(() => parseCsvParam(searchParams.get('regions')));
   const [activePartnerTag, setActivePartnerTag] = useState<string | null>(() => searchParams.get('partnerTag') || null);
 
+  // sicilian-58195: shuffle state. sortMode='random' + seed makes the order
+  // deterministic for that seed so the backend's keyset cursor can paginate
+  // through the shuffled feed. URL params survive refresh / sharing.
+  const [sortMode, setSortMode] = useState<'newest' | 'random'>(
+    () => (searchParams.get('sort') === 'random' && searchParams.get('seed') ? 'random' : 'newest')
+  );
+  const [seed, setSeed] = useState<string | null>(
+    () => (searchParams.get('sort') === 'random' ? searchParams.get('seed') : null)
+  );
+
   // Facets + partner tags
   const [facetCountries, setFacetCountries] = useState<Array<{ name: string; count: number }>>([]);
   const [myPartnerTags, setMyPartnerTags] = useState<string[]>([]);
@@ -59,9 +69,13 @@ export function PhotosFeedPage() {
   const countriesRef = useRef(activeCountries);
   const regionsRef = useRef(activeRegions);
   const partnerTagRef = useRef(activePartnerTag);
+  const sortModeRef = useRef(sortMode);
+  const seedRef = useRef(seed);
   countriesRef.current = activeCountries;
   regionsRef.current = activeRegions;
   partnerTagRef.current = activePartnerTag;
+  sortModeRef.current = sortMode;
+  seedRef.current = seed;
 
   // Sync filter state -> URL so refresh / sharing work.
   useEffect(() => {
@@ -69,10 +83,14 @@ export function PhotosFeedPage() {
     if (activeCountries.length > 0) next.set('countries', activeCountries.join(','));
     if (activeRegions.length > 0) next.set('regions', activeRegions.join(','));
     if (activePartnerTag) next.set('partnerTag', activePartnerTag);
+    if (sortMode === 'random' && seed) {
+      next.set('sort', 'random');
+      next.set('seed', seed);
+    }
     // Replace (don't push) to keep history clean.
     setSearchParams(next, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeCountries, activeRegions, activePartnerTag]);
+  }, [activeCountries, activeRegions, activePartnerTag, sortMode, seed]);
 
   // Build the raw-country list to send to the backend by expanding each
   // selected alpha-2 to all known locale variants intersected with what
@@ -105,6 +123,8 @@ export function PhotosFeedPage() {
         countries: buildCountriesForBackend(countriesRef.current),
         regions: regionsRef.current,
         partnerTag: partnerTagRef.current,
+        sort: sortModeRef.current,
+        seed: seedRef.current,
       };
       const res = await getPhotosFeed(cursorRef.current, 24, filters);
       if (!res) {
@@ -125,10 +145,11 @@ export function PhotosFeedPage() {
     }
   }, [buildCountriesForBackend]);
 
-  // Reset + reload whenever a filter changes.
+  // Reset + reload whenever a filter changes. sicilian-58195: include sort
+  // + seed so picking Shuffle (or reshuffling with a new seed) re-pages.
   const filterKey = useMemo(
-    () => `${activeCountries.slice().sort().join(',')}|${activeRegions.slice().sort().join(',')}|${activePartnerTag || ''}`,
-    [activeCountries, activeRegions, activePartnerTag]
+    () => `${activeCountries.slice().sort().join(',')}|${activeRegions.slice().sort().join(',')}|${activePartnerTag || ''}|${sortMode}|${seed || ''}`,
+    [activeCountries, activeRegions, activePartnerTag, sortMode, seed]
   );
 
   useEffect(() => {
@@ -211,6 +232,23 @@ export function PhotosFeedPage() {
     setActiveCountries([]);
     setActiveRegions([]);
     setActivePartnerTag(null);
+    // sicilian-58195: clearing also returns to default newest-first order.
+    setSortMode('newest');
+    setSeed(null);
+  };
+
+  // sicilian-58195: shuffle handler. Generates a new seed and switches to
+  // random sort. Clicking while already shuffled reshuffles with a fresh seed.
+  const handleShuffle = () => {
+    const newSeed = String(Math.floor(Math.random() * 1e9));
+    setSortMode('random');
+    setSeed(newSeed);
+  };
+
+  // Revert just the shuffle (preserve other filters).
+  const clearShuffle = () => {
+    setSortMode('newest');
+    setSeed(null);
   };
 
   // salame-58195: propagate vote changes back into the photos array so the
@@ -223,7 +261,7 @@ export function PhotosFeedPage() {
     []
   );
 
-  const anyFiltersActive = activeCountries.length > 0 || activeRegions.length > 0 || !!activePartnerTag;
+  const anyFiltersActive = activeCountries.length > 0 || activeRegions.length > 0 || !!activePartnerTag || sortMode === 'random';
 
   return (
     <ThemeProvider theme="gpp">
@@ -262,6 +300,32 @@ export function PhotosFeedPage() {
               onChange={setActivePartnerTag}
             />
           )}
+          {/* sicilian-58195: shuffle toggle. Same pill shape as the filter
+              buttons; click reshuffles (new seed). The adjacent X clears
+              shuffle and returns to newest-first ordering. */}
+          <button
+            onClick={handleShuffle}
+            title={sortMode === 'random' ? 'Reshuffle' : 'Shuffle photos'}
+            className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm transition-colors ${
+              sortMode === 'random'
+                ? 'bg-red-500/10 border-red-500/40 text-red-600 hover:bg-red-500/20'
+                : 'border-black/10 text-gray-900 hover:bg-white'
+            }`}
+            style={sortMode === 'random' ? undefined : { background: 'rgba(255,255,255,0.85)' }}
+          >
+            <Shuffle size={14} />
+            <span>{sortMode === 'random' ? 'Shuffled' : 'Shuffle'}</span>
+            {sortMode === 'random' && (
+              <span
+                role="button"
+                aria-label="Clear shuffle"
+                onClick={(e) => { e.stopPropagation(); clearShuffle(); }}
+                className="inline-flex items-center justify-center w-4 h-4 rounded-full hover:bg-red-500/20"
+              >
+                <X size={12} />
+              </span>
+            )}
+          </button>
           {anyFiltersActive && (
             <button
               onClick={clearAllFilters}


### PR DESCRIPTION
## Summary
- New Shuffle button next to filter dropdowns on /photos
- Click generates a random seed; server uses MD5(id || seed) for deterministic ordering so pagination + filters keep working
- URL persistence: ?sort=random&seed=N is bookmarkable
- Click again to reshuffle (new seed); revert to newest by clearing the filter state

## Test plan
- [ ] Click Shuffle - photos reorder visibly, infinite scroll keeps working
- [ ] Filter by country + shuffle - only matching country photos, randomly ordered
- [ ] Refresh page with shuffle URL - same order restored
- [ ] Click Shuffle again - new order (reshuffles)
- [ ] Vercel preview: https://rsvpizza-git-sicilian-58195-photos-shuffle-pizza-dao.vercel.app/photos

Generated with [Claude Code](https://claude.com/claude-code)