### PR TITLE
fix(oliva-92103): BulkActionsBar no longer hides behind filter

### DIFF
--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -49,7 +49,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   // Send, Export Safe JSON. Approve / Reject stay visible.
   const showFundsActions = viewerRole === 'admin';
   return (
-    <div className="sticky top-[4rem] sm:top-[7rem] z-10 bg-theme-text/95 text-white rounded-xl px-3 py-2 sm:px-4 sm:py-3 mb-3 shadow-lg flex items-center gap-2 sm:gap-3 flex-wrap">
+    <div className="bg-theme-text/95 text-white rounded-xl px-3 py-2 sm:px-4 sm:py-3 mb-3 shadow-lg flex items-center gap-2 sm:gap-3 flex-wrap">
       <span className="text-sm font-medium">{selectedCount} selected</span>
       <div className="sm:ml-auto flex items-center gap-2 flex-wrap">
         <button


### PR DESCRIPTION
## Summary
- `BulkActionsBar` wrapper drops `sticky` + `top-*` classes.
- Filter bar stays sticky; bulk bar scrolls.
- No more visual overlap on either desktop or mobile.

## Test plan
- [ ] Desktop /payments → filter + bulk visible without overlap.
- [ ] Mobile → same.
- [ ] Scroll down → filter sticks, bulk scrolls away. Scroll up → both visible.