### PR TITLE
feat(taleggio-90142): add "Brave browser" to survey discovery options

### DIFF
--- a/backend/src/lib/surveyQuestions.ts
+++ b/backend/src/lib/surveyQuestions.ts
@@ -17,7 +17,7 @@ export interface SurveyQuestion {
   allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
-export const SURVEY_QUESTION_SET_VERSION = 1;
+export const SURVEY_QUESTION_SET_VERSION = 2;
 
 export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
   {
@@ -42,7 +42,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     type: 'multiple',
     multi: false,
     text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'The organizer', 'Other'],
+    options: ['A friend', 'Twitter/X', 'The organizer', 'Brave browser', 'Other'],
     allowOther: true,
   },
   {

--- a/frontend/src/lib/surveyQuestions.ts
+++ b/frontend/src/lib/surveyQuestions.ts
@@ -17,7 +17,7 @@ export interface SurveyQuestion {
   allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
-export const SURVEY_QUESTION_SET_VERSION = 1;
+export const SURVEY_QUESTION_SET_VERSION = 2;
 
 export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
   {
@@ -42,7 +42,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     type: 'multiple',
     multi: false,
     text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'The organizer', 'Other'],
+    options: ['A friend', 'Twitter/X', 'The organizer', 'Brave browser', 'Other'],
     allowOther: true,
   },
   {


### PR DESCRIPTION
Adds **"Brave browser"** to the post-event guest survey's "How did you hear about this event?" (`discovery`) question.

## What changed
Two files, kept byte-for-byte identical for the question set + version:

- `backend/src/lib/surveyQuestions.ts` — added `'Brave browser'` to the `discovery` options array (immediately **before** `'Other'`, which must stay last because the `allowOther` `_other` logic keys on `value === 'Other'`), and bumped `SURVEY_QUESTION_SET_VERSION` `1 -> 2`.
- `frontend/src/lib/surveyQuestions.ts` — the same two edits (declared mirror of the backend file).

No DB migration, no validation-logic change — `validateSurveyAnswers` already accepts any value present in `options`.

## Deploy note
The discovery option list is served by the backend API (`SurveyPage` renders `data.questionSet`). The Vercel preview talks to the **production backend**, so "Brave browser" will **NOT** appear on the preview — it only goes live (prod + all previews) **after the backend deploys from master**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)