### PR TITLE
feat(taralli-92104): editable receipt line items in admin modal

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -597,6 +597,11 @@ function serializePayout(row: any): any {
       originalAmount: d.originalAmount == null ? null : Number(d.originalAmount),
       originalCurrency: d.originalCurrency,
       exchangeRate: d.exchangeRate == null ? null : Number(d.exchangeRate),
+      // taralli-92104: surface the structured line items so the admin
+      // PayoutReviewModal can render the editable per-line grid. JSONB
+      // column — `null` when OCR didn't extract any items (older rows
+      // pre-formaggi-89172 or receipts the model couldn't parse).
+      ocrLineItems: Array.isArray(d.ocrLineItems) ? d.ocrLineItems : null,
       ocrError: d.ocrError,
       sortOrder: d.sortOrder,
       // pancetta-37195: per-doc uploader attribution. Live name from the
@@ -3959,13 +3964,34 @@ router.post(
 // when the model misread a receipt amount or currency.
 //
 // Auth: requireAnyAdminOrPaymentAdmin (admin / super_admin / payment_admin).
-// Body: { ocrAmount?: number | null, ocrCurrency?: string | null }
+// Body: {
+//   ocrAmount?: number | null,
+//   ocrCurrency?: string | null,
+//   // taralli-92104: structured line items the admin has manually edited
+//   // in the reviewer modal. The OCR extractor still seeds the initial
+//   // shape (formaggi-89172) but the admin's edits are authoritative —
+//   // we do NOT re-run OCR here. Pass `null` to clear, `undefined` to
+//   // leave untouched, or an array of { name, qty, unitPrice, subtotal,
+//   // category? } to replace.
+//   ocrLineItems?: Array<{
+//     name?: string,
+//     qty?: number,
+//     unitPrice?: number,
+//     subtotal?: number,
+//     category?: 'pizza'|'beverage'|'topping'|'side'|'dessert'|'tax'|'tip'|'fee'|'other'
+//   }> | null
+// }
 //   - null clears the field; undefined leaves it untouched.
 //   - ocrAmount must be finite (or null).
 //   - ocrCurrency must be a non-empty string ≤8 chars (or null).
+//   - ocrLineItems must be an array; each entry is sanitized (qty/price
+//     coerced to non-negative numbers, name to string, category to one
+//     of the OcrLineItemCategory values — invalid categories fall back
+//     to 'other').
 //
-// Audit: writes a payout_audit row with action='edit_amount' when the document
-// still has a parent payout. Skips audit when payoutId is null (orphaned
+// Audit: writes a payout_audit row with action='edit_amount' for amount/
+// currency changes, and a separate action='edit_documents' row when
+// ocrLineItems is touched. Skips audit when payoutId is null (orphaned
 // receipt — parent payout was deleted; nothing to audit against).
 // ============================================
 router.patch(
@@ -3991,10 +4017,90 @@ router.patch(
           originalCurrency: true,
           exchangeRate: true,
           ocrRaw: true,
+          // taralli-92104: pull the existing line items so the audit row
+          // can record old → new counts when the admin edits them.
+          ocrLineItems: true,
         },
       });
       if (!doc) {
         throw new AppError('Document not found', 404, 'NOT_FOUND');
+      }
+
+      // taralli-92104: sanitize an admin-supplied line item entry. Mirrors
+      // the OCR-side sanitization in `services/ocr.service.ts` so a saved
+      // edit is shape-compatible with the pizza-prices analytics consumer
+      // (which reads `category`, `qty`, `unitPrice`, `subtotal`, `name`).
+      // Defensive defaults: name → '' (empty allowed per task spec), qty/
+      // prices clamped to non-negative finite numbers, unknown categories
+      // collapse to 'other'.
+      const ALLOWED_LINE_ITEM_CATEGORIES = [
+        'pizza',
+        'beverage',
+        'topping',
+        'side',
+        'dessert',
+        'tax',
+        'tip',
+        'fee',
+        'other',
+      ] as const;
+      type SanitizedLineItem = {
+        name: string;
+        qty: number;
+        unitPrice: number;
+        subtotal: number;
+        category: (typeof ALLOWED_LINE_ITEM_CATEGORIES)[number];
+      };
+      function sanitizeLineItem(raw: unknown, idx: number): SanitizedLineItem {
+        if (!raw || typeof raw !== 'object') {
+          throw new AppError(
+            `ocrLineItems[${idx}] must be an object`,
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        const e = raw as Record<string, unknown>;
+        const name = typeof e.name === 'string' ? e.name.trim() : '';
+
+        const qtyNum = Number(e.qty);
+        if (!Number.isFinite(qtyNum) || qtyNum < 0) {
+          throw new AppError(
+            `ocrLineItems[${idx}].qty must be a non-negative finite number`,
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        const qty = qtyNum;
+
+        const unitNum = Number(e.unitPrice);
+        if (!Number.isFinite(unitNum) || unitNum < 0) {
+          throw new AppError(
+            `ocrLineItems[${idx}].unitPrice must be a non-negative finite number`,
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        const unitPrice = unitNum;
+
+        const subNum = Number(e.subtotal);
+        if (!Number.isFinite(subNum) || subNum < 0) {
+          throw new AppError(
+            `ocrLineItems[${idx}].subtotal must be a non-negative finite number`,
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        const subtotal = subNum;
+
+        const rawCategory = typeof e.category === 'string'
+          ? e.category.toLowerCase().trim()
+          : 'other';
+        const category: SanitizedLineItem['category'] =
+          (ALLOWED_LINE_ITEM_CATEGORIES as readonly string[]).includes(rawCategory)
+            ? (rawCategory as SanitizedLineItem['category'])
+            : 'other';
+
+        return { name, qty, unitPrice, subtotal, category };
       }
 
       const data: {
@@ -4003,6 +4109,7 @@ router.patch(
         originalAmount?: number | null;
         originalCurrency?: string | null;
         exchangeRate?: number | null;
+        ocrLineItems?: Prisma.InputJsonValue | typeof Prisma.DbNull;
       } = {};
 
       if (body.ocrAmount !== undefined) {
@@ -4034,6 +4141,37 @@ router.patch(
             );
           }
           data.ocrCurrency = c;
+        }
+      }
+
+      // taralli-92104: accept the admin's manually-edited line items. `null`
+      // clears the column (Prisma.DbNull writes a JSON null to the column);
+      // an array replaces the existing items wholesale (no merge — admin's
+      // edits in the modal are authoritative). Each entry is sanitized via
+      // `sanitizeLineItem` above. Hard cap at 200 entries so a malicious
+      // body can't blow up the row size.
+      if (body.ocrLineItems !== undefined) {
+        if (body.ocrLineItems === null) {
+          data.ocrLineItems = Prisma.DbNull;
+        } else {
+          if (!Array.isArray(body.ocrLineItems)) {
+            throw new AppError(
+              'ocrLineItems must be an array of line items or null',
+              400,
+              'VALIDATION_ERROR',
+            );
+          }
+          if (body.ocrLineItems.length > 200) {
+            throw new AppError(
+              'ocrLineItems may contain at most 200 entries',
+              400,
+              'VALIDATION_ERROR',
+            );
+          }
+          const sanitized: SanitizedLineItem[] = body.ocrLineItems.map(
+            (entry: unknown, idx: number) => sanitizeLineItem(entry, idx),
+          );
+          data.ocrLineItems = sanitized as unknown as Prisma.InputJsonValue;
         }
       }
 
@@ -4140,6 +4278,15 @@ router.patch(
       // audit against, since payout_audit.payout_id is NOT NULL with CASCADE.
       const oldAmount = doc.ocrAmount == null ? null : Number(doc.ocrAmount.toString());
       const oldCurrency = doc.ocrCurrency;
+      // taralli-92104: track whether the admin's edit changed the amount/
+      // currency fields vs only line items, so the audit row is recorded
+      // under the most accurate action (edit_amount vs edit_documents).
+      const amountOrCurrencyChanged =
+        data.ocrAmount !== undefined || data.ocrCurrency !== undefined;
+      const lineItemsChanged = data.ocrLineItems !== undefined;
+      const oldLineItemsCount = Array.isArray(doc.ocrLineItems)
+        ? (doc.ocrLineItems as unknown[]).length
+        : 0;
       const actor = await loadActor(req);
 
       const updated = await prisma.$transaction(async (tx) => {
@@ -4168,6 +4315,13 @@ router.patch(
               : data.exchangeRate === null
                 ? null
                 : (data.exchangeRate as any),
+            // taralli-92104: persist the admin's edited line items. The
+            // backend's POST /backfill-line-items + initial OCR extractor
+            // remain the seed paths; this PATCH is purely user-driven
+            // correction so we trust the sanitized payload.
+            ocrLineItems: data.ocrLineItems === undefined
+              ? undefined
+              : data.ocrLineItems,
           },
         });
 
@@ -4181,22 +4335,48 @@ router.patch(
           const newCurrency = data.ocrCurrency === undefined
             ? oldCurrency
             : data.ocrCurrency;
-          await tx.payoutAudit.create({
-            data: {
-              payoutId: doc.payoutId,
-              action: 'edit_amount',
-              actorEmail: actor.email,
-              actorKind: actor.actorKind,
-              note: JSON.stringify({
-                scope: 'receipt',
-                documentId: docId,
-                oldAmount,
-                newAmount,
-                oldCurrency,
-                newCurrency,
-              }),
-            },
-          });
+          if (amountOrCurrencyChanged) {
+            await tx.payoutAudit.create({
+              data: {
+                payoutId: doc.payoutId,
+                action: 'edit_amount',
+                actorEmail: actor.email,
+                actorKind: actor.actorKind,
+                note: JSON.stringify({
+                  scope: 'receipt',
+                  documentId: docId,
+                  oldAmount,
+                  newAmount,
+                  oldCurrency,
+                  newCurrency,
+                }),
+              },
+            });
+          }
+          // taralli-92104: separate audit row for line item edits so the
+          // forensics tools can attribute them distinctly from amount/
+          // currency tweaks. Action='edit_documents' is the existing enum
+          // value used for receipt-attached changes (PayoutAuditEntry type).
+          if (lineItemsChanged) {
+            const newLineItemsCount = Array.isArray(data.ocrLineItems)
+              ? (data.ocrLineItems as unknown[]).length
+              : 0;
+            await tx.payoutAudit.create({
+              data: {
+                payoutId: doc.payoutId,
+                action: 'edit_documents',
+                actorEmail: actor.email,
+                actorKind: actor.actorKind,
+                note: JSON.stringify({
+                  scope: 'receipt',
+                  documentId: docId,
+                  message: 'edited line items',
+                  oldLineItemsCount,
+                  newLineItemsCount,
+                }),
+              },
+            });
+          }
         }
 
         return row;
@@ -4219,6 +4399,9 @@ router.patch(
           originalAmount: updated.originalAmount == null ? null : Number(updated.originalAmount),
           originalCurrency: updated.originalCurrency,
           exchangeRate: updated.exchangeRate == null ? null : Number(updated.exchangeRate),
+          // taralli-92104: echo the persisted line items so the modal can
+          // sync its draft state to the canonical row without re-fetching.
+          ocrLineItems: Array.isArray(updated.ocrLineItems) ? updated.ocrLineItems : null,
           ocrError: updated.ocrError,
           sortOrder: updated.sortOrder,
           uploadedByUserId: updated.uploadedByUserId ?? null,

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag, Coins, Play } from 'lucide-react';
+import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag, Coins, Play, ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
 import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
-import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal } from '../../types';
+import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal, ReceiptLineItem, ReceiptLineItemCategory } from '../../types';
 import {
   PayoutStatusPill,
   PayoutMethodIcon,
@@ -366,10 +366,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // agnolotti-58291: per-receipt OCR amount + currency edit state. The modal
   // ships an inline form per receipt row (gated to full admins + payment_admin)
   // so admins can correct OCR misreads without recomputing the parent payout.
-  // `receiptOverrides` is a docId -> { ocrAmount, ocrCurrency } map applied on
-  // top of `payout.documents` for rendering, so the row reflects the saved
-  // value immediately without waiting for a parent refresh.
-  type ReceiptOverride = { ocrAmount: number | null; ocrCurrency: string | null };
+  // `receiptOverrides` is a docId -> { ocrAmount, ocrCurrency, ocrLineItems }
+  // map applied on top of `payout.documents` for rendering, so the row
+  // reflects the saved value immediately without waiting for a parent refresh.
+  //
+  // taralli-92104: extended with `ocrLineItems` so the line item grid stays
+  // in sync with what we just persisted (no parent re-fetch required).
+  type ReceiptOverride = {
+    ocrAmount: number | null;
+    ocrCurrency: string | null;
+    ocrLineItems?: ReceiptLineItem[] | null;
+  };
   const [receiptOverrides, setReceiptOverrides] = useState<Record<string, ReceiptOverride>>({});
   // Per-row save state.
   const [receiptSavingId, setReceiptSavingId] = useState<string | null>(null);
@@ -393,6 +400,29 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // on success; failures still surface a per-row error chip.
   const [retryClearedErrors, setRetryClearedErrors] = useState<Record<string, boolean>>({});
 
+  // taralli-92104: per-receipt line-item editor state.
+  //
+  //  - `lineItemsExpanded` tracks the collapse caret per docId. Default
+  //    collapsed (false) so the modal isn't overwhelming when a payout has
+  //    many receipts.
+  //  - `lineItemDrafts` holds the in-flight edits as string-typed inputs so
+  //    admins can type freely (decimals, partial values, etc.) without us
+  //    fighting the cursor. Numeric coercion happens at save time.
+  //  - `lineItemsSavingId` and `lineItemsSaveErrors` are scoped to the
+  //    line-items section so they don't collide with the amount/currency
+  //    save state above.
+  type LineItemDraft = {
+    name: string;
+    qty: string;
+    unitPrice: string;
+    subtotal: string;
+    category: ReceiptLineItemCategory;
+  };
+  const [lineItemsExpanded, setLineItemsExpanded] = useState<Record<string, boolean>>({});
+  const [lineItemDrafts, setLineItemDrafts] = useState<Record<string, LineItemDraft[]>>({});
+  const [lineItemsSavingId, setLineItemsSavingId] = useState<string | null>(null);
+  const [lineItemsSaveErrors, setLineItemsSaveErrors] = useState<Record<string, string>>({});
+
   // Hooks must be declared above any early returns. There aren't any early
   // returns in this component today, but keeping all hooks grouped here makes
   // the rule-of-hooks invariant easier to verify.
@@ -410,7 +440,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         .filter((d) => d.kind === 'receipt')
         .map((d) => {
           const ov = receiptOverrides[d.id];
-          return ov ? { ...d, ocrAmount: ov.ocrAmount, ocrCurrency: ov.ocrCurrency } : d;
+          if (!ov) return d;
+          // taralli-92104: layer the persisted line items on top of the
+          // original document too so the grid renders the saved values
+          // after PATCH without waiting for a parent refresh.
+          return {
+            ...d,
+            ocrAmount: ov.ocrAmount,
+            ocrCurrency: ov.ocrCurrency,
+            ocrLineItems:
+              ov.ocrLineItems !== undefined ? ov.ocrLineItems : d.ocrLineItems,
+          };
         }),
     [payout.documents, receiptOverrides],
   );
@@ -486,6 +526,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         [docId]: {
           ocrAmount: updated.ocrAmount,
           ocrCurrency: updated.ocrCurrency,
+          // taralli-92104: preserve any line items override that was already
+          // saved (e.g. admin saved line items first, then bumped the total).
+          // The backend echoes the current persisted array regardless of
+          // whether we PATCHed it, so trust the server response.
+          ocrLineItems: updated.ocrLineItems,
         },
       }));
       // Sync the draft text to the canonical saved value so the inputs match
@@ -551,6 +596,159 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       });
   }, [receipts, retryClearedErrors]);
   const showQuotaBanner = quotaErrorRows.length >= 2;
+
+  // taralli-92104: helpers + persistence for the per-receipt line items
+  // grid. Drafts are seeded on first expansion from the canonical
+  // `ocrLineItems` so admins can edit freely without round-tripping every
+  // keystroke. `saveLineItemsEdit` flushes the drafts through the same
+  // `updatePayoutDocument` endpoint and updates `receiptOverrides` so the
+  // rendered row reflects the saved values without a parent refresh.
+  function lineItemToDraft(item: ReceiptLineItem): LineItemDraft {
+    return {
+      name: item.name ?? '',
+      qty: String(item.qty ?? 0),
+      unitPrice: String(item.unitPrice ?? 0),
+      subtotal: String(item.subtotal ?? 0),
+      category: item.category ?? 'other',
+    };
+  }
+
+  function emptyLineItemDraft(): LineItemDraft {
+    return { name: '', qty: '1', unitPrice: '0', subtotal: '0', category: 'other' };
+  }
+
+  function ensureLineItemDrafts(docId: string, items: ReceiptLineItem[] | null | undefined) {
+    setLineItemDrafts((m) => {
+      if (m[docId]) return m; // already seeded — don't clobber in-flight edits
+      return {
+        ...m,
+        [docId]: (items ?? []).map(lineItemToDraft),
+      };
+    });
+  }
+
+  function toggleLineItems(docId: string, items: ReceiptLineItem[] | null | undefined) {
+    setLineItemsExpanded((m) => {
+      const next = !m[docId];
+      if (next) ensureLineItemDrafts(docId, items);
+      return { ...m, [docId]: next };
+    });
+  }
+
+  function updateLineItemDraft(
+    docId: string,
+    idx: number,
+    patch: Partial<LineItemDraft>,
+  ) {
+    setLineItemDrafts((m) => {
+      const cur = m[docId] ?? [];
+      const next = cur.slice();
+      next[idx] = { ...next[idx], ...patch };
+      return { ...m, [docId]: next };
+    });
+  }
+
+  function addLineItem(docId: string) {
+    setLineItemDrafts((m) => {
+      const cur = m[docId] ?? [];
+      return { ...m, [docId]: [...cur, emptyLineItemDraft()] };
+    });
+  }
+
+  function removeLineItem(docId: string, idx: number) {
+    setLineItemDrafts((m) => {
+      const cur = m[docId] ?? [];
+      const next = cur.slice();
+      next.splice(idx, 1);
+      return { ...m, [docId]: next };
+    });
+  }
+
+  // Sum of subtotals across the current draft (used by the "Use line sum"
+  // button + the live total at the bottom of the editor).
+  function draftSubtotalSum(drafts: LineItemDraft[] | undefined): number {
+    if (!drafts) return 0;
+    let sum = 0;
+    for (const d of drafts) {
+      const n = Number(d.subtotal);
+      if (Number.isFinite(n) && n >= 0) sum += n;
+    }
+    return sum;
+  }
+
+  // Clamp the receipt-amount draft to the current line-sum. Convenience
+  // affordance — admins still get the explicit Save button to confirm.
+  function useLineSumForAmount(docId: string) {
+    const drafts = lineItemDrafts[docId];
+    const sum = draftSubtotalSum(drafts);
+    setReceiptDrafts((m) => {
+      const prev = m[docId];
+      // Preserve the existing currency draft (or empty) so we don't reset it.
+      return {
+        ...m,
+        [docId]: {
+          amount: sum.toFixed(2),
+          currency: prev?.currency ?? '',
+        },
+      };
+    });
+  }
+
+  async function saveLineItemsEdit(docId: string) {
+    const drafts = lineItemDrafts[docId];
+    if (!drafts) return;
+    setLineItemsSavingId(docId);
+    setLineItemsSaveErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    try {
+      const items: ReceiptLineItem[] = drafts.map((d, idx) => {
+        const qty = Number(d.qty);
+        const unitPrice = Number(d.unitPrice);
+        const subtotal = Number(d.subtotal);
+        if (!Number.isFinite(qty) || qty < 0) {
+          throw new Error(`Line ${idx + 1}: qty must be a non-negative number`);
+        }
+        if (!Number.isFinite(unitPrice) || unitPrice < 0) {
+          throw new Error(`Line ${idx + 1}: unit price must be a non-negative number`);
+        }
+        if (!Number.isFinite(subtotal) || subtotal < 0) {
+          throw new Error(`Line ${idx + 1}: subtotal must be a non-negative number`);
+        }
+        return {
+          name: d.name,
+          qty,
+          unitPrice,
+          subtotal,
+          category: d.category,
+        };
+      });
+      const updated = await updatePayoutDocument(docId, { ocrLineItems: items });
+      setReceiptOverrides((m) => ({
+        ...m,
+        [docId]: {
+          ocrAmount: updated.ocrAmount,
+          ocrCurrency: updated.ocrCurrency,
+          ocrLineItems: updated.ocrLineItems,
+        },
+      }));
+      // Re-seed the draft from the canonical saved array so the next render
+      // matches the persisted state (server may have rounded/sanitized).
+      setLineItemDrafts((m) => ({
+        ...m,
+        [docId]: (updated.ocrLineItems ?? []).map(lineItemToDraft),
+      }));
+    } catch (err: any) {
+      setLineItemsSaveErrors((m) => ({
+        ...m,
+        [docId]: err?.message || 'Failed to save line items',
+      }));
+    } finally {
+      setLineItemsSavingId(null);
+    }
+  }
 
   // bresaola-89172: keyboard nav for the lightbox now lives inside the
   // ReceiptLightbox component itself (Esc to close, arrows to cycle). The
@@ -1394,6 +1592,184 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         {saveError && (
                           <div className="text-xs text-red-600 mt-0.5 ml-4">{saveError}</div>
                         )}
+                        {/* taralli-92104: collapsed line item editor. Caret
+                            toggles expansion; on expand we seed the drafts
+                            from the canonical `ocrLineItems`. Renders for
+                            every admin who can edit receipts, including
+                            receipts with no items today (admin can add).
+                        */}
+                        {canEditReceipts && (() => {
+                          const expanded = !!lineItemsExpanded[r.id];
+                          const persistedItems = r.ocrLineItems ?? null;
+                          const persistedCount = Array.isArray(persistedItems)
+                            ? persistedItems.length
+                            : 0;
+                          const drafts = lineItemDrafts[r.id];
+                          const draftCount = drafts?.length ?? persistedCount;
+                          const lineSum = draftSubtotalSum(drafts);
+                          const itemsSaving = lineItemsSavingId === r.id;
+                          const itemsSaveError = lineItemsSaveErrors[r.id];
+                          // Currency for the live sum label — receipt's
+                          // original currency if known, else USD as a
+                          // last-resort. The save endpoint stores numeric
+                          // values; the label is purely informational.
+                          const sumCurrency =
+                            r.originalCurrency
+                              ?? r.ocrCurrency
+                              ?? 'USD';
+                          return (
+                            <div className="ml-4 mt-1">
+                              <button
+                                type="button"
+                                onClick={() => toggleLineItems(r.id, persistedItems)}
+                                className="text-xs text-theme-text-muted hover:text-theme-text inline-flex items-center gap-1"
+                                title={expanded ? 'Hide line items' : 'Show line items'}
+                              >
+                                {expanded
+                                  ? <ChevronDown size={12} />
+                                  : <ChevronRight size={12} />}
+                                <span>
+                                  {expanded ? 'Hide' : 'Show'} line items ({draftCount})
+                                </span>
+                              </button>
+                              {expanded && (
+                                <div className="mt-2 rounded border border-theme-stroke p-2 bg-theme-bg space-y-1">
+                                  {/*
+                                    taralli-92104: data-grid cells, not form
+                                    fields — IconInput hardcodes `w-full
+                                    !pl-14` which doesn't fit a tight 4-cell
+                                    + remove-button layout. Same precedent as
+                                    agnolotti-58291's per-row amount/currency
+                                    inputs above; raw inputs are intentional
+                                    here.
+                                  */}
+                                  {(drafts ?? []).length === 0 && (
+                                    <div className="text-xs text-theme-text-faint">
+                                      No line items yet. Click "Add line" to start.
+                                    </div>
+                                  )}
+                                  {(drafts ?? []).map((d, idx) => (
+                                    <div
+                                      key={idx}
+                                      className="flex items-center gap-1.5"
+                                    >
+                                      <input
+                                        type="text"
+                                        value={d.name}
+                                        placeholder="name"
+                                        onChange={(e) =>
+                                          updateLineItemDraft(r.id, idx, { name: e.target.value })
+                                        }
+                                        className="flex-1 min-w-0 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
+                                      />
+                                      <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        inputMode="decimal"
+                                        value={d.qty}
+                                        placeholder="qty"
+                                        onChange={(e) =>
+                                          updateLineItemDraft(r.id, idx, { qty: e.target.value })
+                                        }
+                                        className="w-14 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                                      />
+                                      <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        inputMode="decimal"
+                                        value={d.unitPrice}
+                                        placeholder="unit"
+                                        onChange={(e) =>
+                                          updateLineItemDraft(r.id, idx, { unitPrice: e.target.value })
+                                        }
+                                        className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                                      />
+                                      <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        inputMode="decimal"
+                                        value={d.subtotal}
+                                        placeholder="subtotal"
+                                        onChange={(e) =>
+                                          updateLineItemDraft(r.id, idx, { subtotal: e.target.value })
+                                        }
+                                        className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                                      />
+                                      <select
+                                        value={d.category}
+                                        onChange={(e) =>
+                                          updateLineItemDraft(r.id, idx, {
+                                            category: e.target.value as ReceiptLineItemCategory,
+                                          })
+                                        }
+                                        className="px-1 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
+                                        title="Category — pizza-prices analytics filters on 'pizza'"
+                                      >
+                                        <option value="pizza">pizza</option>
+                                        <option value="beverage">beverage</option>
+                                        <option value="topping">topping</option>
+                                        <option value="side">side</option>
+                                        <option value="dessert">dessert</option>
+                                        <option value="tax">tax</option>
+                                        <option value="tip">tip</option>
+                                        <option value="fee">fee</option>
+                                        <option value="other">other</option>
+                                      </select>
+                                      <button
+                                        type="button"
+                                        onClick={() => removeLineItem(r.id, idx)}
+                                        className="p-1 rounded text-theme-text-muted hover:text-red-500 hover:bg-red-50"
+                                        title="Remove this line"
+                                      >
+                                        <Trash2 size={12} />
+                                      </button>
+                                    </div>
+                                  ))}
+                                  <div className="flex items-center gap-2 pt-1">
+                                    <button
+                                      type="button"
+                                      onClick={() => addLineItem(r.id)}
+                                      className="px-2 py-1 rounded border border-theme-stroke text-theme-text text-xs inline-flex items-center gap-1 hover:bg-theme-surface"
+                                      title="Append a new line"
+                                    >
+                                      <Plus size={12} />
+                                      Add line
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() => useLineSumForAmount(r.id)}
+                                      className="px-2 py-1 rounded border border-theme-stroke text-theme-text text-xs inline-flex items-center gap-1 hover:bg-theme-surface"
+                                      title="Copy the line sum into the receipt total above"
+                                      disabled={(drafts ?? []).length === 0}
+                                    >
+                                      Use line sum
+                                    </button>
+                                    <span className="text-xs text-theme-text-muted ml-auto">
+                                      Sum: {sumCurrency} {lineSum.toFixed(2)}
+                                    </span>
+                                    <button
+                                      type="button"
+                                      onClick={() => saveLineItemsEdit(r.id)}
+                                      disabled={itemsSaving}
+                                      className="px-2 py-1 rounded bg-[#E52828] text-white text-xs disabled:opacity-40 inline-flex items-center gap-1"
+                                      title="Save line items"
+                                    >
+                                      {itemsSaving
+                                        ? <Loader2 size={12} className="animate-spin" />
+                                        : 'Save lines'}
+                                    </button>
+                                  </div>
+                                  {itemsSaveError && (
+                                    <div className="text-xs text-red-600">{itemsSaveError}</div>
+                                  )}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })()}
                       </li>
                     );
                   })}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem } from '../types';
 // pancetta-92103: region portal → underlying parties.region slug map. Used by
 // `buildPayoutQuery` to expand the /payments admin Regions multi-select into
 // the existing `?regions=` query the backend already accepts.
@@ -4244,6 +4244,11 @@ export async function updateAdminPayout(
  * Sending `null` clears the field; sending `undefined` (i.e. omitting it from
  * the object) leaves it untouched.
  *
+ * taralli-92104: the same endpoint now also accepts `ocrLineItems` (an array
+ * of structured line items the admin edited in the reviewer modal). The
+ * backend replaces the JSONB column wholesale — no merge — and writes a
+ * separate `edit_documents` audit row when the line items change.
+ *
  * Returns the updated document row shape — same fields as
  * `AdminPayoutDetail.documents[]` minus the uploader join.
  */
@@ -4252,6 +4257,7 @@ export async function updatePayoutDocument(
   patch: {
     ocrAmount?: number | null;
     ocrCurrency?: string | null;
+    ocrLineItems?: ReceiptLineItem[] | null;
   },
 ): Promise<{
   id: string;
@@ -4263,6 +4269,10 @@ export async function updatePayoutDocument(
   ocrAmount: number | null;
   ocrCurrency: string | null;
   ocrConfidence: number | null;
+  originalAmount: number | null;
+  originalCurrency: string | null;
+  exchangeRate: number | null;
+  ocrLineItems: ReceiptLineItem[] | null;
   ocrError: string | null;
   sortOrder: number;
   uploadedByUserId: string | null;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1675,6 +1675,12 @@ export interface PayoutDocument {
   originalAmount?: number | null;
   originalCurrency?: string | null;
   exchangeRate?: number | null;
+  // taralli-92104: structured per-line OCR items (formaggi-89172's
+  // `ocr_line_items` JSONB column) surfaced for the admin reviewer modal.
+  // Admins edit these inline; PATCH /api/admin/payouts/documents/:docId
+  // persists the new array wholesale. `null` when OCR didn't extract any
+  // line items (pre-formaggi rows or unparseable receipts).
+  ocrLineItems?: ReceiptLineItem[] | null;
   ocrError: string | null;
   sortOrder: number;
   // pancetta-37195: per-doc uploader attribution. Null on historical rows
@@ -1682,6 +1688,32 @@ export interface PayoutDocument {
   uploadedByUserId?: string | null;
   uploadedByName?: string | null;
   uploadedByEmail?: string | null;
+}
+
+/**
+ * taralli-92104: line item shape extracted by the OCR pipeline
+ * (formaggi-89172) and edited by admins in the reviewer modal. Categories
+ * mirror the backend `OcrLineItemCategory` enum — the pizza-prices
+ * analytics endpoint (`/api/admin/payouts/pizza-prices`) filters on
+ * `category === 'pizza'`, so the shape must stay compatible.
+ */
+export type ReceiptLineItemCategory =
+  | 'pizza'
+  | 'beverage'
+  | 'topping'
+  | 'side'
+  | 'dessert'
+  | 'tax'
+  | 'tip'
+  | 'fee'
+  | 'other';
+
+export interface ReceiptLineItem {
+  name: string;
+  qty: number;
+  unitPrice: number;
+  subtotal: number;
+  category: ReceiptLineItemCategory;
 }
 
 export interface BankDetails {


### PR DESCRIPTION
## Summary
- Per-receipt `ocr_line_items` (formaggi-89172 JSONB column) now render as an editable inline grid inside the admin `PayoutReviewModal`. Each line exposes Name / Qty / Unit price / Subtotal / Category dropdown + a remove button; admins can also "+ Add line".
- The receipt-level amount + currency editors (mortadella-92103) are unchanged; a new "Use line sum" button copies the live sum of subtotals into the amount draft.
- Backend `PATCH /api/admin/payouts/documents/:docId` accepts `ocrLineItems` (array or null), sanitizes each entry, and writes a separate `edit_documents` audit row when items change. Amount/currency edits keep their existing `edit_amount` audit path.
- `serializePayout` and `updatePayoutDocument` now surface the persisted line items so the modal can sync state without a parent refetch.
- Phase 2 of the per-event receipts model rework — `taralli-92104`.

## Implementation notes
- Line item shape matches the OCR extractor's `OcrLineItem` (`name`, `qty`, `unitPrice`, `subtotal`, `category`) so the existing `/admin/payouts/pizza-prices` analytics consumer stays compatible.
- Editor is collapsed by default behind a "Show line items (N)" caret to avoid swamping multi-receipt payouts.
- Raw `<input>` cells are used in the grid (mirrors the agnolotti-58291 data-grid exception already in this file — IconInput's `w-full !pl-14` doesn't fit the 4-cell + remove-button row).
- Hooks remain declared above any early returns per `feedback_hooks_above_early_returns`.

## Test plan
- [ ] Open a payout with a receipt that already has line items → expand → edit a line's unit price → Save lines → reload modal → edit persists.
- [ ] Add a new line via "+ Add line" → Save → reload → new line persists with correct category.
- [ ] Remove an existing line → Save → reload → removal persists.
- [ ] Click "Use line sum" → amount input clamps to the displayed sum.
- [ ] Try negative or non-numeric qty/price → save fails inline with a per-line error message.
- [ ] Verify `/admin/payouts/pizza-prices` analytics still returns the edited receipt's pizza items.
- [ ] Verify `payout_audit` records a new row with `action='edit_documents'` and `note` JSON including `oldLineItemsCount` / `newLineItemsCount`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>