### PR TITLE
pancetta-58472: backend wallet normalization + admin export

### DIFF
--- a/backend/scripts/dedupe-wallet-addresses.cjs
+++ b/backend/scripts/dedupe-wallet-addresses.cjs
@@ -1,0 +1,186 @@
+// pancetta-58472: backfill script to normalize `guests.ethereum_address` and
+// collapse within-party duplicates.
+//
+// Pass 1 — Lowercase backfill (safety net):
+//   UPDATE guests SET ethereum_address = LOWER(TRIM(ethereum_address))
+//   WHERE ethereum_address IS NOT NULL
+//     AND ethereum_address <> LOWER(TRIM(ethereum_address))
+//
+//   Redundant after PR 1's migration + PR 2's write-site normalization land,
+//   but useful as a catch-all for any rows written between PR 1 and PR 2.
+//
+// Pass 2 — Within-party row collapse:
+//   For each (party_id, ethereum_address) group with COUNT(*) > 1:
+//     - Keep the row with earliest submitted_at (tie-break: id ASC).
+//     - For all other rows in the group, set ethereum_address = NULL and
+//       wallet_source = NULL.
+//     - Do NOT delete the guest row — they may have NFTs, check-ins, or
+//       other state. We only un-link them from the wallet.
+//
+// Per-group transactions so a single group failing doesn't roll back the
+// whole batch. Per-group log lines (party_id, address, kept-id, dropped-ids).
+//
+// Usage (from a main session — not a worktree agent):
+//   cd backend && node scripts/dedupe-wallet-addresses.cjs           # dry-run
+//   cd backend && node scripts/dedupe-wallet-addresses.cjs --apply   # write
+
+const { Client } = require('pg');
+require('dotenv').config();
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+
+async function main() {
+  const c = new Client({ connectionString: process.env.DATABASE_URL });
+  await c.connect();
+  console.log(`pancetta-58472 dedupe-wallet-addresses start${DRY_RUN ? ' (DRY RUN — pass --apply to write)' : ''}`);
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // Pass 1: lowercase backfill
+  // -------------------------------------------------------------------------
+  console.log('Pass 1: lowercase + trim non-canonical wallet addresses');
+
+  const previewQ = await c.query(`
+    SELECT COUNT(*)::int AS cnt
+    FROM guests
+    WHERE ethereum_address IS NOT NULL
+      AND ethereum_address <> LOWER(TRIM(ethereum_address))
+  `);
+  const lowercaseTargets = previewQ.rows[0].cnt;
+  console.log(`  rows needing lowercase/trim: ${lowercaseTargets}`);
+
+  let lowercased = 0;
+  if (lowercaseTargets > 0) {
+    if (!DRY_RUN) {
+      const updQ = await c.query(`
+        UPDATE guests
+        SET ethereum_address = LOWER(TRIM(ethereum_address))
+        WHERE ethereum_address IS NOT NULL
+          AND ethereum_address <> LOWER(TRIM(ethereum_address))
+      `);
+      lowercased = updQ.rowCount;
+      console.log(`  lowercased: ${lowercased} rows`);
+    } else {
+      // Show a sample of what would change
+      const sampleQ = await c.query(`
+        SELECT id, party_id, ethereum_address, LOWER(TRIM(ethereum_address)) AS canonical
+        FROM guests
+        WHERE ethereum_address IS NOT NULL
+          AND ethereum_address <> LOWER(TRIM(ethereum_address))
+        ORDER BY submitted_at ASC
+        LIMIT 10
+      `);
+      console.log('  sample (up to 10):');
+      for (const r of sampleQ.rows) {
+        console.log(`    guest ${r.id} party ${r.party_id}: '${r.ethereum_address}' -> '${r.canonical}'`);
+      }
+      lowercased = lowercaseTargets;
+    }
+  }
+
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // Pass 2: collapse within-party (party_id, ethereum_address) duplicates
+  // -------------------------------------------------------------------------
+  console.log('Pass 2: collapse within-party wallet duplicates');
+
+  // Note: this query reads the post-Pass-1 state if --apply was used. In dry
+  // run mode, we deliberately look at LOWER(TRIM(...)) to surface the groups
+  // that WOULD form after Pass 1 ran for real.
+  const groupsQ = await c.query(`
+    SELECT party_id,
+           LOWER(TRIM(ethereum_address)) AS address,
+           COUNT(*)::int AS cnt
+    FROM guests
+    WHERE ethereum_address IS NOT NULL
+    GROUP BY party_id, LOWER(TRIM(ethereum_address))
+    HAVING COUNT(*) > 1
+    ORDER BY party_id ASC, address ASC
+  `);
+  console.log(`  duplicate (party, wallet) groups: ${groupsQ.rowCount}`);
+
+  let groupsProcessed = 0;
+  let groupsFailed = 0;
+  let totalNulled = 0;
+
+  for (const g of groupsQ.rows) {
+    const { party_id, address } = g;
+
+    try {
+      if (!DRY_RUN) await c.query('BEGIN');
+
+      // Fetch all rows in this group, earliest first. Tie-break by id ASC
+      // for stability.
+      const rowsQ = await c.query(
+        `
+        SELECT id, submitted_at, wallet_source
+        FROM guests
+        WHERE party_id = $1
+          AND LOWER(TRIM(ethereum_address)) = $2
+        ORDER BY submitted_at ASC NULLS LAST, id ASC
+        `,
+        [party_id, address],
+      );
+
+      if (rowsQ.rowCount < 2) {
+        // Race or already collapsed since the GROUP BY ran. Skip cleanly.
+        if (!DRY_RUN) await c.query('COMMIT');
+        continue;
+      }
+
+      const rows = rowsQ.rows;
+      const kept = rows[0];
+      const dropped = rows.slice(1);
+      const droppedIds = dropped.map(r => r.id);
+
+      console.log(
+        `  party ${party_id} wallet ${address}: keep ${kept.id}, null out [${droppedIds.join(', ')}]`,
+      );
+
+      if (!DRY_RUN) {
+        const updQ = await c.query(
+          `
+          UPDATE guests
+          SET ethereum_address = NULL,
+              wallet_source = NULL
+          WHERE id = ANY($1::uuid[])
+          `,
+          [droppedIds],
+        );
+        totalNulled += updQ.rowCount;
+        await c.query('COMMIT');
+      } else {
+        totalNulled += droppedIds.length;
+      }
+
+      groupsProcessed++;
+    } catch (err) {
+      if (!DRY_RUN) {
+        try {
+          await c.query('ROLLBACK');
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      groupsFailed++;
+      console.error(`  group party=${party_id} wallet=${address} FAILED: ${err.message}`);
+    }
+  }
+
+  console.log('');
+  console.log('--- summary ---');
+  console.log(`pass 1: rows lowercased         : ${lowercased}`);
+  console.log(`pass 2: groups processed        : ${groupsProcessed}`);
+  console.log(`pass 2: groups failed           : ${groupsFailed}`);
+  console.log(`pass 2: rows nulled (wallet/src): ${totalNulled}`);
+  if (DRY_RUN) console.log('(dry-run — no writes performed; pass --apply to commit)');
+
+  await c.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -109,6 +109,32 @@ router.post('/add', requireAuth, async (req: AuthRequest, res: Response, next: N
   }
 });
 
+// GET /api/admin/wallet-addresses.csv — Export DISTINCT wallet addresses across
+// all guests (super_admin only). Pushes DISTINCT into SQL per repo guardrail —
+// no JS post-filter on a paginated query.
+router.get('/wallet-addresses.csv', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isSuperAdmin(req.userEmail))) {
+      throw new AppError('Super admin access required', 403, 'FORBIDDEN');
+    }
+
+    const rows = await prisma.$queryRaw<Array<{ ethereum_address: string }>>`
+      SELECT DISTINCT ethereum_address
+      FROM guests
+      WHERE ethereum_address IS NOT NULL
+      ORDER BY ethereum_address ASC
+    `;
+
+    const csv = 'wallet_address\n' + rows.map(r => r.ethereum_address).join('\n');
+    res
+      .setHeader('Content-Type', 'text/csv')
+      .setHeader('Content-Disposition', 'attachment; filename=all-wallets.csv')
+      .send(csv);
+  } catch (error) {
+    next(error);
+  }
+});
+
 // DELETE /api/admin/:id — Remove admin (super_admin only, can't remove self)
 router.delete('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
@@ -732,13 +758,15 @@ router.post('/provision-wallets', async (req: Request, res: Response, next: Next
             await prisma.guest.update({
               where: { id: guest.id },
               data: {
-                ethereumAddress: walletResult.walletAddress,
+                // pancetta-58472: store Privy-returned wallet lowercase to match the
+                // canonical form used by every other write site.
+                ethereumAddress: walletResult.walletAddress.toLowerCase(),
                 privyUserId: walletResult.privyUserId,
                 walletSource: 'privy-embedded',
               },
             });
             provisioned++;
-            console.log(`[provision-wallets] Provisioned wallet for guest ${guest.id}: ${walletResult.walletAddress}`);
+            console.log(`[provision-wallets] Provisioned wallet for guest ${guest.id}: ${walletResult.walletAddress.toLowerCase()}`);
           } else {
             skipped++;
             console.log(`[provision-wallets] Privy returned null for guest ${guest.id} (${guest.email}), skipped`);

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -180,10 +180,15 @@ router.get('/:partyId/report', requireAuth, async (req: AuthRequest, res: Respon
         industryOrgs,
         featuredPhotos: party.photos,
 
-        // Wallet address list for CSV export
-        walletAddressList: party.guests
-          .filter(g => g.ethereumAddress)
-          .map(g => g.ethereumAddress as string),
+        // Wallet address list for CSV export. pancetta-58472: DISTINCT so
+        // duplicate guest rows sharing a wallet don't inflate the CSV.
+        walletAddressList: Array.from(
+          new Set(
+            party.guests
+              .filter(g => g.ethereumAddress)
+              .map(g => g.ethereumAddress as string)
+          )
+        ),
 
         // Calculated stats
         stats: {
@@ -541,10 +546,15 @@ router.get('/public/:publicSlug', optionalAuth, async (req: AuthRequest, res: Re
         industryOrgs,
         featuredPhotos: party.photos,
 
-        // Wallet address list for CSV export
-        walletAddressList: party.guests
-          .filter(g => g.ethereumAddress)
-          .map(g => g.ethereumAddress as string),
+        // Wallet address list for CSV export. pancetta-58472: DISTINCT so
+        // duplicate guest rows sharing a wallet don't inflate the CSV.
+        walletAddressList: Array.from(
+          new Set(
+            party.guests
+              .filter(g => g.ethereumAddress)
+              .map(g => g.ethereumAddress as string)
+          )
+        ),
 
         // Calculated stats (some fields hidden for privacy)
         stats: {

--- a/backend/src/routes/rsvp.routes.ts
+++ b/backend/src/routes/rsvp.routes.ts
@@ -319,12 +319,16 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       throw new AppError('Name is required', 400, 'VALIDATION_ERROR');
     }
 
+    // pancetta-58472: lowercase + trim the wallet/ENS at the boundary so every
+    // downstream write (manual create, manual update, Privy auto-provision)
+    // stores the same canonical form.
+    const normalizedAddress = ethereumAddress ? ethereumAddress.trim().toLowerCase() : null;
+
     // Validate Ethereum address or ENS name format if provided
-    if (ethereumAddress && ethereumAddress.trim()) {
-      const ethAddressRegex = /^0x[a-fA-F0-9]{40}$/;
-      const ensRegex = /^[a-zA-Z0-9-]+\.(eth|xyz|com|org|io|co|app|dev|id)$/;
-      const trimmedAddress = ethereumAddress.trim();
-      if (!ethAddressRegex.test(trimmedAddress) && !ensRegex.test(trimmedAddress)) {
+    if (normalizedAddress) {
+      const ethAddressRegex = /^0x[a-f0-9]{40}$/;
+      const ensRegex = /^[a-z0-9-]+\.(eth|xyz|com|org|io|co|app|dev|id)$/;
+      if (!ethAddressRegex.test(normalizedAddress) && !ensRegex.test(normalizedAddress)) {
         throw new AppError('Invalid Ethereum address or ENS name format', 400, 'VALIDATION_ERROR');
       }
     }
@@ -447,6 +451,14 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
     // Determine if guest should be waitlisted
     const isAtCapacity = party.maxGuests ? confirmedGuestCount >= party.maxGuests : false;
 
+    // response hint only — does not block the save
+    const existingWalletGuest = normalizedAddress
+      ? await prisma.guest.findFirst({
+          where: { partyId: party.id, ethereumAddress: normalizedAddress },
+          select: { id: true, name: true },
+        })
+      : null;
+
     // Check for duplicate email if email is provided
     if (email?.trim()) {
       const existingGuest = await prisma.guest.findFirst({
@@ -493,8 +505,8 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
           where: { id: existingGuest.id },
           data: {
             name: name.trim(),
-            ethereumAddress: ethereumAddress?.trim() || null,
-            ...(ethereumAddress?.trim() ? { walletSource: 'manual' } : {}),
+            ethereumAddress: normalizedAddress || null,
+            ...(normalizedAddress ? { walletSource: 'manual' } : {}),
             roles: roles || [],
             mailingListOptIn: mailingListOptIn || false,
             swcOptIn: swcOptIn || false,
@@ -531,6 +543,9 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
             id: updatedGuest.id,
             name: updatedGuest.name,
           },
+          ...(existingWalletGuest && existingWalletGuest.id !== updatedGuest.id
+            ? { walletShared: { withName: existingWalletGuest.name } }
+            : {}),
           message: 'Your RSVP has been updated!',
         });
       }
@@ -563,8 +578,8 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       data: {
         name: name.trim(),
         email: email?.trim().toLowerCase() || null,
-        ethereumAddress: ethereumAddress?.trim() || null,
-        walletSource: ethereumAddress?.trim() ? 'manual' : null,
+        ethereumAddress: normalizedAddress || null,
+        walletSource: normalizedAddress ? 'manual' : null,
         roles: roles || [],
         mailingListOptIn: mailingListOptIn || false,
         swcOptIn: swcOptIn || false,
@@ -592,19 +607,19 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
     });
 
     // Auto-provision Privy embedded wallet if no wallet address was provided and email exists
-    if (!ethereumAddress?.trim() && email?.trim()) {
+    if (!normalizedAddress && email?.trim()) {
       try {
         const walletResult = await createEmbeddedWalletForGuest(email.trim().toLowerCase(), name.trim());
         if (walletResult) {
           await prisma.guest.update({
             where: { id: guest.id },
             data: {
-              ethereumAddress: walletResult.walletAddress,
+              ethereumAddress: walletResult.walletAddress.toLowerCase(),
               privyUserId: walletResult.privyUserId,
               walletSource: 'privy-embedded',
             },
           });
-          console.log(`Privy embedded wallet provisioned for guest ${guest.id}: ${walletResult.walletAddress}`);
+          console.log(`Privy embedded wallet provisioned for guest ${guest.id}: ${walletResult.walletAddress.toLowerCase()}`);
         }
       } catch (privyError) {
         // Non-fatal: RSVP succeeds even if Privy provisioning fails
@@ -674,6 +689,9 @@ router.post('/:inviteCode/guest', async (req: Request, res: Response, next: Next
       requireApproval: party.requireApproval,
       waitlisted: isAtCapacity,
       waitlistPosition,
+      ...(existingWalletGuest && existingWalletGuest.id !== guest.id
+        ? { walletShared: { withName: existingWalletGuest.name } }
+        : {}),
       message,
     });
   } catch (error) {

--- a/backend/src/routes/v1/guests.ts
+++ b/backend/src/routes/v1/guests.ts
@@ -277,7 +277,8 @@ router.post('/', requireApiKey(SCOPES.GUESTS_WRITE), async (req: ApiKeyRequest, 
       data: {
         name: name.trim(),
         email: email ? email.toLowerCase() : null,
-        ethereumAddress: ethereumAddress || null,
+        // pancetta-58472: lowercase + trim wallet address at the boundary.
+        ethereumAddress: ethereumAddress ? ethereumAddress.trim().toLowerCase() : null,
         roles: roles || [],
         mailingListOptIn: mailingListOptIn || false,
         dietaryRestrictions: dietaryRestrictions || [],
@@ -396,7 +397,10 @@ router.patch('/:guestId', requireApiKey(SCOPES.GUESTS_WRITE), async (req: ApiKey
       data: {
         ...(name !== undefined && { name: name.trim() }),
         ...(email !== undefined && { email: email ? email.toLowerCase() : null }),
-        ...(ethereumAddress !== undefined && { ethereumAddress }),
+        ...(ethereumAddress !== undefined && {
+          // pancetta-58472: lowercase + trim wallet address at the boundary.
+          ethereumAddress: ethereumAddress ? ethereumAddress.trim().toLowerCase() : null,
+        }),
         ...(roles !== undefined && { roles }),
         ...(mailingListOptIn !== undefined && { mailingListOptIn }),
         ...(dietaryRestrictions !== undefined && { dietaryRestrictions }),


### PR DESCRIPTION
## Summary
PR 2 of 3 for wallet-address dedup (see plan in pancetta-58472).

- Lowercase + trim `ethereumAddress` at every write site (manual entry, update branch, Privy auto-provision in rsvp.routes; v1/guests; admin Privy bulk provision).
- DISTINCT the per-event `walletAddressList` in `/api/parties/:partyId/report`.
- New `GET /api/admin/wallet-addresses.csv` — super-admin gated, single SQL `SELECT DISTINCT … ORDER BY`. Pushes DISTINCT into SQL per repo guardrail.
- Soft-warn `walletShared: { withName }` response hint when a new RSVP's wallet matches another guest in the same event. No confirm modal, no block — the save still happens.
- New `backend/scripts/dedupe-wallet-addresses.cjs` for the post-deploy backfill (dry-run default; `--apply` flag for the within-party row collapse).

## Order
Land **after** PR 1 (migration). Snax runs the backfill script post-deploy.

## Test plan
- [ ] `cd backend && npx tsc --noEmit` passes
- [ ] Submit RSVP with `Vitalik.ETH` → stored as `vitalik.eth`
- [ ] Submit RSVP with mixed-case `0xABC…` → stored lowercase
- [ ] Second RSVP with same wallet on same event → response includes `walletShared.withName`
- [ ] `/api/parties/:id/report.walletAddressList` returns unique values when duplicates exist
- [ ] `/api/admin/wallet-addresses.csv` returns DISTINCT addresses, super-admin gated, 401 for non-admin
- [ ] Script dry-run prints expected plan against dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)