### PR TITLE
crust-71429: ethconf opt-in email CSV download

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1559,3 +1559,63 @@ sponsorDashboardRouter.get('/newsletter-emails', requireAuth, requireSponsorAuth
     next(error);
   }
 });
+
+// GET /api/sponsor/opt-in-emails - crust-71429: ethconf-only combined opt-in
+// download. Returns per-guest rows of guests at ethconf-tagged events who
+// opted into EITHER `mailingListOptIn` (PizzaDAO) OR `ethconfOptIn`, with
+// each guest's event city + which flags they opted into. The frontend dedupes
+// by lowercased email and renders an "Opt-In Source" (Mailing List / Ethconf /
+// Both) column. Only `tag=ethconf` is accepted for now.
+sponsorDashboardRouter.get('/opt-in-emails', requireAuth, requireSponsorAuth, async (req: SponsorRequest, res: Response, next: NextFunction) => {
+  try {
+    const queryTag = ((req.query.tag as string | undefined) || 'ethconf').trim().toLowerCase();
+    if (queryTag !== 'ethconf') {
+      throw new AppError('Only tag=ethconf is supported.', 400, 'VALIDATION_ERROR');
+    }
+
+    // Auth: requireSponsorAuth already gates by tag-match for non-admins (it 403s
+    // when ?tag= doesn't match any of the user's sponsor rows). Defense in depth:
+    // ensure the resolved sponsorUser tag matches OR the caller is an admin.
+    if (!req.isAdminViewing && req.sponsorUser?.tag !== queryTag) {
+      throw new AppError('Not authorized for this tag', 403, 'FORBIDDEN');
+    }
+
+    const parties = await prisma.party.findMany({
+      where: { eventTags: { has: queryTag } },
+      select: { id: true, name: true, country: true },
+    });
+    const partyById = new Map(parties.map(p => [p.id, p]));
+
+    if (parties.length === 0) {
+      return res.json([]);
+    }
+
+    const guests = await prisma.guest.findMany({
+      where: {
+        partyId: { in: parties.map(p => p.id) },
+        email: { not: null },
+        NOT: { email: '' },
+        OR: [
+          { mailingListOptIn: true },
+          { ethconfOptIn: true },
+        ],
+      },
+      select: { email: true, partyId: true, mailingListOptIn: true, ethconfOptIn: true },
+    });
+
+    const rows = guests.map(g => {
+      const party = partyById.get(g.partyId);
+      const city = (party?.name || '').replace(/^Global Pizza Party\s*/i, '').trim();
+      return {
+        email: g.email,
+        city,
+        mailingListOptIn: g.mailingListOptIn,
+        ethconfOptIn: g.ethconfOptIn,
+      };
+    });
+
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/frontend/src/pages/PartnerDashboardPage.tsx
+++ b/frontend/src/pages/PartnerDashboardPage.tsx
@@ -8,7 +8,7 @@ import { LoginModal } from '../components/LoginModal';
 import { IconInput } from '../components/IconInput';
 import { Checkbox } from '../components/Checkbox';
 import { useAuth } from '../contexts/AuthContext';
-import { fetchSponsorMe, fetchSponsorEvents, toggleSponsorChecklistItem, updatePartnerEventNote, getPartyPhotos } from '../lib/api';
+import { fetchSponsorMe, fetchSponsorEvents, toggleSponsorChecklistItem, updatePartnerEventNote, getPartyPhotos, apiRequest } from '../lib/api';
 import {
   Loader2, Shield, Tag, Users,
   Search, BarChart3, Calendar, MapPin,
@@ -306,6 +306,63 @@ export function PartnerDashboardPage() {
     a.download = `partner-events-${tagPart}-${datePart}.csv`;
     a.click();
     URL.revokeObjectURL(url);
+  }
+
+  // crust-71429: ethconf-only — download combined PizzaDAO + ethconf opt-in
+  // email list for guests at ethconf-tagged events. Dedupes by lowercased
+  // email (OR-ing both flags, first-seen city), then builds a CSV with
+  // Email, City, Opt-In Source columns.
+  async function handleDownloadOptInEmails() {
+    try {
+      const rows = await apiRequest<Array<{
+        email: string | null;
+        city: string;
+        mailingListOptIn: boolean;
+        ethconfOptIn: boolean;
+      }>>('/api/sponsor/opt-in-emails?tag=ethconf');
+
+      const merged = new Map<string, { city: string; mailingListOptIn: boolean; ethconfOptIn: boolean }>();
+      for (const r of rows) {
+        if (!r.email) continue;
+        const key = r.email.toLowerCase();
+        const existing = merged.get(key);
+        if (existing) {
+          existing.mailingListOptIn = existing.mailingListOptIn || r.mailingListOptIn;
+          existing.ethconfOptIn = existing.ethconfOptIn || r.ethconfOptIn;
+          // keep first-seen city
+        } else {
+          merged.set(key, {
+            city: r.city,
+            mailingListOptIn: r.mailingListOptIn,
+            ethconfOptIn: r.ethconfOptIn,
+          });
+        }
+      }
+
+      const csvRows: (string | number | null | undefined)[][] = [['Email', 'City', 'Opt-In Source']];
+      for (const [email, info] of merged) {
+        let source = '';
+        if (info.mailingListOptIn && info.ethconfOptIn) source = 'Both';
+        else if (info.mailingListOptIn) source = 'Mailing List';
+        else if (info.ethconfOptIn) source = 'Ethconf';
+        csvRows.push([email, info.city, source]);
+      }
+
+      const csv = csvRows
+        .map((row) => row.map((cell) => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(','))
+        .join('\n');
+
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const datePart = new Date().toISOString().slice(0, 10);
+      a.href = url;
+      a.download = `ethconf-opt-in-emails-${datePart}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to download opt-in emails');
+    }
   }
 
   async function handleToggleChecklist(eventId: string, itemId: string) {
@@ -866,6 +923,18 @@ export function PartnerDashboardPage() {
                 <Download size={14} />
                 {t('dashboard.downloadCsv')}
               </button>
+              {/* crust-71429: ethconf-only — download combined PizzaDAO + ethconf opt-in emails.
+                  Gate on dashboardData.tag (server-resolved tag) rather than selectedTag, which
+                  is undefined for non-admin single-tag partners. */}
+              {dashboardData?.tag === 'ethconf' && (
+                <button
+                  onClick={handleDownloadOptInEmails}
+                  className="inline-flex items-center gap-1.5 bg-theme-input border border-theme-stroke rounded-lg px-3 py-1.5 text-sm text-theme-text hover:border-theme-stroke-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  <Mail size={14} />
+                  Download Opt-In Emails
+                </button>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
Adds a "Download Opt-In Emails" button on the partner dashboard, visible only when the resolved partner tag is `ethconf`. Exports a deduplicated CSV of guests at ethconf-tagged events who opted into either:
- `mailingListOptIn` ("hear from pizzadao + partners"), or
- `ethconfOptIn` (ethconf-specific opt-in)

## Changes
**Backend** (`backend/src/routes/sponsor-user.routes.ts`):
- New `GET /api/sponsor/opt-in-emails?tag=ethconf` handler
- Auth via existing `requireSponsorAuth` (sponsor with matching tag OR admin)
- Rejects `tag !== 'ethconf'` with 400
- Returns `[{ email, city, mailingListOptIn, ethconfOptIn }]`

**Frontend** (`frontend/src/pages/PartnerDashboardPage.tsx`):
- `handleDownloadOptInEmails`: fetches endpoint, dedupes by lowercased email, merges opt-in flags, keeps first-seen city
- CSV columns: `Email`, `City`, `Opt-In Source` (Mailing List / Ethconf / Both)
- Filename: `ethconf-opt-in-emails-{YYYY-MM-DD}.csv`
- Button gated by `dashboardData?.tag === 'ethconf'` (works for ethconf sponsor + admin viewing ethconf)

## Deployment note
Preview frontends talk to the **production backend**. Once this PR merges, the backend must be manually redeployed before the new endpoint is callable on prod:
```
cd backend && vercel --prod --scope pizza-dao
```

Preview: https://rsvpizza-git-crust-71429-ethconf-emails-pizza-dao.vercel.app

## Test plan
- [ ] As ethconf sponsor user: button visible on `/partner`, downloads expected CSV
- [ ] As admin viewing ethconf: same
- [ ] As non-ethconf sponsor: button hidden; direct API call → 403
- [ ] CSV dedupes a guest who appears at 2 ethconf events
- [ ] Rows with empty/null email excluded
- [ ] Source column accurate when one opt-in vs both

🤖 Generated with [Claude Code](https://claude.com/claude-code)