### PR TITLE
fix(pancetta-92104): stop re-OCR loop on failed receipts

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1790,6 +1790,16 @@ model PayoutDocument {
   // analytics queries (e.g. average pizza prices by country/city).
   ocrLineItems     Json?    @map("ocr_line_items")
   ocrError         String?  @map("ocr_error")
+  // pancetta-92104: timestamp + attempt-count for the line-items backfill
+  // loop. The backfill used to query `ocr_line_items IS NULL` candidates
+  // unconditionally, so docs whose `analyzeReceipt` threw (OpenAI 429, bad
+  // image, timeout) stayed candidates forever and the loop burned quota
+  // re-trying the same rows every iteration. Now: the loop filters out
+  // docs whose last attempt was < 24h ago AND caps at 3 attempts. The
+  // marker is written success-or-failure. Reset both to retry a stuck doc
+  // via the `/documents/:docId/retry-ocr` admin endpoint.
+  ocrAttemptedAt   DateTime? @map("ocr_attempted_at") @db.Timestamptz
+  ocrAttemptCount  Int       @default(0) @map("ocr_attempt_count")
   // pancetta-37195: per-receipt uploader attribution. Both nullable so
   // historical rows are valid. uploadedByEmail caches the email at upload
   // time so display still works if the User is later deleted.

--- a/backend/scripts/loop-backfill-line-items.cjs
+++ b/backend/scripts/loop-backfill-line-items.cjs
@@ -42,7 +42,17 @@ const BATCH = Number(process.env.BATCH || 25);
     console.log(
       `+ ${j.succeeded} (${j.failed.length} failed) — remaining: ${j.remaining}`,
     );
+    // pancetta-92104: bail out on either natural completion OR a quota
+    // signal from the server. quotaExceeded means the OpenAI account is
+    // rate-limited and the backfill endpoint already short-circuited mid
+    // batch; firing another request would just hit the same wall.
     if (j.done) break;
+    if (j.quotaExceeded) {
+      console.error(
+        'Quota exceeded — stopping. Resolve OpenAI quota issue then re-run.',
+      );
+      break;
+    }
   }
   console.log(`Done. Total succeeded: ${total}.`);
 })();

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -4188,11 +4188,43 @@ router.get(
 //    the OCR service but have no DB columns yet, so they're discarded here.
 //  - On failure, the error is logged + pushed onto `failed` and we continue.
 //
-// Returns:
-//   { processed, succeeded, failed: [{id, error}], remaining, done }
+// pancetta-92104: the original implementation only wrote `ocr_line_items` on
+// success, so failed docs (429 quota errors, timeouts, bad images) stayed
+// queryable as candidates forever. The loop script kept hitting the same
+// failed docs every iteration and burned through our OpenAI quota. Now we
+// always stamp `ocr_attempted_at` + bump `ocr_attempt_count` (success OR
+// failure), the candidate filter excludes docs attempted in the last 24h
+// AND caps at 3 attempts, and the loop short-circuits if the FIRST error
+// looks like a 429/quota response.
 //
-// Loop externally with backend/scripts/loop-backfill-line-items.cjs.
+// Returns:
+//   { processed, succeeded, failed: [{id, error}], remaining, done,
+//     quotaExceeded? }
+//
+// Loop externally with backend/scripts/loop-backfill-line-items.cjs (which
+// also breaks on `quotaExceeded: true`).
 // ============================================
+
+/**
+ * pancetta-92104: detect the OpenAI 429/quota-exceeded response shape so the
+ * backfill loop can short-circuit instead of waiting through the remaining
+ * throttled iterations. Defensive: matches either the literal 429 status
+ * code substring or the word "quota" in the error message.
+ */
+function isQuotaError(message: string): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return lower.includes('429') || lower.includes('quota');
+}
+
+/**
+ * pancetta-92104: 24-hour cooldown between automatic OCR re-attempts on a
+ * single doc. Admin can bypass via `POST /:docId/retry-ocr` (resets both
+ * counter columns to zero).
+ */
+const OCR_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const OCR_MAX_AUTO_ATTEMPTS = 3;
+
 router.post(
   '/backfill-line-items',
   requireAuth,
@@ -4208,14 +4240,22 @@ router.post(
       }
       const limit = Math.max(1, Math.min(50, Math.floor(rawLimit)));
 
-      // Candidates: receipts with no line items yet and a non-empty URL.
-      // `url: { not: '' }` excludes blank rows; the `IS NOT NULL` semantic is
-      // implicit because `url` is a non-nullable column on PayoutDocument.
+      // pancetta-92104: candidates are receipts with no line items yet, a
+      // non-empty URL, AND either never attempted OR last attempted >24h
+      // ago, AND under the per-doc attempt cap. This is the surgical fix
+      // for the re-OCR-loop bug — failed docs stop being "free candidates
+      // every iteration" once their attempt marker is set.
+      const cooldownCutoff = new Date(Date.now() - OCR_RETRY_COOLDOWN_MS);
       const candidates = await prisma.payoutDocument.findMany({
         where: {
           kind: 'receipt',
           ocrLineItems: { equals: Prisma.DbNull },
           url: { not: '' },
+          ocrAttemptCount: { lt: OCR_MAX_AUTO_ATTEMPTS },
+          OR: [
+            { ocrAttemptedAt: null },
+            { ocrAttemptedAt: { lt: cooldownCutoff } },
+          ],
         },
         orderBy: { createdAt: 'asc' },
         take: limit,
@@ -4224,18 +4264,23 @@ router.post(
 
       const failed: Array<{ id: string; error: string }> = [];
       let succeeded = 0;
+      let quotaExceeded = false;
 
       for (let i = 0; i < candidates.length; i++) {
         const doc = candidates[i];
         try {
           const result = await analyzeReceipt(doc.url);
-          // Additive write: ONLY ocr_line_items. Do not overwrite
-          // ocr_amount / ocr_currency / ocr_confidence / ocr_raw — admins may
-          // have already approved payouts based on those values.
+          // Additive write: ONLY ocr_line_items + attempt marker. Do not
+          // overwrite ocr_amount / ocr_currency / ocr_confidence / ocr_raw
+          // — admins may have already approved payouts based on those.
+          // Clear any prior ocrError since this attempt succeeded.
           await prisma.payoutDocument.update({
             where: { id: doc.id },
             data: {
               ocrLineItems: (result.lineItems ?? []) as unknown as Prisma.InputJsonValue,
+              ocrAttemptedAt: new Date(),
+              ocrAttemptCount: { increment: 1 },
+              ocrError: null,
             },
           });
           succeeded += 1;
@@ -4244,7 +4289,26 @@ router.post(
           console.error(
             `[backfill-line-items] doc=${doc.id} url=${doc.url} failed: ${message}`,
           );
+          // pancetta-92104: persist the attempt marker on failure too —
+          // this is the bug fix. Without this, a failed doc stays a
+          // candidate forever and the loop burns quota retrying it.
+          // Truncate the error to 500 chars to keep the column sane.
+          await prisma.payoutDocument.update({
+            where: { id: doc.id },
+            data: {
+              ocrAttemptedAt: new Date(),
+              ocrAttemptCount: { increment: 1 },
+              ocrError: message.slice(0, 500),
+            },
+          });
           failed.push({ id: doc.id, error: message });
+
+          // Short-circuit on quota errors: no point waiting through the
+          // remaining 500ms throttles when the account is rate-limited.
+          if (isQuotaError(message)) {
+            quotaExceeded = true;
+            break;
+          }
         }
 
         // Throttle between iterations (skip the wait after the last one).
@@ -4253,11 +4317,19 @@ router.post(
         }
       }
 
+      // pancetta-92104: `remaining` reflects docs still eligible for the
+      // NEXT loop call (same cooldown + cap filters). A doc that just
+      // failed today won't count again until 24h pass.
       const remaining = await prisma.payoutDocument.count({
         where: {
           kind: 'receipt',
           ocrLineItems: { equals: Prisma.DbNull },
           url: { not: '' },
+          ocrAttemptCount: { lt: OCR_MAX_AUTO_ATTEMPTS },
+          OR: [
+            { ocrAttemptedAt: null },
+            { ocrAttemptedAt: { lt: cooldownCutoff } },
+          ],
         },
       });
 
@@ -4267,6 +4339,134 @@ router.post(
         failed,
         remaining,
         done: remaining === 0,
+        // pancetta-92104: loop driver checks this and breaks early so it
+        // doesn't spam more requests once the account is rate-limited.
+        quotaExceeded,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ============================================
+// pancetta-92104: POST /documents/:docId/retry-ocr
+//
+// Admin-only: reset a single doc's `ocr_attempted_at` and `ocr_attempt_count`
+// so it becomes a candidate again on the next backfill call. Useful for
+// un-sticking docs that hit the 3-attempt cap once the underlying OpenAI
+// quota issue is resolved (or to retry a one-off failure manually).
+//
+// If `runNow` is true (default), also re-runs analyzeReceipt synchronously
+// and stamps the result. Otherwise just clears the counters and the doc
+// gets picked up by the next backfill batch.
+//
+// Returns:
+//   { document: <updated row> }
+// ============================================
+router.post(
+  '/documents/:docId/retry-ocr',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { docId } = req.params;
+      const body = (req.body || {}) as { runNow?: unknown };
+      const runNow = body.runNow === undefined ? true : Boolean(body.runNow);
+
+      const existing = await prisma.payoutDocument.findUnique({
+        where: { id: docId },
+        select: { id: true, url: true, kind: true },
+      });
+      if (!existing) {
+        throw new AppError('Document not found', 404, 'NOT_FOUND');
+      }
+
+      // Always clear the cooldown + counter first so the next backfill
+      // call (whether we run inline below or not) will pick this row up.
+      await prisma.payoutDocument.update({
+        where: { id: docId },
+        data: {
+          ocrAttemptedAt: null,
+          ocrAttemptCount: 0,
+          ocrError: null,
+        },
+      });
+
+      let ranInline = false;
+      let inlineError: string | null = null;
+
+      if (runNow && existing.kind === 'receipt' && existing.url) {
+        const { analyzeReceipt } = await import('../services/ocr.service.js');
+        try {
+          const result = await analyzeReceipt(existing.url);
+          await prisma.payoutDocument.update({
+            where: { id: docId },
+            data: {
+              ocrLineItems: (result.lineItems ?? []) as unknown as Prisma.InputJsonValue,
+              ocrAttemptedAt: new Date(),
+              ocrAttemptCount: { increment: 1 },
+              ocrError: null,
+            },
+          });
+          ranInline = true;
+        } catch (err: any) {
+          inlineError = err?.message ? String(err.message) : String(err);
+          await prisma.payoutDocument.update({
+            where: { id: docId },
+            data: {
+              ocrAttemptedAt: new Date(),
+              ocrAttemptCount: { increment: 1 },
+              ocrError: inlineError.slice(0, 500),
+            },
+          });
+        }
+      }
+
+      const updated = await prisma.payoutDocument.findUnique({
+        where: { id: docId },
+        select: {
+          id: true,
+          kind: true,
+          url: true,
+          fileName: true,
+          ocrAmount: true,
+          ocrCurrency: true,
+          ocrConfidence: true,
+          originalAmount: true,
+          originalCurrency: true,
+          exchangeRate: true,
+          ocrError: true,
+          ocrAttemptedAt: true,
+          ocrAttemptCount: true,
+          sortOrder: true,
+        },
+      });
+
+      res.json({
+        document: updated && {
+          id: updated.id,
+          kind: updated.kind,
+          url: updated.url,
+          fileName: updated.fileName,
+          ocrAmount: updated.ocrAmount == null ? null : Number(updated.ocrAmount),
+          ocrCurrency: updated.ocrCurrency,
+          ocrConfidence:
+            updated.ocrConfidence == null ? null : Number(updated.ocrConfidence),
+          originalAmount:
+            updated.originalAmount == null ? null : Number(updated.originalAmount),
+          originalCurrency: updated.originalCurrency,
+          exchangeRate:
+            updated.exchangeRate == null ? null : Number(updated.exchangeRate),
+          ocrError: updated.ocrError,
+          ocrAttemptedAt: updated.ocrAttemptedAt
+            ? updated.ocrAttemptedAt.toISOString()
+            : null,
+          ocrAttemptCount: updated.ocrAttemptCount,
+          sortOrder: updated.sortOrder,
+        },
+        ranInline,
+        inlineError,
       });
     } catch (err) {
       next(err);

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -3,7 +3,7 @@ import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSig
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
-import { updatePartyApi, updatePayoutDocument } from '../../lib/api';
+import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal } from '../../types';
 import {
@@ -349,6 +349,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   type ReceiptDraft = { amount: string; currency: string };
   const [receiptDrafts, setReceiptDrafts] = useState<Record<string, ReceiptDraft>>({});
 
+  // pancetta-92104: per-row "Retry OCR" state. Admin can re-trigger the OCR
+  // pipeline on a single doc that previously errored (e.g. quota / timeout /
+  // bad image). The retry resets ocr_attempt_count + ocr_attempted_at and
+  // runs analyzeReceipt inline; on success we clear ocrError locally so the
+  // per-row error chip and the global 429 banner both update without a
+  // parent refetch.
+  const [retryingDocId, setRetryingDocId] = useState<string | null>(null);
+  const [retryErrors, setRetryErrors] = useState<Record<string, string>>({});
+  // Map of docId -> cleared (true) so the row stops rendering the stale
+  // ocrError from `payout.documents` once retry succeeds. We only set true
+  // on success; failures still surface a per-row error chip.
+  const [retryClearedErrors, setRetryClearedErrors] = useState<Record<string, boolean>>({});
+
   // Hooks must be declared above any early returns. There aren't any early
   // returns in this component today, but keeping all hooks grouped here makes
   // the rule-of-hooks invariant easier to verify.
@@ -462,6 +475,51 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       setReceiptSavingId(null);
     }
   }
+
+  // pancetta-92104: admin-triggered single-doc OCR retry. Resets the cooldown
+  // + attempt counter on the doc and re-runs analyzeReceipt inline. On a
+  // non-quota success we drop the local ocrError so the row updates without
+  // a parent refetch; on failure we surface the new error inline.
+  async function retryOcr(docId: string) {
+    setRetryingDocId(docId);
+    setRetryErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    try {
+      const res = await retryPayoutDocumentOcr(docId, { runNow: true });
+      if (res.inlineError) {
+        setRetryErrors((m) => ({ ...m, [docId]: res.inlineError ?? 'OCR failed' }));
+      } else if (res.ranInline) {
+        // Success — locally suppress the stale ocrError from payout.documents.
+        setRetryClearedErrors((m) => ({ ...m, [docId]: true }));
+      }
+    } catch (err: any) {
+      setRetryErrors((m) => ({
+        ...m,
+        [docId]: err?.message || 'Retry failed',
+      }));
+    } finally {
+      setRetryingDocId(null);
+    }
+  }
+
+  // pancetta-92104: collapse identical OpenAI 429/quota errors across rows
+  // into ONE banner at the top of the receipt section. Cuts noise when the
+  // entire event's receipts share the same upload-time OCR quota failure
+  // (the Mexico City symptom that triggered this task). Per-row chips hide
+  // when the banner is showing so admins don't see "429 You exceeded your
+  // current quota" repeated six times.
+  const quotaErrorRows = useMemo(() => {
+    return receipts
+      .filter((r) => !retryClearedErrors[r.id])
+      .filter((r) => {
+        const msg = (r.ocrError || '').toLowerCase();
+        return msg && (msg.includes('429') || msg.includes('quota'));
+      });
+  }, [receipts, retryClearedErrors]);
+  const showQuotaBanner = quotaErrorRows.length >= 2;
 
   // bresaola-89172: keyboard nav for the lightbox now lives inside the
   // ReceiptLightbox component itself (Esc to close, arrows to cycle). The
@@ -1111,10 +1169,45 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             {receipts.length > 0 && (
               <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
                 <h3 className="text-sm font-semibold text-theme-text mb-2">Receipts ({receipts.length})</h3>
+                {/* pancetta-92104: global quota banner collapses N identical
+                    429s into one row of context. Per-row chips are hidden
+                    below when this banner is showing. */}
+                {showQuotaBanner && (
+                  <div className="mb-2 flex items-start gap-2 rounded-lg border border-amber-400/40 bg-amber-50 p-2 text-xs text-amber-900">
+                    <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
+                    <div className="flex-1">
+                      <span className="font-semibold">OpenAI OCR quota exceeded</span>
+                      {' '}— line-item extraction temporarily unavailable on{' '}
+                      {quotaErrorRows.length} receipt{quotaErrorRows.length === 1 ? '' : 's'}.
+                      Receipts uploaded normally; manual amount/currency edits work.
+                      {canEditReceipts && (
+                        <span className="block mt-0.5 text-amber-800">
+                          Use Retry OCR on a row to re-attempt once the quota issue is resolved.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
                 <ul className="space-y-1.5">
                   {receipts.map((r) => {
                     const conf = r.ocrConfidence ?? 0;
                     const lowConf = conf > 0 && conf < 0.8;
+                    // pancetta-92104: locally suppress ocrError after a
+                    // successful inline retry so the per-row chip + dot
+                    // refresh without a parent refetch.
+                    const localOcrError = retryClearedErrors[r.id]
+                      ? null
+                      : (retryErrors[r.id] ?? r.ocrError);
+                    const isQuotaErr = !!localOcrError
+                      && (localOcrError.toLowerCase().includes('429')
+                        || localOcrError.toLowerCase().includes('quota'));
+                    // When the global banner is shown, per-row quota errors
+                    // hide (the banner covers them). Non-quota errors still
+                    // render so admins can distinguish which rows need a
+                    // targeted fix vs which are waiting on the quota reset.
+                    const hidePerRowError = isQuotaErr && showQuotaBanner;
+                    const renderOcrError = hidePerRowError ? null : localOcrError;
+                    const isRetrying = retryingDocId === r.id;
                     // agnolotti-58291: capture the OCR'd values as placeholders
                     // so admins can see what the model originally returned
                     // when they're correcting the field. `original*` reflects
@@ -1134,7 +1227,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         <div className="flex items-center gap-2">
                           <span
                             className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                              r.ocrError ? 'bg-red-500' :
+                              localOcrError ? (isQuotaErr ? 'bg-amber-500' : 'bg-red-500') :
                               lowConf ? 'bg-amber-500' :
                               conf >= 0.8 ? 'bg-emerald-500' :
                               'bg-gray-400'
@@ -1189,14 +1282,35 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                               >
                                 {saving ? <Loader2 size={12} className="animate-spin" /> : 'Save'}
                               </button>
+                              {/* pancetta-92104: per-row "Retry OCR" — admin
+                                  resets attempt counter + re-runs analyze
+                                  inline. Surfaced for any failed row so a
+                                  one-off bad image / timeout doesn't need
+                                  the global backfill loop. */}
+                              {localOcrError && (
+                                <button
+                                  type="button"
+                                  onClick={() => retryOcr(r.id)}
+                                  disabled={isRetrying}
+                                  className="px-2 py-1 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center gap-1"
+                                  title="Reset attempt counter and re-run OCR for this receipt"
+                                >
+                                  {isRetrying ? (
+                                    <Loader2 size={12} className="animate-spin" />
+                                  ) : (
+                                    <RefreshCw size={12} />
+                                  )}
+                                  Retry OCR
+                                </button>
+                              )}
                               {conf > 0 && (
                                 <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
                                   {(conf * 100).toFixed(0)}%
                                 </span>
                               )}
                             </>
-                          ) : r.ocrError ? (
-                            <span className="text-xs text-red-600">{r.ocrError}</span>
+                          ) : renderOcrError ? (
+                            <span className="text-xs text-red-600">{renderOcrError}</span>
                           ) : r.ocrAmount != null && r.ocrCurrency ? (
                             <>
                               {/* mortadella-92103: ocrAmount is the USD-converted
@@ -1231,8 +1345,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                             <span className="text-xs text-theme-text-faint">no OCR</span>
                           )}
                         </div>
-                        {canEditReceipts && r.ocrError && (
-                          <div className="text-xs text-red-600 mt-0.5 ml-4">{r.ocrError}</div>
+                        {canEditReceipts && renderOcrError && (
+                          <div className="text-xs text-red-600 mt-0.5 ml-4">{renderOcrError}</div>
                         )}
                         {saveError && (
                           <div className="text-xs text-red-600 mt-0.5 ml-4">{saveError}</div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4257,6 +4257,46 @@ export async function updatePayoutDocument(
   return res.document;
 }
 
+/**
+ * pancetta-92104: reset a single doc's OCR retry counter so the next backfill
+ * call (or this call's inline run) re-attempts `analyzeReceipt` against the
+ * receipt. Used to un-stick docs that hit the 3-attempt cap once the
+ * underlying OpenAI quota issue is resolved, and as a one-click "Retry OCR"
+ * affordance on rows that failed for a non-quota reason (timeout, bad image).
+ *
+ * `runNow: true` (default) runs analyzeReceipt synchronously and returns the
+ * stamped result. `runNow: false` just clears the counters and lets the next
+ * scheduled backfill batch pick it up.
+ */
+export async function retryPayoutDocumentOcr(
+  docId: string,
+  opts?: { runNow?: boolean },
+): Promise<{
+  document: {
+    id: string;
+    kind: 'pizza' | 'receipt';
+    url: string;
+    fileName: string;
+    ocrAmount: number | null;
+    ocrCurrency: string | null;
+    ocrConfidence: number | null;
+    originalAmount: number | null;
+    originalCurrency: string | null;
+    exchangeRate: number | null;
+    ocrError: string | null;
+    ocrAttemptedAt: string | null;
+    ocrAttemptCount: number;
+    sortOrder: number;
+  } | null;
+  ranInline: boolean;
+  inlineError: string | null;
+}> {
+  return apiRequest(
+    `/api/admin/payouts/documents/${docId}/retry-ocr`,
+    { method: 'POST', body: { runNow: opts?.runNow ?? true } },
+  );
+}
+
 export async function approveAdminPayout(
   id: string,
   opts?: { note?: string; autoExecute?: boolean; regions?: string[] },


### PR DESCRIPTION
## Summary

- `POST /api/admin/payouts/backfill-line-items` only wrote `ocr_line_items` on success. Failed docs (OpenAI 429, timeouts, bad images) stayed queryable as candidates forever, so the loop script kept hitting them every iteration and burned through our OpenAI quota.
- Adds `ocr_attempted_at` (timestamptz) + `ocr_attempt_count` (int default 0) columns. Candidates filter now excludes docs attempted within the last 24h AND caps at 3 attempts. Always writes the attempt marker, success or failure. Short-circuits the loop on `429`/`quota` errors so the remaining throttle waits aren't wasted.
- New `POST /api/admin/payouts/documents/:docId/retry-ocr` lets admin reset the cooldown + counter on a single doc and re-run `analyzeReceipt` inline. Returns `{ document, ranInline, inlineError }`.
- Backfill endpoint response now includes `quotaExceeded: boolean`. `backend/scripts/loop-backfill-line-items.cjs` updated to break the loop on `quotaExceeded: true` in addition to `done: true`.
- `PayoutReviewModal` collapses identical OpenAI 429/quota errors into ONE banner above the receipt list (kicks in at ≥2 quota-erroring rows). Per-row quota chips hide when the banner is showing; non-quota errors still surface inline so admins can distinguish targeted fixes from waiting-on-quota rows. Per-row \"Retry OCR\" button (admin-only) resets the cap and re-runs OCR inline.

## What did NOT change

- Upload-time OCR path in `payout.routes.ts` — already writes `ocrError`, so failed-on-upload docs continue to display correctly. The backfill loop is the only thing that was burning quota.
- `mortadella-92103` FX/per-receipt currency persistence.
- Per-receipt admin OCR override (`PATCH /documents/:docId`).

## Migration

Applied directly to prod via `pg + DATABASE_URL` before merge (per project workflow):

```sql
ALTER TABLE payout_documents ADD COLUMN IF NOT EXISTS ocr_attempted_at timestamptz NULL;
ALTER TABLE payout_documents ADD COLUMN IF NOT EXISTS ocr_attempt_count integer NOT NULL DEFAULT 0;
GRANT SELECT (ocr_attempted_at, ocr_attempt_count) ON payout_documents TO anon, authenticated;
```

Prisma schema updated to match.

## Test plan

- [ ] `cd backend && npx tsc --noEmit` clean (modulo pre-existing `sharp`/`openai`/`archiver` errors).
- [ ] `cd frontend && npx tsc --noEmit` clean.
- [ ] Hit `/backfill-line-items` with `limit=1` against a receipt with `ocr_line_items IS NULL`. Verify `ocr_attempted_at` + `ocr_attempt_count` update whether OCR succeeded or threw.
- [ ] Hit `/backfill-line-items` again immediately. Verify the same row is NOT re-attempted (24h cooldown).
- [ ] Hit `POST /documents/:docId/retry-ocr` on a quota-failed Mexico City receipt. Verify counter resets and inline retry runs.
- [ ] Open the Mexico City review modal — confirm the global 429 banner replaces the six identical inline 429 chips, and per-row Retry OCR buttons appear.
- [ ] Simulate a 3rd consecutive failure on a row — verify the row stops being picked as a backfill candidate (attempt cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)