### PR TITLE
feat(vodka-58294): wrap survey title in a card

### DIFF
--- a/frontend/src/pages/SurveyPage.tsx
+++ b/frontend/src/pages/SurveyPage.tsx
@@ -150,7 +150,7 @@ function SurveyPageInner() {
         <title>{data ? `Survey · ${data.eventName}` : 'Survey'} | RSV.Pizza</title>
       </Helmet>
       <div className="max-w-2xl mx-auto px-4 py-10">
-        <div className="mb-8 text-center">
+        <div className="card p-5 mb-6 text-center">
           <h1 className="text-3xl font-bold text-theme-text mb-1">
             How was {data?.eventName}?
           </h1>


### PR DESCRIPTION
Wrap the SurveyPage header (event-name title + lead paragraph) in the same `card p-5` treatment used by each question row below, so it visually matches on the GPP blue gradient.

Test link: https://rsv.pizza/survey/041010e7-b32b-4040-b1d1-070d9c2806f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)