### PR TITLE
feat(pecorino-64118): newsletter CSV adds name + city columns

### DIFF
--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1409,12 +1409,13 @@ sponsorDashboardRouter.get('/newsletter-emails', requireAuth, requireSponsorAuth
     // Find party ids in the event-set first, then fetch matching guest emails.
     const parties = await prisma.party.findMany({
       where,
-      select: { id: true },
+      select: { id: true, city: true, name: true, date: true },
     });
+    const partyById = new Map(parties.map(p => [p.id, p]));
     const partyIds = parties.map(p => p.id);
 
     if (partyIds.length === 0) {
-      return res.json({ emails: [], count: 0, tag, optinField });
+      return res.json({ rows: [], emails: [], count: 0, tag, optinField });
     }
 
     const guests = await prisma.guest.findMany({
@@ -1426,18 +1427,39 @@ sponsorDashboardRouter.get('/newsletter-emails', requireAuth, requireSponsorAuth
         OR: [{ approved: true }, { approved: null }],
         [optinField]: true,
       },
-      select: { email: true },
+      select: { email: true, name: true, partyId: true },
     });
 
-    // Dedupe (lowercased), drop empties, sort alphabetically.
-    const seen = new Set<string>();
-    for (const g of guests) {
-      const e = (g.email || '').trim().toLowerCase();
-      if (e) seen.add(e);
-    }
-    const emails = Array.from(seen).sort();
+    // Sort matching guests by party.date DESC NULLS LAST so the most-recent
+    // event wins when we dedupe by lowercased email below.
+    const sortedGuests = guests.slice().sort((a, b) => {
+      const pa = partyById.get(a.partyId);
+      const pb = partyById.get(b.partyId);
+      const ta = pa?.date ? new Date(pa.date).getTime() : Number.NEGATIVE_INFINITY;
+      const tb = pb?.date ? new Date(pb.date).getTime() : Number.NEGATIVE_INFINITY;
+      return tb - ta;
+    });
 
-    res.json({ emails, count: emails.length, tag, optinField });
+    // Dedupe by lowercased email, keeping the row from the most recent event.
+    const rowByEmail = new Map<string, { email: string; name: string; city: string }>();
+    for (const g of sortedGuests) {
+      const e = (g.email || '').trim().toLowerCase();
+      if (!e) continue;
+      if (rowByEmail.has(e)) continue;
+      const party = partyById.get(g.partyId);
+      rowByEmail.set(e, {
+        email: e,
+        name: (g.name || '').trim(),
+        // Do NOT fall back to party.name — leave empty if party has no city.
+        city: party?.city ?? '',
+      });
+    }
+
+    // Sort final list alphabetically by email.
+    const rows = Array.from(rowByEmail.values()).sort((a, b) => a.email.localeCompare(b.email));
+    const emails = rows.map(r => r.email);
+
+    res.json({ rows, emails, count: rows.length, tag, optinField });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/report/ConsolidatedReportPreview.tsx
+++ b/frontend/src/components/report/ConsolidatedReportPreview.tsx
@@ -83,7 +83,19 @@ export function ConsolidatedReportPreview({ report }: ConsolidatedReportPreviewP
   const downloadNewsletterEmails = hasNewsletterSignups ? async () => {
     try {
       const result = await fetchPartnerNewsletterEmails(report.tag || undefined);
-      const csv = 'email\n' + result.emails.join('\n');
+      // RFC 4180-style CSV field escape: wrap in quotes if the value contains
+      // comma, double-quote, CR, or LF; double internal quotes.
+      const csvEscape = (v: string): string => {
+        if (/[",\r\n]/.test(v)) {
+          return `"${v.replace(/"/g, '""')}"`;
+        }
+        return v;
+      };
+      const header = 'email,name,city';
+      const lines = result.rows.map(r =>
+        [csvEscape(r.email), csvEscape(r.name), csvEscape(r.city)].join(',')
+      );
+      const csv = [header, ...lines].join('\n');
       const blob = new Blob([csv], { type: 'text/csv' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3405,11 +3405,21 @@ export async function revokePartnerAiShareToken(
 // without a newsletter (e.g. pizzadao).
 export async function fetchPartnerNewsletterEmails(
   tag?: string
-): Promise<{ emails: string[]; count: number; tag: string; optinField: string }> {
+): Promise<{
+  rows: { email: string; name: string; city: string }[];
+  emails: string[];
+  count: number;
+  tag: string;
+  optinField: string;
+}> {
   const params = tag ? `?tag=${encodeURIComponent(tag)}` : '';
-  return apiRequest<{ emails: string[]; count: number; tag: string; optinField: string }>(
-    `/api/sponsor/newsletter-emails${params}`
-  );
+  return apiRequest<{
+    rows: { email: string; name: string; city: string }[];
+    emails: string[];
+    count: number;
+    tag: string;
+    optinField: string;
+  }>(`/api/sponsor/newsletter-emails${params}`);
 }
 
 // Admin-only time-series for partner dashboard chart


### PR DESCRIPTION
Newsletter CSV download from the consolidated report's "Newsletter signups" KPI tile now has `email,name,city` columns instead of just `email`.

Dedupe is by lowercased email; when the same email appears at multiple events, the row from the **most recent event** (by `party.date DESC NULLS LAST`) wins. Final list is sorted alphabetically by email.

City is empty when the party has no `city` column value — no fallback to `party.name`. CSV escaping is RFC-4180 style (commas, double-quotes, and newlines wrap the field in quotes; internal quotes are doubled).

### Files
- `backend/src/routes/sponsor-user.routes.ts` — `GET /api/sponsor/newsletter-emails` returns `{ rows, emails, count, tag, optinField }` (kept `emails` for back-compat).
- `frontend/src/lib/api.ts` — `fetchPartnerNewsletterEmails` return type adds `rows`.
- `frontend/src/components/report/ConsolidatedReportPreview.tsx` — `downloadNewsletterEmails` builds a 3-column CSV with proper escaping.

### Deploy notes
Backend redeploy required from `master` before previews see the new shape (backend ships from master only). Frontend on this branch keeps reading `result.rows`, which will be undefined against the un-deployed backend — the wrapping try/catch logs and skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)