### PR TITLE
feat(gouda-92103): silent payment removal (skip host notify)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2588,6 +2588,14 @@ router.post(
         throw new AppError('rejectionReason is required', 400, 'VALIDATION_ERROR');
       }
 
+      // gouda-92103: admin can suppress host notification on reject when
+      // cleaning up bogus/duplicate/over-cap rows where the host already
+      // knows (or doesn't need to be re-notified). Default is notify
+      // (silent === false) so behavior matches today's contract. The audit
+      // note captures `[silent]` so the trail records the suppression.
+      const silent = req.body?.silent === true;
+      const auditNote = silent ? `${reason} [silent]` : reason;
+
       const updated = await prisma.$transaction(async (tx) => {
         const row = await tx.payout.update({
           where: { id: existing.id },
@@ -2616,12 +2624,19 @@ router.post(
             newStatus: 'rejected',
             actorEmail: actor.email,
             actorKind: actor.actorKind,
-            note: reason,
+            note: auditNote,
           },
         });
 
         return row;
       });
+
+      // gouda-92103: host-notification side effects belong here. The reject
+      // endpoint does not currently fire an email or Telegram to the host
+      // (the rejection reason on the host's payouts list is the visible
+      // signal), so there is nothing to skip today. When a reject-notify
+      // channel is added in the future, gate it behind `if (!silent) {...}`
+      // here so this contract still holds.
 
       res.json({ payout: serializePayout(updated) });
     } catch (error) {

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -41,7 +41,13 @@ interface PayoutReviewModalProps {
   selfPayoutBlocked?: boolean;
   onClose: () => void;
   onApprove: (note?: string) => Promise<void> | void;
-  onReject: (reason: string) => Promise<void> | void;
+  /**
+   * gouda-92103: optional second arg lets the admin opt into a silent
+   * reject — backend suppresses host-notify side effects and records
+   * `[silent]` on the audit row. Default (no opts) preserves today's
+   * notify-on-reject contract.
+   */
+  onReject: (reason: string, opts?: { silent?: boolean }) => Promise<void> | void;
   /**
    * caprino-92103: revert an `approved` payout back to `pending`. Surfaced
    * as an amber "Revert to Pending" button in the modal footer when the
@@ -258,6 +264,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
   const [showRejectForm, setShowRejectForm] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
+  // gouda-92103: silent-reject ack. UNCHECKED by default so today's
+  // notify-on-reject contract holds; admin opts into suppression by ticking.
+  const [rejectSilent, setRejectSilent] = useState(false);
 
   // caprino-92103: inline error for "Revert to Pending". Rendered below the
   // footer button row. Mirrors the saveAmountError pattern from aglio-62584.
@@ -1242,14 +1251,28 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   value={rejectReason}
                   onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setRejectReason(e.target.value)}
                 />
+                {/* gouda-92103: silent-removal ack. UNCHECKED by default so
+                    today's notify-on-reject contract holds. Ticking forwards
+                    `silent: true` to onReject → API; backend appends [silent]
+                    to the audit note and skips any host-notify side effect. */}
+                <div className="mt-2">
+                  <Checkbox
+                    checked={rejectSilent}
+                    onChange={() => setRejectSilent((v) => !v)}
+                    label="Don't notify host"
+                    labelClassName="text-sm text-red-900"
+                    disabled={busy}
+                  />
+                </div>
                 <div className="flex gap-2 mt-2">
                   <button
                     type="button"
                     onClick={async () => {
                       if (!rejectReason.trim()) return;
-                      await onReject(rejectReason.trim());
+                      await onReject(rejectReason.trim(), { silent: rejectSilent });
                       setShowRejectForm(false);
                       setRejectReason('');
+                      setRejectSilent(false);
                     }}
                     disabled={busy || !rejectReason.trim()}
                     className="px-3 py-1.5 rounded-lg bg-red-500 text-white text-xs disabled:opacity-50"
@@ -1258,7 +1281,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   </button>
                   <button
                     type="button"
-                    onClick={() => setShowRejectForm(false)}
+                    onClick={() => {
+                      setShowRejectForm(false);
+                      setRejectSilent(false);
+                    }}
                     className="px-3 py-1.5 rounded-lg text-xs text-theme-text-secondary hover:bg-theme-surface-hover"
                   >
                     Cancel

--- a/frontend/src/components/payments-admin/RejectReasonModal.tsx
+++ b/frontend/src/components/payments-admin/RejectReasonModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X, MessageSquare, Loader2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
 
 export interface RejectReasonModalProps {
   isOpen: boolean;
@@ -14,7 +15,13 @@ export interface RejectReasonModalProps {
     | { kind: 'single'; hostName: string }
     | { kind: 'bulk'; count: number };
   onCancel: () => void;
-  onConfirm: (reason: string) => Promise<void>;
+  /**
+   * gouda-92103: `silent` defaults to false (= notify-as-today). When the
+   * admin ticks the "Don't notify host" ack, the caller forwards
+   * `silent: true` to the API so the backend suppresses any host-notify
+   * side effect AND records `[silent]` on the audit row.
+   */
+  onConfirm: (reason: string, opts: { silent: boolean }) => Promise<void>;
 }
 
 const MAX_LEN = 1000;
@@ -37,14 +44,17 @@ export const RejectReasonModal: React.FC<RejectReasonModalProps> = ({
   onConfirm,
 }) => {
   const [reason, setReason] = useState('');
+  const [silent, setSilent] = useState(false);
   const [busy, setBusy] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   // Reset state whenever the modal transitions to closed (so re-opening is
-  // a clean slate).
+  // a clean slate). gouda-92103: `silent` defaults back to UNCHECKED on
+  // every re-open so the admin has to opt-in to suppression each time.
   useEffect(() => {
     if (!isOpen) {
       setReason('');
+      setSilent(false);
       setBusy(false);
       setErrorMsg(null);
     }
@@ -75,7 +85,7 @@ export const RejectReasonModal: React.FC<RejectReasonModalProps> = ({
     setErrorMsg(null);
     setBusy(true);
     try {
-      await onConfirm(trimmed);
+      await onConfirm(trimmed, { silent });
       // Caller closes the modal on success (so it can sequence refreshes
       // first). If `onConfirm` resolves without the parent closing us, we'll
       // still drop back to idle so the user can retry / cancel.
@@ -127,6 +137,21 @@ export const RejectReasonModal: React.FC<RejectReasonModalProps> = ({
         />
         <div className="mt-1 text-xs text-theme-text-muted text-right">
           {trimmed.length}/{MAX_LEN}
+        </div>
+
+        {/* gouda-92103: silent-removal ack. UNCHECKED by default so the
+            modal's normal behavior (today: rejection reason becomes visible
+            to the host on their payouts list) is unchanged. Ticking the box
+            forwards `silent: true` to the API, which suppresses host-notify
+            side effects and appends [silent] to the audit note. */}
+        <div className="mt-3">
+          <Checkbox
+            checked={silent}
+            onChange={() => setSilent((v) => !v)}
+            label="Don't notify host"
+            labelClassName="text-sm text-theme-text-secondary"
+            disabled={busy}
+          />
         </div>
 
         {errorMsg && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4208,13 +4208,15 @@ export async function approveAdminPayout(
 export async function rejectAdminPayout(
   id: string,
   rejectionReason: string,
-  opts?: { regions?: string[] },
+  opts?: { regions?: string[]; silent?: boolean },
 ): Promise<AdminPayout> {
   const res = await apiRequest<{ payout: AdminPayout }>(
     `/api/admin/payouts/${id}/reject${regionsQuery(opts?.regions)}`,
     {
       method: 'POST',
-      body: { rejectionReason },
+      // gouda-92103: `silent: true` suppresses host notification on reject.
+      // Default omitted (= notify-as-today). Audit note records [silent].
+      body: { rejectionReason, silent: opts?.silent === true ? true : undefined },
     },
   );
   return res.payout;

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -656,9 +656,15 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   // and clicks Reject. Performs the actual API call(s), refreshes BOTH the
   // payouts list AND the prepay queue (a rejected prepayment correctly
   // re-appears in the queue), and closes the modal on success.
-  async function confirmReject(reason: string) {
+  // gouda-92103: the modal passes `silent` as a second-arg ack — true means
+  // the admin ticked "Don't notify host"; false (default) preserves
+  // pre-gouda behavior. Threaded into `rejectAdminPayout(id, reason, opts)`.
+  async function confirmReject(reason: string, ackOpts: { silent: boolean }) {
     if (!rejectTarget) return;
-    const rejectOpts = regions ? { regions } : undefined;
+    const rejectOpts = {
+      ...(regions ? { regions } : {}),
+      ...(ackOpts.silent ? { silent: true } : {}),
+    };
     if (rejectTarget.kind === 'single') {
       setRowBusyId(rejectTarget.id);
       try {
@@ -1045,10 +1051,17 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 setModalBusy(false);
               }
             }}
-            onReject={async (reason) => {
+            onReject={async (reason, opts) => {
               setModalBusy(true);
               try {
-                await rejectAdminPayout(detail.id, reason, regions ? { regions } : undefined);
+                // gouda-92103: forward the modal's silent ack (when ticked)
+                // alongside the regional scope. Default (undefined) preserves
+                // today's notify-on-reject contract.
+                const rejectOpts = {
+                  ...(regions ? { regions } : {}),
+                  ...(opts?.silent ? { silent: true } : {}),
+                };
+                await rejectAdminPayout(detail.id, reason, rejectOpts);
                 const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await refresh();


### PR DESCRIPTION
## Summary

- Adds an optional `silent` flag to `POST /api/admin/payouts/:id/reject`. When `silent === true`, the audit note is suffixed with `[silent]` and the endpoint skips any host-notification side effect (today the reject endpoint doesn't email/Telegram the host, but the gate is in place for any reject-notify channel added later).
- Surfaces a `Don't notify host` checkbox in both reject affordances:
  - `RejectReasonModal` (single + bulk reject from `/payments` row buttons)
  - `PayoutReviewModal` inline reject form (single-row review modal)
- Checkbox is UNCHECKED by default — today's notify-on-reject contract is preserved. Admin must opt-in per click; state resets on modal close.

## Use case

Cleaning up bogus / duplicate / over-cap payment rows where the host already knows or doesn't need to be re-notified.

## Files changed

- `backend/src/routes/admin-payout.routes.ts` — accept `silent` on `/:id/reject`, append `[silent]` to audit note when set
- `frontend/src/lib/api.ts` — thread `opts.silent` into `rejectAdminPayout`
- `frontend/src/components/payments-admin/RejectReasonModal.tsx` — Checkbox + new `onConfirm(reason, {silent})` signature
- `frontend/src/components/payments-admin/PayoutReviewModal.tsx` — Checkbox in inline reject form + new `onReject(reason, {silent?})` signature
- `frontend/src/pages/PaymentsAdminPage.tsx` — forward `silent` from both modal callbacks to the API client

## Test plan

- [ ] Open `/payments`, click the row-level Reject (X) button, type a reason WITHOUT ticking the box -> reject succeeds; behavior matches today (rejection reason visible to host on their payouts list).
- [ ] Same flow but tick `Don't notify host` -> verify in the DB that the corresponding `payout_audit` row has `note` ending in ` [silent]`.
- [ ] Open `PayoutReviewModal` (click a payout row), use the inline Reject form WITHOUT the box -> normal reject, no `[silent]` in audit note.
- [ ] Same inline form WITH the box ticked -> `[silent]` appended to audit note.
- [ ] Bulk-reject (select multiple rows, click Reject bulk) WITH the box ticked -> every audit row has `[silent]`.
- [ ] Verify backend tsc + frontend tsc clean (manually confirmed in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)