### PR TITLE
feat(crocchetta-92103): payout amount defaults to min(receipts, cap)

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -913,8 +913,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     });
 
     // Final amount: host override (if provided) or OCR sum
-    const finalUsd = typeof finalAmountUsd === 'number' && finalAmountUsd > 0
-      ? finalAmountUsd
+    const hasExplicitAmount = typeof finalAmountUsd === 'number' && finalAmountUsd > 0;
+    let finalUsd = hasExplicitAmount
+      ? (finalAmountUsd as number)
       : extractedUsdSum;
 
     if (finalUsd <= 0) {
@@ -923,6 +924,25 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         400,
         'INVALID_AMOUNT'
       );
+    }
+
+    // crocchetta-92103: default the payout's amount to min(receipts_sum, party_cap).
+    // Receipts persist as evidence of the host's gross claim; final_amount_usd is
+    // what we'll reimburse. Admin can edit later to over-cap. Host's explicit
+    // `finalAmountUsd` body field bypasses the clamp (matching speck-89172's
+    // "hosts can submit any amount" — the warning still surfaces in UI).
+    if (!hasExplicitAmount) {
+      const partyForCap = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { reimbursementCapUsd: true, eventTags: true },
+      });
+      const cap = computeEffectiveCapUsd({
+        reimbursementCapUsd: partyForCap?.reimbursementCapUsd,
+        eventTags: partyForCap?.eventTags,
+      });
+      if (typeof cap === 'number' && cap > 0 && finalUsd > cap) {
+        finalUsd = cap;
+      }
     }
 
     // speck-89172: host POST is no longer cap-enforced. Hosts can submit any
@@ -1603,6 +1623,23 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
 
       if (!explicitAmount && fullOcrSum > 0) {
         recomputedAmount = new Decimal(fullOcrSum);
+
+        // crocchetta-92103: clamp the recomputed amount to the party's effective
+        // cap. Receipts retain their full OCR amounts as evidence; the payout's
+        // final_amount_usd reflects what we'll actually reimburse. Admin PATCH
+        // (panettone-92103) bypasses this path entirely.
+        const partyForCap = await prisma.party.findUnique({
+          where: { id: partyId },
+          select: { reimbursementCapUsd: true, eventTags: true },
+        });
+        const cap = computeEffectiveCapUsd({
+          reimbursementCapUsd: partyForCap?.reimbursementCapUsd,
+          eventTags: partyForCap?.eventTags,
+        });
+        const recomputedNum = Number(recomputedAmount.toString());
+        if (typeof cap === 'number' && cap > 0 && recomputedNum > cap) {
+          recomputedAmount = new Decimal(cap);
+        }
       }
 
       // If this is the first receipt OCR'd successfully, pull FX headline

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -412,7 +412,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           <div className="flex items-start gap-2.5">
             <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
             <div className="flex-1 text-sm text-amber-100">
-              Heads up: ${finalAmount.toFixed(2)} exceeds your ${effectiveCapUsd!.toFixed(2)} reimbursement cap. Admin will review.
+              Heads up: receipts total ${finalAmount.toFixed(2)}, but your reimbursement cap is ${effectiveCapUsd!.toFixed(2)}. We'll reimburse the cap; the receipts stay attached as evidence. Admin can approve more in special cases.
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Host POST `/payouts` and PATCH receipt-recompute now clamp `final_amount_usd` to the party's effective cap when no explicit amount is provided.
- Receipts keep their full OCR amounts as evidence.
- Admin edits + explicit-amount POSTs bypass the clamp.
- Forward-only; no backfill of existing rows.

## Test plan
- [ ] $1500 of receipts on $625-cap party -> payout final_amount_usd = $625.
- [ ] $300 of receipts on $625-cap -> payout final_amount_usd = $300 (no clamp).
- [ ] Explicit body `finalAmountUsd: 1200` on $625-cap -> payout = $1200 (override).
- [ ] Admin edits clamped payout to $800 with override -> succeeds.
- [ ] Existing $1500 payouts stay $1500.