### PR TITLE
chore(cassoeula-92103): raise per-tx cap from $650 to $675

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -56,14 +56,14 @@ const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'fai
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 
 /**
- * acciuga-62583: hard per-submission ceiling of $650 (grana-92103, was $625) —
+ * acciuga-62583: hard per-submission ceiling of $675 (cassoeula-92103, was $650) —
  * same value as `HARD_PER_TX_CEILING_USD` in usdc-base.service.ts (the
  * USDC-execute ceiling) but enforced here at SUBMISSION time across all admin
  * create/edit paths (external POST + PATCH). No override path. Inlined here
  * per task spec — mirror of the helper in payout.routes.ts so we don't extract
  * a shared module just for two callsites.
  */
-const PER_SUBMISSION_MAX_USD = 650;
+const PER_SUBMISSION_MAX_USD = 675;
 
 function assertWithinPerSubmissionCap(amountUsd: number) {
   if (!Number.isFinite(amountUsd) || amountUsd <= 0) return;
@@ -2150,7 +2150,7 @@ router.patch(
           // the admin couldn't edit it down because aglio-62584's checkbox
           // override only covered the user-typed amount, not the in-flight
           // value the modal recomputed against the bad OCR sum. Admins can
-          // always proceed; the soft $650 default is now informational in
+          // always proceed; the soft $675 default is now informational in
           // the modal. The USDC execute hard ceiling
           // (HARD_PER_TX_CEILING_USD in usdc-base.service.ts) remains as a
           // separate safety net at on-chain send time — admins can split
@@ -2837,7 +2837,7 @@ router.get(
 // Returns cumulative paid USDC for a single recipient wallet, optionally with
 // a `wouldExceed` flag for a proposed additional amount. Backs the warning
 // panels in PayoutReviewModal + BulkSendModal so admins can see "wallet X has
-// already received $Y; sending $Z more would push past the $651 per-address
+// already received $Y; sending $Z more would push past the $676 per-address
 // cap" before they fire off a duplicate payment.
 //
 // Query params:
@@ -2916,7 +2916,7 @@ async function executePayout(params: {
   };
   body: any;
   /**
-   * bianco-89172: when true, skip the per-address $651 cumulative cap
+   * bianco-89172: when true, skip the per-address $676 cumulative cap
    * pre-flight inside `sendUsdcPayment`. The admin UI sets this only when
    * the warning's acknowledgement checkbox has been ticked.
    */
@@ -3207,7 +3207,7 @@ router.post(
         payoutId: existing.id,
         actor: { email: actor.email, actorKind: actor.actorKind },
         body: req.body || {},
-        // bianco-89172: admin can acknowledge the per-address $651 cap
+        // bianco-89172: admin can acknowledge the per-address $676 cap
         // warning via the PayoutReviewModal checkbox; the frontend forwards
         // the flag here.
         allowOverPerAddressCap: !!(req.body && req.body.allowOverPerAddressCap),

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -363,14 +363,14 @@ async function assertMercuryAllowed(
 }
 
 /**
- * acciuga-62583: hard per-submission ceiling of $650 (grana-92103, was $625).
+ * acciuga-62583: hard per-submission ceiling of $675 (cassoeula-92103, was $650).
  * Independent of the per-party cap (tiramisu-49102): even on uncapped parties,
- * no single payout row can exceed $650. Same numeric value as
+ * no single payout row can exceed $675. Same numeric value as
  * `HARD_PER_TX_CEILING_USD` in usdc-base.service.ts (the USDC-execute ceiling)
  * but enforced here at SUBMISSION time across all methods — no override path.
  * Hosts split larger expenses across multiple submissions.
  */
-const PER_SUBMISSION_MAX_USD = 650;
+const PER_SUBMISSION_MAX_USD = 675;
 
 function assertWithinPerSubmissionCap(amountUsd: number) {
   if (!Number.isFinite(amountUsd) || amountUsd <= 0) return;

--- a/backend/src/services/usdc-base.service.ts
+++ b/backend/src/services/usdc-base.service.ts
@@ -35,21 +35,21 @@ import { prisma } from '../config/database.js';
 
 const USDC_BASE_ADDRESS: Hex = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 const USDC_DECIMALS = 6;
-const HARD_PER_TX_CEILING_USD = 650;
+const HARD_PER_TX_CEILING_USD = 675;
 const DEFAULT_PER_TX_CAP_USD = 200;
 const DEFAULT_DAILY_CAP_USD = 2000;
 const TX_RECEIPT_TIMEOUT_MS = 90_000;
 
 /**
  * bianco-89172: per-address cumulative cap. No single 0x address should ever
- * receive more than $651 USDC (grana-92103, was $626) across all parties
+ * receive more than $676 USDC (cassoeula-92103, was $651) across all parties
  * without explicit admin acknowledgement. Matches HARD_PER_TX_CEILING_USD +
  * $1 cushion (so a single at-the-ceiling tx doesn't accidentally trip this)
  * while still catching the double-payment scenarios observed in Osogbo ($626)
  * and Seropédica ($600).
  * Override via `sendUsdcPayment(addr, amt, { allowOverPerAddressCap: true })`.
  */
-export const PER_ADDRESS_HARD_CAP_USD = 651;
+export const PER_ADDRESS_HARD_CAP_USD = 676;
 
 const ERC20_TRANSFER_ABI = [
   {
@@ -215,7 +215,7 @@ export async function getPerAddressPaidTotals(
  * Throws on any pre-flight failure or onchain revert. Caller must persist the
  * resulting `txHash` on the payout row.
  *
- * `opts.allowOverPerAddressCap` (bianco-89172): bypass the per-address $651
+ * `opts.allowOverPerAddressCap` (bianco-89172): bypass the per-address $676
  * cumulative-paid pre-flight. Required when the admin has acknowledged the
  * warning in PayoutReviewModal / BulkSendModal. Default false.
  */

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -39,7 +39,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
 
   // bianco-89172: per-wallet prior-paid totals (lowercased addr → WalletPaidTotal).
   // Fetched once per modal-open, then locally combined with the in-batch
-  // amounts to determine which wallets would push past the $651 cap. The
+  // amounts to determine which wallets would push past the $676 cap. The
   // admin must tick `overrideCap` to enable Send when any wallet would exceed.
   const [walletTotals, setWalletTotals] = useState<Map<string, WalletPaidTotal>>(new Map());
   const [walletTotalsLoading, setWalletTotalsLoading] = useState(false);
@@ -105,7 +105,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
         } catch {
           return [
             addr,
-            { address: addr, paidUsd: 0, paidCount: 0, capUsd: 651, wouldExceed: null },
+            { address: addr, paidUsd: 0, paidCount: 0, capUsd: 676, wouldExceed: null },
           ] as const;
         }
       }),
@@ -129,7 +129,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
   // on Send + the warning panel.
   const capAnalysis = useMemo(() => {
     if (walletTotals.size === 0 || eligible.length === 0) {
-      return { overCapRowIds: new Set<string>(), overCapWalletCount: 0, capUsd: 651 };
+      return { overCapRowIds: new Set<string>(), overCapWalletCount: 0, capUsd: 676 };
     }
     // First, sum up each wallet's in-batch total.
     const inBatchByWallet = new Map<string, number>();
@@ -138,7 +138,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
       if (!addr) continue;
       inBatchByWallet.set(addr, (inBatchByWallet.get(addr) || 0) + Number(p.finalAmountUsd || 0));
     }
-    let capUsd = 651;
+    let capUsd = 676;
     const overCapWallets = new Set<string>();
     for (const [addr, batchTotal] of inBatchByWallet.entries()) {
       const wt = walletTotals.get(addr);
@@ -267,7 +267,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
 
             {/* bianco-89172: per-address cap warning. Surfaces a count of
                 wallets in this selection whose prior-paid + in-batch total
-                would exceed the $651 cap, and requires an explicit override
+                would exceed the $676 cap, and requires an explicit override
                 checkbox to enable Send. The server-side pre-flight is the
                 ultimate gate; this is just defense-in-depth for admins. */}
             {walletTotalsLoading && eligible.length > 0 && (

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -17,11 +17,11 @@ function stripGppPrefix(name: string): string {
 }
 
 /**
- * acciuga-62583: hard per-submission ceiling of $650 (grana-92103, was $625).
+ * acciuga-62583: hard per-submission ceiling of $675 (cassoeula-92103, was $650).
  * Matches backend `PER_SUBMISSION_CAP_EXCEEDED` (400). No override path —
  * admin must split larger prepayments across multiple submissions.
  */
-const PER_SUBMISSION_MAX_USD = 650;
+const PER_SUBMISSION_MAX_USD = 675;
 
 interface CreatePrepaymentModalProps {
   row: PrepayQueueRow;
@@ -63,7 +63,7 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
   // decimals round-trip through the backend without loss.
   // tiramisu-49102: clamp the default to whatever's actually left under the
   // cap (so a paid-down event doesn't pre-fill an over-cap default).
-  // acciuga-62583: also clamp to the hard $650 per-submission ceiling so the
+  // acciuga-62583: also clamp to the hard $675 per-submission ceiling so the
   // pre-filled default never trips the backend limit.
   const rawDefault = cap > 0 ? cap / 2 : 1;
   const clampedDefault =
@@ -109,7 +109,7 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
   const exceedsRemaining =
     remainingUsd != null && Number.isFinite(amountNum) && amountNum > remainingUsd + 1e-9;
 
-  // acciuga-62583: hard per-submission $650 ceiling, no override. Backend
+  // acciuga-62583: hard per-submission $675 ceiling, no override. Backend
   // also enforces with 400 PER_SUBMISSION_CAP_EXCEEDED.
   const exceedsPerSubmission = Number.isFinite(amountNum) && amountNum > PER_SUBMISSION_MAX_USD;
 
@@ -313,7 +313,7 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
                 Exceeds cap: ${remainingUsd.toFixed(2)} remaining
               </p>
             )}
-            {/* acciuga-62583: per-submission $650 ceiling */}
+            {/* acciuga-62583: per-submission $675 ceiling */}
             {exceedsPerSubmission && (
               <p className="text-xs text-red-500 mt-1">
                 Single payments capped at ${PER_SUBMISSION_MAX_USD}

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -28,14 +28,14 @@ import { uploadPayoutPhoto } from '../../lib/supabase';
 import type { ExternalPaymentInput, PayoutMethod } from '../../types';
 
 /**
- * lasagna-92103: $650 is the "sane-default" per-submission soft cap. The
+ * lasagna-92103: $675 is the "sane-default" per-submission soft cap. The
  * backend admin POST /external no longer enforces it (admin amount is
  * canonical), so this constant now drives a purely informational amber
  * warning — no Checkbox, no Submit block. The USDC execute hard ceiling
  * is irrelevant for external (off-platform) payments which are already
  * settled outside our hot wallet.
  */
-const PER_SUBMISSION_MAX_USD = 650;
+const PER_SUBMISSION_MAX_USD = 675;
 
 interface ExternalPaymentModalProps {
   onClose: () => void;
@@ -147,7 +147,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
 
   const amountNum = useMemo(() => Number(amountStr), [amountStr]);
 
-  // lasagna-92103: typed amount exceeds the $650 soft cap. Drives the
+  // lasagna-92103: typed amount exceeds the $675 soft cap. Drives the
   // informational amber warning below — no longer blocks Submit.
   const exceedsCap =
     Number.isFinite(amountNum) && amountNum > PER_SUBMISSION_MAX_USD;
@@ -516,7 +516,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
               required
             />
             {/* lasagna-92103: informational amber heads-up when the typed
-                amount exceeds the $650 sane-default cap. NOT a gate — admin
+                amount exceeds the $675 sane-default cap. NOT a gate — admin
                 amount is canonical for external records. External payments
                 don't go through our hot wallet so the per-tx ceiling is
                 irrelevant; this is purely a visual nudge so admins notice

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -25,7 +25,7 @@ function stripGppPrefix(name: string): string {
 }
 
 /**
- * lasagna-92103: $650 is the "sane-default" per-submission soft cap. The
+ * lasagna-92103: $675 is the "sane-default" per-submission soft cap. The
  * backend admin PATCH no longer enforces it (admin amount is canonical), so
  * this constant now drives a purely informational amber warning — no
  * Checkbox, no Save block. The USDC execute hard ceiling
@@ -33,7 +33,7 @@ function stripGppPrefix(name: string): string {
  * safety net at on-chain send time, but admins can split executes or record
  * external payments to handle larger sums.
  */
-const PER_SUBMISSION_MAX_USD = 650;
+const PER_SUBMISSION_MAX_USD = 675;
 
 interface PayoutReviewModalProps {
   payout: AdminPayoutDetail;
@@ -81,7 +81,7 @@ interface PayoutReviewModalProps {
    * For wire / mercury_card → admin-supplied refs.
    *
    * `allowOverPerAddressCap` (bianco-89172): forwarded when the admin has
-   * acknowledged the per-address $651 cap warning by ticking the override
+   * acknowledged the per-address $676 cap warning by ticking the override
    * checkbox in the execute form.
    */
   onExecute: (body: {
@@ -244,7 +244,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // lasagna-92103: `ackOverSubmissionCap` is gone — admin amount is now
   // canonical on the backend, so the modal doesn't gate Save on an
   // acknowledgement. The amber warning below stays as an informational
-  // heads-up when the typed amount exceeds the $650 sane-default cap.
+  // heads-up when the typed amount exceeds the $675 sane-default cap.
   // `saveAmountError` still renders inline below the Save button when
   // the backend (or any other failure path) rejects — wallet/method
   // validation, etc.
@@ -275,7 +275,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   >(null);
   const [usdcCapLoading, setUsdcCapLoading] = useState(false);
 
-  // bianco-89172: per-address $651 cap warning state. `walletPaidTotal` is
+  // bianco-89172: per-address $676 cap warning state. `walletPaidTotal` is
   // null until the USDC execute form opens; `overrideCap` is the admin's
   // acknowledgement of the warning (required to enable Execute when
   // `wouldExceed === true`).
@@ -472,7 +472,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       }
     }
     // bianco-89172: fetch the per-address paid-total for the recipient wallet
-    // so we can warn the admin if this payout would push past the $651 cap.
+    // so we can warn the admin if this payout would push past the $676 cap.
     if (
       payout.payoutMethod === 'usdc_base' &&
       payout.payoutWalletAddress &&
@@ -779,7 +779,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         </button>
                       </div>
                       {/* lasagna-92103: informational amber heads-up when the
-                          typed value exceeds the $650 sane-default cap. NOT a
+                          typed value exceeds the $675 sane-default cap. NOT a
                           gate — admin amount is canonical on the backend; the
                           warning is purely a visual nudge so admins notice
                           unusually large amounts before saving. */}
@@ -1273,7 +1273,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         <span className="text-emerald-800/70">Daily cap status unavailable.</span>
                       )}
                     </div>
-                    {/* bianco-89172: per-address $651 cap warning. Only shown
+                    {/* bianco-89172: per-address $676 cap warning. Only shown
                         when the proposed send would push the recipient's
                         cumulative paid total past the cap. The admin must
                         explicitly tick the override checkbox; until they do,

--- a/frontend/src/components/payouts/AppealCapModal.tsx
+++ b/frontend/src/components/payouts/AppealCapModal.tsx
@@ -7,7 +7,7 @@ import { appealReimbursementCap } from '../../lib/api';
 // Mirrors HARD_PER_TX_CEILING_USD in backend/src/services/usdc-base.service.ts.
 // Hosts already at this cap can't be pushed higher via the appeal form; they
 // need to talk to an underboss directly.
-const MAX_PER_TX_CEILING_USD = 650;
+const MAX_PER_TX_CEILING_USD = 675;
 
 interface AppealCapModalProps {
   partyId: string;

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -12,13 +12,13 @@ import { PayoutAmountSummary } from './PayoutAmountSummary';
 import { AppealCapModal } from './AppealCapModal';
 
 /**
- * speck-89172: the $650 per-payment hard ceiling is still informative — USDC
- * execute still caps at $650 per tx (grana-92103, was $625), so a single
+ * speck-89172: the $675 per-payment hard ceiling is still informative — USDC
+ * execute still caps at $675 per tx (cassoeula-92103, was $650), so a single
  * oversize submission may require admin to split into multiple sends. Host
  * submission is no longer blocked; instead we render an amber warning so the
  * host knows what to expect on the admin side.
  */
-const PER_PAYMENT_HARD_CEILING_USD = 650;
+const PER_PAYMENT_HARD_CEILING_USD = 675;
 
 interface NewPayoutFormProps {
   partyId: string;
@@ -148,7 +148,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
     || (estimatedAttendance != null && estimatedAttendance > 0);
 
   // speck-89172: hosts can now submit any positive amount. The party-cap and
-  // $650 hard-ceiling checks are surfaced as non-blocking amber warnings
+  // $675 hard-ceiling checks are surfaced as non-blocking amber warnings
   // instead. Admin moderates over-cap rows from /payments.
   const effectiveCapUsd = party?.effectiveReimbursementCapUsd ?? null;
   const exceedsPartyCap =
@@ -418,8 +418,8 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         </div>
       )}
 
-      {/* speck-89172: $650 hard-ceiling amber warning. USDC execute caps at
-          $650 per tx, so admin may need to split this into multiple sends. */}
+      {/* speck-89172: $675 hard-ceiling amber warning. USDC execute caps at
+          $675 per tx, so admin may need to split this into multiple sends. */}
       {exceedsHardCeiling && (
         <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
           <div className="flex items-start gap-2.5">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4131,7 +4131,7 @@ export async function updateAdminPayout(
     note?: string;
     /**
      * lasagna-92103: previously the admin override for the acciuga-62583
-     * per-submission $650 cap. The backend admin PATCH no longer enforces
+     * per-submission $675 cap. The backend admin PATCH no longer enforces
      * the cap (admin amount is canonical), so this field is now a no-op
      * kept only for back-compat with any caller that still sets it. Safe
      * to omit.
@@ -4435,7 +4435,7 @@ export async function markPartyPaid(
  *   - mercury_card → { mercuryCardLast4: 'NNNN', mercuryCardId?: string, note?: string } REQUIRED
  *
  * `allowOverPerAddressCap` (bianco-89172): forwarded to the server to bypass
- * the per-address $651 cumulative cap when the admin has acknowledged the
+ * the per-address $676 cumulative cap when the admin has acknowledged the
  * warning in PayoutReviewModal.
  *
  * Returns the updated payout. Throws on any server-side validation/execution failure.
@@ -4493,7 +4493,7 @@ export async function bulkExecutePayouts(
 /**
  * bianco-89172: fetch the cumulative paid-USDC total for a single recipient
  * wallet, optionally with a "wouldExceed" check for a proposed additional
- * amount. Backs the per-address $651 cap warning in PayoutReviewModal +
+ * amount. Backs the per-address $676 cap warning in PayoutReviewModal +
  * BulkSendModal. Returns `wouldExceed: null` when `amount` is omitted.
  *
  * Admin-only — throws via `apiRequest` if the caller is not a payment admin.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1790,7 +1790,7 @@ export interface ExternalPaymentInput {
   adminNotes: string;         // REQUIRED — must explain why this is being recorded
   /**
    * lasagna-92103: previously the admin override for the acciuga-62583
-   * per-submission $650 cap. The backend POST /external no longer enforces
+   * per-submission $675 cap. The backend POST /external no longer enforces
    * the cap (admin amount is canonical), so this field is now a no-op kept
    * only for back-compat with any caller that still sets it. Safe to omit.
    */
@@ -1948,7 +1948,7 @@ export interface AdminPayoutDetail extends AdminPayout {
 
 /**
  * bianco-89172: cumulative paid-USDC summary for a single recipient wallet.
- * Backs the per-address $651 cap warning in PayoutReviewModal + BulkSendModal.
+ * Backs the per-address $676 cap warning in PayoutReviewModal + BulkSendModal.
  * `wouldExceed` is null when no proposed `amount` was supplied to the
  * `/wallet-paid-total` endpoint; true / false when one was.
  */


### PR DESCRIPTION
## Summary
- Backend HARD_PER_TX_CEILING_USD → 675
- Backend PER_SUBMISSION_MAX_USD → 675 (host + admin)
- PER_ADDRESS_HARD_CAP_USD → 676
- Frontend mirrors + visible copy → $675
- AppealCapModal copy: "$675 is the most we fund each city"

## Test plan
- [ ] $670 host receipt → no warning.
- [ ] $680 host receipt → amber warning.
- [ ] $670 USDC execute → goes through (was capped at 650 before).