### PR TITLE
feat(sicilian-58196): dedup photos + upload-endpoint dedup check

### DIFF
--- a/backend/scripts/dedup-photos.cjs
+++ b/backend/scripts/dedup-photos.cjs
@@ -1,0 +1,280 @@
+// sicilian-58196: dedup `photos` rows for the same party that share
+// (file_size, mime_type) — these are the same bytes uploaded multiple times.
+//
+// Sources of the existing 266 duplicate rows:
+//   - native dupes: same user uploaded same file twice via event-page UI
+//   - napoletana-58211 backfill: payout-side dupes that didn't match by
+//     file_name (file_name differs but file_size + mime_type are identical)
+//
+// For each (party_id, file_size, mime_type) group with >1 rows and
+// file_size > 10000 (skip tiny-file collisions):
+//   1. Pick CANONICAL = earliest created_at. Tie-break by highest vote_count,
+//      then by id (lexicographic) for stability.
+//   2. Absorb metadata from siblings into canonical:
+//        caption       — canonical's if non-null, else first non-null sibling
+//        tags          — union(canonical, all siblings) preserving order
+//        photo_year    — canonical's if set, else first sibling's
+//        starred       — true if any of (canonical, siblings) is starred. If
+//                        canonical was false but a sibling true, also pull
+//                        starred_at + reviewed_at + reviewed_by from that
+//                        sibling.
+//        status        — upgrade 'pending' -> 'approved' if any sibling
+//                        already approved
+//   3. Transfer photo_votes from siblings -> canonical. ON CONFLICT
+//      (photo_id, user_id) DO NOTHING — a user might have voted on both
+//      copies, but we only count once.
+//   4. Re-point payout_documents.photo_id from any sibling -> canonical.
+//   5. DELETE the sibling photos rows. The schema cascades photo_votes;
+//      payout_documents.photo_id has ON DELETE SET NULL but we already
+//      retargeted those above.
+//   6. Recompute canonical's vote_count from the surviving photo_votes.
+//
+// Each group runs inside its own transaction so a per-group failure rolls
+// back cleanly without half-merging.
+//
+// Important scoping caveat: the candidate query is scoped per-party_id, so
+// the same bytes uploaded to two different parties are NEVER merged. They
+// are separate photos that just happen to share size.
+//
+// Run from a main session (not a worktree agent):
+//   cd backend && node scripts/dedup-photos.cjs
+// Optional dry-run: pass --dry-run to print the plan without writing.
+
+const { Client } = require('pg');
+require('dotenv').config();
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function uniqOrdered(...arrays) {
+  const seen = new Set();
+  const out = [];
+  for (const arr of arrays) {
+    if (!arr) continue;
+    for (const v of arr) {
+      if (v == null) continue;
+      if (!seen.has(v)) {
+        seen.add(v);
+        out.push(v);
+      }
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const c = new Client({ connectionString: process.env.DATABASE_URL });
+  await c.connect();
+  console.log(`sicilian-58196 dedup-photos start${DRY_RUN ? ' (DRY RUN)' : ''}`);
+
+  // Find every (party_id, file_size, mime_type) group with >1 rows. file_size
+  // gate keeps trivially-small files (icons, junk, sub-10KB) out of the dedup
+  // bucket where collisions are likely meaningless.
+  const groupsQ = await c.query(`
+    SELECT party_id, file_size, mime_type, COUNT(*) AS cnt
+    FROM photos
+    WHERE file_size > 10000
+    GROUP BY party_id, file_size, mime_type
+    HAVING COUNT(*) > 1
+    ORDER BY COUNT(*) DESC, party_id ASC
+  `);
+  console.log(`Duplicate groups: ${groupsQ.rowCount}`);
+
+  let groupsProcessed = 0;
+  let siblingsDeleted = 0;
+  let votesTransferred = 0;
+  let payoutRelinks = 0;
+  let groupsFailed = 0;
+
+  for (const g of groupsQ.rows) {
+    const { party_id, file_size, mime_type } = g;
+
+    try {
+      await c.query('BEGIN');
+
+      // Fetch all rows in this group. Order canonicalization rule:
+      //   1) earliest created_at first
+      //   2) then highest vote_count first (canonical absorbs popularity)
+      //   3) then id ASC for stability
+      const rowsQ = await c.query(
+        `
+        SELECT id,
+               party_id,
+               created_at,
+               vote_count,
+               caption,
+               tags,
+               photo_year,
+               starred,
+               starred_at,
+               status,
+               reviewed_at,
+               reviewed_by
+        FROM photos
+        WHERE party_id = $1 AND file_size = $2 AND mime_type = $3
+        ORDER BY created_at ASC, vote_count DESC, id ASC
+        `,
+        [party_id, file_size, mime_type],
+      );
+
+      if (rowsQ.rowCount < 2) {
+        // Race: another process merged this group between SELECT GROUP BY and
+        // the row fetch. Nothing to do.
+        await c.query('COMMIT');
+        continue;
+      }
+
+      const rows = rowsQ.rows;
+      const canonical = rows[0];
+      const siblings = rows.slice(1);
+
+      // Sanity: every row in the group MUST belong to the same party. This
+      // should be guaranteed by the GROUP BY scope, but assert it loudly so
+      // we never cross parties.
+      for (const r of rows) {
+        if (r.party_id !== canonical.party_id) {
+          throw new Error(
+            `cross-party row in group ${party_id}/${file_size}/${mime_type}: ` +
+              `${r.id} party=${r.party_id} vs canonical party=${canonical.party_id}`,
+          );
+        }
+      }
+
+      // 2. Absorb metadata into canonical.
+      const newCaption =
+        canonical.caption ?? siblings.find((s) => s.caption != null)?.caption ?? null;
+      const newTags = uniqOrdered(canonical.tags, ...siblings.map((s) => s.tags));
+      const newPhotoYear =
+        canonical.photo_year ?? siblings.find((s) => s.photo_year != null)?.photo_year ?? null;
+
+      const anyStarred = canonical.starred || siblings.some((s) => s.starred);
+      let newStarred = canonical.starred;
+      let newStarredAt = canonical.starred_at;
+      let newReviewedAt = canonical.reviewed_at;
+      let newReviewedBy = canonical.reviewed_by;
+      if (anyStarred && !canonical.starred) {
+        const starSib = siblings.find((s) => s.starred);
+        newStarred = true;
+        newStarredAt = starSib.starred_at ?? newStarredAt;
+        newReviewedAt = starSib.reviewed_at ?? newReviewedAt;
+        newReviewedBy = starSib.reviewed_by ?? newReviewedBy;
+      }
+
+      const anyApproved =
+        canonical.status === 'approved' || siblings.some((s) => s.status === 'approved');
+      const newStatus =
+        canonical.status === 'pending' && anyApproved ? 'approved' : canonical.status;
+
+      const siblingIds = siblings.map((s) => s.id);
+
+      if (!DRY_RUN) {
+        // Write absorbed metadata to canonical first so the snapshot is
+        // consistent even if vote_count is recomputed later.
+        await c.query(
+          `
+          UPDATE photos
+          SET caption = $1,
+              tags = $2,
+              photo_year = $3,
+              starred = $4,
+              starred_at = $5,
+              reviewed_at = $6,
+              reviewed_by = $7,
+              status = $8
+          WHERE id = $9
+          `,
+          [
+            newCaption,
+            newTags,
+            newPhotoYear,
+            newStarred,
+            newStarredAt,
+            newReviewedAt,
+            newReviewedBy,
+            newStatus,
+            canonical.id,
+          ],
+        );
+
+        // 3. Transfer photo_votes from siblings -> canonical. ON CONFLICT
+        // skips duplicates (same user voted on both copies).
+        const transferQ = await c.query(
+          `
+          INSERT INTO photo_votes (id, photo_id, user_id, created_at)
+          SELECT gen_random_uuid(), $1, pv.user_id, pv.created_at
+          FROM photo_votes pv
+          WHERE pv.photo_id = ANY($2::uuid[])
+          ON CONFLICT (photo_id, user_id) DO NOTHING
+          RETURNING id
+          `,
+          [canonical.id, siblingIds],
+        );
+        votesTransferred += transferQ.rowCount;
+
+        // 4. Re-point payout_documents.photo_id (any kind) from sibling ->
+        // canonical. The FK has ON DELETE SET NULL, but we want the link to
+        // survive — retarget before the delete.
+        const relinkQ = await c.query(
+          `
+          UPDATE payout_documents
+          SET photo_id = $1
+          WHERE photo_id = ANY($2::uuid[])
+          `,
+          [canonical.id, siblingIds],
+        );
+        payoutRelinks += relinkQ.rowCount;
+
+        // 5. Delete sibling photos rows. photo_votes still owned by the
+        // siblings cascade away; we already moved the ones that mattered.
+        const delQ = await c.query(
+          `DELETE FROM photos WHERE id = ANY($1::uuid[])`,
+          [siblingIds],
+        );
+        siblingsDeleted += delQ.rowCount;
+
+        // 6. Recompute canonical's vote_count from surviving photo_votes.
+        await c.query(
+          `
+          UPDATE photos
+          SET vote_count = (SELECT COUNT(*) FROM photo_votes WHERE photo_id = $1)
+          WHERE id = $1
+          `,
+          [canonical.id],
+        );
+      } else {
+        // Dry-run accounting — count what we would do.
+        siblingsDeleted += siblings.length;
+      }
+
+      await c.query('COMMIT');
+      groupsProcessed++;
+
+      if (groupsProcessed % 25 === 0) {
+        console.log(
+          `  ...${groupsProcessed}/${groupsQ.rowCount} groups, ${siblingsDeleted} sibling rows deleted so far`,
+        );
+      }
+    } catch (err) {
+      await c.query('ROLLBACK');
+      groupsFailed++;
+      console.error(
+        `Group ${party_id}/${file_size}/${mime_type} FAILED: ${err.message}`,
+      );
+    }
+  }
+
+  console.log('');
+  console.log('--- summary ---');
+  console.log(`groups processed:    ${groupsProcessed}`);
+  console.log(`groups failed:       ${groupsFailed}`);
+  console.log(`sibling rows deleted:${siblingsDeleted}`);
+  console.log(`votes transferred:   ${votesTransferred}`);
+  console.log(`payout_docs relinked:${payoutRelinks}`);
+  if (DRY_RUN) console.log('(dry-run — no writes performed)');
+
+  await c.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -1031,27 +1031,44 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         docsToCreate.map(async (d) => {
           let photoId: string | null = d.photoId;
           if (d.kind === 'pizza') {
-            const photo = await tx.photo.create({
-              data: {
+            // sicilian-58196: dedup pre-check. If a photo with the same
+            // (partyId, fileSize, mimeType) already exists, reuse its id
+            // instead of inserting a new row. Same bytes uploaded a second
+            // time via the payout flow should NOT create a duplicate row in
+            // the canonical `photos` table.
+            const dup = await tx.photo.findFirst({
+              where: {
                 partyId,
-                url: d.url,
-                fileName: d.fileName,
                 fileSize: d.fileSize,
                 mimeType: d.mimeType,
-                // uploadedBy is a Guest FK; payout submitters are Users.
-                // Leave null and rely on uploaderEmail for attribution.
-                uploadedBy: null,
-                uploaderName: null,
-                uploaderEmail: uploaderEmail,
-                status: 'approved',
-                starred: true,
-                starredAt: now,
-                reviewedAt: now,
-                reviewedBy: uploaderUserId,
               },
               select: { id: true },
             });
-            photoId = photo.id;
+            if (dup) {
+              photoId = dup.id;
+            } else {
+              const photo = await tx.photo.create({
+                data: {
+                  partyId,
+                  url: d.url,
+                  fileName: d.fileName,
+                  fileSize: d.fileSize,
+                  mimeType: d.mimeType,
+                  // uploadedBy is a Guest FK; payout submitters are Users.
+                  // Leave null and rely on uploaderEmail for attribution.
+                  uploadedBy: null,
+                  uploaderName: null,
+                  uploaderEmail: uploaderEmail,
+                  status: 'approved',
+                  starred: true,
+                  starredAt: now,
+                  reviewedAt: now,
+                  reviewedBy: uploaderUserId,
+                },
+                select: { id: true },
+              });
+              photoId = photo.id;
+            }
           }
           return {
             ...d,
@@ -1686,8 +1703,24 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         // payout_documents row links to the canonical photos record. If any
         // photos.create fails, the surrounding transaction aborts and the
         // patch is rolled back. Receipts skip this step (photoId stays null).
+        //
+        // sicilian-58196: dedup pre-check before insert — if a photo already
+        // exists with the same (partyId, fileSize, mimeType), reuse it
+        // instead of creating a duplicate row.
         const now = new Date();
         for (const d of newPizzaDocs) {
+          const dup = await tx.photo.findFirst({
+            where: {
+              partyId,
+              fileSize: d.fileSize,
+              mimeType: d.mimeType,
+            },
+            select: { id: true },
+          });
+          if (dup) {
+            d.photoId = dup.id;
+            continue;
+          }
           const photo = await tx.photo.create({
             data: {
               partyId,

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -529,6 +529,28 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
       }
     }
 
+    // sicilian-58196: dedup pre-check. If a photo already exists in this party
+    // with identical (fileSize, mimeType), return the original instead of
+    // creating a duplicate row. Returns 200 (not 201) with `deduped: true` so
+    // the client can render a soft "already uploaded" hint. Skipped if either
+    // fileSize or mimeType is missing — those are required by the validation
+    // above, but be defensive. The original photo keeps its existing
+    // starred / status / votes; we do NOT replay host-auto-star or
+    // auto-approve on the dedup hit.
+    if (fileSize && mimeType) {
+      const existing = await prisma.photo.findFirst({
+        where: { partyId, fileSize, mimeType },
+        select: { id: true },
+      });
+      if (existing) {
+        const dedupedPhoto = await prisma.photo.findUnique({
+          where: { id: existing.id },
+          include: { guest: { select: { id: true, name: true } } },
+        });
+        return res.status(200).json({ photo: dedupedPhoto, deduped: true });
+      }
+    }
+
     // margherita-43821: host uploads (owner / co-host w/ canEdit / super-admin /
     // GPP editor) are auto-approved + auto-starred so they appear in /photos
     // immediately. Guest uploads still go through pending moderation.


### PR DESCRIPTION
## Summary
- backend/scripts/dedup-photos.cjs — one-shot cleanup that merges existing 266 duplicate `photos` rows by (party_id, file_size, mime_type). Canonical = earliest created_at; absorbs caption/tags/votes/starred/status from siblings; retargets `payout_documents.photo_id` and `photo_votes` FKs; deletes sibling rows.
- POST /api/parties/:partyId/photos — pre-check returns existing row (200, `deduped: true`) when (party, size, mime) match. Prevents new dupes.
- Payout pizza upload flow (from napoletana-58211) — same dedup pre-check so payout-side reuses existing photo IDs.

## Site-wide impact
- 266 redundant rows merged into canonical originals
- Worst-affected events: Osogbo (20), Bangkok (10), San Jose de Buenavista (10), Adama (8), AASTU/Kisumu/Diani Beach/Dar es Salaam/Sablayan (7 each)
- Fukuoka: 5 rows -> 3 unique pizzas after cleanup

## Deploy order
1. Merge -> backend deploys with upload dedup check (no DB migration needed)
2. Run cleanup script from main session: `node backend/scripts/dedup-photos.cjs`
3. Verify: re-run audit query, expect 0 groups

## Test plan
- [ ] Upload same file twice via event page -> second request returns 200 with `deduped: true` and the SAME photo id
- [ ] Cleanup script: Fukuoka goes from 5 rows to 3 unique
- [ ] No vote-count loss after merge (sum votes from siblings)

Generated with [Claude Code](https://claude.com/claude-code)