### PR TITLE
fix(salami-58120): finish HEIC/HEIF/AVIF allowlist — 4 missed frontend gates

### DIFF
--- a/frontend/src/components/PreviousYearPhotos.tsx
+++ b/frontend/src/components/PreviousYearPhotos.tsx
@@ -617,7 +617,7 @@ function UploadModal({
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/jpeg,image/png,image/webp,image/gif"
+            accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,image/avif"
             multiple
             onChange={(e) => e.target.files && onFiles(e.target.files)}
             className="hidden"

--- a/frontend/src/components/photos/PhotoUpload.tsx
+++ b/frontend/src/components/photos/PhotoUpload.tsx
@@ -25,7 +25,7 @@ interface UploadingFile {
   photo?: Photo;
 }
 
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif', 'image/avif'];
 const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
 const MAX_VIDEO_DURATION = 300; // 5 minutes in seconds
 
@@ -268,7 +268,7 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm,video/quicktime"
+          accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,image/avif,video/mp4,video/webm,video/quicktime"
           multiple
           onChange={(e) => e.target.files && handleFiles(e.target.files)}
           className="hidden"

--- a/frontend/src/components/venue/VenuePhotoUpload.tsx
+++ b/frontend/src/components/venue/VenuePhotoUpload.tsx
@@ -110,7 +110,7 @@ export const VenuePhotoUpload: React.FC<VenuePhotoUploadProps> = ({ partyId, ven
       <input
         ref={fileInputRef}
         type="file"
-        accept="image/jpeg,image/png,image/webp,image/gif"
+        accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,image/avif"
         multiple
         onChange={handleFileSelect}
         className="hidden"


### PR DESCRIPTION
## Summary
- Follow-up to PR #618 which added HEIC/HEIF/AVIF in 3 places but missed 4 frontend gates
- iPhone users picking HEIC files from their photo library were getting silently dropped before the request even reached the (HEIC-permitted) backend
- 3 files, ~4 line changes total

## Test plan
- [ ] iPhone Safari: select HEIC from camera roll → upload succeeds
- [ ] Android Chrome: select AVIF → upload succeeds
- [ ] Regression: JPEG/PNG still work
- [ ] Vercel preview: https://rsvpizza-git-salami-58120-heic-finish-pizza-dao.vercel.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)