### PR TITLE
feat(cannelloni-92103): regional UB can edit payout amounts on /payments/<region>

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2094,8 +2094,12 @@ router.get(
 router.patch(
   '/:id',
   requireAuth,
-  requireAnyAdminOrPaymentAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  // cannelloni-92103: regional underbosses can EDIT payouts on parties in
+  // their region (via `?regions=`). Admins always pass. The per-row scope
+  // check is inlined below for underbosses, matching the pattern used by
+  // approve/reject/unapprove/flag-ready (argentina-92103).
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
@@ -2119,6 +2123,20 @@ router.patch(
       }
 
       assertNotSelfPayout(actor, existing.hostUserId);
+
+      // cannelloni-92103: underboss-scope gate. Prevents a regional underboss
+      // from editing an out-of-region payout by spoofing the `?regions=`
+      // query. Admins skip this check.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        const party = await prisma.party.findUnique({
+          where: { id: existing.partyId },
+          select: { region: true },
+        });
+        if (!party?.region || !regionsFromQuery.includes(party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
+      }
 
       const data: any = {};
       const {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4138,11 +4138,20 @@ export async function updateAdminPayout(
      */
     allowOverSubmissionCap?: boolean;
   },
+  /**
+   * cannelloni-92103: regional underbosses can edit payouts on parties in
+   * their region. The backend PATCH gate (`requireAdminOrRegionalUnderboss`)
+   * needs the `regions=` CSV query to verify scope. Admins ignore it.
+   */
+  opts?: { regions?: string[] },
 ): Promise<AdminPayout> {
-  const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}`, {
-    method: 'PATCH',
-    body: fields,
-  });
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}${regionsQuery(opts?.regions)}`,
+    {
+      method: 'PATCH',
+      body: fields,
+    },
+  );
   return res.payout;
 }
 

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1071,13 +1071,20 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             onSaveAmount={async (newAmount, opts) => {
               setModalBusy(true);
               try {
-                await updateAdminPayout(detail.id, {
-                  finalAmountUsd: newAmount,
-                  note: opts?.note,
-                  // aglio-62584: forward the admin's per-submission cap
-                  // acknowledgement so the backend bypasses the 400.
-                  allowOverSubmissionCap: opts?.allowOverSubmissionCap,
-                });
+                await updateAdminPayout(
+                  detail.id,
+                  {
+                    finalAmountUsd: newAmount,
+                    note: opts?.note,
+                    // aglio-62584: forward the admin's per-submission cap
+                    // acknowledgement so the backend bypasses the 400.
+                    allowOverSubmissionCap: opts?.allowOverSubmissionCap,
+                  },
+                  // cannelloni-92103: thread `?regions=` so regional UB
+                  // PATCH passes the `requireAdminOrRegionalUnderboss`
+                  // gate on the backend.
+                  regions ? { regions } : undefined,
+                );
                 const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();
@@ -1095,7 +1102,12 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             onSaveAdminNotes={async (notes) => {
               setModalBusy(true);
               try {
-                await updateAdminPayout(detail.id, { adminNotes: notes });
+                await updateAdminPayout(
+                  detail.id,
+                  { adminNotes: notes },
+                  // cannelloni-92103: same regions thread for UB notes edits.
+                  regions ? { regions } : undefined,
+                );
                 const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
               } catch (err: any) {


### PR DESCRIPTION
## Summary
- Backend PATCH `/api/admin/payouts/:id` now accepts regional UB with in-scope party check.
- Frontend Edit affordance (PayoutReviewModal + PayoutsTable row pencil) visible for UB on regional portals.
- Audit row records actor_kind='underboss'.

## Test plan
- [ ] LATAM UB -> Edit on LATAM payout -> succeeds.
- [ ] LATAM UB -> Edit on Africa payout (out of scope) -> 403.
- [ ] Admin -> unchanged.
- [ ] Execute / Mark paid / Bulk Send still hidden for UB.