### PR TITLE
feat(caciotta-92104): resolve ENS in wallet fields end-to-end

### DIFF
--- a/backend/prisma/migrations/20260529150000_add_payout_wallet_input/migration.sql
+++ b/backend/prisma/migrations/20260529150000_add_payout_wallet_input/migration.sql
@@ -1,0 +1,20 @@
+-- caciotta-92104: preserve the original user-supplied wallet input
+-- alongside the canonical resolved 0x address.
+--
+-- payout_wallet_address holds the on-chain 0x destination (what
+-- viem.sendTransaction sees). payout_wallet_input holds whatever the user
+-- originally typed -- usually identical to the address, but for ENS-name
+-- payouts it preserves the human-readable name (e.g. 'ariutokintumi.eth')
+-- so the admin UI can display "ariutokintumi.eth -> 0xa1b2..." instead of
+-- silently losing the ENS string at write time. Nullable for backward-compat
+-- with historical rows where we never captured the input.
+--
+-- Applied to prod manually via pg before this migration was committed; the
+-- file exists so a fresh `prisma migrate deploy` doesn't try to re-apply.
+
+ALTER TABLE "payouts" ADD COLUMN IF NOT EXISTS "payout_wallet_input" TEXT;
+
+-- caciotta-92104: column-level SELECT grants. The repo's security audit
+-- switched to column-level grants for new payout columns; mirror the
+-- existing payout_wallet_address grants.
+GRANT SELECT ("payout_wallet_input") ON "payouts" TO anon, authenticated;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1701,6 +1701,12 @@ model Payout {
   payoutMethod String? @map("payout_method")
 
   payoutWalletAddress String? @map("payout_wallet_address")
+  // caciotta-92104: original user-typed wallet input (e.g. an ENS name like
+  // `ariutokintumi.eth`). `payoutWalletAddress` stays canonical (always 0x for
+  // viem.sendTransaction). When the input is identical to the resolved 0x
+  // we leave this null. Used by admin UI to show "name.eth -> 0xa1b2..."
+  // instead of silently losing the ENS string at write time.
+  payoutWalletInput   String? @map("payout_wallet_input")
   payoutBankDetails   Json?   @map("payout_bank_details")
   mercuryCardId       String? @map("mercury_card_id")
   mercuryCardLast4    String? @map("mercury_card_last4")

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -35,7 +35,7 @@ import {
 import { createPublicClient, http, formatUnits, erc20Abi } from 'viem';
 import { base } from 'viem/chains';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
-import { resolveWalletInput } from '../services/ens.service.js';
+import { resolveWalletInput, resolveWalletInputWithMeta } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 import { notifyHostOfPaymentExecution } from '../services/payoutTelegramNotify.js';
 import { emailHostOfPaymentExecution } from '../services/payoutEmailNotify.js';
@@ -539,6 +539,10 @@ function serializePayout(row: any): any {
     status: row.status,
     payoutMethod: row.payoutMethod,
     payoutWalletAddress: row.payoutWalletAddress,
+    // caciotta-92104: original ENS input (e.g. `puebla.eth`) when the
+    // canonical 0x came from ENS resolution. Null when the host typed a
+    // 0x directly. Frontend renders "name.eth -> 0xa1b2..." in admin views.
+    payoutWalletInput: row.payoutWalletInput ?? null,
     payoutBankDetails: row.payoutBankDetails,
     mercuryCardId: row.mercuryCardId,
     mercuryCardLast4: row.mercuryCardLast4,
@@ -2309,16 +2313,27 @@ router.patch(
         // taleggio-30219: admin override also accepts ENS names; resolve to
         // 0x before persisting so the execution path (which already expects
         // 0x) stays untouched.
+        // caciotta-92104: also persist the original input alongside the
+        // resolved 0x so admin UI can render "name.eth -> 0xa1b2..." instead
+        // of silently losing the ENS string at write time. Resolution failures
+        // surface as 400 ENS_RESOLUTION_FAILED so the admin sees the problem
+        // BEFORE clicking Execute (not as a silent fail at send time).
         if (payoutWalletAddress === null) {
           data.payoutWalletAddress = null;
+          data.payoutWalletInput = null;
         } else {
           try {
-            data.payoutWalletAddress = await resolveWalletInput(String(payoutWalletAddress));
+            const resolved = await resolveWalletInputWithMeta(String(payoutWalletAddress));
+            data.payoutWalletAddress = resolved.address;
+            // Only persist the input when it differs from the canonical 0x
+            // (i.e. when ENS was used). Storing the 0x in both columns is
+            // redundant and clutters the display logic.
+            data.payoutWalletInput = resolved.wasEns ? resolved.input : null;
           } catch (err: any) {
             throw new AppError(
               err?.message || 'Could not resolve wallet address',
               400,
-              'INVALID_WALLET_ADDRESS'
+              'ENS_RESOLUTION_FAILED'
             );
           }
         }
@@ -3240,6 +3255,17 @@ async function executePayout(params: {
             status: 'paid',
             paidAt: new Date(),
             transactionHash: result.txHash,
+            // caciotta-92104: when ENS was resolved at send time, persist
+            // the canonical 0x back to `payoutWalletAddress` and preserve
+            // the original ENS string in `payoutWalletInput`. Future retries
+            // skip the lookup, and the admin UI can show "name.eth -> 0xa1b2..."
+            // alongside the audit trail. No-op when the input was already 0x.
+            ...(result.resolvedFromEns
+              ? {
+                  payoutWalletAddress: result.resolvedFromEns.address,
+                  payoutWalletInput: result.resolvedFromEns.input,
+                }
+              : {}),
           },
           include: {
             party: { select: PAYOUT_PARTY_SELECT },
@@ -3261,9 +3287,16 @@ async function executePayout(params: {
             actorKind: actor.actorKind,
             // salame-92103: append the override marker so the audit row
             // captures that the per-party cap was bypassed for this payout.
+            // caciotta-92104: when ENS was resolved, the audit note records
+            // the name -> 0x mapping so the audit trail reflects what was
+            // sent on-chain (the 0x) and where the human-readable input came
+            // from (the ENS name).
             note: `USDC on Base sent: tx ${result.txHash}, ` +
               `from ${result.fromAddress} to ${result.toAddress}, ` +
               `$${result.amountUsd.toFixed(2)}` +
+              (result.resolvedFromEns
+                ? ` [resolved ENS ${result.resolvedFromEns.input} -> ${result.resolvedFromEns.address}]`
+                : '') +
               (allowOverPartyCap ? ' [override: party cap]' : ''),
           },
         });

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -23,7 +23,7 @@ import { AppError } from '../middleware/error.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
-import { looksLikeEnsName, resolveWalletInput } from '../services/ens.service.js';
+import { looksLikeEnsName, resolveWalletInput, resolveWalletInputWithMeta } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 
@@ -91,6 +91,10 @@ function serializePayout(p: any) {
     status: p.status,
     payoutMethod: p.payoutMethod,
     payoutWalletAddress: p.payoutWalletAddress ?? null,
+    // caciotta-92104: original user input (ENS name) when the resolved 0x
+    // came from ENS resolution. Null otherwise — frontend uses this to
+    // render "name.eth -> 0xa1b2..." in admin views.
+    payoutWalletInput: p.payoutWalletInput ?? null,
     payoutBankDetails: p.payoutBankDetails ?? null,
     mercuryCardId: p.mercuryCardId ?? null,
     mercuryCardLast4: p.mercuryCardLast4 ?? null,
@@ -243,6 +247,31 @@ function validateMethodSpecificFields(
 async function resolveWalletOrThrow(input: string): Promise<string> {
   try {
     return await resolveWalletInput(input);
+  } catch (err: any) {
+    throw new AppError(
+      err?.message || 'Could not resolve wallet address',
+      400,
+      'INVALID_WALLET_ADDRESS'
+    );
+  }
+}
+
+/**
+ * caciotta-92104: same as `resolveWalletOrThrow` but also returns the original
+ * input + whether it was ENS. Used by POST/PATCH so we can persist the human-
+ * readable input (e.g. `puebla.eth`) alongside the canonical 0x address.
+ */
+async function resolveWalletOrThrowWithMeta(input: string): Promise<{
+  address: string;
+  /** The original input when ENS was used, null otherwise (no display needed). */
+  walletInput: string | null;
+}> {
+  try {
+    const resolved = await resolveWalletInputWithMeta(input);
+    return {
+      address: resolved.address,
+      walletInput: resolved.wasEns ? resolved.input : null,
+    };
   } catch (err: any) {
     throw new AppError(
       err?.message || 'Could not resolve wallet address',
@@ -1068,9 +1097,14 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     // taleggio-30219: resolve the wallet input once, BEFORE the create, so
     // we persist a canonical 0x address even if the host typed an ENS name.
     // Reused by the `saveAsDefault` write below so we don't resolve twice.
+    // caciotta-92104: also capture the original input so we can persist
+    // `payoutWalletInput` for display.
     let resolvedWallet: string | null = null;
+    let resolvedWalletInput: string | null = null;
     if (hasMethod && payoutMethod === 'usdc_base' && typeof payoutWalletAddress === 'string') {
-      resolvedWallet = await resolveWalletOrThrow(payoutWalletAddress);
+      const r = await resolveWalletOrThrowWithMeta(payoutWalletAddress);
+      resolvedWallet = r.address;
+      resolvedWalletInput = r.walletInput;
     }
 
     // pancetta-37195: stamp each new document with the uploader.
@@ -1167,6 +1201,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           // when the host hasn't set their payment details yet.
           payoutMethod: hasMethod ? payoutMethod : null,
           payoutWalletAddress: resolvedWallet,
+          // caciotta-92104: preserve original ENS input alongside 0x. Null
+          // when the host typed a 0x directly (no display difference to show).
+          payoutWalletInput: resolvedWalletInput,
           ...(hasMethod && payoutMethod === 'wire' && payoutBankDetails && typeof payoutBankDetails === 'object'
             ? { payoutBankDetails: payoutBankDetails as Prisma.InputJsonValue }
             : {}),
@@ -1466,16 +1503,28 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       await assertMercuryAllowed(partyId, payoutMethod);
       data.payoutMethod = payoutMethod;
       // Clear stale method-specific fields when method changes
-      if (payoutMethod !== 'usdc_base') data.payoutWalletAddress = null;
+      if (payoutMethod !== 'usdc_base') {
+        data.payoutWalletAddress = null;
+        // caciotta-92104: paired with payoutWalletAddress; never leave a
+        // stale ENS string after the host switches to wire/mercury.
+        data.payoutWalletInput = null;
+      }
       if (payoutMethod !== 'wire') data.payoutBankDetails = Prisma.JsonNull;
       if (payoutMethod !== 'mercury_card') data.mercuryCardLast4 = null;
     }
 
     if (payoutWalletAddress !== undefined) {
       // taleggio-30219: resolve ENS → 0x before persisting. Null clears the field.
-      data.payoutWalletAddress = payoutWalletAddress === null
-        ? null
-        : await resolveWalletOrThrow(String(payoutWalletAddress));
+      // caciotta-92104: also persist the original input alongside the resolved
+      // 0x so admin UI can render "name.eth -> 0xa1b2...". Null clears both.
+      if (payoutWalletAddress === null) {
+        data.payoutWalletAddress = null;
+        data.payoutWalletInput = null;
+      } else {
+        const r = await resolveWalletOrThrowWithMeta(String(payoutWalletAddress));
+        data.payoutWalletAddress = r.address;
+        data.payoutWalletInput = r.walletInput;
+      }
     }
     if (payoutBankDetails !== undefined) {
       data.payoutBankDetails = payoutBankDetails === null

--- a/backend/src/services/ens.service.ts
+++ b/backend/src/services/ens.service.ts
@@ -61,3 +61,33 @@ export async function resolveWalletInput(input: string): Promise<`0x${string}`> 
   }
   throw new Error('Wallet address must be a 0x… address or an ENS name (e.g. alice.eth)');
 }
+
+/**
+ * caciotta-92104: same contract as `resolveWalletInput` but also returns
+ * whether the resolution went through ENS, plus the canonical input shape.
+ * Lets callers persist both the resolved 0x AND the human-readable input
+ * (e.g. `ariutokintumi.eth`) without re-deriving "was this ENS?" downstream.
+ */
+export interface WalletResolution {
+  address: `0x${string}`;
+  /** The trimmed user input — preserved as-is for display (ENS name or 0x). */
+  input: string;
+  /** True when the input was an ENS name (so display can show "name -> 0x"). */
+  wasEns: boolean;
+}
+
+export async function resolveWalletInputWithMeta(input: string): Promise<WalletResolution> {
+  const trimmed = input.trim();
+  if (/^0x[0-9a-fA-F]{40}$/.test(trimmed)) {
+    return {
+      address: trimmed.toLowerCase() as `0x${string}`,
+      input: trimmed.toLowerCase(),
+      wasEns: false,
+    };
+  }
+  if (looksLikeEnsName(trimmed)) {
+    const address = await resolveEns(trimmed);
+    return { address, input: trimmed, wasEns: true };
+  }
+  throw new Error('Wallet address must be a 0x… address or an ENS name (e.g. alice.eth)');
+}

--- a/backend/src/services/usdc-base.service.ts
+++ b/backend/src/services/usdc-base.service.ts
@@ -32,6 +32,7 @@ import {
 import { privateKeyToAccount, type PrivateKeyAccount } from 'viem/accounts';
 import { base } from 'viem/chains';
 import { prisma } from '../config/database.js';
+import { looksLikeEnsName, resolveEns } from './ens.service.js';
 
 const USDC_BASE_ADDRESS: Hex = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 const USDC_DECIMALS = 6;
@@ -76,6 +77,14 @@ export interface SendUsdcResult {
   fromAddress: `0x${string}`;
   toAddress: `0x${string}`;
   amountUsd: number;
+  /**
+   * caciotta-92104: when the caller passed an ENS name, this is the
+   * resolved 0x address used on-chain (same as `toAddress`); when the
+   * caller passed a 0x address, this is null. Used by the execute path
+   * to persist the canonical 0x back onto the Payout row so subsequent
+   * retries skip resolution and the audit trail shows what was sent.
+   */
+  resolvedFromEns: { input: string; address: `0x${string}` } | null;
 }
 
 function getEnvNumber(name: string, fallback: number): number {
@@ -224,11 +233,43 @@ export async function sendUsdcPayment(
   amountUsd: number,
   opts?: { allowOverPerAddressCap?: boolean },
 ): Promise<SendUsdcResult> {
-  // 1. Address validation
-  if (!toAddress || !isAddress(toAddress)) {
+  // 1. Address validation. caciotta-92104: also accept ENS names — older
+  //    Payout rows (or any path that slipped past the write-side resolver)
+  //    can carry an ENS string in `payoutWalletAddress`. Resolving here is
+  //    defense-in-depth so the execute path never silently fails on a
+  //    `.eth` recipient. Puebla's ariutokintumi.eth payout died this way
+  //    (status -> failed) before this fix.
+  if (!toAddress || typeof toAddress !== 'string') {
     throw new Error(`Invalid recipient address: ${toAddress}`);
   }
-  const recipient = toAddress as `0x${string}`;
+  const trimmedInput = toAddress.trim();
+  let recipient: `0x${string}`;
+  let resolvedFromEns: { input: string; address: `0x${string}` } | null = null;
+  if (isAddress(trimmedInput)) {
+    recipient = trimmedInput as `0x${string}`;
+  } else if (looksLikeEnsName(trimmedInput)) {
+    try {
+      const resolved = await resolveEns(trimmedInput);
+      recipient = resolved;
+      resolvedFromEns = { input: trimmedInput, address: resolved };
+      console.log(
+        `[usdc-base] resolved ENS ${trimmedInput} -> ${resolved} via ETH mainnet`,
+      );
+    } catch (err: any) {
+      // Surface a clear, machine-checkable error code so the admin UI can
+      // distinguish "ENS lookup failed" from "address is malformed" or
+      // "balance too low". The execute path catches this and writes the
+      // message into the failed payout audit row.
+      const reason = err?.message || 'ENS resolution failed';
+      const e = new Error(
+        `ENS_RESOLUTION_FAILED: could not resolve ${trimmedInput} on Ethereum mainnet (${reason}). ` +
+          `Edit the wallet to a 0x address or a different ENS name and retry.`,
+      );
+      throw e;
+    }
+  } else {
+    throw new Error(`Invalid recipient address: ${toAddress}`);
+  }
 
   // 2. Amount range checks
   if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
@@ -322,5 +363,6 @@ export async function sendUsdcPayment(
     fromAddress,
     toAddress: recipient,
     amountUsd,
+    resolvedFromEns,
   };
 }

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1275,7 +1275,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               )}
               {payout.payoutMethod === 'usdc_base' && payout.payoutWalletAddress && (
                 <div className="font-mono text-xs break-all text-theme-text-secondary">
-                  {payout.payoutWalletAddress}
+                  {/* caciotta-92104: when the host typed an ENS name, show
+                      "name.eth -> 0xa1b2…" so admins see both the input and
+                      the canonical on-chain destination. */}
+                  {payout.payoutWalletInput &&
+                  payout.payoutWalletInput.toLowerCase() !== payout.payoutWalletAddress.toLowerCase() ? (
+                    <>
+                      {payout.payoutWalletInput}
+                      <span className="text-theme-text-muted"> → </span>
+                      {payout.payoutWalletAddress}
+                    </>
+                  ) : (
+                    payout.payoutWalletAddress
+                  )}
                 </div>
               )}
               {payout.payoutMethod === 'wire' && payout.payoutBankDetails && (
@@ -1514,7 +1526,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       Send <strong>{formatUsd(Number(payout.finalAmountUsd))}</strong> USDC on Base to:
                     </p>
                     <p className="font-mono text-xs break-all text-emerald-900/80 bg-white/50 px-2 py-1.5 rounded">
-                      {payout.payoutWalletAddress || '(no address set — cannot execute)'}
+                      {/* caciotta-92104: render ENS -> 0x when input differs
+                          from the canonical 0x so admins see the human-readable
+                          name AND the on-chain destination before executing. */}
+                      {payout.payoutWalletAddress
+                        ? payout.payoutWalletInput &&
+                          payout.payoutWalletInput.toLowerCase() !== payout.payoutWalletAddress.toLowerCase()
+                          ? `${payout.payoutWalletInput} → ${payout.payoutWalletAddress}`
+                          : payout.payoutWalletAddress
+                        : '(no address set — cannot execute)'}
                     </p>
                     <div className="text-xs text-emerald-800">
                       {usdcCapLoading ? (

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -436,7 +436,12 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 </p>
                 {payout.payoutMethod === 'usdc_base' && payout.payoutWalletAddress && (
                   <p className="text-xs text-theme-text-muted font-mono mt-1">
-                    {payout.payoutWalletAddress}
+                    {/* caciotta-92104: show "name.eth -> 0xa1b2..." when the
+                        host typed an ENS name. Falls back to the raw address. */}
+                    {payout.payoutWalletInput &&
+                    payout.payoutWalletInput.toLowerCase() !== payout.payoutWalletAddress.toLowerCase()
+                      ? `${payout.payoutWalletInput} → ${payout.payoutWalletAddress}`
+                      : payout.payoutWalletAddress}
                   </p>
                 )}
                 {payout.payoutMethod === 'wire' && payout.payoutBankDetails && (() => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1751,6 +1751,14 @@ export interface Payout {
   // them via PaymentDetailsCard.
   payoutMethod: PayoutMethod | null;
   payoutWalletAddress: string | null;
+  /**
+   * caciotta-92104: original user-typed wallet input. Non-null only when the
+   * input was an ENS name (e.g. `puebla.eth`) that was resolved to the
+   * canonical 0x stored in `payoutWalletAddress`. Frontend renders
+   * "name.eth -> 0xa1b2..." in admin views when this differs from the address.
+   * Optional for backward-compat with cached payloads during rolling deploy.
+   */
+  payoutWalletInput?: string | null;
   payoutBankDetails: BankDetails | null;
   mercuryCardId: string | null;
   mercuryCardLast4: string | null;


### PR DESCRIPTION
## Summary

- USDC execute path now resolves ENS names (e.g. `ariutokintumi.eth`) to a 0x address before calling `viem.sendTransaction`. Previously any payout whose `payoutWalletAddress` held an ENS string blew up silently at send time (status: approved -> failed). Puebla's payout died this way.
- New `payouts.payout_wallet_input` column preserves the original user input alongside the canonical resolved 0x in `payout_wallet_address`. Admin views render `name.eth -> 0xa1b2...` when the two differ; address stays canonical for cap math + on-chain send.
- Admin PATCH `payoutWalletAddress` now resolves at save time and returns `ENS_RESOLUTION_FAILED` (400) so admins see the problem before clicking Execute, not as a silent fail at send.
- Execute path persists the resolved 0x + original input back to the Payout row on success, plus an audit-note entry recording the ENS -> 0x mapping. Future retries skip resolution; audit trail shows what was sent on-chain.

## Files

- `backend/prisma/migrations/20260529150000_add_payout_wallet_input/migration.sql` — adds `payouts.payout_wallet_input TEXT NULL` + column-level SELECT grant. Already applied to prod via pg before merge.
- `backend/prisma/schema.prisma` — `Payout.payoutWalletInput`
- `backend/src/services/ens.service.ts` — new `resolveWalletInputWithMeta` helper returning `{address, input, wasEns}`
- `backend/src/services/usdc-base.service.ts` — accepts ENS input, resolves via mainnet, returns `resolvedFromEns` in `SendUsdcResult`. Throws `ENS_RESOLUTION_FAILED` (clear error, not silent) on lookup failure.
- `backend/src/routes/admin-payout.routes.ts` — execute persists resolved 0x + input back; PATCH resolves at edit time with 400 surfacing.
- `backend/src/routes/payout.routes.ts` — host POST + PATCH persist `payoutWalletInput` alongside resolved 0x; clear both when method switches away from `usdc_base`.
- `frontend/src/types.ts` — `Payout.payoutWalletInput?: string | null`
- `frontend/src/components/payments-admin/PayoutReviewModal.tsx` + `payouts/PayoutDetailModal.tsx` — render `name.eth -> 0xa1b2...` when input differs from canonical 0x.

## Test plan

- [ ] Create a new payout with ENS `vitalik.eth` -> save -> execute -> succeeds and `payout_wallet_address` is the resolved 0x in the DB; `payout_wallet_input` is `vitalik.eth`.
- [ ] Edit an existing payout's wallet to `ariutokintumi.eth` -> PayoutReviewModal shows `ariutokintumi.eth -> 0xa1b2...`.
- [ ] Failed-resolution case (`nonexistent12345.eth`) on the admin PATCH -> 400 with `ENS_RESOLUTION_FAILED`, no silent fail.
- [ ] Retry the previously-failed Puebla payout once this lands: status flips approved -> paid, `payoutWalletInput` is set to `ariutokintumi.eth`, `payoutWalletAddress` becomes the 0x.
- [ ] Switch method usdc_base -> wire on a pending payout -> `payoutWalletInput` cleared alongside `payoutWalletAddress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)