### PR TITLE
feat(pecorino-64118): newsletter-emails CSV download for partners

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1480,3 +1480,73 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
     next(error);
   }
 });
+
+// GET /api/sponsor/newsletter-emails - CSV-source list of emails opted into THIS
+// partner's newsletter (ethconf + SWC family). Follow-up to pecorino-64118: lets
+// newsletter-eligible partners download their newsletter signups from the
+// consolidated report's "Newsletter signups" KPI tile.
+// Same tag-resolution + event-set rules as GET /report.
+sponsorDashboardRouter.get('/newsletter-emails', requireAuth, requireSponsorAuth, async (req: SponsorRequest, res: Response, next: NextFunction) => {
+  try {
+    const queryTag = req.query.tag as string | undefined;
+    const tag = req.isAdminViewing
+      ? (queryTag?.trim().toLowerCase() || undefined)
+      : (queryTag?.trim().toLowerCase() || req.sponsorUser?.tag);
+
+    const optinField = tag ? NEWSLETTER_OPTIN_FIELD[tag] : undefined;
+    if (!optinField) {
+      throw new AppError('No newsletter for this partner tag.', 400, 'NO_NEWSLETTER');
+    }
+
+    // Build event-set where clause — mirrors GET /report.
+    const where: any = {};
+    if (tag && tag !== 'pizzadao') {
+      where.eventTags = { has: tag };
+    } else if (tag === 'pizzadao') {
+      where.eventType = 'gpp';
+    } else if (req.isAdminViewing) {
+      where.eventType = 'gpp';
+      where.NOT = { eventTags: { equals: [] } };
+    }
+
+    if (!req.isAdminViewing) {
+      where.underbossStatus = 'approved';
+    }
+    where.cancelledAt = null;
+
+    // Find party ids in the event-set first, then fetch matching guest emails.
+    const parties = await prisma.party.findMany({
+      where,
+      select: { id: true },
+    });
+    const partyIds = parties.map(p => p.id);
+
+    if (partyIds.length === 0) {
+      return res.json({ emails: [], count: 0, tag, optinField });
+    }
+
+    const guests = await prisma.guest.findMany({
+      where: {
+        partyId: { in: partyIds },
+        email: { not: null },
+        status: { not: 'INVITED' },
+        // Prisma { not: false } silently excludes NULL rows under 3VL; use explicit OR.
+        OR: [{ approved: true }, { approved: null }],
+        [optinField]: true,
+      },
+      select: { email: true },
+    });
+
+    // Dedupe (lowercased), drop empties, sort alphabetically.
+    const seen = new Set<string>();
+    for (const g of guests) {
+      const e = (g.email || '').trim().toLowerCase();
+      if (e) seen.add(e);
+    }
+    const emails = Array.from(seen).sort();
+
+    res.json({ emails, count: emails.length, tag, optinField });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -5,6 +5,7 @@ import {
   FileText, Download, X, ChevronLeft, ChevronRight, ExternalLink, Play,
 } from 'lucide-react';
 import { ConsolidatedReport, ConsolidatedReportPhoto, ConsolidatedReportSocialPost } from '../../types';
+import { fetchPartnerNewsletterEmails } from '../../lib/api';
 import { KPICard, OrgDomainChip } from './reportShared';
 import { CircleFlag } from '../CircleFlag';
 import { PlatformIcon, detectPlatform } from './platformIcon';
@@ -74,6 +75,29 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
     URL.revokeObjectURL(url);
   } : undefined;
 
+  // pecorino-64118 follow-up: download CSV of guest emails opted into THIS
+  // partner's newsletter. Backend returns 400 for tags without a newsletter
+  // (e.g. pizzadao); the tile only renders for newsletter-eligible tags
+  // because `mailingListSignups` is null in that case (see backend /report).
+  const hasNewsletterSignups = report.stats.mailingListSignups != null && report.stats.mailingListSignups > 0;
+  const downloadNewsletterEmails = hasNewsletterSignups ? async () => {
+    try {
+      const result = await fetchPartnerNewsletterEmails(report.tag || undefined);
+      const csv = 'email\n' + result.emails.join('\n');
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const namePart = (report.partnerName || report.tag || 'partner').replace(/[^a-zA-Z0-9]/g, '_');
+      a.href = url;
+      a.download = `${namePart}_newsletter_emails.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      // Don't break the report render — newsletter CSV is a side action.
+      console.error('Failed to download newsletter emails CSV:', err);
+    }
+  } : undefined;
+
   const statsDefs: { key: string; label: string; value: number | null | undefined; icon: React.ElementType; color: string; onAction?: () => void; actionIcon?: React.ElementType }[] = [
     { key: 'pageViews', label: t('report.pageViews'), value: report.impressions.totalViews || null, icon: MousePointerClick, color: 'text-[#ff393a]' },
     { key: 'uniqueVisitors', label: t('report.uniqueVisitors'), value: report.impressions.uniqueVisitors || null, icon: Eye, color: 'text-[#ff393a]' },
@@ -81,7 +105,7 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
     { key: 'socialPostViews', label: t('report.socialPostViews'), value: report.stats.socialPostViews || null, icon: Eye, color: 'text-blue-400' },
     { key: 'socialPosts', label: t('report.socialPosts'), value: report.stats.socialPostCount || null, icon: FileText, color: 'text-blue-400' },
     { key: 'totalRsvps', label: t('report.totalRsvps'), value: report.stats.totalRsvps || null, icon: Users, color: 'text-green-400' },
-    { key: 'newsletterSignups', label: t('report.newsletterSignups'), value: report.stats.mailingListSignups || null, icon: Mail, color: 'text-orange-400' },
+    { key: 'newsletterSignups', label: t('report.newsletterSignups'), value: report.stats.mailingListSignups || null, icon: Mail, color: 'text-orange-400', onAction: downloadNewsletterEmails, actionIcon: Download },
     { key: 'walletAddresses', label: t('report.walletAddresses'), value: report.stats.walletAddresses || null, icon: Wallet, color: 'text-cyan-400', onAction: downloadWallets, actionIcon: Download },
     { key: 'poapMints', label: t('report.poapMints'), value: report.stats.poapMints || null, icon: Award, color: 'text-yellow-400' },
     { key: 'poapMoments', label: t('report.poapMoments'), value: report.stats.poapMoments || null, icon: Video, color: 'text-yellow-400' },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3352,6 +3352,18 @@ export async function fetchSponsorConsolidatedReport(tag?: string): Promise<Cons
   return apiRequest<ConsolidatedReport>(`/api/sponsor/report${params}`);
 }
 
+// pecorino-64118 follow-up: download list of guest emails opted into a partner's
+// newsletter (ethconf + SWC family). Errors with 400 NO_NEWSLETTER for tags
+// without a newsletter (e.g. pizzadao).
+export async function fetchPartnerNewsletterEmails(
+  tag?: string
+): Promise<{ emails: string[]; count: number; tag: string; optinField: string }> {
+  const params = tag ? `?tag=${encodeURIComponent(tag)}` : '';
+  return apiRequest<{ emails: string[]; count: number; tag: string; optinField: string }>(
+    `/api/sponsor/newsletter-emails${params}`
+  );
+}
+
 // Admin-only time-series for partner dashboard chart
 export type PartnerTimeSeriesRange = '6hr' | '24hr' | '3d' | '7d';
 


### PR DESCRIPTION
## What

Adds a download CSV action on the **Newsletter signups** KPI tile of the consolidated partner report (`/partner/report`), mirroring how the **Wallet addresses** tile already offers a CSV download. Lets ethconf + SWC family partners pull the list of guests who opted into THEIR newsletter across every event they have access to.

## Backend

New endpoint:

```
GET /api/sponsor/newsletter-emails    (requireAuth + requireSponsorAuth)
```

- Reuses the existing `NEWSLETTER_OPTIN_FIELD` map (already at module scope) — same tag→opt-in column wiring as the existing `mailingListSignups` count: `swc`, `swcca`, `swcau`, `swceu`, `swcuk`, `swcbr`, `ethconf`.
- Returns `400 NO_NEWSLETTER` for tags without a newsletter (e.g. `pizzadao`).
- Tag resolution / event-set rules are identical to `/report`:
  - non-admin → defaults to `req.sponsorUser.tag`, requires `underbossStatus = approved`
  - admin → `?tag=` override, sees pending/non-approved too
  - cancelled events excluded
- Emails filtered to `email IS NOT NULL`, `status != 'INVITED'`, opt-in column = true, and `approved != false` via NULL-safe `{ OR: [{ approved: true }, { approved: null }] }` (avoids the known `{ not: false }` excludes-NULL trap).
- Deduped lowercased, sorted alphabetically.

Response: `{ emails: string[]; count: number; tag; optinField }`.

## Frontend

- `fetchPartnerNewsletterEmails(tag?)` in `lib/api.ts`.
- `downloadNewsletterEmails` handler in `ConsolidatedReportPreview` mirrors `downloadWallets` (Blob → anchor → revoke). Filename: `{partnerName||tag||partner}_newsletter_emails.csv`.
- Wired onto the `newsletterSignups` tile via `onAction` / `actionIcon: Download`.
- Only enabled when `report.stats.mailingListSignups != null && > 0` — since the backend returns `null` for non-newsletter tags, non-eligible partners never see the action.
- Failed fetch logs to console and is a no-op (does not break the report render).

## Deploy

Backend redeploy required from `master` for the new route to be live on preview frontends (shared production backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)