### PR TITLE
feat(argentina-92103): /payments/latam regional portal + flag-ready signal

### DIFF
--- a/backend/src/middleware/regionalUnderboss.ts
+++ b/backend/src/middleware/regionalUnderboss.ts
@@ -1,0 +1,127 @@
+/**
+ * argentina-92103: Regional underboss access gate for /payments dashboard.
+ *
+ * Layered on top of the existing payment_admin / admin / super_admin gate
+ * (see `isPaymentAdmin` in auth.ts). When a `regions=` CSV query param is
+ * supplied, this middleware accepts EITHER:
+ *   - a payment-admin-class actor (admin / super_admin / payment_admin), OR
+ *   - an active underboss whose `regions` (or legacy single `region`) array
+ *     overlaps with the requested region scope.
+ *
+ * Used by the LATAM portal (`/payments/latam`) so `donmalbec.eth@gmail.com`
+ * — the LATAM underboss whose regions cover `central-america` and
+ * `south-america` — can read the queue + approve / reject / revert payouts on
+ * LATAM events without elevating him to a full payment_admin.
+ *
+ * Funds-sending endpoints (execute / mark-paid / bulk-execute / external)
+ * stay gated by the unchanged `requireAnyAdminOrPaymentAdmin` and remain
+ * admin-only.
+ */
+import { Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { AuthRequest, isPaymentAdmin } from './auth.js';
+import { AppError } from './error.js';
+
+export type ViewerRole = 'admin' | 'underboss';
+
+export interface RegionalAuthRequest extends AuthRequest {
+  /**
+   * Resolved viewer kind once the middleware grants access. Used by
+   * mutating handlers (approve / reject / unapprove / flag-ready) to apply
+   * the secondary "target party must be in scope" check ONLY for
+   * underbosses — admins skip that gate.
+   */
+  viewerRole?: ViewerRole;
+}
+
+/** Default region scope when `?regions=` is not supplied on the LATAM portal. */
+export const LATAM_REGIONS = ['central-america', 'south-america'] as const;
+
+/**
+ * Returns whether `email` is allowed to view the requested region scope.
+ * - Admin-class actors always pass; `kind: 'admin'`.
+ * - An active underboss whose `regions` (or legacy single `region`) overlap
+ *   the requested scope passes; `kind: 'underboss'`.
+ */
+export async function callerHasRegionalAccess(
+  email: string | undefined,
+  regions: string[],
+): Promise<{ ok: boolean; kind: ViewerRole | null }> {
+  if (await isPaymentAdmin(email)) return { ok: true, kind: 'admin' };
+  if (!email) return { ok: false, kind: null };
+  const ub = await prisma.underboss.findFirst({
+    where: {
+      isActive: true,
+      email: { equals: email, mode: 'insensitive' },
+      OR: [
+        { regions: { hasSome: regions } },
+        { region: { in: regions } },
+      ],
+    },
+    select: { id: true },
+  });
+  return ub ? { ok: true, kind: 'underboss' } : { ok: false, kind: null };
+}
+
+/**
+ * Parse the `?regions=` CSV query into a clean array. Returns `null` when
+ * the param is absent (callers fall back to admin-only behavior).
+ */
+export function parseRegionsQuery(raw: unknown): string[] | null {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return null;
+  const list = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length > 0 ? list : null;
+}
+
+/**
+ * Middleware factory: gate an endpoint behind `admin OR (underboss whose
+ * regions overlap the requested scope)`.
+ *
+ * - When no `regions=` param is supplied: behaves like the existing
+ *   `requireAnyAdminOrPaymentAdmin` — admin-class only.
+ * - When `regions=` is supplied: admin OR matching-region underboss passes;
+ *   `req.viewerRole` is set to 'admin' or 'underboss' so handlers can apply
+ *   the per-row "target party must be in scope" check for underbosses.
+ *
+ * The optional `defaultRegions` is a safety net for portals (e.g. LATAM)
+ * that always run in a fixed scope — if the caller forgets the query param,
+ * we still apply the portal's scope rather than 403-ing.
+ */
+export function requireAdminOrRegionalUnderboss(defaultRegions?: readonly string[]) {
+  return async function regionalGate(
+    req: RegionalAuthRequest,
+    _res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const queryRegions = parseRegionsQuery(req.query.regions);
+      const regions = queryRegions ?? (defaultRegions ? [...defaultRegions] : null);
+
+      if (!regions || regions.length === 0) {
+        // No regional scope at all — admin-class only.
+        if (!(await isPaymentAdmin(req.userEmail))) {
+          throw new AppError('Payments admin access required', 403, 'FORBIDDEN');
+        }
+        req.viewerRole = 'admin';
+        next();
+        return;
+      }
+
+      const result = await callerHasRegionalAccess(req.userEmail, regions);
+      if (!result.ok) {
+        throw new AppError(
+          'You do not have access to this regional payments portal.',
+          403,
+          'FORBIDDEN',
+        );
+      }
+      req.viewerRole = result.kind!;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -39,6 +39,12 @@ import { resolveWalletInput } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 import { notifyHostOfPaymentExecution } from '../services/payoutTelegramNotify.js';
 import { emailHostOfPaymentExecution } from '../services/payoutEmailNotify.js';
+import { notifyPaymentsTeam } from '../services/paymentsTeamNotify.js';
+import {
+  requireAdminOrRegionalUnderboss,
+  parseRegionsQuery,
+  type RegionalAuthRequest,
+} from '../middleware/regionalUnderboss.js';
 
 const router = Router();
 
@@ -112,11 +118,21 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   },
 };
 
-type AdminActorKind = 'admin' | 'super_admin' | 'payment_admin';
+// argentina-92103: 'underboss' added so regional UBs can be recorded as
+// the actor on payout_audit rows. Admin-class kinds are unchanged.
+type AdminActorKind = 'admin' | 'super_admin' | 'payment_admin' | 'underboss';
 
 /**
- * Loads the admin row + the currently-authenticated user's id (used for
- * self-payout restriction). Returns `null` for either if the lookup fails.
+ * Loads the actor row + the currently-authenticated user's id (used for
+ * self-payout restriction).
+ *
+ * Falls back to an underboss lookup when no admin row exists for the email,
+ * so regional underbosses (argentina-92103) can be the actor on approve /
+ * reject / unapprove / flag-ready mutations they're authorized to make.
+ *
+ * Throws 403 if neither an admin nor an active underboss record is found —
+ * the route-level middleware (`requireAdminOrRegionalUnderboss`) should
+ * have rejected such a caller already; this is defensive belt-and-braces.
  */
 async function loadActor(req: AuthRequest): Promise<{
   email: string;
@@ -134,31 +150,48 @@ async function loadActor(req: AuthRequest): Promise<{
     where: { email },
     select: { role: true },
   });
-  if (!admin) {
-    // Shouldn't happen because requireAnyAdminOrPaymentAdmin guards earlier,
-    // but defensive.
-    throw new AppError('Admin record not found', 403, 'FORBIDDEN');
-  }
-
-  const actorKind: AdminActorKind =
-    admin.role === 'super_admin' ? 'super_admin' :
-    admin.role === 'payment_admin' ? 'payment_admin' :
-    'admin';
 
   // Self-payout restriction needs the user id linked to this email so we can
-  // compare to payout.hostUserId. Best-effort lookup — many admins are not
+  // compare to payout.hostUserId. Best-effort lookup — many actors are not
   // also hosts, in which case there's nothing to compare.
   const user = await prisma.user.findUnique({
     where: { email },
     select: { id: true },
   });
 
+  if (admin) {
+    const actorKind: AdminActorKind =
+      admin.role === 'super_admin' ? 'super_admin' :
+      admin.role === 'payment_admin' ? 'payment_admin' :
+      'admin';
+    return {
+      email,
+      adminRole: admin.role,
+      actorKind,
+      userId: user?.id ?? null,
+      isFull: actorKind !== 'payment_admin',
+    };
+  }
+
+  // argentina-92103: fallback to underboss. `requireAdminOrRegionalUnderboss`
+  // should have already verified this UB has scope for the requested region;
+  // here we just need to record them as the actor on the audit row.
+  const ub = await prisma.underboss.findFirst({
+    where: { isActive: true, email: { equals: email, mode: 'insensitive' } },
+    select: { id: true },
+  });
+  if (!ub) {
+    throw new AppError('Actor record not found', 403, 'FORBIDDEN');
+  }
   return {
     email,
-    adminRole: admin.role,
-    actorKind,
+    adminRole: 'underboss',
+    actorKind: 'underboss',
     userId: user?.id ?? null,
-    isFull: actorKind !== 'payment_admin',
+    // Underbosses are "full" for self-payout purposes — they don't fall
+    // under the payment_admin self-restriction rule. (The OUT_OF_SCOPE
+    // gate already prevents them from acting on out-of-region payouts.)
+    isFull: true,
   };
 }
 
@@ -368,16 +401,27 @@ function buildPayoutWhere(query: Request['query']): any {
       ? { eventTags: { has: tag.trim() } }
       : {};
 
+  // argentina-92103: regional scope filter — when /payments/latam (or any
+  // future regional portal) sends `?regions=central-america,south-america`,
+  // restrict the queue to parties whose `region` is in the list. Merged with
+  // the existing approval gate + country/tag filters so all gates compose.
+  const regionsFromQuery = parseRegionsQuery(query.regions);
+  const regionClause = regionsFromQuery && regionsFromQuery.length > 0
+    ? { region: { in: regionsFromQuery } }
+    : {};
+
   // tartufo-58291: hide payouts from unapproved parties from the admin queue
   // + CSV export. Existing rows from before the bresaola-49185 backend gate
   // shouldn't surface in routine review. Stats/totals reuse this same `where`
   // so they stay consistent. bruschetta-58291: merged with optional country
   // filter so both apply. mascarpone-49102: merged with optional tag filter
   // (single event_tag "has" match) so the queue can be sliced by tag.
+  // argentina-92103: merged with optional region filter for regional portals.
   where.party = {
     underbossStatus: 'approved',
     ...countryClause,
     ...tagClause,
+    ...regionClause,
   };
 
   return where;
@@ -403,8 +447,67 @@ function isPrimaryHostInCohosts(party: any): boolean {
   );
 }
 
+/**
+ * argentina-92103: derive whether a payout is currently "flagged ready for
+ * payment" by a regional underboss. The signal is sticky until invalidated by
+ * a downstream lifecycle event — once an admin marks it paid or anyone
+ * rejects / reverts the row, the flag is considered consumed.
+ *
+ * Implementation: scan the row's `audits` (already sorted DESC by createdAt
+ * in callsites that include them). The most recent `flag_ready` audit "wins"
+ * iff there is NO subsequent `mark_paid` / `reject` / `unapprove` audit at
+ * or after its timestamp.
+ *
+ * Returns `null` shape when the audits weren't loaded so older queries don't
+ * accidentally claim "not flagged" — clients should treat `flaggedReady`
+ * undefined as "unknown" but TS-wise we always emit a boolean.
+ */
+function deriveFlaggedReady(audits: any[] | undefined): {
+  flaggedReady: boolean;
+  flaggedReadyAt: string | null;
+  flaggedReadyBy: string | null;
+} {
+  if (!Array.isArray(audits) || audits.length === 0) {
+    return { flaggedReady: false, flaggedReadyAt: null, flaggedReadyBy: null };
+  }
+  // Find the most-recent flag_ready audit.
+  let latestFlag: any = null;
+  for (const a of audits) {
+    if (a.action === 'flag_ready') {
+      if (!latestFlag || (a.createdAt && a.createdAt > latestFlag.createdAt)) {
+        latestFlag = a;
+      }
+    }
+  }
+  if (!latestFlag) {
+    return { flaggedReady: false, flaggedReadyAt: null, flaggedReadyBy: null };
+  }
+  // Check whether a state-changing audit landed AT OR AFTER the flag.
+  const flagTs = latestFlag.createdAt instanceof Date
+    ? latestFlag.createdAt.getTime()
+    : new Date(latestFlag.createdAt).getTime();
+  const consumed = audits.some((a) => {
+    if (a === latestFlag) return false;
+    if (a.action !== 'mark_paid' && a.action !== 'reject' && a.action !== 'unapprove') return false;
+    const ts = a.createdAt instanceof Date ? a.createdAt.getTime() : new Date(a.createdAt).getTime();
+    return ts >= flagTs;
+  });
+  if (consumed) {
+    return { flaggedReady: false, flaggedReadyAt: null, flaggedReadyBy: null };
+  }
+  const at = latestFlag.createdAt instanceof Date
+    ? latestFlag.createdAt.toISOString()
+    : new Date(latestFlag.createdAt).toISOString();
+  return {
+    flaggedReady: true,
+    flaggedReadyAt: at,
+    flaggedReadyBy: latestFlag.actorEmail ?? null,
+  };
+}
+
 /** Shape a Prisma payout row for the API response. */
 function serializePayout(row: any): any {
+  const flag = deriveFlaggedReady(row.audits);
   return {
     id: row.id,
     partyId: row.partyId,
@@ -509,7 +612,67 @@ function serializePayout(row: any): any {
           createdAt: a.createdAt.toISOString(),
         }))
       : undefined,
+    // argentina-92103: derived from the audit trail above. When `row.audits`
+    // wasn't loaded (e.g. list endpoint), these surface as `false / null` so
+    // the wire shape stays consistent. The list endpoint augments per-row
+    // below via a follow-up query — see "flag-ready augmentation" in GET /.
+    flaggedReady: flag.flaggedReady,
+    flaggedReadyAt: flag.flaggedReadyAt,
+    flaggedReadyBy: flag.flaggedReadyBy,
   };
+}
+
+/**
+ * argentina-92103: bulk-fetch the latest `flag_ready` audit per payoutId and
+ * derive the sticky flag state for each. Used by the LIST endpoint, which
+ * doesn't include `audits` per row to keep the response small. Returns a
+ * Map keyed by payoutId. Payouts with no flag entry are absent.
+ *
+ * Sticky semantics: the latest `flag_ready` audit wins UNLESS a subsequent
+ * `mark_paid` / `reject` / `unapprove` audit exists at or after it.
+ */
+async function fetchFlaggedReadyByPayoutId(
+  payoutIds: string[],
+): Promise<Map<string, { at: string; by: string | null }>> {
+  if (payoutIds.length === 0) return new Map();
+  // Pull every relevant audit in one query so we can derive sticky state in
+  // memory. `flag_ready` + the three "consumes" actions. This is bounded:
+  // the page size of LIST is 100, and each payout typically has <20 audits.
+  const audits = await prisma.payoutAudit.findMany({
+    where: {
+      payoutId: { in: payoutIds },
+      action: { in: ['flag_ready', 'mark_paid', 'reject', 'unapprove'] },
+    },
+    select: {
+      payoutId: true,
+      action: true,
+      actorEmail: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  const latestFlag = new Map<string, { at: Date; by: string | null }>();
+  const latestConsumeAt = new Map<string, Date>();
+  for (const a of audits) {
+    if (a.action === 'flag_ready') {
+      const cur = latestFlag.get(a.payoutId);
+      if (!cur || a.createdAt > cur.at) {
+        latestFlag.set(a.payoutId, { at: a.createdAt, by: a.actorEmail ?? null });
+      }
+    } else {
+      const cur = latestConsumeAt.get(a.payoutId);
+      if (!cur || a.createdAt > cur) {
+        latestConsumeAt.set(a.payoutId, a.createdAt);
+      }
+    }
+  }
+  const out = new Map<string, { at: string; by: string | null }>();
+  for (const [payoutId, flag] of latestFlag.entries()) {
+    const consume = latestConsumeAt.get(payoutId);
+    if (consume && consume >= flag.at) continue; // sticky flag was invalidated
+    out.set(payoutId, { at: flag.at.toISOString(), by: flag.by });
+  }
+  return out;
 }
 
 // ============================================
@@ -736,9 +899,18 @@ router.get(
 router.get(
   '/prepay-queue',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+  // argentina-92103: regional underbosses can READ the prepay queue scoped to
+  // their region via `?regions=`. Without the param, admin-class only.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
+      // argentina-92103: when a regional scope is supplied, narrow the
+      // prepay queue to parties in that region. Same merge pattern as
+      // `buildPayoutWhere` — region clause folds into the existing where.
+      const regionsFromQuery = parseRegionsQuery(req.query.regions);
+      const regionFilter = regionsFromQuery && regionsFromQuery.length > 0
+        ? { region: { in: regionsFromQuery } }
+        : {};
       // salame-58921: PizzaDAO (the platform admin user) and underbosses were
       // showing up as candidate "hosts" because they're set as primary host
       // (`parties.userId`) or appear in `parties.coHosts` on parties they
@@ -754,10 +926,12 @@ router.get(
       const staffEmails = new Set<string>([...adminEmails, ...underbossEmails]);
 
       // 1. All approved parties flagged for prepayment, with their primary host.
+      // argentina-92103: optional regional scope merged in for /payments/latam.
       const parties = await prisma.party.findMany({
         where: {
           eventTags: { has: 'prepay' },
           underbossStatus: 'approved',
+          ...regionFilter,
         },
         select: {
           id: true,
@@ -1267,8 +1441,12 @@ router.post(
 router.get(
   '/',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  // argentina-92103: regional underbosses can READ the LATAM queue via
+  // `?regions=central-america,south-america`. Without the param this still
+  // requires admin-class. Filtering by `?regions=` is enforced inside
+  // `buildPayoutWhere`.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
       const where = buildPayoutWhere(req.query);
 
@@ -1411,12 +1589,23 @@ router.get(
         ),
       );
       const pagePaidTotals = await fetchPaidTotalsByParty(pagePartyIds);
+      // argentina-92103: per-row "flagged ready for payment" augmentation.
+      // The list query doesn't include `audits` to keep responses small, so
+      // `serializePayout` can't derive the flag inline — instead we run one
+      // batched audit query covering every payout in the page.
+      const pageFlagged = await fetchFlaggedReadyByPayoutId(page.map(p => p.id));
       const serializedPayouts = page.map(p => {
         const serialized = serializePayout(p);
         if (serialized.party?.id) {
           const totals = pagePaidTotals.get(serialized.party.id);
           serialized.party.paidTotalUsd = totals?.paidUsd ?? 0;
           serialized.party.paidTotalCount = totals?.paidCount ?? 0;
+        }
+        const flag = pageFlagged.get(serialized.id);
+        if (flag) {
+          serialized.flaggedReady = true;
+          serialized.flaggedReadyAt = flag.at;
+          serialized.flaggedReadyBy = flag.by;
         }
         return serialized;
       });
@@ -1446,13 +1635,17 @@ router.get(
 router.get(
   '/:id',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  // argentina-92103: regional underbosses can READ payout detail scoped to
+  // their region via `?regions=`. The per-row "is this party in scope?"
+  // check is enforced below for underbosses so they can't peek out-of-scope
+  // rows by spoofing the query.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
       const row = await prisma.payout.findUnique({
         where: { id: req.params.id },
         include: {
-          party: { select: PAYOUT_PARTY_SELECT },
+          party: { select: { ...PAYOUT_PARTY_SELECT, region: true } },
           host: { select: { id: true, name: true, email: true } },
           documents: {
             orderBy: { sortOrder: 'asc' },
@@ -1464,6 +1657,15 @@ router.get(
 
       if (!row) {
         throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+
+      // argentina-92103: underbosses get blocked when the target party's
+      // region isn't in the requested scope. Admins skip this check.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        if (!(row as any).party?.region || !regionsFromQuery.includes((row as any).party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
       }
 
       const serialized = serializePayout(row);
@@ -1695,8 +1897,11 @@ router.patch(
 router.post(
   '/:id/approve',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  // argentina-92103: regional underbosses can APPROVE payouts on parties in
+  // their region (via `?regions=`). Admins always pass. The per-row scope
+  // check is inlined below for underbosses.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
@@ -1722,6 +1927,20 @@ router.post(
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      // argentina-92103: underboss-scope gate. Prevents a regional underboss
+      // from approving an out-of-region payout by spoofing the `?regions=`
+      // query. Admins skip this check.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        const party = await prisma.party.findUnique({
+          where: { id: existing.partyId },
+          select: { region: true },
+        });
+        if (!party?.region || !regionsFromQuery.includes(party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
+      }
 
       // bocconcini-49102: re-run the per-submission + per-party cap checks at
       // approve time so rows created/edited BEFORE the cap rules landed (or
@@ -1770,6 +1989,13 @@ router.post(
 
         return row;
       });
+
+      // argentina-92103: fire-and-forget Telegram + email to the payments
+      // team when a regional underboss approves. Admins skip — they're
+      // already on /payments. Silent no-op when env vars are unset.
+      if (req.viewerRole === 'underboss') {
+        void notifyPaymentsTeam({ kind: 'approved', payoutId: existing.id });
+      }
 
       // autoExecute (PR 5): synchronously execute after approval — only for
       // usdc_base, since wire + mercury_card require body refs (wireReference,
@@ -1855,13 +2081,15 @@ router.post(
 router.post(
   '/:id/unapprove',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  // argentina-92103: regional underbosses can REVERT approved payouts on
+  // parties in their region (via `?regions=`). Per-row scope check below.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true },
+        select: { id: true, status: true, hostUserId: true, partyId: true },
       });
 
       if (!existing) {
@@ -1876,6 +2104,18 @@ router.post(
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      // argentina-92103: underboss-scope gate.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        const party = await prisma.party.findUnique({
+          where: { id: existing.partyId },
+          select: { region: true },
+        });
+        if (!party?.region || !regionsFromQuery.includes(party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
+      }
 
       const { note } = req.body || {};
 
@@ -1926,13 +2166,15 @@ router.post(
 router.post(
   '/:id/reject',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  // argentina-92103: regional underbosses can REJECT payouts on parties in
+  // their region (via `?regions=`). Per-row scope check below.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true },
+        select: { id: true, status: true, hostUserId: true, partyId: true },
       });
 
       if (!existing) {
@@ -1943,6 +2185,18 @@ router.post(
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      // argentina-92103: underboss-scope gate.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        const party = await prisma.party.findUnique({
+          where: { id: existing.partyId },
+          select: { region: true },
+        });
+        if (!party?.region || !regionsFromQuery.includes(party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
+      }
 
       const reason = typeof req.body?.rejectionReason === 'string'
         ? req.body.rejectionReason.trim()
@@ -1987,6 +2241,102 @@ router.post(
       });
 
       res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/flag-ready — argentina-92103
+//
+// Regional underboss (or admin) signals that this payout is ready to be
+// paid by the payments team. Writes a `payout_audit` row with
+// action='flag_ready' and fires Telegram + email notifications to the
+// payments-team distribution (silent no-op when env vars unset).
+//
+// Status is NOT changed — the flag is a soft signal layered on top of
+// the existing pending/approved lifecycle. Admins still need to execute /
+// mark-paid to actually transition the row.
+//
+// The sticky-flag derivation (`serializePayout` + `fetchFlaggedReadyByPayoutId`)
+// makes this idempotent: clicking twice doesn't change the wire state,
+// and the flag self-invalidates once an admin marks the row paid /
+// rejected / reverted.
+// ============================================
+router.post(
+  '/:id/flag-ready',
+  requireAuth,
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true, partyId: true },
+      });
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status === 'paid' || existing.status === 'rejected' || existing.status === 'withdrawn') {
+        // Flagging a terminal-state row is a no-op signal; reject up front
+        // so the UI doesn't render a stale-looking flag icon afterward.
+        throw new AppError(
+          `Cannot flag a payout in status '${existing.status}'`,
+          400,
+          'INVALID_STATE',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      // argentina-92103: underboss-scope gate. Admins skip.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        const party = await prisma.party.findUnique({
+          where: { id: existing.partyId },
+          select: { region: true },
+        });
+        if (!party?.region || !regionsFromQuery.includes(party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
+      }
+
+      const note = typeof req.body?.note === 'string' ? req.body.note.slice(0, 500) : null;
+
+      await prisma.payoutAudit.create({
+        data: {
+          payoutId: existing.id,
+          action: 'flag_ready',
+          oldStatus: existing.status,
+          newStatus: existing.status, // status unchanged
+          actorEmail: actor.email,
+          actorKind: actor.actorKind,
+          note,
+        },
+      });
+
+      // Fire-and-forget — never block the response on notification delivery.
+      void notifyPaymentsTeam({ kind: 'flag_ready', payoutId: existing.id });
+
+      // Re-fetch with audits so `serializePayout` derives the fresh
+      // `flaggedReady=true` value for the client.
+      const fresh = await prisma.payout.findUnique({
+        where: { id: existing.id },
+        include: {
+          party: { select: PAYOUT_PARTY_SELECT },
+          host: { select: { id: true, name: true, email: true } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
+          audits: { orderBy: { createdAt: 'desc' }, take: 20 },
+        },
+      });
+      if (!fresh) {
+        throw new AppError('Payout not found after flag', 500, 'INTERNAL');
+      }
+      res.json({ payout: serializePayout(fresh) });
     } catch (error) {
       next(error);
     }

--- a/backend/src/services/paymentsTeamNotify.ts
+++ b/backend/src/services/paymentsTeamNotify.ts
@@ -1,0 +1,117 @@
+/**
+ * argentina-92103: payments-team notifications for regional-underboss signals.
+ *
+ * Fire-and-forget Telegram + email notification when:
+ *   - a regional underboss APPROVES a payout (admin doesn't fire — they're
+ *     already on /payments)
+ *   - anyone clicks "Flag ready for payment" on a row
+ *
+ * Both delivery channels silently no-op when their env vars are unset, so
+ * this helper is safe to call even before `PAYMENTS_TEAM_TG_CHAT_ID` /
+ * `PAYMENTS_TEAM_EMAILS` are configured on Vercel.
+ *
+ * Required env vars:
+ *   - `TELEGRAM_BOT_TOKEN` + `PAYMENTS_TEAM_TG_CHAT_ID` for Telegram
+ *   - `RESEND_API_KEY` + `PAYMENTS_TEAM_EMAILS` (csv) for email
+ *
+ * Caller pattern: `void notifyPaymentsTeam({ kind, payoutId })` — never await.
+ * Every failure path is swallowed inside so a notification outage cannot
+ * block an approve/flag action.
+ */
+import { prisma } from '../config/database.js';
+
+type NotifyKind = 'approved' | 'flag_ready';
+
+export async function notifyPaymentsTeam(opts: {
+  kind: NotifyKind;
+  payoutId: string;
+}): Promise<void> {
+  try {
+    const payout = await prisma.payout.findUnique({
+      where: { id: opts.payoutId },
+      include: {
+        party: { select: { name: true, country: true, region: true } },
+        host: { select: { name: true, email: true } },
+      },
+    });
+    if (!payout) return;
+
+    const amount = Number(payout.finalAmountUsd).toFixed(2);
+    const cityName = payout.party.name.replace(/^Global Pizza Party\s+/i, '').trim() || payout.party.name;
+    const recipient = payout.host?.name ?? payout.host?.email ?? 'unknown';
+    const verb =
+      opts.kind === 'flag_ready'
+        ? 'Flagged ready for payment'
+        : 'Approved by underboss';
+    const verbWithIcon =
+      opts.kind === 'flag_ready'
+        ? '🚩 Flagged ready for payment'
+        : '✅ Approved by underboss';
+
+    const baseUrl = process.env.FRONTEND_BASE_URL || 'https://rsv.pizza';
+    const reviewUrl = `${baseUrl}/payments`;
+    const text = `${verbWithIcon}\n*${cityName}* — $${amount} USDC to ${recipient}\n${reviewUrl}`;
+
+    // Telegram — single shared chat id (group or DM). Skip if either env var
+    // is missing.
+    const tgChat = process.env.PAYMENTS_TEAM_TG_CHAT_ID;
+    const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+    if (tgChat && tgToken) {
+      await fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: tgChat,
+          text,
+          parse_mode: 'Markdown',
+          disable_web_page_preview: true,
+        }),
+      }).catch((e: any) => {
+        console.warn('[notifyPaymentsTeam] telegram fail:', e?.message || e);
+      });
+    }
+
+    // Email — csv list via Resend. Skip if RESEND_API_KEY is missing OR
+    // no recipients are configured.
+    const emails = (process.env.PAYMENTS_TEAM_EMAILS || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const resendKey = process.env.RESEND_API_KEY;
+    if (emails.length > 0 && resendKey) {
+      const subject = `${verbWithIcon}: ${cityName} $${amount}`;
+      const html = `
+        <p>${verb}</p>
+        <p><b>${escapeHtml(cityName)}</b> — $${amount} USDC to ${escapeHtml(recipient)}</p>
+        <p><a href="${reviewUrl}">Review on rsv.pizza</a></p>
+      `.trim();
+      await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${resendKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'RSV.Pizza <noreply@rsv.pizza>',
+          to: emails,
+          subject,
+          html,
+        }),
+      }).catch((e: any) => {
+        console.warn('[notifyPaymentsTeam] resend fail:', e?.message || e);
+      });
+    }
+  } catch (err: any) {
+    console.warn('[notifyPaymentsTeam] error:', err?.message || err);
+  }
+}
+
+/** Minimal HTML escape for interpolating user-provided names/cities. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { UnderbossDashboard } from './pages/UnderbossDashboard';
 import { ShippingDashboard } from './pages/ShippingDashboard';
 import { AdminPage } from './pages/AdminPage';
 import { PaymentsAdminPage } from './pages/PaymentsAdminPage';
+import { LatamPaymentsPage } from './pages/LatamPaymentsPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
 import { ConsolidatedReportPage } from './pages/ConsolidatedReportPage';
@@ -76,6 +77,10 @@ function App() {
             <Route path="/gpp/leaderboard" element={<LeaderboardPage />} />
             {/* /payments must come before /:slug */}
             <Route path="/payments" element={<PaymentsAdminPage />} />
+            {/* argentina-92103: regional LATAM portal for the LATAM
+                underboss. Wraps PaymentsAdminPage with regionFilter +
+                portalSlug. Must come before /:slug. */}
+            <Route path="/payments/latam" element={<LatamPaymentsPage />} />
             {/* margherita-43821: /photos public global feed; must come before /:slug */}
             <Route path="/photos" element={<PhotosFeedPage />} />
             <Route path="/account" element={<AccountPage />} />

--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -23,6 +23,12 @@ interface BulkActionsBarProps {
    * is grayed out + tooltip explains why.
    */
   eligibleBulkSendCount?: number;
+  /**
+   * argentina-92103: viewer role drives which buttons render. Underbosses
+   * see Approve / Reject only — Bulk Send, Mark Paid, Export Safe JSON are
+   * funds-adjacent operations that stay admin-only.
+   */
+  viewerRole?: 'admin' | 'underboss';
   busy?: boolean;
 }
 
@@ -35,9 +41,13 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   onExportSafeJson,
   onBulkSend,
   eligibleBulkSendCount = 0,
+  viewerRole = 'admin',
   busy = false,
 }) => {
   if (selectedCount === 0) return null;
+  // argentina-92103: underbosses can't send funds — hide Mark Paid, Bulk
+  // Send, Export Safe JSON. Approve / Reject stay visible.
+  const showFundsActions = viewerRole === 'admin';
   return (
     <div className="sticky top-[4rem] sm:top-[7rem] z-10 bg-theme-text/95 text-white rounded-xl px-3 py-2 sm:px-4 sm:py-3 mb-3 shadow-lg flex items-center gap-2 sm:gap-3 flex-wrap">
       <span className="text-sm font-medium">{selectedCount} selected</span>
@@ -60,16 +70,18 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
           <X size={14} />
           Reject
         </button>
-        <button
-          type="button"
-          onClick={onMarkPaid}
-          disabled={busy}
-          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
-        >
-          <DollarSign size={14} />
-          Mark paid
-        </button>
-        {onBulkSend && (
+        {showFundsActions && (
+          <button
+            type="button"
+            onClick={onMarkPaid}
+            disabled={busy}
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+          >
+            <DollarSign size={14} />
+            Mark paid
+          </button>
+        )}
+        {showFundsActions && onBulkSend && (
           <button
             type="button"
             onClick={onBulkSend}
@@ -85,7 +97,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
             Bulk Send{eligibleBulkSendCount > 0 ? ` (${eligibleBulkSendCount})` : ''}
           </button>
         )}
-        {onExportSafeJson && (
+        {showFundsActions && onExportSafeJson && (
           <button
             type="button"
             onClick={onExportSafeJson}

--- a/frontend/src/components/payments-admin/HotWalletCard.tsx
+++ b/frontend/src/components/payments-admin/HotWalletCard.tsx
@@ -39,7 +39,17 @@ function formatBalance(raw: string, decimals: number): string {
   });
 }
 
-export const HotWalletCard: React.FC = () => {
+interface HotWalletCardProps {
+  /**
+   * argentina-92103: regional-portal mode (e.g. /payments/latam). When true,
+   * the refresh button + low-gas warning + "Base only" caption are hidden
+   * so the underboss can see balances without touching them. Address + the
+   * two balance tiles still render.
+   */
+  readOnly?: boolean;
+}
+
+export const HotWalletCard: React.FC<HotWalletCardProps> = ({ readOnly = false }) => {
   const [info, setInfo] = useState<PayoutWalletInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -94,18 +104,21 @@ export const HotWalletCard: React.FC = () => {
             Self-custodied payout wallet — funds outgoing USDC payments.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={load}
-          disabled={loading}
-          className="p-2 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover disabled:opacity-50"
-          title="Refresh balances"
-          aria-label="Refresh balances"
-        >
-          {loading
-            ? <Loader2 size={14} className="animate-spin" />
-            : <RefreshCcw size={14} />}
-        </button>
+        {/* argentina-92103: refresh button hidden in read-only (UB) mode. */}
+        {!readOnly && (
+          <button
+            type="button"
+            onClick={load}
+            disabled={loading}
+            className="p-2 rounded-md text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover disabled:opacity-50"
+            title="Refresh balances"
+            aria-label="Refresh balances"
+          >
+            {loading
+              ? <Loader2 size={14} className="animate-spin" />
+              : <RefreshCcw size={14} />}
+          </button>
+        )}
       </div>
 
       {errorMsg ? (
@@ -160,7 +173,10 @@ export const HotWalletCard: React.FC = () => {
               >
                 {formatBalance(info.ethBalance, 6)}
               </div>
-              {lowGas && (
+              {/* argentina-92103: low-gas warning suppressed in read-only
+                  mode — the UB can't refill or send so the call-to-action
+                  isn't actionable for him. */}
+              {lowGas && !readOnly && (
                 <div className="text-[11px] text-amber-300/80 mt-1">
                   Below {LOW_GAS_THRESHOLD_ETH} ETH — top up to avoid stalled payouts.
                 </div>
@@ -179,9 +195,14 @@ export const HotWalletCard: React.FC = () => {
             </div>
           </div>
 
-          <div className="text-xs text-theme-text-muted mt-3">
-            Send only ETH (gas) and USDC on Base (chainId {info.chainId}) — other tokens/chains will be lost.
-          </div>
+          {/* argentina-92103: "send only ETH/USDC on Base" caption is hidden
+              in read-only mode — the UB isn't depositing, so the warning is
+              clutter. */}
+          {!readOnly && (
+            <div className="text-xs text-theme-text-muted mt-3">
+              Send only ETH (gas) and USDC on Base (chainId {info.chainId}) — other tokens/chains will be lost.
+            </div>
+          )}
         </>
       ) : null}
     </section>

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2 } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -122,6 +122,22 @@ interface PayoutReviewModalProps {
    * underlying row picks up the new tag set (effective cap, etc.).
    */
   onTagsChanged?: (next: string[]) => void;
+  /**
+   * argentina-92103: viewer role. `'underboss'` hides Execute Payment +
+   * Mark paid (manual) and surfaces a green "Flag ready for payment"
+   * button instead. Defaults to `'admin'` so existing callers keep the
+   * full power-user UI.
+   */
+  viewerRole?: 'admin' | 'underboss';
+  /**
+   * argentina-92103: flag the payout as "ready for payment" — writes an
+   * audit row + notifies the payments team. Surfaced as a green Flag
+   * button in the footer for underbosses; admins also see it so they can
+   * pre-flag rows before exiting the modal. Returns an error message
+   * string on failure (same contract as `onUnapprove`) so the modal can
+   * render it inline.
+   */
+  onFlagReady?: () => Promise<string | void> | string | void;
   busy?: boolean;
 }
 
@@ -142,8 +158,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onPayAgain,
   adminRole,
   onTagsChanged,
+  viewerRole = 'admin',
+  onFlagReady,
   busy = false,
 }) => {
+  // argentina-92103: underbosses lose Execute/Mark-paid affordances. The
+  // green Flag-ready button replaces them in the footer slot.
+  const isAdminViewer = viewerRole === 'admin';
+  // Flag-ready inline error (mirrors the unapproveError pattern).
+  const [flagReadyError, setFlagReadyError] = useState<string | null>(null);
   // tagliatelle-49102: in-modal event_tags editor. Full admins (admin /
   // super_admin) can add + remove tags via PATCH /api/parties/:id;
   // payment_admin sees the chips read-only. Hooks must be declared above
@@ -1492,24 +1515,31 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   Revert to Pending
                 </button>
               )}
-              <button
-                type="button"
-                onClick={openExecuteForm}
-                disabled={busy || selfPayoutBlocked || showExecuteForm}
-                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
-              >
-                <Send size={14} />
-                {isFailed ? 'Retry Payment' : 'Execute Payment'}
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowMarkPaidForm(true)}
-                disabled={busy || selfPayoutBlocked}
-                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
-              >
-                <DollarSign size={14} />
-                Mark paid (manual)
-              </button>
+              {/* argentina-92103: Execute + Mark-paid are admin-only — they
+                  send funds. Underbosses can still flag-ready (rendered below
+                  in the shared block) but cannot run the funds operations. */}
+              {isAdminViewer && (
+                <>
+                  <button
+                    type="button"
+                    onClick={openExecuteForm}
+                    disabled={busy || selfPayoutBlocked || showExecuteForm}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
+                  >
+                    <Send size={14} />
+                    {isFailed ? 'Retry Payment' : 'Execute Payment'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowMarkPaidForm(true)}
+                    disabled={busy || selfPayoutBlocked}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+                  >
+                    <DollarSign size={14} />
+                    Mark paid (manual)
+                  </button>
+                </>
+              )}
             </>
           )}
           {isClosed && onReopen && (
@@ -1555,6 +1585,47 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               </button>
             );
           })()}
+          {/* argentina-92103: Flag ready for payment. Visible for both UB
+              and admin (admins can pre-flag a row so the payments-team
+              channel surfaces it as a to-do). Hidden once the row is in
+              a terminal state (paid / rejected / withdrawn) — the
+              backend would 400 in that case anyway. Renders sticky-green
+              "Flagged" pill instead when already flagged so the actor
+              doesn't double-fire notifications. */}
+          {onFlagReady && !isPaid && !isClosed && payout.status !== 'withdrawn' && (
+            payout.flaggedReady ? (
+              <span
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 text-sm font-medium"
+                title={
+                  `Flagged ready` +
+                  (payout.flaggedReadyBy ? ` by ${payout.flaggedReadyBy}` : '') +
+                  (payout.flaggedReadyAt
+                    ? ` on ${new Date(payout.flaggedReadyAt).toLocaleString()}`
+                    : '')
+                }
+              >
+                <Flag size={14} />
+                Flagged ready
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={async () => {
+                  setFlagReadyError(null);
+                  const err = await onFlagReady();
+                  if (typeof err === 'string' && err) {
+                    setFlagReadyError(err);
+                  }
+                }}
+                disabled={busy || selfPayoutBlocked}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
+                title="Notify the payments team that this payout is ready to be paid"
+              >
+                <Flag size={14} />
+                Flag ready for payment
+              </button>
+            )
+          )}
           <button
             type="button"
             onClick={onClose}
@@ -1569,6 +1640,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
               <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
               <span>{unapproveError}</span>
+            </div>
+          )}
+          {/* argentina-92103: inline error for Flag-ready. Same pattern
+              as unapproveError above. */}
+          {flagReadyError && (
+            <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{flagReadyError}</span>
             </div>
           )}
         </div>

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -19,6 +19,12 @@ interface PrepayQueueTableProps {
    * vs cap" indicators).
    */
   onPartyUpdated?: (partyId: string) => void;
+  /**
+   * argentina-92103: viewer role. Underbosses see the queue read-only — the
+   * "Create prepayment" button is hidden because creating a prepayment is
+   * a funds-sending operation reserved for admins.
+   */
+  viewerRole?: 'admin' | 'underboss';
 }
 
 /**
@@ -117,7 +123,11 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
   onCreatePrepayment,
   onHostClick,
   onPartyUpdated,
+  viewerRole = 'admin',
 }) => {
+  // argentina-92103: hide the "Create prepayment" button for underbosses
+  // — creating a prepayment is funds-sending and stays admin-only.
+  const canCreatePrepayment = viewerRole === 'admin';
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
       {/* regina-89172: mobile card list (<640px). Each row becomes a stacked
@@ -179,13 +189,15 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                     onUpdated={() => onPartyUpdated?.(row.party.id)}
                   />
                 </div>
-                <button
-                  type="button"
-                  onClick={() => onCreatePrepayment(row)}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium shrink-0"
-                >
-                  Create prepayment
-                </button>
+                {canCreatePrepayment && (
+                  <button
+                    type="button"
+                    onClick={() => onCreatePrepayment(row)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium shrink-0"
+                  >
+                    Create prepayment
+                  </button>
+                )}
               </div>
             </li>
           );
@@ -268,13 +280,15 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                     />
                   </td>
                   <td className="px-3 py-3 align-top text-right">
-                    <button
-                      type="button"
-                      onClick={() => onCreatePrepayment(row)}
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
-                    >
-                      Create prepayment
-                    </button>
+                    {canCreatePrepayment && (
+                      <button
+                        type="button"
+                        onClick={() => onCreatePrepayment(row)}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
+                      >
+                        Create prepayment
+                      </button>
+                    )}
                   </td>
                 </tr>
               );

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Flag } from 'lucide-react';
 import type { AdminPayout, Payout } from '../../types';
 import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
@@ -250,7 +250,27 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       </td>
 
       <td className="px-3 py-3">
-        <PayoutStatusPill status={payout.status} />
+        <div className="inline-flex items-center gap-1.5">
+          <PayoutStatusPill status={payout.status} />
+          {/* argentina-92103: green Flag icon when a regional underboss (or
+              admin) has marked the row "ready for payment". Tooltip carries
+              the actor email + timestamp. Sticky until the row is paid /
+              rejected / reverted. */}
+          {showAdminColumns && admin.flaggedReady && (
+            <Flag
+              size={14}
+              className="text-emerald-500 shrink-0"
+              aria-label="Flagged ready for payment"
+              title={
+                `Flagged ready` +
+                (admin.flaggedReadyBy ? ` by ${admin.flaggedReadyBy}` : '') +
+                (admin.flaggedReadyAt
+                  ? ` on ${new Date(admin.flaggedReadyAt).toLocaleString()}`
+                  : '')
+              }
+            />
+          )}
+        </div>
       </td>
 
       {actions && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4065,16 +4065,36 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.dateTo) params.set('dateTo', filters.dateTo);
   if (filters.cursor) params.set('cursor', filters.cursor);
   if (filters.limit) params.set('limit', String(filters.limit));
+  // argentina-92103: regional scope for /payments/latam (and any future
+  // regional portal). CSV of `parties.region` values; backend filters the
+  // query, totals, and per-row aggregates by region when present.
+  if (filters.regions && filters.regions.length > 0) {
+    params.set('regions', filters.regions.join(','));
+  }
   const qs = params.toString();
   return qs ? `?${qs}` : '';
+}
+
+/**
+ * argentina-92103: small helper for endpoints that don't accept the full
+ * AdminPayoutFilters object — appends `?regions=` when supplied.
+ */
+function regionsQuery(regions?: string[]): string {
+  if (!regions || regions.length === 0) return '';
+  return `?regions=${encodeURIComponent(regions.join(','))}`;
 }
 
 export async function listAdminPayouts(filters?: AdminPayoutFilters): Promise<AdminPayoutsResponse> {
   return apiRequest<AdminPayoutsResponse>(`/api/admin/payouts${buildPayoutQuery(filters)}`);
 }
 
-export async function getAdminPayout(id: string): Promise<AdminPayoutDetail> {
-  const res = await apiRequest<{ payout: AdminPayoutDetail }>(`/api/admin/payouts/${id}`);
+export async function getAdminPayout(
+  id: string,
+  opts?: { regions?: string[] },
+): Promise<AdminPayoutDetail> {
+  const res = await apiRequest<{ payout: AdminPayoutDetail }>(
+    `/api/admin/payouts/${id}${regionsQuery(opts?.regions)}`,
+  );
   return res.payout;
 }
 
@@ -4144,19 +4164,26 @@ export async function updatePayoutDocument(
 
 export async function approveAdminPayout(
   id: string,
-  opts?: { note?: string; autoExecute?: boolean },
+  opts?: { note?: string; autoExecute?: boolean; regions?: string[] },
 ): Promise<{ payout: AdminPayout; autoExecuteDeferred: boolean }> {
-  return apiRequest(`/api/admin/payouts/${id}/approve`, {
+  return apiRequest(`/api/admin/payouts/${id}/approve${regionsQuery(opts?.regions)}`, {
     method: 'POST',
     body: { note: opts?.note, autoExecute: opts?.autoExecute },
   });
 }
 
-export async function rejectAdminPayout(id: string, rejectionReason: string): Promise<AdminPayout> {
-  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/reject`, {
-    method: 'POST',
-    body: { rejectionReason },
-  });
+export async function rejectAdminPayout(
+  id: string,
+  rejectionReason: string,
+  opts?: { regions?: string[] },
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}/reject${regionsQuery(opts?.regions)}`,
+    {
+      method: 'POST',
+      body: { rejectionReason },
+    },
+  );
   return res.payout;
 }
 
@@ -4169,11 +4196,41 @@ export async function rejectAdminPayout(id: string, rejectionReason: string): Pr
  * Backend validates the current status is 'approved' (400 NOT_APPROVED
  * otherwise) and writes a payout_audit row with action='unapprove'.
  */
-export async function unapproveAdminPayout(id: string, note?: string): Promise<AdminPayout> {
-  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/unapprove`, {
-    method: 'POST',
-    body: { note },
-  });
+export async function unapproveAdminPayout(
+  id: string,
+  noteOrOpts?: string | { note?: string; regions?: string[] },
+): Promise<AdminPayout> {
+  // Backward-compat: callers passing a bare `note` string still work.
+  const note = typeof noteOrOpts === 'string' ? noteOrOpts : noteOrOpts?.note;
+  const regions = typeof noteOrOpts === 'string' ? undefined : noteOrOpts?.regions;
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}/unapprove${regionsQuery(regions)}`,
+    {
+      method: 'POST',
+      body: { note },
+    },
+  );
+  return res.payout;
+}
+
+/**
+ * argentina-92103: regional underbosses (and admins) signal "this payout is
+ * ready for the payments team to pay" without actually changing status or
+ * sending funds. Writes a payout_audit row + fires Telegram + email to the
+ * payments-team distribution. The flag is sticky (admins see a green Flag
+ * icon on the row until they execute or revert).
+ */
+export async function flagReadyForPayment(
+  id: string,
+  opts?: { regions?: string[]; note?: string },
+): Promise<AdminPayoutDetail> {
+  const res = await apiRequest<{ payout: AdminPayoutDetail }>(
+    `/api/admin/payouts/${id}/flag-ready${regionsQuery(opts?.regions)}`,
+    {
+      method: 'POST',
+      body: { note: opts?.note },
+    },
+  );
   return res.payout;
 }
 
@@ -4353,9 +4410,9 @@ export async function fetchUserPaymentDetails(userId: string): Promise<UserPayme
  * have a saved payment method, excluding parties that already have an
  * in-flight payout. Surfaced as the "Prepay queue" section on /payments.
  */
-export async function fetchPrepayQueue(): Promise<PrepayQueueRow[]> {
+export async function fetchPrepayQueue(opts?: { regions?: string[] }): Promise<PrepayQueueRow[]> {
   const res = await apiRequest<{ rows: PrepayQueueRow[] }>(
-    '/api/admin/payouts/prepay-queue',
+    `/api/admin/payouts/prepay-queue${regionsQuery(opts?.regions)}`,
   );
   return res.rows;
 }

--- a/frontend/src/pages/LatamPaymentsPage.tsx
+++ b/frontend/src/pages/LatamPaymentsPage.tsx
@@ -1,0 +1,25 @@
+/**
+ * argentina-92103: LATAM regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * Central + South America so the LATAM underboss (`donmalbec.eth@gmail.com`)
+ * can review every LATAM payout, approve/reject/revert, edit per-event caps,
+ * leave admin notes, and click "Flag ready for payment" — which records an
+ * audit row + notifies the payments team via Telegram + email.
+ *
+ * Funds-sending operations (USDC execute, Mercury / wire mark-paid, Bulk
+ * Send, Export Safe JSON, Record External Payment, Hot Wallet refresh)
+ * stay admin-only — the underboss sees the Hot Wallet card in read-only mode.
+ */
+import React from 'react';
+import { LATAM_REGIONS } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function LatamPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(LATAM_REGIONS)}
+      portalSlug="latam"
+    />
+  );
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -5,6 +5,7 @@ import { Layout } from '../components/Layout';
 import { IconInput } from '../components/IconInput';
 import {
   fetchAdminMe,
+  fetchUnderbossMe,
   listAdminPayouts,
   getAdminPayout,
   approveAdminPayout,
@@ -17,6 +18,7 @@ import {
   fetchWalletPaidTotal,
   exportAdminPayoutsCsv,
   fetchPrepayQueue,
+  flagReadyForPayment,
 } from '../lib/api';
 import type {
   AdminPayout,
@@ -44,10 +46,34 @@ import {
 } from '../components/payments-admin';
 import type { BulkSendResult } from '../lib/api';
 
+/**
+ * argentina-92103: viewer-role state. The full /payments dashboard accepts
+ * admin / super_admin / payment_admin (`viewerKind: 'admin'`). A regional
+ * portal (`regionFilter` supplied) additionally accepts an underboss whose
+ * regions overlap the requested scope (`viewerKind: 'underboss'`).
+ */
 type RoleState =
   | { kind: 'loading' }
   | { kind: 'denied' }
-  | { kind: 'allowed'; role: 'admin' | 'super_admin' | 'payment_admin'; email: string };
+  | {
+      kind: 'allowed';
+      role: 'admin' | 'super_admin' | 'payment_admin' | 'underboss';
+      viewerKind: 'admin' | 'underboss';
+      email: string;
+    };
+
+/**
+ * argentina-92103: optional props that turn the dashboard into a regional
+ * portal. When set:
+ *  - All payouts queries forward `?regions=` so the queue is scoped server-side.
+ *  - Page title flips to `"{portalSlug.toUpperCase()} Payments"`.
+ *  - Viewer-role resolution accepts a matching-region underboss in addition
+ *    to admin-class. Funds-sending affordances stay admin-only.
+ */
+export interface PaymentsAdminPageProps {
+  regionFilter?: string[];
+  portalSlug?: string;
+}
 
 const DEFAULT_FILTERS: AdminPayoutFilters = {
   status: 'all',
@@ -80,9 +106,20 @@ function matchesPrepaySearch(row: PrepayQueueRow, q: string): boolean {
   return false;
 }
 
-export function PaymentsAdminPage() {
+export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPageProps = {}) {
+  // argentina-92103: stable region list to thread into API calls + filter
+  // defaults. `undefined` when running as the unscoped /payments dashboard.
+  const regions = useMemo(
+    () => (regionFilter && regionFilter.length > 0 ? [...regionFilter] : undefined),
+    [regionFilter],
+  );
+  const portalLabel = portalSlug ? portalSlug.toUpperCase() : null;
+  const isRegionalPortal = !!regions;
+
   const [role, setRole] = useState<RoleState>({ kind: 'loading' });
-  const [filters, setFilters] = useState<AdminPayoutFilters>(DEFAULT_FILTERS);
+  const [filters, setFilters] = useState<AdminPayoutFilters>(() =>
+    regions ? { ...DEFAULT_FILTERS, regions } : DEFAULT_FILTERS,
+  );
   const [payouts, setPayouts] = useState<AdminPayout[]>([]);
   const [totals, setTotals] = useState<AdminPayoutTotals | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
@@ -158,16 +195,20 @@ export function PaymentsAdminPage() {
 
   const loadPrepayQueue = useCallback(async () => {
     try {
-      const rows = await fetchPrepayQueue();
+      const rows = await fetchPrepayQueue(regions ? { regions } : undefined);
       setPrepayQueue(rows);
     } catch {
       // Non-fatal — the rest of the dashboard works without it. Silently
       // collapse the section by leaving the array empty.
       setPrepayQueue([]);
     }
-  }, []);
+  }, [regions]);
 
   // Role gate
+  // argentina-92103: when running as a regional portal (regions set), we
+  // accept EITHER an admin-class user OR an underboss whose regions overlap
+  // the requested scope. The unscoped /payments dashboard keeps the
+  // pre-existing admin-class-only behavior.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -176,33 +217,65 @@ export function PaymentsAdminPage() {
         if (cancelled) return;
         const r = me.role;
         if (me.isAdmin && (r === 'admin' || r === 'super_admin' || r === 'payment_admin')) {
-          setRole({ kind: 'allowed', role: r, email: me.email || '' });
-        } else {
-          setRole({ kind: 'denied' });
+          setRole({
+            kind: 'allowed',
+            role: r,
+            viewerKind: 'admin',
+            email: me.email || '',
+          });
+          return;
         }
+        // Regional portal fallback — check for underboss with matching region.
+        if (regions) {
+          try {
+            const ub = await fetchUnderbossMe();
+            if (cancelled) return;
+            if (ub.isUnderboss && Array.isArray(ub.regions)) {
+              const overlap = ub.regions.some((reg) => regions.includes(reg));
+              if (overlap) {
+                setRole({
+                  kind: 'allowed',
+                  role: 'underboss',
+                  viewerKind: 'underboss',
+                  email: ub.email || '',
+                });
+                return;
+              }
+            }
+          } catch {
+            // fall through to denied
+          }
+        }
+        setRole({ kind: 'denied' });
       } catch {
         if (!cancelled) setRole({ kind: 'denied' });
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [regions]);
 
-  const loadPage = useCallback(async (f: AdminPayoutFilters, append = false) => {
-    if (append) setLoadingMore(true);
-    else setLoading(true);
-    setErrorMsg(null);
-    try {
-      const res = await listAdminPayouts(f);
-      setPayouts((prev) => (append ? [...prev, ...res.payouts] : res.payouts));
-      setTotals(res.totals);
-      setNextCursor(res.nextCursor);
-    } catch (err: any) {
-      setErrorMsg(err.message || 'Failed to load payments');
-    } finally {
-      if (append) setLoadingMore(false);
-      else setLoading(false);
-    }
-  }, []);
+  const loadPage = useCallback(
+    async (f: AdminPayoutFilters, append = false) => {
+      if (append) setLoadingMore(true);
+      else setLoading(true);
+      setErrorMsg(null);
+      try {
+        // argentina-92103: always re-inject the portal's region scope so a
+        // user clearing filters can't accidentally fetch the global queue.
+        const merged = regions ? { ...f, regions } : f;
+        const res = await listAdminPayouts(merged);
+        setPayouts((prev) => (append ? [...prev, ...res.payouts] : res.payouts));
+        setTotals(res.totals);
+        setNextCursor(res.nextCursor);
+      } catch (err: any) {
+        setErrorMsg(err.message || 'Failed to load payments');
+      } finally {
+        if (append) setLoadingMore(false);
+        else setLoading(false);
+      }
+    },
+    [regions],
+  );
 
   // Re-load when filters change (and we're allowed)
   useEffect(() => {
@@ -410,7 +483,9 @@ export function PaymentsAdminPage() {
     setDetail(null);
     setDetailLoading(true);
     try {
-      const d = await getAdminPayout(p.id);
+      // argentina-92103: forward the portal's region scope so underbosses
+      // can't peek at out-of-region detail by direct id lookup.
+      const d = await getAdminPayout(p.id, regions ? { regions } : undefined);
       setDetail(d);
     } catch (err: any) {
       setErrorMsg(err.message || 'Failed to load payment');
@@ -426,7 +501,7 @@ export function PaymentsAdminPage() {
   async function handleRowApprove(id: string) {
     setRowBusyId(id);
     try {
-      await approveAdminPayout(id);
+      await approveAdminPayout(id, regions ? { regions } : undefined);
       // crudo-91827: refresh BOTH lists — an approved prepayment row stays in
       // the payouts table but may affect prepay-queue derivations.
       await Promise.all([refresh(), loadPrepayQueue()]);
@@ -443,7 +518,7 @@ export function PaymentsAdminPage() {
   async function handleRowUnapprove(id: string) {
     setRowBusyId(id);
     try {
-      await unapproveAdminPayout(id);
+      await unapproveAdminPayout(id, regions ? { regions } : undefined);
       await Promise.all([refresh(), loadPrepayQueue()]);
     } catch (err: any) {
       setErrorMsg(err.message || 'Revert failed');
@@ -467,7 +542,7 @@ export function PaymentsAdminPage() {
     setDetail(null);
     setDetailLoading(true);
     try {
-      const d = await getAdminPayout(p.id);
+      const d = await getAdminPayout(p.id, regions ? { regions } : undefined);
       setDetail(d);
     } finally {
       setDetailLoading(false);
@@ -480,7 +555,7 @@ export function PaymentsAdminPage() {
     setBulkBusy(true);
     try {
       for (const id of Array.from(selectedIds)) {
-        await approveAdminPayout(id).catch(() => null);
+        await approveAdminPayout(id, regions ? { regions } : undefined).catch(() => null);
       }
       clearSelection();
       // crudo-91827: refresh BOTH lists for the same reason as the row variant.
@@ -503,10 +578,11 @@ export function PaymentsAdminPage() {
   // re-appears in the queue), and closes the modal on success.
   async function confirmReject(reason: string) {
     if (!rejectTarget) return;
+    const rejectOpts = regions ? { regions } : undefined;
     if (rejectTarget.kind === 'single') {
       setRowBusyId(rejectTarget.id);
       try {
-        await rejectAdminPayout(rejectTarget.id, reason);
+        await rejectAdminPayout(rejectTarget.id, reason, rejectOpts);
         await Promise.all([refresh(), loadPrepayQueue()]);
         setRejectTarget(null);
       } catch (err: any) {
@@ -518,7 +594,7 @@ export function PaymentsAdminPage() {
       setBulkBusy(true);
       try {
         for (const id of rejectTarget.ids) {
-          await rejectAdminPayout(id, reason).catch(() => null);
+          await rejectAdminPayout(id, reason, rejectOpts).catch(() => null);
         }
         setSelectedIds(new Set());
         await Promise.all([refresh(), loadPrepayQueue()]);
@@ -576,7 +652,12 @@ export function PaymentsAdminPage() {
           <ShieldX size={48} className="text-red-400/60 mb-4" />
           <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
           <p className="text-theme-text-muted text-center max-w-md">
-            The host payments dashboard is only available to admins and payment admins.
+            {/* argentina-92103: tailored message for regional portals so the
+                UB knows which account to sign in as. Falls back to the
+                global message for the unscoped /payments dashboard. */}
+            {portalSlug
+              ? `Sign in as the ${portalSlug.toLowerCase()} underboss or as an admin to view this portal.`
+              : 'The host payments dashboard is only available to admins and payment admins.'}
           </p>
         </div>
       </Layout>
@@ -585,10 +666,17 @@ export function PaymentsAdminPage() {
 
   const meUserId = ''; // not needed client-side — backend enforces self-payout block
 
+  // argentina-92103: regional portals show "{PORTAL} Payments" in the
+  // header + title (e.g. "LATAM Payments"). Underbosses also see a
+  // softer subhead — they can review + flag but not send funds.
+  const pageTitle = portalLabel ? `${portalLabel} Payments` : 'Host Payments';
+  const viewerKind = role.viewerKind;
+  const isUnderboss = viewerKind === 'underboss';
+
   return (
     <Layout>
       <Helmet>
-        <title>Host Payments | RSV.Pizza</title>
+        <title>{pageTitle} | RSV.Pizza</title>
       </Helmet>
       <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
         {/* Header */}
@@ -597,9 +685,11 @@ export function PaymentsAdminPage() {
             <DollarSign size={20} className="text-emerald-600" />
           </div>
           <div className="flex-1 min-w-0">
-            <h1 className="text-2xl font-bold text-theme-text">Host Payments</h1>
+            <h1 className="text-2xl font-bold text-theme-text">{pageTitle}</h1>
             <p className="text-sm text-theme-text-muted">
-              Review, approve, and pay out host payments ({role.role.replace('_', ' ')})
+              {isUnderboss
+                ? 'Review, approve, and flag payments ready for the payments team to pay.'
+                : `Review, approve, and pay out host payments (${role.role.replace('_', ' ')})`}
             </p>
           </div>
           {totals && totals.totalUsdPending > 0 && (
@@ -607,14 +697,18 @@ export function PaymentsAdminPage() {
               {formatUsd(totals.totalUsdPending)} pending
             </span>
           )}
-          <button
-            type="button"
-            onClick={() => setShowExternalModal(true)}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium"
-          >
-            <Plus size={14} />
-            Record External Payment
-          </button>
+          {/* argentina-92103: Record External Payment is funds-adjacent
+              (it records a paid-status payout out-of-band). Stays admin-only. */}
+          {!isUnderboss && (
+            <button
+              type="button"
+              onClick={() => setShowExternalModal(true)}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium"
+            >
+              <Plus size={14} />
+              Record External Payment
+            </button>
+          )}
           <button
             type="button"
             onClick={handleExportCsv}
@@ -627,8 +721,11 @@ export function PaymentsAdminPage() {
         </div>
 
         {/* coppa-91827: hot wallet address + ETH/USDC balances so admins know
-            where to deposit funds and can verify they landed. Self-fetches. */}
-        <HotWalletCard />
+            where to deposit funds and can verify they landed. Self-fetches.
+            argentina-92103: read-only for regional underbosses — they can
+            see balances but the refresh button + low-gas warning + "Base
+            only" caption are hidden. */}
+        <HotWalletCard readOnly={isUnderboss} />
 
         <PaymentsStatsCards totals={totals} loading={loading && !totals} />
 
@@ -689,6 +786,7 @@ export function PaymentsAdminPage() {
                 onCreatePrepayment={(row) => setPrepayModalRow(row)}
                 onHostClick={(userId) => setHostDetailUserId(userId)}
                 onPartyUpdated={() => loadPrepayQueue()}
+                viewerRole={viewerKind}
               />
             )}
           </section>
@@ -713,6 +811,7 @@ export function PaymentsAdminPage() {
           eligibleBulkSendCount={eligibleBulkSendCount}
           onClear={clearSelection}
           busy={bulkBusy}
+          viewerRole={viewerKind}
         />
 
         {errorMsg && (
@@ -765,8 +864,11 @@ export function PaymentsAdminPage() {
             onApprove={async (note) => {
               setModalBusy(true);
               try {
-                await approveAdminPayout(detail.id, { note });
-                const fresh = await getAdminPayout(detail.id);
+                await approveAdminPayout(detail.id, {
+                  note,
+                  ...(regions ? { regions } : {}),
+                });
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();
               } catch (err: any) {
@@ -778,8 +880,8 @@ export function PaymentsAdminPage() {
             onReject={async (reason) => {
               setModalBusy(true);
               try {
-                await rejectAdminPayout(detail.id, reason);
-                const fresh = await getAdminPayout(detail.id);
+                await rejectAdminPayout(detail.id, reason, regions ? { regions } : undefined);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();
               } catch (err: any) {
@@ -795,8 +897,8 @@ export function PaymentsAdminPage() {
             onUnapprove={async () => {
               setModalBusy(true);
               try {
-                await unapproveAdminPayout(detail.id);
-                const fresh = await getAdminPayout(detail.id);
+                await unapproveAdminPayout(detail.id, regions ? { regions } : undefined);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await Promise.all([refresh(), loadPrepayQueue()]);
                 return;
@@ -816,7 +918,7 @@ export function PaymentsAdminPage() {
                   // acknowledgement so the backend bypasses the 400.
                   allowOverSubmissionCap: opts?.allowOverSubmissionCap,
                 });
-                const fresh = await getAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();
                 return;
@@ -834,7 +936,7 @@ export function PaymentsAdminPage() {
               setModalBusy(true);
               try {
                 await updateAdminPayout(detail.id, { adminNotes: notes });
-                const fresh = await getAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
               } catch (err: any) {
                 setErrorMsg(err.message || 'Save failed');
@@ -846,7 +948,7 @@ export function PaymentsAdminPage() {
               setModalBusy(true);
               try {
                 await markAdminPayoutPaid(detail.id, refs);
-                const fresh = await getAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();
               } catch (err: any) {
@@ -859,7 +961,7 @@ export function PaymentsAdminPage() {
               setModalBusy(true);
               try {
                 await executeAdminPayout(detail.id, body);
-                const fresh = await getAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();
               } catch (err: any) {
@@ -894,14 +996,38 @@ export function PaymentsAdminPage() {
             // tagliatelle-49102: surface the actor's role so the modal can
             // gate the in-modal event_tags editor. `payment_admin` sees the
             // chips read-only; `admin` / `super_admin` get add + remove.
-            adminRole={role.kind === 'allowed' ? role.role : null}
+            // argentina-92103: underbosses pass `null` here so the tag
+            // editor stays read-only for them too.
+            adminRole={
+              role.kind === 'allowed' && role.role !== 'underboss' ? role.role : null
+            }
+            // argentina-92103: viewer-role threading. The modal hides
+            // Execute / Mark-paid for underbosses and surfaces the green
+            // Flag-ready button.
+            viewerRole={viewerKind}
+            onFlagReady={async () => {
+              setModalBusy(true);
+              try {
+                const fresh = await flagReadyForPayment(
+                  detail.id,
+                  regions ? { regions } : undefined,
+                );
+                setDetail(fresh);
+                await refresh();
+                return;
+              } catch (err: any) {
+                return err?.message || 'Flag failed';
+              } finally {
+                setModalBusy(false);
+              }
+            }}
             // tagliatelle-49102: after a tag mutation, refresh the payouts
             // list so the row picks up the new tag set (effective cap, etc.).
             // Re-fetch the modal detail too so its local `payout.party.eventTags`
             // stays in sync with anything the backend derives.
             onTagsChanged={async () => {
               try {
-                const fresh = await getAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
               } catch {
                 /* ignore — modal already updated its local state */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1801,7 +1801,25 @@ export interface ShippingPayout extends Payout {
 }
 
 // Admin-list payout: includes embedded party + host info
-export interface AdminPayout extends Payout {
+/**
+ * argentina-92103: per-payout "flagged ready for payment" signal.
+ *
+ * Set when a regional underboss (or any admin) clicks the "Flag ready for
+ * payment" button on PayoutReviewModal. Records an audit row and notifies
+ * the payments team via Telegram + email. The flag is sticky until invalidated
+ * by a downstream mark_paid / reject / unapprove audit on the same row, so
+ * the green icon stays visible on admins' /payments queue until they act on it.
+ *
+ * Fields are optional for backward-compat with cached responses during a
+ * rolling deploy — clients should treat `undefined` as `false`.
+ */
+export interface FlaggedReadyFields {
+  flaggedReady?: boolean;
+  flaggedReadyAt?: string | null;
+  flaggedReadyBy?: string | null;
+}
+
+export interface AdminPayout extends Payout, FlaggedReadyFields {
   party: {
     id: string;
     name: string;
@@ -1924,6 +1942,13 @@ export interface AdminPayoutFilters {
   country?: string;
   /** mascarpone-49102: event-tag filter — single tag "has" match on `parties.event_tags`. `'all'` / undefined = no filter. */
   tag?: string;
+  /**
+   * argentina-92103: regional scope for regional /payments portals (e.g.
+   * `/payments/latam` -> `['central-america','south-america']`). When set,
+   * only payouts whose `party.region` is in the list are returned. Used to
+   * gate regional underbosses to their region scope.
+   */
+  regions?: string[];
   currency?: string;
   /**
    * salumi-89172: Purpose filter — 'event' (host reimbursements) or

--- a/frontend/src/utils/regions.ts
+++ b/frontend/src/utils/regions.ts
@@ -1,0 +1,21 @@
+/**
+ * argentina-92103: Regional /payments portals.
+ *
+ * Each portal-slug maps to a fixed list of `parties.region` values the
+ * payments-admin queue should be filtered down to. The LATAM portal
+ * (`/payments/latam`) covers Central + South America so the LATAM
+ * underboss (`donmalbec.eth@gmail.com`) can review and approve every
+ * payout in his region without exposing the rest of the world.
+ */
+
+export const LATAM_REGIONS = ['central-america', 'south-america'] as const;
+
+export type PaymentsRegionPortal = 'latam';
+
+export const PAYMENTS_REGION_LABELS: Record<PaymentsRegionPortal, string> = {
+  latam: 'LATAM',
+};
+
+export const PAYMENTS_REGION_SCOPES: Record<PaymentsRegionPortal, readonly string[]> = {
+  latam: LATAM_REGIONS,
+};


### PR DESCRIPTION
## Summary
- New `/payments/latam` portal for the LATAM underboss; admins keep full /payments.
- LATAM UB can approve/reject/revert/cap-edit/notes; can't execute funds.
- New "Flag ready for payment" button writes audit + notifies payments team (Telegram + email).
- Green Flag icon surfaces flagged rows to admins on /payments.
- Hot Wallet card read-only for the UB.

## Env vars to set after merge
- `PAYMENTS_TEAM_TG_CHAT_ID` (single chat id; group or DM)
- `PAYMENTS_TEAM_EMAILS` (csv list)
Notifications silently no-op without these.

## Test plan
- [ ] Admin -> `/payments/latam` loads with full controls.
- [ ] donmalbec -> `/payments/latam` loads LATAM-only; no execute/bulk-send/external.
- [ ] UB approves -> audit row written + (with env vars) payments team notified.
- [ ] UB flags ready -> audit + notify + green flag icon on row.
- [ ] UB hits `/admin/payouts/:id/execute` directly -> 403.
- [ ] Random user -> 403.
- [ ] UB tries to approve out-of-region payout -> 403 OUT_OF_SCOPE.