### PR TITLE
feat(etruria-92103): /payments table groups by city by default

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1436,6 +1436,232 @@ router.post(
 );
 
 // ============================================
+// GET /api/admin/payouts/by-party — etruria-92103
+//
+// Group-by-city view of the /payments admin queue. Same filters as the LIST
+// endpoint scope the underlying payouts BEFORE grouping; the response shape is
+// one row per Party with per-status counts/sums + receipt count + last
+// activity, plus the underlying AdminPayout[] for the expansion section.
+//
+// Auth chain mirrors GET /:  admin/payment-admin OR regional underboss via
+// `?regions=`. Funds-sending affordances stay admin-only and aren't reachable
+// from this endpoint anyway.
+//
+// Literal `/by-party` MUST be declared before `/:id` so the literal path wins
+// on route matching.
+// ============================================
+router.get(
+  '/by-party',
+  requireAuth,
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const where = buildPayoutWhere(req.query);
+
+      // 1. Fetch every payout matching the filter set — no skip cursor in v1.
+      //    Same include shape as the LIST endpoint so `serializePayout` returns
+      //    a consistent AdminPayout. Ordered DESC by createdAt so the inner
+      //    payouts array per party is already newest-first.
+      const payoutRows = await prisma.payout.findMany({
+        where,
+        include: {
+          party: { select: PAYOUT_PARTY_SELECT },
+          host: { select: { id: true, name: true, email: true } },
+          documents: {
+            orderBy: { sortOrder: 'asc' },
+            include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      // 2. Per-party paid totals + flag-ready signal — same augmentation as
+      //    the LIST endpoint so the embedded AdminPayout rows match shape.
+      const uniquePartyIds = Array.from(
+        new Set(
+          payoutRows
+            .map((p) => (p as any).party?.id)
+            .filter((id): id is string => typeof id === 'string' && id.length > 0),
+        ),
+      );
+      const [pagePaidTotals, pageFlagged] = await Promise.all([
+        fetchPaidTotalsByParty(uniquePartyIds),
+        fetchFlaggedReadyByPayoutId(payoutRows.map((p) => p.id)),
+      ]);
+
+      // 3. Per-party receipt count from payout_documents (kind='receipt'). One
+      //    batched groupBy over every party id present in the filtered set.
+      const receiptCounts = new Map<string, number>();
+      if (uniquePartyIds.length > 0) {
+        const docRows = await prisma.payoutDocument.groupBy({
+          by: ['partyId'],
+          where: { partyId: { in: uniquePartyIds }, kind: 'receipt' },
+          _count: { id: true },
+        });
+        for (const r of docRows) {
+          receiptCounts.set(r.partyId, r._count.id);
+        }
+      }
+
+      // 4. Group payouts by partyId in JS. Sum amounts by status, take the
+      //    most recent updatedAt, count flagged-ready, capture the party meta
+      //    from the first row encountered (PAYOUT_PARTY_SELECT is identical
+      //    across rows in the same party).
+      type Bucket = {
+        partyMeta: any;
+        pendingCount: number;
+        pendingUsd: number;
+        approvedCount: number;
+        approvedUsd: number;
+        paidCount: number;
+        paidUsd: number;
+        rejectedCount: number;
+        rejectedUsd: number;
+        failedCount: number;
+        failedUsd: number;
+        withdrawnCount: number;
+        withdrawnUsd: number;
+        flaggedReadyCount: number;
+        lastActivityAt: Date;
+        payouts: any[]; // raw Prisma rows; serialized below
+      };
+
+      const buckets = new Map<string, Bucket>();
+
+      for (const row of payoutRows) {
+        const partyMeta = (row as any).party;
+        if (!partyMeta) continue;
+        const partyId = partyMeta.id;
+        const usd = Number(row.finalAmountUsd);
+        let b = buckets.get(partyId);
+        if (!b) {
+          b = {
+            partyMeta,
+            pendingCount: 0, pendingUsd: 0,
+            approvedCount: 0, approvedUsd: 0,
+            paidCount: 0, paidUsd: 0,
+            rejectedCount: 0, rejectedUsd: 0,
+            failedCount: 0, failedUsd: 0,
+            withdrawnCount: 0, withdrawnUsd: 0,
+            flaggedReadyCount: 0,
+            lastActivityAt: row.updatedAt,
+            payouts: [],
+          };
+          buckets.set(partyId, b);
+        }
+        if (row.updatedAt > b.lastActivityAt) b.lastActivityAt = row.updatedAt;
+        switch (row.status) {
+          case 'pending':
+            b.pendingCount += 1; b.pendingUsd += usd; break;
+          case 'approved':
+            b.approvedCount += 1; b.approvedUsd += usd; break;
+          case 'paid':
+            b.paidCount += 1; b.paidUsd += usd; break;
+          case 'rejected':
+            b.rejectedCount += 1; b.rejectedUsd += usd; break;
+          case 'failed':
+            b.failedCount += 1; b.failedUsd += usd; break;
+          case 'withdrawn':
+            b.withdrawnCount += 1; b.withdrawnUsd += usd; break;
+        }
+        if (pageFlagged.has(row.id)) b.flaggedReadyCount += 1;
+        b.payouts.push(row);
+      }
+
+      // 5. Serialize. Reuse `serializePayout` for the inner AdminPayout array
+      //    so the embedded rows are byte-identical to the LIST endpoint's. Also
+      //    apply the same per-party paidTotal + flag-ready augmentation so
+      //    PayoutRow renders the "Already paid" caption + the green flag icon
+      //    inside the expansion.
+      const rows = Array.from(buckets.values()).map((b) => {
+        const partyId = b.partyMeta.id;
+        const totals = pagePaidTotals.get(partyId);
+        const serializedPayouts = b.payouts.map((p) => {
+          const sp = serializePayout(p);
+          if (sp.party?.id) {
+            sp.party.paidTotalUsd = totals?.paidUsd ?? 0;
+            sp.party.paidTotalCount = totals?.paidCount ?? 0;
+          }
+          const flag = pageFlagged.get(sp.id);
+          if (flag) {
+            sp.flaggedReady = true;
+            sp.flaggedReadyAt = flag.at;
+            sp.flaggedReadyBy = flag.by;
+          }
+          return sp;
+        });
+
+        return {
+          party: {
+            id: partyId,
+            name: b.partyMeta.name,
+            customUrl: b.partyMeta.customUrl ?? null,
+            inviteCode: b.partyMeta.inviteCode ?? null,
+            country: b.partyMeta.country ?? null,
+            // region isn't on PAYOUT_PARTY_SELECT; surface null so frontend
+            // doesn't depend on it (party object also rendered in expansion).
+            region: null as string | null,
+            effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+              reimbursementCapUsd: b.partyMeta.reimbursementCapUsd,
+              eventTags: b.partyMeta.eventTags,
+            }),
+            eventTags: Array.isArray(b.partyMeta.eventTags) ? b.partyMeta.eventTags : [],
+            primaryHostInCohosts: isPrimaryHostInCohosts(b.partyMeta),
+            userId: b.partyMeta.userId ?? null,
+          },
+          aggregates: {
+            pendingCount: b.pendingCount,
+            pendingUsd: b.pendingUsd,
+            approvedCount: b.approvedCount,
+            approvedUsd: b.approvedUsd,
+            paidCount: b.paidCount,
+            paidUsd: b.paidUsd,
+            rejectedCount: b.rejectedCount,
+            rejectedUsd: b.rejectedUsd,
+            failedCount: b.failedCount,
+            failedUsd: b.failedUsd,
+            withdrawnCount: b.withdrawnCount,
+            withdrawnUsd: b.withdrawnUsd,
+            totalReceiptCount: receiptCounts.get(partyId) ?? 0,
+            lastActivityAt: b.lastActivityAt.toISOString(),
+            flaggedReadyCount: b.flaggedReadyCount,
+          },
+          payouts: serializedPayouts,
+        };
+      });
+
+      // 6. Sort outer rows. Default: most recent activity desc. The same
+      //    `sort` query param shape is supported as the LIST endpoint for
+      //    forward-compat, but only a handful of keys make sense at the
+      //    party-row level — fall back to activity-desc for unknown values.
+      const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : 'activity_desc';
+      rows.sort((a, b) => {
+        switch (sortRaw) {
+          case 'amount_desc':
+            return (b.aggregates.pendingUsd + b.aggregates.approvedUsd + b.aggregates.paidUsd)
+                 - (a.aggregates.pendingUsd + a.aggregates.approvedUsd + a.aggregates.paidUsd);
+          case 'amount_asc':
+            return (a.aggregates.pendingUsd + a.aggregates.approvedUsd + a.aggregates.paidUsd)
+                 - (b.aggregates.pendingUsd + b.aggregates.approvedUsd + b.aggregates.paidUsd);
+          case 'name_asc':
+            return a.party.name.localeCompare(b.party.name);
+          case 'name_desc':
+            return b.party.name.localeCompare(a.party.name);
+          case 'activity_desc':
+          default:
+            return new Date(b.aggregates.lastActivityAt).getTime()
+                 - new Date(a.aggregates.lastActivityAt).getTime();
+        }
+      });
+
+      res.json({ rows, total: rows.length });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
 // GET /api/admin/payouts — list with filters + totals + cursor pagination
 // ============================================
 router.get(

--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -3,6 +3,13 @@ import { Check, X, DollarSign, Loader2, FileJson, Send } from 'lucide-react';
 
 interface BulkActionsBarProps {
   selectedCount: number;
+  /**
+   * etruria-92103: when the page is in by-city view, also pass the number of
+   * distinct cities (parties) the current selection spans so the label reads
+   * "N payments across M cities selected". Omitted (or 0) reverts to the
+   * existing "N selected" label.
+   */
+  selectedCityCount?: number;
   onApprove: () => void;
   onReject: () => void;
   onMarkPaid: () => void;
@@ -34,6 +41,7 @@ interface BulkActionsBarProps {
 
 export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   selectedCount,
+  selectedCityCount,
   onApprove,
   onReject,
   onMarkPaid,
@@ -48,9 +56,16 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   // argentina-92103: underbosses can't send funds — hide Mark Paid, Bulk
   // Send, Export Safe JSON. Approve / Reject stay visible.
   const showFundsActions = viewerRole === 'admin';
+  // etruria-92103: in by-city view, surface "N payments across M cities
+  // selected" so admins understand that their selection lives at the
+  // payment level (not the party level).
+  const label =
+    selectedCityCount && selectedCityCount > 0
+      ? `${selectedCount} payment${selectedCount === 1 ? '' : 's'} across ${selectedCityCount} cit${selectedCityCount === 1 ? 'y' : 'ies'} selected`
+      : `${selectedCount} selected`;
   return (
     <div className="bg-theme-text/95 text-white rounded-xl px-3 py-2 sm:px-4 sm:py-3 mb-3 shadow-lg flex items-center gap-2 sm:gap-3 flex-wrap">
-      <span className="text-sm font-medium">{selectedCount} selected</span>
+      <span className="text-sm font-medium">{label}</span>
       <div className="sm:ml-auto flex items-center gap-2 flex-wrap">
         <button
           type="button"

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -1,0 +1,373 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Paperclip,
+  Flag,
+  Check,
+  X,
+  Pencil,
+  Eye,
+  DollarSign,
+  Send,
+  Undo2,
+} from 'lucide-react';
+import type { AdminPayout, PartyPayoutsRow, PayoutStatus } from '../../types';
+import { PayoutRow } from '../payments-shared';
+
+/**
+ * etruria-92103: group-by-city view of /payments. Top-level rows show one
+ * party with status aggregates + receipt count + last activity. Click the
+ * chevron (or the row) to expand and render the underlying payouts using the
+ * shared `PayoutRow` primitive — same actions, same review-modal handlers as
+ * the per-payment view.
+ *
+ * Row selection (Bulk Send / Mark Paid / Export Safe JSON) lives on the
+ * INNER payouts inside the expansion — selecting a whole party doesn't make
+ * sense as a bulk action and would surprise admins.
+ */
+
+interface PayoutsByPartyTableProps {
+  rows: PartyPayoutsRow[];
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  /** Opens the per-payout review modal (same shape as PayoutsTable). */
+  onRowClick: (payout: AdminPayout) => void;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  onEdit: (payout: AdminPayout) => void;
+  onMarkPaid: (payout: AdminPayout) => void;
+  onExecute: (payout: AdminPayout) => void;
+  onUnapprove?: (id: string) => void;
+  onHostClick?: (userId: string) => void;
+  onCapUpdated?: (partyId: string) => void;
+  busyRowId?: string | null;
+  loading?: boolean;
+}
+
+function stripGppPrefix(name: string): string {
+  return name.replace(/^Global Pizza Party\s+/i, '');
+}
+
+function relativeTime(date: Date): string {
+  const diff = Date.now() - date.getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
+
+/** Status-dependent action menu rendered in the expanded inner row's trailing cell. */
+function InnerActionsCell({
+  payout,
+  busy,
+  onApprove,
+  onReject,
+  onEdit,
+  onMarkPaid,
+  onExecute,
+  onUnapprove,
+}: {
+  payout: AdminPayout;
+  busy: boolean;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  onEdit: (payout: AdminPayout) => void;
+  onMarkPaid: (payout: AdminPayout) => void;
+  onExecute: (payout: AdminPayout) => void;
+  onUnapprove?: (id: string) => void;
+}) {
+  const status: PayoutStatus = payout.status;
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onEdit(payout)}
+        className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-secondary"
+        title="View / Edit"
+        disabled={busy}
+      >
+        <Eye size={15} />
+      </button>
+
+      {status === 'pending' && (
+        <>
+          <button
+            type="button"
+            onClick={() => onApprove(payout.id)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
+            title="Approve"
+          >
+            {busy ? <Loader2 size={15} className="animate-spin" /> : <Check size={15} />}
+          </button>
+          <button
+            type="button"
+            onClick={() => onReject(payout.id)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-red-50 text-red-600 disabled:opacity-50"
+            title="Reject"
+          >
+            <X size={15} />
+          </button>
+          <button
+            type="button"
+            onClick={() => onEdit(payout)}
+            className="p-1.5 rounded-md hover:bg-theme-surface-hover text-theme-text-secondary"
+            title="Edit amount"
+            disabled={busy}
+          >
+            <Pencil size={15} />
+          </button>
+        </>
+      )}
+
+      {(status === 'approved' || status === 'failed') && (
+        <>
+          <button
+            type="button"
+            onClick={() => onExecute(payout)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-emerald-50 text-emerald-600 disabled:opacity-50"
+            title={status === 'failed' ? 'Retry Payment' : 'Execute Payment'}
+          >
+            {busy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
+          </button>
+          {status === 'approved' && onUnapprove && (
+            <button
+              type="button"
+              onClick={() => onUnapprove(payout.id)}
+              disabled={busy}
+              className="p-1.5 rounded-md hover:bg-amber-50 text-amber-600 disabled:opacity-50"
+              title="Revert to Pending"
+            >
+              <Undo2 size={15} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => onMarkPaid(payout)}
+            disabled={busy}
+            className="p-1.5 rounded-md hover:bg-blue-50 text-blue-600 disabled:opacity-50"
+            title="Mark paid (manual)"
+          >
+            <DollarSign size={15} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
+  rows,
+  selectedIds,
+  onToggleSelect,
+  onRowClick,
+  onApprove,
+  onReject,
+  onEdit,
+  onMarkPaid,
+  onExecute,
+  onUnapprove,
+  onHostClick,
+  onCapUpdated,
+  busyRowId,
+  loading,
+}) => {
+  // Default state: all collapsed. Tracks `party.id`s the admin has expanded.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggleExpanded(partyId: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(partyId)) next.delete(partyId);
+      else next.add(partyId);
+      return next;
+    });
+  }
+
+  return (
+    <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead>
+            <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
+              <th className="px-3 py-3 w-10"></th>
+              <th className="px-3 py-3 font-medium">Event</th>
+              <th className="px-3 py-3 font-medium">Pending</th>
+              <th className="px-3 py-3 font-medium">Approved</th>
+              <th className="px-3 py-3 font-medium">Paid</th>
+              <th className="px-3 py-3 font-medium">Receipts</th>
+              <th className="px-3 py-3 font-medium">Last activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-12 text-center text-theme-text-muted">
+                  <Loader2 size={20} className="inline-block animate-spin mr-2" />
+                  Loading payments…
+                </td>
+              </tr>
+            )}
+            {!loading && rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-12 text-center text-theme-text-faint">
+                  No events match these filters.
+                </td>
+              </tr>
+            )}
+            {rows.map((row) => {
+              const isOpen = expanded.has(row.party.id);
+              const partySlug = row.party.customUrl ?? row.party.inviteCode ?? '';
+              return (
+                <React.Fragment key={row.party.id}>
+                  {/* Outer party row */}
+                  <tr
+                    className="border-b border-theme-stroke transition-colors cursor-pointer hover:bg-theme-surface-hover"
+                    onClick={() => toggleExpanded(row.party.id)}
+                  >
+                    <td className="px-3 py-3 w-10 text-theme-text-muted">
+                      {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                    </td>
+                    <td className="px-3 py-3 text-sm min-w-[12rem]">
+                      {partySlug ? (
+                        <Link
+                          to={`/host/${partySlug}/details`}
+                          className="font-medium text-theme-text hover:text-[#E52828] hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {stripGppPrefix(row.party.name)}
+                        </Link>
+                      ) : (
+                        <span className="font-medium text-theme-text">
+                          {stripGppPrefix(row.party.name)}
+                        </span>
+                      )}
+                      {row.party.country && (
+                        <div className="text-xs text-theme-text-muted">{row.party.country}</div>
+                      )}
+                      {row.aggregates.flaggedReadyCount > 0 && (
+                        <div
+                          className="inline-flex items-center gap-1 text-[11px] text-emerald-500 mt-0.5"
+                          title={`${row.aggregates.flaggedReadyCount} payment${row.aggregates.flaggedReadyCount === 1 ? '' : 's'} flagged ready for payment`}
+                        >
+                          <Flag size={11} />
+                          {row.aggregates.flaggedReadyCount} flagged ready
+                        </div>
+                      )}
+                    </td>
+                    <td
+                      className={`px-3 py-3 text-sm ${
+                        row.aggregates.pendingCount > 0 ? 'text-amber-500 font-medium' : 'text-theme-text-faint'
+                      }`}
+                    >
+                      {row.aggregates.pendingCount > 0
+                        ? `${row.aggregates.pendingCount} · $${row.aggregates.pendingUsd.toFixed(2)}`
+                        : '—'}
+                    </td>
+                    <td
+                      className={`px-3 py-3 text-sm ${
+                        row.aggregates.approvedCount > 0 ? 'text-sky-500 font-medium' : 'text-theme-text-faint'
+                      }`}
+                    >
+                      {row.aggregates.approvedCount > 0
+                        ? `${row.aggregates.approvedCount} · $${row.aggregates.approvedUsd.toFixed(2)}`
+                        : '—'}
+                    </td>
+                    <td
+                      className={`px-3 py-3 text-sm ${
+                        row.aggregates.paidCount > 0 ? 'text-emerald-500 font-medium' : 'text-theme-text-faint'
+                      }`}
+                    >
+                      {row.aggregates.paidCount > 0
+                        ? `${row.aggregates.paidCount} · $${row.aggregates.paidUsd.toFixed(2)}`
+                        : '—'}
+                    </td>
+                    <td className="px-3 py-3 text-sm text-theme-text-secondary">
+                      {row.aggregates.totalReceiptCount > 0 ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Paperclip size={12} className="text-theme-text-muted" />
+                          {row.aggregates.totalReceiptCount}
+                        </span>
+                      ) : (
+                        <span className="text-theme-text-faint">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-sm text-theme-text-secondary">
+                      <div title={new Date(row.aggregates.lastActivityAt).toLocaleString()}>
+                        {relativeTime(new Date(row.aggregates.lastActivityAt))}
+                      </div>
+                    </td>
+                  </tr>
+
+                  {/* Expanded inner payouts — same PayoutRow primitive as the
+                      per-payment view, indented with a left border. */}
+                  {isOpen && row.payouts.length > 0 && (
+                    <tr>
+                      <td colSpan={7} className="p-0 bg-theme-surface/40">
+                        <div className="border-l-4 border-theme-stroke ml-3 pl-2">
+                          <table className="w-full min-w-[600px] text-sm">
+                            <thead>
+                              <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
+                                <th className="px-3 py-2 w-10"></th>
+                                <th className="px-3 py-2 w-14"></th>
+                                <th className="px-3 py-2 font-medium">Host</th>
+                                <th className="px-3 py-2 font-medium">Party</th>
+                                <th className="px-3 py-2 font-medium">Submitted</th>
+                                <th className="px-3 py-2 font-medium">Amount</th>
+                                <th className="px-3 py-2 font-medium">Method</th>
+                                <th className="px-3 py-2 font-medium">Status</th>
+                                <th className="px-3 py-2 font-medium text-right">Actions</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {row.payouts.map((p) => (
+                                <PayoutRow
+                                  key={p.id}
+                                  payout={p}
+                                  showAdminColumns
+                                  selectable
+                                  selected={selectedIds.has(p.id)}
+                                  onSelectToggle={() => onToggleSelect(p.id)}
+                                  onClick={() => onRowClick(p)}
+                                  onHostClick={onHostClick}
+                                  onCapUpdated={onCapUpdated}
+                                  actions={
+                                    <InnerActionsCell
+                                      payout={p}
+                                      busy={busyRowId === p.id}
+                                      onApprove={onApprove}
+                                      onReject={onReject}
+                                      onEdit={onEdit}
+                                      onMarkPaid={onMarkPaid}
+                                      onExecute={onExecute}
+                                      onUnapprove={onUnapprove}
+                                    />
+                                  }
+                                />
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -1,5 +1,6 @@
 export { PayoutsFilterBar } from './PayoutsFilterBar';
 export { PayoutsTable } from './PayoutsTable';
+export { PayoutsByPartyTable } from './PayoutsByPartyTable';
 export { PayoutReviewModal } from './PayoutReviewModal';
 export { PaymentsStatsCards } from './PaymentsStatsCards';
 export { BulkActionsBar } from './BulkActionsBar';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse } from '../types';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -4086,6 +4086,21 @@ function regionsQuery(regions?: string[]): string {
 
 export async function listAdminPayouts(filters?: AdminPayoutFilters): Promise<AdminPayoutsResponse> {
   return apiRequest<AdminPayoutsResponse>(`/api/admin/payouts${buildPayoutQuery(filters)}`);
+}
+
+/**
+ * etruria-92103: group-by-city view of the /payments admin queue. Reuses
+ * `buildPayoutQuery` so every filter scopes the underlying payouts BEFORE the
+ * server groups them. Returns one row per party with status aggregates +
+ * receipt count + last activity, plus the underlying AdminPayouts so the
+ * expansion section can render with the existing PayoutRow.
+ */
+export async function fetchPayoutsByParty(
+  filters?: AdminPayoutFilters,
+): Promise<PartyPayoutsResponse> {
+  return apiRequest<PartyPayoutsResponse>(
+    `/api/admin/payouts/by-party${buildPayoutQuery(filters)}`,
+  );
 }
 
 export async function getAdminPayout(

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -7,6 +7,7 @@ import {
   fetchAdminMe,
   fetchUnderbossMe,
   listAdminPayouts,
+  fetchPayoutsByParty,
   getAdminPayout,
   approveAdminPayout,
   rejectAdminPayout,
@@ -25,6 +26,7 @@ import type {
   AdminPayoutDetail,
   AdminPayoutFilters,
   AdminPayoutTotals,
+  PartyPayoutsRow,
   PrepayQueueRow,
   PrepayCandidate,
 } from '../types';
@@ -32,6 +34,7 @@ import { formatUsd } from '../components/payments-shared';
 import {
   PayoutsFilterBar,
   PayoutsTable,
+  PayoutsByPartyTable,
   PayoutReviewModal,
   PaymentsStatsCards,
   BulkActionsBar,
@@ -120,7 +123,40 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   const [filters, setFilters] = useState<AdminPayoutFilters>(() =>
     regions ? { ...DEFAULT_FILTERS, regions } : DEFAULT_FILTERS,
   );
+
+  // etruria-92103: primary view is `by-city` (one row per party with status
+  // aggregates, click to expand). `by-payment` keeps the existing per-row
+  // view available as a fallback. The choice persists in localStorage so an
+  // admin's preference sticks across reloads. Falls back to `by-city` on
+  // first visit OR if the stored value is corrupted.
+  type ViewMode = 'by-city' | 'by-payment';
+  const VIEW_MODE_LS_KEY = 'paymentsAdminViewMode';
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (typeof window === 'undefined') return 'by-city';
+    try {
+      const stored = window.localStorage.getItem(VIEW_MODE_LS_KEY);
+      if (stored === 'by-city' || stored === 'by-payment') return stored;
+    } catch {
+      /* localStorage disabled (Safari private etc.) — fall through */
+    }
+    return 'by-city';
+  });
+  // Persist on change. Guarded against localStorage failures so private-mode
+  // browsing doesn't crash the page.
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(VIEW_MODE_LS_KEY, viewMode);
+    } catch {
+      /* ignore */
+    }
+  }, [viewMode]);
+
   const [payouts, setPayouts] = useState<AdminPayout[]>([]);
+  // etruria-92103: by-city grouped rows from /by-party. Empty when viewing
+  // the per-payment list. `byPartyRows` and `payouts` are populated by the
+  // same loader (`loadPage`) so the rest of the page can read from whichever
+  // is active.
+  const [byPartyRows, setByPartyRows] = useState<PartyPayoutsRow[]>([]);
   const [totals, setTotals] = useState<AdminPayoutTotals | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -263,10 +299,21 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         // argentina-92103: always re-inject the portal's region scope so a
         // user clearing filters can't accidentally fetch the global queue.
         const merged = regions ? { ...f, regions } : f;
-        const res = await listAdminPayouts(merged);
-        setPayouts((prev) => (append ? [...prev, ...res.payouts] : res.payouts));
-        setTotals(res.totals);
-        setNextCursor(res.nextCursor);
+        // etruria-92103: when by-city is active, ALSO fetch the grouped
+        // shape from /by-party so the new table can render. The per-payment
+        // list is still fetched so:
+        //   1. Stats cards / totals / bulk-selection still work identically.
+        //   2. Toggling back to by-payment is instant (no extra fetch).
+        // append (load-more) only applies to the per-payment list; by-city
+        // returns all matching parties in one go (v1).
+        const listRes = await listAdminPayouts(merged);
+        setPayouts((prev) => (append ? [...prev, ...listRes.payouts] : listRes.payouts));
+        setTotals(listRes.totals);
+        setNextCursor(listRes.nextCursor);
+        if (!append && viewMode === 'by-city') {
+          const grouped = await fetchPayoutsByParty(merged);
+          setByPartyRows(grouped.rows);
+        }
       } catch (err: any) {
         setErrorMsg(err.message || 'Failed to load payments');
       } finally {
@@ -274,7 +321,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         else setLoading(false);
       }
     },
-    [regions],
+    [regions, viewMode],
   );
 
   // Re-load when filters change (and we're allowed)
@@ -339,6 +386,19 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     () => payouts.filter((p) => selectedIds.has(p.id)),
     [payouts, selectedIds],
   );
+
+  // etruria-92103: in by-city view, surface how many distinct cities (parties)
+  // the current selection spans so the BulkActionsBar can render "N payments
+  // across M cities selected". Derived from `selectedPayouts` so it stays in
+  // sync with the same source of truth.
+  const selectedCityCount = useMemo(() => {
+    if (viewMode !== 'by-city') return 0;
+    const partyIds = new Set<string>();
+    for (const p of selectedPayouts) {
+      if (p.party?.id) partyIds.add(p.party.id);
+    }
+    return partyIds.size;
+  }, [selectedPayouts, viewMode]);
 
   // salsiccia-49102: count of selected payouts eligible for bulk USDC send.
   // Mirrors the backend filter (usdc_base + approved/failed + valid 0x
@@ -801,8 +861,49 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           availableTags={availableTags}
         />
 
+        {/* etruria-92103: by-city / by-payment view toggle. by-city is the
+            default; the choice persists in localStorage. Lives on its own
+            row above the bulk-actions bar so it doesn't fight the filter
+            bar's sticky position. */}
+        <div className="flex items-center justify-end gap-2 mb-3">
+          <span className="text-xs uppercase tracking-wide text-theme-text-muted">View:</span>
+          <div
+            role="tablist"
+            aria-label="Payments view mode"
+            className="inline-flex rounded-lg overflow-hidden border border-theme-stroke bg-theme-surface"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={viewMode === 'by-city'}
+              onClick={() => setViewMode('by-city')}
+              className={`px-3 py-1.5 text-sm font-medium ${
+                viewMode === 'by-city'
+                  ? 'bg-emerald-600 text-white'
+                  : 'text-theme-text-muted hover:bg-theme-surface-hover'
+              }`}
+            >
+              By city
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={viewMode === 'by-payment'}
+              onClick={() => setViewMode('by-payment')}
+              className={`px-3 py-1.5 text-sm font-medium ${
+                viewMode === 'by-payment'
+                  ? 'bg-emerald-600 text-white'
+                  : 'text-theme-text-muted hover:bg-theme-surface-hover'
+              }`}
+            >
+              By payment
+            </button>
+          </div>
+        </div>
+
         <BulkActionsBar
           selectedCount={selectedIds.size}
+          selectedCityCount={selectedCityCount}
           onApprove={handleBulkApprove}
           onReject={handleBulkReject}
           onMarkPaid={handleBulkMarkPaid}
@@ -820,26 +921,51 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           </div>
         )}
 
-        <PayoutsTable
-          payouts={payouts}
-          selectedIds={selectedIds}
-          onToggleSelect={toggleSelect}
-          onToggleSelectAll={toggleSelectAll}
-          onRowClick={openDetail}
-          onApprove={handleRowApprove}
-          onReject={handleRowReject}
-          onEdit={openDetail}
-          onMarkPaid={handleRowMarkPaid}
-          onExecute={openDetail}
-          onUnapprove={handleRowUnapprove}
-          onHostClick={(userId) => setHostDetailUserId(userId)}
-          onCapUpdated={() => refresh()}
-          busyRowId={rowBusyId}
-          loading={loading}
-          loadingMore={loadingMore}
-          onLoadMore={() => loadPage({ ...filters, cursor: nextCursor || undefined }, true)}
-          hasMore={!!nextCursor}
-        />
+        {/* etruria-92103: render the by-city table when toggled on; the
+            per-payment table is the fallback view + the "old" experience for
+            admins who prefer the flat list. Both share the same handlers /
+            selection state. Bulk-action selection still operates on per-
+            payment ids — selecting a whole party doesn't make sense as a
+            bulk-action concept, so selection lives inside the expansion. */}
+        {viewMode === 'by-city' ? (
+          <PayoutsByPartyTable
+            rows={byPartyRows}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleSelect}
+            onRowClick={openDetail}
+            onApprove={handleRowApprove}
+            onReject={handleRowReject}
+            onEdit={openDetail}
+            onMarkPaid={handleRowMarkPaid}
+            onExecute={openDetail}
+            onUnapprove={handleRowUnapprove}
+            onHostClick={(userId) => setHostDetailUserId(userId)}
+            onCapUpdated={() => refresh()}
+            busyRowId={rowBusyId}
+            loading={loading}
+          />
+        ) : (
+          <PayoutsTable
+            payouts={payouts}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleSelect}
+            onToggleSelectAll={toggleSelectAll}
+            onRowClick={openDetail}
+            onApprove={handleRowApprove}
+            onReject={handleRowReject}
+            onEdit={openDetail}
+            onMarkPaid={handleRowMarkPaid}
+            onExecute={openDetail}
+            onUnapprove={handleRowUnapprove}
+            onHostClick={(userId) => setHostDetailUserId(userId)}
+            onCapUpdated={() => refresh()}
+            busyRowId={rowBusyId}
+            loading={loading}
+            loadingMore={loadingMore}
+            onLoadMore={() => loadPage({ ...filters, cursor: nextCursor || undefined }, true)}
+            hasMore={!!nextCursor}
+          />
+        )}
 
         {detailLoading && (
           <div className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm flex items-center justify-center">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2051,3 +2051,59 @@ export interface OcrPreviewResult {
   fxSource: 'jsdelivr' | 'frankfurter' | 'fallback' | 'usd-passthrough' | 'unknown';
   conversionNote?: string;
 }
+
+/**
+ * etruria-92103: one row of the by-city payments table — `GET
+ * /api/admin/payouts/by-party`. Top-level rows are one per party; click the
+ * chevron to expand and see the underlying AdminPayout[] (rendered with the
+ * same PayoutRow primitive as the per-payment view).
+ *
+ * The filters that scope the LIST endpoint (status / country / region /
+ * purpose / search / dateRange) all scope the underlying payouts BEFORE this
+ * aggregation runs — a party with no pending payouts simply doesn't appear in
+ * the queue when "Pending" is selected.
+ */
+export interface PartyPayoutsRow {
+  party: {
+    id: string;
+    name: string;
+    customUrl: string | null;
+    /** Mirrors `party.inviteCode` so the frontend can build `/host/:slug` links. */
+    inviteCode: string | null;
+    country: string | null;
+    /** Optional — backend currently surfaces null since the value isn't on PAYOUT_PARTY_SELECT. */
+    region: string | null;
+    effectiveReimbursementCapUsd: number | null;
+    eventTags: string[];
+    primaryHostInCohosts: boolean;
+    /** Primary host (parties.userId). */
+    userId: string | null;
+  };
+  aggregates: {
+    pendingCount: number;
+    pendingUsd: number;
+    approvedCount: number;
+    approvedUsd: number;
+    paidCount: number;
+    paidUsd: number;
+    rejectedCount: number;
+    rejectedUsd: number;
+    failedCount: number;
+    failedUsd: number;
+    withdrawnCount: number;
+    withdrawnUsd: number;
+    /** payout_documents rows where kind='receipt' for this party. */
+    totalReceiptCount: number;
+    /** ISO timestamp — max(updated_at) across this party's payouts. */
+    lastActivityAt: string;
+    /** Count of payouts whose sticky `flaggedReady` is currently true (argentina-92103). */
+    flaggedReadyCount: number;
+  };
+  /** Underlying AdminPayouts for this party, scoped to the same filters. */
+  payouts: AdminPayout[];
+}
+
+export interface PartyPayoutsResponse {
+  rows: PartyPayoutsRow[];
+  total: number;
+}


### PR DESCRIPTION
## Summary
- New `GET /api/admin/payouts/by-party` endpoint aggregates payouts by party with per-status counts/sums + receipt count + last activity.
- New `PayoutsByPartyTable` renders the grouped view; chevron expands to show the underlying payouts (reuses existing PayoutRow).
- Toggle in PaymentsAdminPage: `By city` (new default) / `By payment` (existing). Persisted in localStorage.
- Filters scope the underlying payouts before aggregation.
- No schema, no migration.

## Test plan
- [ ] Default view shows one row per party with aggregate counts.
- [ ] Toggle to By payment -> existing per-row view.
- [ ] Status=Pending filter -> only parties with pending; expansion shows only pending rows.
- [ ] Click a party row -> expands inline; click again -> collapses.
- [ ] PayoutRow inside expansion still opens PayoutReviewModal correctly.
- [ ] localStorage persistence: refresh keeps last choice.