### PR TITLE
feat(lasagna-92103): admin amount is canonical — no cap guards on PATCH or external POST

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1396,25 +1396,14 @@ router.post(
         throw new AppError('Host user not found', 404, 'HOST_NOT_FOUND');
       }
 
-      // acciuga-62583: hard per-submission $650 ceiling — enforced BEFORE the
-      // party-cap check so the error message is clearer even on uncapped
-      // events. Out-of-band records still get split by default.
-      // aglio-62584: admin override available here too — when the admin is
-      // recording an out-of-band payment that intentionally exceeds the cap
-      // (e.g. backfilling a pre-cap historical wire) they can pass
-      // `allowOverSubmissionCap: true`.
-      if (
-        finalAmountUsd > PER_SUBMISSION_MAX_USD &&
-        body.allowOverSubmissionCap === true
-      ) {
-        // admin acknowledged — proceed
-      } else {
-        assertWithinPerSubmissionCap(finalAmountUsd);
-      }
-
-      // tiramisu-49102: hard cap — block external records that would push the
-      // cumulative paid+pending+approved past the party's effective cap.
-      await assertWithinPartyCap(partyId, finalAmountUsd);
+      // lasagna-92103: admin amount is canonical on the external-record path
+      // too. Removed the per-submission cap throw + the per-party cap throw.
+      // Admins recording an out-of-band payment (already executed via bank /
+      // Mercury dashboard / etc.) shouldn't be cap-gated at the API
+      // boundary — they're documenting reality, not requesting an action.
+      // The USDC execute hard ceiling is irrelevant here (these are external
+      // payments, not on-chain sends). `body.allowOverSubmissionCap` is no
+      // longer read; legacy clients that still send it are ignored (no-op).
 
       const paidAt = body.paidAt ? new Date(body.paidAt) : new Date();
       if (Number.isNaN(paidAt.getTime())) {
@@ -2154,24 +2143,23 @@ router.patch(
         if (oldAmount !== newAmount) {
           amountChanged = true;
           data.finalAmountUsd = parsed;
-          // aglio-62584: admin override for the acciuga-62583 per-submission
-          // cap. When the admin is intentionally setting an over-cap amount
-          // (e.g. editing a grandfathered $750 row, or splitting on their own),
-          // they can pass `allowOverSubmissionCap: true` to bypass. The modal
-          // surfaces an amber warning + ack Checkbox before forwarding the
-          // flag. Host-side PATCH (payout.routes.ts) still has no override.
-          if (
-            parsed > PER_SUBMISSION_MAX_USD &&
-            req.body?.allowOverSubmissionCap === true
-          ) {
-            // admin acknowledged — proceed
-          } else {
-            assertWithinPerSubmissionCap(parsed);
-          }
-          // tiramisu-49102: re-check per-party cap when admin edits amount.
-          // Exclude THIS row from the existing-total so the edit doesn't
-          // count against itself.
-          await assertWithinPartyCap(existing.partyId, parsed, existing.id);
+          // lasagna-92103: admin amount is canonical. The admin PATCH edit
+          // path is intentionally uncapped — no per-submission cap throw, no
+          // per-party cap throw. Incident that motivated this: a Medellín
+          // payout was OCR'd at $465,101.77 (COP→USD conversion error) and
+          // the admin couldn't edit it down because aglio-62584's checkbox
+          // override only covered the user-typed amount, not the in-flight
+          // value the modal recomputed against the bad OCR sum. Admins can
+          // always proceed; the soft $650 default is now informational in
+          // the modal. The USDC execute hard ceiling
+          // (HARD_PER_TX_CEILING_USD in usdc-base.service.ts) remains as a
+          // separate safety net at on-chain send time — admins can split
+          // executes or record as external payment to handle larger sums.
+          // The per-party cap (tiramisu-49102) and per-address cap
+          // (bianco-89172) likewise stay on the approve/mark-paid/execute
+          // paths below; only the edit path is uncapped.
+          // `body.allowOverSubmissionCap` is no longer read here; existing
+          // frontends that still send it are ignored (no-op).
         }
       }
 

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -19,7 +19,6 @@ import {
   Star,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
-import { Checkbox } from '../Checkbox';
 import {
   recordExternalPayment,
   searchApprovedParties,
@@ -29,10 +28,12 @@ import { uploadPayoutPhoto } from '../../lib/supabase';
 import type { ExternalPaymentInput, PayoutMethod } from '../../types';
 
 /**
- * vegetariana-92103: client-side mirror of backend `PER_SUBMISSION_MAX_USD`
- * (see backend/src/routes/admin-payout.routes.ts). Used to surface the amber
- * warning + ack Checkbox when an admin enters > $650. Server is the source
- * of truth — this is purely UX so admins can opt into the override.
+ * lasagna-92103: $650 is the "sane-default" per-submission soft cap. The
+ * backend admin POST /external no longer enforces it (admin amount is
+ * canonical), so this constant now drives a purely informational amber
+ * warning — no Checkbox, no Submit block. The USDC execute hard ceiling
+ * is irrelevant for external (off-platform) payments which are already
+ * settled outside our hot wallet.
  */
 const PER_SUBMISSION_MAX_USD = 650;
 
@@ -97,10 +98,9 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  // vegetariana-92103: ack for the per-submission cap override. Required
-  // before Record Payment enables when the typed amount > $650. Reset on
-  // every modal close so re-opening starts clean.
-  const [ackOverSubmissionCap, setAckOverSubmissionCap] = useState(false);
+  // lasagna-92103: removed `ackOverSubmissionCap` — backend POST /external no
+  // longer enforces the per-submission cap. Admin amount is canonical; the
+  // amber warning below is informational only.
 
   // Close on Escape
   useEffect(() => {
@@ -110,14 +110,6 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
-
-  // vegetariana-92103: reset the over-cap ack whenever the modal unmounts so
-  // the next open doesn't carry a stale acknowledgement forward.
-  useEffect(() => {
-    return () => {
-      setAckOverSubmissionCap(false);
-    };
-  }, []);
 
   // Debounced party search — only runs when the picker is "open" (no party
   // selected yet) and the query has ≥2 chars.
@@ -155,8 +147,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
 
   const amountNum = useMemo(() => Number(amountStr), [amountStr]);
 
-  // vegetariana-92103: typed amount exceeds the per-submission cap. Recomputed
-  // every render so the amber warning toggles as the admin types.
+  // lasagna-92103: typed amount exceeds the $650 soft cap. Drives the
+  // informational amber warning below — no longer blocks Submit.
   const exceedsCap =
     Number.isFinite(amountNum) && amountNum > PER_SUBMISSION_MAX_USD;
 
@@ -181,8 +173,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     if (!recipientReady) return false;
     if (!Number.isFinite(amountNum) || amountNum <= 0) return false;
     if (!adminNotes.trim()) return false;
-    // vegetariana-92103: over-cap submissions require an explicit ack.
-    if (exceedsCap && !ackOverSubmissionCap) return false;
+    // lasagna-92103: over-cap submissions are no longer gated on an ack —
+    // admin amount is canonical; the warning is informational only.
     return !submitting && !uploading;
   }, [
     partyId,
@@ -191,8 +183,6 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     adminNotes,
     submitting,
     uploading,
-    exceedsCap,
-    ackOverSubmissionCap,
   ]);
 
   function handlePickParty(p: ApprovedPartySearchResult) {
@@ -283,11 +273,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
       } else {
         body.recipientHostUserId = recipientUserId;
       }
-      // vegetariana-92103: only forward the override when the admin actually
-      // acked the over-cap warning. Backend rejects > $650 without it.
-      if (exceedsCap && ackOverSubmissionCap) {
-        body.allowOverSubmissionCap = true;
-      }
+      // lasagna-92103: no longer forward `allowOverSubmissionCap` — the
+      // backend POST /external ignores it. Admin amount is canonical.
       if (method === 'wire' || method === 'other') {
         if (wireReference.trim()) body.wireReference = wireReference.trim();
       }
@@ -528,33 +515,25 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
               onChange={(e) => setAmountStr(e.target.value)}
               required
             />
-            {/* vegetariana-92103: amber warning + ack Checkbox when the typed
-                amount exceeds the per-submission cap. The backend will reject
-                the record unless `allowOverSubmissionCap: true` is forwarded.
-                External (off-platform) payments don't go through our hot
-                wallet so the admin override is fine when the funds already
-                moved via Venmo/wire/multisig. */}
+            {/* lasagna-92103: informational amber heads-up when the typed
+                amount exceeds the $650 sane-default cap. NOT a gate — admin
+                amount is canonical for external records. External payments
+                don't go through our hot wallet so the per-tx ceiling is
+                irrelevant; this is purely a visual nudge so admins notice
+                unusually large amounts before submitting. */}
             {exceedsCap && (
               <div className="card p-4 border-l-4 border-l-amber-500 bg-amber-500/10 mt-3">
                 <div className="flex items-start gap-3">
                   <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={18} />
                   <div className="flex-1 text-sm">
                     <div className="font-medium text-amber-200 mb-1">
-                      Over per-submission cap
+                      Heads-up: over per-submission soft cap
                     </div>
                     <div className="text-theme-text-secondary">
-                      ${amountNum.toFixed(2)} exceeds the ${PER_SUBMISSION_MAX_USD} per-submission cap.
-                      Most rsv.pizza-managed sends still cap at ${PER_SUBMISSION_MAX_USD} per tx for safety,
-                      but external (off-platform) payments don't go through our hot wallet —
-                      admin override is fine here when you've already paid via Venmo/wire/your own multisig.
-                    </div>
-                    <div className="mt-3">
-                      <Checkbox
-                        checked={ackOverSubmissionCap}
-                        onChange={() => setAckOverSubmissionCap((v) => !v)}
-                        label="I acknowledge — record the over-cap external payment"
-                        labelClassName="text-sm text-amber-100"
-                      />
+                      ${amountNum.toFixed(2)} is over the ${PER_SUBMISSION_MAX_USD} per-submission
+                      soft cap. Admin edits aren&apos;t gated by this — proceed if intentional.
+                      External payments don&apos;t go through our hot wallet so the USDC per-tx
+                      ceiling doesn&apos;t apply here.
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -24,12 +24,13 @@ function stripGppPrefix(name: string): string {
 }
 
 /**
- * aglio-62584: client-side mirror of backend `PER_SUBMISSION_MAX_USD` (see
- * admin-payout.routes.ts). Inlined here so the modal can render an amber
- * warning + ack Checkbox BEFORE submitting an over-cap edit. The server is
- * still the source of truth — if this constant drifts, the backend will
- * 400 with PER_SUBMISSION_CAP_EXCEEDED and the inline error panel
- * surfaces the message.
+ * lasagna-92103: $650 is the "sane-default" per-submission soft cap. The
+ * backend admin PATCH no longer enforces it (admin amount is canonical), so
+ * this constant now drives a purely informational amber warning — no
+ * Checkbox, no Save block. The USDC execute hard ceiling
+ * (HARD_PER_TX_CEILING_USD in usdc-base.service.ts) remains as a separate
+ * safety net at on-chain send time, but admins can split executes or record
+ * external payments to handle larger sums.
  */
 const PER_SUBMISSION_MAX_USD = 650;
 
@@ -52,10 +53,11 @@ interface PayoutReviewModalProps {
    */
   onUnapprove?: () => Promise<string | void> | string | void;
   /**
-   * aglio-62584: `allowOverSubmissionCap` is forwarded when the admin has
-   * acknowledged the amber $650 cap warning by ticking the override
-   * Checkbox below the amount input. Parent should forward to
-   * `updateAdminPayout`'s `allowOverSubmissionCap` field.
+   * lasagna-92103: backend admin PATCH no longer enforces the per-submission
+   * cap, so `allowOverSubmissionCap` is no longer forwarded by this modal.
+   * The signature still accepts the field for back-compat with parents that
+   * pass it through to the API client; the value (if any) is ignored by the
+   * server.
    *
    * Returns a string error message (NOT throws) when the save fails — the
    * modal renders it inline below the Save button so the failure isn't
@@ -238,11 +240,13 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const [adminNotes, setAdminNotes] = useState(payout.adminNotes ?? '');
   const [adminNotesDirty, setAdminNotesDirty] = useState(false);
 
-  // aglio-62584: per-submission $650 cap override + inline error surface.
-  // `ackOverSubmissionCap` is required before Save enables when the draft
-  // amount exceeds the cap; `saveAmountError` renders inline below the
-  // Save button when the backend (or any other failure path) rejects.
-  const [ackOverSubmissionCap, setAckOverSubmissionCap] = useState(false);
+  // lasagna-92103: `ackOverSubmissionCap` is gone — admin amount is now
+  // canonical on the backend, so the modal doesn't gate Save on an
+  // acknowledgement. The amber warning below stays as an informational
+  // heads-up when the typed amount exceeds the $650 sane-default cap.
+  // `saveAmountError` still renders inline below the Save button when
+  // the backend (or any other failure path) rejects — wallet/method
+  // validation, etc.
   const [saveAmountError, setSaveAmountError] = useState<string | null>(null);
 
   const [showRejectForm, setShowRejectForm] = useState(false);
@@ -653,9 +657,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     onClick={() => {
                       setDraftAmount(String(payout.finalAmountUsd));
                       setEditingAmount(true);
-                      // aglio-62584: clear any stale cap-ack / error state
-                      // from a prior open so the warning behaviour is fresh.
-                      setAckOverSubmissionCap(false);
+                      // lasagna-92103: clear any stale error from a prior open.
                       setSaveAmountError(null);
                     }}
                     disabled={selfPayoutBlocked || busy}
@@ -668,13 +670,13 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               </div>
               {editingAmount ? (
                 (() => {
-                  // aglio-62584: per-submission cap warning + ack. Recompute
-                  // on every render so the warning toggles as the admin types.
+                  // lasagna-92103: amber warning is informational only. Save
+                  // is gated on validity (Number.isFinite + non-negative) and
+                  // not-busy — no longer on an over-cap acknowledgement.
                   const draftNum = Number(draftAmount);
                   const draftIsValid = Number.isFinite(draftNum) && draftNum >= 0;
                   const exceedsCap = draftIsValid && draftNum > PER_SUBMISSION_MAX_USD;
-                  const saveDisabled =
-                    busy || !draftIsValid || (exceedsCap && !ackOverSubmissionCap);
+                  const saveDisabled = busy || !draftIsValid;
                   return (
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
@@ -695,22 +697,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                           type="button"
                           onClick={async () => {
                             if (!draftIsValid) return;
-                            if (exceedsCap && !ackOverSubmissionCap) return;
                             setSaveAmountError(null);
                             try {
-                              const result = await onSaveAmount(draftNum, {
-                                allowOverSubmissionCap: exceedsCap
-                                  ? ackOverSubmissionCap
-                                  : undefined,
-                              });
-                              // aglio-62584: parent may return a string instead
-                              // of throwing — surface it inline.
+                              // lasagna-92103: no longer forward
+                              // `allowOverSubmissionCap` — the backend admin
+                              // PATCH ignores it. Admin amount is canonical.
+                              const result = await onSaveAmount(draftNum);
+                              // Parent may return a string instead of throwing
+                              // — surface it inline.
                               if (typeof result === 'string' && result.length > 0) {
                                 setSaveAmountError(result);
                                 return;
                               }
                               setEditingAmount(false);
-                              setAckOverSubmissionCap(false);
                             } catch (err: any) {
                               setSaveAmountError(
                                 (err && (err.message || String(err))) ||
@@ -727,7 +726,6 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                           type="button"
                           onClick={() => {
                             setEditingAmount(false);
-                            setAckOverSubmissionCap(false);
                             setSaveAmountError(null);
                           }}
                           className="px-3 py-2 rounded-lg text-sm text-theme-text-secondary hover:bg-theme-surface-hover"
@@ -735,41 +733,34 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                           Cancel
                         </button>
                       </div>
-                      {/* aglio-62584: amber warning + ack Checkbox when the
-                          typed value exceeds the per-submission cap. The
-                          backend will reject the save unless the modal
-                          forwards `allowOverSubmissionCap: true`. */}
+                      {/* lasagna-92103: informational amber heads-up when the
+                          typed value exceeds the $650 sane-default cap. NOT a
+                          gate — admin amount is canonical on the backend; the
+                          warning is purely a visual nudge so admins notice
+                          unusually large amounts before saving. */}
                       {exceedsCap && (
                         <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
                           <div className="flex items-start gap-2.5">
                             <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
                             <div className="flex-1 text-sm">
                               <div className="font-medium text-amber-200 mb-1">
-                                Per-submission cap warning
+                                Heads-up: over per-submission soft cap
                               </div>
                               <div className="text-theme-text-secondary text-xs">
-                                Payments are normally capped at{' '}
-                                <b>${PER_SUBMISSION_MAX_USD}</b> per submission.
-                                Saving <b>${draftNum.toFixed(2)}</b> requires an
-                                explicit override (used for grandfathered or
-                                pre-cap rows).
-                              </div>
-                              <div className="mt-3">
-                                <Checkbox
-                                  checked={ackOverSubmissionCap}
-                                  onChange={() => setAckOverSubmissionCap((v) => !v)}
-                                  label={`I acknowledge — this exceeds the $${PER_SUBMISSION_MAX_USD} per-submission cap`}
-                                  labelClassName="text-sm text-amber-100"
-                                />
+                                <b>${draftNum.toFixed(2)}</b> is over the{' '}
+                                <b>${PER_SUBMISSION_MAX_USD}</b> per-submission
+                                soft cap. Admin edits aren&apos;t gated by
+                                this — proceed if intentional. USDC execute
+                                still caps at <b>${PER_SUBMISSION_MAX_USD}</b>{' '}
+                                per on-chain tx.
                               </div>
                             </div>
                           </div>
                         </div>
                       )}
-                      {/* aglio-62584: inline error surface so save failures
-                          aren't silent. Covers backend rejections (bad
-                          wallet, party cap exceeded, etc.) and network
-                          errors. */}
+                      {/* Inline error surface so save failures aren't silent.
+                          Covers backend rejections (bad wallet, etc.) and
+                          network errors. */}
                       {saveAmountError && (
                         <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10">
                           <div className="flex items-start gap-2.5">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4130,9 +4130,11 @@ export async function updateAdminPayout(
     payoutBankDetails?: BankDetails | null;
     note?: string;
     /**
-     * aglio-62584: admin override for the acciuga-62583 per-submission
-     * $650 cap. Forwarded only when the admin has ticked the ack Checkbox
-     * in PayoutReviewModal's amount-edit form (or recordExternalPayment).
+     * lasagna-92103: previously the admin override for the acciuga-62583
+     * per-submission $650 cap. The backend admin PATCH no longer enforces
+     * the cap (admin amount is canonical), so this field is now a no-op
+     * kept only for back-compat with any caller that still sets it. Safe
+     * to omit.
      */
     allowOverSubmissionCap?: boolean;
   },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1789,10 +1789,10 @@ export interface ExternalPaymentInput {
   externalProofUrl?: string;
   adminNotes: string;         // REQUIRED — must explain why this is being recorded
   /**
-   * aglio-62584: admin override for the acciuga-62583 per-submission $650
-   * cap. Set to `true` when backfilling a pre-cap historical out-of-band
-   * payment that legitimately exceeded $650. Without this, finalAmountUsd
-   * > $650 is rejected with PER_SUBMISSION_CAP_EXCEEDED.
+   * lasagna-92103: previously the admin override for the acciuga-62583
+   * per-submission $650 cap. The backend POST /external no longer enforces
+   * the cap (admin amount is canonical), so this field is now a no-op kept
+   * only for back-compat with any caller that still sets it. Safe to omit.
    */
   allowOverSubmissionCap?: boolean;
 }


### PR DESCRIPTION
## Summary
- Admin PATCH + external POST: removed all per-submission and per-party cap throws.
- Frontend PayoutReviewModal + ExternalPaymentModal: amber warning becomes informational only (no Checkbox / no Submit block).
- Host-side cap behavior + USDC execute ceiling + per-address cap unchanged.

## Test plan
- [ ] Admin edits Medellín $465K payout to $250 → save succeeds, no cap error.
- [ ] Admin sets $1000 → succeeds with informational warning.
- [ ] Admin records external $5000 → succeeds.
- [ ] Host submits $1500 receipts on $625 cap → still clamps to $625.
- [ ] Admin tries to USDC-execute a saved $1000 row → fails at execute time (different layer).