### PR TITLE
fix(pecorino-64118): exclude test.com placeholder domain from Industry RSVPs

### DIFF
--- a/backend/src/lib/emailDomains.ts
+++ b/backend/src/lib/emailDomains.ts
@@ -45,7 +45,11 @@ export const PERSONAL_BRAND_STEMS: string[] = [
 // are placeholder / test addresses (e.g. example.invalid) that should never be
 // counted as a real industry org. pecorino-64118 follow-up.
 const RESERVED_TLD_SUFFIXES: string[] = ['.invalid', '.test', '.localhost', '.example'];
-const RESERVED_EXAMPLE_DOMAINS: Set<string> = new Set(['example.com', 'example.org', 'example.net']);
+const RESERVED_EXAMPLE_DOMAINS: Set<string> = new Set([
+  'example.com', 'example.org', 'example.net',
+  // pecorino-64118: common placeholder/test domains seen in fake/test RSVPs.
+  'test.com', 'test.org', 'test.net',
+]);
 
 // Returns the lowercased email domain if it is NOT a personal provider,
 // internal/host domain, or personal-brand variant; otherwise null. Also


### PR DESCRIPTION
Exclude `test.com` / `test.org` / `test.net` placeholder domains from Industry RSVPs.

Adds these to the exact-match placeholder exclusion set (`RESERVED_EXAMPLE_DOMAINS`) in `backend/src/lib/emailDomains.ts` so `orgDomainFromEmail` returns null for them — they're treated as non-org and never appear as Industry RSVPs, same as `example.com`.

**Needs backend redeploy from master** to take effect (Industry RSVPs is a backend report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)