### PR TITLE
feat(caprino-92104): FX recompute + searchable currency picker

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -4272,21 +4272,49 @@ router.patch(
         data.isDuplicate = body.isDuplicate;
       }
 
-      // mortadella-92103: when admin changes the currency on a doc that has
-      // a known original-amount (either persisted in the column or buried in
-      // ocrRaw.ocr.amount), re-run FX so ocr_amount is the correctly-converted
-      // USD value. Admin can override by passing both ocrAmount + ocrCurrency
-      // explicitly; in that case we trust the admin's numbers and skip FX.
+      // mortadella-92103 + caprino-92104: when admin changes the currency on a
+      // doc that has a known original-amount (either persisted in the column,
+      // buried in ocrRaw.ocr.amount, or — caprino-92104 — inferable from the
+      // current ocr_amount on a legacy row), re-run FX so ocr_amount is the
+      // correctly-converted USD value. Admin can override by passing both
+      // ocrAmount + ocrCurrency explicitly; in that case we trust the admin's
+      // numbers and skip FX.
+      //
+      // caprino-92104: also re-run FX when the admin sent BOTH originalAmount
+      // + ocrCurrency together (the new editor's standard save shape). This is
+      // distinct from `adminSetBothExplicitly` (which is ocrAmount + ocrCurrency
+      // and means "trust the admin's USD value verbatim").
       const currencyChanged =
         data.ocrCurrency !== undefined && data.ocrCurrency !== doc.ocrCurrency;
       const adminSetBothExplicitly =
         body.ocrAmount !== undefined && body.ocrCurrency !== undefined;
+      const adminSentOriginalAmountAndCurrency =
+        body.originalAmount !== undefined
+        && body.originalAmount !== null
+        && body.ocrCurrency !== undefined
+        && data.ocrCurrency != null;
 
-      if (currencyChanged && !adminSetBothExplicitly && data.ocrCurrency != null) {
+      // Track whether the original amount was inferred from the legacy
+      // ocrAmount fallback so we can record it in the audit note (helps when
+      // forensically tracing FX recomputes on pre-mortadella receipts).
+      let originalAmountInferred = false;
+
+      if (
+        (currencyChanged || adminSentOriginalAmountAndCurrency)
+        && !adminSetBothExplicitly
+        && data.ocrCurrency != null
+      ) {
         // Resolve the original foreign-currency amount. Preference order:
         //   1. body.originalAmount if the admin provided it
         //   2. the existing originalAmount column (mortadella-92103+)
         //   3. ocrRaw.ocr.amount (pre-mortadella-92103 rows)
+        //   4. caprino-92104: existing ocr_amount on the doc — treat it as
+        //      the receipt's original-currency amount. This is the legacy-row
+        //      fallback for pre-mortadella receipts where neither column nor
+        //      ocr_raw has data; without it the PATCH would 400 with
+        //      FX_ORIGINAL_AMOUNT_MISSING and the admin would be stuck.
+        //      Audit row records `originalAmountInferred: true` so this
+        //      fallback is traceable.
         let originalAmount: number | null = null;
         if (body.originalAmount !== undefined && body.originalAmount !== null) {
           const n = Number(body.originalAmount);
@@ -4307,6 +4335,9 @@ router.patch(
           && typeof (doc.ocrRaw as any).ocr?.amount === 'number'
         ) {
           originalAmount = (doc.ocrRaw as any).ocr.amount;
+        } else if (doc.ocrAmount != null) {
+          originalAmount = Number(doc.ocrAmount.toString());
+          originalAmountInferred = true;
         }
 
         if (originalAmount == null) {
@@ -4326,11 +4357,15 @@ router.patch(
             'CURRENCY_UNRESOLVED',
           );
         }
-        if (fx.source === 'unknown') {
+        if (fx.source === 'unknown' || fx.exchangeRate == null) {
+          // caprino-92104: distinguish "we don't know this currency" /
+          // "network providers all failed" from "currency was missing". The
+          // frontend surfaces FX_RATE_UNAVAILABLE with a retry-or-set-USD
+          // affordance.
           throw new AppError(
-            `Could not look up exchange rate for currency "${data.ocrCurrency}".`,
+            `Could not fetch an exchange rate for ${data.ocrCurrency}. Try again, or set the USD value manually.`,
             400,
-            'UNKNOWN_CURRENCY',
+            'FX_RATE_UNAVAILABLE',
           );
         }
         data.ocrAmount = fx.usdAmount;
@@ -4345,6 +4380,11 @@ router.patch(
         // Admin updated originalAmount directly (e.g. correcting a misread
         // number on an already-correct currency). Re-run FX on the doc's
         // existing currency too.
+        //
+        // caprino-92104: previously this silently no-op'd on FX failure
+        // (`if (fx.usdAmount != null...)`), which meant the admin's edit
+        // didn't persist but they got a 200 response. Now we throw the same
+        // FX_RATE_UNAVAILABLE the currency-changed branch throws.
         const n = Number(body.originalAmount);
         if (!Number.isFinite(n) || n <= 0) {
           throw new AppError(
@@ -4354,16 +4394,33 @@ router.patch(
           );
         }
         const cur = data.ocrCurrency ?? doc.ocrCurrency;
-        if (cur) {
-          const { convertToUSD } = await import('../services/fx.service.js');
-          const fx = await convertToUSD(n, cur);
-          if (fx.usdAmount != null && fx.exchangeRate != null) {
-            data.ocrAmount = fx.usdAmount;
-            data.originalAmount = n;
-            data.originalCurrency = fx.originalCurrency;
-            data.exchangeRate = fx.exchangeRate;
-          }
+        if (!cur) {
+          throw new AppError(
+            'Cannot re-convert FX: receipt has no currency. Set ocrCurrency in the same request.',
+            400,
+            'CURRENCY_UNRESOLVED',
+          );
         }
+        const { convertToUSD } = await import('../services/fx.service.js');
+        const fx = await convertToUSD(n, cur);
+        if (fx.source === 'unresolved' || fx.usdAmount == null) {
+          throw new AppError(
+            `Could not convert ${n} ${cur} to USD — unresolved currency.`,
+            400,
+            'CURRENCY_UNRESOLVED',
+          );
+        }
+        if (fx.source === 'unknown' || fx.exchangeRate == null) {
+          throw new AppError(
+            `Could not fetch an exchange rate for ${cur}. Try again, or set the USD value manually.`,
+            400,
+            'FX_RATE_UNAVAILABLE',
+          );
+        }
+        data.ocrAmount = fx.usdAmount;
+        data.originalAmount = n;
+        data.originalCurrency = fx.originalCurrency;
+        data.exchangeRate = fx.exchangeRate;
       }
 
       if (Object.keys(data).length === 0) {
@@ -4450,6 +4507,17 @@ router.patch(
                   newAmount,
                   oldCurrency,
                   newCurrency,
+                  // caprino-92104: flag rows where we fell through to the
+                  // legacy ocr_amount fallback so forensics tools can
+                  // distinguish "FX recompute with known original" from
+                  // "FX recompute: original amount inferred from prior
+                  // ocr_amount value".
+                  ...(originalAmountInferred
+                    ? {
+                      note: 'FX recompute: original amount inferred from prior ocr_amount value',
+                      originalAmountInferred: true,
+                    }
+                    : {}),
                 }),
               },
             });

--- a/frontend/src/components/payments-admin/CurrencyPicker.tsx
+++ b/frontend/src/components/payments-admin/CurrencyPicker.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import {
+  SUPPORTED_CURRENCIES,
+  findCurrencyByCode,
+  searchCurrencies,
+  type CurrencyOption,
+} from '../../utils/currencies';
+
+/**
+ * caprino-92104: searchable currency picker for the admin receipt editor.
+ *
+ * Combobox pattern: a text input that doubles as a search field + a dropdown
+ * panel of matching currencies. Matches on ISO code, country name, currency
+ * name, OR country alias (e.g. "Germany" → EUR, "UK" → GBP). Keyboard nav:
+ * ArrowDown/Up to highlight, Enter to select, Esc to close.
+ *
+ * Renders rows as: [flag] [Country] — [Code] · [Currency name]. The picker
+ * does NOT call out to a network — the currency catalog ships in
+ * `utils/currencies.ts` (~40 ISO codes covering the GPP party set).
+ */
+interface CurrencyPickerProps {
+  /** Currently-selected ISO code. */
+  value: string | null | undefined;
+  /** Fires with the new ISO code (always uppercase). */
+  onChange: (code: string) => void;
+  /** Disable interaction (e.g. saving in flight). */
+  disabled?: boolean;
+  /** Optional className passthrough for the outer wrapper. */
+  className?: string;
+}
+
+export const CurrencyPicker: React.FC<CurrencyPickerProps> = ({
+  value,
+  onChange,
+  disabled,
+  className = '',
+}) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [highlightedIdx, setHighlightedIdx] = useState(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Resolve the currently-selected option from `value` so the input can
+  // display "Egypt — EGP" while not-focused. If value is an unknown code
+  // (legacy receipt with a custom string), fall back to the raw code.
+  const selected = useMemo(() => findCurrencyByCode(value ?? null), [value]);
+  const selectedLabel = selected
+    ? `${selected.flag} ${selected.country} — ${selected.code}`
+    : (value ?? '');
+
+  // Filtered list — recomputed each query change. When query is empty we
+  // show the full catalog so admins can browse without typing.
+  const filtered = useMemo<CurrencyOption[]>(() => {
+    return query.trim() ? searchCurrencies(query) : SUPPORTED_CURRENCIES;
+  }, [query]);
+
+  // Keep highlighted row in range when the filter changes.
+  useEffect(() => {
+    setHighlightedIdx(0);
+  }, [query]);
+
+  // Close on click outside the wrapper.
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery('');
+      }
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  function commit(option: CurrencyOption) {
+    onChange(option.code);
+    setOpen(false);
+    setQuery('');
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setHighlightedIdx((i) => Math.min(i + 1, Math.max(filtered.length - 1, 0)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const option = filtered[highlightedIdx];
+      if (option) commit(option);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+      setQuery('');
+      inputRef.current?.blur();
+    }
+  }
+
+  return (
+    <div ref={wrapperRef} className={`relative ${className}`}>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={open ? query : selectedLabel}
+          placeholder={selected ? selected.code : 'Currency'}
+          disabled={disabled}
+          onFocus={() => {
+            setOpen(true);
+            setQuery('');
+          }}
+          onChange={(e) => {
+            setOpen(true);
+            setQuery(e.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          className="w-full pl-3 pr-8 py-2 rounded-lg border border-theme-stroke bg-theme-surface text-theme-text text-sm disabled:opacity-50"
+        />
+        <ChevronDown
+          size={14}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-muted pointer-events-none"
+        />
+      </div>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border border-theme-stroke bg-theme-surface shadow-xl">
+          {filtered.length === 0 && (
+            <div className="px-3 py-2 text-xs text-theme-text-muted">
+              No currencies match "{query}".
+            </div>
+          )}
+          {filtered.map((c, idx) => {
+            const isSelected = selected?.code === c.code;
+            const isHighlighted = idx === highlightedIdx;
+            return (
+              <button
+                key={c.code}
+                type="button"
+                onMouseEnter={() => setHighlightedIdx(idx)}
+                // Use onMouseDown (not onClick) so the option commits before
+                // the input's blur handler can close the dropdown first —
+                // otherwise the picker closes without the selection landing.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  commit(c);
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm flex items-center gap-2 ${
+                  isHighlighted ? 'bg-theme-bg' : ''
+                } ${isSelected ? 'text-theme-text font-medium' : 'text-theme-text'}`}
+              >
+                <span className="text-base leading-none" aria-hidden>{c.flag}</span>
+                <span className="flex-1 truncate">{c.country}</span>
+                <span className="text-xs text-theme-text-muted">{c.code}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -406,6 +406,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     // culatello-92104: per-receipt duplicate flag override so the modal
     // reflects an in-flight toggle without waiting for parent refresh.
     isDuplicate?: boolean;
+    // caprino-92104: post-FX-recompute fields so the lightbox editor's "USD
+    // value" + "at rate X" display refreshes immediately on save.
+    originalAmount?: number | null;
+    originalCurrency?: string | null;
+    exchangeRate?: number | null;
   };
   const [receiptOverrides, setReceiptOverrides] = useState<Record<string, ReceiptOverride>>({});
   // Per-row save state.
@@ -414,8 +419,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // Per-row drafts so admins can edit without re-typing on re-render. Drafts
   // are seeded from the original OCR value on first edit and kept until the
   // row is saved or the modal closes.
-  type ReceiptDraft = { amount: string; currency: string };
+  //
+  // caprino-92104: draft now tracks the receipt's ORIGINAL-currency amount
+  // (what's printed on the receipt) plus currency; USD is derived server-side
+  // via FX on save. `manualUsdAmount` is an opt-in fallback when FX fails.
+  type ReceiptDraft = {
+    originalAmount: string;
+    currency: string;
+    manualUsdAmount?: string;
+  };
   const [receiptDrafts, setReceiptDrafts] = useState<Record<string, ReceiptDraft>>({});
+  // caprino-92104: per-row backend error code (e.g. FX_RATE_UNAVAILABLE) so
+  // the editor can render the "Set USD manually" fallback toggle.
+  const [receiptSaveErrorCodes, setReceiptSaveErrorCodes] = useState<Record<string, string>>({});
 
   // pancetta-92104: per-row "Retry OCR" state. Admin can re-trigger the OCR
   // pipeline on a single doc that previously errored (e.g. quota / timeout /
@@ -494,6 +510,15 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               ov.ocrLineItems !== undefined ? ov.ocrLineItems : d.ocrLineItems,
             isDuplicate:
               ov.isDuplicate !== undefined ? ov.isDuplicate : d.isDuplicate,
+            // caprino-92104: layer the FX recompute fields too so the
+            // lightbox editor's "USD value" + rate display reflects the new
+            // server-side values without a parent refetch.
+            originalAmount:
+              ov.originalAmount !== undefined ? ov.originalAmount : d.originalAmount,
+            originalCurrency:
+              ov.originalCurrency !== undefined ? ov.originalCurrency : d.originalCurrency,
+            exchangeRate:
+              ov.exchangeRate !== undefined ? ov.exchangeRate : d.exchangeRate,
           };
         }),
     [payout.documents, receiptOverrides],
@@ -572,21 +597,27 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       delete next[docId];
       return next;
     });
+    setReceiptSaveErrorCodes((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
     try {
-      // Empty string -> null (clear the field). Otherwise parse as number /
-      // upper-case the currency.
-      const trimmedAmt = draft.amount.trim();
+      // caprino-92104: send `originalAmount` + `ocrCurrency` together. The
+      // backend recomputes the USD value via convertToUSD() and returns the
+      // canonical (ocrAmount, originalAmount, exchangeRate, originalCurrency)
+      // tuple. When the admin has opted into manual-USD mode (after an
+      // FX_RATE_UNAVAILABLE failure), send `ocrAmount` + `ocrCurrency`
+      // instead — the backend's `adminSetBothExplicitly` branch trusts the
+      // admin's numbers and skips FX.
+      const trimmedOrig = draft.originalAmount.trim();
       const trimmedCur = draft.currency.trim();
-      const patch: { ocrAmount?: number | null; ocrCurrency?: string | null } = {};
-      if (trimmedAmt === '') {
-        patch.ocrAmount = null;
-      } else {
-        const n = Number(trimmedAmt);
-        if (!Number.isFinite(n) || n < 0) {
-          throw new Error('Amount must be a non-negative number');
-        }
-        patch.ocrAmount = n;
-      }
+      const patch: {
+        ocrAmount?: number | null;
+        ocrCurrency?: string | null;
+        originalAmount?: number | null;
+      } = {};
+
       if (trimmedCur === '') {
         patch.ocrCurrency = null;
       } else if (trimmedCur.length > 8) {
@@ -594,6 +625,41 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       } else {
         patch.ocrCurrency = trimmedCur.toUpperCase();
       }
+
+      if (draft.manualUsdAmount !== undefined) {
+        // Manual-USD fallback: trust the admin's USD value verbatim. Still
+        // persist the original amount so future re-conversions work.
+        const trimmedUsd = draft.manualUsdAmount.trim();
+        if (trimmedUsd === '') {
+          patch.ocrAmount = null;
+        } else {
+          const n = Number(trimmedUsd);
+          if (!Number.isFinite(n) || n < 0) {
+            throw new Error('USD value must be a non-negative number');
+          }
+          patch.ocrAmount = n;
+        }
+        if (trimmedOrig !== '') {
+          const n = Number(trimmedOrig);
+          if (!Number.isFinite(n) || n < 0) {
+            throw new Error('Original amount must be a non-negative number');
+          }
+          patch.originalAmount = n;
+        }
+      } else {
+        // Standard FX path: send the original amount + currency and let the
+        // backend derive USD. Empty original amount clears the field.
+        if (trimmedOrig === '') {
+          patch.originalAmount = null;
+        } else {
+          const n = Number(trimmedOrig);
+          if (!Number.isFinite(n) || n <= 0) {
+            throw new Error('Original amount must be a positive number');
+          }
+          patch.originalAmount = n;
+        }
+      }
+
       const updated = await updatePayoutDocument(docId, patch);
       setReceiptOverrides((m) => ({
         ...m,
@@ -609,14 +675,24 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           // through so a previous dup toggle isn't lost when amount/currency
           // is also edited.
           isDuplicate: updated.isDuplicate,
+          // caprino-92104: surface the recomputed FX details so the lightbox
+          // editor's "USD value" display renders the new numbers without a
+          // parent refetch.
+          originalAmount: updated.originalAmount,
+          originalCurrency: updated.originalCurrency,
+          exchangeRate: updated.exchangeRate,
         },
       }));
       // Sync the draft text to the canonical saved value so the inputs match
-      // the rendered row on the next render.
+      // the rendered row on the next render. Drop manualUsdAmount because
+      // the save succeeded (either FX path or admin's manual value — both
+      // are now persisted as the canonical state).
       setReceiptDrafts((m) => ({
         ...m,
         [docId]: {
-          amount: updated.ocrAmount == null ? '' : String(updated.ocrAmount),
+          originalAmount: updated.originalAmount == null
+            ? ''
+            : String(updated.originalAmount),
           currency: updated.ocrCurrency ?? '',
         },
       }));
@@ -625,6 +701,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         ...m,
         [docId]: err?.message || 'Failed to save',
       }));
+      const code = (err && typeof err.code === 'string') ? err.code : '';
+      if (code) {
+        setReceiptSaveErrorCodes((m) => ({ ...m, [docId]: code }));
+      }
     } finally {
       setReceiptSavingId(null);
     }
@@ -756,6 +836,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
 
   // Clamp the receipt-amount draft to the current line-sum. Convenience
   // affordance — admins still get the explicit Save button to confirm.
+  //
+  // caprino-92104: line items are in the receipt's ORIGINAL currency (see
+  // `sumCurrency` in ReceiptEditor), so the sum maps to `originalAmount`,
+  // not the USD value.
   function useLineSumForAmount(docId: string) {
     const drafts = lineItemDrafts[docId];
     const sum = draftSubtotalSum(drafts);
@@ -765,7 +849,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       return {
         ...m,
         [docId]: {
-          amount: sum.toFixed(2),
+          originalAmount: sum.toFixed(2),
           currency: prev?.currency ?? '',
         },
       };
@@ -951,9 +1035,21 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     if (!r) return false;
     const draft = receiptDrafts[docId];
     if (draft) {
-      const persistedAmt = r.ocrAmount == null ? '' : String(r.ocrAmount);
-      const persistedCur = r.ocrCurrency ?? '';
-      if (draft.amount !== persistedAmt || draft.currency !== persistedCur) {
+      // caprino-92104: compare against the originalAmount column (the field
+      // the editor binds to) and the originalCurrency (falling back to
+      // ocrCurrency when the FX detail isn't persisted yet).
+      const seededOriginal =
+        r.originalAmount != null
+          ? String(r.originalAmount)
+          : r.ocrAmount != null
+            ? String(r.ocrAmount)
+            : '';
+      const seededCurrency = r.originalCurrency ?? r.ocrCurrency ?? '';
+      if (
+        draft.originalAmount !== seededOriginal
+        || draft.currency !== seededCurrency
+        || draft.manualUsdAmount !== undefined
+      ) {
         return true;
       }
     }
@@ -1012,17 +1108,25 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     if (!lightboxReceipt) return null;
     if (!canEditReceipts) return null;
     const r = lightboxReceipt;
-    // Seed the amount/currency draft from current persisted values if the
-    // admin hasn't typed anything yet. Keeps the editor's inputs reflecting
-    // whatever the row shows in the right-pane.
+    // caprino-92104: seed the draft from the canonical persisted shape. Prefer
+    // the receipt's `originalAmount` column (mortadella-92103+) and fall back
+    // to `ocrAmount` for legacy rows (treats the stored value as the original-
+    // currency amount on first edit — backend mirrors this fallback).
+    const seededOriginal =
+      r.originalAmount != null
+        ? String(r.originalAmount)
+        : r.ocrAmount != null
+          ? String(r.ocrAmount)
+          : '';
+    const seededCurrency = r.originalCurrency ?? r.ocrCurrency ?? '';
     const draft: ReceiptDraft = receiptDrafts[r.id] ?? {
-      amount: r.ocrAmount == null ? '' : String(r.ocrAmount),
-      currency: r.ocrCurrency ?? '',
+      originalAmount: seededOriginal,
+      currency: seededCurrency,
     };
-    const persistedAmt = r.ocrAmount == null ? '' : String(r.ocrAmount);
-    const persistedCur = r.ocrCurrency ?? '';
     const isDirty =
-      draft.amount !== persistedAmt || draft.currency !== persistedCur;
+      draft.originalAmount !== seededOriginal
+      || draft.currency !== seededCurrency
+      || draft.manualUsdAmount !== undefined;
     // Seed line item drafts lazily (mirrors ensureLineItemDrafts on
     // expansion in the right-pane). For the lightbox we always show the
     // editor, so seed immediately if no draft exists yet.
@@ -1041,6 +1145,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         }
         saving={receiptSavingId === r.id}
         saveError={receiptSaveErrors[r.id]}
+        saveErrorCode={receiptSaveErrorCodes[r.id]}
         onSave={() => saveReceiptEdit(r.id)}
         isDirty={isDirty}
         isDuplicate={r.isDuplicate === true}
@@ -1094,6 +1199,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     receiptDrafts,
     receiptSavingId,
     receiptSaveErrors,
+    receiptSaveErrorCodes,
     duplicateSavingId,
     duplicateSaveErrors,
     lineItemDrafts,
@@ -1908,14 +2014,35 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     // so admins can see what the model originally returned
                     // when they're correcting the field. `original*` reflects
                     // the saved-but-not-yet-overridden value.
-                    const originalAmt = payout.documents.find((d) => d.id === r.id)?.ocrAmount;
-                    const originalCur = payout.documents.find((d) => d.id === r.id)?.ocrCurrency;
+                    //
+                    // caprino-92104: the right-pane row's amount input now
+                    // edits the receipt's ORIGINAL-currency value (same field
+                    // the lightbox editor binds to) — on save, backend re-runs
+                    // FX and stores the recomputed USD. Seeded from the
+                    // `originalAmount` column, falling back to `ocrAmount`
+                    // for legacy rows (mirrors the editor's seed logic).
+                    const rawDoc = payout.documents.find((d) => d.id === r.id);
+                    const placeholderAmt =
+                      rawDoc?.originalAmount != null
+                        ? String(rawDoc.originalAmount)
+                        : rawDoc?.ocrAmount != null
+                          ? String(rawDoc.ocrAmount)
+                          : null;
+                    const placeholderCur = rawDoc?.originalCurrency ?? rawDoc?.ocrCurrency ?? null;
+                    const seededOriginalAmt =
+                      r.originalAmount != null
+                        ? String(r.originalAmount)
+                        : r.ocrAmount != null
+                          ? String(r.ocrAmount)
+                          : '';
+                    const seededCur = r.originalCurrency ?? r.ocrCurrency ?? '';
                     const draft = receiptDrafts[r.id];
-                    const draftAmt = draft?.amount ?? (r.ocrAmount == null ? '' : String(r.ocrAmount));
-                    const draftCur = draft?.currency ?? (r.ocrCurrency ?? '');
+                    const draftAmt = draft?.originalAmount ?? seededOriginalAmt;
+                    const draftCur = draft?.currency ?? seededCur;
                     const dirty =
-                      draftAmt !== (r.ocrAmount == null ? '' : String(r.ocrAmount)) ||
-                      draftCur !== (r.ocrCurrency ?? '');
+                      draftAmt !== seededOriginalAmt
+                      || draftCur !== seededCur
+                      || draft?.manualUsdAmount !== undefined;
                     const saving = receiptSavingId === r.id;
                     const saveError = receiptSaveErrors[r.id];
                     // culatello-92104: dim the row when marked duplicate +
@@ -1961,11 +2088,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                 min="0"
                                 inputMode="decimal"
                                 value={draftAmt}
-                                placeholder={originalAmt == null ? 'amount' : String(originalAmt)}
+                                placeholder={placeholderAmt ?? 'orig amt'}
+                                title="Original-currency amount (printed on receipt). USD recomputed on save."
                                 onChange={(e) =>
                                   setReceiptDrafts((m) => ({
                                     ...m,
-                                    [r.id]: { amount: e.target.value, currency: draftCur },
+                                    [r.id]: { originalAmount: e.target.value, currency: draftCur },
                                   }))
                                 }
                                 className="w-24 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
@@ -1974,11 +2102,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                 type="text"
                                 maxLength={8}
                                 value={draftCur}
-                                placeholder={originalCur || 'CUR'}
+                                placeholder={placeholderCur || 'CUR'}
                                 onChange={(e) =>
                                   setReceiptDrafts((m) => ({
                                     ...m,
-                                    [r.id]: { amount: draftAmt, currency: e.target.value },
+                                    [r.id]: { originalAmount: draftAmt, currency: e.target.value },
                                   }))
                                 }
                                 className="w-16 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs uppercase"

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -350,12 +350,20 @@ function CityExpansion({
     ocrCurrency: string | null;
     ocrLineItems?: ReceiptLineItem[] | null;
     isDuplicate?: boolean;
+    // caprino-92104: persist the FX recompute details so the lightbox
+    // editor's "USD value @ rate" line refreshes immediately on save.
+    originalAmount?: number | null;
+    originalCurrency?: string | null;
+    exchangeRate?: number | null;
   };
   const [receiptOverrides, setReceiptOverrides] = useState<Record<string, ReceiptOverride>>({});
   // Amount/currency drafts (string-typed so admins can type freely).
   const [receiptDrafts, setReceiptDrafts] = useState<Record<string, ReceiptDraft>>({});
   const [receiptSavingId, setReceiptSavingId] = useState<string | null>(null);
   const [receiptSaveErrors, setReceiptSaveErrors] = useState<Record<string, string>>({});
+  // caprino-92104: per-row backend error code (e.g. FX_RATE_UNAVAILABLE) so
+  // the editor can render the "Set USD manually" fallback toggle.
+  const [receiptSaveErrorCodes, setReceiptSaveErrorCodes] = useState<Record<string, string>>({});
   // Mark-duplicate state.
   const [duplicateSavingId, setDuplicateSavingId] = useState<string | null>(null);
   const [duplicateSaveErrors, setDuplicateSaveErrors] = useState<Record<string, string>>({});
@@ -389,6 +397,14 @@ function CityExpansion({
             ov.ocrLineItems !== undefined ? ov.ocrLineItems : e.doc.ocrLineItems,
           isDuplicate:
             ov.isDuplicate !== undefined ? ov.isDuplicate : e.doc.isDuplicate,
+          // caprino-92104: layer the FX recompute fields so the lightbox
+          // editor's "USD value @ rate" row refreshes without a refetch.
+          originalAmount:
+            ov.originalAmount !== undefined ? ov.originalAmount : e.doc.originalAmount,
+          originalCurrency:
+            ov.originalCurrency !== undefined ? ov.originalCurrency : e.doc.originalCurrency,
+          exchangeRate:
+            ov.exchangeRate !== undefined ? ov.exchangeRate : e.doc.exchangeRate,
         },
       };
     });
@@ -555,19 +571,23 @@ function CityExpansion({
       delete next[docId];
       return next;
     });
+    setReceiptSaveErrorCodes((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
     try {
-      const trimmedAmt = draft.amount.trim();
+      // caprino-92104: send originalAmount + ocrCurrency; backend re-runs FX
+      // and returns the canonical USD value + exchange rate. Manual-USD mode
+      // bypasses FX and sends ocrAmount + ocrCurrency verbatim.
+      const trimmedOrig = draft.originalAmount.trim();
       const trimmedCur = draft.currency.trim();
-      const patch: { ocrAmount?: number | null; ocrCurrency?: string | null } = {};
-      if (trimmedAmt === '') {
-        patch.ocrAmount = null;
-      } else {
-        const n = Number(trimmedAmt);
-        if (!Number.isFinite(n) || n < 0) {
-          throw new Error('Amount must be a non-negative number');
-        }
-        patch.ocrAmount = n;
-      }
+      const patch: {
+        ocrAmount?: number | null;
+        ocrCurrency?: string | null;
+        originalAmount?: number | null;
+      } = {};
+
       if (trimmedCur === '') {
         patch.ocrCurrency = null;
       } else if (trimmedCur.length > 8) {
@@ -575,6 +595,37 @@ function CityExpansion({
       } else {
         patch.ocrCurrency = trimmedCur.toUpperCase();
       }
+
+      if (draft.manualUsdAmount !== undefined) {
+        const trimmedUsd = draft.manualUsdAmount.trim();
+        if (trimmedUsd === '') {
+          patch.ocrAmount = null;
+        } else {
+          const n = Number(trimmedUsd);
+          if (!Number.isFinite(n) || n < 0) {
+            throw new Error('USD value must be a non-negative number');
+          }
+          patch.ocrAmount = n;
+        }
+        if (trimmedOrig !== '') {
+          const n = Number(trimmedOrig);
+          if (!Number.isFinite(n) || n < 0) {
+            throw new Error('Original amount must be a non-negative number');
+          }
+          patch.originalAmount = n;
+        }
+      } else {
+        if (trimmedOrig === '') {
+          patch.originalAmount = null;
+        } else {
+          const n = Number(trimmedOrig);
+          if (!Number.isFinite(n) || n <= 0) {
+            throw new Error('Original amount must be a positive number');
+          }
+          patch.originalAmount = n;
+        }
+      }
+
       const updated = await updatePayoutDocument(docId, patch);
       setReceiptOverrides((m) => ({
         ...m,
@@ -583,12 +634,17 @@ function CityExpansion({
           ocrCurrency: updated.ocrCurrency,
           ocrLineItems: updated.ocrLineItems,
           isDuplicate: updated.isDuplicate,
+          originalAmount: updated.originalAmount,
+          originalCurrency: updated.originalCurrency,
+          exchangeRate: updated.exchangeRate,
         },
       }));
       setReceiptDrafts((m) => ({
         ...m,
         [docId]: {
-          amount: updated.ocrAmount == null ? '' : String(updated.ocrAmount),
+          originalAmount: updated.originalAmount == null
+            ? ''
+            : String(updated.originalAmount),
           currency: updated.ocrCurrency ?? '',
         },
       }));
@@ -597,6 +653,10 @@ function CityExpansion({
         ...m,
         [docId]: err?.message || 'Failed to save',
       }));
+      const code = (err && typeof err.code === 'string') ? err.code : '';
+      if (code) {
+        setReceiptSaveErrorCodes((m) => ({ ...m, [docId]: code }));
+      }
     } finally {
       setReceiptSavingId(null);
     }
@@ -691,12 +751,14 @@ function CityExpansion({
       const n = Number(d.subtotal);
       if (Number.isFinite(n) && n >= 0) sum += n;
     }
+    // caprino-92104: line items are in the receipt's ORIGINAL currency, so
+    // the line sum maps to the originalAmount draft, not USD.
     setReceiptDrafts((m) => {
       const prev = m[docId];
       return {
         ...m,
         [docId]: {
-          amount: sum.toFixed(2),
+          originalAmount: sum.toFixed(2),
           currency: prev?.currency ?? '',
         },
       };
@@ -790,9 +852,20 @@ function CityExpansion({
     if (!r) return false;
     const draft = receiptDrafts[docId];
     if (draft) {
-      const persistedAmt = r.ocrAmount == null ? '' : String(r.ocrAmount);
-      const persistedCur = r.ocrCurrency ?? '';
-      if (draft.amount !== persistedAmt || draft.currency !== persistedCur) {
+      // caprino-92104: compare against the seed (originalAmount column,
+      // falling back to ocrAmount for legacy rows) and originalCurrency.
+      const seededOriginal =
+        r.originalAmount != null
+          ? String(r.originalAmount)
+          : r.ocrAmount != null
+            ? String(r.ocrAmount)
+            : '';
+      const seededCurrency = r.originalCurrency ?? r.ocrCurrency ?? '';
+      if (
+        draft.originalAmount !== seededOriginal
+        || draft.currency !== seededCurrency
+        || draft.manualUsdAmount !== undefined
+      ) {
         return true;
       }
     }
@@ -838,14 +911,24 @@ function CityExpansion({
     if (lightbox?.bucket !== 'receipt') return null;
     if (!lightboxReceipt) return null;
     const r = lightboxReceipt;
+    // caprino-92104: seed from the canonical persisted shape — prefer the
+    // `originalAmount` column, fall back to `ocrAmount` for legacy rows
+    // (matches the backend's legacy fallback for FX recompute).
+    const seededOriginal =
+      r.originalAmount != null
+        ? String(r.originalAmount)
+        : r.ocrAmount != null
+          ? String(r.ocrAmount)
+          : '';
+    const seededCurrency = r.originalCurrency ?? r.ocrCurrency ?? '';
     const draft: ReceiptDraft = receiptDrafts[r.id] ?? {
-      amount: r.ocrAmount == null ? '' : String(r.ocrAmount),
-      currency: r.ocrCurrency ?? '',
+      originalAmount: seededOriginal,
+      currency: seededCurrency,
     };
-    const persistedAmt = r.ocrAmount == null ? '' : String(r.ocrAmount);
-    const persistedCur = r.ocrCurrency ?? '';
     const isDirty =
-      draft.amount !== persistedAmt || draft.currency !== persistedCur;
+      draft.originalAmount !== seededOriginal
+      || draft.currency !== seededCurrency
+      || draft.manualUsdAmount !== undefined;
     const liDraftsExisting = lineItemDrafts[r.id];
     const liDrafts =
       liDraftsExisting ?? (r.ocrLineItems ?? []).map(lineItemToDraft);
@@ -861,6 +944,7 @@ function CityExpansion({
         }
         saving={receiptSavingId === r.id}
         saveError={receiptSaveErrors[r.id]}
+        saveErrorCode={receiptSaveErrorCodes[r.id]}
         onSave={() => saveReceiptEdit(r.id)}
         isDirty={isDirty}
         isDuplicate={r.isDuplicate === true}
@@ -915,6 +999,7 @@ function CityExpansion({
     receiptDrafts,
     receiptSavingId,
     receiptSaveErrors,
+    receiptSaveErrorCodes,
     duplicateSavingId,
     duplicateSaveErrors,
     lineItemDrafts,

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw } from 'lucide-react';
+import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw, Receipt } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
+import { CurrencyPicker } from './CurrencyPicker';
 import type { PayoutDocument, ReceiptLineItem, ReceiptLineItemCategory } from '../../types';
 
 /**
@@ -19,7 +20,30 @@ import type { PayoutDocument, ReceiptLineItem, ReceiptLineItemCategory } from '.
  * data-grid) so the existing flow isn't regressed.
  */
 
-export type ReceiptDraft = { amount: string; currency: string };
+/**
+ * caprino-92104: per-receipt draft. The editor now exposes the receipt's
+ * original-currency amount + the currency picker (the inputs admins type
+ * into) plus a derived USD value that's recomputed server-side via FX on
+ * save. The deprecated single-`amount` field (USD-only) has been replaced
+ * by `originalAmount`; `manualUsdAmount` is an optional opt-in for the
+ * "FX rate unavailable — set USD manually" fallback path.
+ *
+ * The field name `originalAmount` here matches the server-side column
+ * name (`payout_documents.original_amount`).
+ */
+export type ReceiptDraft = {
+  /** Receipt's local-currency value (what's printed on the paper). */
+  originalAmount: string;
+  /** ISO 4217 code, uppercase. */
+  currency: string;
+  /**
+   * Optional manual USD value. Only set when the admin has opted into the
+   * "Set USD manually" fallback after an FX_RATE_UNAVAILABLE error — the
+   * default save path leaves this undefined and lets the backend derive USD
+   * from `originalAmount` + `currency`.
+   */
+  manualUsdAmount?: string;
+};
 export type LineItemDraft = {
   name: string;
   qty: string;
@@ -35,6 +59,11 @@ interface ReceiptEditorProps {
   onDraftChange: (next: ReceiptDraft) => void;
   saving: boolean;
   saveError?: string;
+  /**
+   * caprino-92104: backend error code surfaced from a failed save (e.g.
+   * `FX_RATE_UNAVAILABLE`). Drives the "Set USD manually" fallback toggle.
+   */
+  saveErrorCode?: string;
   onSave: () => void;
 
   /** Mark-duplicate state. */
@@ -80,6 +109,7 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   onDraftChange,
   saving,
   saveError,
+  saveErrorCode,
   onSave,
   isDuplicate,
   dupSaving,
@@ -106,6 +136,22 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   // matches what admins are typing into the per-line subtotals.
   const sumCurrency = doc.originalCurrency ?? doc.ocrCurrency ?? 'USD';
 
+  // caprino-92104: legacy-row hint. When the receipt has no persisted
+  // `originalAmount` column (pre-mortadella row that's never been edited via
+  // the new editor), we surface a small note telling the admin the seeded
+  // value comes from `ocrAmount` — they should sanity-check before saving in
+  // case the OCR'd value was actually USD-converted.
+  const isLegacyRow = doc.originalAmount == null;
+  // Hide the rate line when the receipt is already USD (rate=1 is noise).
+  const rateAvailable =
+    doc.exchangeRate != null
+    && doc.exchangeRate !== 1
+    && doc.originalCurrency
+    && doc.originalCurrency !== 'USD'
+    && doc.ocrAmount != null;
+  const fxRateUnavailable = saveErrorCode === 'FX_RATE_UNAVAILABLE';
+  const manualUsdMode = draft.manualUsdAmount !== undefined;
+
   return (
     <div className="p-4 space-y-4 text-theme-text">
       {/* Header */}
@@ -130,44 +176,111 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
         )}
       </div>
 
-      {/* Amount + currency */}
-      <div className="space-y-2">
-        <div className="grid grid-cols-1 sm:grid-cols-[1fr_120px] gap-2">
-          <IconInput
-            icon={DollarSign}
-            type="number"
-            step="0.01"
-            min="0"
-            placeholder="Amount"
-            value={draft.amount}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              onDraftChange({ ...draft, amount: e.target.value })
-            }
-          />
-          {/*
-            Currency is short (3-letter ISO usually). IconInput's full-width
-            layout would crowd the row, so a compact uppercase input cell
-            keeps the field reasonable — same precedent as the per-row
-            data-grid currency input in PayoutReviewModal. */}
-          <input
-            type="text"
-            maxLength={8}
-            value={draft.currency}
-            placeholder={doc.ocrCurrency || 'CUR'}
-            onChange={(e) => onDraftChange({ ...draft, currency: e.target.value })}
-            className="w-full px-3 py-2 rounded-lg border border-theme-stroke bg-theme-surface text-theme-text text-sm uppercase"
-          />
+      {/* caprino-92104: Amount + currency split into two visible rows.
+          Top row = "Original amount" (the local-currency value the admin
+          types) + the searchable currency picker. Bottom row = derived USD
+          value, read-only display unless the admin opts into "Set USD
+          manually" after an FX_RATE_UNAVAILABLE error.
+
+          Save sends both `originalAmount` + `ocrCurrency` together; backend
+          re-runs convertToUSD and persists the recomputed ocr_amount +
+          exchange_rate. */}
+      <div className="space-y-3">
+        {/* Original amount row */}
+        <div className="space-y-1">
+          <div className="grid grid-cols-1 sm:grid-cols-[1fr_220px] gap-2 items-start">
+            <IconInput
+              icon={Receipt}
+              type="number"
+              step="0.01"
+              min="0"
+              inputMode="decimal"
+              placeholder="Original amount (as printed)"
+              value={draft.originalAmount}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                onDraftChange({ ...draft, originalAmount: e.target.value })
+              }
+            />
+            <CurrencyPicker
+              value={draft.currency}
+              onChange={(code) => onDraftChange({ ...draft, currency: code })}
+              disabled={saving}
+            />
+          </div>
+          <p className="text-xs text-white/40">
+            The receipt's local-currency total. USD is derived via FX on save.
+          </p>
+          {isLegacyRow && !manualUsdMode && (
+            <p className="text-xs text-amber-400">
+              Legacy receipt — original amount inferred from stored value. Verify before saving.
+            </p>
+          )}
         </div>
-        <p className="text-xs text-white/40">
-          Amount is the USD-converted total stored on this receipt. Changing the
-          currency re-runs FX automatically against the receipt's original
-          amount on save.
-        </p>
+
+        {/* USD value (derived, read-only) — or manual-USD mode after FX failure */}
+        {!manualUsdMode ? (
+          <div className="space-y-1">
+            <div className="px-3 py-2 rounded-lg border border-theme-stroke bg-theme-bg text-theme-text text-sm flex items-baseline gap-2">
+              <DollarSign size={14} className="text-theme-text-muted self-center" />
+              <span className="font-medium">
+                {doc.ocrAmount == null ? '—' : doc.ocrAmount.toFixed(2)}
+              </span>
+              {rateAvailable && (
+                <span className="text-xs text-theme-text-muted">
+                  at rate 1 {doc.originalCurrency} = ${(doc.exchangeRate ?? 0).toFixed(4)}
+                </span>
+              )}
+              <span className="ml-auto text-xs text-white/40">USD (auto)</span>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            <p className="text-xs text-amber-400">
+              Set USD manually — FX rate unavailable for {draft.currency || 'this currency'}.
+            </p>
+            <IconInput
+              icon={DollarSign}
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="USD value"
+              value={draft.manualUsdAmount ?? ''}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                onDraftChange({ ...draft, manualUsdAmount: e.target.value })
+              }
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const { manualUsdAmount: _, ...rest } = draft;
+                onDraftChange(rest);
+              }}
+              className="text-xs text-theme-text-muted underline hover:text-theme-text"
+            >
+              Cancel manual USD — try FX again
+            </button>
+          </div>
+        )}
+
         {saveError && (
           <div className="text-xs text-red-300 flex items-start gap-1.5">
             <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
             <span>{saveError}</span>
           </div>
+        )}
+        {fxRateUnavailable && !manualUsdMode && (
+          <button
+            type="button"
+            onClick={() =>
+              onDraftChange({
+                ...draft,
+                manualUsdAmount: doc.ocrAmount == null ? '' : String(doc.ocrAmount),
+              })
+            }
+            className="text-xs text-amber-400 underline hover:text-amber-300"
+          >
+            Set USD manually instead
+          </button>
         )}
       </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,7 +63,17 @@ export async function apiRequest<T>(
 
     const error = await response.json().catch(() => ({ message: 'Request failed' }));
 
-    throw new Error(error.message || error.error?.message || `API error: ${response.status}`);
+    // caprino-92104: surface the structured error code from the backend's
+    // AppError shape (`{ error: { message, code } }`) so callers that need to
+    // branch on it (e.g. ReceiptEditor on FX_RATE_UNAVAILABLE) can do so
+    // without parsing the message string. Plain `new Error()` callers ignore
+    // the extra property.
+    const err = new Error(
+      error.message || error.error?.message || `API error: ${response.status}`,
+    ) as Error & { code?: string };
+    if (typeof error.error?.code === 'string') err.code = error.error.code;
+    else if (typeof error.code === 'string') err.code = error.code;
+    throw err;
   }
 
   return response.json();
@@ -4257,6 +4267,12 @@ export async function updatePayoutDocument(
   patch: {
     ocrAmount?: number | null;
     ocrCurrency?: string | null;
+    // caprino-92104: original-currency amount. When sent alongside
+    // `ocrCurrency`, the backend runs `convertToUSD(originalAmount,
+    // ocrCurrency)` and persists the recomputed USD value + exchange
+    // rate. Sending originalAmount alone (without ocrCurrency) re-runs
+    // FX against the receipt's existing currency.
+    originalAmount?: number | null;
     ocrLineItems?: ReceiptLineItem[] | null;
     // culatello-92104: admin-toggleable duplicate flag. Reversible.
     isDuplicate?: boolean;

--- a/frontend/src/utils/currencies.ts
+++ b/frontend/src/utils/currencies.ts
@@ -1,0 +1,141 @@
+/**
+ * caprino-92104: ISO 4217 currency catalog for the admin receipt editor's
+ * searchable currency picker. Covers the GPP party set (~40 codes spanning
+ * the regions we run events in). Hardcoded — these are stable, and we'd
+ * rather not block the picker on a network round-trip just to render a list.
+ *
+ * `country` is the principal country whose name a user is most likely to
+ * type when searching (e.g. typing "Egypt" should match EGP). For EUR/USD
+ * which span many jurisdictions, the country reads as "Eurozone" / "United
+ * States" — the picker matches on `code`, `name`, AND `country`, so users
+ * who type "Germany" still get EUR via the alias list below.
+ *
+ * `flag` is an emoji flag (two regional-indicator code points). The picker
+ * renders it as text; OS font fallback handles platforms without color
+ * emoji.
+ */
+export interface CurrencyOption {
+  /** ISO 4217 code, uppercase. */
+  code: string;
+  /** Currency name, e.g. "Egyptian Pound". */
+  name: string;
+  /** Principal country name the picker shows next to the flag. */
+  country: string;
+  /** Emoji flag (regional indicators for the country's ISO 3166 alpha-2). */
+  flag: string;
+  /** Extra country names that should also match this currency in search. */
+  aliases?: string[];
+}
+
+export const SUPPORTED_CURRENCIES: CurrencyOption[] = [
+  // Americas
+  { code: 'USD', name: 'US Dollar', country: 'United States', flag: '🇺🇸', aliases: ['USA', 'America'] },
+  { code: 'CAD', name: 'Canadian Dollar', country: 'Canada', flag: '🇨🇦' },
+  { code: 'MXN', name: 'Mexican Peso', country: 'Mexico', flag: '🇲🇽' },
+  { code: 'BRL', name: 'Brazilian Real', country: 'Brazil', flag: '🇧🇷' },
+  { code: 'ARS', name: 'Argentine Peso', country: 'Argentina', flag: '🇦🇷' },
+  { code: 'CLP', name: 'Chilean Peso', country: 'Chile', flag: '🇨🇱' },
+  { code: 'COP', name: 'Colombian Peso', country: 'Colombia', flag: '🇨🇴' },
+  { code: 'UYU', name: 'Uruguayan Peso', country: 'Uruguay', flag: '🇺🇾' },
+  { code: 'PEN', name: 'Peruvian Sol', country: 'Peru', flag: '🇵🇪' },
+
+  // Europe
+  {
+    code: 'EUR',
+    name: 'Euro',
+    country: 'Eurozone',
+    flag: '🇪🇺',
+    aliases: [
+      'Germany', 'France', 'Spain', 'Italy', 'Portugal', 'Netherlands',
+      'Belgium', 'Austria', 'Ireland', 'Greece', 'Finland', 'Estonia',
+      'Latvia', 'Lithuania', 'Luxembourg', 'Slovakia', 'Slovenia', 'Malta',
+      'Cyprus', 'Croatia',
+    ],
+  },
+  { code: 'GBP', name: 'British Pound', country: 'United Kingdom', flag: '🇬🇧', aliases: ['UK', 'Britain', 'England', 'Scotland', 'Wales'] },
+  { code: 'CHF', name: 'Swiss Franc', country: 'Switzerland', flag: '🇨🇭' },
+  { code: 'PLN', name: 'Polish Zloty', country: 'Poland', flag: '🇵🇱' },
+  { code: 'CZK', name: 'Czech Koruna', country: 'Czechia', flag: '🇨🇿', aliases: ['Czech Republic'] },
+  { code: 'SEK', name: 'Swedish Krona', country: 'Sweden', flag: '🇸🇪' },
+  { code: 'NOK', name: 'Norwegian Krone', country: 'Norway', flag: '🇳🇴' },
+  { code: 'DKK', name: 'Danish Krone', country: 'Denmark', flag: '🇩🇰' },
+  { code: 'TRY', name: 'Turkish Lira', country: 'Türkiye', flag: '🇹🇷', aliases: ['Turkey'] },
+  { code: 'RUB', name: 'Russian Ruble', country: 'Russia', flag: '🇷🇺' },
+  { code: 'UAH', name: 'Ukrainian Hryvnia', country: 'Ukraine', flag: '🇺🇦' },
+
+  // Africa
+  { code: 'EGP', name: 'Egyptian Pound', country: 'Egypt', flag: '🇪🇬' },
+  { code: 'NGN', name: 'Nigerian Naira', country: 'Nigeria', flag: '🇳🇬' },
+  { code: 'ZAR', name: 'South African Rand', country: 'South Africa', flag: '🇿🇦' },
+  { code: 'KES', name: 'Kenyan Shilling', country: 'Kenya', flag: '🇰🇪' },
+  { code: 'GHS', name: 'Ghanaian Cedi', country: 'Ghana', flag: '🇬🇭' },
+  { code: 'MAD', name: 'Moroccan Dirham', country: 'Morocco', flag: '🇲🇦' },
+  { code: 'ETB', name: 'Ethiopian Birr', country: 'Ethiopia', flag: '🇪🇹' },
+
+  // Middle East
+  { code: 'AED', name: 'UAE Dirham', country: 'United Arab Emirates', flag: '🇦🇪', aliases: ['UAE', 'Dubai', 'Abu Dhabi'] },
+  { code: 'SAR', name: 'Saudi Riyal', country: 'Saudi Arabia', flag: '🇸🇦' },
+  { code: 'ILS', name: 'Israeli Shekel', country: 'Israel', flag: '🇮🇱' },
+
+  // Asia
+  { code: 'INR', name: 'Indian Rupee', country: 'India', flag: '🇮🇳' },
+  { code: 'IDR', name: 'Indonesian Rupiah', country: 'Indonesia', flag: '🇮🇩' },
+  { code: 'PHP', name: 'Philippine Peso', country: 'Philippines', flag: '🇵🇭' },
+  { code: 'MYR', name: 'Malaysian Ringgit', country: 'Malaysia', flag: '🇲🇾' },
+  { code: 'SGD', name: 'Singapore Dollar', country: 'Singapore', flag: '🇸🇬' },
+  { code: 'JPY', name: 'Japanese Yen', country: 'Japan', flag: '🇯🇵' },
+  { code: 'KRW', name: 'South Korean Won', country: 'South Korea', flag: '🇰🇷', aliases: ['Korea'] },
+  { code: 'CNY', name: 'Chinese Yuan', country: 'China', flag: '🇨🇳', aliases: ['Renminbi', 'RMB'] },
+  { code: 'HKD', name: 'Hong Kong Dollar', country: 'Hong Kong', flag: '🇭🇰' },
+  { code: 'TWD', name: 'Taiwan Dollar', country: 'Taiwan', flag: '🇹🇼' },
+  { code: 'THB', name: 'Thai Baht', country: 'Thailand', flag: '🇹🇭' },
+  { code: 'VND', name: 'Vietnamese Dong', country: 'Vietnam', flag: '🇻🇳' },
+
+  // Oceania
+  { code: 'AUD', name: 'Australian Dollar', country: 'Australia', flag: '🇦🇺' },
+  { code: 'NZD', name: 'New Zealand Dollar', country: 'New Zealand', flag: '🇳🇿' },
+];
+
+/**
+ * Look up a currency option by ISO code (case-insensitive). Returns null
+ * for unknown codes so the picker can render unknown values verbatim
+ * without crashing.
+ */
+export function findCurrencyByCode(code: string | null | undefined): CurrencyOption | null {
+  if (!code) return null;
+  const upper = code.trim().toUpperCase();
+  return SUPPORTED_CURRENCIES.find((c) => c.code === upper) ?? null;
+}
+
+/**
+ * Filter currencies by a free-text query. Matches against the ISO code,
+ * currency name, principal country, and aliases — all case-insensitive
+ * substring matches. Results are ranked: exact code match first, then
+ * code prefix, then country prefix / name prefix, then any-substring.
+ */
+export function searchCurrencies(query: string): CurrencyOption[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return SUPPORTED_CURRENCIES;
+  const scored: { c: CurrencyOption; score: number }[] = [];
+  for (const c of SUPPORTED_CURRENCIES) {
+    const code = c.code.toLowerCase();
+    const name = c.name.toLowerCase();
+    const country = c.country.toLowerCase();
+    const aliases = (c.aliases ?? []).map((a) => a.toLowerCase());
+
+    let score = -1;
+    if (code === q) score = 100;
+    else if (code.startsWith(q)) score = 80;
+    else if (country.startsWith(q)) score = 60;
+    else if (name.startsWith(q)) score = 55;
+    else if (aliases.some((a) => a.startsWith(q))) score = 50;
+    else if (country.includes(q)) score = 30;
+    else if (name.includes(q)) score = 25;
+    else if (aliases.some((a) => a.includes(q))) score = 20;
+    else if (code.includes(q)) score = 10;
+
+    if (score >= 0) scored.push({ c, score });
+  }
+  scored.sort((a, b) => b.score - a.score || a.c.code.localeCompare(b.c.code));
+  return scored.map((s) => s.c);
+}


### PR DESCRIPTION
## Summary

- Split the receipt editor's single Amount field into two visible fields: **Original amount** (local-currency value the admin types) + a **CurrencyPicker** (searchable combobox), with a derived, read-only **USD value** display below showing the recomputed total + exchange rate. Save sends `originalAmount` + `ocrCurrency` together; backend re-runs `convertToUSD` and persists the canonical `ocrAmount` / `exchangeRate` / `originalCurrency`.
- Backend (`PATCH /api/admin/payouts/documents/:docId`) gains a third fallback for legacy rows: when neither the `original_amount` column nor `ocrRaw.ocr.amount` has data, the existing `ocr_amount` is treated as the receipt's original-currency value (audit note records `originalAmountInferred: true`). FX provider failures now return `FX_RATE_UNAVAILABLE` so the editor can offer a "Set USD manually" fallback instead of silently no-op'ing.
- New `frontend/src/components/payments-admin/CurrencyPicker.tsx` + `frontend/src/utils/currencies.ts` — combobox matching on ISO code, country name, currency name, or country alias (e.g. "Germany" -> EUR, "UK" -> GBP) across ~40 ISO codes covering the GPP party set. Keyboard nav (arrow keys + Enter + Esc), click-outside-to-close, country flag rendered alongside.

Fixes the EGP-change-didn't-convert bug Snax hit: the admin changed currency to EGP and entered the local amount, but the prior single-field editor was sending it as `ocrAmount` (USD) so the row stamped `28329.34 USD` instead of `~$566`.

## Test plan

- [ ] Edit a receipt's currency to EGP via the picker, enter `28329.34` as original amount, save -> USD value updates to ~$566 + rate `1 EGP = $0.02XX` is displayed.
- [ ] Type "Egypt" in the currency picker -> EGP appears first; type "EUR" -> Euro appears; type "Germany" -> EUR also matches via alias list.
- [ ] Open a legacy receipt (no `original_amount` column data) -> editor shows "Legacy receipt - original amount inferred from stored value" hint; changing currency + saving recomputes USD correctly.
- [ ] Trigger an FX provider failure (e.g. pass an unsupported currency) -> editor shows "Couldn't fetch rate" with a "Set USD manually" toggle that switches to a USD-only IconInput; save with manual USD persists `ocrAmount` directly.
- [ ] Right-pane row editor in `PayoutReviewModal` still works (compact data-grid mode) and now also sends `originalAmount` + `ocrCurrency` on save.
- [ ] `/admin/payouts/by-city` lightbox receipt editor (`PayoutsByPartyTable`) renders the same new editor and saves correctly.
- [ ] `cd backend && npx tsc --noEmit` clean.
- [ ] `cd frontend && npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)