### PR TITLE
feat(pizzaiolo-92103): require payment method before receipt submission

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -278,6 +278,66 @@ async function assertPartyApproved(partyId: string): Promise<void> {
 }
 
 /**
+ * pizzaiolo-92103: gate host payout submission on the submitting user having
+ * a valid saved payment method. Re-introduces the gate that arugula-38633 v3
+ * removed — admins shouldn't have to chase hosts for method details after the
+ * receipt is already in the queue.
+ *
+ * "Valid" mirrors the frontend `methodValid` check in PaymentDetailsCard:
+ *   - method must be one of usdc_base | mercury_card | wire
+ *   - usdc_base: payoutWalletAddress must be a non-empty trimmed string. NOT
+ *     gated on the strict 0x regex — ENS strings are valid (taleggio-30219).
+ *   - wire: payoutBankDetails.email must match the loose email regex
+ *   - mercury_card: no extra fields required
+ *
+ * Throws 400 PAYMENT_METHOD_NOT_SET when no method is set, 400
+ * PAYMENT_METHOD_INCOMPLETE when method is set but its required field is
+ * missing/invalid. Admin /external POSTs bypass this gate (admin records
+ * off-platform sends).
+ */
+async function assertUserHasValidPayoutMethod(userId: string): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      preferredPayoutMethod: true,
+      payoutWalletAddress: true,
+      payoutBankDetails: true,
+    },
+  });
+  if (!user) {
+    throw new AppError('User not found', 401, 'UNAUTHORIZED');
+  }
+  const m = user.preferredPayoutMethod;
+  if (m == null) {
+    throw new AppError(
+      'Set your payment method on the Payments tab before submitting a receipt.',
+      400,
+      'PAYMENT_METHOD_NOT_SET',
+    );
+  }
+  if (m === 'usdc_base' && !(user.payoutWalletAddress ?? '').trim()) {
+    throw new AppError(
+      'Set your USDC wallet address before submitting a receipt.',
+      400,
+      'PAYMENT_METHOD_INCOMPLETE',
+    );
+  }
+  if (m === 'wire') {
+    const bank = user.payoutBankDetails as { email?: unknown } | null;
+    const email = bank && typeof bank.email === 'string' ? bank.email : '';
+    const ok = email.length > 0 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    if (!ok) {
+      throw new AppError(
+        'Set the email address for bank correspondence before submitting a receipt.',
+        400,
+        'PAYMENT_METHOD_INCOMPLETE',
+      );
+    }
+  }
+  // mercury_card: no extra fields required.
+}
+
+/**
  * pepperoni-47301: Mercury (our virtual debit card issuer) cannot issue cards
  * to hosts in sanctioned/restricted countries. When the host (or admin) tries
  * to submit `mercury_card` for a party whose `country` matches the block list,
@@ -642,6 +702,23 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     // legitimate reason to disburse funds for a party the underboss hasn't
     // approved yet.
     await assertPartyApproved(partyId);
+
+    // pizzaiolo-92103: gate host submission on the submitter having a valid
+    // saved payment method. Re-introduces the gate arugula-38633 v3 removed.
+    // SKIP when an admin is creating a prepayment ON BEHALF OF a cohost
+    // (bismarck-92103) — the admin's own method isn't the relevant signal in
+    // that flow. Shipping-coordinator submissions DO get the gate (they're
+    // recipients of the resulting payout, same as event-reimbursement hosts).
+    // Admins recording fully off-platform sends use POST /api/admin/payouts/external
+    // and don't pass through this handler at all.
+    if (!req.userId) {
+      throw new AppError('Authenticated user has no userId', 500, 'NO_USER_ID');
+    }
+    const adminPrepayingForCohost =
+      recipientOverrideRequested && (await isAnyAdmin(req.userEmail));
+    if (!adminPrepayingForCohost) {
+      await assertUserHasValidPayoutMethod(req.userId);
+    }
 
     // Validate optional one-shot attendance setup. Only persisted to the party
     // below if the party's current expectedGuests is null (see updateMany call).

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -155,13 +155,49 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
     effectiveCapUsd != null && effectiveCapUsd > 0 && finalAmount > effectiveCapUsd;
   const exceedsHardCeiling = finalAmount > PER_PAYMENT_HARD_CEILING_USD;
 
-  // arugula-38633 v3 follow-up: payment details + receipts are no longer
-  // required for submission. The submit button stays active whenever the
-  // host has entered a positive amount and nothing async is in flight.
+  // pizzaiolo-92103: re-introduce the payment-method gate that arugula-38633
+  // v3 removed. Hosts can submit receipts only when they have a saved method
+  // AND its required field is filled in. Mirrors the methodValid check used
+  // by PaymentDetailsCard (see comment there). Wallet validity is non-empty
+  // only — ENS strings count (taleggio-30219), no 0x regex enforcement.
+  const userMethodValid = useMemo(() => {
+    const m = user?.preferredPayoutMethod;
+    if (m == null) return false;
+    if (m === 'usdc_base') {
+      return Boolean((user?.payoutWalletAddress ?? '').trim());
+    }
+    if (m === 'wire') {
+      const email = user?.payoutBankDetails?.email;
+      return typeof email === 'string'
+        && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    }
+    return true; // mercury_card has no extra required fields
+  }, [user]);
+
+  // pizzaiolo-92103: explanatory message for the amber notice — varies by
+  // which sub-state of "no valid method" the host is in.
+  const methodNoticeText = useMemo(() => {
+    const m = user?.preferredPayoutMethod;
+    if (m == null) {
+      return 'Set your payment method on the Payments tab to submit this receipt.';
+    }
+    if (m === 'usdc_base') {
+      return 'Add your USDC wallet address on the Payments tab to submit this receipt.';
+    }
+    if (m === 'wire') {
+      return 'Add the email for bank correspondence on the Payments tab to submit this receipt.';
+    }
+    return '';
+  }, [user]);
+
+  // pizzaiolo-92103: submission now requires a valid saved payment method
+  // (gate also enforced backend-side as PAYMENT_METHOD_NOT_SET /
+  // PAYMENT_METHOD_INCOMPLETE).
   const canSubmit = finalAmount > 0
     && attendanceValid
     && !isProcessing
-    && !submitting;
+    && !submitting
+    && userMethodValid;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -395,11 +431,28 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         </div>
       )}
 
-      {/* arugula-38633 v3 (follow-up): the amber "set your payment details
-          above before submitting a receipt" notice was removed. Payment
-          details remain in the PaymentDetailsCard at the top of the
-          Payments tab but no longer gate submission — admin asks the host
-          for them later if absent. */}
+      {/* pizzaiolo-92103: payment-method gate reinstated. When the host
+          hasn't saved a valid method (or a method-specific field is missing),
+          render an amber notice with an anchor link back up to the
+          PaymentDetailsCard at the top of the Payments tab. Submit stays
+          disabled until userMethodValid is true. Backend mirrors this gate
+          (PAYMENT_METHOD_NOT_SET / PAYMENT_METHOD_INCOMPLETE). */}
+      {!userMethodValid && (
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-100">
+              {methodNoticeText}{' '}
+              <a
+                href="#payment-details-card"
+                className="underline underline-offset-2 hover:text-amber-50"
+              >
+                Go to payment details →
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
         <button

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -318,7 +318,9 @@ export const PaymentDetailsCard: React.FC = () => {
   const submitDisabled = !partyId || optInPending || !methodValid;
 
   return (
-    <div className="card p-6">
+    // pizzaiolo-92103: `id` is the scroll target for the inline notice in
+    // NewPayoutForm when the host hasn't saved a valid payment method yet.
+    <div id="payment-details-card" className="card p-6">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-theme-text">


### PR DESCRIPTION
## Summary
- Backend host POST `/api/parties/:partyId/payouts` rejects when the submitting User lacks `preferredPayoutMethod` or method-specific fields. New error codes `PAYMENT_METHOD_NOT_SET` / `PAYMENT_METHOD_INCOMPLETE`.
- Frontend `NewPayoutForm` gates Submit on `userMethodValid`; inline amber notice with anchor link to `PaymentDetailsCard`.
- Admin override path unchanged.

## Test plan
- [ ] Host with no method -> notice visible, Submit disabled.
- [ ] Host with method=usdc_base, no wallet -> blocked.
- [ ] Host with method=wire, no email -> blocked.
- [ ] Host with method=mercury_card -> Submit enabled.
- [ ] Direct POST without method -> 400 PAYMENT_METHOD_NOT_SET.
- [ ] Admin external payment -> unaffected.