### PR TITLE
feat(culatello-92103): undo external/wire/mercury payments

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2946,6 +2946,102 @@ router.post(
 );
 
 // ============================================
+// POST /api/admin/payouts/:id/revert-paid — culatello-92103
+//
+// Flip a `paid` payout back to `approved` so the admin can re-execute or
+// re-mark-paid. Mirrors `unapprove` (approved -> pending) one step further
+// up the lifecycle for cases where an out-of-band payment was recorded in
+// error (wrong recipient, wrong amount, never actually sent, etc.).
+//
+// Works for ALL payout methods — USDC, wire, mercury_card, external,
+// off-platform — not just USDC. The original implementation gap was that
+// `unapprove` returns 400 NOT_APPROVED on a paid row and no separate endpoint
+// existed, so admins had no way to undo a `mark-paid` after the fact.
+//
+// On revert we clear the mark-paid metadata:
+//   - paidAt -> null
+//   - transactionHash, wireReference, mercuryCardId, mercuryCardLast4,
+//     externalProofUrl -> null
+//
+// The audit trail (payout_audit rows) is preserved — both the original
+// mark_paid audit and the new unmark_paid audit stay on the row so the
+// reversal is auditable.
+//
+// Idempotent: rejects unless status === 'paid' (400 NOT_PAID).
+// ============================================
+router.post(
+  '/:id/revert-paid',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'paid') {
+        throw new AppError(
+          `Cannot revert a payout in status '${existing.status}'`,
+          400,
+          'NOT_PAID',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const { note } = req.body || {};
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: {
+            status: 'approved',
+            paidAt: null,
+            transactionHash: null,
+            wireReference: null,
+            mercuryCardId: null,
+            mercuryCardLast4: null,
+            externalProofUrl: null,
+          },
+          include: {
+            party: { select: PAYOUT_PARTY_SELECT },
+            host: { select: { id: true, name: true, email: true } },
+            documents: {
+              orderBy: { sortOrder: 'asc' },
+              include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+            },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'unmark_paid',
+            oldStatus: 'paid',
+            newStatus: 'approved',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: typeof note === 'string' ? note : null,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
 // GET /api/admin/payouts/usdc-daily-cap-remaining
 //   - Used by the UI to show "Daily cap remaining: $Y" before USDC execute.
 //   - Must be declared BEFORE POST /:id/execute (literal path) but it's a GET

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -60,6 +60,22 @@ interface PayoutReviewModalProps {
    */
   onUnapprove?: () => Promise<string | void> | string | void;
   /**
+   * culatello-92103: revert a `paid` payout back to `approved`. Surfaced as
+   * an amber "Revert to Approved" button in the modal footer when the
+   * current status is `paid`. Works for every payout method (USDC, wire,
+   * mercury_card, external, off-platform) — previously there was no UI
+   * affordance to undo a `mark-paid` after the fact.
+   *
+   * Mirrors `onUnapprove`'s contract: returns a string error message (NOT
+   * throws) when the call fails so the modal can surface it inline;
+   * resolves to `undefined` on success.
+   *
+   * Surfaces a one-step confirm before firing — the action clears
+   * paidAt + tx metadata (preserving the audit trail) and the parent will
+   * normally re-fetch the row, so a misclick is recoverable but unwanted.
+   */
+  onRevertPaid?: () => Promise<string | void> | string | void;
+  /**
    * lasagna-92103: backend admin PATCH no longer enforces the per-submission
    * cap, so `allowOverSubmissionCap` is no longer forwarded by this modal.
    * The signature still accepts the field for back-compat with parents that
@@ -170,6 +186,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onApprove,
   onReject,
   onUnapprove,
+  onRevertPaid,
   onSaveAmount,
   onSaveAdminNotes,
   onMarkPaid,
@@ -271,6 +288,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // caprino-92103: inline error for "Revert to Pending". Rendered below the
   // footer button row. Mirrors the saveAmountError pattern from aglio-62584.
   const [unapproveError, setUnapproveError] = useState<string | null>(null);
+
+  // culatello-92103: inline error + confirm gate for "Revert to Approved"
+  // (paid -> approved). Confirm is a one-click ack so the admin doesn't
+  // accidentally drop the historical mark-paid record.
+  const [revertPaidError, setRevertPaidError] = useState<string | null>(null);
+  const [revertPaidConfirming, setRevertPaidConfirming] = useState(false);
 
   const [showMarkPaidForm, setShowMarkPaidForm] = useState(false);
   const [wireRef, setWireRef] = useState('');
@@ -1735,6 +1758,46 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               Re-open
             </button>
           )}
+          {/* culatello-92103: revert paid -> approved. Surfaced for ANY
+              payout method (USDC, wire, mercury_card, external,
+              off-platform) — previously the only "undo" affordance lived on
+              `approved` rows. Click 1 = arm confirm; click 2 = fire.
+              Confirms are unusual on reversible actions per project
+              convention, but this one drops the historical mark-paid record
+              (paidAt + tx metadata cleared) so a misclick is undesirable.
+              Audit trail is preserved either way. Admin-only — gated on
+              isAdminViewer to match mark-paid's own permission. */}
+          {isPaid && isAdminViewer && onRevertPaid && (
+            <button
+              type="button"
+              onClick={async () => {
+                if (!revertPaidConfirming) {
+                  setRevertPaidConfirming(true);
+                  return;
+                }
+                setRevertPaidError(null);
+                const err = await onRevertPaid();
+                setRevertPaidConfirming(false);
+                if (typeof err === 'string' && err) {
+                  setRevertPaidError(err);
+                }
+              }}
+              disabled={busy || selfPayoutBlocked}
+              className={
+                revertPaidConfirming
+                  ? 'inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium disabled:opacity-50'
+                  : 'inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-500/50 text-amber-300 hover:bg-amber-500/10 text-sm font-medium disabled:opacity-50'
+              }
+              title={
+                revertPaidConfirming
+                  ? 'Click again to confirm — clears paidAt + tx metadata'
+                  : 'Move this paid payout back to approved (clears paidAt + tx metadata)'
+              }
+            >
+              <Undo2 size={14} />
+              {revertPaidConfirming ? 'Click again to confirm' : 'Revert to Approved'}
+            </button>
+          )}
           {/* tiramisu-49102: Pay-again button. Surfaced only when status is
               paid AND we have enough to pre-fill the CreatePrepaymentModal —
               i.e. a method is set, and (for USDC) a wallet, or (for wire) a
@@ -1843,6 +1906,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
               <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
               <span>{unapproveError}</span>
+            </div>
+          )}
+          {/* culatello-92103: inline error for Revert-paid. Surfaces backend
+              NOT_PAID + network failure. */}
+          {revertPaidError && (
+            <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{revertPaidError}</span>
             </div>
           )}
           {/* argentina-92103: inline error for Flag-ready. Same pattern

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4311,6 +4311,32 @@ export async function unapproveAdminPayout(
 }
 
 /**
+ * culatello-92103: revert a `paid` payout back to `approved`. The previous
+ * "Revert to Pending" affordance only worked for `approved` rows — there
+ * was no way to undo an out-of-band `mark-paid` (wire, mercury_card,
+ * external, off-platform). This endpoint covers every payout method:
+ * status flips paid -> approved and the mark-paid metadata (paidAt,
+ * transactionHash, wireReference, mercuryCardId, mercuryCardLast4,
+ * externalProofUrl) is cleared. The audit trail is preserved.
+ *
+ * Backend validates the current status is 'paid' (400 NOT_PAID otherwise)
+ * and writes a payout_audit row with action='unmark_paid'.
+ */
+export async function revertPaidAdminPayout(
+  id: string,
+  opts?: { note?: string },
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}/revert-paid`,
+    {
+      method: 'POST',
+      body: { note: opts?.note },
+    },
+  );
+  return res.payout;
+}
+
+/**
  * argentina-92103: regional underbosses (and admins) signal "this payout is
  * ready for the payments team to pay" without actually changing status or
  * sending funds. Writes a payout_audit row + fires Telegram + email to the

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -12,6 +12,7 @@ import {
   approveAdminPayout,
   rejectAdminPayout,
   unapproveAdminPayout,
+  revertPaidAdminPayout,
   updateAdminPayout,
   markAdminPayoutPaid,
   executeAdminPayout,
@@ -1080,6 +1081,41 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);
                 await Promise.all([refresh(), loadPrepayQueue()]);
+                return;
+              } catch (err: any) {
+                return err?.message || 'Revert failed';
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            // culatello-92103: revert a paid payout back to approved. Works
+            // for every payout method (USDC, wire, mercury_card, external,
+            // off-platform). Stays-open + refreshes the same way unapprove
+            // does so the admin can immediately re-execute / re-mark-paid.
+            // Toast on success surfaces the method so the admin can confirm
+            // the right row reverted.
+            onRevertPaid={async () => {
+              setModalBusy(true);
+              try {
+                const priorMethod = detail.payoutMethod;
+                await revertPaidAdminPayout(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
+                setDetail(fresh);
+                await Promise.all([refresh(), loadPrepayQueue()]);
+                const m = fresh.payoutMethod ?? priorMethod;
+                const methodLabel =
+                  m === 'usdc_base'
+                    ? 'USDC'
+                    : m === 'wire'
+                      ? 'wire'
+                      : m === 'mercury_card'
+                        ? 'Mercury card'
+                        : m === 'external'
+                          ? 'external'
+                          : m === 'off_platform'
+                            ? 'off-platform'
+                            : (m ?? 'external');
+                pushToast(`Reverted ${methodLabel} payment to approved status`, 'success');
                 return;
               } catch (err: any) {
                 return err?.message || 'Revert failed';

--- a/supabase/migrations/20260529_culatello_92103_add_unmark_paid_audit_action.sql
+++ b/supabase/migrations/20260529_culatello_92103_add_unmark_paid_audit_action.sql
@@ -1,0 +1,31 @@
+-- culatello-92103: add 'unmark_paid' to payout_audit action CHECK constraint.
+--
+-- Adds the audit action for the new POST /api/admin/payouts/:id/revert-paid
+-- endpoint, which flips a paid payout back to 'approved' so the admin can
+-- re-execute (or re-mark-paid out-of-band) after correcting an error. Mirrors
+-- the existing 'unapprove' action (approved -> pending).
+--
+-- The constraint as it stands in prod allows:
+--   create, approve, unapprove, reject, edit_amount, edit_documents,
+--   edit_recipient, mark_paid, mark_failed, flag_ready, bulk_execute, retry,
+--   cancel
+-- This drops + recreates with 'unmark_paid' appended.
+
+ALTER TABLE payout_audit DROP CONSTRAINT IF EXISTS payout_audit_action_check;
+ALTER TABLE payout_audit ADD CONSTRAINT payout_audit_action_check
+  CHECK (action = ANY (ARRAY[
+    'create'::text,
+    'approve'::text,
+    'unapprove'::text,
+    'reject'::text,
+    'edit_amount'::text,
+    'edit_documents'::text,
+    'edit_recipient'::text,
+    'mark_paid'::text,
+    'unmark_paid'::text,
+    'mark_failed'::text,
+    'flag_ready'::text,
+    'bulk_execute'::text,
+    'retry'::text,
+    'cancel'::text
+  ]));


### PR DESCRIPTION
## Summary
- Adds a new `POST /api/admin/payouts/:id/revert-paid` endpoint that flips a paid payout back to `approved` for **any** payout method (USDC, wire, mercury_card, external, off-platform). Clears `paidAt`, `transactionHash`, `wireReference`, `mercuryCardId`, `mercuryCardLast4`, `externalProofUrl`; writes a `payout_audit` row with action `unmark_paid`.
- Surfaces a "Revert to Approved" amber button in `PayoutReviewModal` when `status === 'paid'`. One-click arms a confirm, second click fires. Inline error on failure mirrors the existing `unapprove` pattern.
- Wires `onRevertPaid` from `PaymentsAdminPage` with a success toast (`"Reverted ${method} payment to approved status"`) and the same stay-open refresh as `unapprove`.
- Adds DB migration `20260529_culatello_92103_add_unmark_paid_audit_action.sql` to extend the `payout_audit_action_check` constraint with `'unmark_paid'`. Migration applied to prod prior to merge (per project convention — backend deploys quickly off master).

## Why
The previous "Revert to pending" affordance only worked for `approved` rows; once an admin clicked **Mark paid (manual)** on a wire/mercury/external row, there was no UI path to undo it. Snax needed to revert a Puebla external payment but the existing endpoint returned `Cannot unapprove a payout in status 'paid'` (and there was no button rendered at all on paid rows). This adds the missing inverse of `mark-paid` that works for every method.

## Test plan
- [ ] Open Puebla's paid external payout in the modal at `/payments`
- [ ] Confirm an amber "Revert to Approved" button is visible
- [ ] Click once → button shifts to filled "Click again to confirm"
- [ ] Click again → row flips to `approved`, toast reads "Reverted external payment to approved status"
- [ ] Verify in DB: `payouts.paid_at IS NULL`, `payouts.status = 'approved'`, audit row inserted with `action = 'unmark_paid'`, `old_status = 'paid'`, `new_status = 'approved'`
- [ ] Retry on a USDC row (or wire/mercury) to confirm the affordance is no longer USDC-gated
- [ ] Confirm row-level revert icon on `approved` rows still works (caprino-92103 path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)