### PR TITLE
fix(caciotta-92103): Mark Party Paid reconciles instead of double-counting

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -4002,10 +4002,38 @@ partyMarkPaidRouter.get(
         0,
       );
 
+      // caciotta-92103: also surface the already-paid payouts on this party so
+      // the modal can warn about double-counting. If the host was already paid
+      // out-of-band (recorded as a separate paid row), marking the pending
+      // claim paid would inflate /payments totals.
+      const existingPaid = await prisma.payout.findMany({
+        where: {
+          partyId,
+          status: 'paid',
+        },
+        select: { id: true, finalAmountUsd: true },
+      });
+      const existingPaidCount = existingPaid.length;
+      const existingPaidUsd = existingPaid.reduce(
+        (sum, p) => sum + Number(p.finalAmountUsd),
+        0,
+      );
+
+      // Recommend `withdraw_pending` when the already-paid bucket fully
+      // covers what we'd otherwise create as new paid rows. Otherwise
+      // `mark_paid` (the legacy behavior).
+      const suggestedMode: 'mark_paid' | 'withdraw_pending' =
+        existingPaidCount > 0 && existingPaidUsd >= totalUsd
+          ? 'withdraw_pending'
+          : 'mark_paid';
+
       res.json({
         party: { id: party.id, name: party.name },
         count: payouts.length,
         totalUsd,
+        existingPaidCount,
+        existingPaidUsd,
+        suggestedMode,
         payouts: payouts.map((p) => ({
           id: p.id,
           status: p.status,
@@ -4026,6 +4054,25 @@ partyMarkPaidRouter.get(
  *
  * Body:
  *   {
+ *     mode?: 'mark_paid' | 'withdraw_pending' | 'auto';
+ *                          // caciotta-92103: how to close out the in-flight
+ *                          // rows.
+ *                          //   'mark_paid' — legacy behavior: every pending
+ *                          //     + approved row flips to status='paid'.
+ *                          //     Creates new paid amounts on /payments.
+ *                          //   'withdraw_pending' — soft-withdraw via
+ *                          //     status='withdrawn' (ravioli-82931). Used
+ *                          //     when an external paid row is already on the
+ *                          //     party and the pending claims are
+ *                          //     duplicates. Does NOT create new paid
+ *                          //     amounts. Receipts stay attached to the
+ *                          //     party (payout_documents.party_id
+ *                          //     unchanged).
+ *                          //   'auto' (default) — picks 'withdraw_pending'
+ *                          //     when the party already has paid payouts
+ *                          //     whose sum >= the pending+approved being
+ *                          //     acted on; else 'mark_paid'. Prevents
+ *                          //     double-counting external payments.
  *     note?: string;       // shared admin note appended (with timestamp) to
  *                          // each payout's admin_notes; also written to
  *                          // payout_audit.note
@@ -4033,21 +4080,37 @@ partyMarkPaidRouter.get(
  *                          // optional; if set, stamps payout_method on each
  *                          // row ONLY when currently null. Existing methods
  *                          // are preserved so we don't lie about how an
- *                          // already-routed payout was paid.
+ *                          // already-routed payout was paid. Only relevant
+ *                          // for 'mark_paid' — ignored for
+ *                          // 'withdraw_pending'.
  *   }
  *
  * Atomic via `prisma.$transaction`. For each in-flight payout on the party:
- *   1. status -> 'paid'
- *   2. paid_at -> now()
- *   3. admin_notes: append "[YYYY-MM-DDTHH:MM:SS] <note>" on a new line
- *      preserving any existing notes; no-op when note is missing/blank.
- *   4. payout_method: set to `paidMethod` ONLY IF currently null. (External
- *      payouts that had no on-platform method get stamped; existing methods
- *      are left untouched.)
- *   5. payout_audit row with action='mark_paid', old_status, new_status='paid'.
  *
- * Returns `{ count, party: { id, name }, payoutIds }`. count=0 with HTTP 200
- * when there are no in-flight payouts to flip — not an error.
+ *   mode='mark_paid':
+ *     1. status -> 'paid'
+ *     2. paid_at -> now()
+ *     3. admin_notes: append "[YYYY-MM-DDTHH:MM:SS] <note>" on a new line
+ *        preserving any existing notes; no-op when note is missing/blank.
+ *     4. payout_method: set to `paidMethod` ONLY IF currently null. (External
+ *        payouts that had no on-platform method get stamped; existing methods
+ *        are left untouched.)
+ *     5. payout_audit row with action='mark_paid', old_status, new_status='paid'.
+ *
+ *   mode='withdraw_pending':
+ *     1. status -> 'withdrawn'
+ *     2. paid_at / payout_method UNCHANGED — the row was never actually paid;
+ *        it's being reconciled against an already-recorded external payment.
+ *     3. admin_notes: append "[YYYY-MM-DDTHH:MM:SS] Withdrawn during Mark
+ *        Party Paid reconciliation; <note>" on a new line.
+ *     4. payout_audit row with action='cancel' (the valid enum value used by
+ *        ravioli-82931's host-side withdraw — there is no 'withdraw' action
+ *        in the check constraint), old_status, new_status='withdrawn'.
+ *
+ * Returns `{ count, mode, party: { id, name }, payoutIds }`. count=0 with
+ * HTTP 200 when there are no in-flight payouts to flip — not an error.
+ * `mode` is the resolved mode (auto -> mark_paid or withdraw_pending) so
+ * the frontend can render the correct success toast.
  */
 partyMarkPaidRouter.post(
   '/:partyId/mark-paid',
@@ -4081,6 +4144,16 @@ partyMarkPaidRouter.post(
       // a method" rather than persisting the literal string.
       const methodToStamp = paidMethod && paidMethod !== 'external' ? paidMethod : null;
 
+      // caciotta-92103: mode selector. Default 'auto' picks withdraw_pending
+      // when the party already has enough paid rows to cover the in-flight
+      // sum (prevents double-counting after an external payment was
+      // recorded). Otherwise it falls through to the legacy mark_paid path.
+      const rawMode = typeof body.mode === 'string' ? body.mode.trim() : 'auto';
+      if (!['mark_paid', 'withdraw_pending', 'auto'].includes(rawMode)) {
+        throw new AppError('Invalid mode', 400, 'VALIDATION_ERROR');
+      }
+      const requestedMode = rawMode as 'mark_paid' | 'withdraw_pending' | 'auto';
+
       // Find all in-flight payouts BEFORE the transaction so we can do per-row
       // self-payout checks + log a clean count even if zero match.
       const inflight = await prisma.payout.findMany({
@@ -4094,13 +4167,39 @@ partyMarkPaidRouter.post(
           hostUserId: true,
           adminNotes: true,
           payoutMethod: true,
+          finalAmountUsd: true,
         },
       });
+
+      // Resolve 'auto' to a concrete mode. Even at count=0 we resolve so the
+      // response carries a meaningful `mode` value.
+      let resolvedMode: 'mark_paid' | 'withdraw_pending';
+      if (requestedMode === 'auto') {
+        const inflightUsd = inflight.reduce(
+          (sum, p) => sum + Number(p.finalAmountUsd),
+          0,
+        );
+        const existingPaid = await prisma.payout.findMany({
+          where: { partyId, status: 'paid' },
+          select: { finalAmountUsd: true },
+        });
+        const existingPaidUsd = existingPaid.reduce(
+          (sum, p) => sum + Number(p.finalAmountUsd),
+          0,
+        );
+        resolvedMode =
+          existingPaid.length > 0 && existingPaidUsd >= inflightUsd
+            ? 'withdraw_pending'
+            : 'mark_paid';
+      } else {
+        resolvedMode = requestedMode;
+      }
 
       if (inflight.length === 0) {
         // Not an error — modal can render "0 payouts to mark paid".
         res.json({
           count: 0,
+          mode: resolvedMode,
           party: { id: party.id, name: party.name },
           payoutIds: [],
         });
@@ -4110,6 +4209,10 @@ partyMarkPaidRouter.post(
       // Self-payout guard — payment_admin actors can't mark their own row
       // paid. Even one self-row in the batch aborts the whole operation
       // (atomic semantics; safer than silently skipping one row).
+      // Applies to both modes: withdraw_pending of one's own pending row is
+      // a permission concern too (a payment_admin shouldn't close out their
+      // own claim against an externally-paid row without a second pair of
+      // eyes).
       for (const p of inflight) {
         assertNotSelfPayout(actor, p.hostUserId);
       }
@@ -4121,48 +4224,88 @@ partyMarkPaidRouter.post(
       await prisma.$transaction(async (tx) => {
         for (const p of inflight) {
           // Preserve existing admin_notes, append the bulk note with a
-          // timestamp on its own line so the trail is readable.
+          // timestamp on its own line so the trail is readable. For the
+          // withdraw_pending path we prefix the note so the audit trail
+          // makes clear *why* a pending row was withdrawn (vs a host
+          // self-withdraw via ravioli-82931's DELETE endpoint).
           let nextAdminNotes: string | null | undefined = undefined;
-          if (note) {
+          const noteBody =
+            resolvedMode === 'withdraw_pending'
+              ? `Withdrawn during Mark Party Paid reconciliation${note ? `; ${note}` : ''}`
+              : note;
+          if (noteBody) {
             const existing = p.adminNotes && p.adminNotes.trim() ? p.adminNotes : '';
-            const appended = `[${noteTimestamp}] ${note}`;
+            const appended = `[${noteTimestamp}] ${noteBody}`;
             nextAdminNotes = existing
               ? `${existing}\n${appended}`
               : appended;
           }
 
-          // Only stamp payoutMethod when (a) admin supplied one AND (b) the
-          // row currently has none. Preserves the truth of how routed rows
-          // were originally configured.
-          const shouldStampMethod = !!methodToStamp && !p.payoutMethod;
+          if (resolvedMode === 'mark_paid') {
+            // Only stamp payoutMethod when (a) admin supplied one AND (b) the
+            // row currently has none. Preserves the truth of how routed rows
+            // were originally configured.
+            const shouldStampMethod = !!methodToStamp && !p.payoutMethod;
 
-          const data: any = {
-            status: 'paid',
-            paidAt: now,
-          };
-          if (nextAdminNotes !== undefined) {
-            data.adminNotes = nextAdminNotes;
+            const data: any = {
+              status: 'paid',
+              paidAt: now,
+            };
+            if (nextAdminNotes !== undefined) {
+              data.adminNotes = nextAdminNotes;
+            }
+            if (shouldStampMethod) {
+              data.payoutMethod = methodToStamp;
+            }
+
+            await tx.payout.update({
+              where: { id: p.id },
+              data,
+            });
+
+            await tx.payoutAudit.create({
+              data: {
+                payoutId: p.id,
+                action: 'mark_paid',
+                oldStatus: p.status,
+                newStatus: 'paid',
+                actorEmail: actor.email,
+                actorKind: actor.actorKind,
+                note: note,
+              },
+            });
+          } else {
+            // resolvedMode === 'withdraw_pending'
+            // Soft-withdraw without touching paid_at or payout_method —
+            // this row was never actually paid; we're reconciling it
+            // against an already-recorded external payment.
+            const data: any = {
+              status: 'withdrawn',
+            };
+            if (nextAdminNotes !== undefined) {
+              data.adminNotes = nextAdminNotes;
+            }
+
+            await tx.payout.update({
+              where: { id: p.id },
+              data,
+            });
+
+            // ravioli-82931 audit pattern: 'cancel' is the valid action enum
+            // value for soft-withdraw; 'withdraw' isn't in the check
+            // constraint.
+            await tx.payoutAudit.create({
+              data: {
+                payoutId: p.id,
+                action: 'cancel',
+                oldStatus: p.status,
+                newStatus: 'withdrawn',
+                actorEmail: actor.email,
+                actorKind: actor.actorKind,
+                note: noteBody,
+              },
+            });
           }
-          if (shouldStampMethod) {
-            data.payoutMethod = methodToStamp;
-          }
-
-          await tx.payout.update({
-            where: { id: p.id },
-            data,
-          });
-
-          await tx.payoutAudit.create({
-            data: {
-              payoutId: p.id,
-              action: 'mark_paid',
-              oldStatus: p.status,
-              newStatus: 'paid',
-              actorEmail: actor.email,
-              actorKind: actor.actorKind,
-              note: note,
-            },
-          });
 
           updatedIds.push(p.id);
         }
@@ -4170,6 +4313,7 @@ partyMarkPaidRouter.post(
 
       res.json({
         count: updatedIds.length,
+        mode: resolvedMode,
         party: { id: party.id, name: party.name },
         payoutIds: updatedIds,
       });

--- a/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
+++ b/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, DollarSign, Loader2, Pencil, AlertTriangle } from 'lucide-react';
+import { X, DollarSign, Loader2, Pencil, AlertTriangle, Archive } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import {
   fetchMarkPartyPaidPreview,
@@ -7,6 +7,8 @@ import {
   type MarkPartyPaidPreviewResponse,
 } from '../../lib/api';
 import type { PayoutMethod } from '../../types';
+
+type MarkPaidMode = 'mark_paid' | 'withdraw_pending';
 
 /**
  * parmigiana-58291: strip the "Global Pizza Party " prefix from event names
@@ -40,8 +42,11 @@ interface MarkPartyPaidModalProps {
    * Called after a successful mark-paid POST. Parent should refresh both the
    * payouts list (so rows flip to paid) and the prepay queue (so the source
    * party drops off). The summary lets the parent flash a city-specific toast.
+   *
+   * caciotta-92103: `mode` is the resolved mode the server applied so the
+   * toast can phrase "Marked N paid" vs "Withdrew N pending claims".
    */
-  onSuccess: (summary: { count: number; partyName: string }) => void;
+  onSuccess: (summary: { count: number; mode: MarkPaidMode; partyName: string }) => void;
 }
 
 /**
@@ -77,6 +82,11 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
   const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
   const [note, setNote] = useState<string>(() => `Marked paid in bulk on ${today}`);
   const [method, setMethod] = useState<PaidMethodChoice>('unchanged');
+  /**
+   * caciotta-92103: mode selector. `null` until the preview lands; then we
+   * default to the server's suggestedMode. Admin can override either way.
+   */
+  const [mode, setMode] = useState<MarkPaidMode | null>(null);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -100,6 +110,9 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
       .then((res) => {
         if (cancelled) return;
         setPreview(res);
+        // caciotta-92103: default-select the server's recommendation. Admin
+        // can still override before submitting.
+        setMode(res.suggestedMode);
       })
       .catch((err) => {
         if (cancelled) return;
@@ -118,8 +131,11 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
   const cityName = stripGppPrefix(partyName);
   const count = preview?.count ?? 0;
   const totalUsd = preview?.totalUsd ?? 0;
+  const existingPaidCount = preview?.existingPaidCount ?? 0;
+  const existingPaidUsd = preview?.existingPaidUsd ?? 0;
 
-  const canSubmit = !!preview && count > 0 && !submitting && !previewLoading;
+  const canSubmit =
+    !!preview && count > 0 && !submitting && !previewLoading && mode !== null;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -128,11 +144,18 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
     setSubmitError(null);
     try {
       const trimmedNote = note.trim();
-      const body: { note?: string; paidMethod?: PayoutMethod | 'external' } = {};
+      const body: {
+        note?: string;
+        paidMethod?: PayoutMethod | 'external';
+        mode?: MarkPaidMode;
+      } = {};
       if (trimmedNote) body.note = trimmedNote;
-      if (method !== 'unchanged') body.paidMethod = method;
+      // payout_method is meaningful for mark_paid only; we skip it for
+      // withdraw_pending because we don't touch payout_method on withdraw.
+      if (mode === 'mark_paid' && method !== 'unchanged') body.paidMethod = method;
+      if (mode) body.mode = mode;
       const res = await markPartyPaid(partyId, body);
-      onSuccess({ count: res.count, partyName: cityName });
+      onSuccess({ count: res.count, mode: res.mode, partyName: cityName });
       onClose();
     } catch (err: any) {
       setSubmitError(err?.message || 'Failed to mark party paid');
@@ -203,6 +226,26 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
                     )}
                   </div>
                 </div>
+                {/* caciotta-92103: show what's already been paid on this party
+                    so the admin sees the recommendation rationale. When this
+                    is >= the in-flight sum the modal defaults to Withdraw
+                    pending so a re-click after recording an external payment
+                    doesn't double-count. */}
+                {existingPaidCount > 0 && (
+                  <div className="mt-2 flex items-baseline justify-between gap-3 text-xs">
+                    <div className="uppercase tracking-wide text-theme-text-muted">
+                      Existing paid
+                    </div>
+                    <div className="text-theme-text">
+                      <span className="font-semibold">
+                        ${existingPaidUsd.toFixed(2)}
+                      </span>
+                      <span className="text-theme-text-muted">
+                        {' '}({existingPaidCount})
+                      </span>
+                    </div>
+                  </div>
+                )}
                 {count === 0 ? (
                   <p className="text-xs text-theme-text-muted mt-2">
                     Nothing to mark paid — every payout for this event is already
@@ -229,6 +272,57 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
             </div>
           )}
 
+          {/* caciotta-92103: mode selector — Mark all as paid (legacy) vs
+              Withdraw pending (new). Default-selected radio mirrors the
+              server's suggestedMode so the safe action is one-click in the
+              common "I already paid externally and recorded it" case. */}
+          {preview && !previewLoading && count > 0 && mode !== null && (
+            <div>
+              <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
+                What should happen to these {count} payment{count === 1 ? '' : 's'}?
+              </div>
+              <div className="space-y-2">
+                {(['mark_paid', 'withdraw_pending'] as MarkPaidMode[]).map((m) => {
+                  const active = mode === m;
+                  const isMarkPaid = m === 'mark_paid';
+                  const title = isMarkPaid
+                    ? 'Mark all as paid'
+                    : 'Withdraw pending (reconciled by existing paid)';
+                  const explanation = isMarkPaid
+                    ? `Creates ${count} new paid record${count === 1 ? '' : 's'} summing to $${totalUsd.toFixed(2)}. Use this if you actually paid out additionally.`
+                    : `Closes out ${count} pending claim${count === 1 ? '' : 's'} without creating new paid records. Use this when you've already recorded the payment externally and the pending claims are duplicates.`;
+                  return (
+                    <label
+                      key={m}
+                      className={`flex items-start gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-colors ${
+                        active
+                          ? 'border-emerald-500 bg-emerald-500/10'
+                          : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="markPaidMode"
+                        value={m}
+                        checked={active}
+                        onChange={() => setMode(m)}
+                        className="mt-1"
+                      />
+                      <span className="flex-1 min-w-0">
+                        <span className="block text-sm text-theme-text font-medium">
+                          {title}
+                        </span>
+                        <span className="block text-xs text-theme-text-muted mt-0.5">
+                          {explanation}
+                        </span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
           {/* Shared note */}
           <IconInput
             icon={Pencil}
@@ -240,7 +334,9 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
             maxLength={500}
           />
 
-          {/* Optional method override */}
+          {/* Optional method override — only meaningful for mark_paid; the
+              withdraw_pending mode never stamps payout_method. */}
+          {mode === 'mark_paid' && (
           <div>
             <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
               Payout method (optional)
@@ -274,6 +370,7 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
               existing methods are preserved.
             </p>
           </div>
+          )}
 
           {submitError && (
             <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
@@ -295,15 +392,23 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
           <button
             type="submit"
             disabled={!canSubmit}
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
+            className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-white text-sm font-medium disabled:opacity-50 ${
+              mode === 'withdraw_pending'
+                ? 'bg-amber-600 hover:bg-amber-700'
+                : 'bg-red-500 hover:bg-red-600'
+            }`}
           >
             {submitting ? (
               <Loader2 size={14} className="animate-spin" />
+            ) : mode === 'withdraw_pending' ? (
+              <Archive size={14} />
             ) : (
               <DollarSign size={14} />
             )}
             {count > 0
-              ? `Mark ${count} payment${count === 1 ? '' : 's'} paid ($${totalUsd.toFixed(2)})`
+              ? mode === 'withdraw_pending'
+                ? `Withdraw ${count} pending claim${count === 1 ? '' : 's'}`
+                : `Mark ${count} payment${count === 1 ? '' : 's'} paid ($${totalUsd.toFixed(2)})`
               : 'Mark party paid'}
           </button>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4286,6 +4286,20 @@ export interface MarkPartyPaidPreviewResponse {
   party: { id: string; name: string };
   count: number;
   totalUsd: number;
+  /**
+   * caciotta-92103: sum + count of payouts on this party that are already
+   * `paid`. Used by the modal to warn about double-counting — if the host
+   * was already paid externally and that payment was recorded as its own
+   * paid row, marking the pending claim paid would inflate /payments
+   * totals by 2x.
+   */
+  existingPaidCount: number;
+  existingPaidUsd: number;
+  /**
+   * caciotta-92103: what 'auto' mode will do given the current state. The
+   * modal default-selects the radio matching this value.
+   */
+  suggestedMode: 'mark_paid' | 'withdraw_pending';
   payouts: MarkPartyPaidPreviewPayout[];
 }
 
@@ -4318,10 +4332,26 @@ export async function markPartyPaid(
   body?: {
     note?: string;
     paidMethod?: PayoutMethod | 'external';
+    /**
+     * caciotta-92103: how to close out the in-flight rows.
+     *   'mark_paid' — legacy behavior; flips pending+approved to paid.
+     *   'withdraw_pending' — soft-withdraws pending+approved (no new paid
+     *     amounts; receipts preserved). Use when the host was already paid
+     *     externally and that payment is already on the party.
+     *   'auto' (default) — picks withdraw_pending when existing paid sum
+     *     >= pending+approved sum; else mark_paid.
+     */
+    mode?: 'mark_paid' | 'withdraw_pending' | 'auto';
   },
-): Promise<{ count: number; party: { id: string; name: string }; payoutIds: string[] }> {
+): Promise<{
+  count: number;
+  mode: 'mark_paid' | 'withdraw_pending';
+  party: { id: string; name: string };
+  payoutIds: string[];
+}> {
   return apiRequest<{
     count: number;
+    mode: 'mark_paid' | 'withdraw_pending';
     party: { id: string; name: string };
     payoutIds: string[];
   }>(`/api/admin/parties/${partyId}/mark-paid`, {

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1227,13 +1227,20 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             partyId={markPartyPaidTarget.partyId}
             partyNameHint={markPartyPaidTarget.partyNameHint}
             onClose={() => setMarkPartyPaidTarget(null)}
-            onSuccess={async ({ count, partyName }) => {
-              pushToast(
-                count > 0
-                  ? `Marked ${count} payment${count === 1 ? '' : 's'} paid for ${partyName}`
-                  : `No in-flight payouts for ${partyName} — nothing changed`,
-                'success',
-              );
+            onSuccess={async ({ count, mode, partyName }) => {
+              // caciotta-92103: toast verb mirrors the resolved server mode
+              // so admins see whether new paid rows were created
+              // (mark_paid) or pending claims were closed
+              // (withdraw_pending).
+              let msg: string;
+              if (count === 0) {
+                msg = `No in-flight payouts for ${partyName} — nothing changed`;
+              } else if (mode === 'withdraw_pending') {
+                msg = `Withdrew ${count} pending claim${count === 1 ? '' : 's'} for ${partyName}`;
+              } else {
+                msg = `Marked ${count} payment${count === 1 ? '' : 's'} paid for ${partyName}`;
+              }
+              pushToast(msg, 'success');
               await Promise.all([refresh(), loadPrepayQueue()]);
               if (detail && detail.partyId === markPartyPaidTarget.partyId) {
                 try {


### PR DESCRIPTION
## Summary
- Backend `POST /api/admin/parties/:id/mark-paid` accepts `mode: 'mark_paid' | 'withdraw_pending' | 'auto'` (default auto).
- `withdraw_pending` soft-withdraws pending+approved rows (status='withdrawn' via ravioli-82931) without creating new paid amounts.
- `auto` picks `withdraw_pending` when existing paid >= pending+approved; else `mark_paid`.
- Preview endpoint adds existingPaidCount/Usd + suggestedMode.
- MarkPartyPaidModal renders the radio + explainer; defaults to the suggestion.

## Test plan
- [ ] Party with $1000 paid + $1000 pending -> modal defaults Withdraw; submit -> pending withdrawn; total stays $1000.
- [ ] Party with $0 paid + $500 pending -> modal defaults Mark Paid; submit -> flips to paid.
- [ ] Admin overrides the default -> backend honors the explicit mode.