### PR TITLE
pecorino-64118: explanatory note on Social Post Views KPI

### DIFF
--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -98,11 +98,11 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
     }
   } : undefined;
 
-  const statsDefs: { key: string; label: string; value: number | null | undefined; icon: React.ElementType; color: string; onAction?: () => void; actionIcon?: React.ElementType }[] = [
+  const statsDefs: { key: string; label: string; value: number | null | undefined; icon: React.ElementType; color: string; onAction?: () => void; actionIcon?: React.ElementType; note?: string }[] = [
     { key: 'pageViews', label: t('report.pageViews'), value: report.impressions.totalViews || null, icon: MousePointerClick, color: 'text-[#ff393a]' },
     { key: 'uniqueVisitors', label: t('report.uniqueVisitors'), value: report.impressions.uniqueVisitors || null, icon: Eye, color: 'text-[#ff393a]' },
     { key: 'linkClicks', label: t('report.linkClicks'), value: report.clickStats.totalClicks || null, icon: MousePointerClick, color: 'text-purple-400' },
-    { key: 'socialPostViews', label: t('report.socialPostViews'), value: report.stats.socialPostViews || null, icon: Eye, color: 'text-blue-400' },
+    { key: 'socialPostViews', label: t('report.socialPostViews'), value: report.stats.socialPostViews || null, icon: Eye, color: 'text-blue-400', note: t('report.socialPostViewsNote') },
     { key: 'socialPosts', label: t('report.socialPosts'), value: report.stats.socialPostCount || null, icon: FileText, color: 'text-blue-400' },
     { key: 'totalRsvps', label: t('report.totalRsvps'), value: report.stats.totalRsvps || null, icon: Users, color: 'text-green-400' },
     { key: 'newsletterSignups', label: t('report.newsletterSignups'), value: report.stats.mailingListSignups || null, icon: Mail, color: 'text-orange-400', onAction: downloadNewsletterEmails, actionIcon: Download },
@@ -150,6 +150,7 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
                 color={stat.color}
                 onAction={stat.onAction}
                 actionIcon={stat.actionIcon}
+                note={stat.note}
               />
             ))}
           </div>

--- a/frontend/src/components/report/ReportPreview.tsx
+++ b/frontend/src/components/report/ReportPreview.tsx
@@ -32,12 +32,12 @@ export function ReportPreview({ report, onClose, pageViewStats }: ReportPreviewP
     URL.revokeObjectURL(url);
   } : undefined;
 
-  const statsDefs: { key: string; label: string; autoValue: number | null | undefined; icon: React.ElementType; color: string; url?: string; onAction?: () => void; actionIcon?: React.ElementType }[] = [
+  const statsDefs: { key: string; label: string; autoValue: number | null | undefined; icon: React.ElementType; color: string; url?: string; onAction?: () => void; actionIcon?: React.ElementType; note?: string }[] = [
     ...(pageViewStats ? [
       { key: 'pageViews', label: t('report.pageViews'), autoValue: pageViewStats.totalViews, icon: MousePointerClick, color: 'text-[#ff393a]' },
       { key: 'uniqueVisitors', label: t('report.uniqueVisitors'), autoValue: pageViewStats.uniqueViews, icon: Eye, color: 'text-[#ff393a]' },
     ] : []),
-    { key: 'socialPostViews', label: t('report.socialPostViews'), autoValue: socialPostViews || null, icon: Eye, color: 'text-blue-400' },
+    { key: 'socialPostViews', label: t('report.socialPostViews'), autoValue: socialPostViews || null, icon: Eye, color: 'text-blue-400', note: t('report.socialPostViewsNote') },
     { key: 'socialPosts', label: t('report.socialPosts'), autoValue: socialPostCount || null, icon: FileText, color: 'text-blue-400' },
     { key: 'totalRsvps', label: t('report.totalRsvps'), autoValue: report.stats.totalRsvps, icon: Users, color: 'text-green-400' },
     { key: 'attendees', label: t('report.attendees'), autoValue: report.stats.approvedGuests, icon: Users, color: 'text-emerald-400' },
@@ -217,6 +217,7 @@ export function ReportPreview({ report, onClose, pageViewStats }: ReportPreviewP
                 url={stat.url}
                 onAction={stat.onAction}
                 actionIcon={stat.actionIcon}
+                note={stat.note}
               />
             ))}
           </div>

--- a/frontend/src/components/report/reportShared.tsx
+++ b/frontend/src/components/report/reportShared.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Building2, Globe } from 'lucide-react';
+import { Building2, Globe, Info } from 'lucide-react';
 import { NotableAttendee } from '../../types';
 import { extractEmailDomain, getDomainFaviconUrl } from '../../utils/emailUtils';
 
@@ -16,15 +16,23 @@ export interface KPICardProps {
   url?: string | null;
   onAction?: () => void;
   actionIcon?: React.ElementType;
+  note?: string;
 }
 
-export function KPICard({ label, value, icon: Icon, color, url, onAction, actionIcon: ActionIcon }: KPICardProps) {
+export function KPICard({ label, value, icon: Icon, color, url, onAction, actionIcon: ActionIcon, note }: KPICardProps) {
   const { t } = useTranslation('host');
   const content = (
     <div className="bg-theme-surface rounded-xl p-4 border border-theme-stroke">
       <div className="flex items-center gap-2 mb-2">
         <Icon size={16} className={color} />
-        <span className="text-xs text-theme-text-secondary flex-1">{label}</span>
+        <span className="text-xs text-theme-text-secondary flex-1 inline-flex items-center gap-1">
+          {label}
+          {note && (
+            <span title={note} aria-label={note} className="inline-flex items-center cursor-help">
+              <Info size={12} className="text-theme-text-muted flex-shrink-0" />
+            </span>
+          )}
+        </span>
         {onAction && ActionIcon && (
           <button
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); onAction(); }}

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "Aufrufe werden erfasst, wenn Besucher Ihre Eventseite laden",
     "stats": "Statistiken",
     "socialPostViews": "Social-Post-Aufrufe",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "Social Posts",
     "totalRsvps": "Gesamte RSVPs",
     "attendees": "Teilnehmer",

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -148,6 +148,7 @@
     "pageViewsTracked": "Views are tracked when visitors load your event page",
     "stats": "Stats",
     "socialPostViews": "Social Post Views",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "Social Posts",
     "totalRsvps": "Total RSVPs",
     "attendees": "Attendees",

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "Las vistas se registran cuando los visitantes cargan tu página de evento",
     "stats": "Estadísticas",
     "socialPostViews": "Vistas de Publicaciones",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "Publicaciones Sociales",
     "totalRsvps": "RSVPs Totales",
     "attendees": "Asistentes",

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "Les vues sont suivies lorsque les visiteurs chargent votre page d'événement",
     "stats": "Statistiques",
     "socialPostViews": "Vues des publications sociales",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "Publications sociales",
     "totalRsvps": "Total RSVPs",
     "attendees": "Participants",

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "訪問者がイベントページを読み込んだ時に閲覧が記録されます",
     "stats": "統計",
     "socialPostViews": "ソーシャル投稿閲覧数",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "ソーシャル投稿",
     "totalRsvps": "総RSVP数",
     "attendees": "参加者",

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "방문자가 이벤트 페이지를 로드하면 조회수가 추적됩니다",
     "stats": "통계",
     "socialPostViews": "소셜 포스트 조회수",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "소셜 포스트",
     "totalRsvps": "총 RSVP",
     "attendees": "참석자",

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "As visualizações são rastreadas quando visitantes carregam a página do seu evento",
     "stats": "Estatísticas",
     "socialPostViews": "Visualizações de Posts Sociais",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "Posts Sociais",
     "totalRsvps": "Total de RSVPs",
     "attendees": "Participantes",

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -111,6 +111,7 @@
     "pageViewsTracked": "当访客加载您的活动页面时会记录浏览量",
     "stats": "统计",
     "socialPostViews": "社交帖子浏览",
+    "socialPostViewsNote": "Only counts social posts that hosts submitted to this event's report — actual social impressions are likely much higher.",
     "socialPosts": "社交帖子",
     "totalRsvps": "总 RSVP 数",
     "attendees": "参与者",


### PR DESCRIPTION
Social Post Views KPI now has an info-tooltip explaining it only counts hand-submitted posts so undercounts. Frontend-only, no backend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)