### PR TITLE
feat(caciotta-58293): survey "Other" custom-text input

### DIFF
--- a/backend/src/lib/surveyQuestions.ts
+++ b/backend/src/lib/surveyQuestions.ts
@@ -14,6 +14,7 @@ export interface SurveyQuestion {
   scale?: number;     // for type 'rating' — max value (ratings are 1..scale)
   multi?: boolean;    // for type 'multiple' — true = multi-select, false/absent = single-select
   options?: string[]; // for type 'multiple'
+  allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
 export const SURVEY_QUESTION_SET_VERSION = 1;
@@ -42,6 +43,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     multi: false,
     text: 'How did you hear about this event?',
     options: ['A friend', 'Twitter/X', 'The organizer', 'Other'],
+    allowOther: true,
   },
   {
     id: 'highlight',
@@ -123,6 +125,21 @@ export function validateSurveyAnswers(
           out[q.id] = v.trim().slice(0, 5000);
         }
         break;
+      }
+    }
+
+    // "Other" custom-text sibling key for questions that opt in via allowOther.
+    // We only persist `${qid}_other` when the chosen value of `qid` is strictly
+    // the literal string "Other" AND a non-empty trimmed string remains. This
+    // strips stale `_other` values when the user switches their choice.
+    if (q.allowOther) {
+      const otherKey = `${q.id}_other`;
+      const rawOther = input[otherKey];
+      if (typeof rawOther === 'string' && out[q.id] === 'Other') {
+        const trimmed = rawOther.trim();
+        if (trimmed.length > 0) {
+          out[otherKey] = trimmed.slice(0, 200);
+        }
       }
     }
   }

--- a/backend/src/routes/survey.routes.ts
+++ b/backend/src/routes/survey.routes.ts
@@ -325,6 +325,7 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
     const yesno: Record<string, { yes: number; no: number }> = {};
     const multiple: Record<string, Record<string, number>> = {};
     const comments: Record<string, string[]> = {};
+    const otherTexts: Record<string, string[]> = {};
 
     for (const q of SURVEY_QUESTION_SET) {
       if (q.type === 'rating') ratings[q.id] = { sum: 0, count: 0, average: null };
@@ -333,6 +334,7 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
         multiple[q.id] = {};
         for (const opt of q.options ?? []) multiple[q.id][opt] = 0;
       } else if (q.type === 'text') comments[q.id] = [];
+      if (q.allowOther) otherTexts[q.id] = [];
     }
 
     for (const r of responses) {
@@ -357,6 +359,15 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
           comments[q.id].push(v.trim());
         }
       }
+      // Collect "Other" custom-text free responses for any question with allowOther.
+      for (const q of SURVEY_QUESTION_SET) {
+        if (!q.allowOther) continue;
+        const otherRaw = a[`${q.id}_other`];
+        if (typeof otherRaw === 'string') {
+          const trimmed = otherRaw.trim();
+          if (trimmed.length > 0) otherTexts[q.id].push(trimmed);
+        }
+      }
     }
 
     for (const id of Object.keys(ratings)) {
@@ -374,6 +385,7 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
       yesno,
       multiple,
       comments,
+      otherTexts,
     });
   } catch (error) {
     next(error);

--- a/frontend/src/lib/surveyQuestions.ts
+++ b/frontend/src/lib/surveyQuestions.ts
@@ -14,6 +14,7 @@ export interface SurveyQuestion {
   scale?: number;     // for type 'rating' — max value (ratings are 1..scale)
   multi?: boolean;    // for type 'multiple' — true = multi-select
   options?: string[]; // for type 'multiple'
+  allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
 export const SURVEY_QUESTION_SET_VERSION = 1;
@@ -42,6 +43,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     multi: false,
     text: 'How did you hear about this event?',
     options: ['A friend', 'Twitter/X', 'The organizer', 'Other'],
+    allowOther: true,
   },
   {
     id: 'highlight',

--- a/frontend/src/pages/SurveyPage.tsx
+++ b/frontend/src/pages/SurveyPage.tsx
@@ -166,20 +166,27 @@ function SurveyPageInner() {
         </div>
 
         <div className="space-y-6">
-          {questions.map((q) => (
-            <div key={q.id} className="card p-5">
-              <p className="text-sm font-medium text-theme-text mb-3">{q.text}</p>
-              <SurveyQuestionField
-                question={q}
-                value={answers[q.id]}
-                onRating={(n) => setAnswer(q.id, n)}
-                onYesNo={(b) => setAnswer(q.id, b)}
-                onSingle={(opt) => setAnswer(q.id, opt)}
-                onToggleMulti={(opt) => toggleMulti(q.id, opt)}
-                onText={(s) => setAnswer(q.id, s)}
-              />
-            </div>
-          ))}
+          {questions.map((q) => {
+            const otherKey = `${q.id}_other`;
+            const otherRaw = answers[otherKey];
+            const otherValue = typeof otherRaw === 'string' ? otherRaw : '';
+            return (
+              <div key={q.id} className="card p-5">
+                <p className="text-sm font-medium text-theme-text mb-3">{q.text}</p>
+                <SurveyQuestionField
+                  question={q}
+                  value={answers[q.id]}
+                  otherValue={otherValue}
+                  onRating={(n) => setAnswer(q.id, n)}
+                  onYesNo={(b) => setAnswer(q.id, b)}
+                  onSingle={(opt) => setAnswer(q.id, opt)}
+                  onToggleMulti={(opt) => toggleMulti(q.id, opt)}
+                  onText={(s) => setAnswer(q.id, s)}
+                  onOther={(s) => setAnswer(otherKey, s)}
+                />
+              </div>
+            );
+          })}
         </div>
 
         {error && (
@@ -205,21 +212,25 @@ function SurveyPageInner() {
 interface FieldProps {
   question: SurveyQuestion;
   value: SurveyAnswerValue | undefined;
+  otherValue: string;
   onRating: (n: number) => void;
   onYesNo: (b: boolean) => void;
   onSingle: (opt: string) => void;
   onToggleMulti: (opt: string) => void;
   onText: (s: string) => void;
+  onOther: (s: string) => void;
 }
 
 const SurveyQuestionField: React.FC<FieldProps> = ({
   question,
   value,
+  otherValue,
   onRating,
   onYesNo,
   onSingle,
   onToggleMulti,
   onText,
+  onOther,
 }) => {
   if (question.type === 'rating') {
     const scale = question.scale ?? 5;
@@ -292,21 +303,33 @@ const SurveyQuestionField: React.FC<FieldProps> = ({
     }
     // single-select — radio-style buttons
     return (
-      <div className="flex flex-wrap gap-2">
-        {options.map((opt) => (
-          <button
-            key={opt}
-            type="button"
-            onClick={() => onSingle(opt)}
-            className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
-              value === opt
-                ? 'bg-[#ff393a] text-white border-[#ff393a]'
-                : 'border-white/20 text-theme-text hover:border-white/40'
-            }`}
-          >
-            {opt}
-          </button>
-        ))}
+      <div>
+        <div className="flex flex-wrap gap-2">
+          {options.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onSingle(opt)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                value === opt
+                  ? 'bg-[#ff393a] text-white border-[#ff393a]'
+                  : 'border-white/20 text-theme-text hover:border-white/40'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+        {question.allowOther && value === 'Other' && (
+          <div className="mt-3">
+            <IconInput
+              icon={MessageSquare}
+              placeholder="Please tell us how"
+              value={otherValue}
+              onChange={(e) => onOther((e.target as HTMLInputElement).value)}
+            />
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Adds a custom-text IconInput on the post-event survey when the user picks "Other" for the discovery question; free text persists to `answers.discovery_other` and surfaces in the host results aggregator as `otherTexts`.

Server strips `_other` if the chosen value isn't literally "Other", so switching the choice clears stale text. No question-set version bump (backward-compatible addition).

Test link: https://rsv.pizza/survey/041010e7-b32b-4040-b1d1-070d9c2806f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)