### PR TITLE
pancetta-58472: frontend wallet normalization + admin download button

### DIFF
--- a/frontend/src/components/RSVPFlowContent.tsx
+++ b/frontend/src/components/RSVPFlowContent.tsx
@@ -110,6 +110,13 @@ export function RSVPFlowContent({
             Your RSVP is pending approval from the host. You'll receive an email with your check-in QR code once approved.
           </p>
         )}
+        {/* pancetta-58472: wallet is also on another event's guest list. Saved
+            anyway; non-blocking heads-up. */}
+        {form.walletShared && (
+          <p className="text-xs text-theme-text-muted mb-4">
+            Heads up — this wallet is already on the guest list for {form.walletShared.withName}. Saved anyway.
+          </p>
+        )}
         {/* Share Section */}
         {(!form.alreadyRegistered || form.wasUpdated) && (
           <ShareRSVP

--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -42,6 +42,9 @@ export interface RSVPSubmitResult {
   updated: boolean;
   waitlisted: boolean;
   waitlistPosition: number | null;
+  // pancetta-58472: backend hint that this wallet is also on another event's
+  // guest list (saved anyway, surfaced as inline heads-up).
+  walletShared: { withName: string } | null;
 }
 
 export interface UseRSVPFormOptions {
@@ -154,6 +157,9 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
   const [waitlisted, setWaitlisted] = useState(false);
   const [waitlistPosition, setWaitlistPosition] = useState<number | null>(null);
   const [guestId, setGuestId] = useState<string | null>(null);
+  // pancetta-58472: heads-up shown on success when backend reports this wallet
+  // is on another event's guest list. Saved anyway; non-blocking.
+  const [walletShared, setWalletShared] = useState<{ withName: string } | null>(null);
 
   // Pizzeria state
   const [nearbyPizzerias, setNearbyPizzerias] = useState<Pizzeria[]>([]);
@@ -257,6 +263,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     setWaitlisted(false);
     setWaitlistPosition(null);
     setGuestId(null);
+    setWalletShared(null);
     setStep(1);
     setError(null);
     setSwcOptIn(false);
@@ -531,6 +538,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
         setWaitlisted(result.waitlisted);
         setWaitlistPosition(result.waitlistPosition);
         setGuestId(result.guest?.id || null);
+        setWalletShared(result.walletShared ?? null);
         setSubmitted(true);
 
         onSuccess?.({
@@ -540,6 +548,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
           updated: isEditing || result.updated,
           waitlisted: result.waitlisted,
           waitlistPosition: result.waitlistPosition,
+          walletShared: result.walletShared ?? null,
         });
       } else {
         setError('Failed to submit. Please try again.');
@@ -647,6 +656,8 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     setWaitlistPosition,
     guestId,
     setGuestId,
+    walletShared,
+    setWalletShared,
 
     // Pizzeria state
     nearbyPizzerias,

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1483,11 +1483,15 @@ export async function addGuestToParty(
   ethconfOptIn?: boolean,
   optinAbVariant?: 'control' | 'variant' | null,
   visitorSessionId?: string,
-): Promise<{ guest: DbGuest; alreadyRegistered: boolean; requireApproval: boolean; updated: boolean; waitlisted: boolean; waitlistPosition: number | null }> {
+): Promise<{ guest: DbGuest; alreadyRegistered: boolean; requireApproval: boolean; updated: boolean; waitlisted: boolean; waitlistPosition: number | null; walletShared: { withName: string } | null }> {
   if (!inviteCode) {
     console.error('Invite code is required to add guest');
     throw new Error('Invite code is required to submit RSVP');
   }
+
+  // pancetta-58472: lowercase+trim wallet on the wire (belt + suspenders;
+  // backend already normalizes). Caller keeps the user-typed value in state.
+  const normalizedWallet = ethereumAddress?.trim().toLowerCase() || null;
 
   try {
     const response = await fetch(`${API_URL}/api/rsvp/${inviteCode}/guest`, {
@@ -1496,7 +1500,7 @@ export async function addGuestToParty(
       body: JSON.stringify({
         name,
         email: email || null,
-        ethereumAddress: ethereumAddress || null,
+        ethereumAddress: normalizedWallet,
         roles: roles || [],
         mailingListOptIn: mailingListOptIn || false,
         dietaryRestrictions,
@@ -1536,7 +1540,7 @@ export async function addGuestToParty(
       party_id: partyId,
       name: data.guest.name,
       email: email || null,
-      ethereum_address: ethereumAddress || null,
+      ethereum_address: normalizedWallet,
       roles: roles || [],
       mailing_list_opt_in: mailingListOptIn || false,
       dietary_restrictions: dietaryRestrictions,
@@ -1567,6 +1571,11 @@ export async function addGuestToParty(
       updated: data.updated || false,
       waitlisted: data.waitlisted || false,
       waitlistPosition: data.waitlistPosition || null,
+      // pancetta-58472: backend may signal that this wallet is also on another
+      // event's guest list. Saved anyway; surfaced as a heads-up on success.
+      walletShared: data.walletShared && typeof data.walletShared.withName === 'string'
+        ? { withName: data.walletShared.withName }
+        : null,
     };
   } catch (error) {
     console.error('Error adding guest:', error);

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, Check } from 'lucide-react';
+import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, Check, Download } from 'lucide-react';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
@@ -190,6 +190,34 @@ export function UnderbossDashboard() {
     }
     return t('underbossDashboard.regionsCount', { count: selectedRegions.length });
   }, [selectedRegions, availableRegions.length, t]);
+
+  // pancetta-58472: admin-only download of all guest wallet addresses across
+  // events. Backend endpoint added in PR 2. Uses the same Bearer-auth pattern
+  // as exportShippingKitsCsv.
+  const handleDownloadAllWallets = useCallback(async () => {
+    try {
+      const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
+      const token = localStorage.getItem('authToken');
+      const response = await fetch(`${API_URL}/api/admin/wallet-addresses.csv`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to download wallets CSV (${response.status})`);
+      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'all-wallets.csv';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err: any) {
+      console.error('wallet csv download failed:', err);
+      alert(err?.message || 'Failed to download wallets CSV');
+    }
+  }, []);
 
   const loadDashboard = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
@@ -468,6 +496,15 @@ export function UnderbossDashboard() {
               >
                 <UserPlus size={14} />
                 {t('underbossDashboard.addUnderboss')}
+              </button>
+            )}
+            {isAdmin && (
+              <button
+                onClick={handleDownloadAllWallets}
+                className="flex items-center gap-1.5 text-sm text-red-500/70 hover:text-red-500 transition-colors"
+              >
+                <Download size={14} />
+                Download all wallets (CSV)
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary
PR 3 of 3 for wallet-address dedup (see plan in pancetta-58472).

- `useRSVPForm` / `addGuestToParty` lowercase + trim `ethereumAddress` at submit time (belt + suspenders; backend already normalizes in PR 2). Display value stays as-typed in the input — only the wire format is normalized.
- Inline heads-up on the RSVP success screen when backend returns `walletShared.withName`: "Heads up — this wallet is already on the guest list for {withName}. Saved anyway." No modal, no block, muted text style.
- "Download all wallets (CSV)" button on `/underboss`, admin-only. Calls `GET /api/admin/wallet-addresses.csv` (added in PR 2) using the existing `localStorage authToken` Bearer pattern (matches `exportShippingKitsCsv`).

## Order
Land **after** PR 2 (backend). The download button calls an endpoint that only exists once PR 2 deploys; the `walletShared` heads-up only renders when backend populates that field.

## Test plan
- [x] `cd frontend && npx tsc -b --noEmit` — no new errors in changed files (pre-existing errors unrelated)
- [ ] `cd frontend && npm run build` passes (could not run locally — disk full + no `node_modules`; Vercel preview will confirm)
- [ ] RSVP submit with `Vitalik.ETH` sends `vitalik.eth` in the network payload
- [ ] Display value in the input stays as-typed (no flicker)
- [ ] Second RSVP with shared wallet shows the inline heads-up on success
- [ ] Underboss download button: visible for admin, absent for non-admin
- [ ] Click → downloads `all-wallets.csv`

Preview: https://rsvpizza-git-pancetta-58472-frontend-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)