### PR TITLE
fix(lardo-92103): vercel.json builds/functions conflict

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -3,12 +3,10 @@
   "builds": [
     {
       "src": "src/index.ts",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": { "maxDuration": 300 }
     }
   ],
-  "functions": {
-    "src/index.ts": { "maxDuration": 300 }
-  },
   "routes": [
     {
       "src": "/api/(.*)",


### PR DESCRIPTION
## Summary

Backend prod deploys were rejected by Vercel:

> Error: The functions property cannot be used in conjunction with the builds property.

PR #722 (`nduja-58295`) added a top-level `functions` block to `backend/vercel.json` to set `maxDuration: 300` for the ZIP download endpoint, but the existing config uses the legacy `builds` array. These are mutually exclusive.

This PR moves `maxDuration` into the build entry's `config` block, which is the documented pattern for `@vercel/node` under legacy `builds`. The ZIP download keeps its 300s limit and the deploy goes through.

## Changes

- `backend/vercel.json`: delete top-level `functions` object; add `config: { maxDuration: 300 }` to the existing `@vercel/node` build entry.

## Test plan

- [x] `node -e "JSON.parse(...)"` parses cleanly
- [ ] Vercel backend deploy succeeds on merge to master
- [ ] ZIP download endpoint still runs to completion past 60s

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)