### PR TITLE
fix(gorgonzola-92103): dark <option> popup for Chrome Win

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -300,6 +300,22 @@ html {
   color-scheme: dark;
 }
 
+.gpp-theme {
+  color-scheme: light;
+}
+
+/* gorgonzola-92103: Chrome on Windows ignores color-scheme for the <option>
+   popup — bg/color on <option> is the one styling Chrome still respects. */
+option {
+  background-color: #1a1a2e;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.gpp-theme option {
+  background-color: #ffffff;
+  color: #1a1a1a;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- Explicit `option { background-color; color }` rules for dark + gpp-theme.
- Chrome ignores `color-scheme` on the native <option> popup, so polenta-92103 only fixed the <select> button, not the dropdown list.

## Test plan
- [ ] Open `/payments` in Chrome on Windows.
- [ ] Click a `<select>` (e.g. country filter, status filter) → unselected options should render dark with white text.
- [ ] Verify gpp-theme pages (`/map`) still show light option lists.