### PR TITLE
feat(cotechino-92103): PAID CITIES KPI tile

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1915,6 +1915,17 @@ router.get(
       // serialization semantics are unchanged.
       const committedByParty = new Map<string, number>();
 
+      // cotechino-92103: per-party status-breakdown for the PAID CITIES
+      // KPI. A party is "paid/complete" when it has at least one payout
+      // in `paid` OR `completed` AND zero payouts in `pending` OR
+      // `approved`. `rejected`/`failed`/`withdrawn` rows don't count
+      // either way (dead claims). Same filter-window scope as the rest
+      // of `totals` since this derives from `allFiltered`.
+      const byPartyStatusCounts = new Map<
+        string,
+        { paidOrCompletedCount: number; pendingOrApprovedCount: number }
+      >();
+
       const now = new Date();
       const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
 
@@ -1964,6 +1975,30 @@ router.get(
             r.party.id,
             (committedByParty.get(r.party.id) ?? 0) + usd,
           );
+        }
+
+        // cotechino-92103: tally paid/completed vs pending/approved
+        // counts per party for the PAID CITIES KPI below.
+        if (r.party) {
+          const existing = byPartyStatusCounts.get(r.party.id) ?? {
+            paidOrCompletedCount: 0,
+            pendingOrApprovedCount: 0,
+          };
+          if (r.status === 'paid' || r.status === 'completed') {
+            existing.paidOrCompletedCount += 1;
+          } else if (r.status === 'pending' || r.status === 'approved') {
+            existing.pendingOrApprovedCount += 1;
+          }
+          byPartyStatusCounts.set(r.party.id, existing);
+        }
+      }
+
+      // cotechino-92103: count cities whose payouts are all "settled" —
+      // at least one paid/completed row AND no in-flight pending/approved.
+      let paidCitiesCount = 0;
+      for (const counts of byPartyStatusCounts.values()) {
+        if (counts.paidOrCompletedCount > 0 && counts.pendingOrApprovedCount === 0) {
+          paidCitiesCount++;
         }
       }
 
@@ -2035,6 +2070,7 @@ router.get(
           totalUsdThisMonth,
           avgUsd,
           awaitingReview,
+          paidCitiesCount,
         },
       });
     } catch (error) {

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DollarSign, Calendar, TrendingUp, Inbox } from 'lucide-react';
+import { DollarSign, Calendar, TrendingUp, Inbox, CheckCircle2 } from 'lucide-react';
 import type { AdminPayoutTotals } from '../../types';
 import { formatUsd } from '../payments-shared';
 
@@ -34,8 +34,8 @@ const StatCard: React.FC<StatCardProps> = ({ icon, label, value, tone = 'default
 export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, loading }) => {
   if (loading || !totals) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-        {[0, 1, 2, 3].map((i) => (
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+        {[0, 1, 2, 3, 4].map((i) => (
           <div key={i} className="rounded-xl border border-theme-stroke bg-theme-surface p-4 animate-pulse h-20" />
         ))}
       </div>
@@ -43,7 +43,7 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
   }
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
       <StatCard
         icon={<DollarSign size={14} />}
         label="Pending"
@@ -60,6 +60,14 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
         icon={<TrendingUp size={14} />}
         label="Avg payment"
         value={formatUsd(totals.avgUsd)}
+      />
+      {/* cotechino-92103: cities (parties) with at least one paid/completed
+          payout and no in-flight pending/approved payouts. */}
+      <StatCard
+        icon={<CheckCircle2 size={14} />}
+        label="Paid cities"
+        value={String(totals.paidCitiesCount)}
+        tone="emerald"
       />
       <StatCard
         icon={<Inbox size={14} />}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2045,6 +2045,13 @@ export interface AdminPayoutTotals {
   totalUsdThisMonth: number;
   avgUsd: number;
   awaitingReview: number;
+  /**
+   * cotechino-92103: count of cities (parties) that are fully paid /
+   * complete — at least one payout in `paid` OR `completed` status AND
+   * zero payouts in `pending` OR `approved` status. Same filter-window
+   * scope as the other KPI fields.
+   */
+  paidCitiesCount: number;
 }
 
 export interface AdminPayoutsResponse {


### PR DESCRIPTION
## Summary
- Adds a new PAID CITIES tile to the top KPI row on `/payments`, between AVG PAYMENT and AWAITING REVIEW.
- Definition: a city/party with at least one payout in `paid` OR `completed` status AND zero payouts in `pending` OR `approved` status. `rejected`/`failed`/`withdrawn` rows on the same party don't disqualify it.
- Same filter-window scope as the adjacent KPIs (status/method/country/date filters from `allFiltered`).

## Implementation
- Backend: new `byPartyStatusCounts` map sibling to `committedByParty` in the totals rollup loop, tallying paid/completed vs pending/approved per party. Final `paidCitiesCount` is the count of parties where paid/completed > 0 and pending/approved == 0.
- Frontend: extends `AdminPayoutTotals` with `paidCitiesCount`; bumps `PaymentsStatsCards` grid from 4 to 5 columns at md; inserts the new tile with `CheckCircle2` (lucide-react) in emerald tone.

## Test plan
- [ ] Tile renders on `/payments` with a numeric count.
- [ ] Count matches reality for a small filter (e.g., one region with known done-cities).
- [ ] A party with one `paid` payout and one `pending` payout does NOT count.
- [ ] A party with one `paid` payout and one `rejected` payout DOES count.
- [ ] A party with one `completed` payout DOES count.
- [ ] Loading skeleton shows 5 placeholders, not 4.

Generated with [Claude Code](https://claude.com/claude-code)