### PR TITLE
pecorino-64118 follow-up: admin-only "Approved events only" toggle on consolidated report

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1120,6 +1120,13 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       ? (queryTag?.trim().toLowerCase() || undefined)
       : (queryTag?.trim().toLowerCase() || req.sponsorUser?.tag);
 
+    // pecorino-64118 follow-up: admin-only "Approved events only" opt-in toggle.
+    // Non-admins are already limited to approved events below; admins normally
+    // see everything for debugging, but can opt in to the same approved-only
+    // filter via ?approvedOnly=1 (lenient parsing).
+    const rawApprovedOnly = (req.query.approvedOnly as string | undefined)?.trim().toLowerCase();
+    const approvedOnlyParam = rawApprovedOnly === '1' || rawApprovedOnly === 'true' || rawApprovedOnly === 'yes';
+
     // pecorino-64118: newsletter signups count THIS tag's own opt-in column, if any.
     const optinField = tag ? NEWSLETTER_OPTIN_FIELD[tag] : undefined;
 
@@ -1137,6 +1144,9 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
     // Non-admin partners only see approved events.
     if (!req.isAdminViewing) {
       where.underbossStatus = 'approved';
+    } else if (approvedOnlyParam) {
+      // Admin opted in to approved-only via the toggle.
+      where.underbossStatus = 'approved';
     }
     // Exclude cancelled events (consistent with GET /events).
     where.cancelledAt = null;
@@ -1146,6 +1156,9 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
       return res.json({
         partnerName: null,
         tag: null,
+        isAdmin: false,
+        // Non-admins are always approved-only (server-enforced above).
+        approvedOnly: true,
         eventCount: 0,
         dateRange: null,
         stats: {
@@ -1463,6 +1476,11 @@ sponsorDashboardRouter.get('/report', requireAuth, requireSponsorAuth, async (re
     res.json({
       partnerName,
       tag: tag || null,
+      // pecorino-64118 follow-up: surface admin viewing + the resolved
+      // "approved events only" state so the frontend can render the toggle
+      // and reflect the applied filter. Non-admins are always approved-only.
+      isAdmin: req.isAdminViewing || false,
+      approvedOnly: req.isAdminViewing ? approvedOnlyParam : true,
       eventCount: parties.length,
       dateRange,
       stats: {

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "Zurück zum Dashboard",
     "notAvailableTitle": "Bericht noch nicht verfügbar",
     "notAvailableDesc": "Der Gesamtbericht ist noch nicht verfügbar. Bitte schauen Sie bald wieder vorbei.",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "Event",
       "date": "Datum",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -261,6 +261,7 @@
     "backToDashboard": "Back to dashboard",
     "notAvailableTitle": "Report not available yet",
     "notAvailableDesc": "The consolidated report is not available yet. Please check back soon.",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "Event",
       "date": "Date",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "Volver al panel",
     "notAvailableTitle": "Reporte aún no disponible",
     "notAvailableDesc": "El reporte consolidado aún no está disponible. Vuelve a consultar pronto.",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "Evento",
       "date": "Fecha",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "Retour au tableau de bord",
     "notAvailableTitle": "Rapport pas encore disponible",
     "notAvailableDesc": "Le rapport consolidé n'est pas encore disponible. Veuillez revenir bientôt.",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "Événement",
       "date": "Date",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "ダッシュボードに戻る",
     "notAvailableTitle": "レポートはまだ利用できません",
     "notAvailableDesc": "統合レポートはまだ利用できません。しばらくしてからもう一度ご確認ください。",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "イベント",
       "date": "日付",

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "대시보드로 돌아가기",
     "notAvailableTitle": "리포트를 아직 사용할 수 없습니다",
     "notAvailableDesc": "통합 리포트를 아직 사용할 수 없습니다. 잠시 후 다시 확인해 주세요.",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "이벤트",
       "date": "날짜",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "Voltar ao painel",
     "notAvailableTitle": "Relatório ainda não disponível",
     "notAvailableDesc": "O relatório consolidado ainda não está disponível. Volte em breve.",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "Evento",
       "date": "Data",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -250,6 +250,7 @@
     "backToDashboard": "返回仪表板",
     "notAvailableTitle": "报告尚不可用",
     "notAvailableDesc": "汇总报告尚不可用，请稍后再查看。",
+    "approvedOnly": "Approved events only",
     "table": {
       "event": "活动",
       "date": "日期",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3347,8 +3347,16 @@ export async function fetchSponsorEvents(tag?: string): Promise<SponsorDashboard
 }
 
 // pecorino-64118: consolidated cross-event partner report (private, full rollup).
-export async function fetchSponsorConsolidatedReport(tag?: string): Promise<ConsolidatedReport> {
-  const params = tag ? `?tag=${encodeURIComponent(tag)}` : '';
+// pecorino-64118 follow-up: optional admin-only `approvedOnly` opt-in filter
+// (non-admins are server-scoped to approved-only regardless).
+export async function fetchSponsorConsolidatedReport(
+  tag?: string,
+  approvedOnly?: boolean
+): Promise<ConsolidatedReport> {
+  const parts: string[] = [];
+  if (tag) parts.push(`tag=${encodeURIComponent(tag)}`);
+  if (approvedOnly) parts.push('approvedOnly=1');
+  const params = parts.length > 0 ? `?${parts.join('&')}` : '';
   return apiRequest<ConsolidatedReport>(`/api/sponsor/report${params}`);
 }
 

--- a/frontend/src/pages/ConsolidatedReportPage.tsx
+++ b/frontend/src/pages/ConsolidatedReportPage.tsx
@@ -6,6 +6,7 @@ import { Loader2, Shield, FileText, ArrowLeft } from 'lucide-react';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
+import { Checkbox } from '../components/Checkbox';
 import { useAuth } from '../contexts/AuthContext';
 import { fetchSponsorMe, fetchSponsorConsolidatedReport } from '../lib/api';
 import { ConsolidatedReportPreview } from '../components/report/ConsolidatedReportPreview';
@@ -20,8 +21,13 @@ const backgroundStyle = { background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4
 export function ConsolidatedReportPage() {
   const { t } = useTranslation('partner');
   const { user, loading: authLoading } = useAuth();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const tagParam = searchParams.get('tag') || undefined;
+  // pecorino-64118 follow-up: admin-only "Approved events only" opt-in.
+  // Read from URL so the filter persists across reloads / shares.
+  const approvedOnlyParam = ['1', 'true', 'yes'].includes(
+    (searchParams.get('approvedOnly') || '').toLowerCase()
+  );
 
   // Set body class for elements outside React tree
   useEffect(() => {
@@ -60,7 +66,7 @@ export function ConsolidatedReportPage() {
           || undefined;
 
         try {
-          const data = await fetchSponsorConsolidatedReport(resolvedTag);
+          const data = await fetchSponsorConsolidatedReport(resolvedTag, approvedOnlyParam);
           setReport(data);
         } catch (err: any) {
           // Backend not deployed yet (preview talks to prod backend) → friendly state.
@@ -79,7 +85,19 @@ export function ConsolidatedReportPage() {
     }
 
     load();
-  }, [user, authLoading, tagParam]);
+  }, [user, authLoading, tagParam, approvedOnlyParam]);
+
+  // pecorino-64118 follow-up: toggle the approvedOnly URL param (admin-only).
+  // useSearchParams will trigger the load effect above to re-fetch.
+  const handleToggleApprovedOnly = () => {
+    const next = new URLSearchParams(searchParams);
+    if (approvedOnlyParam) {
+      next.delete('approvedOnly');
+    } else {
+      next.set('approvedOnly', '1');
+    }
+    setSearchParams(next, { replace: true });
+  };
 
   // Loading state
   if (authLoading || loading) {
@@ -171,7 +189,21 @@ export function ConsolidatedReportPage() {
               <p className="text-theme-text-muted max-w-md mx-auto">{t('consolidated.notAvailableDesc')}</p>
             </div>
           ) : report ? (
-            <ConsolidatedReportPreview report={report} />
+            <>
+              {/* pecorino-64118 follow-up: admin-only "Approved events only" toggle.
+                  Non-admins are already server-scoped to approved+non-cancelled. */}
+              {report.isAdmin && (
+                <div className="mb-4 flex justify-end">
+                  <Checkbox
+                    checked={!!report.approvedOnly}
+                    onChange={handleToggleApprovedOnly}
+                    label={t('consolidated.approvedOnly')}
+                    labelClassName="text-sm text-theme-text-secondary"
+                  />
+                </div>
+              )}
+              <ConsolidatedReportPreview report={report} />
+            </>
           ) : (
             <div className="text-center py-16">
               <FileText size={48} className="text-theme-text-faint mx-auto mb-4" />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1552,6 +1552,11 @@ export interface ConsolidatedReportSocialPost {
 export interface ConsolidatedReport {
   partnerName: string | null;
   tag: string | null;
+  // pecorino-64118 follow-up: server tells us whether the caller is admin
+  // viewing (so we can render the admin-only "Approved events only" toggle)
+  // and the resolved approvedOnly state actually applied to the result.
+  isAdmin?: boolean;
+  approvedOnly?: boolean;
   eventCount: number;
   dateRange: { start: string; end: string } | null;
   stats: {


### PR DESCRIPTION
Admin-only "Approved events only" toggle on the consolidated report (`/partner/report`), persisted via `?approvedOnly=1`. Non-admins are unaffected — they're already server-scoped to approved + non-cancelled. Needs backend redeploy from master.

## Backend
`GET /api/sponsor/report` now accepts lenient `?approvedOnly=(1|true|yes)`. The filter only applies when `req.isAdminViewing` (non-admins already get `underbossStatus='approved'`). Response gains top-level `{ isAdmin, approvedOnly }` so the frontend can render the toggle and reflect the applied state.

## Frontend
- `ConsolidatedReport` type gains `isAdmin?: boolean` and `approvedOnly?: boolean`.
- `fetchSponsorConsolidatedReport(tag, approvedOnly)` appends `?approvedOnly=1` when toggled.
- `ConsolidatedReportPage` reads `approvedOnly` from URL (default false), passes it to the fetcher, and renders a `Checkbox` above `ConsolidatedReportPreview` only when `report.isAdmin`. Toggling updates the URL via `setSearchParams` (replace) and triggers re-fetch.

## i18n
Adds `partner:consolidated.approvedOnly` to all 8 partner.json locales (English real; English placeholder elsewhere per existing convention).

## Verify
- `backend && npx tsc --noEmit` — no errors in changed files (only pre-existing `auth.test.ts(38,14)` + `sharp`/`openai` module-not-found).
- `frontend && npm run build` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)