### PR TITLE
feat(lievito-92103): Last activity sort options on /payments

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1704,6 +1704,9 @@ router.get(
       //    `sort` query param shape is supported as the LIST endpoint for
       //    forward-compat, but only a handful of keys make sense at the
       //    party-row level — fall back to activity-desc for unknown values.
+      //    lievito-92103: `activity_desc` and `activity_asc` are explicit
+      //    options on the admin Sort dropdown (the latter useful for
+      //    surfacing stale cities first).
       const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : 'activity_desc';
       rows.sort((a, b) => {
         switch (sortRaw) {
@@ -1717,6 +1720,9 @@ router.get(
             return a.party.name.localeCompare(b.party.name);
           case 'name_desc':
             return b.party.name.localeCompare(a.party.name);
+          case 'activity_asc':
+            return new Date(a.aggregates.lastActivityAt).getTime()
+                 - new Date(b.aggregates.lastActivityAt).getTime();
           case 'activity_desc':
           default:
             return new Date(b.aggregates.lastActivityAt).getTime()
@@ -1762,11 +1768,16 @@ router.get(
       // `createdAt`, so when the caller picks a non-default sort we fall back
       // to offset-based pagination (parses `cursor` as the offset count)
       // instead of encoding cursors per orderBy.
+      // lievito-92103: `activity_desc` / `activity_asc` map to `updatedAt`
+      // here so the per-payout view orders by most/least recently touched.
+      // They use the same offset-pagination fallback as the amount sorts.
       const sortMap: Record<string, Prisma.PayoutOrderByWithRelationInput> = {
         created_desc: { createdAt: 'desc' },
         created_asc: { createdAt: 'asc' },
         amount_desc: { finalAmountUsd: 'desc' },
         amount_asc: { finalAmountUsd: 'asc' },
+        activity_desc: { updatedAt: 'desc' },
+        activity_asc: { updatedAt: 'asc' },
       };
       const sortKey = typeof req.query.sort === 'string' && sortMap[req.query.sort]
         ? (req.query.sort as keyof typeof sortMap)

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -51,12 +51,17 @@ const PURPOSE_OPTIONS: Array<{ value: PayoutPurpose | 'all'; label: string }> = 
 
 // arancino-92103: sort order for the payouts list. `created_desc` is the
 // default (newest submitted first) and matches the prior implicit ordering.
+// lievito-92103: `activity_desc` / `activity_asc` expose the by-city default
+// (lastActivityAt) as an explicit picker entry, and also order the per-payout
+// view by `updatedAt`. Useful for surfacing stale cities first.
 type SortValue = NonNullable<AdminPayoutFilters['sort']>;
 const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
   { value: 'created_desc', label: 'Newest first' },
   { value: 'created_asc', label: 'Oldest first' },
   { value: 'amount_desc', label: 'Highest amount' },
   { value: 'amount_asc', label: 'Lowest amount' },
+  { value: 'activity_desc', label: 'Most recently active' },
+  { value: 'activity_asc', label: 'Least recently active' },
 ];
 const SORT_LABEL: Record<SortValue, string> = SORT_OPTIONS.reduce(
   (acc, opt) => ({ ...acc, [opt.value]: opt.label }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1983,8 +1983,16 @@ export interface AdminPayoutFilters {
    * arancino-92103: sort order for the payouts queue. Default `created_desc`
    * preserves prior implicit ordering. When non-default, the backend falls
    * back to offset-based pagination (cursor is encoded as an offset count).
+   * lievito-92103: `activity_desc` / `activity_asc` order by `lastActivityAt`
+   * on the by-city view and by `updatedAt` on the per-payout view.
    */
-  sort?: 'created_desc' | 'created_asc' | 'amount_desc' | 'amount_asc';
+  sort?:
+    | 'created_desc'
+    | 'created_asc'
+    | 'amount_desc'
+    | 'amount_asc'
+    | 'activity_desc'
+    | 'activity_asc';
   cursor?: string;
   limit?: number;
 }


### PR DESCRIPTION
## Summary
- Two new sort dropdown options: Most recently active / Least recently active.
- Maps to lastActivityAt on by-city view (already supported by etruria-92103) and updatedAt on per-payout view.

## Test plan
- [ ] Pick "Most recently active" → cities ordered by lastActivityAt desc.
- [ ] Pick "Least recently active" → reverse.
- [ ] By-payment view → sort by updated_at.