### PR TITLE
fix(nduja-92103): accept ENS in payment details autosave

### DIFF
--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -90,7 +90,13 @@ export const PaymentDetailsCard: React.FC = () => {
   const methodValid = useMemo(() => {
     if (method == null) return false;
     if (method === 'usdc_base') {
-      return /^0x[0-9a-fA-F]{40}$/.test(walletAddress.trim());
+      // nduja-92103: accept hex OR ENS (matches PayoutMethodPicker
+      // taleggio-30219). Strict 0x-only check silently grayed out
+      // the autosave for hosts typing puebla.eth-style names.
+      const trimmed = walletAddress.trim();
+      const isHex = /^0x[0-9a-fA-F]{40}$/.test(trimmed);
+      const isEns = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(trimmed);
+      return isHex || isEns;
     }
     if (method === 'wire') {
       // arugula-38633 (follow-up): wire is now a single email field —


### PR DESCRIPTION
## Summary
- `PaymentDetailsCard`'s `methodValid` only accepted `0x`-hex wallet addresses, so hosts who picked USDC on Base and typed an ENS name (e.g. `puebla.eth`, `vitalik.eth`) saw the Submit button stay grayed out and autosave never fired.
- `PayoutMethodPicker` (taleggio-30219) and `NewPayoutForm` already accept either a hex address or an ENS-style name; this fix mirrors that behavior in the autosave gate so the two stay in sync.

## Test plan
- [ ] On an event payouts tab, switch payment method to **USDC on Base**.
- [ ] Type `vitalik.eth` (or any `*.eth`-style name) — Submit button should become active and autosave should fire after the debounce.
- [ ] Type a valid `0x` wallet address — still works as before.
- [ ] Type an obviously invalid string (`foo`, `0xshort`) — Submit stays disabled.
- [ ] `cd frontend && npx tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)