### PR TITLE
feat(sfincione-60412): admin city notes on /underboss Cities tab

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1378,6 +1378,7 @@ model CityStatus {
   cityKey   String   @unique @map("city_key")
   status    String   @default("todo")
   priority  Boolean  @default(false)
+  notes     String?  @map("notes")
   updatedBy String?  @map("updated_by")
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -299,11 +299,12 @@ router.get('/me', requireAuth, async (req: UnderbossRequest, res: Response, next
 router.get('/city-statuses', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {
     const rows = await prisma.cityStatus.findMany();
-    const map: Record<string, { status: string; priority: boolean; updatedBy: string | null; updatedAt: string }> = {};
+    const map: Record<string, { status: string; priority: boolean; notes: string | null; updatedBy: string | null; updatedAt: string }> = {};
     for (const row of rows) {
       map[row.cityKey] = {
         status: row.status,
         priority: row.priority,
+        notes: row.notes ?? null,
         updatedBy: row.updatedBy,
         updatedAt: row.updatedAt.toISOString(),
       };
@@ -319,7 +320,8 @@ router.get('/city-statuses', requireAuth, requireUnderbossAuth, async (req: Unde
 // effective state is { status: 'todo', priority: false } (the default).
 router.patch('/city-statuses', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {
-    const { cityKey, status, priority } = req.body;
+    const { cityKey, status, priority, notes } = req.body;
+    const notesProvided = Object.prototype.hasOwnProperty.call(req.body, 'notes');
 
     if (!cityKey || typeof cityKey !== 'string') {
       throw new AppError('cityKey is required', 400, 'VALIDATION_ERROR');
@@ -333,8 +335,8 @@ router.patch('/city-statuses', requireAuth, requireUnderbossAuth, async (req: Un
       throw new AppError('priority must be a boolean', 400, 'VALIDATION_ERROR');
     }
 
-    if (status === undefined && priority === undefined) {
-      throw new AppError('nothing to update — provide status and/or priority', 400, 'VALIDATION_ERROR');
+    if (status === undefined && priority === undefined && !notesProvided) {
+      throw new AppError('nothing to update — provide status, priority and/or notes', 400, 'VALIDATION_ERROR');
     }
 
     // Scope check: city-scoped UBs can update only their cities (mozzarella-25815).
@@ -356,7 +358,16 @@ router.patch('/city-statuses', requireAuth, requireUnderbossAuth, async (req: Un
     const nextStatus = status ?? existing?.status ?? 'todo';
     const nextPriority = priority ?? existing?.priority ?? false;
 
-    if (nextStatus === 'todo' && nextPriority === false) {
+    // Notes: only override if the `notes` key was sent; otherwise preserve existing.
+    let effNotes = notesProvided
+      ? (typeof notes === 'string' ? notes.trim() : null)
+      : (existing?.notes ?? null);
+    if (effNotes === '') effNotes = null;
+    if (effNotes && effNotes.length > 2000) {
+      throw new AppError('notes must be 2000 characters or fewer', 400, 'VALIDATION_ERROR');
+    }
+
+    if (nextStatus === 'todo' && nextPriority === false && !effNotes) {
       // Default state — no need to store
       await prisma.cityStatus.deleteMany({ where: { cityKey } });
       return res.json({ success: true, deleted: true });
@@ -364,8 +375,8 @@ router.patch('/city-statuses', requireAuth, requireUnderbossAuth, async (req: Un
 
     const result = await prisma.cityStatus.upsert({
       where: { cityKey },
-      update: { status: nextStatus, priority: nextPriority, updatedBy },
-      create: { cityKey, status: nextStatus, priority: nextPriority, updatedBy },
+      update: { status: nextStatus, priority: nextPriority, notes: effNotes, updatedBy },
+      create: { cityKey, status: nextStatus, priority: nextPriority, notes: effNotes, updatedBy },
     });
 
     res.json({ success: true, cityStatus: result });

--- a/frontend/src/components/underboss/CitiesTable.tsx
+++ b/frontend/src/components/underboss/CitiesTable.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Search, MapPin, Check, X, Clock, ExternalLink, ArrowUpDown, ChevronDown, Camera, ChevronLeft, ChevronRight, Send, Star } from 'lucide-react';
+import { Search, MapPin, Check, X, Clock, ExternalLink, ArrowUpDown, ChevronDown, Camera, ChevronLeft, ChevronRight, Send, Star, StickyNote } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { fetchSheetCities, SheetCity } from '../../lib/cities';
-import { fetchCityStatuses, updateCityStatus, CityStatusMap, getPartyPhotos } from '../../lib/api';
+import { fetchCityStatuses, updateCityStatus, updateCityNotes, CityStatusMap, getPartyPhotos } from '../../lib/api';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
 import type { UnderbossMeResponse } from '../../lib/api';
 import { GPP_REGIONS } from '../../types';
@@ -30,6 +30,7 @@ interface MergedCity {
   chatUrl: string;
   status: CityStatusValue;
   priority: boolean;
+  notes: string | null;
   isAuto: boolean; // true if status came from matching event (no DB override)
   matchedEventUrl: string | null; // link to the matching event if auto-detected
   photoCount: number;
@@ -89,6 +90,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [showActionDropdown, setShowActionDropdown] = useState(false);
   const [gppCounts, setGppCounts] = useState<Record<string, number>>({});
+  const [notesEditingKey, setNotesEditingKey] = useState<string | null>(null);
 
   // Load GPP photo counts (cached at module level)
   useEffect(() => {
@@ -192,6 +194,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
         chatUrl: sc.chatUrl,
         status,
         priority,
+        notes: dbStatus?.notes ?? null,
         isAuto,
         matchedEventUrl: matchedEvent ? `/${matchedEvent}` : null,
         photoCount: matchedEvents.reduce((sum, e) => sum + (e.photoCount || 0), 0) + (gppCounts[gppKey] || 0),
@@ -239,7 +242,8 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
         (c) =>
           c.city.toLowerCase().includes(q) ||
           c.country.toLowerCase().includes(q) ||
-          c.underboss.toLowerCase().includes(q)
+          c.underboss.toLowerCase().includes(q) ||
+          (c.notes ? c.notes.toLowerCase().includes(q) : false)
       );
     }
 
@@ -283,8 +287,11 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
       const existing = cityStatuses[cityKey];
       const nextStatus: CityStatusValue = (patch.status ?? (existing?.status as CityStatusValue) ?? 'todo');
       const nextPriority: boolean = patch.priority ?? existing?.priority ?? false;
+      const existingNotes = existing?.notes ?? null;
 
-      if (nextStatus === 'todo' && nextPriority === false) {
+      // Keep the row if it carries a note, even at the default state, so the
+      // note isn't visually dropped (backend now preserves notes too).
+      if (nextStatus === 'todo' && nextPriority === false && !existingNotes) {
         // Default — remove from map
         setCityStatuses((prev) => {
           const next = { ...prev };
@@ -297,6 +304,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
           [cityKey]: {
             status: nextStatus,
             priority: nextPriority,
+            notes: prev[cityKey]?.notes ?? null,
             updatedBy: prev[cityKey]?.updatedBy ?? null,
             updatedAt: new Date().toISOString(),
           },
@@ -319,6 +327,49 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
       handleStatusChange(cityKey, { priority });
     },
     [handleStatusChange]
+  );
+
+  const handleSaveNotes = useCallback(
+    async (cityKey: string, rawValue: string) => {
+      const trimmed = rawValue.trim();
+      const nextNotes = trimmed || null;
+
+      // Optimistic local update
+      const previousStatuses = { ...cityStatuses };
+      const existing = cityStatuses[cityKey];
+      const existingStatus: CityStatusValue = (existing?.status as CityStatusValue) ?? 'todo';
+      const existingPriority = existing?.priority ?? false;
+
+      if (!nextNotes && existingStatus === 'todo' && !existingPriority) {
+        // Mirror backend: row drops back to default state
+        setCityStatuses((prev) => {
+          const next = { ...prev };
+          delete next[cityKey];
+          return next;
+        });
+      } else {
+        setCityStatuses((prev) => ({
+          ...prev,
+          [cityKey]: {
+            status: existingStatus,
+            priority: existingPriority,
+            notes: nextNotes,
+            updatedBy: prev[cityKey]?.updatedBy ?? null,
+            updatedAt: new Date().toISOString(),
+          },
+        }));
+      }
+
+      setNotesEditingKey(null);
+
+      try {
+        await updateCityNotes(cityKey, nextNotes);
+      } catch (err) {
+        setCityStatuses(previousStatuses);
+        console.error('Failed to update city notes:', err);
+      }
+    },
+    [cityStatuses]
   );
 
   const toggleSelect = useCallback((key: string) => {
@@ -591,6 +642,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
                 city={city}
                 onStatusChange={handleStatusChange}
                 onTogglePriority={handleTogglePriority}
+                onEditNotes={setNotesEditingKey}
                 isSelected={selectedKeys.has(city.key)}
                 onToggleSelect={toggleSelect}
               />
@@ -609,7 +661,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
       {/* Cards (mobile) */}
       <div className="md:hidden space-y-2">
         {filteredCities.map((city) => (
-          <CityCard key={city.key} city={city} onStatusChange={handleStatusChange} onTogglePriority={handleTogglePriority} isSelected={selectedKeys.has(city.key)} onToggleSelect={toggleSelect} />
+          <CityCard key={city.key} city={city} onStatusChange={handleStatusChange} onTogglePriority={handleTogglePriority} onEditNotes={setNotesEditingKey} isSelected={selectedKeys.has(city.key)} onToggleSelect={toggleSelect} />
         ))}
         {filteredCities.length === 0 && (
           <p className="py-8 text-center text-theme-text-faint text-sm">
@@ -621,7 +673,86 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
       <p className="text-xs text-theme-text-faint">
         {t('cities.showingOf', { shown: filteredCities.length, total: mergedCities.length })}
       </p>
+
+      {notesEditingKey && (() => {
+        const editingCity = mergedCities.find((c) => c.key === notesEditingKey);
+        return (
+          <CityNotesModal
+            cityLabel={editingCity?.city || notesEditingKey}
+            initialNotes={editingCity?.notes ?? null}
+            onSave={(value) => handleSaveNotes(notesEditingKey, value)}
+            onClose={() => setNotesEditingKey(null)}
+          />
+        );
+      })()}
     </div>
+  );
+}
+
+// === City Notes Modal ===
+function CityNotesModal({
+  cityLabel,
+  initialNotes,
+  onSave,
+  onClose,
+}: {
+  cityLabel: string;
+  initialNotes: string | null;
+  onSave: (value: string) => void;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation('partner');
+  const [value, setValue] = useState(initialNotes ?? '');
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md bg-theme-surface border border-theme-stroke rounded-xl p-5 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-theme-text font-semibold text-sm flex items-center gap-2">
+            <StickyNote size={16} className="text-amber-500" />
+            {t('cities.notes.title', { city: cityLabel })}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-theme-text-faint hover:text-theme-text transition-colors"
+            aria-label={t('cities.notes.close')}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <IconInput
+          multiline
+          rows={5}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={t('cities.notes.placeholder')}
+          maxLength={2000}
+        />
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-lg text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
+          >
+            {t('cities.notes.cancel')}
+          </button>
+          <button
+            onClick={() => onSave(value)}
+            className="px-4 py-1.5 rounded-lg text-sm font-medium bg-red-500 text-white hover:bg-red-600 transition-colors"
+          >
+            {t('cities.notes.save')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
   );
 }
 
@@ -792,12 +923,14 @@ function CityRow({
   city,
   onStatusChange,
   onTogglePriority,
+  onEditNotes,
   isSelected,
   onToggleSelect,
 }: {
   city: MergedCity;
   onStatusChange: (cityKey: string, patch: { status?: CityStatusValue; priority?: boolean }) => void;
   onTogglePriority: (cityKey: string, priority: boolean) => void;
+  onEditNotes: (cityKey: string) => void;
   isSelected: boolean;
   onToggleSelect: (key: string) => void;
 }) {
@@ -923,6 +1056,18 @@ function CityRow({
             >
               <Star size={16} className={city.priority ? 'fill-yellow-400' : ''} />
             </button>
+            <button
+              onClick={() => onEditNotes(city.key)}
+              className={`p-1.5 rounded transition-colors ${
+                city.notes
+                  ? 'text-amber-500 hover:text-amber-400'
+                  : 'text-theme-text-faint hover:text-amber-500'
+              }`}
+              title={city.notes || t('cities.notes.add')}
+              aria-label={city.notes ? t('cities.notes.edit') : t('cities.notes.add')}
+            >
+              <StickyNote size={16} className={city.notes ? 'fill-amber-500/30' : ''} />
+            </button>
             <StatusToggle
               currentStatus={city.status}
               onStatusChange={(status) => onStatusChange(city.key, { status })}
@@ -994,12 +1139,14 @@ function CityCard({
   city,
   onStatusChange,
   onTogglePriority,
+  onEditNotes,
   isSelected,
   onToggleSelect,
 }: {
   city: MergedCity;
   onStatusChange: (cityKey: string, patch: { status?: CityStatusValue; priority?: boolean }) => void;
   onTogglePriority: (cityKey: string, priority: boolean) => void;
+  onEditNotes: (cityKey: string) => void;
   isSelected: boolean;
   onToggleSelect: (key: string) => void;
 }) {
@@ -1104,6 +1251,18 @@ function CityCard({
           aria-label={city.priority ? t('cities.unmarkPriorityTitle') : t('cities.markPriorityTitle')}
         >
           <Star size={16} className={city.priority ? 'fill-yellow-400' : ''} />
+        </button>
+        <button
+          onClick={() => onEditNotes(city.key)}
+          className={`p-1.5 rounded transition-colors ${
+            city.notes
+              ? 'text-amber-500 hover:text-amber-400'
+              : 'text-theme-text-faint hover:text-amber-500'
+          }`}
+          title={city.notes || t('cities.notes.add')}
+          aria-label={city.notes ? t('cities.notes.edit') : t('cities.notes.add')}
+        >
+          <StickyNote size={16} className={city.notes ? 'fill-amber-500/30' : ''} />
         </button>
         <StatusToggle
           currentStatus={city.status}

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -311,6 +311,15 @@
       "created": "Erstellt",
       "todo": "Zu erledigen",
       "skip": "Überspringen"
+    },
+    "notes": {
+      "title": "Notizen — {{city}}",
+      "add": "Notiz hinzufügen",
+      "edit": "Notiz bearbeiten",
+      "placeholder": "Notizen für diese Stadt (bleibt Jahr für Jahr erhalten)",
+      "save": "Speichern",
+      "cancel": "Abbrechen",
+      "close": "Schließen"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -328,6 +328,15 @@
       "created": "Created",
       "todo": "To Do",
       "skip": "Skip"
+    },
+    "notes": {
+      "title": "Notes — {{city}}",
+      "add": "Add note",
+      "edit": "Edit note",
+      "placeholder": "Notes for this city (persists year over year)",
+      "save": "Save",
+      "cancel": "Cancel",
+      "close": "Close"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -311,6 +311,15 @@
       "created": "Creado",
       "todo": "Pendiente",
       "skip": "Omitir"
+    },
+    "notes": {
+      "title": "Notas — {{city}}",
+      "add": "Añadir nota",
+      "edit": "Editar nota",
+      "placeholder": "Notas para esta ciudad (se conservan año tras año)",
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "close": "Cerrar"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -311,6 +311,15 @@
       "created": "Créé",
       "todo": "À faire",
       "skip": "Ignorer"
+    },
+    "notes": {
+      "title": "Notes — {{city}}",
+      "add": "Ajouter une note",
+      "edit": "Modifier la note",
+      "placeholder": "Notes pour cette ville (conservées dannée en année)",
+      "save": "Enregistrer",
+      "cancel": "Annuler",
+      "close": "Fermer"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -311,6 +311,15 @@
       "created": "作成済み",
       "todo": "未対応",
       "skip": "スキップ"
+    },
+    "notes": {
+      "title": "メモ — {{city}}",
+      "add": "メモを追加",
+      "edit": "メモを編集",
+      "placeholder": "この都市のメモ（年をまたいで保持されます）",
+      "save": "保存",
+      "cancel": "キャンセル",
+      "close": "閉じる"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -311,6 +311,15 @@
       "created": "생성됨",
       "todo": "할 일",
       "skip": "건너뛰기"
+    },
+    "notes": {
+      "title": "메모 — {{city}}",
+      "add": "메모 추가",
+      "edit": "메모 편집",
+      "placeholder": "이 도시에 대한 메모 (매년 유지됨)",
+      "save": "저장",
+      "cancel": "취소",
+      "close": "닫기"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -311,6 +311,15 @@
       "created": "Criado",
       "todo": "A fazer",
       "skip": "Pular"
+    },
+    "notes": {
+      "title": "Notas — {{city}}",
+      "add": "Adicionar nota",
+      "edit": "Editar nota",
+      "placeholder": "Notas para esta cidade (mantidas ano após ano)",
+      "save": "Salvar",
+      "cancel": "Cancelar",
+      "close": "Fechar"
     }
   },
   "funnel": {

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -311,6 +311,15 @@
       "created": "已创建",
       "todo": "待办",
       "skip": "跳过"
+    },
+    "notes": {
+      "title": "备注 — {{city}}",
+      "add": "添加备注",
+      "edit": "编辑备注",
+      "placeholder": "此城市的备注（逐年保留）",
+      "save": "保存",
+      "cancel": "取消",
+      "close": "关闭"
     }
   },
   "funnel": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2901,7 +2901,7 @@ export async function bulkUpdateEventTags(
 // City Status API (Underboss)
 
 export interface CityStatusMap {
-  [cityKey: string]: { status: string; priority: boolean; updatedBy: string | null; updatedAt: string };
+  [cityKey: string]: { status: string; priority: boolean; notes: string | null; updatedBy: string | null; updatedAt: string };
 }
 
 export async function fetchCityStatuses(): Promise<CityStatusMap> {
@@ -2915,6 +2915,13 @@ export async function updateCityStatus(
   await apiRequest('/api/underboss/city-statuses', {
     method: 'PATCH',
     body: { cityKey, ...patch },
+  });
+}
+
+export async function updateCityNotes(cityKey: string, notes: string | null): Promise<void> {
+  await apiRequest('/api/underboss/city-statuses', {
+    method: 'PATCH',
+    body: { cityKey, notes },
   });
 }
 


### PR DESCRIPTION
## Summary
Adds free-text, admin-facing **city notes** to the **Cities** tab of `/underboss`. Notes are keyed by city (cityKey = `city.toLowerCase().trim()`) and persist year over year on the existing `CityStatus` model (`city_statuses` table) — no new table.

A sticky-note icon in each city's Actions cell (desktop row + mobile card) opens a small modal editor (`IconInput` multiline, Save/Cancel, click-outside-to-close). The icon is amber/filled when a note exists, faint otherwise, and its tooltip shows the note text. Editing is reversible, so there is no confirm step.

## Changes
- **Prisma** (`backend/prisma/schema.prisma`): add nullable `notes` column to `CityStatus`.
- **Backend** (`underboss.routes.ts`):
  - `GET /city-statuses` now returns `notes` in the map.
  - `PATCH /city-statuses` accepts optional `notes` (only overrides when the `notes` key is sent), trims, empty→null, 2000-char max. **Behavior change:** the row is now only deleted at the default state when there is *also* no note (`status === 'todo' && !priority && !notes`), so a note is never dropped on a todo city. Existing `status`/`priority` logic preserved.
- **Frontend API** (`lib/api.ts`): extend `CityStatusMap` with `notes`, add `updateCityNotes(cityKey, notes)`.
- **CitiesTable.tsx**: thread `notes` through `MergedCity`; search now matches notes; `status -> todo` keeps the row if it has a note; new `CityNotesModal`; optimistic local update + revert-on-error.
- **i18n**: `cities.notes.*` keys added to all 8 locales (de, en, es, fr, ja, ko, pt, zh).

## DB migration required before backend deploy
This adds a Prisma column that must exist in prod **before** the backend deploys:
```sql
ALTER TABLE city_statuses ADD COLUMN IF NOT EXISTS notes TEXT;
```

## Verification
- `frontend`: `npx tsc -b` reports **zero** errors in the changed files (`CitiesTable.tsx`, `api.ts`). Pre-existing repo-wide `tsc -b` errors (AppsHub LucideIcon, unused imports) are unrelated.
- `backend`: `prisma generate` + `npx tsc` reports **zero** errors in `underboss.routes.ts`. Remaining backend errors are pre-existing missing optional deps (`sharp`, `openai`, `archiver`) not installed in the worktree.
- Lint could not run in the worktree (eslint deps not installed); code follows existing file patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)