### PR TITLE
feat(provola-92103): server-side OCR line-items backfill endpoint

### DIFF
--- a/backend/scripts/loop-backfill-line-items.cjs
+++ b/backend/scripts/loop-backfill-line-items.cjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * provola-92103: loops the /api/admin/payouts/backfill-line-items endpoint
+ * until done. The endpoint hard-caps each call at 50 receipts and throttles
+ * 500ms between OCR calls; this driver simply re-POSTs until `remaining=0`.
+ *
+ * Usage:
+ *   ADMIN_JWT=eyJ... node backend/scripts/loop-backfill-line-items.cjs
+ *
+ * Get the JWT from your browser devtools (login to rsv.pizza as admin →
+ * Network → any /api/admin/* request → Request Headers → Authorization).
+ *
+ * Optional env:
+ *   API_BASE  — default https://api.rsv.pizza
+ *   BATCH     — per-call limit, default 25 (server caps at 50)
+ */
+const API = process.env.API_BASE || 'https://api.rsv.pizza';
+const TOKEN = process.env.ADMIN_JWT;
+if (!TOKEN) {
+  console.error('Set ADMIN_JWT env var');
+  process.exit(1);
+}
+const BATCH = Number(process.env.BATCH || 25);
+
+(async () => {
+  let total = 0;
+  while (true) {
+    const res = await fetch(`${API}/api/admin/payouts/backfill-line-items`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ limit: BATCH }),
+    });
+    if (!res.ok) {
+      console.error('HTTP ' + res.status + ': ' + (await res.text()));
+      process.exit(1);
+    }
+    const j = await res.json();
+    total += j.succeeded;
+    console.log(
+      `+ ${j.succeeded} (${j.failed.length} failed) — remaining: ${j.remaining}`,
+    );
+    if (j.done) break;
+  }
+  console.log(`Done. Total succeeded: ${total}.`);
+})();

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2942,6 +2942,114 @@ router.get(
   },
 );
 
+// ============================================
+// POST /api/admin/payouts/backfill-line-items — provola-92103
+//
+// One-shot ops endpoint to re-OCR existing receipts that were uploaded before
+// formaggi-89172 added structured `ocr_line_items` extraction. OPENAI_API_KEY
+// only exists on the backend Vercel deploy (auto-classifier blocks pulling it
+// locally), so the backfill MUST run server-side.
+//
+// Auth: requireAnyAdminOrPaymentAdmin (admin / super_admin / payment_admin).
+// Body: { limit?: number }  // 1..50, default 25
+//
+// Behavior:
+//  - Selects up to `limit` receipts where `ocr_line_items IS NULL` and the
+//    URL is present, oldest first.
+//  - Calls `analyzeReceipt(url)` sequentially with a 500ms throttle between
+//    iterations (gentle on OpenAI rate limits).
+//  - On success, writes ONLY `ocr_line_items` — leaves `ocr_amount`,
+//    `ocr_currency`, `ocr_confidence`, `ocr_raw` untouched so admin-approved
+//    payout totals don't shift. `merchant` and `receiptDate` are returned by
+//    the OCR service but have no DB columns yet, so they're discarded here.
+//  - On failure, the error is logged + pushed onto `failed` and we continue.
+//
+// Returns:
+//   { processed, succeeded, failed: [{id, error}], remaining, done }
+//
+// Loop externally with backend/scripts/loop-backfill-line-items.cjs.
+// ============================================
+router.post(
+  '/backfill-line-items',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { analyzeReceipt } = await import('../services/ocr.service.js');
+
+      const body = (req.body || {}) as { limit?: unknown };
+      const rawLimit = body.limit === undefined ? 25 : Number(body.limit);
+      if (!Number.isFinite(rawLimit)) {
+        throw new AppError('limit must be a finite number', 400, 'VALIDATION_ERROR');
+      }
+      const limit = Math.max(1, Math.min(50, Math.floor(rawLimit)));
+
+      // Candidates: receipts with no line items yet and a non-empty URL.
+      // `url: { not: '' }` excludes blank rows; the `IS NOT NULL` semantic is
+      // implicit because `url` is a non-nullable column on PayoutDocument.
+      const candidates = await prisma.payoutDocument.findMany({
+        where: {
+          kind: 'receipt',
+          ocrLineItems: { equals: Prisma.DbNull },
+          url: { not: '' },
+        },
+        orderBy: { createdAt: 'asc' },
+        take: limit,
+        select: { id: true, url: true },
+      });
+
+      const failed: Array<{ id: string; error: string }> = [];
+      let succeeded = 0;
+
+      for (let i = 0; i < candidates.length; i++) {
+        const doc = candidates[i];
+        try {
+          const result = await analyzeReceipt(doc.url);
+          // Additive write: ONLY ocr_line_items. Do not overwrite
+          // ocr_amount / ocr_currency / ocr_confidence / ocr_raw — admins may
+          // have already approved payouts based on those values.
+          await prisma.payoutDocument.update({
+            where: { id: doc.id },
+            data: {
+              ocrLineItems: (result.lineItems ?? []) as unknown as Prisma.InputJsonValue,
+            },
+          });
+          succeeded += 1;
+        } catch (err: any) {
+          const message = err?.message ? String(err.message) : String(err);
+          console.error(
+            `[backfill-line-items] doc=${doc.id} url=${doc.url} failed: ${message}`,
+          );
+          failed.push({ id: doc.id, error: message });
+        }
+
+        // Throttle between iterations (skip the wait after the last one).
+        if (i < candidates.length - 1) {
+          await new Promise((r) => setTimeout(r, 500));
+        }
+      }
+
+      const remaining = await prisma.payoutDocument.count({
+        where: {
+          kind: 'receipt',
+          ocrLineItems: { equals: Prisma.DbNull },
+          url: { not: '' },
+        },
+      });
+
+      res.json({
+        processed: candidates.length,
+        succeeded,
+        failed,
+        remaining,
+        done: remaining === 0,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // Re-export the helper so other backend code (e.g. PR 5 execute route) can
 // reuse the composed guard without re-deriving it.
 export { requireAnyAdminOrPaymentAdmin, isFullAdmin };


### PR DESCRIPTION
## Summary
- New admin-only `POST /api/admin/payouts/backfill-line-items` re-OCRs existing receipts that don't have `ocr_line_items` yet (502 candidates as of dispatch).
- Additive: only writes `ocr_line_items`; existing amount/currency/confidence stay so admin-approved totals don't shift.
- Sequential + 0.5s throttle to be gentle on OpenAI rate limits.
- Loop helper script `backend/scripts/loop-backfill-line-items.cjs` for one-command full backfill via curl loop.

## Test plan
- [ ] Admin POST with limit=3 → processes 3 rows, returns counts.
- [ ] Verify those rows now have `ocr_line_items`; their `ocr_amount` unchanged.
- [ ] Loop script with ADMIN_JWT runs to `done: true`.