### PR TITLE
feat(caciotta-92105): hide closed cities by default on /payments

### DIFF
--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -95,6 +95,8 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   // salumi-89172: purpose filter default — 'all' shows both event and
   // shipping payouts so the existing admin queue is unchanged out of box.
   purpose: 'all',
+  // caciotta-92105: hide payments-closed cities (pinsa-92103) by default.
+  hideClosed: true,
   // arancino-92103: sort order default — newest submitted first. Matches the
   // prior implicit backend ordering, so non-sorting callers see no change.
   sort: 'created_desc',


### PR DESCRIPTION
## Summary
- Flip `DEFAULT_FILTERS.hideClosed` from implicit `false` to `true` in `PaymentsAdminPage.tsx` so the /payments by-city table hides payments-closed cities (pinsa-92103) by default.
- Admins can still uncheck the "Hide closed cities" filter to see them.

## Test plan
- [ ] Visit `/payments` on preview deploy → closed cities are hidden by default
- [ ] "Hide closed cities" checkbox shows checked on load
- [ ] Unchecking the box surfaces the closed cities again

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>