### PR TITLE
fix(ricotta-92103): cap-warning contrast on gpp-theme

### DIFF
--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -340,14 +340,18 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
               </div>
             )}
             {!walletTotalsLoading && capAnalysis.overCapWalletCount > 0 && (
+              // ricotta-92103: amber values wash out on gpp-theme where
+              // `.gpp-theme .card` repaints the panel white. Mirror the dark-
+              // amber override from PayoutReviewModal so both modals stay
+              // readable on `/payments/<region>`.
               <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mb-4">
                 <div className="flex items-start gap-2.5">
-                  <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                  <AlertTriangle className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0" size={16} />
                   <div className="flex-1 text-sm">
-                    <div className="font-medium text-amber-200 mb-1">
+                    <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
                       Per-address cap warning
                     </div>
-                    <div className="text-theme-text-secondary text-xs">
+                    <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
                       {capAnalysis.overCapWalletCount} selected wallet
                       {capAnalysis.overCapWalletCount === 1 ? '' : 's'} would exceed the
                       ${capAnalysis.capUsd} per-address cap once this batch sends
@@ -359,7 +363,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                         checked={overrideCap}
                         onChange={() => setOverrideCap((v) => !v)}
                         label="Allow over-cap sends — I acknowledge"
-                        labelClassName="text-sm text-amber-100"
+                        labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                       />
                     </div>
                   </div>
@@ -373,14 +377,16 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                 `[override: party cap]` to each affected audit row. Mirrors the
                 per-address pattern above. */}
             {partyCapAnalysis.overPartyCapPartyCount > 0 && (
+              // ricotta-92103: dark-amber overrides under .gpp-theme to keep
+              // the warning panel legible on light-mint pages.
               <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mb-4">
                 <div className="flex items-start gap-2.5">
-                  <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                  <AlertTriangle className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0" size={16} />
                   <div className="flex-1 text-sm">
-                    <div className="font-medium text-amber-200 mb-1">
+                    <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
                       Per-party cap warning
                     </div>
-                    <div className="text-theme-text-secondary text-xs">
+                    <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
                       {partyCapAnalysis.overPartyCapRowIds.size} selected payment
                       {partyCapAnalysis.overPartyCapRowIds.size === 1 ? '' : 's'} would
                       exceed {partyCapAnalysis.overPartyCapPartyCount === 1 ? 'their' : 'their'}{' '}
@@ -393,7 +399,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                         checked={overridePartyCap}
                         onChange={() => setOverridePartyCap((v) => !v)}
                         label="Allow over-party-cap sends — I acknowledge"
-                        labelClassName="text-sm text-amber-100"
+                        labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                       />
                     </div>
                   </div>

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1292,14 +1292,21 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     agnostic; the server-side check fires for usdc / wire /
                     mercury_card alike. */}
                 {partyWouldExceedCap && partyCap != null && (
+                  // ricotta-92103: amber values (text-amber-200/100/300) read
+                  // fine on dark `.card` backgrounds but wash out on gpp-theme,
+                  // where `.gpp-theme .card { background: rgba(255,255,255,.92)
+                  // !important }` repaints the panel white. Override to dark
+                  // amber under `.gpp-theme` via Tailwind arbitrary variants.
+                  // See architecture_gpp_theme_text_white_override + screenshot
+                  // 2026-05-29 (/payments/latam cap-warning unreadable).
                   <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
                     <div className="flex items-start gap-2.5">
-                      <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                      <AlertTriangle className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0" size={16} />
                       <div className="flex-1 text-sm">
-                        <div className="font-medium text-amber-200 mb-1">
+                        <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
                           Per-party cap warning
                         </div>
-                        <div className="text-theme-text-secondary text-xs">
+                        <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
                           This payment exceeds the party's ${partyCap.toFixed(2)} cap by{' '}
                           <b>${partyOverBy.toFixed(2)}</b>{' '}
                           (remaining: ${(partyCapRemaining ?? 0).toFixed(2)}).
@@ -1309,7 +1316,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                             checked={overridePartyCap}
                             onChange={() => setOverridePartyCap((v) => !v)}
                             label="I acknowledge — proceed anyway"
-                            labelClassName="text-sm text-amber-100"
+                            labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                           />
                         </div>
                       </div>
@@ -1350,14 +1357,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       </div>
                     )}
                     {!walletPaidLoading && walletPaidTotal?.wouldExceed && payout.payoutWalletAddress && (
+                      // ricotta-92103: same gpp-theme contrast fix as the
+                      // per-party warning above. Bumps amber text to dark
+                      // shades under `.gpp-theme` where the panel paints white.
                       <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
                         <div className="flex items-start gap-2.5">
-                          <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+                          <AlertTriangle className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0" size={16} />
                           <div className="flex-1 text-sm">
-                            <div className="font-medium text-amber-200 mb-1">
+                            <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
                               Per-address cap warning
                             </div>
-                            <div className="text-theme-text-secondary text-xs">
+                            <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
                               Wallet{' '}
                               <code className="font-mono text-[11px]">
                                 {payout.payoutWalletAddress.slice(0, 6)}…{payout.payoutWalletAddress.slice(-4)}
@@ -1377,7 +1387,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                 checked={overrideCap}
                                 onChange={() => setOverrideCap((v) => !v)}
                                 label="I acknowledge — proceed anyway"
-                                labelClassName="text-sm text-amber-100"
+                                labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                               />
                             </div>
                           </div>


### PR DESCRIPTION
## Summary
- The salame-92103 amber cap-warning panel (per-party + per-address) in `PayoutReviewModal` and `BulkSendModal` washed out on gpp-theme pages (`/payments/<region>`). `.gpp-theme .card` repaints the panel white via `!important`, so light amber text (`text-amber-200`, `text-amber-100`, `text-amber-300`) on white was unreadable.
- Adds `[.gpp-theme_&]:text-amber-900` / `text-amber-700` arbitrary-variant overrides on the heading, body, ack checkbox label, and warning icon. Dark pages keep the existing light-amber treatment; gpp pages now render dark amber on the white card.
- Same fix applied to all four cap-warning panels (2 in PayoutReviewModal, 2 in BulkSendModal) so the visual treatment stays consistent.

## Test plan
- [ ] `/payments/latam` (gpp-theme) → open over-cap payout → "Per-party cap warning" body and "I acknowledge — proceed anyway" label are clearly readable.
- [ ] Same modal, USDC-Base method → "Per-address cap warning" panel is readable.
- [ ] Dark `/payments` (non-gpp) → same panels still look correct in the original amber styling.
- [ ] `BulkSendModal` over-cap and over-party-cap acks readable in both themes.
- [ ] `npx tsc --noEmit` clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>