### PR TITLE
fix(scamorza-71820): legible text in AI-share modal

### DIFF
--- a/frontend/src/components/report/ShareWithAiButton.tsx
+++ b/frontend/src/components/report/ShareWithAiButton.tsx
@@ -117,31 +117,31 @@ export function ShareWithAiButton({ tag }: ShareWithAiButtonProps) {
             onClick={() => setOpen(false)}
           >
             <div
-              className="bg-white border border-theme-stroke rounded-2xl p-6 w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto"
+              className="bg-white border border-gray-200 rounded-2xl p-6 w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-start justify-between mb-4">
-                <h3 className="text-lg font-semibold text-theme-text flex items-center gap-2">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
                   <Sparkles size={18} />
                   {t('consolidated.shareWithAi')}
                 </h3>
                 <button
                   type="button"
                   onClick={() => setOpen(false)}
-                  className="text-theme-text-faint hover:text-theme-text-secondary"
+                  className="text-gray-400 hover:text-gray-600"
                   aria-label="Close"
                 >
                   <X size={20} />
                 </button>
               </div>
 
-              <p className="text-sm text-theme-text-muted mb-4">
+              <p className="text-sm text-gray-600 mb-4">
                 {t('consolidated.shareWithAiHint')}
               </p>
 
               {loading ? (
                 <div className="flex items-center justify-center py-8">
-                  <Loader2 size={20} className="animate-spin text-theme-text-muted" />
+                  <Loader2 size={20} className="animate-spin text-gray-500" />
                 </div>
               ) : data?.token && data.url ? (
                 <>
@@ -151,7 +151,7 @@ export function ShareWithAiButton({ tag }: ShareWithAiButtonProps) {
                         readOnly
                         value={data.url}
                         onFocus={(e) => e.currentTarget.select()}
-                        className="flex-1 px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke text-sm text-theme-text font-mono"
+                        className="flex-1 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-900 font-mono"
                       />
                       <button
                         type="button"
@@ -166,7 +166,7 @@ export function ShareWithAiButton({ tag }: ShareWithAiButtonProps) {
                     </div>
                   </div>
 
-                  <div className="text-xs text-theme-text-faint mb-4">
+                  <div className="text-xs text-gray-400 mb-4">
                     {lastUsedDisplay
                       ? `${t('consolidated.shareWithAiLastUsed')}: ${lastUsedDisplay}`
                       : t('consolidated.shareWithAiNever')}
@@ -188,7 +188,7 @@ export function ShareWithAiButton({ tag }: ShareWithAiButtonProps) {
                       type="button"
                       onClick={handleRotate}
                       disabled={acting !== null}
-                      className="px-3 py-2 rounded-lg text-sm bg-theme-surface border border-theme-stroke hover:border-theme-text-muted text-theme-text disabled:opacity-50 inline-flex items-center gap-1"
+                      className="px-3 py-2 rounded-lg text-sm bg-gray-50 border border-gray-200 hover:border-gray-400 text-gray-900 disabled:opacity-50 inline-flex items-center gap-1"
                     >
                       {acting === 'rotate' ? (
                         <Loader2 size={14} className="animate-spin" />
@@ -213,7 +213,7 @@ export function ShareWithAiButton({ tag }: ShareWithAiButtonProps) {
                     {t('consolidated.shareWithAiCreate')}
                   </button>
                   {!effectiveTag && (
-                    <p className="text-xs text-theme-text-faint text-center max-w-xs">
+                    <p className="text-xs text-gray-400 text-center max-w-xs">
                       {t('consolidated.shareWithAiNoTag')}
                     </p>
                   )}


### PR DESCRIPTION
## Problem
`ShareWithAiButton.tsx` renders its modal via `createPortal(..., document.body)`. Because it is portaled to the body it sits **outside** the `.gpp-theme` wrapper, so the `--theme-*` CSS variables never resolve. Every `text-theme-*` / `border-theme-*` / `bg-theme-*` class inside the modal rendered invisible (white-on-white) or unstyled.

PR #727 hardcoded the modal background to `bg-white` but left the text classes theme-scoped, so the title and hint text were invisible.

## Fix
Swap the theme-scoped utility classes inside the portaled modal for explicit Tailwind gray-scale colors (`text-gray-900`, `text-gray-600`, `text-gray-400`, `border-gray-200`, `bg-gray-50`).

Surgical — only the 9 affected classNames inside the portal. The trigger button (inside `.gpp-theme`, works fine), the red action buttons, the error box, and all logic are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)