### PR TITLE
pecorino-64118: 'Wallets submitted' tile on partner dashboard

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -566,6 +566,9 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
             approved: true,
             checkedInAt: true,
             status: true,
+            // pecorino-64118 follow-up: count of guests with a wallet address
+            // (count only; raw addresses are never returned on this endpoint).
+            ethereumAddress: true,
             // Newsletter opt-in fields (admin-only response)
             mailingListOptIn: true,
             swcOptIn: true,
@@ -722,6 +725,11 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
       const submittedGuests = event.guests.filter(g => g.status !== 'INVITED');
       const guestCount = submittedGuests.length;
       const approvedCount = submittedGuests.filter(g => g.approved !== false).length;
+      // pecorino-64118 follow-up: count approved guests who submitted a wallet
+      // address. Count only — raw addresses are not exposed via this endpoint.
+      const walletCount = submittedGuests.filter(
+        g => g.approved !== false && typeof g.ethereumAddress === 'string' && g.ethereumAddress.length > 0
+      ).length;
 
       // Admin-only: newsletter opt-in counts per event.
       // Field is intentionally `undefined` for non-admins so JSON.stringify drops it
@@ -830,6 +838,7 @@ sponsorDashboardRouter.get('/events', requireAuth, requireSponsorAuth, async (re
         rsvpCount: guestCount,
         invitedCount: event.guests.filter(g => g.status === 'INVITED').length,
         approvedCount,
+        walletCount,
         maxGuests: event.maxGuests,
         expectedGuests: event.expectedGuests || null,
         budget,

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -186,6 +186,7 @@
     "impressions": "Impressionen",
     "uniqueCount": "{{count}} eindeutig",
     "partnerLinkClicks": "Partner-Link-Klicks",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "Mit Veranstaltungsort",
     "withBudget": "Mit Budget",
     "completion": "Fertigstellung",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -197,6 +197,7 @@
     "impressions": "Impressions",
     "uniqueCount": "{{count}} unique",
     "partnerLinkClicks": "Partner Link Clicks",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "With Venue",
     "withBudget": "With Budget",
     "completion": "Completion",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -186,6 +186,7 @@
     "impressions": "Impresiones",
     "uniqueCount": "{{count}} únicos",
     "partnerLinkClicks": "Clics en Enlaces de Socios",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "Con Lugar",
     "withBudget": "Con Presupuesto",
     "completion": "Finalización",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -186,6 +186,7 @@
     "impressions": "Impressions",
     "uniqueCount": "{{count}} uniques",
     "partnerLinkClicks": "Clics sur les liens partenaires",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "Avec lieu",
     "withBudget": "Avec budget",
     "completion": "Avancement",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -186,6 +186,7 @@
     "impressions": "インプレッション",
     "uniqueCount": "{{count}}件のユニーク",
     "partnerLinkClicks": "パートナーリンククリック",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "会場あり",
     "withBudget": "予算あり",
     "completion": "完了",

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -186,6 +186,7 @@
     "impressions": "노출수",
     "uniqueCount": "{{count}} 고유",
     "partnerLinkClicks": "파트너 링크 클릭",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "베뉴 있음",
     "withBudget": "예산 있음",
     "completion": "완료율",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -186,6 +186,7 @@
     "impressions": "Impressões",
     "uniqueCount": "{{count}} únicos",
     "partnerLinkClicks": "Cliques em Links de Parceiros",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "Com Local",
     "withBudget": "Com Orçamento",
     "completion": "Conclusão",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -186,6 +186,7 @@
     "impressions": "印象数",
     "uniqueCount": "{{count}} 个独立",
     "partnerLinkClicks": "合作伙伴链接点击",
+    "walletsSubmitted": "Wallets submitted",
     "withVenue": "有场地",
     "withBudget": "有预算",
     "completion": "完成度",

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -546,6 +546,10 @@ export function PartnerDashboardPage() {
           const totalUniqueVisitors = events.reduce((sum, e) => sum + (e.impressions?.uniqueVisitors || 0), 0);
           const totalClicks = events.reduce((sum, e) => sum + (e.clickStats?.totalClicks || 0), 0);
           const totalUniqueClickers = events.reduce((sum, e) => sum + (e.clickStats?.uniqueClickers || 0), 0);
+          // pecorino-64118 follow-up: total approved guests who submitted a wallet
+          // address (sum of per-event walletCount returned by /api/sponsor/events).
+          const totalWallets = events.reduce((sum, e) => sum + (e.walletCount || 0), 0);
+          const avgWallets = events.length > 0 ? Math.round(totalWallets / events.length) : 0;
           // Aggregate clicks: per-partner with per-platform breakdown
           const clicksByPartnerPlatformAgg: Record<string, { total: number; uniqueTotal: number; platforms: Record<string, { clicks: number; uniqueClickers: number }> }> = {};
           for (const e of events) {
@@ -595,10 +599,11 @@ export function PartnerDashboardPage() {
           const valueRsvps = totalRsvps * VALUE_PER_RSVP;
           const valueTotal = valueImpressions + valueClicks + valueNewsletter + valueRsvps;
 
-          // Grid columns: expand when admin tiles are present
+          // Grid columns: expand when admin tiles are present.
+          // pecorino-64118 follow-up: +1 tile ("Wallets submitted") in every variant.
           const gridColsClass = isSwc
-            ? (isAdmin ? 'md:grid-cols-3 lg:grid-cols-5' : 'md:grid-cols-3 lg:grid-cols-5')
-            : (isAdmin ? 'md:grid-cols-3 lg:grid-cols-6' : 'lg:grid-cols-4');
+            ? (isAdmin ? 'md:grid-cols-3 lg:grid-cols-6' : 'md:grid-cols-3 lg:grid-cols-6')
+            : (isAdmin ? 'md:grid-cols-3 lg:grid-cols-7' : 'md:grid-cols-3 lg:grid-cols-5');
           return (
             <div className="mb-6 space-y-3">
               <div className={`grid grid-cols-2 gap-3 ${gridColsClass}`}>
@@ -659,6 +664,17 @@ export function PartnerDashboardPage() {
                           </div>
                         ))}
                     </div>
+                  )}
+                </div>
+                {/* pecorino-64118 follow-up: total approved guests with a wallet address. */}
+                <div className="bg-theme-card border border-theme-stroke rounded-xl p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-white/10 text-theme-text-muted"><Wallet size={16} /></div>
+                    <span className="text-xs text-theme-text-muted uppercase tracking-wider">{t('dashboard.walletsSubmitted')}</span>
+                  </div>
+                  <div className="text-2xl font-bold text-theme-text">{totalWallets.toLocaleString()}</div>
+                  {totalWallets > 0 && (
+                    <div className="text-xs text-theme-text-muted mt-1">{t('dashboard.perEvent', { avg: avgWallets })}</div>
                   )}
                 </div>
                 {isAdmin && newsletterTotals && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1415,6 +1415,9 @@ export interface SponsorDashboardEvent {
   rsvpCount: number;
   invitedCount: number;
   approvedCount: number;
+  // pecorino-64118 follow-up: count of approved guests with a wallet address.
+  // Optional for backward-compat with cached payloads before backend ships.
+  walletCount?: number;
   maxGuests: number | null;
   expectedGuests?: number | null;
   budget: {


### PR DESCRIPTION
New "Wallets submitted" tile on the partner dashboard (`/partner`), summing per-event `walletCount` across all of the partner's events.

Backend `/api/sponsor/events` now returns `walletCount` per event (count of approved guests with a non-empty `ethereumAddress`, count only — no raw addresses).

Needs backend redeploy from master before the tile shows live data on preview deploys.

i18n: new key `dashboard.walletsSubmitted` added to all 8 locales (en, de, es, fr, ja, ko, pt, zh) to satisfy the i18n guardrail; non-EN values use the English string as a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)