### PR TITLE
feat(bismarck-58295): add Brave Browser to discovery options

### DIFF
--- a/backend/src/lib/surveyQuestions.ts
+++ b/backend/src/lib/surveyQuestions.ts
@@ -42,7 +42,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     type: 'multiple',
     multi: false,
     text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'The organizer', 'Other'],
+    options: ['A friend', 'Twitter/X', 'The organizer', 'Brave Browser', 'Other'],
     allowOther: true,
   },
   {

--- a/frontend/src/lib/surveyQuestions.ts
+++ b/frontend/src/lib/surveyQuestions.ts
@@ -42,7 +42,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     type: 'multiple',
     multi: false,
     text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'The organizer', 'Other'],
+    options: ['A friend', 'Twitter/X', 'The organizer', 'Brave Browser', 'Other'],
     allowOther: true,
   },
   {


### PR DESCRIPTION
Adds 'Brave Browser' as the 4th option (right before 'Other') in the post-event survey's discovery question.

Test link: https://rsv.pizza/survey/041010e7-b32b-4040-b1d1-070d9c2806f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)