### PR TITLE
feat(pinsa-92103): mark city paid (close out) when no pending

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -232,6 +232,14 @@ model Party {
   reimbursementCapAppealNote String?   @map("reimbursement_cap_appeal_note")
   reimbursementCapAppealedAt DateTime? @map("reimbursement_cap_appealed_at") @db.Timestamptz
 
+  // pinsa-92103: "fully paid out / closed" timestamp on the city's payout
+  // ledger. Stamped by the panettone-92103 Mark Party Paid flow when there's
+  // nothing left in-flight — either because every pending+approved row just
+  // flipped to paid, or because the admin closed out a city whose payouts
+  // were already paid (Ekiti, Tangier). NULL = still open. Partial index
+  // makes "show closed cities" filter cheap; most rows stay NULL.
+  paymentsClosedAt DateTime? @map("payments_closed_at") @db.Timestamptz
+
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -106,6 +106,10 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   userId: true,
   coHosts: true,
   user: { select: { email: true } },
+  // pinsa-92103: surface the "city closed out" timestamp. Drives the green
+  // ✓ Closed pill on the by-city table + hides the Mark Paid affordance for
+  // already-closed parties.
+  paymentsClosedAt: true,
   _count: {
     select: {
       guests: {
@@ -589,6 +593,12 @@ function serializePayout(row: any): any {
           // event UI.
           userId: row.party.userId ?? null,
           primaryHostInCohosts: isPrimaryHostInCohosts(row.party),
+          // pinsa-92103: payments-closed-at timestamp drives the by-city
+          // ✓ Closed pill + hides the Mark Paid affordance for fully
+          // closed-out cities (Ekiti, Tangier).
+          paymentsClosedAt: row.party.paymentsClosedAt
+            ? row.party.paymentsClosedAt.toISOString()
+            : null,
         }
       : undefined,
     host: row.host
@@ -1678,6 +1688,12 @@ router.get(
             eventTags: Array.isArray(b.partyMeta.eventTags) ? b.partyMeta.eventTags : [],
             primaryHostInCohosts: isPrimaryHostInCohosts(b.partyMeta),
             userId: b.partyMeta.userId ?? null,
+            // pinsa-92103: surface the close timestamp on the outer party so
+            // the by-city table can hide the Mark paid button + render the
+            // green ✓ Closed pill without expanding the row first.
+            paymentsClosedAt: b.partyMeta.paymentsClosedAt
+              ? b.partyMeta.paymentsClosedAt.toISOString()
+              : null,
           },
           aggregates: {
             pendingCount: b.pendingCount,
@@ -1700,6 +1716,15 @@ router.get(
         };
       });
 
+      // pinsa-92103: optional `?hideClosed=true` filters out rows the admin
+      // has explicitly closed out (Ekiti, Tangier). Doing this server-side
+      // (vs. in the table component) keeps row counts honest and is cheap —
+      // grouping has already happened and the bucket meta has the flag.
+      const hideClosed = req.query.hideClosed === 'true' || req.query.hideClosed === '1';
+      const filteredRows = hideClosed
+        ? rows.filter((r) => !r.party.paymentsClosedAt)
+        : rows;
+
       // 6. Sort outer rows. Default: most recent activity desc. The same
       //    `sort` query param shape is supported as the LIST endpoint for
       //    forward-compat, but only a handful of keys make sense at the
@@ -1708,7 +1733,7 @@ router.get(
       //    options on the admin Sort dropdown (the latter useful for
       //    surfacing stale cities first).
       const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : 'activity_desc';
-      rows.sort((a, b) => {
+      filteredRows.sort((a, b) => {
         switch (sortRaw) {
           case 'amount_desc':
             return (b.aggregates.pendingUsd + b.aggregates.approvedUsd + b.aggregates.paidUsd)
@@ -1730,7 +1755,7 @@ router.get(
         }
       });
 
-      res.json({ rows, total: rows.length });
+      res.json({ rows: filteredRows, total: filteredRows.length });
     } catch (error) {
       next(error);
     }
@@ -3987,7 +4012,14 @@ partyMarkPaidRouter.get(
       const { partyId } = req.params;
       const party = await prisma.party.findUnique({
         where: { id: partyId },
-        select: { id: true, name: true },
+        select: {
+          id: true,
+          name: true,
+          // pinsa-92103: surface so the modal can branch into close-out mode
+          // when there's nothing in-flight but the city still needs a "done"
+          // signal (e.g. Ekiti / Tangier — all rows already paid).
+          paymentsClosedAt: true,
+        },
       });
       if (!party) {
         throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
@@ -4013,38 +4045,54 @@ partyMarkPaidRouter.get(
         0,
       );
 
-      // caciotta-92103: also surface the already-paid payouts on this party so
-      // the modal can warn about double-counting. If the host was already paid
-      // out-of-band (recorded as a separate paid row), marking the pending
-      // claim paid would inflate /payments totals.
-      const existingPaid = await prisma.payout.findMany({
-        where: {
-          partyId,
-          status: 'paid',
-        },
-        select: { id: true, finalAmountUsd: true },
+      // caciotta-92103 + pinsa-92103: surface the already-paid payouts on this
+      // party. Caciotta uses count + sum to warn the modal about
+      // double-counting (and to pick suggestedMode). Pinsa uses the same data
+      // for the close-out body copy ("Existing paid records (N payments,
+      // $X.XX total) stay unchanged") and the `eligible` flag that drives
+      // Mark Paid button visibility in the by-city table.
+      const paidAgg = await prisma.payout.aggregate({
+        where: { partyId, status: 'paid' },
+        _count: { _all: true },
+        _sum: { finalAmountUsd: true },
       });
-      const existingPaidCount = existingPaid.length;
-      const existingPaidUsd = existingPaid.reduce(
-        (sum, p) => sum + Number(p.finalAmountUsd),
-        0,
-      );
+      const paidCount = paidAgg._count?._all ?? 0;
+      const paidTotalUsd = Number(paidAgg._sum?.finalAmountUsd ?? 0);
+      // caciotta-92103 aliases — same data, surfaced under the field names the
+      // existing modal already reads.
+      const existingPaidCount = paidCount;
+      const existingPaidUsd = paidTotalUsd;
 
-      // Recommend `withdraw_pending` when the already-paid bucket fully
-      // covers what we'd otherwise create as new paid rows. Otherwise
-      // `mark_paid` (the legacy behavior).
+      // caciotta-92103: recommend `withdraw_pending` when the already-paid
+      // bucket fully covers what we'd otherwise create as new paid rows.
+      // Otherwise `mark_paid` (the legacy behavior).
       const suggestedMode: 'mark_paid' | 'withdraw_pending' =
         existingPaidCount > 0 && existingPaidUsd >= totalUsd
           ? 'withdraw_pending'
           : 'mark_paid';
 
+      const paymentsClosedAt = party.paymentsClosedAt
+        ? party.paymentsClosedAt.toISOString()
+        : null;
+
+      // pinsa-92103: the by-city table uses `eligible` to decide whether to
+      // render the Mark Paid button. True when there's work to do (anything
+      // in-flight) OR when the city has paid history but no close stamp
+      // (Ekiti / Tangier). Cities with no payouts at all stay ineligible —
+      // there's nothing to close.
+      const eligible = payouts.length > 0 || (paymentsClosedAt === null && paidCount > 0);
+
       res.json({
-        party: { id: party.id, name: party.name },
+        party: { id: party.id, name: party.name, paymentsClosedAt },
         count: payouts.length,
         totalUsd,
         existingPaidCount,
         existingPaidUsd,
         suggestedMode,
+        paidCount,
+        paidTotalUsd,
+        paymentsClosedAt,
+        eligible,
         payouts: payouts.map((p) => ({
           id: p.id,
           status: p.status,
@@ -4134,7 +4182,13 @@ partyMarkPaidRouter.post(
 
       const party = await prisma.party.findUnique({
         where: { id: partyId },
-        select: { id: true, name: true },
+        select: {
+          id: true,
+          name: true,
+          // pinsa-92103: needed so we don't double-stamp paymentsClosedAt
+          // on a city that's already marked closed.
+          paymentsClosedAt: true,
+        },
       });
       if (!party) {
         throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
@@ -4207,12 +4261,52 @@ partyMarkPaidRouter.post(
       }
 
       if (inflight.length === 0) {
-        // Not an error — modal can render "0 payouts to mark paid".
+        // pinsa-92103: nothing in-flight. If the city has any paid rows AND
+        // isn't already marked closed, treat this as a close-out: stamp
+        // payments_closed_at and return `action: 'closed'` so the modal can
+        // flash the right toast. Cities with no payouts at all stay
+        // unchanged — there's nothing to close.
+        const paidCount = await prisma.payout.count({
+          where: { partyId, status: 'paid' },
+        });
+
+        if (paidCount > 0 && !party.paymentsClosedAt) {
+          const closedAt = new Date();
+          const updated = await prisma.party.update({
+            where: { id: partyId },
+            data: { paymentsClosedAt: closedAt },
+            select: { id: true, name: true, paymentsClosedAt: true },
+          });
+          res.json({
+            count: 0,
+            party: {
+              id: updated.id,
+              name: updated.name,
+              paymentsClosedAt: updated.paymentsClosedAt
+                ? updated.paymentsClosedAt.toISOString()
+                : null,
+            },
+            payoutIds: [],
+            action: 'closed',
+          });
+          return;
+        }
+
+        // Either no paid rows at all, or already-closed — no-op. Surface the
+        // current close timestamp so the frontend can refresh its UI either
+        // way.
         res.json({
           count: 0,
           mode: resolvedMode,
-          party: { id: party.id, name: party.name },
+          party: {
+            id: party.id,
+            name: party.name,
+            paymentsClosedAt: party.paymentsClosedAt
+              ? party.paymentsClosedAt.toISOString()
+              : null,
+          },
           payoutIds: [],
+          action: party.paymentsClosedAt ? 'already_closed' : 'noop',
         });
         return;
       }
@@ -4320,13 +4414,59 @@ partyMarkPaidRouter.post(
 
           updatedIds.push(p.id);
         }
+
+        // pinsa-92103 + caciotta-92103: when this run leaves nothing in-flight,
+        // auto-stamp paymentsClosedAt. Skip if already closed. We re-query
+        // inside the tx so the check is atomic with the status flips.
+        //
+        // For mark_paid: every flipped row is now 'paid', so the city has
+        // paid history by construction — safe to close.
+        // For withdraw_pending: the flipped rows are 'withdrawn', not 'paid',
+        // so only close when the city has OTHER paid history (matches pinsa's
+        // close-out invariant: never close a city with zero real payments).
+        if (!party.paymentsClosedAt && updatedIds.length > 0) {
+          const remainingInflight = await tx.payout.count({
+            where: { partyId, status: { in: ['pending', 'approved'] } },
+          });
+          if (remainingInflight === 0) {
+            const hasPaid =
+              resolvedMode === 'mark_paid'
+                ? true
+                : (await tx.payout.count({
+                    where: { partyId, status: 'paid' },
+                  })) > 0;
+            if (hasPaid) {
+              await tx.party.update({
+                where: { id: partyId },
+                data: { paymentsClosedAt: now },
+              });
+            }
+          }
+        }
+      });
+
+      // Re-read so the response surfaces the (possibly newly stamped)
+      // paymentsClosedAt. Cheap follow-up read — one indexed pkey lookup.
+      const finalParty = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { id: true, name: true, paymentsClosedAt: true },
       });
 
       res.json({
         count: updatedIds.length,
         mode: resolvedMode,
-        party: { id: party.id, name: party.name },
+        party: {
+          id: party.id,
+          name: party.name,
+          paymentsClosedAt: finalParty?.paymentsClosedAt
+            ? finalParty.paymentsClosedAt.toISOString()
+            : null,
+        },
         payoutIds: updatedIds,
+        // caciotta-92103: action mirrors the resolved mode so the frontend
+        // doesn't have to infer it. 'withdraw_pending' is its own action
+        // value distinct from pinsa's 'closed'/'already_closed'/'noop'.
+        action: resolvedMode === 'withdraw_pending' ? 'withdraw_pending' : 'mark_paid',
       });
     } catch (err) {
       next(err);

--- a/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
+++ b/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, DollarSign, Loader2, Pencil, AlertTriangle, Archive } from 'lucide-react';
+import { X, DollarSign, Loader2, Pencil, AlertTriangle, Archive, CheckCircle2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import {
   fetchMarkPartyPaidPreview,
@@ -45,8 +45,22 @@ interface MarkPartyPaidModalProps {
    *
    * caciotta-92103: `mode` is the resolved mode the server applied so the
    * toast can phrase "Marked N paid" vs "Withdrew N pending claims".
+   * pinsa-92103: `action` lets the parent vary the toast copy — `'closed'`
+   * (or `'mark_paid'` when the flip auto-stamped the close timestamp) means
+   * the city is now fully closed-out.
    */
-  onSuccess: (summary: { count: number; mode: MarkPaidMode; partyName: string }) => void;
+  onSuccess: (summary: {
+    count: number;
+    mode?: MarkPaidMode;
+    partyName: string;
+    action?:
+      | 'mark_paid'
+      | 'withdraw_pending'
+      | 'closed'
+      | 'already_closed'
+      | 'noop';
+    paymentsClosedAt?: string | null;
+  }) => void;
 }
 
 /**
@@ -133,9 +147,28 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
   const totalUsd = preview?.totalUsd ?? 0;
   const existingPaidCount = preview?.existingPaidCount ?? 0;
   const existingPaidUsd = preview?.existingPaidUsd ?? 0;
+  // pinsa-92103: separate from caciotta's existingPaid* (which is the same
+  // data via a different field name). Modal body uses `paidCount` /
+  // `paidTotalUsd` for the close-out copy, falling back to caciotta's fields
+  // so the optional pinsa fields don't break in older payloads.
+  const paidCount = preview?.paidCount ?? existingPaidCount;
+  const paidTotalUsd = preview?.paidTotalUsd ?? existingPaidUsd;
+  const alreadyClosedAt = preview?.paymentsClosedAt ?? null;
 
+  // pinsa-92103: close-out mode = preview loaded, nothing in-flight, party has
+  // paid history, and not already closed. In this mode the modal hides the
+  // method-override radio and switches the button copy to "Close out {city}".
+  const isCloseOutMode =
+    !!preview && count === 0 && paidCount > 0 && !alreadyClosedAt;
+
+  // caciotta + pinsa: standard mark-paid mode requires in-flight rows AND a
+  // resolved mode selection. Close-out mode (pinsa) is a valid submit even
+  // with count===0 because it stamps a timestamp; it doesn't need `mode`.
   const canSubmit =
-    !!preview && count > 0 && !submitting && !previewLoading && mode !== null;
+    !!preview &&
+    !submitting &&
+    !previewLoading &&
+    (isCloseOutMode || (count > 0 && mode !== null));
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -150,12 +183,24 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
         mode?: MarkPaidMode;
       } = {};
       if (trimmedNote) body.note = trimmedNote;
-      // payout_method is meaningful for mark_paid only; we skip it for
-      // withdraw_pending because we don't touch payout_method on withdraw.
-      if (mode === 'mark_paid' && method !== 'unchanged') body.paidMethod = method;
-      if (mode) body.mode = mode;
+      // payout_method is meaningful for mark_paid only; skip it for
+      // withdraw_pending (caciotta) and for close-out mode (pinsa) since
+      // neither path touches payout_method on existing rows.
+      if (!isCloseOutMode && mode === 'mark_paid' && method !== 'unchanged') {
+        body.paidMethod = method;
+      }
+      // caciotta-92103: send the resolved mode when there's something to act
+      // on. In close-out mode we leave it unset and let the server pick the
+      // pure close-out path.
+      if (!isCloseOutMode && mode) body.mode = mode;
       const res = await markPartyPaid(partyId, body);
-      onSuccess({ count: res.count, mode: res.mode, partyName: cityName });
+      onSuccess({
+        count: res.count,
+        mode: res.mode,
+        partyName: cityName,
+        action: res.action,
+        paymentsClosedAt: res.party?.paymentsClosedAt ?? null,
+      });
       onClose();
     } catch (err: any) {
       setSubmitError(err?.message || 'Failed to mark party paid');
@@ -178,10 +223,14 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
         <div className="flex items-center gap-3 px-5 py-4 border-b border-theme-stroke">
           <div className="flex-1 min-w-0">
             <h2 className="text-lg font-semibold text-theme-text truncate">
-              Mark party paid: {cityName}
+              {isCloseOutMode
+                ? `Mark ${cityName} as fully paid out`
+                : `Mark party paid: ${cityName}`}
             </h2>
             <p className="text-xs text-theme-text-muted mt-0.5">
-              Flips every pending + approved payout for this event to paid.
+              {isCloseOutMode
+                ? 'Closes out this city — every expected reimbursement is already paid.'
+                : 'Flips every pending + approved payout for this event to paid.'}
             </p>
           </div>
           <button
@@ -211,64 +260,94 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
           )}
           {preview && !previewLoading && (
             <div>
-              <div className="rounded-lg border border-theme-stroke bg-theme-surface-hover p-3">
-                <div className="flex items-baseline justify-between gap-3">
-                  <div className="text-xs uppercase tracking-wide text-theme-text-muted">
-                    In-flight payouts
-                  </div>
-                  <div className="text-sm text-theme-text">
-                    <span className="font-semibold">{count}</span>
-                    {count > 0 && (
-                      <>
-                        {' '}for a total of{' '}
-                        <span className="font-semibold">${totalUsd.toFixed(2)}</span>
-                      </>
-                    )}
+              {/* pinsa-92103: close-out mode renders a distinct emerald
+                  panel so admins immediately see this is the "no work to do,
+                  just record completion" path, not the bulk-flip one. */}
+              {isCloseOutMode ? (
+                <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-3">
+                  <div className="flex items-start gap-2">
+                    <CheckCircle2
+                      size={16}
+                      className="text-emerald-500 mt-0.5 flex-shrink-0"
+                    />
+                    <div className="text-sm text-theme-text">
+                      <p>
+                        This city has no pending payments. Closing it out
+                        records that all expected reimbursements have been
+                        completed.
+                      </p>
+                      <p className="text-xs text-theme-text-muted mt-2">
+                        Existing paid records ({paidCount} payment
+                        {paidCount === 1 ? '' : 's'},{' '}
+                        <span className="font-medium text-theme-text">
+                          ${paidTotalUsd.toFixed(2)}
+                        </span>{' '}
+                        total) stay unchanged.
+                      </p>
+                    </div>
                   </div>
                 </div>
-                {/* caciotta-92103: show what's already been paid on this party
-                    so the admin sees the recommendation rationale. When this
-                    is >= the in-flight sum the modal defaults to Withdraw
-                    pending so a re-click after recording an external payment
-                    doesn't double-count. */}
-                {existingPaidCount > 0 && (
-                  <div className="mt-2 flex items-baseline justify-between gap-3 text-xs">
-                    <div className="uppercase tracking-wide text-theme-text-muted">
-                      Existing paid
+              ) : (
+                <div className="rounded-lg border border-theme-stroke bg-theme-surface-hover p-3">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <div className="text-xs uppercase tracking-wide text-theme-text-muted">
+                      In-flight payouts
                     </div>
-                    <div className="text-theme-text">
-                      <span className="font-semibold">
-                        ${existingPaidUsd.toFixed(2)}
-                      </span>
-                      <span className="text-theme-text-muted">
-                        {' '}({existingPaidCount})
-                      </span>
+                    <div className="text-sm text-theme-text">
+                      <span className="font-semibold">{count}</span>
+                      {count > 0 && (
+                        <>
+                          {' '}for a total of{' '}
+                          <span className="font-semibold">${totalUsd.toFixed(2)}</span>
+                        </>
+                      )}
                     </div>
                   </div>
-                )}
-                {count === 0 ? (
-                  <p className="text-xs text-theme-text-muted mt-2">
-                    Nothing to mark paid — every payout for this event is already
-                    paid, rejected, or withdrawn.
-                  </p>
-                ) : (
-                  <ul className="mt-2 space-y-1 text-xs text-theme-text-secondary">
-                    {preview.payouts.map((p) => (
-                      <li key={p.id} className="flex items-baseline gap-2">
-                        <span className="text-theme-text-muted uppercase text-[10px] tracking-wide w-16 flex-shrink-0">
-                          {p.status}
+                  {/* caciotta-92103: show what's already been paid on this party
+                      so the admin sees the recommendation rationale. When this
+                      is >= the in-flight sum the modal defaults to Withdraw
+                      pending so a re-click after recording an external payment
+                      doesn't double-count. */}
+                  {existingPaidCount > 0 && (
+                    <div className="mt-2 flex items-baseline justify-between gap-3 text-xs">
+                      <div className="uppercase tracking-wide text-theme-text-muted">
+                        Existing paid
+                      </div>
+                      <div className="text-theme-text">
+                        <span className="font-semibold">
+                          ${existingPaidUsd.toFixed(2)}
                         </span>
-                        <span className="flex-1 truncate">
-                          {p.hostName ?? p.hostEmail ?? 'Unknown host'}
+                        <span className="text-theme-text-muted">
+                          {' '}({existingPaidCount})
                         </span>
-                        <span className="font-medium text-theme-text">
-                          ${p.finalAmountUsd.toFixed(2)}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
+                      </div>
+                    </div>
+                  )}
+                  {count === 0 ? (
+                    <p className="text-xs text-theme-text-muted mt-2">
+                      {alreadyClosedAt
+                        ? 'This city is already closed out — every payout is paid, rejected, or withdrawn.'
+                        : 'Nothing to mark paid — every payout for this event is already paid, rejected, or withdrawn.'}
+                    </p>
+                  ) : (
+                    <ul className="mt-2 space-y-1 text-xs text-theme-text-secondary">
+                      {preview.payouts.map((p) => (
+                        <li key={p.id} className="flex items-baseline gap-2">
+                          <span className="text-theme-text-muted uppercase text-[10px] tracking-wide w-16 flex-shrink-0">
+                            {p.status}
+                          </span>
+                          <span className="flex-1 truncate">
+                            {p.hostName ?? p.hostEmail ?? 'Unknown host'}
+                          </span>
+                          <span className="font-medium text-theme-text">
+                            ${p.finalAmountUsd.toFixed(2)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
             </div>
           )}
 
@@ -334,42 +413,45 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
             maxLength={500}
           />
 
-          {/* Optional method override — only meaningful for mark_paid; the
-              withdraw_pending mode never stamps payout_method. */}
-          {mode === 'mark_paid' && (
-          <div>
-            <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
-              Payout method (optional)
+          {/* Optional method override.
+              caciotta-92103: only meaningful for mark_paid; withdraw_pending
+              never stamps payout_method.
+              pinsa-92103: hidden in close-out mode — there are no in-flight
+              rows for the method to stamp, so the choice is meaningless. */}
+          {!isCloseOutMode && mode === 'mark_paid' && (
+            <div>
+              <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
+                Payout method (optional)
+              </div>
+              <div className="space-y-1.5">
+                {(Object.keys(METHOD_LABELS) as PaidMethodChoice[]).map((k) => {
+                  const active = method === k;
+                  return (
+                    <label
+                      key={k}
+                      className={`flex items-center gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-colors ${
+                        active
+                          ? 'border-emerald-500 bg-emerald-500/10'
+                          : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="paidMethod"
+                        value={k}
+                        checked={active}
+                        onChange={() => setMethod(k)}
+                      />
+                      <span className="text-sm text-theme-text">{METHOD_LABELS[k]}</span>
+                    </label>
+                  );
+                })}
+              </div>
+              <p className="text-xs text-theme-text-muted mt-1">
+                Only stamps the method on payouts that don't already have one —
+                existing methods are preserved.
+              </p>
             </div>
-            <div className="space-y-1.5">
-              {(Object.keys(METHOD_LABELS) as PaidMethodChoice[]).map((k) => {
-                const active = method === k;
-                return (
-                  <label
-                    key={k}
-                    className={`flex items-center gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-colors ${
-                      active
-                        ? 'border-emerald-500 bg-emerald-500/10'
-                        : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="paidMethod"
-                      value={k}
-                      checked={active}
-                      onChange={() => setMethod(k)}
-                    />
-                    <span className="text-sm text-theme-text">{METHOD_LABELS[k]}</span>
-                  </label>
-                );
-              })}
-            </div>
-            <p className="text-xs text-theme-text-muted mt-1">
-              Only stamps the method on payouts that don't already have one —
-              existing methods are preserved.
-            </p>
-          </div>
           )}
 
           {submitError && (
@@ -393,23 +475,29 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
             type="submit"
             disabled={!canSubmit}
             className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-white text-sm font-medium disabled:opacity-50 ${
-              mode === 'withdraw_pending'
-                ? 'bg-amber-600 hover:bg-amber-700'
-                : 'bg-red-500 hover:bg-red-600'
+              isCloseOutMode
+                ? 'bg-emerald-600 hover:bg-emerald-700'
+                : mode === 'withdraw_pending'
+                  ? 'bg-amber-600 hover:bg-amber-700'
+                  : 'bg-red-500 hover:bg-red-600'
             }`}
           >
             {submitting ? (
               <Loader2 size={14} className="animate-spin" />
+            ) : isCloseOutMode ? (
+              <CheckCircle2 size={14} />
             ) : mode === 'withdraw_pending' ? (
               <Archive size={14} />
             ) : (
               <DollarSign size={14} />
             )}
-            {count > 0
-              ? mode === 'withdraw_pending'
-                ? `Withdraw ${count} pending claim${count === 1 ? '' : 's'}`
-                : `Mark ${count} payment${count === 1 ? '' : 's'} paid ($${totalUsd.toFixed(2)})`
-              : 'Mark party paid'}
+            {isCloseOutMode
+              ? `Close out ${cityName}`
+              : count > 0
+                ? mode === 'withdraw_pending'
+                  ? `Withdraw ${count} pending claim${count === 1 ? '' : 's'}`
+                  : `Mark ${count} payment${count === 1 ? '' : 's'} paid ($${totalUsd.toFixed(2)})`
+                : 'Mark party paid'}
           </button>
         </div>
       </form>

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -7,6 +7,7 @@ import {
   Paperclip,
   Flag,
   Check,
+  CheckCircle2,
   X,
   Pencil,
   Eye,
@@ -257,7 +258,19 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
               // (no pending/approved rows) and for underboss viewers.
               const hasInFlight =
                 row.aggregates.pendingCount + row.aggregates.approvedCount > 0;
-              const showMarkPartyPaid = canMarkPartyPaid && hasInFlight;
+              // pinsa-92103: ALSO show the button when the city has paid
+              // payouts but hasn't been closed yet (Ekiti, Tangier) so the
+              // admin can stamp the close timestamp. Cities with NO payouts
+              // at all stay hidden — there's nothing to close.
+              const closedAt = row.party.paymentsClosedAt ?? null;
+              const isClosed = !!closedAt;
+              const canCloseOut =
+                !hasInFlight && !isClosed && row.aggregates.paidCount > 0;
+              const showMarkPartyPaid =
+                canMarkPartyPaid && !isClosed && (hasInFlight || canCloseOut);
+              const markPaidTooltip = hasInFlight
+                ? 'Mark all pending + approved payments paid for this city'
+                : 'Close out this city — no pending payments to action';
               return (
                 <React.Fragment key={row.party.id}>
                   {/* Outer party row */}
@@ -292,6 +305,20 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                         >
                           <Flag size={11} />
                           {row.aggregates.flaggedReadyCount} flagged ready
+                        </div>
+                      )}
+                      {/* pinsa-92103: ✓ Closed pill — admin marked this
+                          city's payouts fully closed-out. Renders next to
+                          the city name so it's the first thing the admin
+                          sees on the row. Tooltip surfaces the close
+                          timestamp for audit traceability. */}
+                      {isClosed && (
+                        <div
+                          className="inline-flex items-center gap-1 text-[11px] text-emerald-500 mt-0.5 px-1.5 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/30"
+                          title={`Closed out ${new Date(closedAt!).toLocaleString()}`}
+                        >
+                          <CheckCircle2 size={11} />
+                          Closed
                         </div>
                       )}
                     </td>
@@ -340,7 +367,12 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                         {/* bocconcini-92103: per-row "Mark paid" — bridges
                             the panettone modal into the by-city default view.
                             Click stops propagation so it doesn't toggle the
-                            row's expansion. */}
+                            row's expansion.
+                            pinsa-92103: also shown when the city has only
+                            paid payouts (no pending/approved) and hasn't
+                            been closed yet — admin clicks to stamp the
+                            close timestamp (Ekiti / Tangier). Hidden when
+                            the city is already closed. */}
                         {showMarkPartyPaid && onMarkPartyPaid && (
                           <button
                             type="button"
@@ -349,7 +381,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                               onMarkPartyPaid(row.party.id);
                             }}
                             className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-red-500/40 text-red-300 hover:bg-red-500/10 text-xs font-medium"
-                            title="Mark all pending + approved payments paid for this city"
+                            title={markPaidTooltip}
                           >
                             <Coins size={12} />
                             Mark paid

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
 import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
 import type { AdminPayoutFilters, PayoutMethod, PayoutPurpose, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
 
@@ -22,6 +23,12 @@ interface PayoutsFilterBarProps {
    * ascending.
    */
   availableTags: string[];
+  /**
+   * pinsa-92103: when true, render the "Hide closed cities" checkbox.
+   * Only meaningful on the by-city view (`paymentsClosedAt` lives at the
+   * party level), so the parent controls visibility. Defaults to false.
+   */
+  showHideClosedToggle?: boolean;
 }
 
 const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
@@ -88,6 +95,8 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   // arancino-92103: count sort as an active filter when it differs from
   // the default `created_desc` (newest first).
   if (filters.sort && filters.sort !== 'created_desc') n += 1;
+  // pinsa-92103: count Hide closed cities so admins see they've hidden rows.
+  if (filters.hideClosed) n += 1;
   return n;
 }
 
@@ -110,6 +119,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   availableCurrencies,
   availableCountries,
   availableTags,
+  showHideClosedToggle,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const activeCount = countActiveFilters(filters);
@@ -307,6 +317,19 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-[#E52828]/10 text-[#E52828] text-xs font-medium">
                 Sort: {SORT_LABEL[filters.sort]}
               </span>
+            )}
+            {/* pinsa-92103: Hide closed cities toggle. Only rendered on the
+                by-city view (`paymentsClosedAt` is a party-level signal so
+                the by-payment view has nothing to hide). Backend honors
+                `hideClosed=true` on the /by-party endpoint. */}
+            {showHideClosedToggle && (
+              <Checkbox
+                checked={!!filters.hideClosed}
+                onChange={() => update({ hideClosed: !filters.hideClosed })}
+                label="Hide closed cities"
+                labelClassName="text-xs text-theme-text-secondary"
+                size={14}
+              />
             )}
           </div>
           <button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4073,6 +4073,11 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.regions && filters.regions.length > 0) {
     params.set('regions', filters.regions.join(','));
   }
+  // pinsa-92103: hide-closed-cities toggle on the by-city view. Backend
+  // accepts `hideClosed=true`; the LIST endpoint ignores it.
+  if (filters.hideClosed) {
+    params.set('hideClosed', 'true');
+  }
   const qs = params.toString();
   return qs ? `?${qs}` : '';
 }
@@ -4283,8 +4288,20 @@ export interface MarkPartyPaidPreviewPayout {
 }
 
 export interface MarkPartyPaidPreviewResponse {
-  party: { id: string; name: string };
+  party: {
+    id: string;
+    name: string;
+    /**
+     * pinsa-92103: surfaced so the modal can pre-render the close-out body
+     * when the city is already closed (rare — the by-city table normally
+     * hides the entry button in that case, but PayoutReviewModal can still
+     * open this modal directly).
+     */
+    paymentsClosedAt?: string | null;
+  };
+  /** In-flight (pending + approved) payouts. */
   count: number;
+  /** Sum of in-flight payouts in USD. */
   totalUsd: number;
   /**
    * caciotta-92103: sum + count of payouts on this party that are already
@@ -4300,6 +4317,25 @@ export interface MarkPartyPaidPreviewResponse {
    * modal default-selects the radio matching this value.
    */
   suggestedMode: 'mark_paid' | 'withdraw_pending';
+  /**
+   * pinsa-92103: count of paid payouts for the party. Powers the close-out
+   * body copy ("Existing paid records (N payments, $X.XX total) stay
+   * unchanged"). Optional for backward-compat with cached payloads.
+   */
+  paidCount?: number;
+  /** pinsa-92103: sum of paid payouts in USD. */
+  paidTotalUsd?: number;
+  /**
+   * pinsa-92103: when null and `count + paidCount > 0`, the modal switches to
+   * close-out mode. Mirrors `party.paymentsClosedAt` for convenience.
+   */
+  paymentsClosedAt?: string | null;
+  /**
+   * pinsa-92103: false = no payouts of any status, so admin shouldn't see
+   * the Mark Paid button at all. True = at least something to action.
+   * Optional for backward-compat (older payloads default to in-flight-only).
+   */
+  eligible?: boolean;
   payouts: MarkPartyPaidPreviewPayout[];
 }
 
@@ -4327,6 +4363,43 @@ export async function fetchMarkPartyPaidPreview(
  * Returns `{ count, party, payoutIds }`. count=0 (HTTP 200) when there are no
  * in-flight payouts — modal renders "0 payouts to mark paid".
  */
+/**
+ * pinsa-92103 + caciotta-92103: response shape for POST
+ * /api/admin/parties/:id/mark-paid.
+ *
+ * `action` distinguishes the executed path. The handler resolves caciotta's
+ * `mode` first ('auto' picks between mark_paid and withdraw_pending) and
+ * then, if nothing is left in-flight after that resolution, pinsa's close-out
+ * path may auto-stamp `paymentsClosedAt`.
+ *
+ *   - `'mark_paid'`       — flipped 1+ in-flight payouts to paid.
+ *   - `'withdraw_pending'`— soft-withdrew pending+approved rows (caciotta).
+ *   - `'closed'`          — no in-flight rows, but the city had paid history,
+ *                           so we stamped `paymentsClosedAt` as a pure
+ *                           close-out (pinsa).
+ *   - `'already_closed'`  — no-op, city was already closed.
+ *   - `'noop'`            — no in-flight, no paid history; nothing to do.
+ *
+ * `mode` is preserved for backward compat with callers that pre-dated
+ * `action` — for mark_paid / withdraw_pending it mirrors `action`.
+ */
+export interface MarkPartyPaidResponse {
+  count: number;
+  mode?: 'mark_paid' | 'withdraw_pending';
+  party: {
+    id: string;
+    name: string;
+    paymentsClosedAt?: string | null;
+  };
+  payoutIds: string[];
+  action?:
+    | 'mark_paid'
+    | 'withdraw_pending'
+    | 'closed'
+    | 'already_closed'
+    | 'noop';
+}
+
 export async function markPartyPaid(
   partyId: string,
   body?: {
@@ -4343,21 +4416,14 @@ export async function markPartyPaid(
      */
     mode?: 'mark_paid' | 'withdraw_pending' | 'auto';
   },
-): Promise<{
-  count: number;
-  mode: 'mark_paid' | 'withdraw_pending';
-  party: { id: string; name: string };
-  payoutIds: string[];
-}> {
-  return apiRequest<{
-    count: number;
-    mode: 'mark_paid' | 'withdraw_pending';
-    party: { id: string; name: string };
-    payoutIds: string[];
-  }>(`/api/admin/parties/${partyId}/mark-paid`, {
-    method: 'POST',
-    body: body ?? {},
-  });
+): Promise<MarkPartyPaidResponse> {
+  return apiRequest<MarkPartyPaidResponse>(
+    `/api/admin/parties/${partyId}/mark-paid`,
+    {
+      method: 'POST',
+      body: body ?? {},
+    },
+  );
 }
 
 /**

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -877,6 +877,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           availableCurrencies={availableCurrencies}
           availableCountries={availableCountries}
           availableTags={availableTags}
+          // pinsa-92103: Hide closed cities only makes sense on the by-city
+          // view (paymentsClosedAt is a party-level signal). The per-payment
+          // view has no party-row, so the toggle would be confusing there.
+          showHideClosedToggle={viewMode === 'by-city'}
         />
 
         {/* etruria-92103: by-city / by-payment view toggle. by-city is the
@@ -1227,20 +1231,32 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             partyId={markPartyPaidTarget.partyId}
             partyNameHint={markPartyPaidTarget.partyNameHint}
             onClose={() => setMarkPartyPaidTarget(null)}
-            onSuccess={async ({ count, mode, partyName }) => {
-              // caciotta-92103: toast verb mirrors the resolved server mode
-              // so admins see whether new paid rows were created
-              // (mark_paid) or pending claims were closed
-              // (withdraw_pending).
-              let msg: string;
-              if (count === 0) {
-                msg = `No in-flight payouts for ${partyName} — nothing changed`;
-              } else if (mode === 'withdraw_pending') {
-                msg = `Withdrew ${count} pending claim${count === 1 ? '' : 's'} for ${partyName}`;
+            onSuccess={async ({ count, mode, partyName, action, paymentsClosedAt }) => {
+              // caciotta-92103 + pinsa-92103: split the toast copy by the
+              // resolved server action so the admin gets a clear signal
+              // whether they (a) flipped payouts to paid, (b) withdrew
+              // pending claims (caciotta), (c) closed out a fully-paid
+              // city (pinsa), or (d) the city was already closed / no-op.
+              let toastMsg: string;
+              if (action === 'closed') {
+                toastMsg = `Closed out ${partyName} — all payouts already paid`;
+              } else if (action === 'already_closed') {
+                toastMsg = `${partyName} is already closed out`;
+              } else if (action === 'noop') {
+                toastMsg = `No payouts to action for ${partyName}`;
+              } else if (action === 'withdraw_pending' || mode === 'withdraw_pending') {
+                toastMsg = count > 0
+                  ? `Withdrew ${count} pending claim${count === 1 ? '' : 's'} for ${partyName}`
+                  : `No in-flight payouts for ${partyName} — nothing changed`;
+              } else if (count > 0) {
+                const closedNow = !!paymentsClosedAt;
+                toastMsg = closedNow
+                  ? `Marked ${count} payment${count === 1 ? '' : 's'} paid for ${partyName} — city closed out`
+                  : `Marked ${count} payment${count === 1 ? '' : 's'} paid for ${partyName}`;
               } else {
-                msg = `Marked ${count} payment${count === 1 ? '' : 's'} paid for ${partyName}`;
+                toastMsg = `No in-flight payouts for ${partyName} — nothing changed`;
               }
-              pushToast(msg, 'success');
+              pushToast(toastMsg, 'success');
               await Promise.all([refresh(), loadPrepayQueue()]);
               if (detail && detail.partyId === markPartyPaidTarget.partyId) {
                 try {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1900,6 +1900,13 @@ export interface AdminPayout extends Payout, FlaggedReadyFields {
      * backward-compat.
      */
     primaryHostInCohosts?: boolean;
+    /**
+     * pinsa-92103: ISO timestamp when the admin marked the city's payouts
+     * fully closed-out. Null = still open. Used by the by-city table to
+     * render the ✓ Closed pill and hide the Mark paid affordance. Optional
+     * for backward-compat with cached payloads during a rolling deploy.
+     */
+    paymentsClosedAt?: string | null;
   };
   host: {
     id: string;
@@ -1995,6 +2002,13 @@ export interface AdminPayoutFilters {
     | 'activity_asc';
   cursor?: string;
   limit?: number;
+  /**
+   * pinsa-92103: hide cities whose payouts have been marked fully closed-out
+   * (paymentsClosedAt IS NOT NULL). Only the by-city endpoint honors this
+   * — the flat LIST endpoint ignores it. Default false / undefined = show
+   * closed cities (with the ✓ Closed pill).
+   */
+  hideClosed?: boolean;
 }
 
 export interface AdminPayoutTotals {
@@ -2110,6 +2124,13 @@ export interface PartyPayoutsRow {
     primaryHostInCohosts: boolean;
     /** Primary host (parties.userId). */
     userId: string | null;
+    /**
+     * pinsa-92103: ISO timestamp marking the city as fully closed out. Null
+     * = still open. The by-city table renders a ✓ Closed pill on these rows
+     * and hides the Mark paid button. Optional for backward-compat with
+     * cached payloads during a rolling deploy.
+     */
+    paymentsClosedAt?: string | null;
   };
   aggregates: {
     pendingCount: number;


### PR DESCRIPTION
## Summary
- New `parties.payments_closed_at` timestamptz + partial index.
- Mark paid button visible on no-pending paid-rows cities; opens a close-out flow.
- Auto-stamps close timestamp when pending+approved flip results in zero in-flight.
- Closed pill on closed rows.

## Test plan
- [ ] Ekiti / Tangier (fully paid) -> button visible -> close out flow -> Closed pill.
- [ ] City with pending -> mark_paid runs first; if zero remains, close stamped automatically.
- [ ] City with no payouts at all -> button hidden.