### PR TITLE
panzerotti-58291: /underboss stats row polish (lens + tab badge + progress %s + label)

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -68,8 +68,8 @@ function computeProgress(party: any, underbossEmails: string[] = []) {
 
 // Helper: compute stats from events
 function computeStats(events: any[], underbossEmails: string[] = []) {
-  // pizzetta-58924: per-event counters use approved + not-cancelled lens;
-  // per-guest sums stay across all events.
+  // panzerotti-58291: per-guest sums + per-event counters share one loop
+  // because both apply the same approved+not-cancelled lens now.
   const approvedEvents = events.filter(
     (e: any) => e.underbossStatus === 'approved' && !e.cancelledAt
   );
@@ -81,8 +81,12 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
   let eventsWithVenue = 0;
   let eventsWithBudget = 0;
   let eventsWithKit = 0;
+  let eventsWithTeam = 0;
+  let eventsWithSponsors = 0;
+  let eventsWithSocial = 0;
+  let eventsWithThrown = 0;
 
-  for (const event of events) {
+  for (const event of approvedEvents) {
     const invited = event.guests?.filter((g: any) => g.status === 'INVITED').length || 0;
     const guestCount = (event._count?.guests || 0) - invited;
     const approvedCount = event.guests?.filter((g: any) => g.approved !== false && g.status !== 'INVITED').length || 0;
@@ -90,13 +94,15 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
     totalInvited += invited;
     totalRsvps += guestCount;
     totalApproved += approvedCount;
-  }
 
-  for (const event of approvedEvents) {
     const progress = computeProgress(event, underbossEmails);
     if (progress.hasVenue) eventsWithVenue++;
     if (progress.hasBudget) eventsWithBudget++;
     if (progress.hasPartyKit) eventsWithKit++;
+    if (progress.hasCoHosts) eventsWithTeam++;
+    if (progress.hasSponsors) eventsWithSponsors++;
+    if (progress.hasSocialPosts) eventsWithSocial++;
+    if (progress.hasThrown) eventsWithThrown++;
   }
 
   return {
@@ -107,10 +113,18 @@ function computeStats(events: any[], underbossEmails: string[] = []) {
     eventsWithVenue,
     eventsWithBudget,
     eventsWithKit,
+    eventsWithTeam,
+    eventsWithSponsors,
+    eventsWithSocial,
+    eventsWithThrown,
     completionRate: {
       venue: totalEvents > 0 ? Math.round((eventsWithVenue / totalEvents) * 100) : 0,
       budget: totalEvents > 0 ? Math.round((eventsWithBudget / totalEvents) * 100) : 0,
       partyKit: totalEvents > 0 ? Math.round((eventsWithKit / totalEvents) * 100) : 0,
+      team: totalEvents > 0 ? Math.round((eventsWithTeam / totalEvents) * 100) : 0,
+      sponsors: totalEvents > 0 ? Math.round((eventsWithSponsors / totalEvents) * 100) : 0,
+      social: totalEvents > 0 ? Math.round((eventsWithSocial / totalEvents) * 100) : 0,
+      thrown: totalEvents > 0 ? Math.round((eventsWithThrown / totalEvents) * 100) : 0,
     },
     avgRsvpsPerEvent: totalEvents > 0 ? Math.round(totalRsvps / totalEvents) : 0,
   };

--- a/frontend/src/components/underboss/RegionStats.tsx
+++ b/frontend/src/components/underboss/RegionStats.tsx
@@ -76,7 +76,7 @@ export function RegionStats({ stats }: RegionStatsProps) {
         />
         <StatCard
           icon={Users}
-          label={t('regionStats.approved')}
+          label={t('regionStats.approvedRsvps')}
           value={stats.totalApproved}
           color="bg-green-500/20 text-green-400"
         />
@@ -101,8 +101,13 @@ export function RegionStats({ stats }: RegionStatsProps) {
           <span className="text-xs text-theme-text-muted uppercase tracking-wider">{t('regionStats.completionRates')}</span>
         </div>
         <div className="space-y-3">
+          <CompletionBar label={t('regionStats.kit')} percent={stats.completionRate.partyKit} />
+          <CompletionBar label={t('regionStats.team')} percent={stats.completionRate.team} />
           <CompletionBar label={t('regionStats.venue')} percent={stats.completionRate.venue} />
           <CompletionBar label={t('regionStats.budget')} percent={stats.completionRate.budget} />
+          <CompletionBar label={t('regionStats.sponsors')} percent={stats.completionRate.sponsors} />
+          <CompletionBar label={t('regionStats.social')} percent={stats.completionRate.social} />
+          <CompletionBar label={t('regionStats.thrown')} percent={stats.completionRate.thrown} />
         </div>
       </div>
     </div>

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -139,11 +139,17 @@
     "totalRsvps": "Total RSVPs",
     "perEvent": "~{{avg}} per event",
     "approved": "Approved",
+    "approvedRsvps": "Approved RSVPs",
     "withVenue": "With Venue",
     "withBudget": "With Budget",
     "completionRates": "Completion Rates",
+    "kit": "Kit",
+    "team": "Team",
     "venue": "Venue",
-    "budget": "Budget"
+    "budget": "Budget",
+    "sponsors": "Partners",
+    "social": "Social",
+    "thrown": "Thrown"
   },
   "intake": {
     "linkNotFound": "Link Not Found",

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -16,8 +16,8 @@ import { GPP_REGIONS } from '../types';
 import type { UnderbossDashboardData, UnderbossStats, UnderbossEvent } from '../types';
 
 function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStats {
-  // pizzetta-58924: per-event counters use approved + not-cancelled lens;
-  // per-guest sums stay across all events.
+  // panzerotti-58291: per-guest sums + per-event counters share one loop
+  // because both apply the same approved+not-cancelled lens now.
   const approvedEvents = events.filter(
     e => e.underbossStatus === 'approved' && !e.cancelledAt
   );
@@ -28,16 +28,24 @@ function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStat
   let totalApproved = 0;
   let eventsWithVenue = 0;
   let eventsWithBudget = 0;
+  let eventsWithKit = 0;
+  let eventsWithTeam = 0;
+  let eventsWithSponsors = 0;
+  let eventsWithSocial = 0;
+  let eventsWithThrown = 0;
 
-  for (const e of events) {
+  for (const e of approvedEvents) {
     totalRsvps += e.guestCount;
     totalInvited += e.invitedCount || 0;
     totalApproved += e.approvedCount;
-  }
 
-  for (const e of approvedEvents) {
     if (e.progress.hasVenue) eventsWithVenue++;
     if (e.progress.hasBudget) eventsWithBudget++;
+    if (e.progress.hasPartyKit) eventsWithKit++;
+    if (e.progress.hasCoHosts) eventsWithTeam++;
+    if (e.progress.hasSponsors) eventsWithSponsors++;
+    if (e.progress.hasSocialPosts) eventsWithSocial++;
+    if (e.progress.hasThrown) eventsWithThrown++;
   }
 
   return {
@@ -47,9 +55,19 @@ function recomputeStats(events: UnderbossDashboardData['events']): UnderbossStat
     totalApproved,
     eventsWithVenue,
     eventsWithBudget,
+    eventsWithKit,
+    eventsWithTeam,
+    eventsWithSponsors,
+    eventsWithSocial,
+    eventsWithThrown,
     completionRate: {
       venue: totalEvents > 0 ? Math.round((eventsWithVenue / totalEvents) * 100) : 0,
       budget: totalEvents > 0 ? Math.round((eventsWithBudget / totalEvents) * 100) : 0,
+      partyKit: totalEvents > 0 ? Math.round((eventsWithKit / totalEvents) * 100) : 0,
+      team: totalEvents > 0 ? Math.round((eventsWithTeam / totalEvents) * 100) : 0,
+      sponsors: totalEvents > 0 ? Math.round((eventsWithSponsors / totalEvents) * 100) : 0,
+      social: totalEvents > 0 ? Math.round((eventsWithSocial / totalEvents) * 100) : 0,
+      thrown: totalEvents > 0 ? Math.round((eventsWithThrown / totalEvents) * 100) : 0,
     },
     avgRsvpsPerEvent: totalEvents > 0 ? Math.round(totalRsvps / totalEvents) : 0,
   };
@@ -534,7 +552,7 @@ export function UnderbossDashboard() {
                   : 'text-theme-text-muted hover:text-theme-text-secondary'
               }`}
             >
-              {t('underbossDashboard.tabs.events')} ({displayData.events.length})
+              {t('underbossDashboard.tabs.events')} ({filteredData.stats.totalEvents} of {filteredData.events.length})
               {openAppealCount > 0 && (
                 <span
                   className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-300 text-[10px] font-semibold ml-1.5"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1175,10 +1175,18 @@ export interface UnderbossStats {
   eventsWithVenue: number;
   eventsWithBudget: number;
   eventsWithKit: number;
+  eventsWithTeam: number;
+  eventsWithSponsors: number;
+  eventsWithSocial: number;
+  eventsWithThrown: number;
   completionRate: {
     venue: number;
     budget: number;
     partyKit: number;
+    team: number;
+    sponsors: number;
+    social: number;
+    thrown: number;
   };
   avgRsvpsPerEvent: number;
 }


### PR DESCRIPTION
## Summary
- Guest totals (Total RSVPs / Invited / Approved RSVPs) now apply the same approved+not-cancelled lens as the Events card, so the whole stats row describes the same event set.
- Events tab badge: `Events (400 of 1056)` — disambiguates the card-vs-table count split.
- Completion Rates card: shows all 7 progress %s (kit, team, venue, budget, partners, social, thrown), not just venue + budget.
- 'Approved' card renamed to 'Approved RSVPs' to avoid colliding with the approved-events count.

## Test plan
- [ ] Events: ~400
- [ ] Total RSVPs / Invited / Approved RSVPs drop noticeably vs prod (now over 400 events, not 1056)
- [ ] Events tab badge reads 'Events (400 of 1056)' or similar
- [ ] Completion Rates card shows 7 bars, each <=100%
- [ ] De-select a region -> row recomputes consistently

Extends pizzetta-58924 (#653).

Generated with [Claude Code](https://claude.com/claude-code)