### PR TITLE
feat(gnocchi-92104): queued payout status

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -57,7 +57,13 @@ const router = Router();
 // 'paid' for cap math (counts toward usedUsd) but distinct on the UI so admins
 // can tell "city was paid out, possibly less than the requested claim amount"
 // apart from a direct paid row.
-const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'rejected', 'paid', 'failed', 'withdrawn', 'completed'] as const;
+// gnocchi-92104: 'queued' added — intermediate "wire request sent, awaiting
+// settlement" status between approved and paid. Used when the wire-transfer
+// email has been sent to the payments team / bank but the wire hasn't cleared
+// yet. Money is committed (counts toward cap math like paid/approved) but
+// the row hasn't terminated — admins flip queued → paid once settlement is
+// confirmed, or queued → failed if the wire bounces.
+const ALLOWED_PAYOUT_STATUSES = ['pending', 'approved', 'queued', 'rejected', 'paid', 'failed', 'withdrawn', 'completed'] as const;
 const ALLOWED_PAYOUT_METHODS = ['mercury_card', 'wire', 'usdc_base'] as const;
 
 /**
@@ -314,8 +320,13 @@ async function assertWithinPartyCap(
     // approval is authoritative.
     // provolone-92103: 'completed' is a terminal close-out semantically
     // equivalent to 'paid' for cap purposes — include it here.
+    // gnocchi-92104: 'queued' is "wire request sent, settlement pending" —
+    // money is committed (the admin signaled "we're sending this") so it
+    // counts toward usedUsd same as approved/paid/completed. Otherwise an
+    // admin queuing a wire could overshoot the cap by approving and queueing
+    // a second payment that totals over the limit before the first settles.
     partyId,
-    status: { in: ['paid', 'approved', 'completed'] },
+    status: { in: ['paid', 'approved', 'queued', 'completed'] },
   };
   if (ignorePayoutId) {
     where.id = { not: ignorePayoutId };
@@ -470,8 +481,9 @@ function isPrimaryHostInCohosts(party: any): boolean {
  *
  * Implementation: scan the row's `audits` (already sorted DESC by createdAt
  * in callsites that include them). The most recent `flag_ready` audit "wins"
- * iff there is NO subsequent `mark_paid` / `reject` / `unapprove` audit at
- * or after its timestamp.
+ * iff there is NO subsequent `mark_paid` / `mark_queued` / `reject` /
+ * `unapprove` audit at or after its timestamp (gnocchi-92104 added
+ * `mark_queued` to the consume list).
  *
  * Returns `null` shape when the audits weren't loaded so older queries don't
  * accidentally claim "not flagged" — clients should treat `flaggedReady`
@@ -503,7 +515,17 @@ function deriveFlaggedReady(audits: any[] | undefined): {
     : new Date(latestFlag.createdAt).getTime();
   const consumed = audits.some((a) => {
     if (a === latestFlag) return false;
-    if (a.action !== 'mark_paid' && a.action !== 'reject' && a.action !== 'unapprove') return false;
+    // gnocchi-92104: 'mark_queued' (wire request sent) also consumes the
+    // flag — the payments team has visibly taken action, so re-flagging is
+    // a stale signal.
+    if (
+      a.action !== 'mark_paid' &&
+      a.action !== 'mark_queued' &&
+      a.action !== 'reject' &&
+      a.action !== 'unapprove'
+    ) {
+      return false;
+    }
     const ts = a.createdAt instanceof Date ? a.createdAt.getTime() : new Date(a.createdAt).getTime();
     return ts >= flagTs;
   });
@@ -658,19 +680,22 @@ function serializePayout(row: any): any {
  * Map keyed by payoutId. Payouts with no flag entry are absent.
  *
  * Sticky semantics: the latest `flag_ready` audit wins UNLESS a subsequent
- * `mark_paid` / `reject` / `unapprove` audit exists at or after it.
+ * `mark_paid` / `mark_queued` / `reject` / `unapprove` audit exists at or
+ * after it (gnocchi-92104 added `mark_queued` to the consume list).
  */
 async function fetchFlaggedReadyByPayoutId(
   payoutIds: string[],
 ): Promise<Map<string, { at: string; by: string | null }>> {
   if (payoutIds.length === 0) return new Map();
   // Pull every relevant audit in one query so we can derive sticky state in
-  // memory. `flag_ready` + the three "consumes" actions. This is bounded:
+  // memory. `flag_ready` + the four "consumes" actions. This is bounded:
   // the page size of LIST is 100, and each payout typically has <20 audits.
+  // gnocchi-92104: include 'mark_queued' so a wire-request-sent audit
+  // invalidates a prior flag the same way mark_paid does.
   const audits = await prisma.payoutAudit.findMany({
     where: {
       payoutId: { in: payoutIds },
-      action: { in: ['flag_ready', 'mark_paid', 'reject', 'unapprove'] },
+      action: { in: ['flag_ready', 'mark_paid', 'mark_queued', 'reject', 'unapprove'] },
     },
     select: {
       payoutId: true,
@@ -1221,8 +1246,11 @@ router.get(
       }
 
       // 6. For each assembled row, drop it if ANY candidate already has an
-      //    in-flight payout for that party. "In-flight" = pending/approved/paid
+      //    in-flight payout for that party. "In-flight" = pending/approved/queued/paid
       //    (failed/rejected don't count — that prepayment never went through).
+      //    gnocchi-92104: 'queued' (wire request sent, awaiting settlement) is
+      //    in-flight too — we shouldn't surface a fresh prepay candidate while
+      //    a wire is mid-flight.
       //    Run as a single grouped query: pull all matching payouts and bucket
       //    by partyId in memory.
       const inFlight = filteredCandidateUserIds.size
@@ -1230,7 +1258,7 @@ router.get(
             where: {
               partyId: { in: optedInAssembled.map(r => r.partyMeta.id) },
               hostUserId: { in: Array.from(filteredCandidateUserIds) },
-              status: { in: ['pending', 'approved', 'paid'] },
+              status: { in: ['pending', 'approved', 'queued', 'paid'] },
             },
             select: { partyId: true, hostUserId: true },
           })
@@ -2777,7 +2805,11 @@ router.post(
         existing.status === 'paid' ||
         existing.status === 'rejected' ||
         existing.status === 'withdrawn' ||
-        existing.status === 'completed'
+        existing.status === 'completed' ||
+        // gnocchi-92104: a queued payout is already moving (wire request
+        // sent, awaiting settlement) — re-flagging it as "ready for payment"
+        // is a stale signal. Treat as terminal-ish for flag purposes.
+        existing.status === 'queued'
       ) {
         // Flagging a terminal-state row is a no-op signal; reject up front
         // so the UI doesn't render a stale-looking flag icon afterward.
@@ -3028,6 +3060,195 @@ router.post(
             actorEmail: actor.email,
             actorKind: actor.actorKind,
             note: typeof note === 'string' ? note : null,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/mark-queued — gnocchi-92104
+//
+// Flip an `approved` payout to `queued`, meaning "the wire transfer email
+// request has been sent to the payments team / bank but the wire hasn't
+// settled yet." Semantically between approved (admin signed off) and paid
+// (money actually moved).
+//
+// `queued` counts toward the per-party committed cap the same as approved /
+// paid / completed — it's money committed, just not yet settled.
+//
+// Valid transitions:
+//   approved -> queued   (this endpoint)
+//   queued   -> paid     (POST /:id/mark-paid; existing flow, accepts queued)
+//   queued   -> failed   (mark-failed; existing flow accepts non-paid)
+//   queued   -> approved (POST /:id/unmark-queued; admin "oops un-queue")
+//
+// Not method-gated — the typical use is wire payouts, but admins may queue
+// any approved row when the settlement signal needs a staging step.
+//
+// Auth: admin / super_admin / payment_admin. payment_admin actors are
+// blocked from queueing a row they would receive (assertNotSelfPayout).
+//
+// Body:
+//   { note?: string }   — optional, written to payout_audit.note. Cap 500
+//                         chars to match flag-ready's note budget.
+// ============================================
+router.post(
+  '/:id/mark-queued',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: {
+          id: true,
+          status: true,
+          hostUserId: true,
+          partyId: true,
+          finalAmountUsd: true,
+        },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'approved') {
+        throw new AppError(
+          `Can only queue an approved payout (current status: ${existing.status})`,
+          400,
+          'NOT_APPROVED',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      // Cap math: queueing the row promotes it from "committed" to
+      // "committed-and-settling", but the cap rules already counted it
+      // (approved is in the assertWithinPartyCap status array). Re-running the
+      // checks here is belt-and-braces — if the party cap was tightened
+      // between approve and queue, we surface the violation instead of
+      // silently letting the wire request go out.
+      assertWithinPerSubmissionCap(Number(existing.finalAmountUsd));
+      await assertWithinPartyCap(
+        existing.partyId,
+        Number(existing.finalAmountUsd),
+        existing.id,
+      );
+
+      const note = typeof req.body?.note === 'string'
+        ? req.body.note.slice(0, 500)
+        : null;
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: { status: 'queued' },
+          include: {
+            party: { select: PAYOUT_PARTY_SELECT },
+            host: { select: { id: true, name: true, email: true } },
+            documents: {
+              orderBy: { sortOrder: 'asc' },
+              include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+            },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'mark_queued',
+            oldStatus: 'approved',
+            newStatus: 'queued',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// POST /api/admin/payouts/:id/unmark-queued — gnocchi-92104
+//
+// Flip a `queued` payout back to `approved`. The "admin oops un-queue" path
+// — used when the wire request was sent in error and needs to be reset
+// before settlement (e.g. wrong recipient details, duplicate request).
+//
+// Idempotent: rejects unless status === 'queued' (400 NOT_QUEUED).
+// Audit trail (mark_queued + this unmark_queued) is preserved so the
+// reversal is visible.
+// ============================================
+router.post(
+  '/:id/unmark-queued',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'queued') {
+        throw new AppError(
+          `Cannot un-queue a payout in status '${existing.status}'`,
+          400,
+          'NOT_QUEUED',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      const note = typeof req.body?.note === 'string'
+        ? req.body.note.slice(0, 500)
+        : null;
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: { status: 'approved' },
+          include: {
+            party: { select: PAYOUT_PARTY_SELECT },
+            host: { select: { id: true, name: true, email: true } },
+            documents: {
+              orderBy: { sortOrder: 'asc' },
+              include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+            },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'unmark_queued',
+            oldStatus: 'queued',
+            newStatus: 'approved',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note,
           },
         });
 
@@ -4404,7 +4625,11 @@ partyMarkPaidRouter.get(
       const payouts = await prisma.payout.findMany({
         where: {
           partyId,
-          status: { in: ['pending', 'approved'] },
+          // gnocchi-92104: 'queued' (wire-request-sent, awaiting settlement) is
+          // in-flight too — Mark Party Paid should be able to roll it forward
+          // to 'paid' alongside pending + approved when the admin confirms the
+          // settlement out-of-band.
+          status: { in: ['pending', 'approved', 'queued'] },
         },
         select: {
           id: true,
@@ -4610,10 +4835,13 @@ partyMarkPaidRouter.post(
 
       // Find all in-flight payouts BEFORE the transaction so we can do per-row
       // self-payout checks + log a clean count even if zero match.
+      // gnocchi-92104: 'queued' (wire-request-sent, awaiting settlement) is
+      // in-flight too — Mark Party Paid flips it forward along with the
+      // pending/approved rows.
       const inflight = await prisma.payout.findMany({
         where: {
           partyId,
-          status: { in: ['pending', 'approved'] },
+          status: { in: ['pending', 'approved', 'queued'] },
         },
         select: {
           id: true,
@@ -4821,8 +5049,10 @@ partyMarkPaidRouter.post(
         // preserved by the fact that the admin is taking an explicit
         // close-out action.)
         if (!party.paymentsClosedAt && updatedIds.length > 0) {
+          // gnocchi-92104: include 'queued' in the in-flight check so a city
+          // with a pending wire settlement isn't prematurely closed.
           const remainingInflight = await tx.payout.count({
-            where: { partyId, status: { in: ['pending', 'approved'] } },
+            where: { partyId, status: { in: ['pending', 'approved', 'queued'] } },
           });
           if (remainingInflight === 0) {
             await tx.party.update({

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -422,7 +422,13 @@ async function assertWithinPartyCap(
 
   const where: any = {
     partyId,
-    status: { in: ['paid', 'pending', 'approved'] },
+    // gnocchi-92104: 'queued' (wire request sent, awaiting settlement) is
+    // money committed and counts against the cap the same as approved/paid.
+    // The admin-side helper already includes 'completed'; we leave it out
+    // here because hosts don't create payouts on completed parties (the
+    // city is closed out) and we want the host-side error to match the
+    // smaller view they have.
+    status: { in: ['paid', 'pending', 'approved', 'queued'] },
   };
   if (ignorePayoutId) {
     where.id = { not: ignorePayoutId };

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -76,6 +76,24 @@ interface PayoutReviewModalProps {
    */
   onRevertPaid?: () => Promise<string | void> | string | void;
   /**
+   * gnocchi-92104: flip an `approved` payout to `queued` (wire request sent,
+   * awaiting settlement). Surfaced as an amber "Mark queued" button in the
+   * footer when status === 'approved'. Confirms once with body copy
+   * "Mark queued? This signals the wire request has been sent but not
+   * settled yet." Reversible via `onUnmarkQueued`.
+   *
+   * Returns a string error message (NOT throws) when the call fails so the
+   * modal can render it inline; resolves to undefined on success.
+   */
+  onMarkQueued?: () => Promise<string | void> | string | void;
+  /**
+   * gnocchi-92104: revert a `queued` payout back to `approved` (the "admin
+   * oops un-queue" path). Surfaced as an amber "Un-queue" button when
+   * status === 'queued'. Mirrors `onUnapprove`'s contract — no confirm,
+   * reversible. Returns string error / void on success.
+   */
+  onUnmarkQueued?: () => Promise<string | void> | string | void;
+  /**
    * lasagna-92103: backend admin PATCH no longer enforces the per-submission
    * cap, so `allowOverSubmissionCap` is no longer forwarded by this modal.
    * The signature still accepts the field for back-compat with parents that
@@ -187,6 +205,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   onReject,
   onUnapprove,
   onRevertPaid,
+  onMarkQueued,
+  onUnmarkQueued,
   onSaveAmount,
   onSaveAdminNotes,
   onMarkPaid,
@@ -294,6 +314,16 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // accidentally drop the historical mark-paid record.
   const [revertPaidError, setRevertPaidError] = useState<string | null>(null);
   const [revertPaidConfirming, setRevertPaidConfirming] = useState(false);
+
+  // gnocchi-92104: inline error + confirm gate for "Mark queued"
+  // (approved -> queued). Single-click ack mirroring revertPaidConfirming
+  // so the admin acknowledges they're signalling "the wire request has been
+  // sent" even though no money has moved.
+  const [markQueuedError, setMarkQueuedError] = useState<string | null>(null);
+  const [markQueuedConfirming, setMarkQueuedConfirming] = useState(false);
+  // Inline error for "Un-queue" (queued -> approved). No confirm — reversible
+  // action, matches the unapprove pattern.
+  const [unmarkQueuedError, setUnmarkQueuedError] = useState<string | null>(null);
 
   const [showMarkPaidForm, setShowMarkPaidForm] = useState(false);
   const [wireRef, setWireRef] = useState('');
@@ -613,6 +643,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // 'failed' is no longer "closed" — it has the Execute (Retry) button instead
   // of Re-open. Only 'rejected' remains terminal-until-reopened.
   const isClosed = payout.status === 'rejected';
+  // gnocchi-92104: queued = wire request sent, awaiting settlement. Separate
+  // footer cluster from approved — Mark Paid still works (queued → paid),
+  // but Execute / Approve are hidden and Un-queue replaces Mark queued.
+  const isQueued = payout.status === 'queued';
 
   // For Mercury, last4 must be exactly 4 digits before the button enables.
   const execMercuryValid = /^\d{4}$/.test(execCardLast4.trim());
@@ -1844,6 +1878,42 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     <Send size={14} />
                     {isFailed ? 'Retry Payment' : 'Execute Payment'}
                   </button>
+                  {/* gnocchi-92104: Mark queued — flips approved -> queued
+                      (wire request sent, awaiting settlement). Click 1 = arm
+                      confirm; click 2 = fire. Only on strictly-approved (not
+                      failed) rows; admin-only. Amber to signal "money's
+                      committed and moving" without claiming it's settled. */}
+                  {payout.status === 'approved' && onMarkQueued && (
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        if (!markQueuedConfirming) {
+                          setMarkQueuedConfirming(true);
+                          return;
+                        }
+                        setMarkQueuedError(null);
+                        const err = await onMarkQueued();
+                        setMarkQueuedConfirming(false);
+                        if (typeof err === 'string' && err) {
+                          setMarkQueuedError(err);
+                        }
+                      }}
+                      disabled={busy || selfPayoutBlocked}
+                      className={
+                        markQueuedConfirming
+                          ? 'inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium disabled:opacity-50'
+                          : 'inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-500/80 hover:bg-amber-500 text-white text-sm font-medium disabled:opacity-50'
+                      }
+                      title={
+                        markQueuedConfirming
+                          ? 'Click again to confirm — signals the wire request has been sent but not settled yet'
+                          : 'Mark queued — the wire request has been sent but not settled yet'
+                      }
+                    >
+                      <Send size={14} />
+                      {markQueuedConfirming ? 'Click again to confirm' : 'Mark queued'}
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={() => setShowMarkPaidForm(true)}
@@ -1855,6 +1925,42 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   </button>
                 </>
               )}
+            </>
+          )}
+          {/* gnocchi-92104: queued payout cluster — wire request sent,
+              awaiting settlement. Mark paid (manual) confirms settlement;
+              Un-queue reverts back to approved. Admin-only — same gate as
+              the approved-row primary actions. */}
+          {isQueued && isAdminViewer && (
+            <>
+              {onUnmarkQueued && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setUnmarkQueuedError(null);
+                    const err = await onUnmarkQueued();
+                    if (typeof err === 'string' && err) {
+                      setUnmarkQueuedError(err);
+                    }
+                  }}
+                  disabled={busy || selfPayoutBlocked}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-500/50 text-amber-300 hover:bg-amber-500/10 text-sm font-medium disabled:opacity-50"
+                  title="Move this payout back to approved (cancels the queued state)"
+                >
+                  <Undo2 size={14} />
+                  Un-queue
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setShowMarkPaidForm(true)}
+                disabled={busy || selfPayoutBlocked}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+                title="Confirm the wire settled and flip to paid"
+              >
+                <DollarSign size={14} />
+                Mark paid (settled)
+              </button>
             </>
           )}
           {isClosed && onReopen && (
@@ -1951,7 +2057,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             !isPaid &&
             !isClosed &&
             payout.status !== 'withdrawn' &&
-            payout.status !== 'completed' && (
+            payout.status !== 'completed' &&
+            // gnocchi-92104: don't surface flag-ready on queued rows — the
+            // payments team has already taken visible action (wire sent), so
+            // re-flagging is a stale signal. Backend also 400s in this case.
+            payout.status !== 'queued' && (
             payout.flaggedReady ? (
               <span
                 className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 text-sm font-medium"
@@ -2024,6 +2134,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
               <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
               <span>{revertPaidError}</span>
+            </div>
+          )}
+          {/* gnocchi-92104: inline errors for Mark queued + Un-queue. Same
+              red-500 pattern as unapprove/revert-paid above. */}
+          {markQueuedError && (
+            <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{markQueuedError}</span>
+            </div>
+          )}
+          {unmarkQueuedError && (
+            <div className="w-full mt-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">
+              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+              <span>{unmarkQueuedError}</span>
             </div>
           )}
           {/* argentina-92103: inline error for Flag-ready. Same pattern

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -179,6 +179,21 @@ function InnerActionsCell({
           </button>
         </>
       )}
+
+      {/* gnocchi-92104: queued row gets a single Mark paid (settled) button.
+          Approved -> queued / queued -> approved transitions live in the
+          modal so the admin can leave a confirmation note. */}
+      {status === 'queued' && (
+        <button
+          type="button"
+          onClick={() => onMarkPaid(payout)}
+          disabled={busy}
+          className="p-1.5 rounded-md hover:bg-blue-50 text-blue-600 disabled:opacity-50"
+          title="Mark paid (wire settled)"
+        >
+          <DollarSign size={15} />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -41,6 +41,10 @@ const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'pending', label: 'Pending' },
   { value: 'approved', label: 'Approved' },
+  // gnocchi-92104: 'queued' = wire request sent, awaiting settlement. Sits
+  // between Approved and Paid so admins can spot in-flight wires that need
+  // settlement follow-up.
+  { value: 'queued', label: 'Queued' },
   { value: 'paid', label: 'Paid' },
   { value: 'rejected', label: 'Rejected' },
   { value: 'failed', label: 'Failed' },

--- a/frontend/src/components/payments-admin/PayoutsTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsTable.tsx
@@ -138,6 +138,23 @@ function ActionsCell({
           </button>
         </>
       )}
+
+      {/* gnocchi-92104: queued row gets a single inline Mark paid (settled)
+          button. The Un-queue / Mark queued transitions live in the modal —
+          this row affordance is just for the common "wire cleared, flip to
+          paid" path so admins don't have to open the modal for every
+          settlement. */}
+      {status === 'queued' && (
+        <button
+          type="button"
+          onClick={() => onMarkPaid(payout)}
+          disabled={busy}
+          className="p-1.5 rounded-md hover:bg-blue-50 text-blue-600 disabled:opacity-50"
+          title="Mark paid (wire settled)"
+        >
+          <DollarSign size={15} />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/payments-shared/PayoutStatusPill.tsx
+++ b/frontend/src/components/payments-shared/PayoutStatusPill.tsx
@@ -51,6 +51,24 @@ const STATUS_STYLES: Record<PayoutStatus, { bg: string; text: string; border: st
     border: 'border-gray-300',
     label: 'Withdrawn',
   },
+  // gnocchi-92104: 'queued' = wire request sent, awaiting settlement.
+  // Amber/yellow sits visually between approved (blue) and paid (emerald) to
+  // signal "money committed and in motion, but not settled."
+  queued: {
+    bg: 'bg-amber-100',
+    text: 'text-amber-800',
+    border: 'border-amber-300',
+    label: 'Queued',
+  },
+  // provolone-92103: 'completed' is the terminal close-out state used by
+  // Mark-Party-Paid's "mark pending complete" mode. Teal so admins can tell
+  // it apart from a direct paid record (emerald).
+  completed: {
+    bg: 'bg-teal-100',
+    text: 'text-teal-800',
+    border: 'border-teal-300',
+    label: 'Completed',
+  },
 };
 
 export const PayoutStatusPill: React.FC<PayoutStatusPillProps> = ({ status, size = 'sm' }) => {

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -34,6 +34,11 @@ const STATUS_STYLES: Record<PayoutStatus, string> = {
   // emerald so admins can tell "city was closed; org's obligation fulfilled"
   // apart from a direct paid record.
   completed: 'bg-teal-500/20 text-teal-300',
+  // gnocchi-92104: amber/yellow for queued ("wire sent, awaiting settlement")
+  // — sits between approved (sky) and paid (emerald) visually. Distinct from
+  // pending's amber-300 by using a brighter amber-200 text on a slightly
+  // heavier bg, signalling forward-motion rather than waiting-on-host.
+  queued: 'bg-amber-400/25 text-amber-200',
 };
 
 const STATUS_LABEL: Record<PayoutStatus, string> = {
@@ -44,6 +49,9 @@ const STATUS_LABEL: Record<PayoutStatus, string> = {
   failed: 'Failed',
   withdrawn: 'Withdrawn',
   completed: 'Completed',
+  // gnocchi-92104: hosts see this label on their own list while a wire
+  // request is in flight.
+  queued: 'Queued for payment',
 };
 
 // arugula-38633 v3 follow-up: helper to display a method (or "Not set" placeholder).

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4347,6 +4347,55 @@ export async function revertPaidAdminPayout(
 }
 
 /**
+ * gnocchi-92104: flip an `approved` payout to `queued` (wire request sent,
+ * awaiting settlement). Semantically between approved (admin signed off) and
+ * paid (money actually moved). Counts toward the party's committed cap the
+ * same as approved / paid / completed.
+ *
+ * Backend validates the current status is 'approved' (400 NOT_APPROVED
+ * otherwise) and writes a payout_audit row with action='mark_queued'.
+ *
+ * Used primarily for wire payouts where the admin has emailed the bank but
+ * the wire hasn't cleared yet; not method-gated though — admins can queue
+ * any approved row.
+ */
+export async function markPayoutQueued(
+  id: string,
+  opts?: { note?: string },
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}/mark-queued`,
+    {
+      method: 'POST',
+      body: { note: opts?.note },
+    },
+  );
+  return res.payout;
+}
+
+/**
+ * gnocchi-92104: flip a `queued` payout back to `approved`. The "admin oops
+ * un-queue" path — used when the wire request was sent in error and needs to
+ * be reset before settlement (wrong recipient, duplicate request, etc.).
+ *
+ * Backend validates the current status is 'queued' (400 NOT_QUEUED otherwise)
+ * and writes a payout_audit row with action='unmark_queued'.
+ */
+export async function unmarkPayoutQueued(
+  id: string,
+  opts?: { note?: string },
+): Promise<AdminPayout> {
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}/unmark-queued`,
+    {
+      method: 'POST',
+      body: { note: opts?.note },
+    },
+  );
+  return res.payout;
+}
+
+/**
  * argentina-92103: regional underbosses (and admins) signal "this payout is
  * ready for the payments team to pay" without actually changing status or
  * sending funds. Writes a payout_audit row + fires Telegram + email to the

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -13,6 +13,8 @@ import {
   rejectAdminPayout,
   unapproveAdminPayout,
   revertPaidAdminPayout,
+  markPayoutQueued,
+  unmarkPayoutQueued,
   updateAdminPayout,
   markAdminPayoutPaid,
   executeAdminPayout,
@@ -1119,6 +1121,44 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 return;
               } catch (err: any) {
                 return err?.message || 'Revert failed';
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            // gnocchi-92104: mark-queued = approved -> queued (wire request
+            // sent, awaiting settlement). Stays-open like unapprove/revertPaid
+            // so admin sees the queued pill flip in-modal. Refreshes the
+            // payouts list (so the row shows the new pill) and the prepay
+            // queue (so the source party drops off since 'queued' is now in
+            // the in-flight set).
+            onMarkQueued={async () => {
+              setModalBusy(true);
+              try {
+                await markPayoutQueued(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
+                setDetail(fresh);
+                await Promise.all([refresh(), loadPrepayQueue()]);
+                pushToast('Marked queued — wire request sent', 'success');
+                return;
+              } catch (err: any) {
+                return err?.message || 'Mark queued failed';
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            // gnocchi-92104: un-queue = queued -> approved (admin oops
+            // un-queue). Same stays-open/refresh pattern.
+            onUnmarkQueued={async () => {
+              setModalBusy(true);
+              try {
+                await unmarkPayoutQueued(detail.id);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
+                setDetail(fresh);
+                await Promise.all([refresh(), loadPrepayQueue()]);
+                pushToast('Un-queued — payment back to approved', 'success');
+                return;
+              } catch (err: any) {
+                return err?.message || 'Un-queue failed';
               } finally {
                 setModalBusy(false);
               }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1617,7 +1617,11 @@ export interface UnifiedPartner {
 // Mark-Party-Paid's "mark pending complete" mode. Means "the city was fully
 // paid by the org and this row's payment obligation is fulfilled, even if the
 // org paid less than the original claim amount."
-export type PayoutStatus = 'pending' | 'approved' | 'rejected' | 'paid' | 'failed' | 'withdrawn' | 'completed';
+// gnocchi-92104: 'queued' is the intermediate state between 'approved' and
+// 'paid' — used when the wire transfer email request has been sent but the
+// wire hasn't yet settled. Counts toward the per-party committed cap the same
+// as approved/paid/completed (see backend assertWithinPartyCap).
+export type PayoutStatus = 'pending' | 'approved' | 'queued' | 'rejected' | 'paid' | 'failed' | 'withdrawn' | 'completed';
 
 /**
  * ravioli-82931 + agnolotti-58291: one entry in the party-scoped receipts


### PR DESCRIPTION
## Summary
- Adds a new `queued` payout status semantically between `approved` (admin signed off) and `paid` (money actually moved). Used when a wire-transfer email request has been sent but the wire hasn't yet settled.
- `queued` counts toward the per-party committed cap the same as `approved` / `paid` / `completed` — money committed even if not yet settled.
- Adds `POST /api/admin/payouts/:id/mark-queued` (approved → queued) and `POST /api/admin/payouts/:id/unmark-queued` (queued → approved) admin endpoints. Existing `mark-paid` accepts queued as the prior status, so `queued → paid` is the typical settlement flow.

## Schema
Applied to prod directly via `pg` + `DATABASE_URL` before merging:
- `payouts_status_check` extended with `queued`.
- `payout_audit_action_check` extended with `mark_queued` + `unmark_queued`.

## Frontend
- New `Queued` chip in the admin payouts filter bar (between Approved and Paid).
- New amber/yellow status badge (between approved's sky-blue and paid's emerald).
- New `Mark queued` button in `PayoutReviewModal` for approved rows — confirms once before firing, mirrors `Revert to Approved` UX.
- New `Un-queue` button on queued rows for `queued → approved` revert.
- Queued rows surface `Mark paid (settled)` in both the modal and the inline row actions for the common "wire cleared" path.
- `markPayoutQueued(id)` / `unmarkPayoutQueued(id)` typed wrappers in `frontend/src/lib/api.ts`.

## Side effects covered
- Mark-Party-Paid bulk reconciliation now includes `queued` in its in-flight set (so a queued wire flips to paid alongside pending/approved).
- Flag-ready (regional UB signal) excludes `queued` — the payments team has already taken visible action.
- Prepay-queue in-flight check includes `queued` so we don't suggest a fresh prepay for a host already mid-flight on a wire.
- Host-side `assertWithinPartyCap` includes `queued`.

## Test plan
- [ ] Approve a wire payout in `/payments`, click `Mark queued`, confirm pill flips to amber Queued; verify audit row with `action='mark_queued'`.
- [ ] On the same row, click `Mark paid (settled)`; verify status flips to paid and the audit row's `oldStatus='queued', newStatus='paid'`.
- [ ] On a fresh queued row, click `Un-queue`; verify it returns to approved and an `unmark_queued` audit lands.
- [ ] Verify the Queued chip in the filter bar shows the queued rows.
- [ ] Verify cap math: approve two payouts that together hit the cap, queue one, try to approve a third — should 409 PARTY_CAP_EXCEEDED.
- [ ] Verify Mark-Party-Paid preview/flip works when there is at least one queued row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)