### PR TITLE
feat(tortelli-92103): regional /payments/<region> portals for all underbosses

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,12 @@ import { ShippingDashboard } from './pages/ShippingDashboard';
 import { AdminPage } from './pages/AdminPage';
 import { PaymentsAdminPage } from './pages/PaymentsAdminPage';
 import { LatamPaymentsPage } from './pages/LatamPaymentsPage';
+import { SouthAfricaPaymentsPage } from './pages/SouthAfricaPaymentsPage';
+import { AfricaPaymentsPage } from './pages/AfricaPaymentsPage';
+import { NaPaymentsPage } from './pages/NaPaymentsPage';
+import { EuropePaymentsPage } from './pages/EuropePaymentsPage';
+import { IndiaPaymentsPage } from './pages/IndiaPaymentsPage';
+import { AsiaPaymentsPage } from './pages/AsiaPaymentsPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
 import { ConsolidatedReportPage } from './pages/ConsolidatedReportPage';
@@ -81,6 +87,15 @@ function App() {
                 underboss. Wraps PaymentsAdminPage with regionFilter +
                 portalSlug. Must come before /:slug. */}
             <Route path="/payments/latam" element={<LatamPaymentsPage />} />
+            {/* tortelli-92103: regional /payments/<region> portals for the
+                rest of the UB regional split. Each wraps PaymentsAdminPage
+                with a fixed regionFilter + portalSlug. Must come before /:slug. */}
+            <Route path="/payments/southafrica" element={<SouthAfricaPaymentsPage />} />
+            <Route path="/payments/africa" element={<AfricaPaymentsPage />} />
+            <Route path="/payments/na" element={<NaPaymentsPage />} />
+            <Route path="/payments/europe" element={<EuropePaymentsPage />} />
+            <Route path="/payments/india" element={<IndiaPaymentsPage />} />
+            <Route path="/payments/asia" element={<AsiaPaymentsPage />} />
             {/* margherita-43821: /photos public global feed; must come before /:slug */}
             <Route path="/photos" element={<PhotosFeedPage />} />
             <Route path="/account" element={<AccountPage />} />

--- a/frontend/src/pages/AfricaPaymentsPage.tsx
+++ b/frontend/src/pages/AfricaPaymentsPage.tsx
@@ -1,0 +1,23 @@
+/**
+ * tortelli-92103: Africa regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * West / East / South Africa so the Africa underbosses (@BuildwithMc and
+ * @PeriPeriPacino) can review every African payout, approve/reject/revert,
+ * edit per-event caps, leave admin notes, and click "Flag ready for payment".
+ *
+ * Funds-sending operations stay admin-only — underbosses see the Hot Wallet
+ * card in read-only mode.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function AfricaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.africa)}
+      portalSlug="africa"
+    />
+  );
+}

--- a/frontend/src/pages/AsiaPaymentsPage.tsx
+++ b/frontend/src/pages/AsiaPaymentsPage.tsx
@@ -1,0 +1,23 @@
+/**
+ * tortelli-92103: Asia & Oceania regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * China + Middle East + Asia + Oceania so @lianna_adams can review every
+ * Asian/Pacific (non-India) payout, approve/reject/revert, edit per-event
+ * caps, leave admin notes, and click "Flag ready for payment".
+ *
+ * Funds-sending operations stay admin-only — the underboss sees the Hot
+ * Wallet card in read-only mode.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function AsiaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.asia)}
+      portalSlug="asia"
+    />
+  );
+}

--- a/frontend/src/pages/EuropePaymentsPage.tsx
+++ b/frontend/src/pages/EuropePaymentsPage.tsx
@@ -1,0 +1,23 @@
+/**
+ * tortelli-92103: Europe regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * Western + Eastern Europe so @APlazzi can review every European payout,
+ * approve/reject/revert, edit per-event caps, leave admin notes, and click
+ * "Flag ready for payment".
+ *
+ * Funds-sending operations stay admin-only — the underboss sees the Hot
+ * Wallet card in read-only mode.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function EuropePaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.europe)}
+      portalSlug="europe"
+    />
+  );
+}

--- a/frontend/src/pages/IndiaPaymentsPage.tsx
+++ b/frontend/src/pages/IndiaPaymentsPage.tsx
@@ -1,0 +1,23 @@
+/**
+ * tortelli-92103: India regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * India so @simarpreet_019 can review every Indian payout, approve/reject/
+ * revert, edit per-event caps, leave admin notes, and click "Flag ready for
+ * payment".
+ *
+ * Funds-sending operations stay admin-only — the underboss sees the Hot
+ * Wallet card in read-only mode.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function IndiaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.india)}
+      portalSlug="india"
+    />
+  );
+}

--- a/frontend/src/pages/NaPaymentsPage.tsx
+++ b/frontend/src/pages/NaPaymentsPage.tsx
@@ -1,0 +1,23 @@
+/**
+ * tortelli-92103: North America regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * USA + Canada so @cauleneamagi can review every North American payout,
+ * approve/reject/revert, edit per-event caps, leave admin notes, and click
+ * "Flag ready for payment".
+ *
+ * Funds-sending operations stay admin-only — the underboss sees the Hot
+ * Wallet card in read-only mode.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function NaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.na)}
+      portalSlug="na"
+    />
+  );
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -31,6 +31,7 @@ import type {
   PrepayCandidate,
 } from '../types';
 import { formatUsd } from '../components/payments-shared';
+import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
 import {
   PayoutsFilterBar,
   PayoutsTable,
@@ -120,7 +121,14 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     () => (regionFilter && regionFilter.length > 0 ? [...regionFilter] : undefined),
     [regionFilter],
   );
-  const portalLabel = portalSlug ? portalSlug.toUpperCase() : null;
+  // tortelli-92103: use the canonical PAYMENTS_REGION_LABELS map so each
+  // portal renders its proper display name ("Africa", "North America",
+  // "Asia & Oceania") instead of an upper-cased slug. Falls back to the
+  // upper-cased slug for any portal not in the map (defensive — shouldn't
+  // happen, but avoids a runtime crash on a typo).
+  const portalLabel = portalSlug
+    ? PAYMENTS_REGION_LABELS[portalSlug as PaymentsRegionPortal] ?? portalSlug.toUpperCase()
+    : null;
   const isRegionalPortal = !!regions;
 
   const [role, setRole] = useState<RoleState>({ kind: 'loading' });
@@ -727,8 +735,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             {/* argentina-92103: tailored message for regional portals so the
                 UB knows which account to sign in as. Falls back to the
                 global message for the unscoped /payments dashboard. */}
-            {portalSlug
-              ? `Sign in as the ${portalSlug.toLowerCase()} underboss or as an admin to view this portal.`
+            {portalLabel
+              ? `Sign in as the ${portalLabel} underboss or as an admin to view this portal.`
               : 'The host payments dashboard is only available to admins and payment admins.'}
           </p>
         </div>

--- a/frontend/src/pages/SouthAfricaPaymentsPage.tsx
+++ b/frontend/src/pages/SouthAfricaPaymentsPage.tsx
@@ -1,0 +1,28 @@
+/**
+ * tortelli-92103: South Africa regional payments portal.
+ *
+ * Thin wrapper around `PaymentsAdminPage` that fixes the region scope to
+ * the South Africa country slug so @pnsibanda can review every SA payout,
+ * approve/reject/revert, edit per-event caps, leave admin notes, and click
+ * "Flag ready for payment".
+ *
+ * Funds-sending operations (USDC execute, Mercury / wire mark-paid, Bulk
+ * Send, Export Safe JSON, Record External Payment, Hot Wallet refresh)
+ * stay admin-only — the underboss sees the Hot Wallet card in read-only mode.
+ *
+ * Caveat: the broader Africa portal (`/payments/africa`) also includes the
+ * `south-africa` slug, so SA events surface in both portals. v1 ships this
+ * overlap intentionally.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function SouthAfricaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.southafrica)}
+      portalSlug="southafrica"
+    />
+  );
+}

--- a/frontend/src/utils/regions.ts
+++ b/frontend/src/utils/regions.ts
@@ -1,21 +1,64 @@
 /**
- * argentina-92103: Regional /payments portals.
+ * Regional /payments portals.
  *
  * Each portal-slug maps to a fixed list of `parties.region` values the
- * payments-admin queue should be filtered down to. The LATAM portal
- * (`/payments/latam`) covers Central + South America so the LATAM
- * underboss (`donmalbec.eth@gmail.com`) can review and approve every
- * payout in his region without exposing the rest of the world.
+ * payments-admin queue should be filtered down to. Built so a regional
+ * underboss can review and approve every payout in their region without
+ * exposing the rest of the world.
+ *
+ * argentina-92103 shipped the LATAM portal. tortelli-92103 extends the
+ * mapping to cover every other UB region defined by Snax's regional split:
+ *   /payments/latam        → @donmalbec.eth (Central + South America)
+ *   /payments/southafrica  → @pnsibanda (South Africa country)
+ *   /payments/africa       → @BuildwithMc + @PeriPeriPacino (West / East /
+ *                            South Africa region slugs)
+ *   /payments/na           → @cauleneamagi (USA + Canada)
+ *   /payments/europe       → @APlazzi (Western + Eastern Europe)
+ *   /payments/india        → @simarpreet_019 (India)
+ *   /payments/asia         → @lianna_adams (China + Middle East + Asia +
+ *                            Oceania — every non-India Asia/Pacific slug)
+ *
+ * South Africa caveat: @pnsibanda has the SA country in scope, but the
+ * broader Africa UBs also have `south-africa` in their `underbosses.regions`
+ * array, so both `/payments/southafrica` and `/payments/africa` show SA
+ * events. v1 ships this overlap intentionally — Snax can refine if needed.
+ *
+ * Region slugs match the canonical `GPP_REGIONS` enum in `frontend/src/types.ts`.
  */
 
 export const LATAM_REGIONS = ['central-america', 'south-america'] as const;
+export const SOUTHAFRICA_REGIONS = ['south-africa'] as const;
+export const AFRICA_REGIONS = ['west-africa', 'east-africa', 'south-africa'] as const;
+export const NA_REGIONS = ['usa', 'canada'] as const;
+export const EUROPE_REGIONS = ['western-europe', 'eastern-europe'] as const;
+export const INDIA_REGIONS = ['india'] as const;
+export const ASIA_REGIONS = ['china', 'middle-east', 'asia', 'oceania'] as const;
 
-export type PaymentsRegionPortal = 'latam';
+export type PaymentsRegionPortal =
+  | 'latam'
+  | 'southafrica'
+  | 'africa'
+  | 'na'
+  | 'europe'
+  | 'india'
+  | 'asia';
 
 export const PAYMENTS_REGION_LABELS: Record<PaymentsRegionPortal, string> = {
   latam: 'LATAM',
+  southafrica: 'South Africa',
+  africa: 'Africa',
+  na: 'North America',
+  europe: 'Europe',
+  india: 'India',
+  asia: 'Asia & Oceania',
 };
 
 export const PAYMENTS_REGION_SCOPES: Record<PaymentsRegionPortal, readonly string[]> = {
   latam: LATAM_REGIONS,
+  southafrica: SOUTHAFRICA_REGIONS,
+  africa: AFRICA_REGIONS,
+  na: NA_REGIONS,
+  europe: EUROPE_REGIONS,
+  india: INDIA_REGIONS,
+  asia: ASIA_REGIONS,
 };


### PR DESCRIPTION
## Summary
- New routes: `/payments/southafrica`, `/payments/africa`, `/payments/na`, `/payments/europe`, `/payments/india`, `/payments/asia`.
- Each a thin wrapper over `PaymentsAdminPage` with the correct `regionFilter` + `portalSlug`.
- `frontend/src/utils/regions.ts` extended with `PAYMENTS_REGION_SCOPES` map + `PaymentsRegionPortal` union (LATAM unchanged).
- Denial copy + page title use the portal display label (`"Africa"`, `"North America"`, `"Asia & Oceania"`) instead of the upper-cased slug.
- No backend changes — `regionalUnderboss` middleware (argentina-92103) already accepts any region list via `?regions=` CSV.

## Region slug mapping
Region slugs match the canonical `GPP_REGIONS` enum in `frontend/src/types.ts`:

| Portal | Slug list | UB(s) |
|---|---|---|
| `/payments/latam` (existing) | `central-america`, `south-america` | @donmalbec.eth |
| `/payments/southafrica` | `south-africa` | @pnsibanda |
| `/payments/africa` | `west-africa`, `east-africa`, `south-africa` | @BuildwithMc, @PeriPeriPacino |
| `/payments/na` | `usa`, `canada` | @cauleneamagi |
| `/payments/europe` | `western-europe`, `eastern-europe` | @APlazzi |
| `/payments/india` | `india` | @simarpreet_019 |
| `/payments/asia` | `china`, `middle-east`, `asia`, `oceania` | @lianna_adams |

No North-African slug exists in `GPP_REGIONS` (Egypt / Libya / Morocco / etc. fall under broader country fields, not a region slug), so the Africa portal covers `west-africa` / `east-africa` / `south-africa` only.

## South Africa overlap caveat
@pnsibanda has the South Africa country slug in scope, but the broader Africa UBs (@BuildwithMc, @PeriPeriPacino) also have `south-africa` in their `underbosses.regions` array. As a result, SA events surface in BOTH `/payments/southafrica` and `/payments/africa`. v1 ships this overlap intentionally — Snax can refine if it becomes an issue.

## Test plan
- [ ] Admin -> any portal loads with full controls scoped to the right region.
- [ ] Underboss for the matching region -> loads with UB role (review/approve/reject/flag-ready, no funds-send).
- [ ] Underboss for a non-matching region -> 403 with portal-labeled denial copy.
- [ ] Random user -> 403.
- [ ] Existing `/payments/latam` still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)