### PR TITLE
pancetta-58472: lowercase ethereum_address + functional index

### DIFF
--- a/backend/prisma/migrations/20260529010000_lowercase_ethereum_address_and_index/migration.sql
+++ b/backend/prisma/migrations/20260529010000_lowercase_ethereum_address_and_index/migration.sql
@@ -1,0 +1,16 @@
+-- Lowercase + trim all existing ethereum_address values.
+-- Guest wallet addresses (both 0x… and ENS) are case-insensitive at the
+-- chain/DNS layer; storing mixed case caused 8 case-only duplicates in the
+-- prod CSV export. See pancetta-58472.
+UPDATE guests
+SET ethereum_address = LOWER(TRIM(ethereum_address))
+WHERE ethereum_address IS NOT NULL
+  AND ethereum_address <> LOWER(TRIM(ethereum_address));
+
+-- Functional index supports the per-event "is this wallet already on the
+-- guest list?" soft-warn lookup and the cross-event DISTINCT export.
+-- Non-unique on purpose — multi-attendee single-wallet households are
+-- legitimate, so dedup is soft-warn at the app layer, not a constraint.
+CREATE INDEX IF NOT EXISTS idx_guests_ethereum_address_lower
+  ON guests (LOWER(ethereum_address))
+  WHERE ethereum_address IS NOT NULL;


### PR DESCRIPTION
## Summary
PR 1 of 3 for wallet-address dedup (see plan in pancetta-58472).

- Backfills all existing `guests.ethereum_address` rows to `LOWER(TRIM(...))`.
- Adds a non-unique functional index on `LOWER(ethereum_address)` for cheap soft-warn lookups and the global DISTINCT export.
- No constraint added (Snax chose soft-warn over hard reject — multi-attendee households share wallets legitimately).
- No Prisma schema change — functional indexes can't be modeled in Prisma, and a regular `@@index` would mislead.

## Order
This PR must merge **before** the backend write-path PR. Backend goes live seconds after master push; if backend started lowercasing-on-write before existing rows were lowercased, a brief window of mixed-case rows would survive past the cutover.

## Test plan
- [ ] Migration applies idempotently (re-running = no-op)
- [ ] Index is created (`\d+ guests` in psql shows `idx_guests_ethereum_address_lower`)
- [ ] Spot-check: a known mixed-case row (e.g. `Vitalik.eth`) is lowercased after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)