### PR TITLE
feat(salame-92103): admin override for party-cap on execute

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2939,8 +2939,15 @@ async function executePayout(params: {
    * the warning's acknowledgement checkbox has been ticked.
    */
   allowOverPerAddressCap?: boolean;
+  /**
+   * salame-92103: when true, skip the per-party cap re-check at execute
+   * time. Matches the bianco-89172 / aglio-62584 override pattern — admin UI
+   * sets this only when the over-party-cap warning's acknowledgement
+   * checkbox has been ticked. Audited via the mark_paid note suffix.
+   */
+  allowOverPartyCap?: boolean;
 }) {
-  const { payoutId, actor, body, allowOverPerAddressCap } = params;
+  const { payoutId, actor, body, allowOverPerAddressCap, allowOverPartyCap } = params;
 
   const existing = await prisma.payout.findUnique({
     where: { id: payoutId },
@@ -2975,8 +2982,16 @@ async function executePayout(params: {
   // POST /bulk-execute (which serially calls this helper). `assertWithinPartyCap`
   // re-queries on every call, so successive bulk rows see the freshly-paid
   // earlier rows in their `usedUsd` totals.
+  //
+  // salame-92103: when `allowOverPartyCap` is set (admin-class only, sourced
+  // from the modal's acknowledgement checkbox), skip the per-party cap throw
+  // so admins can execute a payment that exceeds the party's effective cap.
+  // The per-submission ceiling ($675), per-address cap, and daily cap are
+  // unchanged.
   assertWithinPerSubmissionCap(finalAmountUsd);
-  await assertWithinPartyCap(existing.partyId, finalAmountUsd, existing.id);
+  if (!allowOverPartyCap) {
+    await assertWithinPartyCap(existing.partyId, finalAmountUsd, existing.id);
+  }
 
   // arugula-38633 v3 follow-up: payout_method can be null when the host
   // submitted before setting their payment details. Block execute with a
@@ -3031,9 +3046,12 @@ async function executePayout(params: {
             newStatus: 'paid',
             actorEmail: actor.email,
             actorKind: actor.actorKind,
+            // salame-92103: append the override marker so the audit row
+            // captures that the per-party cap was bypassed for this payout.
             note: `USDC on Base sent: tx ${result.txHash}, ` +
               `from ${result.fromAddress} to ${result.toAddress}, ` +
-              `$${result.amountUsd.toFixed(2)}`,
+              `$${result.amountUsd.toFixed(2)}` +
+              (allowOverPartyCap ? ' [override: party cap]' : ''),
           },
         });
         return row;
@@ -3116,8 +3134,10 @@ async function executePayout(params: {
           newStatus: 'paid',
           actorEmail: actor.email,
           actorKind: actor.actorKind,
+          // salame-92103: append override marker when per-party cap was bypassed.
           note: `Wire executed out-of-band, reference: ${wireRef}` +
-            (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : ''),
+            (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : '') +
+            (allowOverPartyCap ? ' [override: party cap]' : ''),
         },
       });
       return row;
@@ -3168,9 +3188,11 @@ async function executePayout(params: {
           newStatus: 'paid',
           actorEmail: actor.email,
           actorKind: actor.actorKind,
+          // salame-92103: append override marker when per-party cap was bypassed.
           note: `Mercury card issued via dashboard, last4=${last4Raw}` +
             (cardId ? `, id=${cardId}` : '') +
-            (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : ''),
+            (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : '') +
+            (allowOverPartyCap ? ' [override: party cap]' : ''),
         },
       });
       return row;
@@ -3229,6 +3251,10 @@ router.post(
         // warning via the PayoutReviewModal checkbox; the frontend forwards
         // the flag here.
         allowOverPerAddressCap: !!(req.body && req.body.allowOverPerAddressCap),
+        // salame-92103: admin can acknowledge the per-party cap warning via
+        // the PayoutReviewModal checkbox; same admin-class gate as the route
+        // itself (requireAnyAdminOrPaymentAdmin above).
+        allowOverPartyCap: !!(req.body && req.body.allowOverPartyCap),
       });
 
       res.json({ payout: serializePayout(updated) });
@@ -3381,6 +3407,10 @@ router.post(
       // BulkSendModal disables Send when any selected wallet would exceed the
       // per-address cap unless the admin ticks "Allow over-cap sends".
       const allowOverPerAddressCap = !!(req.body && req.body.allowOverPerAddressCap);
+      // salame-92103: same batch-level acknowledgement model for the per-party
+      // cap. BulkSendModal counts how many selected rows would push their
+      // party past its cap and requires this ack before enabling Send.
+      const allowOverPartyCap = !!(req.body && req.body.allowOverPartyCap);
 
       // SEQUENTIAL execution — nonce safety. Do NOT switch to Promise.all.
       const results: BulkSendResult[] = [];
@@ -3392,6 +3422,7 @@ router.post(
             actor: { email: actor.email, actorKind: actor.actorKind },
             body: {},
             allowOverPerAddressCap,
+            allowOverPartyCap,
           });
           // Record a batch-context audit alongside the mark_paid audit that
           // executePayout already wrote.

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -45,6 +45,12 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
   const [walletTotalsLoading, setWalletTotalsLoading] = useState(false);
   const [overrideCap, setOverrideCap] = useState(false);
 
+  // salame-92103: batch-level acknowledgement for the per-party cap. Surfaced
+  // when one or more selected rows would push their party past its effective
+  // reimbursement cap. The admin ticks a single checkbox to allow over-cap
+  // sends across the whole batch (matches the per-address override pattern).
+  const [overridePartyCap, setOverridePartyCap] = useState(false);
+
   // Eligibility filter — keep in sync with backend bulk-execute filter
   // (USDC + approved-or-failed + valid 0x wallet). passata-49102 added
   // failed-status retry. Anything not matching is shown as "skipped".
@@ -82,6 +88,8 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
       setErrorMsg(null);
       setWalletTotals(new Map());
       setOverrideCap(false);
+      // salame-92103: reset per-party cap ack on every fresh open.
+      setOverridePartyCap(false);
     }
   }, [isOpen]);
 
@@ -156,6 +164,54 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
     return { overCapRowIds, overCapWalletCount: overCapWallets.size, capUsd };
   }, [walletTotals, eligible]);
 
+  // salame-92103: per-party cap analysis. Group eligible rows by party,
+  // accumulate the proposed in-batch amount on top of the party's already-paid
+  // total, and flag every party whose new running total would exceed its
+  // effective cap. Returns:
+  //   - overPartyCapRowIds: ids of rows whose party would exceed cap once
+  //     this batch sends.
+  //   - overPartyCapPartyCount: distinct parties that would exceed.
+  // Uses the payout row's surfaced `party.effectiveReimbursementCapUsd` +
+  // `party.paidTotalUsd`; rows with a null cap are uncapped and skipped.
+  const partyCapAnalysis = useMemo(() => {
+    if (eligible.length === 0) {
+      return { overPartyCapRowIds: new Set<string>(), overPartyCapPartyCount: 0 };
+    }
+    // Accumulate the in-batch amount per party.
+    const inBatchByParty = new Map<string, number>();
+    for (const p of eligible) {
+      const pid = p.party?.id;
+      if (!pid) continue;
+      inBatchByParty.set(
+        pid,
+        (inBatchByParty.get(pid) || 0) + Number(p.finalAmountUsd || 0),
+      );
+    }
+    // Identify parties whose running total (already-paid + in-batch) exceeds
+    // their effective cap.
+    const overParties = new Set<string>();
+    for (const p of eligible) {
+      const pid = p.party?.id;
+      if (!pid) continue;
+      const cap = p.party?.effectiveReimbursementCapUsd;
+      if (cap == null) continue;
+      const alreadyPaid = p.party?.paidTotalUsd ?? 0;
+      const inBatch = inBatchByParty.get(pid) ?? 0;
+      if (alreadyPaid + inBatch > cap + 1e-9) {
+        overParties.add(pid);
+      }
+    }
+    const overPartyCapRowIds = new Set<string>();
+    for (const p of eligible) {
+      const pid = p.party?.id;
+      if (pid && overParties.has(pid)) overPartyCapRowIds.add(p.id);
+    }
+    return {
+      overPartyCapRowIds,
+      overPartyCapPartyCount: overParties.size,
+    };
+  }, [eligible]);
+
   // Close on Escape (only when not sending — never cancel an in-flight batch)
   useEffect(() => {
     if (!isOpen) return;
@@ -177,12 +233,19 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
     // bianco-89172: block submit if any row is over-cap and the admin hasn't
     // ticked the override checkbox.
     if (capAnalysis.overCapWalletCount > 0 && !overrideCap) return;
+    // salame-92103: block submit if any row would push its party past its
+    // effective cap and the admin hasn't ticked the per-party override.
+    if (partyCapAnalysis.overPartyCapPartyCount > 0 && !overridePartyCap) return;
     setPhase('sending');
     setErrorMsg(null);
     try {
       const ids = eligible.map((p) => p.id);
       const res = await bulkExecutePayouts(ids, {
         allowOverPerAddressCap: capAnalysis.overCapWalletCount > 0 ? overrideCap : false,
+        // salame-92103: batch-level per-party cap override. Backend appends
+        // `[override: party cap]` to each affected row's audit note.
+        allowOverPartyCap:
+          partyCapAnalysis.overPartyCapPartyCount > 0 ? overridePartyCap : false,
       });
       setResults(res);
       setPhase('done');
@@ -304,6 +367,40 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
               </div>
             )}
 
+            {/* salame-92103: per-party cap warning. Surfaces when one or more
+                selected rows would push their party past its effective cap. A
+                single batch-level ack covers every row; the backend appends
+                `[override: party cap]` to each affected audit row. Mirrors the
+                per-address pattern above. */}
+            {partyCapAnalysis.overPartyCapPartyCount > 0 && (
+              <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mb-4">
+                <div className="flex items-start gap-2.5">
+                  <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                  <div className="flex-1 text-sm">
+                    <div className="font-medium text-amber-200 mb-1">
+                      Per-party cap warning
+                    </div>
+                    <div className="text-theme-text-secondary text-xs">
+                      {partyCapAnalysis.overPartyCapRowIds.size} selected payment
+                      {partyCapAnalysis.overPartyCapRowIds.size === 1 ? '' : 's'} would
+                      exceed {partyCapAnalysis.overPartyCapPartyCount === 1 ? 'their' : 'their'}{' '}
+                      party's cap ({partyCapAnalysis.overPartyCapPartyCount} part
+                      {partyCapAnalysis.overPartyCapPartyCount === 1 ? 'y' : 'ies'}{' '}
+                      affected).
+                    </div>
+                    <div className="mt-3">
+                      <Checkbox
+                        checked={overridePartyCap}
+                        onChange={() => setOverridePartyCap((v) => !v)}
+                        label="Allow over-party-cap sends — I acknowledge"
+                        labelClassName="text-sm text-amber-100"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* bianco-89172: per-row indicator so admins can see WHICH wallets
                 in their selection would exceed. Folded into the existing
                 eligibility list (kept concise — first 8 rows). */}
@@ -358,7 +455,10 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                   eligible.length === 0 ||
                   walletTotalsLoading ||
                   // bianco-89172: block Send when over-cap and admin hasn't ack'd
-                  (capAnalysis.overCapWalletCount > 0 && !overrideCap)
+                  (capAnalysis.overCapWalletCount > 0 && !overrideCap) ||
+                  // salame-92103: block Send when any row would push its party
+                  // past its cap and admin hasn't ack'd the per-party override.
+                  (partyCapAnalysis.overPartyCapPartyCount > 0 && !overridePartyCap)
                 }
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -90,6 +90,12 @@ interface PayoutReviewModalProps {
     mercuryCardId?: string;
     note?: string;
     allowOverPerAddressCap?: boolean;
+    /**
+     * salame-92103: forwarded when the admin has ticked the per-party cap
+     * override checkbox in the execute form. Server appends
+     * `[override: party cap]` to the audit row's note.
+     */
+    allowOverPartyCap?: boolean;
   }) => Promise<void> | void;
   /**
    * Optional fetcher for the USDC daily-cap-remaining hint. Only called when
@@ -283,6 +289,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const [walletPaidLoading, setWalletPaidLoading] = useState(false);
   const [overrideCap, setOverrideCap] = useState(false);
 
+  // salame-92103: per-party cap override state. The amber warning + ack
+  // surfaces when this proposed payment would push the party past its
+  // effective reimbursement cap (already-paid total + this amount > cap).
+  // Required to enable Execute when `partyWouldExceedCap === true`.
+  const [overridePartyCap, setOverridePartyCap] = useState(false);
+
   // taralli-58291: lightbox uses an index into `allPhotos` so ArrowLeft /
   // ArrowRight can cycle through receipts + pizza photos. Hooks must be
   // declared above any early return — see feedback_hooks_above_early_returns.
@@ -436,6 +448,23 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
   const ocrSum = receipts.reduce((sum, r) => sum + (Number(r.ocrAmount) || 0), 0);
 
+  // salame-92103: party-cap analysis for the Execute panel. Derived from
+  // `payout.party.effectiveReimbursementCapUsd` (the resolved cap — validated
+  // cap OR max numeric event tag) and `payout.party.paidTotalUsd` (sum of
+  // already-paid payouts on this party). When this proposed payment would push
+  // the party's running paid total past its cap, the modal renders an amber
+  // warning + ack checkbox and disables Execute until the admin ticks it.
+  const partyCap = payout.party?.effectiveReimbursementCapUsd ?? null;
+  const partyPaidSoFar = payout.party?.paidTotalUsd ?? 0;
+  const proposedAmount = Number(payout.finalAmountUsd) || 0;
+  const partyCapRemaining =
+    partyCap != null ? Math.max(0, partyCap - partyPaidSoFar) : null;
+  const partyWouldExceedCap =
+    partyCap != null && partyPaidSoFar + proposedAmount > partyCap + 1e-9;
+  const partyOverBy = partyWouldExceedCap && partyCap != null
+    ? Math.max(0, partyPaidSoFar + proposedAmount - partyCap)
+    : 0;
+
   const isPending = payout.status === 'pending';
   const isFailed = payout.status === 'failed';
   // passata-49102: failed payouts are now re-executable, so treat them like
@@ -460,6 +489,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     // ack checkbox doesn't carry over from a previous Execute attempt.
     setWalletPaidTotal(null);
     setOverrideCap(false);
+    // salame-92103: clear the per-party cap ack on every open.
+    setOverridePartyCap(false);
     if (payout.payoutMethod === 'usdc_base' && fetchUsdcCapRemaining) {
       setUsdcCapLoading(true);
       try {
@@ -1251,6 +1282,41 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   </div>
                 )}
 
+                {/* salame-92103: per-party cap warning. Surfaces when the
+                    proposed payment would push this party past its effective
+                    reimbursement cap (e.g. a $135 cap already covered by a
+                    $125 prepayment with $10 remaining can't take another $135
+                    without an explicit acknowledgement). Mirrors the per-
+                    address cap pattern (bianco-89172) — amber panel + ack
+                    Checkbox + Execute button disabled until ticked. Method-
+                    agnostic; the server-side check fires for usdc / wire /
+                    mercury_card alike. */}
+                {partyWouldExceedCap && partyCap != null && (
+                  <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+                    <div className="flex items-start gap-2.5">
+                      <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                      <div className="flex-1 text-sm">
+                        <div className="font-medium text-amber-200 mb-1">
+                          Per-party cap warning
+                        </div>
+                        <div className="text-theme-text-secondary text-xs">
+                          This payment exceeds the party's ${partyCap.toFixed(2)} cap by{' '}
+                          <b>${partyOverBy.toFixed(2)}</b>{' '}
+                          (remaining: ${(partyCapRemaining ?? 0).toFixed(2)}).
+                        </div>
+                        <div className="mt-3">
+                          <Checkbox
+                            checked={overridePartyCap}
+                            onChange={() => setOverridePartyCap((v) => !v)}
+                            label="I acknowledge — proceed anyway"
+                            labelClassName="text-sm text-amber-100"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
                 {payout.payoutMethod === 'usdc_base' && (
                   <div className="space-y-2">
                     <p className="text-emerald-900">
@@ -1386,6 +1452,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       ) {
                         return;
                       }
+                      // salame-92103: block submit if the per-party cap would
+                      // exceed and the admin hasn't ticked the override.
+                      if (partyWouldExceedCap && !overridePartyCap) {
+                        return;
+                      }
                       await onExecute({
                         wireReference: payout.payoutMethod === 'wire' ? execWireRef.trim() : undefined,
                         mercuryCardLast4:
@@ -1401,6 +1472,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                           payout.payoutMethod === 'usdc_base' && walletPaidTotal?.wouldExceed
                             ? overrideCap
                             : undefined,
+                        // salame-92103: forward the admin's acknowledgement so
+                        // the server bypasses its own per-party cap check + adds
+                        // `[override: party cap]` to the audit row's note.
+                        allowOverPartyCap: partyWouldExceedCap ? overridePartyCap : undefined,
                       });
                       setShowExecuteForm(false);
                     }}
@@ -1413,7 +1488,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       // bianco-89172: disabled until ack when the cap would exceed.
                       (payout.payoutMethod === 'usdc_base' &&
                         !!walletPaidTotal?.wouldExceed &&
-                        !overrideCap)
+                        !overrideCap) ||
+                      // salame-92103: disabled until ack when the per-party cap would exceed.
+                      (partyWouldExceedCap && !overridePartyCap)
                     }
                     className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
                   >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4447,6 +4447,10 @@ export async function markPartyPaid(
  * the per-address $676 cumulative cap when the admin has acknowledged the
  * warning in PayoutReviewModal.
  *
+ * `allowOverPartyCap` (salame-92103): forwarded to the server to bypass the
+ * per-party cap when the admin has acknowledged the over-cap warning. The
+ * server appends `[override: party cap]` to the audit row's note.
+ *
  * Returns the updated payout. Throws on any server-side validation/execution failure.
  */
 export async function executeAdminPayout(
@@ -4457,6 +4461,7 @@ export async function executeAdminPayout(
     mercuryCardId?: string;
     note?: string;
     allowOverPerAddressCap?: boolean;
+    allowOverPartyCap?: boolean;
   } = {},
 ): Promise<AdminPayout> {
   const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/execute`, {
@@ -4488,10 +4493,16 @@ export interface BulkSendResult {
 
 export async function bulkExecutePayouts(
   ids: string[],
-  opts?: { allowOverPerAddressCap?: boolean },
+  opts?: { allowOverPerAddressCap?: boolean; allowOverPartyCap?: boolean },
 ): Promise<BulkSendResult[]> {
-  const body: { ids: string[]; allowOverPerAddressCap?: boolean } = { ids };
+  const body: {
+    ids: string[];
+    allowOverPerAddressCap?: boolean;
+    allowOverPartyCap?: boolean;
+  } = { ids };
   if (opts?.allowOverPerAddressCap) body.allowOverPerAddressCap = true;
+  // salame-92103: batch-level acknowledgement for the per-party cap.
+  if (opts?.allowOverPartyCap) body.allowOverPartyCap = true;
   const res = await apiRequest<{ results: BulkSendResult[] }>(`/api/admin/payouts/bulk-execute`, {
     method: 'POST',
     body,


### PR DESCRIPTION
## Summary
- Backend `/execute` + `/payouts/bulk-execute` accept `allowOverPartyCap: true` (admin-class only).
- Frontend amber warning + ack Checkbox in PayoutReviewModal + BulkSendModal when amount exceeds party-cap.
- Audit note appends `[override: party cap]`.
- Other caps unchanged.

## Test plan
- [ ] Portoviejo $135 over cap → ack → execute succeeds; audit shows override.
- [ ] Bulk batch with mixed in-cap + over-cap → batch checkbox surfaces; ack → all execute.
- [ ] Under-cap execute → no warning.
- [ ] Audit row note records the override.