### PR TITLE
feat(taleggio-92104): AVG PAYMENT KPI averages per-city total

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1869,7 +1869,6 @@ router.get(
       let totalUsdPending = 0;
       let totalUsdPaid = 0;
       let totalUsdThisMonth = 0;
-      let sumUsd = 0;
       let awaitingReview = 0;
 
       // parmigiana-58291: per-party rollup over `status === 'paid'` rows.
@@ -1879,6 +1878,13 @@ router.get(
         string,
         { partyId: string; partyName: string; country: string | null; totalPaidUsd: number; payoutCount: number }
       >();
+
+      // taleggio-92104: separate per-party rollup of *committed* USD
+      // (status IN paid+approved) used only to compute `avgUsd` as the
+      // average per-city total, not per-payout. Kept isolated from the
+      // parmigiana-58291 paid-only `partyTotals` Map so existing
+      // serialization semantics are unchanged.
+      const committedByParty = new Map<string, number>();
 
       const now = new Date();
       const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -1890,7 +1896,6 @@ router.get(
         const methodKey = r.payoutMethod ?? 'unset';
         byMethod[methodKey] = (byMethod[methodKey] || 0) + 1;
         const usd = Number(r.finalAmountUsd);
-        sumUsd += usd;
         if (r.status === 'pending') {
           totalUsdPending += usd;
           awaitingReview += 1;
@@ -1919,9 +1924,35 @@ router.get(
             }
           }
         }
+
+        // taleggio-92104: accumulate committed (paid + approved) totals per
+        // party for the AVG PAYMENT KPI. "Committed" matches fontina-92103's
+        // cap-check definition: USD that has either left the wallet (`paid`)
+        // or been queued to leave (`approved`). Pending/rejected/failed do
+        // not count.
+        if ((r.status === 'paid' || r.status === 'approved') && r.party) {
+          committedByParty.set(
+            r.party.id,
+            (committedByParty.get(r.party.id) ?? 0) + usd,
+          );
+        }
       }
 
-      const avgUsd = allFiltered.length > 0 ? sumUsd / allFiltered.length : 0;
+      // taleggio-92104: AVG PAYMENT averages per-city committed totals
+      // (sum of each party's paid+approved finalAmountUsd, then average
+      // across parties with any committed total) instead of averaging
+      // finalAmountUsd per payout row. The per-row average over-weighted
+      // cities with one large payout and under-weighted cities with many
+      // smaller ones. Same filter-window scope as the rest of `totals`
+      // since both derive from `allFiltered`.
+      let avgUsd = 0;
+      if (committedByParty.size > 0) {
+        let committedSum = 0;
+        for (const partyTotal of committedByParty.values()) {
+          committedSum += partyTotal;
+        }
+        avgUsd = committedSum / committedByParty.size;
+      }
 
       // taleggio-49183: the parmigiana-58291 top-level `byParty` aggregate
       // was removed — the per-row "Already paid: $X (N)" rendering on each


### PR DESCRIPTION
## Summary
- The /payments dashboard's AVG PAYMENT KPI previously averaged `finalAmountUsd` per payout row, which under-counted cities that had multiple smaller payouts and over-counted cities with one large payout.
- New computation: build a per-party rollup of committed (`paid` + `approved`) `finalAmountUsd`, then average across parties that have any committed total.
- Same filter-window scope as adjacent KPIs (both derive from the existing `allFiltered` set), so the metric respects whatever status/method/country/dateRange filters the admin has applied.

## Notes
- Isolated in a new `committedByParty` Map so the parmigiana-58291 paid-only `partyTotals` rollup and its downstream serialization are untouched.
- "Committed" = `paid` + `approved` to match fontina-92103's cap-check definition; pending/rejected/failed/withdrawn are excluded so the avg isn't diluted by un-issued claims.
- Parties with zero committed totals are excluded from the denominator.
- Label "AVG PAYMENT" unchanged on purpose.

## Test plan
- [ ] Vercel preview: AVG PAYMENT tile renders a higher number than before for filter sets where some cities have multiple payouts.
- [ ] Spot-check: pick 3-5 cities with paid+approved payouts, sum each party's total, divide by city count — matches the tile.
- [ ] Other KPI tiles (PENDING, PAID THIS MONTH, AWAITING REVIEW) unchanged.
- [ ] Status/method/country/date filters still flow through to AVG PAYMENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)