### PR TITLE
feat(panettone-92103): mark party paid + admin no-recompute on PATCH

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,7 +52,7 @@ import hostTelegramRoutes from './routes/host-telegram.routes.js';
 import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
-import adminPayoutRoutes, { payoutWalletRouter } from './routes/admin-payout.routes.js';
+import adminPayoutRoutes, { payoutWalletRouter, partyMarkPaidRouter } from './routes/admin-payout.routes.js';
 import adminPartyRoutes from './routes/admin-party.routes.js';
 import graphicsAdminRoutes from './routes/graphics-admin.routes.js';
 import logoAuditRoutes from './routes/logoAudit.routes.js';
@@ -141,6 +141,7 @@ app.use('/api/rsvp', rsvpLimiter);
 app.use('/api/admin/logo-bg-audit', logoAuditRoutes); // Graphics-admin logo cleanup (before /api/admin catch-all)
 app.use('/api/admin/payouts', adminPayoutRoutes); // Host payouts admin dashboard (before /api/admin catch-all)
 app.use('/api/admin/payout-wallet', payoutWalletRouter); // coppa-91827: hot wallet address + balances (before /api/admin catch-all)
+app.use('/api/admin/parties', partyMarkPaidRouter); // panettone-92103: party-level "mark party paid" bulk action — before /api/admin catch-all
 app.use('/api/admin/parties', adminPartyRoutes); // fontina-91827: admin party-management routes (transfer ownership) — before /api/admin catch-all
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1724,6 +1724,19 @@ router.get(
 
 // ============================================
 // PATCH /api/admin/payouts/:id — edit amount / notes / method / target
+//
+// panettone-92103: admin PATCH NEVER auto-recomputes `finalAmountUsd` from the
+// child receipts' OCR sum. The admin's `finalAmountUsd` (if provided in the
+// body) is canonical; if it isn't provided, the existing `final_amount_usd`
+// is preserved as-is. OCR is informational once admin has set an amount.
+//
+// Why: when a receipt OCR'd at e.g. $1500 (mis-read) and admin then set
+// `finalAmountUsd = 200`, subsequent admin edits to OTHER fields (notes,
+// wallet, method) used to re-trigger an OCR recompute path that summed the
+// wrong OCR amounts back to $1500 and threw PER_SUBMISSION_CAP_EXCEEDED —
+// admin couldn't save notes. Host-side PATCH (`payout.routes.ts`) keeps the
+// OCR recompute since it's part of the host's in-progress upload UX
+// (provolone-39042: only on `pending` status anyway).
 // ============================================
 router.patch(
   '/:id',
@@ -3592,6 +3605,245 @@ payoutWalletRouter.get(
         usdcBalance: formatUnits(usdcRaw, 6),
         usdcBalanceUnits: usdcRaw.toString(),
         fetchedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ============================================
+// panettone-92103: party-level "mark party paid" bulk action.
+//
+// Exported as a separate Router (mounted at `/api/admin/parties` in
+// `index.ts`) so the URL is `POST /api/admin/parties/:partyId/mark-paid`.
+// Lives in this file to share the existing actor / audit / serialization
+// helpers with the rest of the admin-payout surface.
+//
+// Use case: admin paid the host the full amount out-of-band (Venmo, bank
+// wire, etc.) and wants to close out every in-flight payout for that party
+// in one click instead of clicking through each row.
+//
+// Auth: admin / super_admin / payment_admin (`requireAnyAdminOrPaymentAdmin`).
+// Regional underbosses are NOT allowed — funds-acknowledgement counts as a
+// funds-sending mutation, same gate as `mark-paid` / `execute`.
+// ============================================
+export const partyMarkPaidRouter = Router();
+
+const ALLOWED_MARK_PAID_METHODS = ['mercury_card', 'wire', 'usdc_base', 'external'] as const;
+
+/**
+ * GET /api/admin/parties/:partyId/mark-paid-preview
+ *
+ * Returns the in-flight (pending + approved) payout list + count + total for
+ * a party, so the MarkPartyPaidModal can render the impact summary before the
+ * admin confirms. Read-only; no mutations.
+ */
+partyMarkPaidRouter.get(
+  '/:partyId/mark-paid-preview',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { id: true, name: true },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      const payouts = await prisma.payout.findMany({
+        where: {
+          partyId,
+          status: { in: ['pending', 'approved'] },
+        },
+        select: {
+          id: true,
+          status: true,
+          finalAmountUsd: true,
+          payoutMethod: true,
+          host: { select: { id: true, name: true, email: true } },
+        },
+        orderBy: { createdAt: 'asc' },
+      });
+
+      const totalUsd = payouts.reduce(
+        (sum, p) => sum + Number(p.finalAmountUsd),
+        0,
+      );
+
+      res.json({
+        party: { id: party.id, name: party.name },
+        count: payouts.length,
+        totalUsd,
+        payouts: payouts.map((p) => ({
+          id: p.id,
+          status: p.status,
+          finalAmountUsd: Number(p.finalAmountUsd),
+          payoutMethod: p.payoutMethod ?? null,
+          hostName: p.host?.name ?? null,
+          hostEmail: p.host?.email ?? null,
+        })),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * POST /api/admin/parties/:partyId/mark-paid
+ *
+ * Body:
+ *   {
+ *     note?: string;       // shared admin note appended (with timestamp) to
+ *                          // each payout's admin_notes; also written to
+ *                          // payout_audit.note
+ *     paidMethod?: 'mercury_card' | 'wire' | 'usdc_base' | 'external';
+ *                          // optional; if set, stamps payout_method on each
+ *                          // row ONLY when currently null. Existing methods
+ *                          // are preserved so we don't lie about how an
+ *                          // already-routed payout was paid.
+ *   }
+ *
+ * Atomic via `prisma.$transaction`. For each in-flight payout on the party:
+ *   1. status -> 'paid'
+ *   2. paid_at -> now()
+ *   3. admin_notes: append "[YYYY-MM-DDTHH:MM:SS] <note>" on a new line
+ *      preserving any existing notes; no-op when note is missing/blank.
+ *   4. payout_method: set to `paidMethod` ONLY IF currently null. (External
+ *      payouts that had no on-platform method get stamped; existing methods
+ *      are left untouched.)
+ *   5. payout_audit row with action='mark_paid', old_status, new_status='paid'.
+ *
+ * Returns `{ count, party: { id, name }, payoutIds }`. count=0 with HTTP 200
+ * when there are no in-flight payouts to flip — not an error.
+ */
+partyMarkPaidRouter.post(
+  '/:partyId/mark-paid',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const actor = await loadActor(req);
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { id: true, name: true },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      const body = req.body || {};
+      const note =
+        typeof body.note === 'string' && body.note.trim() ? body.note.trim() : null;
+      const paidMethod =
+        typeof body.paidMethod === 'string' && body.paidMethod.trim()
+          ? body.paidMethod.trim()
+          : null;
+      if (paidMethod && !ALLOWED_MARK_PAID_METHODS.includes(paidMethod as any)) {
+        throw new AppError('Invalid paidMethod', 400, 'VALIDATION_ERROR');
+      }
+      // 'external' isn't a stored payoutMethod enum value — it's the modal's
+      // "leave unchanged / off-platform" sentinel. Treat it as "don't stamp
+      // a method" rather than persisting the literal string.
+      const methodToStamp = paidMethod && paidMethod !== 'external' ? paidMethod : null;
+
+      // Find all in-flight payouts BEFORE the transaction so we can do per-row
+      // self-payout checks + log a clean count even if zero match.
+      const inflight = await prisma.payout.findMany({
+        where: {
+          partyId,
+          status: { in: ['pending', 'approved'] },
+        },
+        select: {
+          id: true,
+          status: true,
+          hostUserId: true,
+          adminNotes: true,
+          payoutMethod: true,
+        },
+      });
+
+      if (inflight.length === 0) {
+        // Not an error — modal can render "0 payouts to mark paid".
+        res.json({
+          count: 0,
+          party: { id: party.id, name: party.name },
+          payoutIds: [],
+        });
+        return;
+      }
+
+      // Self-payout guard — payment_admin actors can't mark their own row
+      // paid. Even one self-row in the batch aborts the whole operation
+      // (atomic semantics; safer than silently skipping one row).
+      for (const p of inflight) {
+        assertNotSelfPayout(actor, p.hostUserId);
+      }
+
+      const now = new Date();
+      const noteTimestamp = now.toISOString();
+      const updatedIds: string[] = [];
+
+      await prisma.$transaction(async (tx) => {
+        for (const p of inflight) {
+          // Preserve existing admin_notes, append the bulk note with a
+          // timestamp on its own line so the trail is readable.
+          let nextAdminNotes: string | null | undefined = undefined;
+          if (note) {
+            const existing = p.adminNotes && p.adminNotes.trim() ? p.adminNotes : '';
+            const appended = `[${noteTimestamp}] ${note}`;
+            nextAdminNotes = existing
+              ? `${existing}\n${appended}`
+              : appended;
+          }
+
+          // Only stamp payoutMethod when (a) admin supplied one AND (b) the
+          // row currently has none. Preserves the truth of how routed rows
+          // were originally configured.
+          const shouldStampMethod = !!methodToStamp && !p.payoutMethod;
+
+          const data: any = {
+            status: 'paid',
+            paidAt: now,
+          };
+          if (nextAdminNotes !== undefined) {
+            data.adminNotes = nextAdminNotes;
+          }
+          if (shouldStampMethod) {
+            data.payoutMethod = methodToStamp;
+          }
+
+          await tx.payout.update({
+            where: { id: p.id },
+            data,
+          });
+
+          await tx.payoutAudit.create({
+            data: {
+              payoutId: p.id,
+              action: 'mark_paid',
+              oldStatus: p.status,
+              newStatus: 'paid',
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: note,
+            },
+          });
+
+          updatedIds.push(p.id);
+        }
+      });
+
+      res.json({
+        count: updatedIds.length,
+        party: { id: party.id, name: party.name },
+        payoutIds: updatedIds,
       });
     } catch (err) {
       next(err);

--- a/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
+++ b/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
@@ -1,0 +1,313 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { X, DollarSign, Loader2, Pencil, AlertTriangle } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import {
+  fetchMarkPartyPaidPreview,
+  markPartyPaid,
+  type MarkPartyPaidPreviewResponse,
+} from '../../lib/api';
+import type { PayoutMethod } from '../../types';
+
+/**
+ * parmigiana-58291: strip the "Global Pizza Party " prefix from event names
+ * everywhere this modal shows the party name. Same convention as PayoutRow,
+ * PrepayQueueTable, and CreatePrepaymentModal.
+ */
+function stripGppPrefix(name: string): string {
+  return name.replace(/^Global Pizza Party\s+/i, '');
+}
+
+type PaidMethodChoice = PayoutMethod | 'external' | 'unchanged';
+
+const METHOD_LABELS: Record<PaidMethodChoice, string> = {
+  unchanged: 'Leave method unchanged',
+  mercury_card: 'Mercury virtual card',
+  wire: 'Wire transfer',
+  usdc_base: 'USDC on Base',
+  external: 'External / off-platform',
+};
+
+interface MarkPartyPaidModalProps {
+  partyId: string;
+  /**
+   * Hint name for the modal header while the preview is loading. The
+   * authoritative name comes back in the preview response and overrides this
+   * once it lands.
+   */
+  partyNameHint?: string;
+  onClose: () => void;
+  /**
+   * Called after a successful mark-paid POST. Parent should refresh both the
+   * payouts list (so rows flip to paid) and the prepay queue (so the source
+   * party drops off). The summary lets the parent flash a city-specific toast.
+   */
+  onSuccess: (summary: { count: number; partyName: string }) => void;
+}
+
+/**
+ * panettone-92103: admin modal that flips every in-flight (pending + approved)
+ * payout for a single party to `paid` in one atomic transaction. Used when the
+ * admin paid the host the full amount out-of-band (Venmo / wire / etc.) and
+ * wants to close out everything without clicking through each row.
+ *
+ * On mount fetches the preview via `GET /api/admin/parties/:partyId/mark-paid-preview`
+ * so the modal renders accurate count + total + per-row breakdown before the
+ * admin confirms. Count=0 is a valid result — the modal renders a "nothing to
+ * mark paid" notice and disables the destructive button.
+ *
+ * The shared `note` is appended (with timestamp) to each row's `admin_notes`
+ * and also written to the per-row payout_audit entry. Optional `paidMethod`
+ * stamps on each payout's `payout_method` ONLY when currently null — existing
+ * methods are preserved server-side.
+ *
+ * Reversible: each row can be flipped back via the existing PayoutReviewModal
+ * "Revert to Pending" path (caprino-92103) — no confirm step here per project
+ * convention (feedback_reversible_actions_no_confirm).
+ */
+export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
+  partyId,
+  partyNameHint,
+  onClose,
+  onSuccess,
+}) => {
+  const [preview, setPreview] = useState<MarkPartyPaidPreviewResponse | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(true);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
+  const [note, setNote] = useState<string>(() => `Marked paid in bulk on ${today}`);
+  const [method, setMethod] = useState<PaidMethodChoice>('unchanged');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Esc to close — same pattern as CreatePrepaymentModal and PayoutReviewModal.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Pre-fetch the in-flight payout list so the body can render the impact
+  // summary before the admin confirms.
+  useEffect(() => {
+    let cancelled = false;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    fetchMarkPartyPaidPreview(partyId)
+      .then((res) => {
+        if (cancelled) return;
+        setPreview(res);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setPreviewError(err?.message || 'Failed to load preview');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setPreviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId]);
+
+  const partyName = preview?.party.name ?? partyNameHint ?? 'this event';
+  const cityName = stripGppPrefix(partyName);
+  const count = preview?.count ?? 0;
+  const totalUsd = preview?.totalUsd ?? 0;
+
+  const canSubmit = !!preview && count > 0 && !submitting && !previewLoading;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const trimmedNote = note.trim();
+      const body: { note?: string; paidMethod?: PayoutMethod | 'external' } = {};
+      if (trimmedNote) body.note = trimmedNote;
+      if (method !== 'unchanged') body.paidMethod = method;
+      const res = await markPartyPaid(partyId, body);
+      onSuccess({ count: res.count, partyName: cityName });
+      onClose();
+    } catch (err: any) {
+      setSubmitError(err?.message || 'Failed to mark party paid');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-theme-surface rounded-2xl shadow-2xl border border-theme-stroke w-full max-w-[95vw] sm:max-w-lg max-h-[95vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-semibold text-theme-text truncate">
+              Mark party paid: {cityName}
+            </h2>
+            <p className="text-xs text-theme-text-muted mt-0.5">
+              Flips every pending + approved payout for this event to paid.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-muted"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* Preview summary */}
+          {previewLoading && (
+            <div className="flex items-center gap-2 text-sm text-theme-text-muted">
+              <Loader2 size={14} className="animate-spin" />
+              Loading in-flight payouts...
+            </div>
+          )}
+          {previewError && !previewLoading && (
+            <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{previewError}</span>
+            </div>
+          )}
+          {preview && !previewLoading && (
+            <div>
+              <div className="rounded-lg border border-theme-stroke bg-theme-surface-hover p-3">
+                <div className="flex items-baseline justify-between gap-3">
+                  <div className="text-xs uppercase tracking-wide text-theme-text-muted">
+                    In-flight payouts
+                  </div>
+                  <div className="text-sm text-theme-text">
+                    <span className="font-semibold">{count}</span>
+                    {count > 0 && (
+                      <>
+                        {' '}for a total of{' '}
+                        <span className="font-semibold">${totalUsd.toFixed(2)}</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                {count === 0 ? (
+                  <p className="text-xs text-theme-text-muted mt-2">
+                    Nothing to mark paid — every payout for this event is already
+                    paid, rejected, or withdrawn.
+                  </p>
+                ) : (
+                  <ul className="mt-2 space-y-1 text-xs text-theme-text-secondary">
+                    {preview.payouts.map((p) => (
+                      <li key={p.id} className="flex items-baseline gap-2">
+                        <span className="text-theme-text-muted uppercase text-[10px] tracking-wide w-16 flex-shrink-0">
+                          {p.status}
+                        </span>
+                        <span className="flex-1 truncate">
+                          {p.hostName ?? p.hostEmail ?? 'Unknown host'}
+                        </span>
+                        <span className="font-medium text-theme-text">
+                          ${p.finalAmountUsd.toFixed(2)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Shared note */}
+          <IconInput
+            icon={Pencil}
+            multiline
+            rows={3}
+            placeholder="Shared admin note (appended to each row's admin_notes)"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            maxLength={500}
+          />
+
+          {/* Optional method override */}
+          <div>
+            <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
+              Payout method (optional)
+            </div>
+            <div className="space-y-1.5">
+              {(Object.keys(METHOD_LABELS) as PaidMethodChoice[]).map((k) => {
+                const active = method === k;
+                return (
+                  <label
+                    key={k}
+                    className={`flex items-center gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-colors ${
+                      active
+                        ? 'border-emerald-500 bg-emerald-500/10'
+                        : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="paidMethod"
+                      value={k}
+                      checked={active}
+                      onChange={() => setMethod(k)}
+                    />
+                    <span className="text-sm text-theme-text">{METHOD_LABELS[k]}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <p className="text-xs text-theme-text-muted mt-1">
+              Only stamps the method on payouts that don't already have one —
+              existing methods are preserved.
+            </p>
+          </div>
+
+          {submitError && (
+            <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{submitError}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-theme-stroke px-5 py-3 flex items-center justify-end gap-2 bg-theme-surface">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-theme-text-secondary hover:bg-theme-surface-hover text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
+          >
+            {submitting ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <DollarSign size={14} />
+            )}
+            {count > 0
+              ? `Mark ${count} payment${count === 1 ? '' : 's'} paid ($${totalUsd.toFixed(2)})`
+              : 'Mark party paid'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag, Coins } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
@@ -138,6 +138,13 @@ interface PayoutReviewModalProps {
    * render it inline.
    */
   onFlagReady?: () => Promise<string | void> | string | void;
+  /**
+   * panettone-92103: open MarkPartyPaidModal for this payout's party so the
+   * admin can flip every in-flight (pending + approved) payout on the event
+   * to paid in one transaction. Hidden for underbosses (admin-only handler).
+   * Parent owns the modal state.
+   */
+  onMarkPartyPaid?: () => void;
   busy?: boolean;
 }
 
@@ -160,6 +167,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onTagsChanged,
   viewerRole = 'admin',
   onFlagReady,
+  onMarkPartyPaid,
   busy = false,
 }) => {
   // argentina-92103: underbosses lose Execute/Mark-paid affordances. The
@@ -1625,6 +1633,23 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 Flag ready for payment
               </button>
             )
+          )}
+          {/* panettone-92103: party-level "Mark party paid" — flips every
+              in-flight payout on this payout's party to paid in one
+              transaction. Less-prominent (border + dim text) so it sits
+              behind the per-row primary actions; admin-only. The modal
+              fetches its own preview (count + total) on open. */}
+          {isAdminViewer && onMarkPartyPaid && (
+            <button
+              type="button"
+              onClick={onMarkPartyPaid}
+              disabled={busy || selfPayoutBlocked}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 text-sm font-medium disabled:opacity-50"
+              title={`Mark every in-flight payout on ${stripGppPrefix(payout.party.name)} paid (out-of-band reconciliation)`}
+            >
+              <Coins size={14} />
+              Mark all paid for {stripGppPrefix(payout.party.name)}
+            </button>
           )}
           <button
             type="button"

--- a/frontend/src/components/payments-admin/PrepayQueueTable.tsx
+++ b/frontend/src/components/payments-admin/PrepayQueueTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { AlertTriangle, Star } from 'lucide-react';
+import { AlertTriangle, Star, DollarSign } from 'lucide-react';
 import type { PrepayCandidate, PrepayQueueRow } from '../../types';
 import { PayoutMethodIcon, PAYOUT_METHOD_LABELS, CapInlineEditor } from '../payments-shared';
 
@@ -25,6 +25,12 @@ interface PrepayQueueTableProps {
    * a funds-sending operation reserved for admins.
    */
   viewerRole?: 'admin' | 'underboss';
+  /**
+   * panettone-92103: open MarkPartyPaidModal for the given row. Admin paid
+   * the host out-of-band (Venmo / wire / etc.) and wants to close out every
+   * in-flight payout in one click. Hidden for underbosses — funds-sending.
+   */
+  onMarkPartyPaid?: (row: PrepayQueueRow) => void;
 }
 
 /**
@@ -124,10 +130,14 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
   onHostClick,
   onPartyUpdated,
   viewerRole = 'admin',
+  onMarkPartyPaid,
 }) => {
   // argentina-92103: hide the "Create prepayment" button for underbosses
   // — creating a prepayment is funds-sending and stays admin-only.
   const canCreatePrepayment = viewerRole === 'admin';
+  // panettone-92103: same gate for "Mark party paid" — it flips rows to
+  // paid which is a funds-acknowledgement action reserved for admins.
+  const canMarkPartyPaid = viewerRole === 'admin' && !!onMarkPartyPaid;
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
       {/* regina-89172: mobile card list (<640px). Each row becomes a stacked
@@ -189,15 +199,28 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                     onUpdated={() => onPartyUpdated?.(row.party.id)}
                   />
                 </div>
-                {canCreatePrepayment && (
-                  <button
-                    type="button"
-                    onClick={() => onCreatePrepayment(row)}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium shrink-0"
-                  >
-                    Create prepayment
-                  </button>
-                )}
+                <div className="flex items-center gap-2 shrink-0">
+                  {canMarkPartyPaid && onMarkPartyPaid && (
+                    <button
+                      type="button"
+                      onClick={() => onMarkPartyPaid(row)}
+                      className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-red-500/50 text-red-300 hover:bg-red-500/10 text-xs font-medium"
+                      title="Mark every in-flight payout for this event as paid (out-of-band reconciliation)"
+                    >
+                      <DollarSign size={12} />
+                      Mark paid
+                    </button>
+                  )}
+                  {canCreatePrepayment && (
+                    <button
+                      type="button"
+                      onClick={() => onCreatePrepayment(row)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
+                    >
+                      Create prepayment
+                    </button>
+                  )}
+                </div>
               </div>
             </li>
           );
@@ -280,15 +303,28 @@ export const PrepayQueueTable: React.FC<PrepayQueueTableProps> = ({
                     />
                   </td>
                   <td className="px-3 py-3 align-top text-right">
-                    {canCreatePrepayment && (
-                      <button
-                        type="button"
-                        onClick={() => onCreatePrepayment(row)}
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
-                      >
-                        Create prepayment
-                      </button>
-                    )}
+                    <div className="inline-flex items-center gap-2 flex-wrap justify-end">
+                      {canMarkPartyPaid && onMarkPartyPaid && (
+                        <button
+                          type="button"
+                          onClick={() => onMarkPartyPaid(row)}
+                          className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-red-500/50 text-red-300 hover:bg-red-500/10 text-xs font-medium"
+                          title="Mark every in-flight payout for this event as paid (out-of-band reconciliation)"
+                        >
+                          <DollarSign size={12} />
+                          Mark paid
+                        </button>
+                      )}
+                      {canCreatePrepayment && (
+                        <button
+                          type="button"
+                          onClick={() => onCreatePrepayment(row)}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
+                        >
+                          Create prepayment
+                        </button>
+                      )}
+                    </div>
                   </td>
                 </tr>
               );

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -6,6 +6,7 @@ export { BulkActionsBar } from './BulkActionsBar';
 export { ExternalPaymentModal } from './ExternalPaymentModal';
 export { PrepayQueueTable } from './PrepayQueueTable';
 export { CreatePrepaymentModal } from './CreatePrepaymentModal';
+export { MarkPartyPaidModal } from './MarkPartyPaidModal';
 export { HostPaymentDetailsModal } from './HostPaymentDetailsModal';
 export { ExportSafeJsonModal } from './ExportSafeJsonModal';
 export { BulkSendModal } from './BulkSendModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4252,6 +4252,68 @@ export async function markAdminPayoutPaid(
 }
 
 /**
+ * panettone-92103: party-level "mark party paid" preview. Returns the in-flight
+ * (pending + approved) payouts for a party so MarkPartyPaidModal can render
+ * the count + total + per-row breakdown before the admin confirms. Read-only.
+ */
+export interface MarkPartyPaidPreviewPayout {
+  id: string;
+  status: 'pending' | 'approved';
+  finalAmountUsd: number;
+  payoutMethod: PayoutMethod | null;
+  hostName: string | null;
+  hostEmail: string | null;
+}
+
+export interface MarkPartyPaidPreviewResponse {
+  party: { id: string; name: string };
+  count: number;
+  totalUsd: number;
+  payouts: MarkPartyPaidPreviewPayout[];
+}
+
+export async function fetchMarkPartyPaidPreview(
+  partyId: string,
+): Promise<MarkPartyPaidPreviewResponse> {
+  return apiRequest<MarkPartyPaidPreviewResponse>(
+    `/api/admin/parties/${partyId}/mark-paid-preview`,
+  );
+}
+
+/**
+ * panettone-92103: flip every in-flight (pending + approved) payout on a
+ * party to `paid` in one atomic transaction. Used when the admin paid the
+ * host the full amount out-of-band (Venmo / wire / etc.) and wants to close
+ * out everything in one click.
+ *
+ * `note` is appended to each row's `admin_notes` with a timestamp and also
+ * written to the per-row payout_audit row.
+ *
+ * `paidMethod` ('external' means "leave method unchanged") stamps the chosen
+ * method on rows whose `payout_method` is currently null. Existing methods
+ * are preserved so we don't lie about how an already-routed payout was paid.
+ *
+ * Returns `{ count, party, payoutIds }`. count=0 (HTTP 200) when there are no
+ * in-flight payouts — modal renders "0 payouts to mark paid".
+ */
+export async function markPartyPaid(
+  partyId: string,
+  body?: {
+    note?: string;
+    paidMethod?: PayoutMethod | 'external';
+  },
+): Promise<{ count: number; party: { id: string; name: string }; payoutIds: string[] }> {
+  return apiRequest<{
+    count: number;
+    party: { id: string; name: string };
+    payoutIds: string[];
+  }>(`/api/admin/parties/${partyId}/mark-paid`, {
+    method: 'POST',
+    body: body ?? {},
+  });
+}
+
+/**
  * Execute an approved payout (PR 5). Body shape is method-specific:
  *   - usdc_base    → no body required; server sends via Privy server-wallet
  *   - wire         → { wireReference: string } REQUIRED

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -43,6 +43,7 @@ import {
   BulkSendModal,
   RejectReasonModal,
   HotWalletCard,
+  MarkPartyPaidModal,
 } from '../components/payments-admin';
 import type { BulkSendResult } from '../lib/api';
 
@@ -146,6 +147,14 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   // bismarck-92103: prepay queue + the "Create prepayment" modal target row.
   const [prepayQueue, setPrepayQueue] = useState<PrepayQueueRow[]>([]);
   const [prepayModalRow, setPrepayModalRow] = useState<PrepayQueueRow | null>(null);
+
+  // panettone-92103: "Mark party paid" modal target. Holds the partyId +
+  // a hint name so the modal header can render the city while the preview
+  // request is in flight.
+  const [markPartyPaidTarget, setMarkPartyPaidTarget] = useState<
+    | { partyId: string; partyNameHint: string }
+    | null
+  >(null);
 
   // lardo-58294: local-only substring filter for the prepay queue. Cleared
   // on tab refresh — no persistence.
@@ -787,6 +796,12 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 onHostClick={(userId) => setHostDetailUserId(userId)}
                 onPartyUpdated={() => loadPrepayQueue()}
                 viewerRole={viewerKind}
+                onMarkPartyPaid={(row) =>
+                  setMarkPartyPaidTarget({
+                    partyId: row.party.id,
+                    partyNameHint: row.party.name,
+                  })
+                }
               />
             )}
           </section>
@@ -1021,6 +1036,16 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 setModalBusy(false);
               }
             }}
+            // panettone-92103: open MarkPartyPaidModal pre-targeted at this
+            // payout's party so the admin can flip every in-flight payout on
+            // the event in one click. Admin-only (PayoutReviewModal already
+            // gates this on viewerRole='admin').
+            onMarkPartyPaid={() =>
+              setMarkPartyPaidTarget({
+                partyId: detail.partyId,
+                partyNameHint: detail.party.name,
+              })
+            }
             // tagliatelle-49102: after a tag mutation, refresh the payouts
             // list so the row picks up the new tag set (effective cap, etc.).
             // Re-fetch the modal detail too so its local `payout.party.eventTags`
@@ -1048,6 +1073,39 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             row={prepayModalRow}
             onClose={() => setPrepayModalRow(null)}
             onCreated={handlePrepaymentCreated}
+          />
+        )}
+
+        {/* panettone-92103: party-level "Mark party paid" modal. Refreshes
+            BOTH the payouts list (so flipped rows show paid) and the prepay
+            queue (so the source party drops off). If the review modal was
+            open over this party, refresh its detail too so the admin sees
+            the rows reflect the new state. */}
+        {markPartyPaidTarget && (
+          <MarkPartyPaidModal
+            partyId={markPartyPaidTarget.partyId}
+            partyNameHint={markPartyPaidTarget.partyNameHint}
+            onClose={() => setMarkPartyPaidTarget(null)}
+            onSuccess={async ({ count, partyName }) => {
+              pushToast(
+                count > 0
+                  ? `Marked ${count} payment${count === 1 ? '' : 's'} paid for ${partyName}`
+                  : `No in-flight payouts for ${partyName} — nothing changed`,
+                'success',
+              );
+              await Promise.all([refresh(), loadPrepayQueue()]);
+              if (detail && detail.partyId === markPartyPaidTarget.partyId) {
+                try {
+                  const fresh = await getAdminPayout(
+                    detail.id,
+                    regions ? { regions } : undefined,
+                  );
+                  setDetail(fresh);
+                } catch {
+                  /* non-fatal */
+                }
+              }
+            }}
           />
         )}
 


### PR DESCRIPTION
## Summary
### Part A
- New admin endpoint `POST /api/admin/parties/:partyId/mark-paid` flips all pending+approved payouts on the party to `paid`, atomic, audit per row.
- New `MarkPartyPaidModal` opens from PrepayQueueTable row + PayoutReviewModal footer.

### Part B
- Admin PATCH no longer auto-recomputes `finalAmountUsd` from OCR receipts. Fixes the case where wrong-OCR amounts blocked notes/wallet edits with PER_SUBMISSION_CAP_EXCEEDED.
- Host PATCH unchanged.

## Test plan
- [ ] Mark Party Paid on a party with 3 pending + 1 approved → 4 rows flip to paid; audit rows written.
- [ ] Mark Party Paid on a party with 0 in-flight → no-op, modal succeeds with count=0.
- [ ] Admin edits notes on a $200 payout (OCR=$1500, over cap) → save succeeds.
- [ ] Admin sets explicit `finalAmountUsd=$700` → cap check fires + ack checkbox appears (aglio).
- [ ] Host PATCH with receipt changes → still auto-recomputes (regression check).