### PR TITLE
feat(melanzane-92103): video thumbnails + lightbox playback

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag, Coins } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag, Coins, Play } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
 import { updatePartyApi, updatePayoutDocument } from '../../lib/api';
+import { isVideoFile } from '../../lib/mediaUtils';
 import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal } from '../../types';
 import {
   PayoutStatusPill,
@@ -580,7 +581,30 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
                     title={doc.fileName}
                   >
-                    <img src={doc.url} alt={doc.fileName} className="w-full h-full object-cover" loading="lazy" />
+                    {/* melanzane-92103: per bottarga-92103, hosts can attach
+                        videos to payment-app pizza photos. Browsers can't
+                        render `.mp4`/`.mov` via <img>, so detect video by
+                        mimeType (or extension fallback for missing MIMEs) and
+                        render a <video> with `preload="metadata"` so the
+                        browser fetches the first frame as a poster. */}
+                    {isVideoFile(doc) ? (
+                      <>
+                        <video
+                          src={doc.url}
+                          preload="metadata"
+                          muted
+                          playsInline
+                          className="w-full h-full object-cover"
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                          <div className="bg-black/50 rounded-full p-3">
+                            <Play className="text-white" size={20} fill="white" />
+                          </div>
+                        </div>
+                      </>
+                    ) : (
+                      <img src={doc.url} alt={doc.fileName} className="w-full h-full object-cover" loading="lazy" />
+                    )}
                     <span
                       className={`absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
                         doc.kind === 'receipt' ? 'bg-amber-500 text-white' : 'bg-emerald-500 text-white'
@@ -614,12 +638,33 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
                         title={p.caption || p.fileName}
                       >
-                        <img
-                          src={p.thumbnailUrl || p.url}
-                          alt={p.fileName}
-                          className="w-full h-full object-cover"
-                          loading="lazy"
-                        />
+                        {/* melanzane-92103: video event-photos render as
+                            <video preload=metadata> so the browser pulls the
+                            first frame for the poster, with a play-icon
+                            overlay to signal it's playable. */}
+                        {isVideoFile(p) ? (
+                          <>
+                            <video
+                              src={p.url}
+                              preload="metadata"
+                              muted
+                              playsInline
+                              className="w-full h-full object-cover"
+                            />
+                            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                              <div className="bg-black/50 rounded-full p-3">
+                                <Play className="text-white" size={20} fill="white" />
+                              </div>
+                            </div>
+                          </>
+                        ) : (
+                          <img
+                            src={p.thumbnailUrl || p.url}
+                            alt={p.fileName}
+                            className="w-full h-full object-cover"
+                            loading="lazy"
+                          />
+                        )}
                         {isHidden && (
                           <span
                             className="absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-red-500 text-white"

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { X, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
+import { isVideoFile } from '../../lib/mediaUtils';
 
 /**
  * bresaola-89172: focused full-screen overlay for receipt / pizza-photo
@@ -96,6 +97,11 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   const current = images[index];
   if (!current) return null;
   const heic = isHeic(current);
+  // melanzane-92103: when the focused item is a video, render a <video> with
+  // controls + autoplay so admins can scrub. `muted` is required for autoplay
+  // under browser policy; `playsInline` keeps mobile from kicking into the
+  // fullscreen video shell.
+  const video = !heic && isVideoFile(current);
 
   return createPortal(
     <div
@@ -176,6 +182,18 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
             </a>
             <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
           </div>
+        ) : video ? (
+          /* melanzane-92103: keying on src so swapping between videos via
+             arrow nav cleanly remounts the <video> with the new source. */
+          <video
+            key={current.url}
+            src={current.url}
+            controls
+            autoPlay
+            muted
+            playsInline
+            className="max-h-[90vh] max-w-[90vw]"
+          />
         ) : (
           <img
             src={current.url}

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign, Trash2 } from 'lucide-react';
+import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign, Trash2, Play } from 'lucide-react';
 import { Payout, PayoutStatus } from '../../types';
 import { cancelPayout, getPayout, updatePayout, fetchAdminMe } from '../../lib/api';
 import { useAuth } from '../../contexts/AuthContext';
@@ -9,6 +9,7 @@ import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { CurrencyOverrideSelect } from './CurrencyOverrideSelect';
 import { ReceiptLightbox } from '../payments-shared';
+import { isVideoFile } from '../../lib/mediaUtils';
 
 interface PayoutDetailModalProps {
   partyId: string;
@@ -529,11 +530,32 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                         <button
                           type="button"
                           onClick={() => setLightboxState({ open: true, initialIndex: pizzasLightboxOffset + idx })}
-                          className="block w-full aspect-square rounded-lg overflow-hidden bg-theme-surface hover:opacity-90 transition-opacity"
+                          className="relative block w-full aspect-square rounded-lg overflow-hidden bg-theme-surface hover:opacity-90 transition-opacity"
                           aria-label={`Open ${d.fileName}`}
                           title={d.fileName}
                         >
-                          <img src={d.url} alt={d.fileName} className="w-full h-full object-cover" />
+                          {/* melanzane-92103: pizza/event photo entries can
+                              be .mp4 videos (per bottarga-92103). Render a
+                              <video> with poster-frame metadata + play
+                              overlay so admins can tell at-a-glance. */}
+                          {isVideoFile(d) ? (
+                            <>
+                              <video
+                                src={d.url}
+                                preload="metadata"
+                                muted
+                                playsInline
+                                className="w-full h-full object-cover"
+                              />
+                              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                                <div className="bg-black/50 rounded-full p-3">
+                                  <Play className="text-white" size={20} fill="white" />
+                                </div>
+                              </div>
+                            </>
+                          ) : (
+                            <img src={d.url} alt={d.fileName} className="w-full h-full object-cover" />
+                          )}
                         </button>
                         {/* pancetta-37195: per-photo uploader attribution.
                             Hidden for historical rows (null uploadedByUserId). */}
@@ -689,7 +711,27 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                   <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
                     {survivingPizzaPhotos.map(d => (
                       <div key={d.id} className="relative aspect-square rounded-lg overflow-hidden bg-theme-surface group">
-                        <img src={d.url} alt="" className="w-full h-full object-cover" />
+                        {/* melanzane-92103: same video-vs-image swap as the
+                            view-mode grid above so edit mode doesn't show
+                            an empty tile for .mp4 attachments. */}
+                        {isVideoFile(d) ? (
+                          <>
+                            <video
+                              src={d.url}
+                              preload="metadata"
+                              muted
+                              playsInline
+                              className="w-full h-full object-cover"
+                            />
+                            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                              <div className="bg-black/50 rounded-full p-3">
+                                <Play className="text-white" size={20} fill="white" />
+                              </div>
+                            </div>
+                          </>
+                        ) : (
+                          <img src={d.url} alt="" className="w-full h-full object-cover" />
+                        )}
                         <button
                           type="button"
                           onClick={() => setRemovedDocIds(prev => new Set(prev).add(d.id))}

--- a/frontend/src/components/payouts/ReceiptsLibrary.tsx
+++ b/frontend/src/components/payouts/ReceiptsLibrary.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Loader2, AlertCircle, RefreshCw, FileText, ExternalLink } from 'lucide-react';
+import { Loader2, AlertCircle, RefreshCw, FileText, ExternalLink, Play } from 'lucide-react';
 import { fetchReceiptsLibrary } from '../../lib/api';
 import type { ReceiptLibraryEntry } from '../../types';
 import { PayoutStatusPill } from '../payments-shared/PayoutStatusPill';
 import { ReceiptLightbox } from '../payments-shared';
+import { isVideoFile } from '../../lib/mediaUtils';
 
 interface ReceiptsLibraryProps {
   partyId: string;
@@ -115,7 +116,8 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
       {!loading && !error && receipts.length > 0 && (
         <ul className="divide-y divide-theme-stroke">
           {receipts.map((r, idx) => {
-            const isImage = (r.mimeType || '').startsWith('image/');
+            const isVideo = isVideoFile(r);
+            const isImage = !isVideo && (r.mimeType || '').startsWith('image/');
             const formattedDate = new Date(r.createdAt).toLocaleDateString(undefined, {
               year: 'numeric',
               month: 'short',
@@ -138,7 +140,25 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
                   aria-label={`Open ${r.fileName}`}
                   title={r.fileName}
                 >
-                  {isImage ? (
+                  {isVideo ? (
+                    /* melanzane-92103: receipt-library entries can include
+                        video uploads — render the first frame via <video
+                        preload="metadata"> with a small play overlay. */
+                    <div className="relative w-12 h-12">
+                      <video
+                        src={r.url}
+                        preload="metadata"
+                        muted
+                        playsInline
+                        className="w-12 h-12 object-cover block"
+                      />
+                      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                        <div className="bg-black/50 rounded-full p-1">
+                          <Play className="text-white" size={10} fill="white" />
+                        </div>
+                      </div>
+                    </div>
+                  ) : isImage ? (
                     <img
                       src={r.url}
                       alt={r.fileName}

--- a/frontend/src/lib/mediaUtils.ts
+++ b/frontend/src/lib/mediaUtils.ts
@@ -1,0 +1,20 @@
+/**
+ * melanzane-92103: shared helper for distinguishing video files from images
+ * across the payments-admin and payouts thumbnail grids and the shared
+ * ReceiptLightbox. Per bottarga-92103 the backend serializers now expose
+ * `mimeType` and `fileName` on `payout_documents` and event `Photo` rows, so
+ * we can detect video media by MIME prefix and fall back to a file-extension
+ * sniff for older rows that may have a missing/incorrect MIME.
+ */
+
+const VIDEO_EXTS = ['.mp4', '.m4v', '.mov', '.webm', '.mkv'];
+
+export function isVideoFile(item: {
+  mimeType?: string | null;
+  fileName?: string | null;
+  url?: string | null;
+}): boolean {
+  if (item.mimeType && item.mimeType.toLowerCase().startsWith('video/')) return true;
+  const path = (item.fileName || item.url || '').toLowerCase();
+  return VIDEO_EXTS.some((ext) => path.endsWith(ext));
+}


### PR DESCRIPTION
## Summary
- New `isVideoFile` helper (mimeType-or-extension detection).
- PayoutReviewModal event/pizza-photo thumbnail grids render `<video>` for video items with a play-icon overlay.
- ReceiptLightbox renders focused videos as `<video controls autoPlay muted playsInline>`.

## Test plan
- [ ] Medellín modal → .mp4 thumbnails show poster + play overlay.
- [ ] Click video tile → lightbox opens, video plays with controls.
- [ ] Arrow nav across mixed images + videos works.
- [ ] Image tiles unchanged.