### PR TITLE
feat(arancino-92103): sort payouts by amount and submitted date

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1460,6 +1460,24 @@ router.get(
         ? req.query.cursor
         : undefined;
 
+      // arancino-92103: optional `?sort=` for the admin payouts queue. Default
+      // (`created_desc`) preserves the prior implicit ordering — non-sorting
+      // callers see no behavior change. Cursor pagination is keyed on
+      // `createdAt`, so when the caller picks a non-default sort we fall back
+      // to offset-based pagination (parses `cursor` as the offset count)
+      // instead of encoding cursors per orderBy.
+      const sortMap: Record<string, Prisma.PayoutOrderByWithRelationInput> = {
+        created_desc: { createdAt: 'desc' },
+        created_asc: { createdAt: 'asc' },
+        amount_desc: { finalAmountUsd: 'desc' },
+        amount_asc: { finalAmountUsd: 'asc' },
+      };
+      const sortKey = typeof req.query.sort === 'string' && sortMap[req.query.sort]
+        ? (req.query.sort as keyof typeof sortMap)
+        : 'created_desc';
+      const orderBy = sortMap[sortKey];
+      const useOffsetPagination = sortKey !== 'created_desc';
+
       const findArgs: any = {
         where,
         include: {
@@ -1470,12 +1488,19 @@ router.get(
             include: { uploadedBy: { select: { id: true, name: true, email: true } } },
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy,
         take: limit + 1,
       };
       if (cursor) {
-        findArgs.cursor = { id: cursor };
-        findArgs.skip = 1;
+        if (useOffsetPagination) {
+          const parsedOffset = parseInt(cursor, 10);
+          if (Number.isFinite(parsedOffset) && parsedOffset > 0) {
+            findArgs.skip = parsedOffset;
+          }
+        } else {
+          findArgs.cursor = { id: cursor };
+          findArgs.skip = 1;
+        }
       }
 
       const rows = await prisma.payout.findMany(findArgs);
@@ -1483,7 +1508,14 @@ router.get(
       let nextCursor: string | null = null;
       const page = rows.slice(0, limit);
       if (rows.length > limit) {
-        nextCursor = page[page.length - 1]?.id ?? null;
+        if (useOffsetPagination) {
+          // arancino-92103: encode cursor as the next offset so subsequent
+          // "load more" calls keep the same sort.
+          const currentOffset = typeof findArgs.skip === 'number' ? findArgs.skip : 0;
+          nextCursor = String(currentOffset + limit);
+        } else {
+          nextCursor = page[page.length - 1]?.id ?? null;
+        }
       }
 
       // Totals — computed over the filtered set (NOT just the current page),

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -49,6 +49,20 @@ const PURPOSE_OPTIONS: Array<{ value: PayoutPurpose | 'all'; label: string }> = 
   { value: 'shipping', label: 'Shipping' },
 ];
 
+// arancino-92103: sort order for the payouts list. `created_desc` is the
+// default (newest submitted first) and matches the prior implicit ordering.
+type SortValue = NonNullable<AdminPayoutFilters['sort']>;
+const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
+  { value: 'created_desc', label: 'Newest first' },
+  { value: 'created_asc', label: 'Oldest first' },
+  { value: 'amount_desc', label: 'Highest amount' },
+  { value: 'amount_asc', label: 'Lowest amount' },
+];
+const SORT_LABEL: Record<SortValue, string> = SORT_OPTIONS.reduce(
+  (acc, opt) => ({ ...acc, [opt.value]: opt.label }),
+  {} as Record<SortValue, string>,
+);
+
 /**
  * regina-89172: count active (non-default) filter fields. Status tab strip is
  * NOT counted here — it's always visible above the collapsible section, so
@@ -66,6 +80,9 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.purpose && filters.purpose !== 'all') n += 1;
   if (filters.dateFrom) n += 1;
   if (filters.dateTo) n += 1;
+  // arancino-92103: count sort as an active filter when it differs from
+  // the default `created_desc` (newest first).
+  if (filters.sort && filters.sort !== 'created_desc') n += 1;
   return n;
 }
 
@@ -141,7 +158,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         id="payouts-filter-controls"
         className={`${expanded ? 'block' : 'hidden'} sm:block`}
       >
-        <div className="grid grid-cols-1 md:grid-cols-8 gap-2 items-start">
+        <div className="grid grid-cols-1 md:grid-cols-9 gap-2 items-start">
           {/* salame-83472: unified search — host email|name OR party name. */}
           <div className="md:col-span-2">
             <IconInput
@@ -242,6 +259,22 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               ))}
             </select>
           </div>
+
+          {/* arancino-92103: Sort dropdown — controls the row order of the
+              payouts table. Default is `created_desc` (newest submitted
+              first), matching the prior implicit backend ordering. */}
+          <div>
+            <select
+              value={filters.sort ?? 'created_desc'}
+              onChange={(e) => update({ sort: e.target.value as SortValue })}
+              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+              aria-label="Sort payouts"
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>Sort: {opt.label}</option>
+              ))}
+            </select>
+          </div>
         </div>
 
         <div className="flex flex-col md:flex-row md:items-end gap-2 mt-3">
@@ -262,6 +295,14 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
               aria-label="Date to"
             />
+            {/* arancino-92103: surface non-default sort as a small chip so
+                admins notice the list is reordered. The dropdown above is
+                the canonical control; this chip is a read-only summary. */}
+            {filters.sort && filters.sort !== 'created_desc' && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-[#E52828]/10 text-[#E52828] text-xs font-medium">
+                Sort: {SORT_LABEL[filters.sort]}
+              </span>
+            )}
           </div>
           <button
             type="button"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4063,6 +4063,8 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.purpose && filters.purpose !== 'all') params.set('purpose', filters.purpose);
   if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
   if (filters.dateTo) params.set('dateTo', filters.dateTo);
+  // arancino-92103: sort order. Omit when default to keep URLs clean.
+  if (filters.sort && filters.sort !== 'created_desc') params.set('sort', filters.sort);
   if (filters.cursor) params.set('cursor', filters.cursor);
   if (filters.limit) params.set('limit', String(filters.limit));
   // argentina-92103: regional scope for /payments/latam (and any future

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -86,6 +86,9 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   // salumi-89172: purpose filter default — 'all' shows both event and
   // shipping payouts so the existing admin queue is unchanged out of box.
   purpose: 'all',
+  // arancino-92103: sort order default — newest submitted first. Matches the
+  // prior implicit backend ordering, so non-sorting callers see no change.
+  sort: 'created_desc',
 };
 
 // lardo-58294: substring filter shared between the search input and the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1961,6 +1961,12 @@ export interface AdminPayoutFilters {
   purpose?: PayoutPurpose | 'all';
   dateFrom?: string;
   dateTo?: string;
+  /**
+   * arancino-92103: sort order for the payouts queue. Default `created_desc`
+   * preserves prior implicit ordering. When non-default, the backend falls
+   * back to offset-based pagination (cursor is encoded as an offset count).
+   */
+  sort?: 'created_desc' | 'created_asc' | 'amount_desc' | 'amount_asc';
   cursor?: string;
   limit?: number;
 }


### PR DESCRIPTION
## Summary
- Backend: `GET /api/admin/payouts?sort=` accepts created_desc | created_asc | amount_desc | amount_asc.
- Frontend: new Sort dropdown in PayoutsFilterBar; threaded through types + api client + Reset Filters.

## Test plan
- [ ] Sort by amount desc → biggest amount on top.
- [ ] Sort by amount asc → smallest on top.
- [ ] Sort by oldest first → oldest createdAt on top.
- [ ] Default → newest-first (no regression).
- [ ] Reset filters returns sort to default.