### PR TITLE
feat(pancetta-92103): regions multi-select filter on /payments

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,9 +1,15 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import type { AdminPayoutFilters, PayoutMethod, PayoutPurpose, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
+import {
+  PAYMENTS_REGION_DISPLAY_ORDER,
+  PAYMENTS_REGION_LABELS,
+  PAYMENTS_REGION_SCOPES,
+  type PaymentsRegionPortal,
+} from '../../utils/regions';
 
 interface PayoutsFilterBarProps {
   filters: AdminPayoutFilters;
@@ -11,15 +17,9 @@ interface PayoutsFilterBarProps {
   onReset: () => void;
   availableCurrencies: string[];
   /**
-   * bruschetta-58291: distinct, non-null `party.country` values across the
-   * currently-loaded payouts. Mirrors the `availableCurrencies` pattern —
-   * derived in `PaymentsAdminPage` from the loaded set. Sorted ascending.
-   */
-  availableCountries: string[];
-  /**
    * mascarpone-49102: distinct event-tag values across the currently-loaded
    * payouts (flattened from each `party.eventTags` array). Mirrors the
-   * `availableCountries` pattern — derived in `PaymentsAdminPage`. Sorted
+   * `availableCurrencies` pattern — derived in `PaymentsAdminPage`. Sorted
    * ascending.
    */
   availableTags: string[];
@@ -29,6 +29,12 @@ interface PayoutsFilterBarProps {
    * party level), so the parent controls visibility. Defaults to false.
    */
   showHideClosedToggle?: boolean;
+  /**
+   * pancetta-92103: when true, render the Regions multi-select dropdown
+   * (admin /payments). Hidden on regional sub-portals (which are already
+   * hard-scoped by their `regionFilter` prop). Defaults to false.
+   */
+  showRegionsFilter?: boolean;
 }
 
 const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
@@ -92,6 +98,9 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.payoutMethod && filters.payoutMethod !== 'all') n += 1;
   if (filters.currency && filters.currency !== 'all') n += 1;
   if (filters.country && filters.country !== 'all') n += 1;
+  // pancetta-92103: regions multi-select counts as a single active filter
+  // when at least one portal is selected (regardless of how many).
+  if (Array.isArray(filters.regionPortals) && filters.regionPortals.length > 0) n += 1;
   if (filters.tag && filters.tag !== 'all') n += 1;
   if (filters.purpose && filters.purpose !== 'all') n += 1;
   if (filters.dateFrom) n += 1;
@@ -121,9 +130,9 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   onChange,
   onReset,
   availableCurrencies,
-  availableCountries,
   availableTags,
   showHideClosedToggle,
+  showRegionsFilter,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const activeCount = countActiveFilters(filters);
@@ -131,6 +140,47 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   const update = (patch: Partial<AdminPayoutFilters>) => {
     onChange({ ...filters, ...patch, cursor: undefined });
   };
+
+  // pancetta-92103: regions multi-select state — dropdown panel open/close +
+  // click-outside-to-close behavior (matches the project's modal/dropdown
+  // pattern). The selected-regions live in `filters.regions`; this widget
+  // only owns the open/close UI state.
+  const [regionsOpen, setRegionsOpen] = useState(false);
+  const regionsRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!regionsOpen) return;
+    function onDocClick(e: MouseEvent) {
+      if (!regionsRef.current) return;
+      if (!regionsRef.current.contains(e.target as Node)) {
+        setRegionsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [regionsOpen]);
+
+  const selectedRegionPortals = useMemo<string[]>(
+    () => (Array.isArray(filters.regionPortals) ? filters.regionPortals : []),
+    [filters.regionPortals],
+  );
+  const regionsButtonLabel = useMemo(() => {
+    if (selectedRegionPortals.length === 0) return 'All regions';
+    if (selectedRegionPortals.length === 1) {
+      const slug = selectedRegionPortals[0] as PaymentsRegionPortal;
+      return PAYMENTS_REGION_LABELS[slug] ?? slug;
+    }
+    return `${selectedRegionPortals.length} regions`;
+  }, [selectedRegionPortals]);
+
+  function toggleRegionPortal(slug: PaymentsRegionPortal) {
+    const current = selectedRegionPortals;
+    const next = current.includes(slug)
+      ? current.filter((s) => s !== slug)
+      : [...current, slug];
+    // Empty array = no filter (treat same as undefined so the URL/query stays
+    // clean and `countActiveFilters` doesn't count an empty selection).
+    update({ regionPortals: next.length > 0 ? next : undefined });
+  }
 
   return (
     <div className="sticky top-0 z-20 bg-theme-surface/95 backdrop-blur-sm border border-theme-stroke rounded-xl p-4 mb-4 shadow-sm">
@@ -229,22 +279,61 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
             </select>
           </div>
 
-          {/* bruschetta-58291: Country dropdown — populated from the loaded
-              payout set (parallels availableCurrencies). Backend filters by
-              exact `parties.country` match. */}
-          <div>
-            <select
-              value={filters.country ?? 'all'}
-              onChange={(e) => update({ country: e.target.value })}
-              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Filter by country"
-            >
-              <option value="all">All countries</option>
-              {availableCountries.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </select>
-          </div>
+          {/* pancetta-92103: Regions multi-select — replaces the prior
+              bruschetta-58291 single-country dropdown. Each region maps to a
+              fixed list of `parties.region` slugs (PAYMENTS_REGION_SCOPES);
+              the backend `?regions=` query filters `parties.region IN (...)`.
+              Selecting zero regions = no filter (same as the old "All
+              countries"). Hidden on regional sub-portals which are already
+              hard-scoped by their parent's `regionFilter` prop. */}
+          {showRegionsFilter && (
+            <div className="relative" ref={regionsRef}>
+              <button
+                type="button"
+                onClick={() => setRegionsOpen((v) => !v)}
+                className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text inline-flex items-center justify-between gap-2"
+                aria-haspopup="listbox"
+                aria-expanded={regionsOpen}
+                aria-label="Filter by region"
+              >
+                <span className="truncate">{regionsButtonLabel}</span>
+                <ChevronDown size={14} className="flex-shrink-0 text-theme-text-muted" />
+              </button>
+              {regionsOpen && (
+                <div
+                  role="listbox"
+                  className="absolute left-0 right-0 mt-1 z-50 rounded-lg border border-theme-stroke bg-theme-surface shadow-lg py-2 min-w-[200px]"
+                >
+                  {PAYMENTS_REGION_DISPLAY_ORDER.map((slug) => {
+                    const checked = selectedRegionPortals.includes(slug);
+                    const scopeCount = PAYMENTS_REGION_SCOPES[slug].length;
+                    return (
+                      <div key={slug} className="px-3 py-1.5 hover:bg-theme-surface-hover">
+                        <Checkbox
+                          checked={checked}
+                          onChange={() => toggleRegionPortal(slug)}
+                          label={`${PAYMENTS_REGION_LABELS[slug]} (${scopeCount})`}
+                          labelClassName="text-sm text-theme-text"
+                          size={16}
+                        />
+                      </div>
+                    );
+                  })}
+                  {selectedRegionPortals.length > 0 && (
+                    <div className="border-t border-theme-stroke mt-1 pt-1 px-3">
+                      <button
+                        type="button"
+                        onClick={() => update({ regionPortals: undefined })}
+                        className="text-xs text-theme-text-muted hover:text-theme-text py-1"
+                      >
+                        Clear regions
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* mascarpone-49102: Tag dropdown — populated from event_tags
               flattened across the loaded payout set (parallels

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,8 @@
 import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse } from '../types';
+// pancetta-92103: region portal → underlying parties.region slug map. Used by
+// `buildPayoutQuery` to expand the /payments admin Regions multi-select into
+// the existing `?regions=` query the backend already accepts.
+import { PAYMENTS_REGION_SCOPES, type PaymentsRegionPortal } from '../utils/regions';
 
 // Authenticated API helper functions
 const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
@@ -4078,8 +4082,22 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   // argentina-92103: regional scope for /payments/latam (and any future
   // regional portal). CSV of `parties.region` values; backend filters the
   // query, totals, and per-row aggregates by region when present.
-  if (filters.regions && filters.regions.length > 0) {
-    params.set('regions', filters.regions.join(','));
+  // pancetta-92103: also expand `regionPortals` (admin /payments multi-select
+  // state — one or more portal slugs like 'latam' / 'na') into their
+  // underlying `parties.region` slugs and merge with `regions` so the backend
+  // sees a single CSV. Deduped via Set so the SA-overlap (Africa + SouthAfrica
+  // both include `south-africa`) collapses cleanly.
+  const regionSet = new Set<string>(filters.regions ?? []);
+  if (filters.regionPortals && filters.regionPortals.length > 0) {
+    for (const portal of filters.regionPortals) {
+      const scope = PAYMENTS_REGION_SCOPES[portal as PaymentsRegionPortal];
+      if (scope) {
+        for (const r of scope) regionSet.add(r);
+      }
+    }
+  }
+  if (regionSet.size > 0) {
+    params.set('regions', Array.from(regionSet).join(','));
   }
   // pinsa-92103: hide-closed-cities toggle on the by-city view. Backend
   // accepts `hideClosed=true`; the LIST endpoint ignores it.

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -373,16 +373,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     return Array.from(set).sort();
   }, [payouts]);
 
-  // bruschetta-58291: derive the country dropdown set from the currently-loaded
-  // payouts (mirrors `availableCurrencies` above). Backend exposes country via
-  // PAYOUT_PARTY_SELECT; null countries are skipped.
-  const availableCountries = useMemo(() => {
-    const set = new Set<string>();
-    for (const p of payouts) {
-      if (p.party.country) set.add(p.party.country);
-    }
-    return Array.from(set).sort();
-  }, [payouts]);
+  // pancetta-92103: the prior `availableCountries` derivation was removed
+  // alongside the single-country dropdown. The new Regions multi-select is
+  // sourced from PAYMENTS_REGION_SCOPES (a static map) — no per-load derivation
+  // needed.
 
   // mascarpone-49102: derive the tag dropdown set from `party.eventTags`
   // (added to PAYOUT_PARTY_SELECT in tagliatelle-49102). Flattens the arrays
@@ -889,12 +883,16 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           onChange={setFilters}
           onReset={() => setFilters(DEFAULT_FILTERS)}
           availableCurrencies={availableCurrencies}
-          availableCountries={availableCountries}
           availableTags={availableTags}
           // pinsa-92103: Hide closed cities only makes sense on the by-city
           // view (paymentsClosedAt is a party-level signal). The per-payment
           // view has no party-row, so the toggle would be confusing there.
           showHideClosedToggle={viewMode === 'by-city'}
+          // pancetta-92103: Regions multi-select is the admin /payments tool;
+          // regional sub-portals (`/payments/latam` etc.) are hard-scoped by
+          // their `regionFilter` prop and shouldn't show a second region
+          // picker on top of that.
+          showRegionsFilter={!isRegionalPortal}
         />
 
         {/* etruria-92103: by-city / by-payment view toggle. by-city is the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1993,6 +1993,16 @@ export interface AdminPayoutFilters {
    * gate regional underbosses to their region scope.
    */
   regions?: string[];
+  /**
+   * pancetta-92103: admin /payments Regions multi-select state — one or more
+   * underboss-region portal slugs (`'latam' | 'na' | 'europe' | ...`). UI
+   * state only; `buildPayoutQuery` expands each portal slug into its
+   * `PAYMENTS_REGION_SCOPES` underlying `parties.region` slugs and merges
+   * them with `regions` when calling the backend. The regional sub-portal
+   * pages (LatamPaymentsPage etc.) do not use this — they hard-scope via the
+   * `regions` field directly.
+   */
+  regionPortals?: string[];
   currency?: string;
   /**
    * salumi-89172: Purpose filter — 'event' (host reimbursements) or

--- a/frontend/src/utils/regions.ts
+++ b/frontend/src/utils/regions.ts
@@ -62,3 +62,18 @@ export const PAYMENTS_REGION_SCOPES: Record<PaymentsRegionPortal, readonly strin
   india: INDIA_REGIONS,
   asia: ASIA_REGIONS,
 };
+
+/**
+ * pancetta-92103: display order for the /payments admin Regions multi-select.
+ * Roughly west-to-east, with the two Africa portals adjacent so the SA-overlap
+ * (see header comment) is visible at a glance.
+ */
+export const PAYMENTS_REGION_DISPLAY_ORDER: PaymentsRegionPortal[] = [
+  'latam',
+  'na',
+  'europe',
+  'africa',
+  'southafrica',
+  'india',
+  'asia',
+];


### PR DESCRIPTION
## Summary

- Replaces the single-country dropdown on /payments with a multi-select Regions dropdown using the 7 underboss regions (LATAM, North America, Europe, Africa, South Africa, India, Asia & Oceania).
- Each region maps to a fixed list of \`parties.region\` slugs via \`PAYMENTS_REGION_SCOPES\` (tortelli-92103). Selecting one or more regions filters the table to parties whose region is in the union of those region scopes; zero selected = no filter (matches the old "All countries" default).
- Backend changes: none. The existing \`?regions=\` query param (argentina-92103) already accepts a CSV of \`parties.region\` slugs and the multi-select expands its portal-slug selection into that CSV at request time.
- Hidden on the regional sub-portal pages (\`/payments/latam\`, \`/payments/na\`, etc.) which are already hard-scoped via the \`regionFilter\` prop — a second region picker on top of that would be confusing.

## Implementation notes

- New optional field \`AdminPayoutFilters.regionPortals: string[]\` holds the user-visible portal-slug selection. \`buildPayoutQuery\` expands it into the existing \`regions\` CSV and dedupes via \`Set\` so the SA-overlap (Africa + South Africa both include \`south-africa\`) collapses cleanly.
- Reset Filters clears the multi-select (DEFAULT_FILTERS doesn't include \`regionPortals\`).
- Uses the project's \`Checkbox\` component; dropdown panel uses click-outside-to-close and \`z-50\` per CLAUDE.md.
- New \`PAYMENTS_REGION_DISPLAY_ORDER\` constant in \`utils/regions.ts\` controls dropdown ordering (LATAM, NA, Europe, Africa, South Africa, India, Asia).

## Preserved

- Search, party-id, status chips, currency, method, tag, purpose, sort, date range, hide-closed-cities, reset filters chip, country column display in the table.
- KPI tiles, by-city table, regional UB portals at /payments/<region>.

## Test plan

- [ ] Open /payments — verify the Regions dropdown shows All regions and "(N)" country counts on each row.
- [ ] Select LATAM only — table filters to LATAM parties (central-america, south-america regions).
- [ ] Select LATAM + Europe — union of both region scopes.
- [ ] Uncheck all — table reverts to unfiltered.
- [ ] Click "Clear regions" in the dropdown footer — same as unchecking all.
- [ ] Open /payments/latam — Regions dropdown is hidden (sub-portal is hard-scoped).
- [ ] Reset filters — clears region selection.
- [ ] Frontend tsc clean; backend tsc clean (modulo pre-existing auth.test.ts errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)