### PR TITLE
feat(mortadella-92103): correct FX conversion for receipt aggregation

### DIFF
--- a/backend/prisma/migrations/20260529000000_payout_documents_fx_fields/migration.sql
+++ b/backend/prisma/migrations/20260529000000_payout_documents_fx_fields/migration.sql
@@ -1,0 +1,26 @@
+-- mortadella-92103: per-receipt original-amount + locked exchange-rate columns.
+--
+-- The existing `ocr_amount` column on `payout_documents` is USD (Decimal(12,2)).
+-- The original receipt amount in the source currency was previously only
+-- preserved on the parent `payouts` row (as the FIRST receipt's headline FX),
+-- or buried inside `ocr_raw` JSONB. That made forensics + per-receipt FX
+-- re-runs impossible. We now persist the original amount/currency/rate on
+-- every receipt document.
+--
+-- All three columns are NULL-able and default NULL — historical rows simply
+-- have no FX detail. Auto-fill on new POST/PATCH writes is wired up in the
+-- TypeScript routes.
+
+ALTER TABLE "payout_documents"
+  ADD COLUMN "original_amount"   NUMERIC(14, 4) NULL,
+  ADD COLUMN "original_currency" CHAR(3)        NULL,
+  ADD COLUMN "exchange_rate"     NUMERIC(18, 8) NULL;
+
+-- Grant the column-level SELECT so the public-read code path (which uses
+-- `safeColumns`-style narrow grants) doesn't 403 on these new fields. The
+-- payouts/receipts API is auth-gated and uses the Prisma client (service role
+-- / shared connection), but mirroring the existing grant pattern keeps the
+-- schema consistent for any future anon-readable views.
+GRANT SELECT ("original_amount", "original_currency", "exchange_rate")
+  ON "payout_documents"
+  TO anon, authenticated;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1754,6 +1754,13 @@ model PayoutDocument {
   ocrAmount        Decimal? @map("ocr_amount") @db.Decimal(12, 2)
   ocrCurrency      String?  @map("ocr_currency")
   ocrConfidence    Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
+  // mortadella-92103: per-receipt FX persistence so non-USD receipts can be
+  // re-converted in-place when the admin corrects the currency, and so the
+  // reviewer modal can render the original-currency amount per receipt
+  // without re-parsing ocrRaw. ocrAmount stays the USD-converted value.
+  originalAmount   Decimal? @map("original_amount") @db.Decimal(14, 4)
+  originalCurrency String?  @map("original_currency") @db.Char(3)
+  exchangeRate     Decimal? @map("exchange_rate") @db.Decimal(18, 8)
   ocrRaw           Json?    @map("ocr_raw")
   // formaggi-89172: structured per-line items extracted from the receipt OCR.
   // Schema is OcrLineItem[] (see backend/src/services/ocr.service.ts) — each

--- a/backend/scripts/backfill-misclassified-usd-receipts.cjs
+++ b/backend/scripts/backfill-misclassified-usd-receipts.cjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+/**
+ * mortadella-92103: backfill receipts that were mis-stamped as USD.
+ *
+ * Background: pre-mortadella-92103, OCR defaulted to currency='USD' when it
+ * couldn't read a currency symbol. For receipts from non-US events (e.g.
+ * Mexico City), the raw MXN amount got persisted as `ocr_amount` (USD) and
+ * the payout's `final_amount_usd` was wildly over-stated (often ~20×).
+ *
+ * Production symptom: Mexico City had a $2,330.56 pending payout where the
+ * receipts were `1624 MXN + 706.56 MXN` (~$120 USD).
+ *
+ * Strategy:
+ *   - Find payout_documents where:
+ *       ocr_currency = 'USD'
+ *       AND parties.country IS NOT NULL AND parties.country != 'US'
+ *       AND parties.country != 'EC' (Ecuador uses USD natively)
+ *       AND parties.country != 'PA' (Panama uses USD natively)
+ *       AND parties.country != 'SV' (El Salvador uses USD natively)
+ *       AND createdAt >= --since (default: 90 days ago, conservative)
+ *       AND original_amount IS NULL  (don't re-touch already-backfilled rows)
+ *   - For each, look up the party's primary currency from the static map.
+ *   - Convert `ocr_amount` (the raw foreign-currency figure) → USD via the
+ *     FX cascade, locked to the receipt creation date.
+ *   - Write `original_amount = old ocr_amount`, `original_currency = primary`,
+ *     `exchange_rate = rate`, `ocr_amount = new USD value`.
+ *   - Recompute parent payout's `final_amount_usd` as the sum of doc
+ *     ocr_amount where status != 'paid' (paid history is immutable).
+ *
+ * Dry-run by default. `--apply` to mutate.
+ *
+ * Usage:
+ *   node backend/scripts/backfill-misclassified-usd-receipts.cjs [--apply] [--since=2026-01-01] [--country=MX]
+ */
+
+const path = require('path');
+const fs = require('fs');
+const envCandidates = [
+  path.join(__dirname, '..', '.env'),
+  'C:/Users/samgo/OneDrive/Documents/PizzaDAO/Code/rsvpizza/backend/.env',
+];
+for (const p of envCandidates) {
+  if (fs.existsSync(p)) {
+    require('dotenv').config({ path: p });
+    if (process.env.DATABASE_URL) break;
+  }
+}
+
+const { Client } = require('pg');
+
+// IMPORTANT: parties.country is stored as the FULL English name (e.g.
+// "Mexico", "Nigeria"), not the ISO-2 code. The runtime path uses the
+// frontend's country dropdown which now writes ISO-2, but historical rows
+// pre-date that. So the script must normalize both shapes. Map of common
+// full-name → ISO-2 (case-insensitive, locale-folded). Anything that
+// doesn't map gets skipped + counted in skipped_no_mapping.
+const COUNTRY_NAME_TO_ISO2 = {
+  'argentina': 'AR', 'armenia': 'AM', 'australia': 'AU', 'austria': 'AT',
+  'bangladesh': 'BD', 'belgium': 'BE', 'bolivia': 'BO', 'botswana': 'BW',
+  'brazil': 'BR', 'brasil': 'BR', 'bulgaria': 'BG',
+  'cambodia': 'KH', 'canada': 'CA', 'chile': 'CL', 'china': 'CN',
+  'colombia': 'CO', 'costa rica': 'CR', "côte d'ivoire": 'CI',
+  'cote d ivoire': 'CI', 'czechia': 'CZ', 'czech republic': 'CZ',
+  'denmark': 'DK', 'danmark': 'DK', 'dominican republic': 'DO',
+  'ecuador': 'EC', 'egypt': 'EG', 'el salvador': 'SV', 'estonia': 'EE',
+  'ethiopia': 'ET', 'finland': 'FI', 'france': 'FR', 'germany': 'DE',
+  'ghana': 'GH', 'greece': 'GR', 'guatemala': 'GT', 'honduras': 'HN',
+  'hong kong': 'HK', 'hungary': 'HU', 'iceland': 'IS', 'india': 'IN',
+  'indonesia': 'ID', 'ireland': 'IE', 'israel': 'IL', 'italy': 'IT',
+  'japan': 'JP', 'kenya': 'KE', 'kuwait': 'KW', 'latvia': 'LV',
+  'lithuania': 'LT', 'luxembourg': 'LU', 'malaysia': 'MY', 'malta': 'MT',
+  'mexico': 'MX', 'méxico': 'MX', 'morocco': 'MA', 'netherlands': 'NL',
+  'new zealand': 'NZ', 'nicaragua': 'NI', 'nigeria': 'NG', 'norway': 'NO',
+  'pakistan': 'PK', 'panama': 'PA', 'paraguay': 'PY', 'peru': 'PE',
+  'philippines': 'PH', 'poland': 'PL', 'portugal': 'PT', 'qatar': 'QA',
+  'romania': 'RO', 'russia': 'RU', 'saudi arabia': 'SA', 'serbia': 'RS',
+  'singapore': 'SG', 'slovakia': 'SK', 'slovenia': 'SI', 'south africa': 'ZA',
+  'spain': 'ES', 'sri lanka': 'LK', 'sweden': 'SE', 'switzerland': 'CH',
+  'taiwan': 'TW', 'tanzania': 'TZ', 'thailand': 'TH', 'tunisia': 'TN',
+  'turkey': 'TR', 'türkiye': 'TR', 'uganda': 'UG', 'ukraine': 'UA',
+  'united arab emirates': 'AE', 'united kingdom': 'GB', 'uk': 'GB',
+  'united states': 'US', 'usa': 'US', 'united states of america': 'US',
+  'uruguay': 'UY', 'venezuela': 'VE', 'vietnam': 'VN', 'zambia': 'ZM',
+  'zimbabwe': 'ZW', 'puerto rico': 'PR', 'antigua and barbuda': 'AG',
+  'bahrain': 'BH',
+};
+
+function normalizeCountryToIso2(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 2 && /^[A-Z]{2}$/.test(trimmed)) return trimmed;
+  if (trimmed.length === 2 && /^[a-zA-Z]{2}$/.test(trimmed)) return trimmed.toUpperCase();
+  const lc = trimmed.toLowerCase();
+  if (COUNTRY_NAME_TO_ISO2[lc]) return COUNTRY_NAME_TO_ISO2[lc];
+  return null;
+}
+
+// Mirror of backend/src/services/ocr.service.ts COUNTRY_TO_PRIMARY_CURRENCY.
+// Keep in sync — this script is one-shot ops, not part of the runtime path.
+const COUNTRY_TO_PRIMARY_CURRENCY = {
+  US: 'USD', CA: 'CAD', MX: 'MXN',
+  AR: 'ARS', BO: 'BOB', BR: 'BRL', CL: 'CLP', CO: 'COP', CR: 'CRC',
+  DO: 'DOP', EC: 'USD', GT: 'GTQ', HN: 'HNL', NI: 'NIO', PA: 'USD',
+  PE: 'PEN', PY: 'PYG', SV: 'USD', UY: 'UYU', VE: 'VES',
+  AT: 'EUR', BE: 'EUR', CY: 'EUR', DE: 'EUR', EE: 'EUR', ES: 'EUR',
+  FI: 'EUR', FR: 'EUR', GR: 'EUR', HR: 'EUR', IE: 'EUR', IT: 'EUR',
+  LT: 'EUR', LU: 'EUR', LV: 'EUR', MT: 'EUR', NL: 'EUR', PT: 'EUR',
+  SI: 'EUR', SK: 'EUR',
+  GB: 'GBP', CH: 'CHF', NO: 'NOK', SE: 'SEK', DK: 'DKK', IS: 'ISK',
+  PL: 'PLN', CZ: 'CZK', HU: 'HUF', RO: 'RON', BG: 'BGN', RS: 'RSD',
+  UA: 'UAH', TR: 'TRY',
+  CN: 'CNY', JP: 'JPY', KR: 'KRW', IN: 'INR', ID: 'IDR', MY: 'MYR',
+  PH: 'PHP', SG: 'SGD', TH: 'THB', VN: 'VND', TW: 'TWD', HK: 'HKD',
+  AU: 'AUD', NZ: 'NZD', PK: 'PKR', BD: 'BDT', LK: 'LKR',
+  AE: 'AED', SA: 'SAR', IL: 'ILS', QA: 'QAR', KW: 'KWD', BH: 'BHD',
+  EG: 'EGP', NG: 'NGN', ZA: 'ZAR', KE: 'KES', GH: 'GHS', MA: 'MAD',
+  TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS',
+};
+
+// Minimal FX fallback rates (mirrored from fx.service.ts). Kept here so the
+// backfill runs even if external FX providers fail. Roughly correct as of
+// 2026-05; admins can re-run with --apply once jsdelivr/frankfurter are up.
+const FALLBACK_RATES_TO_USD = {
+  NGN: 0.00063, EUR: 1.08, GBP: 1.27, JPY: 0.0067, INR: 0.012,
+  BRL: 0.20, PHP: 0.018, THB: 0.029, SEK: 0.096, PLN: 0.25,
+  CHF: 1.13, AUD: 0.66, CAD: 0.74, MXN: 0.058, KRW: 0.00075,
+  CNY: 0.14, ZAR: 0.055, ARS: 0.0011, CLP: 0.0011, COP: 0.00024,
+  UYU: 0.025, PEN: 0.27, BOB: 0.14, CRC: 0.0019, DOP: 0.017,
+  GTQ: 0.13, HNL: 0.040, NIO: 0.027, PYG: 0.00013, VES: 0.027,
+  CZK: 0.043, HUF: 0.0027, RON: 0.22, BGN: 0.55, DKK: 0.145,
+  NOK: 0.094, ISK: 0.0072, RSD: 0.0092, UAH: 0.024, TRY: 0.029,
+  IDR: 0.000063, MYR: 0.21, SGD: 0.74, VND: 0.000041, TWD: 0.031,
+  HKD: 0.13, NZD: 0.61, PKR: 0.0036, BDT: 0.0084, LKR: 0.0033,
+  AED: 0.27, SAR: 0.27, ILS: 0.27, QAR: 0.27, KWD: 3.25, BHD: 2.65,
+  EGP: 0.020, KES: 0.0078, GHS: 0.063, MAD: 0.10, TND: 0.32,
+  ETB: 0.018, UGX: 0.00027, TZS: 0.00039,
+};
+
+async function fetchRate(currency) {
+  // 1. jsdelivr
+  try {
+    const r = await fetch(
+      `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/${currency.toLowerCase()}.json`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (r.ok) {
+      const d = await r.json();
+      const rate = d[currency.toLowerCase()]?.usd;
+      if (rate) return { rate, source: 'jsdelivr' };
+    }
+  } catch (_) {}
+  // 2. frankfurter
+  try {
+    const r = await fetch(
+      `https://api.frankfurter.app/latest?from=${currency}&to=USD`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (r.ok) {
+      const d = await r.json();
+      if (d.rates?.USD) return { rate: d.rates.USD, source: 'frankfurter' };
+    }
+  } catch (_) {}
+  // 3. fallback
+  const fb = FALLBACK_RATES_TO_USD[currency];
+  if (fb) return { rate: fb, source: 'fallback' };
+  return null;
+}
+
+function parseArgs(argv) {
+  const args = { apply: false, since: null, country: null, limit: null };
+  for (const a of argv.slice(2)) {
+    if (a === '--apply') args.apply = true;
+    else if (a.startsWith('--since=')) args.since = a.slice('--since='.length);
+    else if (a.startsWith('--country=')) args.country = a.slice('--country='.length).toUpperCase();
+    else if (a.startsWith('--limit=')) args.limit = Number(a.slice('--limit='.length));
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL not set.');
+    process.exit(1);
+  }
+
+  // Default to a conservative 90-day window. Snax can re-run with a wider
+  // --since after verifying the first batch looks right.
+  const since = args.since || new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString().slice(0, 10);
+
+  const client = new Client({ connectionString: url });
+  await client.connect();
+
+  console.log(`[backfill] mode=${args.apply ? 'APPLY' : 'DRY-RUN'} since=${since}${args.country ? ` country=${args.country}` : ''}${args.limit ? ` limit=${args.limit}` : ''}`);
+
+  try {
+    // Candidate select. Note: country normalization happens in JS — the column
+    // stores a mix of full names ("Mexico") and ISO-2 codes ("MX"), so we
+    // can't reliably filter to "non-US" in SQL. We pull all USD-stamped
+    // non-null-country rows and filter in JS via normalizeCountryToIso2.
+    //
+    // Skip:
+    //   - already-paid payouts (don't rewrite history)
+    //   - rows that already have original_amount set (already-backfilled)
+    const params = [since];
+    let limitClause = '';
+    if (args.limit) {
+      params.push(args.limit * 3);  // over-fetch since JS filter will drop some
+      limitClause = `LIMIT $${params.length}`;
+    }
+
+    const sql = `
+      SELECT
+        pd.id            AS doc_id,
+        pd.payout_id     AS payout_id,
+        pd.ocr_amount    AS ocr_amount,
+        pd.ocr_currency  AS ocr_currency,
+        pd.created_at    AS doc_created_at,
+        p.id             AS party_id,
+        p.name           AS party_name,
+        p.country        AS country,
+        po.status        AS payout_status,
+        po.final_amount_usd AS final_amount_usd
+      FROM payout_documents pd
+      JOIN parties p   ON p.id = pd.party_id
+      LEFT JOIN payouts po ON po.id = pd.payout_id
+      WHERE pd.kind = 'receipt'
+        AND pd.ocr_currency = 'USD'
+        AND pd.ocr_amount IS NOT NULL
+        AND pd.original_amount IS NULL
+        AND p.country IS NOT NULL
+        AND pd.created_at >= $1
+        AND (po.id IS NULL OR po.status NOT IN ('paid'))
+      ORDER BY pd.created_at DESC
+      ${limitClause}
+    `;
+    const { rows: allRows } = await client.query(sql, params);
+
+    // JS-side filter: normalize country, optional --country=XX filter, skip
+    // dollarized countries (US/EC/PA/SV), and apply the post-normalize limit.
+    const rows = [];
+    let skippedDollarized = 0;
+    let skippedUnmappedCountry = 0;
+    for (const r of allRows) {
+      const iso = normalizeCountryToIso2(r.country);
+      if (!iso) { skippedUnmappedCountry++; continue; }
+      if (args.country && iso !== args.country) continue;
+      if (['US', 'EC', 'PA', 'SV'].includes(iso)) { skippedDollarized++; continue; }
+      r.iso2 = iso;
+      rows.push(r);
+      if (args.limit && rows.length >= args.limit) break;
+    }
+    console.log(
+      `[backfill] ${rows.length} candidate receipts after country normalize `
+      + `(dropped: ${skippedDollarized} dollarized, ${skippedUnmappedCountry} unmapped country)`,
+    );
+
+    const rateCache = new Map();
+    const changesByPayout = new Map(); // payoutId -> touched-doc-count
+    // payoutId -> { oldSum: <sum of old USD-stamped values for touched docs>,
+    //               newSum: <sum of new USD values for touched docs> }
+    const projectedDocChanges = new Map();
+    const summaryByCountry = new Map();
+    let skippedNoMapping = 0;
+    let appliedDocs = 0;
+
+    for (const row of rows) {
+      const cc = row.iso2;
+      const primary = COUNTRY_TO_PRIMARY_CURRENCY[cc];
+      if (!primary || primary === 'USD') {
+        skippedNoMapping++;
+        continue;
+      }
+
+      let fx = rateCache.get(primary);
+      if (!fx) {
+        fx = await fetchRate(primary);
+        if (!fx) {
+          console.warn(`[backfill] no rate for ${primary} (${cc}); skipping doc=${row.doc_id}`);
+          continue;
+        }
+        rateCache.set(primary, fx);
+      }
+
+      const originalAmount = Number(row.ocr_amount);
+      const newUsd = Math.round(originalAmount * fx.rate * 100) / 100;
+
+      const countryAcc = summaryByCountry.get(cc) || { docs: 0, oldUsdSum: 0, newUsdSum: 0 };
+      countryAcc.docs += 1;
+      countryAcc.oldUsdSum += originalAmount;
+      countryAcc.newUsdSum += newUsd;
+      summaryByCountry.set(cc, countryAcc);
+
+      console.log(
+        `[backfill] doc=${row.doc_id} party=${row.party_name} (${cc}) `
+        + `orig=${originalAmount} ${primary} → $${newUsd} USD (rate=${fx.rate}, source=${fx.source}, was-USD=${originalAmount})`,
+      );
+
+      if (args.apply) {
+        await client.query(
+          `UPDATE payout_documents
+              SET ocr_amount        = $2,
+                  ocr_currency      = $3,
+                  original_amount   = $4,
+                  original_currency = $3,
+                  exchange_rate     = $5
+            WHERE id = $1`,
+          [row.doc_id, newUsd, primary, originalAmount, fx.rate],
+        );
+        appliedDocs++;
+      }
+
+      if (row.payout_id) {
+        const acc = changesByPayout.get(row.payout_id) || 0;
+        changesByPayout.set(row.payout_id, acc + 1);
+        const proj = projectedDocChanges.get(row.payout_id) || { oldSum: 0, newSum: 0 };
+        proj.oldSum += originalAmount;
+        proj.newSum += newUsd;
+        projectedDocChanges.set(row.payout_id, proj);
+      }
+    }
+
+    // Recompute parent payouts' final_amount_usd. ONLY when the new sum is
+    // LOWER than the old final — that's the "we over-stated USD because the
+    // raw foreign-currency amount was stamped as USD" case we want to fix.
+    // When the new sum is HIGHER than the old final, that means the old
+    // final was clamped to a per-party cap at submission time — leave the
+    // clamp in place; the corrected receipts are still preserved as evidence.
+    //
+    // Skip non-pending/approved/failed statuses (paid/withdrawn/cancelled/
+    // rejected are immutable history).
+    //
+    // NOTE: in dry-run mode we use the projected new-USD deltas accumulated
+    // in `projectedDocChanges` rather than re-reading the DB (which would
+    // still hold the un-mutated values). In apply mode we re-read the DB
+    // so we pick up sibling receipts that were ALREADY USD on this payout.
+    if (changesByPayout.size > 0) {
+      console.log(`\n[backfill] recompute final_amount_usd for ${changesByPayout.size} touched payouts (only when new < old):`);
+      for (const payoutId of changesByPayout.keys()) {
+        const { rows: sumRows } = await client.query(
+          `SELECT
+              po.status AS status,
+              po.final_amount_usd AS old_final,
+              p.name AS party_name,
+              COALESCE(SUM(CASE WHEN pd.ocr_amount IS NOT NULL THEN pd.ocr_amount ELSE 0 END), 0) AS db_sum_usd
+            FROM payouts po
+            JOIN parties p ON p.id = po.party_id
+            LEFT JOIN payout_documents pd ON pd.payout_id = po.id AND pd.kind = 'receipt'
+           WHERE po.id = $1
+           GROUP BY po.id, po.status, po.final_amount_usd, p.name`,
+          [payoutId],
+        );
+        const r = sumRows[0];
+        if (!r) continue;
+        if (!['pending', 'approved', 'failed'].includes(r.status)) {
+          console.log(`[backfill]   payout=${payoutId} (${r.party_name}) status=${r.status} — skipping recompute`);
+          continue;
+        }
+        // In dry-run, projected sum = db_sum - sum-of-old-USD-for-this-payout
+        //                            + sum-of-new-USD-for-this-payout
+        const proj = projectedDocChanges.get(payoutId) || { oldSum: 0, newSum: 0 };
+        const dbSum = Number(r.db_sum_usd);
+        const newSum = args.apply
+          ? Math.round(dbSum * 100) / 100  // already mutated
+          : Math.round((dbSum - proj.oldSum + proj.newSum) * 100) / 100;
+        const oldFinal = Number(r.old_final);
+        if (newSum >= oldFinal) {
+          console.log(
+            `[backfill]   payout=${payoutId} (${r.party_name}) status=${r.status} `
+            + `old_final=$${oldFinal.toFixed(2)} projected_new_sum=$${newSum.toFixed(2)} — keep old (was clamped to cap)`,
+          );
+          continue;
+        }
+        console.log(
+          `[backfill]   payout=${payoutId} (${r.party_name}) status=${r.status} `
+          + `old_final=$${oldFinal.toFixed(2)} → new_final=$${newSum.toFixed(2)} (delta=$${(newSum - oldFinal).toFixed(2)})`,
+        );
+        if (args.apply) {
+          await client.query(
+            `UPDATE payouts SET final_amount_usd = $2, updated_at = NOW() WHERE id = $1`,
+            [payoutId, newSum],
+          );
+        }
+      }
+    }
+
+    console.log('\n[backfill] per-country summary:');
+    for (const [cc, acc] of summaryByCountry.entries()) {
+      console.log(
+        `  ${cc}: ${acc.docs} receipts, `
+        + `old-USD-sum=$${acc.oldUsdSum.toFixed(2)} → new-USD-sum=$${acc.newUsdSum.toFixed(2)} `
+        + `(delta=$${(acc.newUsdSum - acc.oldUsdSum).toFixed(2)})`,
+      );
+    }
+    console.log(`\n[backfill] done. mode=${args.apply ? 'APPLIED' : 'DRY-RUN'} docs_changed=${args.apply ? appliedDocs : rows.length - skippedNoMapping} skipped_no_mapping=${skippedNoMapping}`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('[backfill] failed:', err);
+  process.exit(1);
+});

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -552,6 +552,14 @@ function serializePayout(row: any): any {
       ocrAmount: d.ocrAmount == null ? null : Number(d.ocrAmount),
       ocrCurrency: d.ocrCurrency,
       ocrConfidence: d.ocrConfidence == null ? null : Number(d.ocrConfidence),
+      // mortadella-92103: per-receipt FX. Drives the reviewer pill
+      // ("$X.YZ USD (1234.56 MXN @ rate)") so admins can see exactly what
+      // each receipt was converted from. Null for receipts uploaded before
+      // mortadella-92103 — those rows still have the parent payout's
+      // headline FX, but no per-doc detail.
+      originalAmount: d.originalAmount == null ? null : Number(d.originalAmount),
+      originalCurrency: d.originalCurrency,
+      exchangeRate: d.exchangeRate == null ? null : Number(d.exchangeRate),
       ocrError: d.ocrError,
       sortOrder: d.sortOrder,
       // pancetta-37195: per-doc uploader attribution. Live name from the
@@ -3518,13 +3526,25 @@ router.patch(
           payoutId: true,
           ocrAmount: true,
           ocrCurrency: true,
+          // mortadella-92103: pull the existing original-amount + raw OCR
+          // payload so we can re-run FX when admin changes the currency.
+          originalAmount: true,
+          originalCurrency: true,
+          exchangeRate: true,
+          ocrRaw: true,
         },
       });
       if (!doc) {
         throw new AppError('Document not found', 404, 'NOT_FOUND');
       }
 
-      const data: { ocrAmount?: number | null; ocrCurrency?: string | null } = {};
+      const data: {
+        ocrAmount?: number | null;
+        ocrCurrency?: string | null;
+        originalAmount?: number | null;
+        originalCurrency?: string | null;
+        exchangeRate?: number | null;
+      } = {};
 
       if (body.ocrAmount !== undefined) {
         if (body.ocrAmount === null) {
@@ -3558,6 +3578,100 @@ router.patch(
         }
       }
 
+      // mortadella-92103: when admin changes the currency on a doc that has
+      // a known original-amount (either persisted in the column or buried in
+      // ocrRaw.ocr.amount), re-run FX so ocr_amount is the correctly-converted
+      // USD value. Admin can override by passing both ocrAmount + ocrCurrency
+      // explicitly; in that case we trust the admin's numbers and skip FX.
+      const currencyChanged =
+        data.ocrCurrency !== undefined && data.ocrCurrency !== doc.ocrCurrency;
+      const adminSetBothExplicitly =
+        body.ocrAmount !== undefined && body.ocrCurrency !== undefined;
+
+      if (currencyChanged && !adminSetBothExplicitly && data.ocrCurrency != null) {
+        // Resolve the original foreign-currency amount. Preference order:
+        //   1. body.originalAmount if the admin provided it
+        //   2. the existing originalAmount column (mortadella-92103+)
+        //   3. ocrRaw.ocr.amount (pre-mortadella-92103 rows)
+        let originalAmount: number | null = null;
+        if (body.originalAmount !== undefined && body.originalAmount !== null) {
+          const n = Number(body.originalAmount);
+          if (!Number.isFinite(n) || n <= 0) {
+            throw new AppError(
+              'originalAmount must be a positive number',
+              400,
+              'VALIDATION_ERROR',
+            );
+          }
+          originalAmount = n;
+        } else if (doc.originalAmount != null) {
+          originalAmount = Number(doc.originalAmount.toString());
+        } else if (
+          doc.ocrRaw
+          && typeof doc.ocrRaw === 'object'
+          && 'ocr' in (doc.ocrRaw as any)
+          && typeof (doc.ocrRaw as any).ocr?.amount === 'number'
+        ) {
+          originalAmount = (doc.ocrRaw as any).ocr.amount;
+        }
+
+        if (originalAmount == null) {
+          throw new AppError(
+            'Cannot re-convert FX: original-currency amount unknown. Pass originalAmount in the body, or set both ocrAmount and ocrCurrency explicitly.',
+            400,
+            'FX_ORIGINAL_AMOUNT_MISSING',
+          );
+        }
+
+        const { convertToUSD } = await import('../services/fx.service.js');
+        const fx = await convertToUSD(originalAmount, data.ocrCurrency);
+        if (fx.source === 'unresolved' || fx.usdAmount == null) {
+          throw new AppError(
+            `Could not convert ${originalAmount} ${data.ocrCurrency} to USD — unresolved currency.`,
+            400,
+            'CURRENCY_UNRESOLVED',
+          );
+        }
+        if (fx.source === 'unknown') {
+          throw new AppError(
+            `Could not look up exchange rate for currency "${data.ocrCurrency}".`,
+            400,
+            'UNKNOWN_CURRENCY',
+          );
+        }
+        data.ocrAmount = fx.usdAmount;
+        data.originalAmount = originalAmount;
+        data.originalCurrency = fx.originalCurrency;
+        data.exchangeRate = fx.exchangeRate;
+      } else if (
+        body.originalAmount !== undefined
+        && body.originalAmount !== null
+        && data.originalAmount === undefined
+      ) {
+        // Admin updated originalAmount directly (e.g. correcting a misread
+        // number on an already-correct currency). Re-run FX on the doc's
+        // existing currency too.
+        const n = Number(body.originalAmount);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw new AppError(
+            'originalAmount must be a positive number',
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        const cur = data.ocrCurrency ?? doc.ocrCurrency;
+        if (cur) {
+          const { convertToUSD } = await import('../services/fx.service.js');
+          const fx = await convertToUSD(n, cur);
+          if (fx.usdAmount != null && fx.exchangeRate != null) {
+            data.ocrAmount = fx.usdAmount;
+            data.originalAmount = n;
+            data.originalCurrency = fx.originalCurrency;
+            data.exchangeRate = fx.exchangeRate;
+          }
+        }
+      }
+
       if (Object.keys(data).length === 0) {
         throw new AppError('No editable fields supplied', 400, 'VALIDATION_ERROR');
       }
@@ -3581,6 +3695,20 @@ router.patch(
             ocrCurrency: data.ocrCurrency === undefined
               ? undefined
               : data.ocrCurrency,
+            // mortadella-92103: persist the re-derived FX detail when set.
+            originalAmount: data.originalAmount === undefined
+              ? undefined
+              : data.originalAmount === null
+                ? null
+                : (data.originalAmount as any),
+            originalCurrency: data.originalCurrency === undefined
+              ? undefined
+              : data.originalCurrency,
+            exchangeRate: data.exchangeRate === undefined
+              ? undefined
+              : data.exchangeRate === null
+                ? null
+                : (data.exchangeRate as any),
           },
         });
 
@@ -3626,6 +3754,12 @@ router.patch(
           ocrAmount: updated.ocrAmount == null ? null : Number(updated.ocrAmount),
           ocrCurrency: updated.ocrCurrency,
           ocrConfidence: updated.ocrConfidence == null ? null : Number(updated.ocrConfidence),
+          // mortadella-92103: surface the per-receipt FX detail so the
+          // reviewer modal can render an inline "X.YZ CUR → $X.YZ USD"
+          // pill without re-fetching.
+          originalAmount: updated.originalAmount == null ? null : Number(updated.originalAmount),
+          originalCurrency: updated.originalCurrency,
+          exchangeRate: updated.exchangeRate == null ? null : Number(updated.exchangeRate),
           ocrError: updated.ocrError,
           sortOrder: updated.sortOrder,
           uploadedByUserId: updated.uploadedByUserId ?? null,

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -119,6 +119,12 @@ function serializeDocument(d: any) {
     ocrAmount: d.ocrAmount != null ? numberFromDecimal(d.ocrAmount) : null,
     ocrCurrency: d.ocrCurrency ?? null,
     ocrConfidence: d.ocrConfidence != null ? numberFromDecimal(d.ocrConfidence) : null,
+    // mortadella-92103: per-receipt FX detail. Old rows have null for all
+    // three (no migration backfill — the parent payout's headline FX is
+    // still the source of truth for those).
+    originalAmount: d.originalAmount != null ? numberFromDecimal(d.originalAmount) : null,
+    originalCurrency: d.originalCurrency ?? null,
+    exchangeRate: d.exchangeRate != null ? numberFromDecimal(d.exchangeRate) : null,
     ocrError: d.ocrError ?? null,
     sortOrder: d.sortOrder,
     // pancetta-37195: surface the per-doc uploader so cohosts can tell who
@@ -465,22 +471,40 @@ router.post(
 
       assertSupabasePayoutUrl(imageUrl, partyId);
 
-      const ocr = await analyzeReceipt(imageUrl);
+      // mortadella-92103: country prior for ambiguous-symbol receipts. We
+      // already loaded the canEdit signal above; pulling country here is a
+      // single extra column read.
+      const partyForCountry = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { country: true },
+      });
+      const ocr = await analyzeReceipt({
+        imageUrl,
+        partyCountry: partyForCountry?.country ?? null,
+      });
       const fx = await convertToUSD(ocr.amount, ocr.currency);
 
+      // mortadella-92103: when FX can't resolve (no currency from OCR + no
+      // country prior + no override), surface that to the host so they can
+      // fix it with the currency override dropdown. We still return shape-
+      // compatible fields so the frontend type doesn't have to branch.
+      const unresolved = fx.source === 'unresolved';
       res.json({
-        amount: fx.usdAmount,
+        amount: unresolved ? 0 : (fx.usdAmount ?? 0),
         currency: 'USD',
         originalAmount: fx.originalAmount,
-        originalCurrency: fx.originalCurrency,
-        exchangeRate: fx.exchangeRate,
+        originalCurrency: unresolved ? '' : (fx.originalCurrency ?? ''),
+        exchangeRate: unresolved ? 0 : (fx.exchangeRate ?? 0),
         confidence: ocr.confidence,
         items: ocr.items,
         fxSource: fx.source,
-        conversionNote:
-          fx.originalCurrency !== 'USD'
+        conversionNote: unresolved
+          ? `Currency could not be determined automatically — please pick the correct currency to convert ${fx.originalAmount.toLocaleString()} to USD.`
+          : fx.originalCurrency && fx.originalCurrency !== 'USD' && fx.usdAmount != null && fx.exchangeRate != null
             ? `Converted from ${fx.originalAmount.toLocaleString()} ${fx.originalCurrency} → $${fx.usdAmount.toFixed(2)} USD (1 ${fx.originalCurrency} = $${fx.exchangeRate.toFixed(6)} USD)`
             : undefined,
+        // mortadella-92103: explicit signal so the frontend can warn the host.
+        ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
       });
     } catch (error) {
       next(error);
@@ -535,9 +559,10 @@ router.post(
       const fx = await convertToUSD(amt, originalCurrency.trim());
 
       // convertToUSD never throws — it returns source='unknown' with rate=1
-      // when no provider can serve the currency. Reject that case so the
-      // host gets explicit feedback (and so the dropdown reverts client-side).
-      if (fx.source === 'unknown') {
+      // when no provider can serve the currency, and 'unresolved' when no
+      // currency was supplied at all. Reject those so the host gets explicit
+      // feedback (and so the dropdown reverts client-side).
+      if (fx.source === 'unknown' || fx.source === 'unresolved') {
         throw new AppError(
           `Could not look up exchange rate for currency "${originalCurrency.trim().toUpperCase()}".`,
           400,
@@ -545,15 +570,18 @@ router.post(
         );
       }
 
+      // After the guard above, usdAmount/exchangeRate/originalCurrency are
+      // all non-null. Use `!` rather than coalescing zeros so a future bug
+      // surfaces as a 500 instead of a silent $0 stamp.
       res.json({
-        usdAmount: fx.usdAmount,
+        usdAmount: fx.usdAmount!,
         originalAmount: fx.originalAmount,
-        originalCurrency: fx.originalCurrency,
-        exchangeRate: fx.exchangeRate,
+        originalCurrency: fx.originalCurrency!,
+        exchangeRate: fx.exchangeRate!,
         source: fx.source,
         conversionNote:
           fx.originalCurrency !== 'USD'
-            ? `Converted from ${fx.originalAmount.toLocaleString()} ${fx.originalCurrency} → $${fx.usdAmount.toFixed(2)} USD (1 ${fx.originalCurrency} = $${fx.exchangeRate.toFixed(6)} USD)`
+            ? `Converted from ${fx.originalAmount.toLocaleString()} ${fx.originalCurrency} → $${fx.usdAmount!.toFixed(2)} USD (1 ${fx.originalCurrency} = $${fx.exchangeRate!.toFixed(6)} USD)`
             : undefined,
       });
     } catch (error) {
@@ -787,6 +815,16 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       assertSupabasePayoutUrl(p.url, partyId);
     }
 
+    // mortadella-92103: read the party's country once so OCR can use it as a
+    // currency prior when the receipt symbol is ambiguous (the `$` problem
+    // in MX/AR/CL/CO/UY/...). One column read, hoisted above the parallel
+    // OCR fan-out so it's shared across receipts.
+    const partyForOcr = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { country: true },
+    });
+    const partyCountry = partyForOcr?.country ?? null;
+
     // arugula-38633 v3 follow-up: skip the parallel-OCR step when there are
     // no receipts — the host supplied `finalAmountUsd` directly. FX fields
     // collapse to USD passthrough below.
@@ -798,7 +836,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       : await Promise.allSettled(
           (receiptPhotos as IncomingDocument[]).map(async (r) => {
             try {
-              const ocr = await analyzeReceipt(r.url);
+              const ocr = await analyzeReceipt({ imageUrl: r.url, partyCountry });
               const fx = await convertToUSD(ocr.amount, ocr.currency);
               return { ok: true as const, doc: r, ocr, fx };
             } catch (err: any) {
@@ -828,6 +866,12 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       ocrAmount: Decimal | null;
       ocrCurrency: string | null;
       ocrConfidence: Decimal | null;
+      // mortadella-92103: per-receipt original-amount / original-currency /
+      // exchange-rate columns. ocrAmount stays USD; these capture what the
+      // host actually paid in the source currency + the locked FX rate.
+      originalAmount: Decimal | null;
+      originalCurrency: string | null;
+      exchangeRate: Decimal | null;
       ocrRaw: any;
       // formaggi-89172: per-line structured items extracted from the receipt.
       // null for pizza-photo rows + receipts whose OCR errored.
@@ -847,12 +891,20 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       const doc = (receiptPhotos as IncomingDocument[])[idx];
       if (result && result.ok) {
         const { ocr, fx } = result;
-        extractedUsdSum += fx.usdAmount;
-        if (!foundFirstRate) {
-          originalAmount = fx.originalAmount;
-          originalCurrency = fx.originalCurrency;
-          exchangeRate = fx.exchangeRate;
-          foundFirstRate = true;
+        // mortadella-92103: refuse to count an unresolved-currency receipt
+        // toward the sum. The row is still persisted (so the receipt image
+        // and OCR amount are preserved for forensics + host override) but
+        // ocrAmount is NULL and ocrError carries CURRENCY_UNRESOLVED. Host
+        // /admin must pick the correct currency via the override dropdown.
+        const unresolved = fx.source === 'unresolved' || fx.usdAmount == null;
+        if (!unresolved) {
+          extractedUsdSum += fx.usdAmount!;
+          if (!foundFirstRate) {
+            originalAmount = fx.originalAmount;
+            originalCurrency = fx.originalCurrency ?? 'USD';
+            exchangeRate = fx.exchangeRate ?? 1;
+            foundFirstRate = true;
+          }
         }
         docsToCreate.push({
           kind: 'receipt',
@@ -860,13 +912,19 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           fileName: doc.fileName || extractFileName(doc.url),
           fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
           mimeType: doc.mimeType || 'image/jpeg',
-          ocrAmount: new Decimal(fx.usdAmount),
-          ocrCurrency: fx.originalCurrency,
+          ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
+          ocrCurrency: unresolved ? null : fx.originalCurrency,
           ocrConfidence: new Decimal(ocr.confidence),
+          // mortadella-92103: persist the raw foreign-currency amount + ISO
+          // code + locked rate per receipt. Even unresolved rows carry
+          // originalAmount (the host needs to see what the receipt said).
+          originalAmount: new Decimal(fx.originalAmount),
+          originalCurrency: unresolved ? null : (fx.originalCurrency ?? null),
+          exchangeRate: unresolved ? null : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
           ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
           // formaggi-89172: structured per-line items for pizza-price analytics.
           ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
-          ocrError: null,
+          ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
           sortOrder: idx,
           photoId: null,
         });
@@ -881,6 +939,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           ocrAmount: null,
           ocrCurrency: null,
           ocrConfidence: null,
+          originalAmount: null,
+          originalCurrency: null,
+          exchangeRate: null,
           ocrRaw: null,
           ocrLineItems: null,
           ocrError: err,
@@ -902,6 +963,10 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         ocrAmount: null,
         ocrCurrency: null,
         ocrConfidence: null,
+        // mortadella-92103: pizza photos have no FX detail.
+        originalAmount: null,
+        originalCurrency: null,
+        exchangeRate: null,
         ocrRaw: null,
         ocrLineItems: null,
         ocrError: null,
@@ -1474,6 +1539,13 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       }
     }
 
+    // mortadella-92103: country prior for OCR (`$` ambiguity).
+    const partyForPatchOcr = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { country: true },
+    });
+    const patchPartyCountry = partyForPatchOcr?.country ?? null;
+
     // Run OCR on each new receipt in parallel BEFORE the transaction so the
     // transaction stays short and we can roll up the new OCR sum cleanly.
     const ocrResults = newReceipts.length === 0
@@ -1481,7 +1553,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       : await Promise.allSettled(
           newReceipts.map(async (r) => {
             try {
-              const ocr = await analyzeReceipt(r.url);
+              const ocr = await analyzeReceipt({
+                imageUrl: r.url,
+                partyCountry: patchPartyCountry,
+              });
               const fx = await convertToUSD(ocr.amount, ocr.currency);
               return { ok: true as const, doc: r, ocr, fx };
             } catch (err: any) {
@@ -1500,6 +1575,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrAmount: Decimal | null;
       ocrCurrency: string | null;
       ocrConfidence: Decimal | null;
+      // mortadella-92103: per-receipt FX persistence.
+      originalAmount: Decimal | null;
+      originalCurrency: string | null;
+      exchangeRate: Decimal | null;
       ocrRaw: any;
       // formaggi-89172: per-line structured items extracted from the receipt.
       ocrLineItems: any;
@@ -1525,13 +1604,18 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       const result = settled.status === 'fulfilled' ? settled.value : null;
       if (result && result.ok) {
         const { ocr, fx } = result;
-        newOcrSum += fx.usdAmount;
-        if (firstFxBox.value === null) {
-          firstFxBox.value = {
-            originalAmount: fx.originalAmount,
-            originalCurrency: fx.originalCurrency,
-            exchangeRate: fx.exchangeRate,
-          };
+        // mortadella-92103: don't count unresolved-currency receipts in the
+        // sum. Same rules as the POST aggregator.
+        const unresolved = fx.source === 'unresolved' || fx.usdAmount == null;
+        if (!unresolved) {
+          newOcrSum += fx.usdAmount!;
+          if (firstFxBox.value === null && fx.originalCurrency && fx.exchangeRate != null) {
+            firstFxBox.value = {
+              originalAmount: fx.originalAmount,
+              originalCurrency: fx.originalCurrency,
+              exchangeRate: fx.exchangeRate,
+            };
+          }
         }
         newReceiptDocs.push({
           kind: 'receipt',
@@ -1539,13 +1623,16 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           fileName: doc.fileName || extractFileName(doc.url),
           fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
           mimeType: doc.mimeType || 'image/jpeg',
-          ocrAmount: new Decimal(fx.usdAmount),
-          ocrCurrency: fx.originalCurrency,
+          ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
+          ocrCurrency: unresolved ? null : fx.originalCurrency,
           ocrConfidence: new Decimal(ocr.confidence),
+          originalAmount: new Decimal(fx.originalAmount),
+          originalCurrency: unresolved ? null : (fx.originalCurrency ?? null),
+          exchangeRate: unresolved ? null : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
           ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
           // formaggi-89172: structured per-line items for pizza-price analytics.
           ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
-          ocrError: null,
+          ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
           sortOrder: i,
           photoId: null,
         });
@@ -1560,6 +1647,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrAmount: null,
           ocrCurrency: null,
           ocrConfidence: null,
+          originalAmount: null,
+          originalCurrency: null,
+          exchangeRate: null,
           ocrRaw: null,
           ocrLineItems: null,
           ocrError: err,
@@ -1578,6 +1668,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrAmount: null,
       ocrCurrency: null,
       ocrConfidence: null,
+      // mortadella-92103: pizza photos have no FX detail.
+      originalAmount: null as Decimal | null,
+      originalCurrency: null as string | null,
+      exchangeRate: null as Decimal | null,
       ocrRaw: null,
       ocrLineItems: null,
       ocrError: null,

--- a/backend/src/services/fx.service.ts
+++ b/backend/src/services/fx.service.ts
@@ -53,14 +53,29 @@ export const FALLBACK_RATES_TO_USD: Record<string, number> = {
   ZAR: 0.055,
 };
 
-export type FxSource = 'jsdelivr' | 'frankfurter' | 'fallback' | 'usd-passthrough' | 'unknown';
+export type FxSource =
+  | 'jsdelivr'
+  | 'frankfurter'
+  | 'fallback'
+  | 'usd-passthrough'
+  | 'unknown'
+  // mortadella-92103: the OCR couldn't determine a currency and no override
+  // was supplied. Callers MUST surface this as ocrError = 'CURRENCY_UNRESOLVED'
+  // and refuse to count the receipt toward the USD sum.
+  | 'unresolved';
 
 export interface FxConversionResult {
-  usdAmount: number;
-  exchangeRate: number;
+  // mortadella-92103: when source === 'unresolved' the receipt should be
+  // surfaced to the host/admin for manual currency selection. We don't write
+  // a synthetic USD value — usdAmount is null in that case, NOT zero, so the
+  // caller can distinguish "skip from sum" from "$0 receipt".
+  usdAmount: number | null;
+  exchangeRate: number | null;
   originalAmount: number;
-  originalCurrency: string;
+  originalCurrency: string | null;
   source: FxSource;
+  /** Set when source === 'unresolved'. */
+  error?: 'CURRENCY_UNRESOLVED';
 }
 
 /**
@@ -68,12 +83,35 @@ export interface FxConversionResult {
  * Returns a normalized `originalCurrency`, the locked `exchangeRate`,
  * and which provider supplied the rate (`source`).
  *
+ * Refuses to convert when `fromCurrency` is null/empty/'UNKNOWN' — returns
+ * `source: 'unresolved'` so the caller can surface CURRENCY_UNRESOLVED on
+ * the doc instead of silently writing the raw amount as USD.
+ *
  * Never throws — falls back through the cascade and ultimately returns a
- * passthrough (rate=1) if no provider can serve the currency. Callers should
- * check `source === 'unknown'` if they want to flag suspicious conversions.
+ * passthrough (rate=1) if no provider can serve a *known* currency. Callers
+ * should check `source === 'unknown'` for flag-but-still-accept conversions,
+ * and `source === 'unresolved'` for refuse-to-convert.
  */
-export async function convertToUSD(amount: number, fromCurrency: string): Promise<FxConversionResult> {
-  const normalizedCurrency = CURRENCY_MAP[fromCurrency] || fromCurrency.toUpperCase();
+export async function convertToUSD(
+  amount: number,
+  fromCurrency: string | null | undefined,
+): Promise<FxConversionResult> {
+  // mortadella-92103: refuse the passthrough when currency is missing or
+  // explicitly 'UNKNOWN'. Previously this branched into the USD passthrough
+  // (rate=1), silently stamping the raw foreign-currency amount as USD.
+  const rawInput = typeof fromCurrency === 'string' ? fromCurrency.trim() : '';
+  if (rawInput.length === 0 || rawInput.toUpperCase() === 'UNKNOWN') {
+    return {
+      usdAmount: null,
+      exchangeRate: null,
+      originalAmount: amount,
+      originalCurrency: null,
+      source: 'unresolved',
+      error: 'CURRENCY_UNRESOLVED',
+    };
+  }
+
+  const normalizedCurrency = CURRENCY_MAP[rawInput] || rawInput.toUpperCase();
 
   if (normalizedCurrency === 'USD') {
     return {

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -39,8 +39,12 @@ export interface OcrLineItem {
 }
 
 export interface OcrResult {
+  // mortadella-92103: currency can now be null when the receipt is ambiguous
+  // (`$` symbol with no surrounding country/locale hint). Callers must treat
+  // a null currency as "do not auto-convert" — `convertToUSD` will return
+  // CURRENCY_UNRESOLVED instead of a passthrough.
   amount: number;
-  currency: string;
+  currency: string | null;
   confidence: number;
   items?: string[];
   // formaggi-89172: new — structured line items + merchant/date for analytics.
@@ -50,10 +54,45 @@ export interface OcrResult {
   raw: unknown;
 }
 
-const SYSTEM_PROMPT = `You are a receipt analysis assistant. Extract the total amount and per-line items from the receipt image.
+// mortadella-92103: ISO-2 country → primary ISO-4217 currency. Used as a
+// strong currency prior when the receipt symbol is ambiguous (most LATAM
+// countries use `$`, which OCR otherwise misreads as USD). Keep this list
+// conservative — only include codes where there's a single dominant
+// currency. Multi-currency regions (EU members → EUR is fine; UA → UAH is
+// fine; but countries with significant dollarization like Lebanon are
+// intentionally omitted).
+export const COUNTRY_TO_PRIMARY_CURRENCY: Record<string, string> = {
+  // North America
+  US: 'USD', CA: 'CAD', MX: 'MXN',
+  // LATAM (the actual problem set — `$` ambiguity)
+  AR: 'ARS', BO: 'BOB', BR: 'BRL', CL: 'CLP', CO: 'COP', CR: 'CRC',
+  DO: 'DOP', EC: 'USD', GT: 'GTQ', HN: 'HNL', NI: 'NIO', PA: 'USD',
+  PE: 'PEN', PY: 'PYG', SV: 'USD', UY: 'UYU', VE: 'VES',
+  // Eurozone (EUR — €, but receipts in some regions still use `$` or `S`)
+  AT: 'EUR', BE: 'EUR', CY: 'EUR', DE: 'EUR', EE: 'EUR', ES: 'EUR',
+  FI: 'EUR', FR: 'EUR', GR: 'EUR', HR: 'EUR', IE: 'EUR', IT: 'EUR',
+  LT: 'EUR', LU: 'EUR', LV: 'EUR', MT: 'EUR', NL: 'EUR', PT: 'EUR',
+  SI: 'EUR', SK: 'EUR',
+  // Rest of Europe
+  GB: 'GBP', CH: 'CHF', NO: 'NOK', SE: 'SEK', DK: 'DKK', IS: 'ISK',
+  PL: 'PLN', CZ: 'CZK', HU: 'HUF', RO: 'RON', BG: 'BGN', RS: 'RSD',
+  UA: 'UAH', TR: 'TRY',
+  // Asia-Pacific
+  CN: 'CNY', JP: 'JPY', KR: 'KRW', IN: 'INR', ID: 'IDR', MY: 'MYR',
+  PH: 'PHP', SG: 'SGD', TH: 'THB', VN: 'VND', TW: 'TWD', HK: 'HKD',
+  AU: 'AUD', NZ: 'NZD', PK: 'PKR', BD: 'BDT', LK: 'LKR',
+  // Middle East
+  AE: 'AED', SA: 'SAR', IL: 'ILS', QA: 'QAR', KW: 'KWD', BH: 'BHD',
+  // Africa
+  EG: 'EGP', NG: 'NGN', ZA: 'ZAR', KE: 'KES', GH: 'GHS', MA: 'MAD',
+  TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS',
+};
+
+function buildSystemPrompt(partyCountry?: string | null): string {
+  const base = `You are a receipt analysis assistant. Extract the total amount and per-line items from the receipt image.
 Return ONLY a JSON object with these fields:
 - amount: number (the total amount paid, as a decimal number)
-- currency: string (USD, EUR, INR, etc. - default to USD if unclear)
+- currency: string (USD, EUR, INR, etc. - the ISO-4217 code as printed/implied by the receipt). If the currency is genuinely ambiguous (e.g. just a "$" symbol with no surrounding country/locale hint and no party-country prior), return "UNKNOWN". DO NOT default to USD when uncertain — "UNKNOWN" is correct.
 - confidence: number (0-1, your confidence in the total extraction)
 - merchant: string (restaurant/store name if visible, else null)
 - receiptDate: string (YYYY-MM-DD if visible, else null)
@@ -71,6 +110,19 @@ Use your best judgment for category. Default "other".
 If the receipt is unreadable, return lineItems: [] and confidence: 0.
 
 Always return valid JSON.`;
+
+  // mortadella-92103: country prior. When the host's event has a known country
+  // and that country has a single dominant ISO-4217 currency, prefer it for
+  // ambiguous-symbol receipts (the `$` problem in MX/AR/CL/CO/UY/...).
+  const code = typeof partyCountry === 'string'
+    ? partyCountry.trim().toUpperCase().slice(0, 2)
+    : '';
+  const primary = code ? COUNTRY_TO_PRIMARY_CURRENCY[code] : undefined;
+  if (code && primary) {
+    return `${base}\n\nContext: this receipt is from ${code}; the primary currency in ${code} is ${primary}. If the printed currency symbol is ambiguous (e.g. just "$"), prefer ${primary}. Only return USD if the receipt clearly shows USD (e.g. "USD", "US$", or an unambiguous US-based merchant).`;
+  }
+  return base;
+}
 
 /**
  * Fetch an image from a public URL and convert to a base64 data URL.
@@ -135,13 +187,25 @@ function sanitizeLineItems(raw: unknown): OcrLineItem[] {
  * Throws on network/auth/parse errors. Callers (e.g. the bulk endpoint) should
  * wrap in `Promise.allSettled` so one bad receipt doesn't fail the whole batch.
  */
-export async function analyzeReceipt(imageUrl: string): Promise<OcrResult> {
+/**
+ * mortadella-92103: now accepts an optional `partyCountry` (ISO-2). When the
+ * receipt symbol is ambiguous, the country prior steers OCR toward the local
+ * primary currency instead of silently defaulting to USD.
+ *
+ * Back-compat shim: callers passing a string (legacy `analyzeReceipt(url)`)
+ * still work — the function accepts either a string or `{ imageUrl, partyCountry }`.
+ */
+export async function analyzeReceipt(
+  arg: string | { imageUrl: string; partyCountry?: string | null },
+): Promise<OcrResult> {
+  const imageUrl = typeof arg === 'string' ? arg : arg.imageUrl;
+  const partyCountry = typeof arg === 'string' ? null : (arg.partyCountry ?? null);
   const base64Image = await imageUrlToBase64DataUrl(imageUrl);
 
   const response = await getOpenAI().chat.completions.create({
     model: 'gpt-4o',
     messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'system', content: buildSystemPrompt(partyCountry) },
       {
         role: 'user',
         content: [
@@ -170,12 +234,21 @@ export async function analyzeReceipt(imageUrl: string): Promise<OcrResult> {
 
   // Validate minimum shape
   const amount = typeof parsed.amount === 'number' ? parsed.amount : Number(parsed.amount);
-  const currency = typeof parsed.currency === 'string' && parsed.currency.length > 0
-    ? parsed.currency
-    : 'USD';
-  const confidence = typeof parsed.confidence === 'number'
+  // mortadella-92103: do NOT default to USD on ambiguity. When the model
+  // returns missing/empty/'UNKNOWN' currency, surface `null` so the caller
+  // refuses to auto-convert (CURRENCY_UNRESOLVED on the doc; admin/host must
+  // pick the correct code via the override dropdown).
+  const rawCurrency = typeof parsed.currency === 'string' ? parsed.currency.trim() : '';
+  const currency: string | null =
+    rawCurrency.length === 0 || rawCurrency.toUpperCase() === 'UNKNOWN'
+      ? null
+      : rawCurrency;
+  const modelConfidence = typeof parsed.confidence === 'number'
     ? Math.max(0, Math.min(1, parsed.confidence))
     : 0;
+  // Clamp confidence to 0.49 when currency is unresolved so the UI consistently
+  // surfaces it as "low" and asks for review.
+  const confidence = currency === null ? Math.min(modelConfidence, 0.49) : modelConfidence;
 
   if (!Number.isFinite(amount)) {
     throw new Error(`OpenAI returned non-numeric amount: ${JSON.stringify(parsed)}`);

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1057,9 +1057,30 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                             <span className="text-xs text-red-600">{r.ocrError}</span>
                           ) : r.ocrAmount != null && r.ocrCurrency ? (
                             <>
+                              {/* mortadella-92103: ocrAmount is the USD-converted
+                                  value. Render the original-currency amount as
+                                  a secondary pill when we have it on the doc,
+                                  so admins can see exactly what each receipt
+                                  was converted from. Falls back to just USD
+                                  for pre-mortadella rows that lack the columns. */}
                               <span className="text-theme-text font-medium">
-                                {formatOriginalCurrency(Number(r.ocrAmount), r.ocrCurrency)}
+                                ${Number(r.ocrAmount).toFixed(2)} USD
                               </span>
+                              {r.originalAmount != null
+                                && r.originalCurrency
+                                && r.originalCurrency.toUpperCase() !== 'USD' && (
+                                <span
+                                  className="text-xs text-theme-text-faint"
+                                  title={
+                                    r.exchangeRate != null
+                                      ? `1 ${r.originalCurrency} = $${Number(r.exchangeRate).toFixed(6)} USD`
+                                      : undefined
+                                  }
+                                >
+                                  ({formatOriginalCurrency(Number(r.originalAmount), r.originalCurrency)}
+                                  {r.exchangeRate != null && ` @ ${Number(r.exchangeRate).toFixed(4)}`})
+                                </span>
+                              )}
                               <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
                                 {(conf * 100).toFixed(0)}%
                               </span>
@@ -1079,11 +1100,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   })}
                 </ul>
                 <div className="text-xs text-theme-text-muted mt-2 border-t border-theme-stroke pt-2">
-                  Sum of OCR amounts (in their own currencies, not normalized): {ocrSum.toFixed(2)}
+                  {/* mortadella-92103: ocrAmount is now USD (post-fix). Old
+                      rows uploaded pre-mortadella may have non-USD amounts
+                      stamped as USD — the backfill script corrects those. */}
+                  Sum of OCR amounts (USD): ${ocrSum.toFixed(2)}
                   {canEditReceipts && (
                     <span className="block mt-1 text-theme-text-faint">
                       Editing a receipt's OCR amount or currency here updates the document only —
                       use the Edit Amount affordance on the payment itself to change the final USD total.
+                      Changing the currency re-runs FX automatically using the receipt's original amount.
                     </span>
                   )}
                 </div>

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -132,10 +132,24 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  // mortadella-92103: exclude receipts whose currency couldn't be resolved
+  // (the `$` ambiguity in non-USD countries) from the auto-sum. They keep
+  // their preview row but aren't counted until the host picks a currency
+  // via CurrencyOverrideSelect. The amber notice below tells the host what
+  // to do. `r.ocr.amount` is USD-converted (see OcrPreviewResult).
   const ocrSum = useMemo(
     () => receipts
-      .filter(r => r.status === 'done' && r.ocr)
+      .filter(r => r.status === 'done' && r.ocr && r.ocr.ocrError !== 'CURRENCY_UNRESOLVED')
       .reduce((sum, r) => sum + (r.ocr?.amount ?? 0), 0),
+    [receipts]
+  );
+  // mortadella-92103: count of unresolved-currency receipts so we can show
+  // a single amber notice rather than per-row warnings (the per-receipt
+  // row already shows its low-confidence state via the dropdown).
+  const unresolvedReceiptCount = useMemo(
+    () => receipts.filter(r =>
+      r.status === 'done' && r.ocr && r.ocr.ocrError === 'CURRENCY_UNRESOLVED'
+    ).length,
     [receipts]
   );
   const finalAmount = overrideAmount != null ? overrideAmount : ocrSum;
@@ -401,6 +415,23 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       {submitError && (
         <div className="card p-4 border-red-500/40 bg-red-500/10 text-sm text-red-300">
           {submitError}
+        </div>
+      )}
+
+      {/* mortadella-92103: amber notice when one or more receipts have an
+          unresolved currency (OCR returned $ without a strong country prior).
+          The auto-sum excludes those receipts until the host picks a code via
+          the per-row CurrencyOverrideSelect dropdown. */}
+      {unresolvedReceiptCount > 0 && (
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-100">
+              {unresolvedReceiptCount === 1
+                ? "1 receipt's currency could not be detected. Use the currency picker on that row to set the correct currency — it isn't counted in the total yet."
+                : `${unresolvedReceiptCount} receipts' currencies could not be detected. Use the currency picker on those rows — they aren't counted in the total yet.`}
+            </div>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/payouts/PayoutAmountSummary.tsx
+++ b/frontend/src/components/payouts/PayoutAmountSummary.tsx
@@ -19,8 +19,13 @@ export const PayoutAmountSummary: React.FC<PayoutAmountSummaryProps> = ({
   overrideAmount,
   onOverrideChange,
 }) => {
+  // mortadella-92103: exclude unresolved-currency receipts from the sum so
+  // the host can see at a glance that they need to pick a currency before
+  // the receipt counts. `r.ocr.amount` is USD-converted (see OcrPreviewResult).
   const ocrSum = receipts
-    .filter(r => r.status === 'done' && r.ocr)
+    .filter(r =>
+      r.status === 'done' && r.ocr && r.ocr.ocrError !== 'CURRENCY_UNRESOLVED'
+    )
     .reduce((sum, r) => sum + (r.ocr?.amount ?? 0), 0);
 
   const lowConfidenceCount = receipts.filter(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1655,6 +1655,13 @@ export interface PayoutDocument {
   ocrAmount: number | null;
   ocrCurrency: string | null;
   ocrConfidence: number | null;
+  // mortadella-92103: per-receipt FX persistence. Drives the reviewer pill
+  // ("$X.YZ USD (1234.56 MXN @ rate)") so admins can see exactly what each
+  // receipt was converted from. All three are null on rows uploaded before
+  // mortadella-92103 — those rely on the parent payout's headline FX.
+  originalAmount?: number | null;
+  originalCurrency?: string | null;
+  exchangeRate?: number | null;
   ocrError: string | null;
   sortOrder: number;
   // pancetta-37195: per-doc uploader attribution. Null on historical rows
@@ -2087,15 +2094,22 @@ export interface PrepayQueueRow {
 }
 
 export interface OcrPreviewResult {
-  amount: number;             // USD-converted total
+  amount: number;             // USD-converted total (0 when ocrError='CURRENCY_UNRESOLVED')
   currency: 'USD';
   originalAmount: number;
   originalCurrency: string;
   exchangeRate: number;
   confidence: number;
   items?: string[];
-  fxSource: 'jsdelivr' | 'frankfurter' | 'fallback' | 'usd-passthrough' | 'unknown';
+  // mortadella-92103: 'unresolved' is the new source for "OCR could not
+  // determine currency and no country prior was strong enough to pick one
+  // automatically". Host must override via CurrencyOverrideSelect.
+  fxSource: 'jsdelivr' | 'frankfurter' | 'fallback' | 'usd-passthrough' | 'unknown' | 'unresolved';
   conversionNote?: string;
+  // mortadella-92103: 'CURRENCY_UNRESOLVED' when OCR couldn't pick a code
+  // and FX refused to passthrough. Frontend should surface a warning and
+  // exclude the receipt from the auto-sum.
+  ocrError?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Receipts with `$`-symbol from non-USD countries (MXN/ARS/CLP/COP/UYU/etc) were being persisted as USD because OCR defaulted ambiguous currency to USD, then `convertToUSD` took the passthrough branch. Result: per-party payouts in the affected cities had `final_amount_usd` set to the raw foreign-currency number — often ~20x inflated. Concrete prod symptom uncovered in audit `a87c462cedb230764`: Cali had a single receipt stamped as **\$1,030,000 USD** (raw COP figure).

This PR:

- **OCR (`backend/src/services/ocr.service.ts`)** — surfaces `currency: null` (typed) on ambiguity instead of silently writing `'USD'`. New `partyCountry` param injects a country-currency prior into the prompt for MX/AR/CL/CO/UY/PE/PH/NG/etc. Confidence clamped to `<0.5` when currency unresolved.
- **FX (`backend/src/services/fx.service.ts`)** — new `source: 'unresolved'` return path; `usdAmount`/`exchangeRate` are `null` when currency missing. Callers must surface `CURRENCY_UNRESOLVED`; the USD-passthrough auto-stamp is gone.
- **payout_documents schema** — three new columns: `original_amount NUMERIC(14,4)`, `original_currency CHAR(3)`, `exchange_rate NUMERIC(18,8)`. **Migration applied to prod 2026-05-29** via `pg` + `DATABASE_URL` (per [feedback_apply_migration_before_merging_prisma_changes]). Verified via `information_schema.columns` post-apply. Idempotent on re-run.
- **POST `/api/parties/:partyId/payouts` + PATCH host edit** — plumb `partyCountry` into OCR; persist new FX columns; refuse-to-sum receipts where `fx.source === 'unresolved'` (row still inserted with `ocr_error='CURRENCY_UNRESOLVED'` so host/admin can override).
- **PATCH `/api/admin/payouts/documents/:docId`** — when admin changes `ocrCurrency`, re-run FX using the persisted `original_amount`, or `ocrRaw.ocr.amount` for legacy rows, or a body-supplied `originalAmount`. Rejects with `FX_ORIGINAL_AMOUNT_MISSING` when no source available. Writes all three FX columns + recomputed USD ocrAmount.
- **Host form (`NewPayoutForm` + `PayoutAmountSummary`)** — exclude unresolved receipts from the auto-sum; new amber notice tells host to pick a currency on affected rows via the existing `CurrencyOverrideSelect`.
- **Reviewer modal (`PayoutReviewModal`)** — drop misleading "Sum of OCR amounts (in their own currencies, not normalized)" label (`ocrAmount` is USD post-fix); render an inline \"`1234.56 MXN @ 0.0577`\" pill next to non-USD receipts so admins see exactly what each was converted from. Old rows without per-doc FX detail still render the USD-only form.
- **Backfill script** (`backend/scripts/backfill-misclassified-usd-receipts.cjs`) — dry-run by default; `--apply` mutates. Handles `parties.country` stored as both ISO-2 (`MX`) and full English name (`Mexico`, `Nigeria`). Recomputes `payouts.final_amount_usd` only when the corrected sum is *lower* than the existing final (preserves cap-clamps from submission). Skips dollarized countries (US/EC/PA/SV). Snax to run `--apply` in a separate session.

## Dry-run snippet (sample, --limit=15 --since=2025-01-01)

```
[backfill] doc=a131a515 party=GPP Iloilo City (PH) orig=3740 PHP -> $60.78 USD (rate=0.0163, source=jsdelivr, was-USD=3740)
[backfill] doc=4de58243 party=GPP Kwara (NG)       orig=57500 NGN -> $41.87 USD (rate=0.000728, source=jsdelivr, was-USD=57500)
[backfill] doc=c46663b4 party=GPP Lagos (NG)       orig=37500 NGN -> $27.30 USD (rate=0.000728, source=jsdelivr, was-USD=37500)
[backfill] doc=b4c0f671 party=GPP Warszawa (PL)    orig=373.30 PLN -> $102.78 USD (rate=0.2753, source=jsdelivr, was-USD=373.30)
[backfill] doc=9b562972 party=GPP Culiacan (MX)    orig=315 MXN   -> $18.18 USD (rate=0.0577, source=jsdelivr, was-USD=315)

[backfill] recompute final_amount_usd for 5 touched payouts (only when new < old):
[backfill]   payout=f150a262 (GPP Iloilo City) status=pending old_final=$225.75 -> new_final=$185.07 (delta=$-40.68)
[backfill]   payout=20f87985 (GPP Kwara)       status=pending old_final=$30.00 projected_new_sum=$41.87 -- keep old (was clamped to cap)
[backfill]   payout=6514b4dc (GPP Warszawa)    status=approved old_final=$240.00 projected_new_sum=$479.62 -- keep old (was clamped to cap)
[backfill]   payout=e9fc718d (GPP Culiacan)    status=pending old_final=$675.00 projected_new_sum=$1712.36 -- keep old (was clamped to cap)

[backfill] per-country summary:
  PH: 4 receipts, old-USD-sum=$7098.75  -> new-USD-sum=$115.36  (delta=$-6983.39)
  NG: 2 receipts, old-USD-sum=$95000.00 -> new-USD-sum=$69.17   (delta=$-94930.83)
  PL: 2 receipts, old-USD-sum=$867.40   -> new-USD-sum=$238.81  (delta=$-628.59)
  MX: 2 receipts, old-USD-sum=$765.00   -> new-USD-sum=$44.16   (delta=$-720.84)
```

## Files

- `backend/prisma/schema.prisma`
- `backend/prisma/migrations/20260529000000_payout_documents_fx_fields/migration.sql`
- `backend/src/services/ocr.service.ts`
- `backend/src/services/fx.service.ts`
- `backend/src/routes/payout.routes.ts`
- `backend/src/routes/admin-payout.routes.ts`
- `backend/scripts/backfill-misclassified-usd-receipts.cjs`
- `frontend/src/types.ts`
- `frontend/src/components/payouts/NewPayoutForm.tsx`
- `frontend/src/components/payouts/PayoutAmountSummary.tsx`
- `frontend/src/components/payments-admin/PayoutReviewModal.tsx`

## Test plan

- [ ] Upload a Mexican receipt with `$` symbol on a party with `country='Mexico'` -> OCR picks MXN via the country prior; FX converts; doc shows `ocr_amount` in USD, `original_amount` in MXN, `exchange_rate` non-null.
- [ ] Upload a receipt with no currency symbol on a party with `country=null` -> OCR returns `currency: null`; doc row inserted with `ocr_error='CURRENCY_UNRESOLVED'`; auto-sum excludes it; amber notice on the form.
- [ ] On the reviewer modal, a non-USD receipt renders "$X.XX USD (1234.56 MXN @ 0.0577)" pill.
- [ ] Admin per-receipt PATCH: change a doc's `ocrCurrency` from USD -> MXN with no body `ocrAmount` -> backend re-runs FX automatically using the persisted `original_amount` (or legacy `ocrRaw.ocr.amount`).
- [ ] CurrencyOverrideSelect dropdown (host-side) still works after the OcrPreviewResult shape change.
- [ ] Backfill dry-run output reviewed before `--apply`.
- [ ] `cd backend && npx tsc --noEmit` clean modulo pre-existing `sharp`/`openai`/`auth.test.ts` errors.
- [ ] `cd frontend && npx tsc --noEmit` clean.

## Notes on prod state

- Migration applied to prod ahead of merge (per project memory). The Prisma schema change is now consistent with what's deployed.
- Backfill script is one-shot; Snax to run `--apply` separately. The script is safe to dry-run any number of times.
- Pre-mortadella docs without per-doc FX detail still render correctly via fallback branches in both backend serialization and the reviewer modal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>