### PR TITLE
feat(pesto-92104): edit receipt values inside the lightbox

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { X, Check, AlertTriangle, ExternalLink, Loader2, Pencil, Send, DollarSign, RefreshCw, Repeat2, Tag, Undo2, Flag, Coins, Play, ChevronDown, ChevronRight, Plus, Trash2, Copy } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
@@ -17,6 +17,7 @@ import {
   formatOriginalCurrency,
   ReceiptLightbox,
 } from '../payments-shared';
+import { ReceiptEditor } from './ReceiptEditor';
 
 /**
  * parmigiana-58291: strip the "Global Pizza Party " prefix from event names so
@@ -382,6 +383,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // ArrowRight can cycle through receipts + pizza photos. Hooks must be
   // declared above any early return — see feedback_hooks_above_early_returns.
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  // pesto-92104: the lightbox owns its visible index after open (so arrow
+  // nav works without parent re-renders), but the parent needs to know
+  // which doc is currently in view so it can supply the matching editor
+  // pane. `lightboxCurrentIndex` is mirrored from the lightbox via its
+  // `onIndexChange` prop.
+  const [lightboxCurrentIndex, setLightboxCurrentIndex] = useState<number | null>(null);
 
   // agnolotti-58291: per-receipt OCR amount + currency edit state. The modal
   // ships an inline form per receipt row (gated to full admins + payment_admin)
@@ -922,6 +929,180 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose, lightboxIndex]);
+
+  // pesto-92104: derive the receipt that's currently in the lightbox (if
+  // any). The unified carousel order is pizzas → receipts → pizzaPhotos →
+  // eventPhotos (see `allPhotos` above), so the receipt slice starts at
+  // `pizzas.length` and runs through `pizzas.length + receipts.length`.
+  const lightboxReceipt = useMemo(() => {
+    if (lightboxCurrentIndex == null) return null;
+    const offset = pizzas.length;
+    const idx = lightboxCurrentIndex - offset;
+    if (idx < 0 || idx >= receipts.length) return null;
+    return receipts[idx];
+  }, [lightboxCurrentIndex, pizzas.length, receipts]);
+
+  // pesto-92104: "is the editor dirty?" — used by the navigation prompt
+  // (Save / Discard / Cancel) so admins don't accidentally lose in-flight
+  // amount / currency / line-item edits when arrow-keying through receipts.
+  // Mirrors the dirty-check in the per-row right-pane editor below.
+  function receiptHasUnsavedEdits(docId: string): boolean {
+    const r = receipts.find((x) => x.id === docId);
+    if (!r) return false;
+    const draft = receiptDrafts[docId];
+    if (draft) {
+      const persistedAmt = r.ocrAmount == null ? '' : String(r.ocrAmount);
+      const persistedCur = r.ocrCurrency ?? '';
+      if (draft.amount !== persistedAmt || draft.currency !== persistedCur) {
+        return true;
+      }
+    }
+    const liDrafts = lineItemDrafts[docId];
+    if (liDrafts) {
+      const persisted = (r.ocrLineItems ?? []).map(lineItemToDraft);
+      if (persisted.length !== liDrafts.length) return true;
+      for (let i = 0; i < liDrafts.length; i++) {
+        const a = liDrafts[i];
+        const b = persisted[i];
+        if (
+          a.name !== b.name ||
+          a.qty !== b.qty ||
+          a.unitPrice !== b.unitPrice ||
+          a.subtotal !== b.subtotal ||
+          a.category !== b.category
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // pesto-92104: gate the lightbox's arrow / button nav when the current
+  // receipt has unsaved edits. Surfaces a confirm() with three implied
+  // outcomes — admins answer OK to discard and move on, Cancel to stay on
+  // the current receipt. Save is a separate path (admins explicitly click
+  // the Save button before navigating); we don't auto-save here because
+  // arrow-key navigation through 6 receipts shouldn't fire 6 PATCH calls
+  // in the happy path.
+  const lightboxOnBeforeNavigate = useCallback(async (): Promise<boolean> => {
+    if (!lightboxReceipt) return true;
+    if (!receiptHasUnsavedEdits(lightboxReceipt.id)) return true;
+    const ok = window.confirm(
+      'This receipt has unsaved edits. Discard them and navigate?',
+    );
+    return ok;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lightboxReceipt, receiptDrafts, lineItemDrafts, receipts]);
+
+  // pesto-92104: D key = mark-duplicate toggle for the currently-shown
+  // receipt. Lightbox only wires this handler when an editor is mounted,
+  // so non-receipt photos / non-admin viewers don't accidentally toggle.
+  const lightboxOnDuplicateShortcut = useCallback(() => {
+    if (!lightboxReceipt) return;
+    toggleDuplicate(lightboxReceipt.id, !(lightboxReceipt.isDuplicate === true));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lightboxReceipt]);
+
+  // pesto-92104: render the ReceiptEditor when the lightbox is showing a
+  // receipt AND the viewer can edit (admin / super_admin / payment_admin).
+  // Non-receipt thumbnails (event photos, pizza photos, payment-proof
+  // pizzas) get the plain photo-only lightbox.
+  const lightboxEditorPane = useMemo(() => {
+    if (!lightboxReceipt) return null;
+    if (!canEditReceipts) return null;
+    const r = lightboxReceipt;
+    // Seed the amount/currency draft from current persisted values if the
+    // admin hasn't typed anything yet. Keeps the editor's inputs reflecting
+    // whatever the row shows in the right-pane.
+    const draft: ReceiptDraft = receiptDrafts[r.id] ?? {
+      amount: r.ocrAmount == null ? '' : String(r.ocrAmount),
+      currency: r.ocrCurrency ?? '',
+    };
+    const persistedAmt = r.ocrAmount == null ? '' : String(r.ocrAmount);
+    const persistedCur = r.ocrCurrency ?? '';
+    const isDirty =
+      draft.amount !== persistedAmt || draft.currency !== persistedCur;
+    // Seed line item drafts lazily (mirrors ensureLineItemDrafts on
+    // expansion in the right-pane). For the lightbox we always show the
+    // editor, so seed immediately if no draft exists yet.
+    const liDraftsExisting = lineItemDrafts[r.id];
+    const liDrafts =
+      liDraftsExisting ?? (r.ocrLineItems ?? []).map(lineItemToDraft);
+    const localOcrError = retryClearedErrors[r.id]
+      ? null
+      : (retryErrors[r.id] ?? r.ocrError);
+    return (
+      <ReceiptEditor
+        doc={r}
+        draft={draft}
+        onDraftChange={(next) =>
+          setReceiptDrafts((m) => ({ ...m, [r.id]: next }))
+        }
+        saving={receiptSavingId === r.id}
+        saveError={receiptSaveErrors[r.id]}
+        onSave={() => saveReceiptEdit(r.id)}
+        isDirty={isDirty}
+        isDuplicate={r.isDuplicate === true}
+        dupSaving={duplicateSavingId === r.id}
+        dupError={duplicateSaveErrors[r.id]}
+        onToggleDuplicate={() => toggleDuplicate(r.id, !(r.isDuplicate === true))}
+        lineItemDrafts={liDrafts}
+        lineItemsSaving={lineItemsSavingId === r.id}
+        lineItemsSaveError={lineItemsSaveErrors[r.id]}
+        onLineItemDraftChange={(idx, patch) => {
+          // If the parent hasn't yet seeded the draft (first edit from the
+          // lightbox), persist the freshly seeded `liDrafts` into the draft
+          // map so the next render keeps the in-flight edits.
+          if (!liDraftsExisting) {
+            setLineItemDrafts((m) => ({ ...m, [r.id]: liDrafts }));
+          }
+          updateLineItemDraft(r.id, idx, patch);
+        }}
+        onAddLineItem={() => {
+          if (!liDraftsExisting) {
+            setLineItemDrafts((m) => ({ ...m, [r.id]: liDrafts }));
+          }
+          addLineItem(r.id);
+        }}
+        onRemoveLineItem={(idx) => {
+          if (!liDraftsExisting) {
+            setLineItemDrafts((m) => ({ ...m, [r.id]: liDrafts }));
+          }
+          removeLineItem(r.id, idx);
+        }}
+        onSaveLineItems={() => {
+          if (!liDraftsExisting) {
+            setLineItemDrafts((m) => ({ ...m, [r.id]: liDrafts }));
+          }
+          saveLineItemsEdit(r.id);
+        }}
+        onUseLineSumForAmount={() => useLineSumForAmount(r.id)}
+        hasOcrError={!!localOcrError}
+        retrying={retryingDocId === r.id}
+        retryError={retryErrors[r.id]}
+        onRetryOcr={() => retryOcr(r.id)}
+      />
+    );
+    // The deps list intentionally excludes the function references that
+    // are stable across renders within this component (saveReceiptEdit,
+    // toggleDuplicate, etc.) — they read fresh state internally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    lightboxReceipt,
+    canEditReceipts,
+    receiptDrafts,
+    receiptSavingId,
+    receiptSaveErrors,
+    duplicateSavingId,
+    duplicateSaveErrors,
+    lineItemDrafts,
+    lineItemsSavingId,
+    lineItemsSaveErrors,
+    retryingDocId,
+    retryErrors,
+    retryClearedErrors,
+  ]);
 
   // culatello-92104: duplicates are evidence-only — exclude their OCR
   // amounts from the receipt sum so admins see the corrected total. The
@@ -3076,12 +3257,24 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           owns its own Esc + arrow-key handlers and the HEIC fallback.
           focaccia-92104: `allPhotos` order is pizzas (Payment proof) →
           receipts → pizzaPhotos → eventPhotos so arrow-key nav crosses
-          sections in the same order they're rendered. */}
+          sections in the same order they're rendered.
+          pesto-92104: when admin opens a RECEIPT thumbnail the lightbox
+          renders a 2-pane layout — photo on the left, ReceiptEditor on
+          the right — so amount / currency / line items / duplicate can be
+          edited without leaving the photo view. Event/pizza photos and
+          non-admin viewers get the plain photo-only lightbox. */}
       <ReceiptLightbox
         isOpen={lightboxIndex != null}
         images={allPhotos}
         initialIndex={lightboxIndex ?? 0}
-        onClose={() => setLightboxIndex(null)}
+        onClose={() => {
+          setLightboxIndex(null);
+          setLightboxCurrentIndex(null);
+        }}
+        onIndexChange={setLightboxCurrentIndex}
+        editorPane={lightboxEditorPane}
+        onBeforeNavigate={lightboxOnBeforeNavigate}
+        onDuplicateShortcut={lightboxOnDuplicateShortcut}
       />
     </div>
   );

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -1,0 +1,391 @@
+import React from 'react';
+import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
+import type { PayoutDocument, ReceiptLineItem, ReceiptLineItemCategory } from '../../types';
+
+/**
+ * pesto-92104: shared receipt-editor surface. Today this is rendered inside
+ * the ReceiptLightbox's right pane when the lightbox is showing a receipt
+ * thumbnail in admin mode. State (drafts, save errors, in-flight flags)
+ * lives in the parent (PayoutReviewModal) so a single source of truth
+ * survives lightbox open/close + arrow navigation; this component is
+ * presentational and accepts the current values + callbacks.
+ *
+ * Layout choices match the spacious lightbox real estate (full-width
+ * IconInput for amount/currency, vertical line-item rows that read more
+ * like a form than the tight data-grid the right-pane of the modal uses).
+ * The right-pane row in PayoutReviewModal stays as-is (compact inline
+ * data-grid) so the existing flow isn't regressed.
+ */
+
+export type ReceiptDraft = { amount: string; currency: string };
+export type LineItemDraft = {
+  name: string;
+  qty: string;
+  unitPrice: string;
+  subtotal: string;
+  category: ReceiptLineItemCategory;
+};
+
+interface ReceiptEditorProps {
+  doc: PayoutDocument;
+  /** Amount/currency draft for this receipt. */
+  draft: ReceiptDraft;
+  onDraftChange: (next: ReceiptDraft) => void;
+  saving: boolean;
+  saveError?: string;
+  onSave: () => void;
+
+  /** Mark-duplicate state. */
+  isDuplicate: boolean;
+  dupSaving: boolean;
+  dupError?: string;
+  onToggleDuplicate: () => void;
+
+  /** Line items editor. */
+  lineItemDrafts: LineItemDraft[] | undefined;
+  lineItemsSaving: boolean;
+  lineItemsSaveError?: string;
+  onLineItemDraftChange: (idx: number, patch: Partial<LineItemDraft>) => void;
+  onAddLineItem: () => void;
+  onRemoveLineItem: (idx: number) => void;
+  onSaveLineItems: () => void;
+  /** Copy the line-sum into the amount draft. */
+  onUseLineSumForAmount: () => void;
+
+  /** Optional retry-OCR affordance for failed rows. */
+  hasOcrError?: boolean;
+  retrying?: boolean;
+  retryError?: string;
+  onRetryOcr?: () => void;
+
+  /** Whether the draft differs from persisted values (drives Save button). */
+  isDirty: boolean;
+}
+
+function draftSubtotalSum(drafts: LineItemDraft[] | undefined): number {
+  if (!drafts) return 0;
+  let sum = 0;
+  for (const d of drafts) {
+    const n = Number(d.subtotal);
+    if (Number.isFinite(n) && n >= 0) sum += n;
+  }
+  return sum;
+}
+
+export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
+  doc,
+  draft,
+  onDraftChange,
+  saving,
+  saveError,
+  onSave,
+  isDuplicate,
+  dupSaving,
+  dupError,
+  onToggleDuplicate,
+  lineItemDrafts,
+  lineItemsSaving,
+  lineItemsSaveError,
+  onLineItemDraftChange,
+  onAddLineItem,
+  onRemoveLineItem,
+  onSaveLineItems,
+  onUseLineSumForAmount,
+  hasOcrError,
+  retrying,
+  retryError,
+  onRetryOcr,
+  isDirty,
+}) => {
+  const conf = doc.ocrConfidence ?? 0;
+  const lowConf = conf > 0 && conf < 0.8;
+  const lineSum = draftSubtotalSum(lineItemDrafts);
+  // The "Sum" label uses the receipt's original currency if known so it
+  // matches what admins are typing into the per-line subtotals.
+  const sumCurrency = doc.originalCurrency ?? doc.ocrCurrency ?? 'USD';
+
+  return (
+    <div className="p-4 space-y-4 text-theme-text">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-base font-semibold truncate">
+            Receipt {doc.id.slice(0, 8)}
+          </h3>
+          <p className="text-xs text-theme-text-muted truncate" title={doc.fileName}>
+            {doc.fileName}
+          </p>
+        </div>
+        {conf > 0 && (
+          <span
+            className={`text-xs whitespace-nowrap ${
+              lowConf ? 'text-amber-500' : 'text-theme-text-faint'
+            }`}
+            title="OCR confidence"
+          >
+            {(conf * 100).toFixed(0)}% confidence
+          </span>
+        )}
+      </div>
+
+      {/* Amount + currency */}
+      <div className="space-y-2">
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_120px] gap-2">
+          <IconInput
+            icon={DollarSign}
+            type="number"
+            step="0.01"
+            min="0"
+            placeholder="Amount"
+            value={draft.amount}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onDraftChange({ ...draft, amount: e.target.value })
+            }
+          />
+          {/*
+            Currency is short (3-letter ISO usually). IconInput's full-width
+            layout would crowd the row, so a compact uppercase input cell
+            keeps the field reasonable — same precedent as the per-row
+            data-grid currency input in PayoutReviewModal. */}
+          <input
+            type="text"
+            maxLength={8}
+            value={draft.currency}
+            placeholder={doc.ocrCurrency || 'CUR'}
+            onChange={(e) => onDraftChange({ ...draft, currency: e.target.value })}
+            className="w-full px-3 py-2 rounded-lg border border-theme-stroke bg-theme-surface text-theme-text text-sm uppercase"
+          />
+        </div>
+        <p className="text-xs text-white/40">
+          Amount is the USD-converted total stored on this receipt. Changing the
+          currency re-runs FX automatically against the receipt's original
+          amount on save.
+        </p>
+        {saveError && (
+          <div className="text-xs text-red-300 flex items-start gap-1.5">
+            <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
+            <span>{saveError}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Mark duplicate + Save row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Checkbox
+          checked={isDuplicate}
+          onChange={onToggleDuplicate}
+          label={isDuplicate ? 'Marked as duplicate' : 'Mark as duplicate'}
+          disabled={dupSaving}
+        />
+        {dupSaving && <Loader2 size={12} className="animate-spin text-theme-text-muted" />}
+        <span className="text-xs text-white/40 hidden sm:inline">
+          (press <span className="font-mono">D</span>)
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!isDirty || saving}
+          className="px-3 py-2 rounded-lg bg-[#E52828] text-white text-sm disabled:opacity-40 inline-flex items-center gap-1.5"
+          title="Save amount + currency for this receipt"
+        >
+          {saving ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+        </button>
+      </div>
+      {dupError && (
+        <div className="text-xs text-red-300 flex items-start gap-1.5">
+          <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
+          <span>{dupError}</span>
+        </div>
+      )}
+
+      {/* OCR retry — only visible when the doc errored. Keeps parity with
+          the right-pane row's per-row retry affordance (pancetta-92104). */}
+      {hasOcrError && onRetryOcr && (
+        <div className="rounded-lg border border-theme-stroke p-3 bg-theme-bg space-y-2">
+          <div className="text-xs text-amber-500 flex items-start gap-1.5">
+            <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
+            <span>{doc.ocrError || 'OCR failed for this receipt.'}</span>
+          </div>
+          <button
+            type="button"
+            onClick={onRetryOcr}
+            disabled={retrying}
+            className="px-3 py-1.5 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center gap-1.5"
+          >
+            {retrying ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <RefreshCw size={12} />
+            )}
+            Retry OCR
+          </button>
+          {retryError && (
+            <div className="text-xs text-red-300">{retryError}</div>
+          )}
+        </div>
+      )}
+
+      {/* Line items */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold">
+            Line items ({lineItemDrafts?.length ?? 0})
+          </h4>
+          <span className="text-xs text-theme-text-muted">
+            Sum: {sumCurrency} {lineSum.toFixed(2)}
+          </span>
+        </div>
+        <div className="rounded-lg border border-theme-stroke bg-theme-bg p-2 space-y-1.5">
+          {(lineItemDrafts ?? []).length === 0 && (
+            <p className="text-xs text-theme-text-faint p-2">
+              No line items yet. Click <span className="font-semibold">Add line</span> to start.
+            </p>
+          )}
+          {(lineItemDrafts ?? []).map((d, idx) => (
+            <div
+              key={idx}
+              className="flex flex-wrap items-center gap-1.5 sm:flex-nowrap"
+            >
+              {/*
+                taralli-92104 precedent: line-item rows are data-grid cells,
+                not form fields. Raw inputs keep the layout tight enough to
+                show all 5 columns + remove on one row. */}
+              <input
+                type="text"
+                value={d.name}
+                placeholder="name"
+                onChange={(e) =>
+                  onLineItemDraftChange(idx, { name: e.target.value })
+                }
+                className="flex-1 min-w-[120px] px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
+              />
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                inputMode="decimal"
+                value={d.qty}
+                placeholder="qty"
+                onChange={(e) =>
+                  onLineItemDraftChange(idx, { qty: e.target.value })
+                }
+                className="w-14 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+              />
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                inputMode="decimal"
+                value={d.unitPrice}
+                placeholder="unit"
+                onChange={(e) =>
+                  onLineItemDraftChange(idx, { unitPrice: e.target.value })
+                }
+                className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+              />
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                inputMode="decimal"
+                value={d.subtotal}
+                placeholder="subtotal"
+                onChange={(e) =>
+                  onLineItemDraftChange(idx, { subtotal: e.target.value })
+                }
+                className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+              />
+              <select
+                value={d.category}
+                onChange={(e) =>
+                  onLineItemDraftChange(idx, {
+                    category: e.target.value as ReceiptLineItemCategory,
+                  })
+                }
+                className="px-1 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
+                title="Category — pizza-prices analytics filters on 'pizza'"
+              >
+                <option value="pizza">pizza</option>
+                <option value="beverage">beverage</option>
+                <option value="topping">topping</option>
+                <option value="side">side</option>
+                <option value="dessert">dessert</option>
+                <option value="tax">tax</option>
+                <option value="tip">tip</option>
+                <option value="fee">fee</option>
+                <option value="other">other</option>
+              </select>
+              <button
+                type="button"
+                onClick={() => onRemoveLineItem(idx)}
+                className="p-1 rounded text-theme-text-muted hover:text-red-500 hover:bg-red-50"
+                title="Remove this line"
+              >
+                <Trash2 size={12} />
+              </button>
+            </div>
+          ))}
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onAddLineItem}
+              className="px-2 py-1 rounded border border-theme-stroke text-theme-text text-xs inline-flex items-center gap-1 hover:bg-theme-surface"
+              title="Append a new line"
+            >
+              <Plus size={12} />
+              Add line
+            </button>
+            <button
+              type="button"
+              onClick={onUseLineSumForAmount}
+              className="px-2 py-1 rounded border border-theme-stroke text-theme-text text-xs inline-flex items-center gap-1 hover:bg-theme-surface"
+              title="Copy the line sum into the receipt total above"
+              disabled={(lineItemDrafts ?? []).length === 0}
+            >
+              <Copy size={12} />
+              Use line sum
+            </button>
+            <div className="flex-1" />
+            <button
+              type="button"
+              onClick={onSaveLineItems}
+              disabled={lineItemsSaving}
+              className="px-3 py-1.5 rounded bg-[#E52828] text-white text-xs disabled:opacity-40 inline-flex items-center gap-1.5"
+              title="Save line items"
+            >
+              {lineItemsSaving ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                'Save line items'
+              )}
+            </button>
+          </div>
+          {lineItemsSaveError && (
+            <div className="text-xs text-red-300">{lineItemsSaveError}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Helpers exported for parents that need to seed drafts from the canonical
+ * persisted shape. Mirrors the lineItemToDraft helper in PayoutReviewModal.
+ */
+export function lineItemToDraft(item: ReceiptLineItem): LineItemDraft {
+  return {
+    name: item.name ?? '',
+    qty: String(item.qty ?? 0),
+    unitPrice: String(item.unitPrice ?? 0),
+    subtotal: String(item.subtotal ?? 0),
+    category: item.category ?? 'other',
+  };
+}
+
+export function emptyLineItemDraft(): LineItemDraft {
+  return { name: '', qty: '1', unitPrice: '0', subtotal: '0', category: 'other' };
+}

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -17,6 +17,16 @@ import { isPdfFile } from '../../lib/pdfUtils';
  *   ArrowRight keys also navigate.
  * - HEIC files can't be previewed natively in browsers — show a fallback
  *   link to open the raw URL in a new tab.
+ *
+ * pesto-92104: the lightbox can now host a right-pane editor (admin-only
+ * receipt editor in PayoutReviewModal). When `editorPane` is non-null we
+ * render a two-pane layout: photo on the left, editor on the right; on
+ * narrow viewports (< md) the editor stacks below the photo. The lightbox
+ * stays kind-agnostic — callers decide whether to render an editor based
+ * on which image is current via `onIndexChange`. Optional shortcut hooks:
+ *  - `onDuplicateShortcut` — fired on `D` keypress (admin "mark duplicate").
+ *  - `onBeforeNavigate(direction)` — gate arrow / nav-button navigation so
+ *    the parent can prompt about unsaved edits. Return `true` to proceed.
  */
 export interface ReceiptLightboxImage {
   url: string;
@@ -30,6 +40,34 @@ interface ReceiptLightboxProps {
   /** Index into `images` to display on open. Defaults to 0. */
   initialIndex?: number;
   onClose: () => void;
+  /**
+   * pesto-92104: editor pane content for the CURRENT image. When non-null
+   * the lightbox switches to a 2-pane layout (photo left, editor right on
+   * desktop; stacked on mobile). The parent component is responsible for
+   * deciding what to render based on `onIndexChange` — pass `null` to
+   * render the plain photo-only lightbox (event photos, pizza photos,
+   * non-admin viewers, etc.).
+   */
+  editorPane?: React.ReactNode;
+  /**
+   * pesto-92104: notified whenever the displayed image changes (open,
+   * prev/next, initialIndex clamp). Parent uses this to swap the editor
+   * pane content to match the current doc.
+   */
+  onIndexChange?: (idx: number) => void;
+  /**
+   * pesto-92104: optional gate for nav (arrows + nav buttons). Return
+   * `false` (or a Promise resolving to `false`) to cancel navigation —
+   * used by PayoutReviewModal to prompt "Save changes before navigating?"
+   * when the editor has unsaved drafts.
+   */
+  onBeforeNavigate?: (direction: 'prev' | 'next') => boolean | Promise<boolean>;
+  /**
+   * pesto-92104: `D` keypress handler. Wired by PayoutReviewModal to the
+   * mark-duplicate toggle for the current receipt. Lightbox only fires
+   * when admin context provides this prop.
+   */
+  onDuplicateShortcut?: () => void;
 }
 
 /** Some HEIC files come through with non-image/heic MIME types or no MIME at
@@ -48,6 +86,10 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   images,
   initialIndex = 0,
   onClose,
+  editorPane,
+  onIndexChange,
+  onBeforeNavigate,
+  onDuplicateShortcut,
 }) => {
   // Index lives in this component so callers only need to pass the starting
   // image. Reset whenever the lightbox is (re-)opened so each open starts
@@ -59,22 +101,50 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
       // by the time the lightbox opens.
       const safe = Math.max(0, Math.min(initialIndex, Math.max(0, images.length - 1)));
       setIndex(safe);
+      // pesto-92104: notify parent of the starting index so it can prime
+      // the editor pane for the right doc.
+      onIndexChange?.(safe);
     }
+    // We intentionally exclude `onIndexChange` from deps — it's a callback
+    // the parent may re-create per render, and we only want to fire on
+    // open / initialIndex change to avoid an effect loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, initialIndex, images.length]);
 
   const count = images.length;
   const hasMultiple = count > 1;
+  const hasEditor = editorPane != null && editorPane !== false;
 
-  const goPrev = useCallback(() => {
+  const goPrev = useCallback(async () => {
     if (count === 0) return;
-    setIndex((i) => (i - 1 + count) % count);
-  }, [count]);
-  const goNext = useCallback(() => {
+    // pesto-92104: gate on parent-supplied unsaved-edits prompt.
+    if (onBeforeNavigate) {
+      const ok = await onBeforeNavigate('prev');
+      if (!ok) return;
+    }
+    setIndex((i) => {
+      const next = (i - 1 + count) % count;
+      onIndexChange?.(next);
+      return next;
+    });
+  }, [count, onBeforeNavigate, onIndexChange]);
+  const goNext = useCallback(async () => {
     if (count === 0) return;
-    setIndex((i) => (i + 1) % count);
-  }, [count]);
+    if (onBeforeNavigate) {
+      const ok = await onBeforeNavigate('next');
+      if (!ok) return;
+    }
+    setIndex((i) => {
+      const next = (i + 1) % count;
+      onIndexChange?.(next);
+      return next;
+    });
+  }, [count, onBeforeNavigate, onIndexChange]);
 
   // Keyboard nav — Esc closes, arrows cycle (when more than one image).
+  // pesto-92104: `D` fires onDuplicateShortcut (admin only — guarded by the
+  // prop being supplied). Ignore D when focus is inside an editable input
+  // so typing the letter in a text field doesn't accidentally toggle.
   useEffect(() => {
     if (!isOpen) return;
     const onKey = (e: KeyboardEvent) => {
@@ -83,15 +153,26 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
         onClose();
       } else if (e.key === 'ArrowLeft' && hasMultiple) {
         e.preventDefault();
-        goPrev();
+        void goPrev();
       } else if (e.key === 'ArrowRight' && hasMultiple) {
         e.preventDefault();
-        goNext();
+        void goNext();
+      } else if ((e.key === 'd' || e.key === 'D') && onDuplicateShortcut) {
+        const target = e.target as HTMLElement | null;
+        const tag = target?.tagName?.toLowerCase();
+        const editable =
+          tag === 'input' ||
+          tag === 'textarea' ||
+          tag === 'select' ||
+          (target?.isContentEditable ?? false);
+        if (editable) return;
+        e.preventDefault();
+        onDuplicateShortcut();
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [isOpen, onClose, goPrev, goNext, hasMultiple]);
+  }, [isOpen, onClose, goPrev, goNext, hasMultiple, onDuplicateShortcut]);
 
   if (!isOpen || count === 0) return null;
 
@@ -108,6 +189,15 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   // pages 2+). Falls back to a download link for browsers without a native
   // PDF viewer.
   const pdf = !heic && !video && isPdfFile(current);
+
+  // pesto-92104: when an editor pane is supplied we render a two-column
+  // layout (photo left, editor right). Stacked on narrow viewports so the
+  // editor doesn't crowd the photo. Photo + editor each take ~half the
+  // viewport; the photo's max-height is dialed down so the editor stays
+  // visible without forcing scroll on common laptop sizes.
+  const mediaSizing = hasEditor
+    ? 'max-h-[50vh] md:max-h-[85vh] max-w-full md:max-w-full'
+    : 'max-h-[90vh] max-w-[90vw]';
 
   return createPortal(
     <div
@@ -144,7 +234,7 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              goPrev();
+              void goPrev();
             }}
             className="absolute left-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60 z-10"
             aria-label="Previous image"
@@ -155,7 +245,7 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              goNext();
+              void goNext();
             }}
             className="absolute right-4 top-1/2 -translate-y-1/2 text-white/80 hover:text-white p-2 rounded-full bg-black/40 hover:bg-black/60 z-10"
             aria-label="Next image"
@@ -165,73 +255,104 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
         </>
       )}
 
-      {/* Main content — image OR HEIC fallback. Stop click propagation so the
-          centered image isn't a click-through dead zone that triggers close. */}
+      {/* pesto-92104: outer container switches between centered single-pane
+          (photo only) and a 2-column / stacked grid when an editor pane is
+          supplied. Stop click propagation so neither pane is a click-through
+          dead zone that triggers close. */}
       <div
-        className="max-w-[90vw] max-h-[90vh] flex items-center justify-center"
+        className={
+          hasEditor
+            ? 'w-full max-w-[95vw] max-h-[95vh] grid grid-cols-1 md:grid-cols-2 gap-4 overflow-hidden'
+            : 'max-w-[90vw] max-h-[90vh] flex items-center justify-center'
+        }
         onClick={(e) => e.stopPropagation()}
       >
-        {heic ? (
-          <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
-            <p className="text-sm font-semibold">Can't preview HEIC files</p>
-            <p className="text-xs text-theme-text-muted">
-              Your browser doesn't render <span className="font-mono">.heic</span>{' '}
-              images natively. Open the file in a new tab to download or view it.
-            </p>
-            <a
-              href={current.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
-            >
-              Open in new tab <ExternalLink size={14} />
-            </a>
-            <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
-          </div>
-        ) : video ? (
-          /* melanzane-92103: keying on src so swapping between videos via
-             arrow nav cleanly remounts the <video> with the new source. */
-          <video
-            key={current.url}
-            src={current.url}
-            controls
-            autoPlay
-            muted
-            playsInline
-            className="max-h-[90vh] max-w-[90vw]"
-          />
-        ) : pdf ? (
-          /* bocconcino-92104: embedded native PDF viewer (Chrome/Edge/Safari/
-             Firefox all support this). Keyed on URL so arrow-nav across the
-             carousel remounts the embed with the new source instead of
-             caching the previous file. Sized to match other media slots. */
-          <div className="relative w-[90vw] h-[90vh] bg-white rounded-md overflow-hidden">
-            <embed
+        <div
+          className={
+            hasEditor
+              ? 'flex items-center justify-center min-h-0'
+              : 'flex items-center justify-center'
+          }
+        >
+          {heic ? (
+            <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
+              <p className="text-sm font-semibold">Can't preview HEIC files</p>
+              <p className="text-xs text-theme-text-muted">
+                Your browser doesn't render <span className="font-mono">.heic</span>{' '}
+                images natively. Open the file in a new tab to download or view it.
+              </p>
+              <a
+                href={current.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
+              >
+                Open in new tab <ExternalLink size={14} />
+              </a>
+              <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
+            </div>
+          ) : video ? (
+            /* melanzane-92103: keying on src so swapping between videos via
+               arrow nav cleanly remounts the <video> with the new source. */
+            <video
               key={current.url}
               src={current.url}
-              type="application/pdf"
-              className="w-full h-full"
+              controls
+              autoPlay
+              muted
+              playsInline
+              className={mediaSizing}
             />
-            <a
-              href={current.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="absolute top-2 right-2 inline-flex items-center gap-1.5 text-xs bg-black/60 text-white rounded-full px-2.5 py-1 hover:bg-black/80"
+          ) : pdf ? (
+            /* bocconcino-92104: embedded native PDF viewer (Chrome/Edge/Safari/
+               Firefox all support this). Keyed on URL so arrow-nav across the
+               carousel remounts the embed with the new source instead of
+               caching the previous file. Sized to match other media slots. */
+            <div
+              className={`relative ${hasEditor ? 'w-full h-[50vh] md:h-[85vh]' : 'w-[90vw] h-[90vh]'} bg-white rounded-md overflow-hidden`}
             >
-              Open in new tab <ExternalLink size={12} />
-            </a>
+              <embed
+                key={current.url}
+                src={current.url}
+                type="application/pdf"
+                className="w-full h-full"
+              />
+              <a
+                href={current.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="absolute top-2 right-2 inline-flex items-center gap-1.5 text-xs bg-black/60 text-white rounded-full px-2.5 py-1 hover:bg-black/80"
+              >
+                Open in new tab <ExternalLink size={12} />
+              </a>
+            </div>
+          ) : (
+            <img
+              src={current.url}
+              alt={current.fileName}
+              className={`${mediaSizing} object-contain`}
+            />
+          )}
+        </div>
+
+        {/* pesto-92104: editor pane. Scrolls independently so a long
+            line-items list doesn't push the photo off-screen. */}
+        {hasEditor && (
+          <div className="min-h-0 overflow-y-auto rounded-xl bg-theme-surface border border-theme-stroke">
+            {editorPane}
           </div>
-        ) : (
-          <img
-            src={current.url}
-            alt={current.fileName}
-            className="max-h-[90vh] max-w-[90vw] object-contain"
-          />
         )}
       </div>
 
-      {/* Footer — counter + file name. Only show counter when more than one. */}
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/90 text-xs sm:text-sm flex items-center gap-2 bg-black/40 rounded-full px-3 py-1.5 max-w-[90vw]">
+      {/* Footer — counter + file name. Only show counter when more than one.
+          pesto-92104: when an editor is showing, anchor the footer at the
+          bottom of the PHOTO pane instead of the centre so it doesn't
+          overlap the editor on the right. */}
+      <div
+        className={`absolute ${
+          hasEditor ? 'bottom-4 left-4 md:left-[25%]' : 'bottom-4 left-1/2 -translate-x-1/2'
+        } text-white/90 text-xs sm:text-sm flex items-center gap-2 bg-black/40 rounded-full px-3 py-1.5 max-w-[90vw]`}
+      >
         {hasMultiple && (
           <span className="font-medium">
             {index + 1} of {count}


### PR DESCRIPTION
## Summary
- Two-pane lightbox for receipts: photo on the left, full editor on the right. Amount + currency, line items grid, mark-duplicate toggle live inside the lightbox so admins don't have to leave the photo view.
- New shared `ReceiptEditor` presentational component (`frontend/src/components/payments-admin/ReceiptEditor.tsx`) — state lives in `PayoutReviewModal`, single source of truth for save callbacks (`saveReceiptEdit`, `toggleDuplicate`, `saveLineItemsEdit`).
- `ReceiptLightbox` extended with kind-agnostic `editorPane` slot + `onIndexChange` + `onBeforeNavigate` + `onDuplicateShortcut` props. Existing consumers (event photos, pizza photos, host-side payouts) keep the plain photo lightbox — editor only renders when admin-aware caller (PayoutReviewModal) supplies the pane.
- `D` keypress toggles duplicate (ignored while typing in an input). Arrow-key navigation prompts before discarding unsaved edits. Mobile (< md) stacks photo above editor with photo capped at `max-h-[50vh]`.

## Test plan
- [ ] Open a receipt thumbnail from the left-pane grid in PayoutReviewModal — lightbox shows photo on left, editor on right.
- [ ] Edit amount, click Save, close + reopen, verify persistence.
- [ ] Edit line items, click Save line items, close + reopen, verify persistence.
- [ ] Press `D` while a receipt is shown — duplicate flag toggles; reopen confirms persistence and row dims in the right pane.
- [ ] Arrow through receipts — unsaved edits prompt fires.
- [ ] Open an event photo or pizza photo — single-pane lightbox (no editor).
- [ ] Open in mobile viewport (< 768px) — photo + editor stack vertically.
- [ ] Right-pane receipt row in PayoutReviewModal still works (data-grid amount/currency inputs, Save, line items expand, Mark duplicate) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)