### PR TITLE
feat(parmigiana-92104): SWC Hub reimbursement warning + ack gate

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -773,6 +773,12 @@ router.get(
           inviteCode: true,
           userId: true,
           coHosts: true,
+          // parmigiana-92104: surface country + event_tags so the
+          // ExternalPaymentModal can render the SWC Hub reimbursement warning
+          // (country='United States' OR event_tags includes 'SWC Hub') once a
+          // party is picked. Frontend-only guardrail — no backend gating.
+          country: true,
+          eventTags: true,
           user: { select: { id: true, name: true, email: true } },
         },
         orderBy: { createdAt: 'desc' },
@@ -851,6 +857,10 @@ router.get(
             inviteCode: p.inviteCode,
             hostUserId: p.user!.id,
             hostCandidates,
+            // parmigiana-92104: forwarded so the ExternalPaymentModal can
+            // render the SWC Hub reimbursement warning on the selected party.
+            country: p.country ?? null,
+            eventTags: Array.isArray(p.eventTags) ? p.eventTags : [],
           };
         });
 

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Send, Loader2, CheckCircle2, XCircle, ExternalLink, AlertTriangle } from 'lucide-react';
 import { Checkbox } from '../Checkbox';
+import { SwcHubWarning } from './SwcHubWarning';
+import { isSwcHubParty } from '../../utils/swcHub';
 import type { AdminPayout, WalletPaidTotal } from '../../types';
 import { bulkExecutePayouts, fetchWalletPaidTotal, type BulkSendResult } from '../../lib/api';
 
@@ -51,6 +53,13 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
   // sends across the whole batch (matches the per-address override pattern).
   const [overridePartyCap, setOverridePartyCap] = useState(false);
 
+  // parmigiana-92104: batch-level SWC Hub ack. Surfaced when one or more
+  // selected rows belong to SWC Hub parties (US or `event_tags`-tagged).
+  // A single checkbox covers the whole batch — stacks alongside the
+  // per-address (bianco) and per-party (salame) caps; all three can be
+  // active simultaneously, each with its own checkbox.
+  const [swcHubAck, setSwcHubAck] = useState(false);
+
   // Eligibility filter — keep in sync with backend bulk-execute filter
   // (USDC + approved-or-failed + valid 0x wallet). passata-49102 added
   // failed-status retry. Anything not matching is shown as "skipped".
@@ -90,6 +99,8 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
       setOverrideCap(false);
       // salame-92103: reset per-party cap ack on every fresh open.
       setOverridePartyCap(false);
+      // parmigiana-92104: reset SWC Hub ack on every fresh open.
+      setSwcHubAck(false);
     }
   }, [isOpen]);
 
@@ -212,6 +223,25 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
     };
   }, [eligible]);
 
+  // parmigiana-92104: SWC Hub analysis. Flag every eligible row whose party is
+  // either `country === 'United States'` OR carries the 'SWC Hub' event-tag.
+  // Used for the per-row indicator + the batch-level summary copy + the
+  // disabled state on Send (gated on `swcHubAck` when the count > 0).
+  const swcHubAnalysis = useMemo(() => {
+    if (eligible.length === 0) {
+      return { swcHubRowIds: new Set<string>(), swcHubPartyCount: 0 };
+    }
+    const swcHubRowIds = new Set<string>();
+    const swcHubParties = new Set<string>();
+    for (const p of eligible) {
+      if (isSwcHubParty(p.party)) {
+        swcHubRowIds.add(p.id);
+        if (p.party?.id) swcHubParties.add(p.party.id);
+      }
+    }
+    return { swcHubRowIds, swcHubPartyCount: swcHubParties.size };
+  }, [eligible]);
+
   // Close on Escape (only when not sending — never cancel an in-flight batch)
   useEffect(() => {
     if (!isOpen) return;
@@ -236,6 +266,10 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
     // salame-92103: block submit if any row would push its party past its
     // effective cap and the admin hasn't ticked the per-party override.
     if (partyCapAnalysis.overPartyCapPartyCount > 0 && !overridePartyCap) return;
+    // parmigiana-92104: block submit if any row belongs to an SWC Hub party
+    // and the admin hasn't ticked the SWC Hub ack. Frontend-only guardrail;
+    // the bulk-execute endpoint stays open so admins can still override.
+    if (swcHubAnalysis.swcHubRowIds.size > 0 && !swcHubAck) return;
     setPhase('sending');
     setErrorMsg(null);
     try {
@@ -407,6 +441,29 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
               </div>
             )}
 
+            {/* parmigiana-92104: SWC Hub batch warning. Surfaces a per-batch
+                summary count ("N selected payments are SWC Hub parties") +
+                a single ack checkbox. Stacks with the bianco / salame
+                warnings above. */}
+            {swcHubAnalysis.swcHubRowIds.size > 0 && (
+              <SwcHubWarning
+                isSwcHub={true}
+                acked={swcHubAck}
+                onAckChange={setSwcHubAck}
+                title="SWC Hub parties in this batch"
+                body={
+                  <>
+                    {swcHubAnalysis.swcHubRowIds.size} of {eligible.length} selected
+                    payment{eligible.length === 1 ? '' : 's'} belong to SWC Hub
+                    part{swcHubAnalysis.swcHubPartyCount === 1 ? 'y' : 'ies'} (
+                    {swcHubAnalysis.swcHubPartyCount} affected). Reimbursement for
+                    those should be processed through SWC, not rsv.pizza.
+                  </>
+                }
+                ackLabel="Allow SWC Hub sends — I acknowledge"
+              />
+            )}
+
             {/* bianco-89172: per-row indicator so admins can see WHICH wallets
                 in their selection would exceed. Folded into the existing
                 eligibility list (kept concise — first 8 rows). */}
@@ -464,7 +521,10 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                   (capAnalysis.overCapWalletCount > 0 && !overrideCap) ||
                   // salame-92103: block Send when any row would push its party
                   // past its cap and admin hasn't ack'd the per-party override.
-                  (partyCapAnalysis.overPartyCapPartyCount > 0 && !overridePartyCap)
+                  (partyCapAnalysis.overPartyCapPartyCount > 0 && !overridePartyCap) ||
+                  // parmigiana-92104: block Send when one or more rows belong to
+                  // SWC Hub parties and the admin hasn't ack'd the override.
+                  (swcHubAnalysis.swcHubRowIds.size > 0 && !swcHubAck)
                 }
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -19,6 +19,8 @@ import {
   Star,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
+import { SwcHubWarning } from './SwcHubWarning';
+import { isSwcHubParty } from '../../utils/swcHub';
 import {
   recordExternalPayment,
   searchApprovedParties,
@@ -113,6 +115,13 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
   // longer enforces the per-submission cap. Admin amount is canonical; the
   // amber warning below is informational only.
 
+  // parmigiana-92104: SWC Hub ack. Surfaced after a party is selected if it
+  // matches the SWC Hub heuristic (country='United States' OR event_tags
+  // includes 'SWC Hub'). Confirm button stays disabled until acked. Reset
+  // when the admin picks a different party so the ack doesn't carry across
+  // selections.
+  const [swcAck, setSwcAck] = useState(false);
+
   // Close on Escape
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -179,6 +188,10 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     return true;
   }, [recipientUserId, recipientEmailInput]);
 
+  // parmigiana-92104: derive SWC Hub status from the selected party (clean
+  // when nothing's selected yet).
+  const swcHub = isSwcHubParty(selectedParty);
+
   const canSubmit = useMemo(() => {
     if (!partyId.trim()) return false;
     if (!recipientReady) return false;
@@ -186,6 +199,10 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     if (!adminNotes.trim()) return false;
     // lasagna-92103: over-cap submissions are no longer gated on an ack —
     // admin amount is canonical; the warning is informational only.
+    // parmigiana-92104: SWC Hub parties require an ack before submit. The
+    // backend POST /external stays open so admins can still record the
+    // payment once they confirm.
+    if (swcHub && !swcAck) return false;
     return !submitting && !uploading;
   }, [
     partyId,
@@ -194,6 +211,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     adminNotes,
     submitting,
     uploading,
+    swcHub,
+    swcAck,
   ]);
 
   function handlePickParty(p: ApprovedPartySearchResult) {
@@ -212,6 +231,9 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     setPartyQuery('');
     setPartyResults([]);
     setSearchError(null);
+    // parmigiana-92104: reset SWC Hub ack on every party switch so the prior
+    // ack doesn't bleed into the new selection.
+    setSwcAck(false);
   }
 
   function handleChangeParty() {
@@ -220,6 +242,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     setRecipientEmailInput('');
     setPartyQuery('');
     setPartyResults([]);
+    // parmigiana-92104: also clear the SWC Hub ack when the admin unpicks.
+    setSwcAck(false);
   }
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -412,6 +436,18 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
               </p>
             )}
           </div>
+
+          {/* parmigiana-92104: SWC Hub reimbursement warning. Surfaces once a
+              party is picked AND that party matches the SWC Hub heuristic
+              (country='United States' OR event_tags includes 'SWC Hub').
+              Confirm button stays disabled until the admin ticks the ack. */}
+          {selectedParty && (
+            <SwcHubWarning
+              isSwcHub={swcHub}
+              acked={swcAck}
+              onAckChange={setSwcAck}
+            />
+          )}
 
           {/* Recipient picker — only shown once a party is selected.
               mortazza-92103: radio list (ports the bismarck-92103 prepay UX)

--- a/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
+++ b/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { X, DollarSign, Loader2, Pencil, AlertTriangle, CheckCircle2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
+import { SwcHubWarning } from './SwcHubWarning';
 import {
   fetchMarkPartyPaidPreview,
   markPartyPaid,
@@ -40,6 +41,15 @@ interface MarkPartyPaidModalProps {
    * once it lands.
    */
   partyNameHint?: string;
+  /**
+   * parmigiana-92104: caller-supplied SWC Hub signal. The preview endpoint
+   * doesn't surface party.country / party.eventTags, so the parent (which has
+   * the full row in hand) passes the resolved flag in. When `true`, the modal
+   * renders the amber warning + ack and disables the Mark/Close button until
+   * the admin ticks the override. Optional for backward-compat with callers
+   * that haven't been threaded yet.
+   */
+  isSwcHub?: boolean;
   onClose: () => void;
   /**
    * Called after a successful mark-paid POST. Parent should refresh both the
@@ -90,6 +100,7 @@ interface MarkPartyPaidModalProps {
 export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
   partyId,
   partyNameHint,
+  isSwcHub = false,
   onClose,
   onSuccess,
 }) => {
@@ -108,6 +119,15 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // parmigiana-92104: SWC Hub ack — required when `isSwcHub` is true.
+  // Reset when the modal target changes so an ack doesn't carry across
+  // distinct parties (parent unmounts/remounts the modal per partyId, but
+  // belt-and-suspenders on partyId change for safety).
+  const [swcAck, setSwcAck] = useState(false);
+  useEffect(() => {
+    setSwcAck(false);
+  }, [partyId]);
 
   // Esc to close — same pattern as CreatePrepaymentModal and PayoutReviewModal.
   useEffect(() => {
@@ -168,11 +188,14 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
   // caciotta + pinsa: standard mark-paid mode requires in-flight rows AND a
   // resolved mode selection. Close-out mode (pinsa) is a valid submit even
   // with count===0 because it stamps a timestamp; it doesn't need `mode`.
+  // parmigiana-92104: an SWC Hub party additionally requires an ack from the
+  // admin before any path is enabled.
   const canSubmit =
     !!preview &&
     !submitting &&
     !previewLoading &&
-    (isCloseOutMode || (count > 0 && mode !== null));
+    (isCloseOutMode || (count > 0 && mode !== null)) &&
+    (!isSwcHub || swcAck);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -249,6 +272,16 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* parmigiana-92104: SWC Hub reimbursement warning. Parent passes
+              `isSwcHub` based on the row's party.country / event_tags; the
+              preview endpoint doesn't surface those fields. Confirm button
+              stays disabled until the admin ticks the ack. */}
+          <SwcHubWarning
+            isSwcHub={isSwcHub}
+            acked={swcAck}
+            onAckChange={setSwcAck}
+          />
+
           {/* Preview summary */}
           {previewLoading && (
             <div className="flex items-center gap-2 text-sm text-theme-text-muted">

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -3,6 +3,8 @@ import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSig
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
+import { SwcHubWarning } from './SwcHubWarning';
+import { isSwcHubParty } from '../../utils/swcHub';
 import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
@@ -357,6 +359,24 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // effective reimbursement cap (already-paid total + this amount > cap).
   // Required to enable Execute when `partyWouldExceedCap === true`.
   const [overridePartyCap, setOverridePartyCap] = useState(false);
+
+  // parmigiana-92104: SWC Hub ack. Reimbursement for SWC Hub parties is
+  // processed through SWC, not rsv.pizza — admin reimbursement actions
+  // (Approve, Execute, Mark paid manual) stay disabled until the admin ticks
+  // the override. Revert-to-pending and revert-to-approved are NOT gated
+  // (those are rollback actions, not reimbursement). Reset on every modal
+  // close/reopen by the parent (PayoutReviewModal is re-mounted per payout).
+  const swcHub = isSwcHubParty(payout.party);
+  const [swcAck, setSwcAck] = useState(false);
+  // Re-sync the ack on payout swap (parent reload after refresh()) so admins
+  // don't carry an ack across distinct payouts displayed in the same modal.
+  useEffect(() => {
+    setSwcAck(false);
+  }, [payout.id]);
+  // True when an SWC Hub action button should be disabled (warning surfaces
+  // and admin hasn't acked). Combined with the existing busy / selfPayout
+  // / cap gates downstream.
+  const swcBlocked = swcHub && !swcAck;
 
   // taralli-58291: lightbox uses an index into `allPhotos` so ArrowLeft /
   // ArrowRight can cycle through receipts + pizza photos. Hooks must be
@@ -963,6 +983,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
           {/* Right: details */}
           <section className="space-y-4">
+            {/* parmigiana-92104: SWC Hub reimbursement warning + ack.
+                Surfaces above every reimbursement-action control (the Amount
+                edit and the footer's Approve / Execute / Mark paid). Sticks
+                in the body so it scrolls with the rest of the right column
+                instead of floating above the action footer. */}
+            <SwcHubWarning
+              isSwcHub={swcHub}
+              acked={swcAck}
+              onAckChange={setSwcAck}
+            />
+
             {/* Amount */}
             <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
               <div className="flex items-center justify-between mb-2">
@@ -1601,7 +1632,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       setRejectReason('');
                       setRejectSilent(false);
                     }}
-                    disabled={busy || !rejectReason.trim()}
+                    // parmigiana-92104: Reject is still a reimbursement action
+                    // (the host gets notified the org isn't paying), so gate it
+                    // behind the SWC Hub ack too.
+                    disabled={busy || !rejectReason.trim() || swcBlocked}
                     className="px-3 py-1.5 rounded-lg bg-red-500 text-white text-xs disabled:opacity-50"
                   >
                     Confirm reject
@@ -1861,7 +1895,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         !!walletPaidTotal?.wouldExceed &&
                         !overrideCap) ||
                       // salame-92103: disabled until ack when the per-party cap would exceed.
-                      (partyWouldExceedCap && !overridePartyCap)
+                      (partyWouldExceedCap && !overridePartyCap) ||
+                      // parmigiana-92104: disabled until ack when the party is an SWC Hub
+                      // party (reimbursement should be processed via SWC, not rsv.pizza).
+                      swcBlocked
                     }
                     className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs font-medium disabled:opacity-50 inline-flex items-center gap-1.5"
                   >
@@ -1938,7 +1975,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       });
                       setShowMarkPaidForm(false);
                     }}
-                    disabled={busy}
+                    // parmigiana-92104: also gate the inner "Confirm" in the
+                    // Mark paid form so a stale ack flip between the outer
+                    // button and this confirmation doesn't slip past the SWC
+                    // Hub warning.
+                    disabled={busy || swcBlocked}
                     className="px-3 py-1.5 rounded-lg bg-blue-500 text-white text-xs disabled:opacity-50"
                   >
                     Confirm
@@ -1963,7 +2004,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               <button
                 type="button"
                 onClick={() => onApprove()}
-                disabled={busy || selfPayoutBlocked}
+                disabled={busy || selfPayoutBlocked || swcBlocked}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
               >
                 {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
@@ -1972,7 +2013,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               <button
                 type="button"
                 onClick={() => setShowRejectForm(true)}
-                disabled={busy || selfPayoutBlocked}
+                disabled={busy || selfPayoutBlocked || swcBlocked}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
               >
                 <X size={14} />
@@ -2015,7 +2056,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   <button
                     type="button"
                     onClick={openExecuteForm}
-                    disabled={busy || selfPayoutBlocked || showExecuteForm}
+                    disabled={busy || selfPayoutBlocked || showExecuteForm || swcBlocked}
                     className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
                   >
                     <Send size={14} />
@@ -2060,7 +2101,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   <button
                     type="button"
                     onClick={() => setShowMarkPaidForm(true)}
-                    disabled={busy || selfPayoutBlocked}
+                    disabled={busy || selfPayoutBlocked || swcBlocked}
                     className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
                   >
                     <DollarSign size={14} />
@@ -2181,7 +2222,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               <button
                 type="button"
                 onClick={() => onPayAgain(payout)}
-                disabled={busy || selfPayoutBlocked}
+                // parmigiana-92104: Pay-again issues a new reimbursement to the
+                // same wallet — gate behind the SWC Hub ack like every other
+                // outbound reimbursement action.
+                disabled={busy || selfPayoutBlocked || swcBlocked}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50"
               >
                 <Repeat2 size={14} />
@@ -2247,7 +2291,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             <button
               type="button"
               onClick={onMarkPartyPaid}
-              disabled={busy || selfPayoutBlocked}
+              // parmigiana-92104: party-level mark-paid bulk-flips every
+              // in-flight reimbursement on the city to paid — also gate behind
+              // the SWC Hub ack.
+              disabled={busy || selfPayoutBlocked || swcBlocked}
               className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 text-sm font-medium disabled:opacity-50"
               title={`Mark every in-flight payout on ${stripGppPrefix(payout.party.name)} paid (out-of-band reconciliation)`}
             >

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -29,6 +29,7 @@ import {
   formatUsd,
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
+import { isSwcHubParty } from '../../utils/swcHub';
 
 /**
  * mostarda-92103: rework of the /payments by-city expanded row. Each city
@@ -843,6 +844,19 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                         </div>
                       )}
                       <div className="flex flex-wrap items-center gap-2 mt-1">
+                        {/* parmigiana-92104: tiny SWC Hub pill so admins notice
+                            before they expand the row + click into a modal. The
+                            table-level actions aren't disabled here — the per-
+                            action modals (PayoutReviewModal, MarkPartyPaidModal)
+                            are the canonical gate point. */}
+                        {isSwcHubParty(row.party) && (
+                          <span
+                            className="inline-flex items-center gap-1 text-[11px] text-amber-300 px-1.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/30"
+                            title="SWC Hub party — reimbursement should be processed via SWC, not rsv.pizza"
+                          >
+                            SWC Hub
+                          </span>
+                        )}
                         {row.aggregates.flaggedReadyCount > 0 && (
                           <span
                             className="inline-flex items-center gap-1 text-[11px] text-emerald-500"

--- a/frontend/src/components/payments-admin/SwcHubWarning.tsx
+++ b/frontend/src/components/payments-admin/SwcHubWarning.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Checkbox } from '../Checkbox';
+
+/**
+ * parmigiana-92104: shared amber warning + ack panel surfaced on every admin
+ * reimbursement modal when the target party is an SWC Hub party. Mirrors the
+ * salame-92103 / bianco-89172 per-cap override pattern so the visual + dark-
+ * amber gpp-theme overrides stay consistent across PayoutReviewModal,
+ * BulkSendModal, ExternalPaymentModal, and MarkPartyPaidModal.
+ *
+ * Frontend-only soft block — the action buttons in the parent disable until
+ * `acked` flips true. The backend stays open so admins can override when
+ * needed (this is a guardrail, not a hard wall).
+ *
+ * Props:
+ *  - isSwcHub: when false, the panel renders nothing (callers don't need to
+ *    null-guard).
+ *  - acked / onAckChange: controlled ack state owned by the parent so the
+ *    parent can also use it to flip its action buttons' `disabled`.
+ *  - title / body: optional overrides for the bulk-send batch summary copy.
+ *    Default copy matches the per-party PayoutReviewModal / ExternalPayment /
+ *    MarkPartyPaid case.
+ *  - ackLabel: optional override for the checkbox label so the bulk variant
+ *    can read "Allow SWC Hub sends — I acknowledge".
+ */
+interface SwcHubWarningProps {
+  isSwcHub: boolean;
+  acked: boolean;
+  onAckChange: (next: boolean) => void;
+  title?: string;
+  body?: React.ReactNode;
+  ackLabel?: string;
+}
+
+const DEFAULT_TITLE = 'SWC Hub party';
+const DEFAULT_BODY = (
+  <>
+    Reimbursement for SWC Hub parties is processed through SWC, not rsv.pizza.
+    Don&apos;t push payments through this flow unless you&apos;ve cleared it
+    with the SWC operator.
+  </>
+);
+const DEFAULT_ACK_LABEL = 'I understand — proceed anyway';
+
+export const SwcHubWarning: React.FC<SwcHubWarningProps> = ({
+  isSwcHub,
+  acked,
+  onAckChange,
+  title = DEFAULT_TITLE,
+  body = DEFAULT_BODY,
+  ackLabel = DEFAULT_ACK_LABEL,
+}) => {
+  if (!isSwcHub) return null;
+  return (
+    // ricotta-92103: dark-amber overrides under .gpp-theme to keep the panel
+    // legible on light-mint pages — mirrors PayoutReviewModal's salame /
+    // bianco warning panels.
+    <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mb-4">
+      <div className="flex items-start gap-2.5">
+        <AlertTriangle
+          className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0"
+          size={16}
+        />
+        <div className="flex-1 text-sm">
+          <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
+            {title}
+          </div>
+          <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
+            {body}
+          </div>
+          <div className="mt-3">
+            <Checkbox
+              checked={acked}
+              onChange={() => onAckChange(!acked)}
+              label={ackLabel}
+              labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -13,3 +13,4 @@ export { ExportSafeJsonModal } from './ExportSafeJsonModal';
 export { BulkSendModal } from './BulkSendModal';
 export { RejectReasonModal } from './RejectReasonModal';
 export { HotWalletCard } from './HotWalletCard';
+export { SwcHubWarning } from './SwcHubWarning';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4753,6 +4753,18 @@ export interface ApprovedPartySearchResult {
     email: string | null;
     role: 'host' | 'cohost';
   }>;
+  /**
+   * parmigiana-92104: surfaced so the ExternalPaymentModal can render the
+   * SWC Hub reimbursement warning once a party is selected. Optional for
+   * backward-compat with cached payloads during a rolling deploy — older
+   * clients just skip the warning.
+   */
+  country?: string | null;
+  /**
+   * parmigiana-92104: surfaced so the ExternalPaymentModal can detect the
+   * 'SWC Hub' tag even on non-US events. Optional for backward-compat.
+   */
+  eventTags?: string[];
 }
 
 export async function searchApprovedParties(

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -35,6 +35,7 @@ import type {
 } from '../types';
 import { formatUsd } from '../components/payments-shared';
 import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
+import { isSwcHubParty } from '../utils/swcHub';
 import {
   PayoutsFilterBar,
   PayoutsTable,
@@ -207,8 +208,11 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   // panettone-92103: "Mark party paid" modal target. Holds the partyId +
   // a hint name so the modal header can render the city while the preview
   // request is in flight.
+  // parmigiana-92104: also carries `isSwcHub` so the modal can render the
+  // SWC Hub reimbursement warning (the preview endpoint doesn't expose
+  // country/event_tags).
   const [markPartyPaidTarget, setMarkPartyPaidTarget] = useState<
-    | { partyId: string; partyNameHint: string }
+    | { partyId: string; partyNameHint: string; isSwcHub: boolean }
     | null
   >(null);
 
@@ -880,6 +884,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                   setMarkPartyPaidTarget({
                     partyId: row.party.id,
                     partyNameHint: row.party.name,
+                    // parmigiana-92104: PrepayQueueRow.party already carries
+                    // country + eventTags so we can resolve the flag here and
+                    // let MarkPartyPaidModal stay decoupled from the row shape.
+                    isSwcHub: isSwcHubParty(row.party),
                   })
                 }
               />
@@ -993,6 +1001,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
               setMarkPartyPaidTarget({
                 partyId,
                 partyNameHint: row?.party.name ?? '',
+                // parmigiana-92104: PartyPayoutsRow.party carries
+                // country + eventTags — resolve the SWC Hub flag here so the
+                // modal stays decoupled from the row shape.
+                isSwcHub: isSwcHubParty(row?.party),
               });
             }}
             // mostarda-92103: city-level "Add external payment" — opens the
@@ -1312,6 +1324,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
               setMarkPartyPaidTarget({
                 partyId: detail.partyId,
                 partyNameHint: detail.party.name,
+                // parmigiana-92104: PayoutReviewModal's `payout.party` has
+                // country + eventTags surfaced — propagate the SWC Hub flag.
+                isSwcHub: isSwcHubParty(detail.party),
               })
             }
             // tagliatelle-49102: after a tag mutation, refresh the payouts
@@ -1354,6 +1369,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           <MarkPartyPaidModal
             partyId={markPartyPaidTarget.partyId}
             partyNameHint={markPartyPaidTarget.partyNameHint}
+            // parmigiana-92104: forward the resolved SWC Hub flag so the
+            // modal can render the warning + ack.
+            isSwcHub={markPartyPaidTarget.isSwcHub}
             onClose={() => setMarkPartyPaidTarget(null)}
             onSuccess={async ({ count, mode, partyName, action, paymentsClosedAt }) => {
               // caciotta-92103 + pinsa-92103 + provolone-92103: split the

--- a/frontend/src/utils/swcHub.ts
+++ b/frontend/src/utils/swcHub.ts
@@ -1,0 +1,31 @@
+/**
+ * parmigiana-92104: SWC Hub party detection helper.
+ *
+ * Reimbursement for SWC Hub parties is processed through SWC, not rsv.pizza.
+ * Admin reimbursement actions (approve / execute / mark-paid / external add /
+ * bulk-send / mark-city-paid) surface an amber warning + ack checkbox when
+ * the target party is an SWC Hub party — the action buttons stay disabled
+ * until the admin ticks the ack.
+ *
+ * Signals (either is sufficient):
+ *   1. `event_tags` includes the literal string 'SWC Hub' (preferred — also
+ *      catches any non-US SWC Hub events the admins might tag in the future).
+ *   2. `country` === 'United States'.
+ *
+ * Both signals exist in prod (the 151 US parties were just bulk-tagged with
+ * 'SWC Hub'); either is sufficient. The `country` fallback keeps the gate
+ * working for any US party that's missed the bulk-tag for whatever reason.
+ *
+ * Frontend-only soft block — there is no API-level gate. The admin can still
+ * proceed by acknowledging the warning. Use at every admin reimbursement
+ * entry point (PayoutReviewModal, BulkSendModal, ExternalPaymentModal,
+ * MarkPartyPaidModal).
+ */
+export function isSwcHubParty(
+  party?: { country?: string | null; eventTags?: string[] | null } | null,
+): boolean {
+  if (!party) return false;
+  if (Array.isArray(party.eventTags) && party.eventTags.includes('SWC Hub')) return true;
+  if (party.country === 'United States') return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- Surface an amber **SWC Hub party** warning + ack Checkbox on every admin reimbursement entry point (PayoutReviewModal, BulkSendModal, ExternalPaymentModal, MarkPartyPaidModal). Action buttons (Approve / Execute / Mark paid / external add / bulk-send / mark-city-paid) disable until acked. Frontend-only soft block — backend stays open so admins can still override.
- SWC Hub detection: `country === 'United States'` **OR** `event_tags` includes `'SWC Hub'` (helper at `frontend/src/utils/swcHub.ts`). Either is sufficient; tag check preferred so any future non-US SWC Hub events also get the warning.
- Tiny SWC Hub pill on the by-city table so admins notice before they click in. Per-action modals remain the canonical gate point.
- Small backend tweak: extend `GET /api/admin/payouts/parties/search` to return `country` + `event_tags` so ExternalPaymentModal can resolve the flag on the selected party. No schema change, no migration, no new endpoint, no API-level gating.

## Test plan
- [ ] Open a US party (e.g. an Austin reimbursement) in PayoutReviewModal → amber warning surfaces → Approve / Execute / Mark paid / Pay-again / Mark all paid for city / Confirm reject all disabled until ack.
- [ ] Open a non-US party → no warning, action buttons enabled as before.
- [ ] Revert to Pending + Revert to Approved (rollback actions) remain enabled on US parties without the ack.
- [ ] Hosts on a US event can still upload receipts (host flow unchanged).
- [ ] Bulk send a mix (e.g. 3 US + 2 non-US) → batch summary shows "3 of 5 selected payment(s) belong to SWC Hub parties (N affected)" → ack required → Send enables → existing per-address (bianco) + per-party (salame) cap warnings still stack independently if applicable.
- [ ] External Payment modal — pick a US party → warning surfaces → Record payment disabled until ack → pick a non-US party → warning clears + ack resets.
- [ ] Mark Party Paid from each entry point (PrepayQueueTable, PayoutsByPartyTable, PayoutReviewModal) — confirm `isSwcHub` propagates and the modal's Mark/Close button disables until ack on US parties.
- [ ] By-city table row for a US party renders the `SWC Hub` amber pill; per-row Mark paid button still clickable (modal gate fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)