### PR TITLE
feat(bottarga-92103): show event photos in PayoutReviewModal

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1477,6 +1477,42 @@ router.get(
         serialized.party.paidTotalUsd = t?.paidUsd ?? 0;
         serialized.party.paidTotalCount = t?.paidCount ?? 0;
       }
+
+      // bottarga-92103: surface the party's event-level photos (uploaded via
+      // the host Photos tab — separate from the pizza-kind documents attached
+      // inside the payments flow) so admins reviewing a payout see the full
+      // visual context of the party without bouncing to /host/:slug. Admins
+      // see every photo regardless of moderation status; the frontend surfaces
+      // a "Hidden from public" pill when `status !== 'approved'`.
+      const eventPhotos = await prisma.photo.findMany({
+        where: { partyId: row.partyId },
+        orderBy: { createdAt: 'asc' },
+        select: {
+          id: true,
+          url: true,
+          thumbnailUrl: true,
+          fileName: true,
+          mimeType: true,
+          caption: true,
+          status: true,
+          starred: true,
+          uploaderName: true,
+          createdAt: true,
+        },
+      });
+      (serialized as any).eventPhotos = eventPhotos.map((p) => ({
+        id: p.id,
+        url: p.url,
+        thumbnailUrl: p.thumbnailUrl,
+        fileName: p.fileName,
+        mimeType: p.mimeType,
+        caption: p.caption,
+        status: p.status,
+        starred: p.starred,
+        uploaderName: p.uploaderName,
+        createdAt: p.createdAt.toISOString(),
+      }));
+
       res.json({ payout: serialized });
     } catch (error) {
       next(error);

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -294,7 +294,36 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     () => payout.documents.filter((d) => d.kind === 'pizza'),
     [payout.documents],
   );
-  const allPhotos = useMemo(() => [...pizzas, ...receipts], [pizzas, receipts]);
+  // bottarga-92103: event-level photos from the party's Photos tab. Separate
+  // from payment-app photos (`payout.documents`). Optional on the wire — older
+  // cached responses simply render an empty section.
+  const eventPhotos = useMemo(
+    () => payout.eventPhotos ?? [],
+    [payout.eventPhotos],
+  );
+  // Unified lightbox carousel: payment-app pizzas → payment-app receipts →
+  // event-level photos. Order matters so `lightboxIndex` from each thumbnail
+  // grid resolves to the right starting image.
+  const allPhotos = useMemo(
+    () => [
+      ...pizzas.map((d) => ({
+        url: d.url,
+        fileName: d.fileName,
+        mimeType: d.mimeType,
+      })),
+      ...receipts.map((d) => ({
+        url: d.url,
+        fileName: d.fileName,
+        mimeType: d.mimeType,
+      })),
+      ...eventPhotos.map((p) => ({
+        url: p.url,
+        fileName: p.fileName,
+        mimeType: p.mimeType,
+      })),
+    ],
+    [pizzas, receipts, eventPhotos],
+  );
 
   async function saveReceiptEdit(docId: string) {
     const draft = receiptDrafts[docId];
@@ -497,33 +526,87 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         )}
 
         <div className="flex-1 overflow-y-auto grid grid-cols-1 md:grid-cols-2 gap-4 p-5">
-          {/* Left: photo gallery */}
-          <section>
-            <h3 className="text-sm font-semibold text-theme-text mb-2">
-              Photos ({allPhotos.length})
-            </h3>
-            {allPhotos.length === 0 && (
-              <p className="text-sm text-theme-text-faint">No photos attached.</p>
-            )}
-            <div className="grid grid-cols-3 gap-2">
-              {allPhotos.map((doc, idx) => (
-                <button
-                  key={doc.id}
-                  type="button"
-                  onClick={() => setLightboxIndex(idx)}
-                  className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
-                  title={doc.fileName}
-                >
-                  <img src={doc.url} alt={doc.fileName} className="w-full h-full object-cover" loading="lazy" />
-                  <span
-                    className={`absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
-                      doc.kind === 'receipt' ? 'bg-amber-500 text-white' : 'bg-emerald-500 text-white'
-                    }`}
+          {/* Left: photo galleries
+              bottarga-92103: split into two sections — payment-app docs (the
+              original "Photos" grid) and event-level photos uploaded via the
+              host Photos tab. The lightbox carousel is one merged array
+              (pizzas → receipts → eventPhotos) so arrow-key nav crosses both
+              sections seamlessly. */}
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold text-theme-text mb-2">
+                Payment-app photos ({pizzas.length + receipts.length})
+              </h3>
+              {pizzas.length + receipts.length === 0 && (
+                <p className="text-sm text-theme-text-faint">No payment-app photos attached.</p>
+              )}
+              <div className="grid grid-cols-3 gap-2">
+                {[...pizzas, ...receipts].map((doc, idx) => (
+                  <button
+                    key={doc.id}
+                    type="button"
+                    onClick={() => setLightboxIndex(idx)}
+                    className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
+                    title={doc.fileName}
                   >
-                    {doc.kind}
-                  </span>
-                </button>
-              ))}
+                    <img src={doc.url} alt={doc.fileName} className="w-full h-full object-cover" loading="lazy" />
+                    <span
+                      className={`absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
+                        doc.kind === 'receipt' ? 'bg-amber-500 text-white' : 'bg-emerald-500 text-white'
+                      }`}
+                    >
+                      {doc.kind}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold text-theme-text mb-2">
+                Event photos ({eventPhotos.length})
+              </h3>
+              {eventPhotos.length === 0 ? (
+                <p className="text-sm text-theme-text-faint">No event photos yet.</p>
+              ) : (
+                <div className="grid grid-cols-3 gap-2">
+                  {eventPhotos.map((p, idx) => {
+                    // Carousel index: event photos sit after the payment-app
+                    // pizzas + receipts in the merged `allPhotos` array.
+                    const carouselIdx = pizzas.length + receipts.length + idx;
+                    const isHidden = p.status !== 'approved';
+                    return (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => setLightboxIndex(carouselIdx)}
+                        className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
+                        title={p.caption || p.fileName}
+                      >
+                        <img
+                          src={p.thumbnailUrl || p.url}
+                          alt={p.fileName}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                        />
+                        {isHidden && (
+                          <span
+                            className="absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-red-500 text-white"
+                            title={`Photo status: ${p.status} — not visible to the public`}
+                          >
+                            Hidden
+                          </span>
+                        )}
+                        {p.starred && (
+                          <span className="absolute top-1 right-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-amber-400 text-black">
+                            ★
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </section>
 
@@ -1493,14 +1576,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
       {/* bresaola-89172: shared ReceiptLightbox renders into document.body
           via createPortal, so it isn't clipped by the modal's overflow. It
-          owns its own Esc + arrow-key handlers and the HEIC fallback. */}
+          owns its own Esc + arrow-key handlers and the HEIC fallback.
+          bottarga-92103: `allPhotos` is the unified carousel — pizzas →
+          receipts → event-level photos — so arrow-key nav crosses sections. */}
       <ReceiptLightbox
         isOpen={lightboxIndex != null}
-        images={allPhotos.map((d) => ({
-          url: d.url,
-          fileName: d.fileName,
-          mimeType: d.mimeType,
-        }))}
+        images={allPhotos}
         initialIndex={lightboxIndex ?? 0}
         onClose={() => setLightboxIndex(null)}
       />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1869,8 +1869,35 @@ export interface AdminPayout extends Payout {
   };
 }
 
+/**
+ * bottarga-92103: event-level photo surfaced to admins on the payout-detail
+ * response. Mirrors a row from the `photos` table — photos hosts/guests upload
+ * directly to the event's Photos tab, distinct from the pizza-kind documents
+ * attached inside the payments flow (`Payout.documents`). Admins see every
+ * photo regardless of moderation `status`; the modal surfaces a small "Hidden
+ * from public" pill when `status !== 'approved'`.
+ */
+export interface AdminPayoutEventPhoto {
+  id: string;
+  url: string;
+  thumbnailUrl: string | null;
+  fileName: string;
+  mimeType: string;
+  caption: string | null;
+  status: string;
+  starred: boolean;
+  uploaderName: string | null;
+  createdAt: string;
+}
+
 export interface AdminPayoutDetail extends AdminPayout {
   audits: PayoutAuditEntry[];
+  /**
+   * bottarga-92103: event-level photos for the party. Optional for backward-
+   * compat with cached payloads during a rolling deploy — older clients will
+   * just hide the section.
+   */
+  eventPhotos?: AdminPayoutEventPhoto[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Backend `GET /api/admin/payouts/:id` adds `eventPhotos[]` from the party's photo table.
- Frontend modal renders an "Event photos" section beneath the existing payment-app photos grid.
- Lightbox carousel from bresaola-89172 stitches them all together.
- No schema change.

## Test plan
- [ ] Payout for a party with event photos → modal shows both sections.
- [ ] Clicking either thumbnail set opens the lightbox + nav across all.
- [ ] Party with no event photos → "Event photos" section absent.