### PR TITLE
fix(nduja-58293): hotfix archiver ESM import (backend was down)

### DIFF
--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -1,9 +1,13 @@
 import { Router, Response, NextFunction, Request } from 'express';
 import { Prisma } from '@prisma/client';
 import { Readable } from 'stream';
-import archiver from 'archiver';
+import { createRequire } from 'module';
 import { prisma } from '../config/database.js';
 import { optionalAuth, requireAuth, AuthRequest } from '../middleware/auth.js';
+
+const require = createRequire(import.meta.url);
+// archiver is CJS-only and has no default export; createRequire bypasses ESM resolution
+const archiver = require('archiver') as typeof import('archiver');
 
 const router = Router();
 const DEFAULT_LIMIT = 24;


### PR DESCRIPTION
## Urgent
- Production backend crashed at module load after PR #711 (import archiver from 'archiver' — archiver is CJS-only and has no default export under ESM)
- Every endpoint returned FUNCTION_INVOCATION_FAILED with no CORS headers; users saw \"Failed to fetch\" + CORS errors site-wide
- Backend rolled back manually via \`vercel promote\` to pre-#711 deploy. Year filter + ZIP feature are NOT live right now.

## Fix
\`\`\`ts
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
const archiver = require('archiver') as typeof import('archiver');
\`\`\`

Standard createRequire pattern for CJS-in-ESM. Bypasses Node ESM resolution.

## Re-deploy after merge
Merge → backend redeploys from master → verify all endpoints work + ZIP feature works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)