### PR TITLE
feat(mortadella-58293): GPP theme for SurveyPage

### DIFF
--- a/frontend/src/pages/SurveyPage.tsx
+++ b/frontend/src/pages/SurveyPage.tsx
@@ -5,10 +5,19 @@ import { Loader2, AlertCircle, CheckCircle2, Star, MessageSquare } from 'lucide-
 import { Layout } from '../components/Layout';
 import { IconInput } from '../components/IconInput';
 import { Checkbox } from '../components/Checkbox';
+import { ThemeProvider } from '../contexts/ThemeContext';
 import { fetchSurvey, submitSurvey, type SurveyFetchResponse } from '../lib/api';
 import type { SurveyQuestion, SurveyAnswers, SurveyAnswerValue } from '../lib/surveyQuestions';
 
 export function SurveyPage() {
+  return (
+    <ThemeProvider theme="gpp">
+      <SurveyPageInner />
+    </ThemeProvider>
+  );
+}
+
+function SurveyPageInner() {
   const { token } = useParams<{ token: string }>();
 
   // All hooks declared above any early return (rules-of-hooks).


### PR DESCRIPTION
Applies the PizzaDAO GPP visual treatment (sky-blue gradient + clouds + .gpp-theme overrides) unconditionally to the post-event guest survey (romana-61204). The render tree is wrapped in `<ThemeProvider theme="gpp">`, which propagates through the shared `Layout` component — background, GPPClouds, body class, and theme CSS overrides all flow through automatically. No `event_type` gate — every survey renders in the GPP look.

Test on preview: https://rsv.pizza/survey/041010e7-b32b-4040-b1d1-070d9c2806f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)