### PR TITLE
feat(caprino-92103): revert approved payouts to pending

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1800,6 +1800,91 @@ router.post(
 );
 
 // ============================================
+// POST /api/admin/payouts/:id/unapprove
+//
+// caprino-92103: revert an `approved` payout back to `pending` so the admin
+// can re-review (or ask the host for more info before sending). Approval
+// was previously a one-way door — the only "undo" was reject, which is a
+// different terminal state.
+//
+// Atomic via prisma.$transaction:
+//   1. Lookup payout (404 if missing).
+//   2. Validate status === 'approved' (400 NOT_APPROVED otherwise).
+//   3. status -> 'pending'; clear reviewedAt + reviewedBy.
+//   4. Write payout_audit row with action='unapprove'.
+//
+// Preserves external_proof_url / transactionHash / paidAt from any prior
+// execute attempt — those are history.
+// ============================================
+router.post(
+  '/:id/unapprove',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'approved') {
+        throw new AppError(
+          `Cannot unapprove a payout in status '${existing.status}'`,
+          400,
+          'NOT_APPROVED',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const { note } = req.body || {};
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: {
+            status: 'pending',
+            reviewedAt: null,
+            reviewedBy: null,
+          },
+          include: {
+            party: { select: PAYOUT_PARTY_SELECT },
+            host: { select: { id: true, name: true, email: true } },
+            documents: {
+              orderBy: { sortOrder: 'asc' },
+              include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+            },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'unapprove',
+            oldStatus: 'approved',
+            newStatus: 'pending',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: typeof note === 'string' ? note : null,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
 // POST /api/admin/payouts/:id/reject
 // ============================================
 router.post(

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -40,6 +40,17 @@ interface PayoutReviewModalProps {
   onClose: () => void;
   onApprove: (note?: string) => Promise<void> | void;
   onReject: (reason: string) => Promise<void> | void;
+  /**
+   * caprino-92103: revert an `approved` payout back to `pending`. Surfaced
+   * as an amber "Revert to Pending" button in the modal footer when the
+   * current status is `approved`. Returns a string error message (NOT
+   * throws) when the call fails so the modal can surface it inline; resolves
+   * to `undefined` on success.
+   *
+   * No confirm modal — reversible actions don't get a confirm step per
+   * project convention.
+   */
+  onUnapprove?: () => Promise<string | void> | string | void;
   /**
    * aglio-62584: `allowOverSubmissionCap` is forwarded when the admin has
    * acknowledged the amber $625 cap warning by ticking the override
@@ -120,6 +131,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onClose,
   onApprove,
   onReject,
+  onUnapprove,
   onSaveAmount,
   onSaveAdminNotes,
   onMarkPaid,
@@ -204,6 +216,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
   const [showRejectForm, setShowRejectForm] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
+
+  // caprino-92103: inline error for "Revert to Pending". Rendered below the
+  // footer button row. Mirrors the saveAmountError pattern from aglio-62584.
+  const [unapproveError, setUnapproveError] = useState<string | null>(null);
 
   const [showMarkPaidForm, setShowMarkPaidForm] = useState(false);
   const [wireRef, setWireRef] = useState('');
@@ -1368,6 +1384,31 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           )}
           {isApproved && (
             <>
+              {/* caprino-92103: revert approved -> pending. Only surfaced
+                  when status is strictly 'approved' (not 'failed') and the
+                  parent wired an onUnapprove handler. Placed first so it
+                  sits visually distinct from the primary actions (Execute,
+                  Mark Paid) that follow. Amber border to signal "reverse
+                  course". No confirm modal — reversible action per project
+                  convention (re-approve restores the prior state). */}
+              {payout.status === 'approved' && onUnapprove && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setUnapproveError(null);
+                    const err = await onUnapprove();
+                    if (typeof err === 'string' && err) {
+                      setUnapproveError(err);
+                    }
+                  }}
+                  disabled={busy || selfPayoutBlocked}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-500/50 text-amber-300 hover:bg-amber-500/10 text-sm font-medium disabled:opacity-50"
+                  title="Move this payout back to pending"
+                >
+                  <Undo2 size={14} />
+                  Revert to Pending
+                </button>
+              )}
               <button
                 type="button"
                 onClick={openExecuteForm}
@@ -1438,6 +1479,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           >
             Close
           </button>
+          {/* caprino-92103: inline error for Revert. Takes full row width
+              below the buttons via w-full on the wrapping flex container's
+              flex-wrap. Surfaces backend NOT_APPROVED + any network failure. */}
+          {unapproveError && (
+            <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{unapproveError}</span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Check, X, Pencil, Eye, DollarSign, Send, Loader2 } from 'lucide-react';
+import { Check, X, Pencil, Eye, DollarSign, Send, Loader2, Undo2 } from 'lucide-react';
 import type { AdminPayout, PayoutStatus } from '../../types';
 import { PayoutRow } from '../payments-shared';
 
@@ -15,6 +15,11 @@ interface PayoutsTableProps {
   onMarkPaid: (payout: AdminPayout) => void;
   /** Opens the modal so the admin can execute via the method-specific confirmation form. */
   onExecute: (payout: AdminPayout) => void;
+  /**
+   * caprino-92103: revert an `approved` payout back to `pending`. Surfaced as
+   * a small Undo2 icon in the row's action group when status === 'approved'.
+   */
+  onUnapprove?: (id: string) => void;
   /**
    * siciliana-69183: open the read-only HostPaymentDetailsModal for the given
    * User.id. Surfaced when the admin clicks the host name in a row.
@@ -41,6 +46,7 @@ function ActionsCell({
   onEdit,
   onMarkPaid,
   onExecute,
+  onUnapprove,
 }: {
   payout: AdminPayout;
   busy: boolean;
@@ -49,6 +55,7 @@ function ActionsCell({
   onEdit: (payout: AdminPayout) => void;
   onMarkPaid: (payout: AdminPayout) => void;
   onExecute: (payout: AdminPayout) => void;
+  onUnapprove?: (id: string) => void;
 }) {
   const status: PayoutStatus = payout.status;
   return (
@@ -106,6 +113,20 @@ function ActionsCell({
           >
             {busy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
           </button>
+          {/* caprino-92103: revert approved -> pending. Only surfaced when
+              status is strictly 'approved' (not 'failed') and the parent
+              wired onUnapprove. Amber to signal "reverse course". */}
+          {status === 'approved' && onUnapprove && (
+            <button
+              type="button"
+              onClick={() => onUnapprove(payout.id)}
+              disabled={busy}
+              className="p-1.5 rounded-md hover:bg-amber-50 text-amber-600 disabled:opacity-50"
+              title="Revert to Pending"
+            >
+              <Undo2 size={15} />
+            </button>
+          )}
           <button
             type="button"
             onClick={() => onMarkPaid(payout)}
@@ -132,6 +153,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
   onEdit,
   onMarkPaid,
   onExecute,
+  onUnapprove,
   onHostClick,
   onCapUpdated,
   busyRowId,
@@ -205,6 +227,7 @@ export const PayoutsTable: React.FC<PayoutsTableProps> = ({
                     onEdit={onEdit}
                     onMarkPaid={onMarkPaid}
                     onExecute={onExecute}
+                    onUnapprove={onUnapprove}
                   />
                 }
               />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4148,6 +4148,23 @@ export async function rejectAdminPayout(id: string, rejectionReason: string): Pr
   return res.payout;
 }
 
+/**
+ * caprino-92103: revert an `approved` payout back to `pending`. Approval
+ * was a one-way door — the only "undo" was reject, which is a different
+ * terminal state. This lets admins flip approved -> pending so they can
+ * re-review or ask the host for more info before sending.
+ *
+ * Backend validates the current status is 'approved' (400 NOT_APPROVED
+ * otherwise) and writes a payout_audit row with action='unapprove'.
+ */
+export async function unapproveAdminPayout(id: string, note?: string): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/unapprove`, {
+    method: 'POST',
+    body: { note },
+  });
+  return res.payout;
+}
+
 export async function markAdminPayoutPaid(
   id: string,
   refs: {

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -9,6 +9,7 @@ import {
   getAdminPayout,
   approveAdminPayout,
   rejectAdminPayout,
+  unapproveAdminPayout,
   updateAdminPayout,
   markAdminPayoutPaid,
   executeAdminPayout,
@@ -436,6 +437,21 @@ export function PaymentsAdminPage() {
     }
   }
 
+  // caprino-92103: revert an approved payout back to pending. Same refresh
+  // pattern as handleRowApprove — both queues can shift when a row flips
+  // approved <-> pending.
+  async function handleRowUnapprove(id: string) {
+    setRowBusyId(id);
+    try {
+      await unapproveAdminPayout(id);
+      await Promise.all([refresh(), loadPrepayQueue()]);
+    } catch (err: any) {
+      setErrorMsg(err.message || 'Revert failed');
+    } finally {
+      setRowBusyId(null);
+    }
+  }
+
   // crudo-91827: opens the in-app reject-reason modal. The actual reject work
   // is done by `confirmReject` once the admin types a reason and confirms.
   async function handleRowReject(id: string) {
@@ -716,6 +732,7 @@ export function PaymentsAdminPage() {
           onEdit={openDetail}
           onMarkPaid={handleRowMarkPaid}
           onExecute={openDetail}
+          onUnapprove={handleRowUnapprove}
           onHostClick={(userId) => setHostDetailUserId(userId)}
           onCapUpdated={() => refresh()}
           busyRowId={rowBusyId}
@@ -767,6 +784,24 @@ export function PaymentsAdminPage() {
                 await refresh();
               } catch (err: any) {
                 setErrorMsg(err.message || 'Reject failed');
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            // caprino-92103: stay-open after revert so the admin sees the
+            // new pending state in the modal (and can immediately re-approve
+            // if they want). Returns the error message string on failure so
+            // PayoutReviewModal can render it inline below the footer.
+            onUnapprove={async () => {
+              setModalBusy(true);
+              try {
+                await unapproveAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id);
+                setDetail(fresh);
+                await Promise.all([refresh(), loadPrepayQueue()]);
+                return;
+              } catch (err: any) {
+                return err?.message || 'Revert failed';
               } finally {
                 setModalBusy(false);
               }


### PR DESCRIPTION
## Summary
- New admin-only `POST /api/admin/payouts/:id/unapprove`.
- Frontend "Revert to Pending" affordance in PayoutReviewModal + PayoutsTable row.
- Audit trail captures the unapprove action.

## Test plan
- [ ] Approved payout → click Revert → status pending; audit row written.
- [ ] Pending or paid payout → endpoint 400.
- [ ] Non-admin → 403.
- [ ] After revert, the existing Approve flow re-approves cleanly.