### PR TITLE
fix(fontina-92103): per-party cap check excludes pending claims

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -275,11 +275,12 @@ async function fetchPaidTotalsByParty(
 }
 
 /**
- * tiramisu-49102: hard per-party cap enforcement. Sums every payout for the
- * party that is `pending | approved | paid` and throws 409 PARTY_CAP_EXCEEDED
- * if `usedUsd + proposedUsd` exceeds the party's `effectiveReimbursementCapUsd`
- * (validated cap OR max numeric event tag). Parties without an effective cap
- * stay uncapped.
+ * tiramisu-49102 + fontina-92103: hard per-party cap enforcement. Sums every
+ * COMMITTED payout for the party (status `paid` or `approved`) and throws
+ * 409 PARTY_CAP_EXCEEDED if `usedUsd + proposedUsd` exceeds the party's
+ * `effectiveReimbursementCapUsd`. Pending claims are excluded — hosts may
+ * submit receipts above the approved cap; the cap only constrains what
+ * admins commit (approve/pay).
  *
  * `ignorePayoutId` excludes a row from the existing-total — used by PATCH so a
  * row being edited doesn't count against itself.
@@ -304,7 +305,7 @@ async function assertWithinPartyCap(
 
   const where: any = {
     partyId,
-    status: { in: ['paid', 'pending', 'approved'] },
+    status: { in: ['paid', 'approved'] },
   };
   if (ignorePayoutId) {
     where.id = { not: ignorePayoutId };


### PR DESCRIPTION
## Summary

- Cap check in `assertWithinPartyCap` now sums only **committed** payouts (`paid` + `approved`), excluding `pending`.
- Hosts may submit receipts above the approved cap (inflated, mis-OCR'd, or over-cap items). Admins were being blocked from executing the approved amount on parties with bloated pending stacks.
- The admin's approved amount is authoritative; speculative pending claims no longer constrain admin commits.

## Why

Per Snax: parties may submit receipts higher than the amount they will ultimately be reimbursed. Admins should still be able to send out the approved amount regardless of pending amounts.

Previous behavior summed `paid | pending | approved`; this PR drops `pending` from the cap calculation. The existing `ignorePayoutId` mechanism still excludes the current row.

## Test plan

- [x] `npx tsc --noEmit` on backend — no new type errors on `admin-payout.routes.ts`.
- [ ] Mexico City: $2,330 bogus pending + $675 approved → cap check sees `usedUsd=0` (pending excluded, approved row excluded via `ignorePayoutId`) → passes the $675 cap.
- [ ] Portoviejo: $125 paid prepayment + $135 approved → cap check sees `usedUsd=125` → 125+135=260 > 135 → still throws (admin must use salame-92103 override).
- [ ] Two approved $400 payouts on a $675-capped party → second approval sees `usedUsd=400` → 400+400=800 > 675 → throws (correct double-approval guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)