### PR TITLE
feat(nduja-92106): party-cap override at approve time

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2541,17 +2541,32 @@ router.post(
         }
       }
 
+      // nduja-92106: admin-class can opt to bypass the per-party cap at
+      // approve time via `allowOverPartyCap` (mirrors salame-92103's existing
+      // override on /execute). Underbosses can NEVER skip the cap — only the
+      // four admin-class roles (admin / super_admin / payment_admin) get the
+      // ack pathway. The per-submission ceiling ($675), per-address cap, and
+      // daily cap are unchanged.
+      const allowOverPartyCap =
+        actor.actorKind !== 'underboss' &&
+        !!(req.body && req.body.allowOverPartyCap);
+
       // bocconcini-49102: re-run the per-submission + per-party cap checks at
       // approve time so rows created/edited BEFORE the cap rules landed (or
       // rows whose party's cap was tightened after creation) can't be pushed
       // through to `approved` (and from there to `paid`). Helpers are
       // idempotent — better to over-check than to under-check.
+      //
+      // nduja-92106: skip the per-party throw when the admin has ticked the
+      // override checkbox in PayoutReviewModal. Per-submission ceiling stays.
       assertWithinPerSubmissionCap(Number(existing.finalAmountUsd));
-      await assertWithinPartyCap(
-        existing.partyId,
-        Number(existing.finalAmountUsd),
-        existing.id,
-      );
+      if (!allowOverPartyCap) {
+        await assertWithinPartyCap(
+          existing.partyId,
+          Number(existing.finalAmountUsd),
+          existing.id,
+        );
+      }
 
       const { note, autoExecute } = req.body || {};
 
@@ -2574,6 +2589,13 @@ router.post(
           },
         });
 
+        // nduja-92106: append `[override: party cap]` so the audit row
+        // captures that the per-party cap was bypassed at approve time. Mirrors
+        // salame-92103's mark_paid suffix on /execute.
+        const baseNote = typeof note === 'string' && note ? note : null;
+        const auditNote = allowOverPartyCap
+          ? (baseNote ? `${baseNote} [override: party cap]` : '[override: party cap]')
+          : baseNote;
         await tx.payoutAudit.create({
           data: {
             payoutId: existing.id,
@@ -2582,7 +2604,7 @@ router.post(
             newStatus: 'approved',
             actorEmail: actor.email,
             actorKind: actor.actorKind,
-            note: typeof note === 'string' ? note : null,
+            note: auditNote,
           },
         });
 
@@ -2611,6 +2633,12 @@ router.post(
               payoutId: existing.id,
               actor: { email: actor.email, actorKind: actor.actorKind },
               body: {},
+              // nduja-92106: when the admin ticked the per-party cap override
+              // ack on approve, the same flag has to flow into the inline
+              // execute or the cap recheck inside executePayout will throw
+              // (salame-92103 already wired the override on /execute; we just
+              // forward it here).
+              allowOverPartyCap,
             });
             autoExecuted = true;
           } catch (err: any) {

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -44,7 +44,17 @@ interface PayoutReviewModalProps {
   /** When set, indicates the actor would be paying themselves — disables mutate buttons. */
   selfPayoutBlocked?: boolean;
   onClose: () => void;
-  onApprove: (note?: string) => Promise<void> | void;
+  /**
+   * nduja-92106: optional second arg lets the admin acknowledge the per-
+   * party reimbursement cap warning at approve time (mirrors salame-92103's
+   * existing ack on Execute). When `allowOverPartyCap` is true, the backend
+   * skips the bocconcini-49102 cap recheck and records `[override: party cap]`
+   * on the audit row.
+   */
+  onApprove: (
+    note?: string,
+    opts?: { allowOverPartyCap?: boolean },
+  ) => Promise<void> | void;
   /**
    * gouda-92103: optional second arg lets the admin opt into a silent
    * reject — backend suppresses host-notify side effects and records
@@ -361,6 +371,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // Required to enable Execute when `partyWouldExceedCap === true`.
   const [overridePartyCap, setOverridePartyCap] = useState(false);
 
+  // nduja-92106: separate ack for the Approve button. bocconcini-49102 also
+  // runs the per-party cap recheck at approve time, so the same amber warning
+  // needs an ack on the pending -> approved transition (mirroring the existing
+  // Execute ack above). Kept distinct from `overridePartyCap` because Approve
+  // is shown for `isPending` payouts and Execute for `isApproved` — they
+  // never share a render path, but the ack lifecycles are independent.
+  const [approveOverridePartyCap, setApproveOverridePartyCap] = useState(false);
+
   // parmigiana-92104: SWC Hub ack. Reimbursement for SWC Hub parties is
   // processed through SWC, not rsv.pizza — admin reimbursement actions
   // (Approve, Execute, Mark paid manual) stay disabled until the admin ticks
@@ -371,8 +389,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   const [swcAck, setSwcAck] = useState(false);
   // Re-sync the ack on payout swap (parent reload after refresh()) so admins
   // don't carry an ack across distinct payouts displayed in the same modal.
+  // nduja-92106: also reset the per-party cap Approve ack on payout swap so
+  // it doesn't carry over from a previously-viewed payout.
   useEffect(() => {
     setSwcAck(false);
+    setApproveOverridePartyCap(false);
   }, [payout.id]);
   // True when an SWC Hub action button should be disabled (warning surfaces
   // and admin hasn't acked). Combined with the existing busy / selfPayout
@@ -3027,13 +3048,62 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         </div>
 
         {/* Footer actions */}
-        <div className="border-t border-theme-stroke px-5 py-3 flex items-center gap-2 flex-wrap bg-theme-surface">
+        <div className="border-t border-theme-stroke px-5 py-3 flex flex-col gap-2 bg-theme-surface">
+          {/* nduja-92106: per-party cap warning for the Approve transition.
+              bocconcini-49102 re-runs the cap check at /approve (not just at
+              /execute), so an admin trying to approve a payout that would
+              push the party past its effective cap got hit with a hard 409
+              with no override path. Mirrors the salame-92103 amber-panel +
+              ack-Checkbox pattern already used by the Execute form above. */}
+          {isPending && partyWouldExceedCap && partyCap != null && (
+            <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+              <div className="flex items-start gap-2.5">
+                <AlertTriangle className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0" size={16} />
+                <div className="flex-1 text-sm">
+                  <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
+                    Per-party cap warning
+                  </div>
+                  <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
+                    Approving this payment would exceed the party's ${partyCap.toFixed(2)} cap by{' '}
+                    <b>${partyOverBy.toFixed(2)}</b>{' '}
+                    (remaining: ${(partyCapRemaining ?? 0).toFixed(2)}).
+                  </div>
+                  <div className="mt-3">
+                    <Checkbox
+                      checked={approveOverridePartyCap}
+                      onChange={() => setApproveOverridePartyCap((v) => !v)}
+                      label="I acknowledge — proceed anyway"
+                      labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+          <div className="flex items-center gap-2 flex-wrap">
           {isPending && (
             <>
               <button
                 type="button"
-                onClick={() => onApprove()}
-                disabled={busy || selfPayoutBlocked || swcBlocked}
+                onClick={() => {
+                  // nduja-92106: block submit if the per-party cap would
+                  // exceed and the admin hasn't ticked the override.
+                  if (partyWouldExceedCap && !approveOverridePartyCap) return;
+                  // nduja-92106: forward the admin's acknowledgement so the
+                  // server skips its bocconcini-49102 recheck + records
+                  // `[override: party cap]` on the audit row.
+                  onApprove(
+                    undefined,
+                    partyWouldExceedCap ? { allowOverPartyCap: approveOverridePartyCap } : undefined,
+                  );
+                }}
+                disabled={
+                  busy ||
+                  selfPayoutBlocked ||
+                  swcBlocked ||
+                  // nduja-92106: disabled until ack when the per-party cap would exceed.
+                  (partyWouldExceedCap && !approveOverridePartyCap)
+                }
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
               >
                 {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
@@ -3338,6 +3408,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           >
             Close
           </button>
+          </div>
           {/* caprino-92103: inline error for Revert. Takes full row width
               below the buttons via w-full on the wrapping flex container's
               flex-wrap. Surfaces backend NOT_APPROVED + any network failure. */}

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -281,11 +281,19 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
       // Step 2 + 3: approve, and for USDC autoExecute via Privy server-wallet.
       // For wire / mercury, the approve call won't execute — we follow up
       // with a separate POST /execute carrying the refs (and any cap-override
-      // ack, which only the execute endpoint honors today).
+      // ack).
+      //
+      // nduja-92106: the per-party cap ack now also flows into /approve (both
+      // direct and autoExecute branches) — previously the override only worked
+      // on /execute, so the USDC path here would 409 at approve time even
+      // with the ack ticked. Forward `allowOverPartyCap` on every approve
+      // call so the bocconcini-49102 recheck is skipped consistently.
+      const allowOverPartyCap = partyWouldExceedCap ? overridePartyCap : undefined;
       if (method === 'usdc_base') {
         await approveAdminPayout(created.id, {
           autoExecute: true,
           note: note.trim() || undefined,
+          allowOverPartyCap,
         });
         // The approve handler runs executePayout server-side for USDC; any
         // failure flips the row to `failed` and surfaces here via the API
@@ -293,6 +301,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
       } else {
         await approveAdminPayout(created.id, {
           note: note.trim() || undefined,
+          allowOverPartyCap,
         });
         await executeAdminPayout(created.id, {
           wireReference:
@@ -306,10 +315,8 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
           note: note.trim() || undefined,
           // salame-92103: forward the admin's per-party cap ack so the
           // server bypasses its own check + appends `[override: party cap]`
-          // to the audit row's note. (The approve step's cap check
-          // currently has no override; cap-warned sends on USDC will fail
-          // there until that gap is closed in a follow-up.)
-          allowOverPartyCap: partyWouldExceedCap ? overridePartyCap : undefined,
+          // to the audit row's note.
+          allowOverPartyCap,
         });
       }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4399,11 +4399,28 @@ export async function retryPayoutDocumentOcr(
 
 export async function approveAdminPayout(
   id: string,
-  opts?: { note?: string; autoExecute?: boolean; regions?: string[] },
+  opts?: {
+    note?: string;
+    autoExecute?: boolean;
+    regions?: string[];
+    /**
+     * nduja-92106: admin-class only. When true, the backend skips the per-
+     * party reimbursement cap recheck at approve time (the same recheck that
+     * bocconcini-49102 added). Mirrors `executeAdminPayout`'s salame-92103
+     * override. The PayoutReviewModal Approve button sets this when the
+     * amber per-party cap warning's ack Checkbox has been ticked; passes
+     * through to the autoExecute branch as well.
+     */
+    allowOverPartyCap?: boolean;
+  },
 ): Promise<{ payout: AdminPayout; autoExecuteDeferred: boolean }> {
   return apiRequest(`/api/admin/payouts/${id}/approve${regionsQuery(opts?.regions)}`, {
     method: 'POST',
-    body: { note: opts?.note, autoExecute: opts?.autoExecute },
+    body: {
+      note: opts?.note,
+      autoExecute: opts?.autoExecute,
+      allowOverPartyCap: opts?.allowOverPartyCap,
+    },
   });
 }
 

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1130,12 +1130,16 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             }
             busy={modalBusy}
             onClose={closeDetail}
-            onApprove={async (note) => {
+            onApprove={async (note, opts) => {
               setModalBusy(true);
               try {
                 await approveAdminPayout(detail.id, {
                   note,
                   ...(regions ? { regions } : {}),
+                  // nduja-92106: forward the per-party cap override ack so the
+                  // backend skips its bocconcini-49102 recheck + records the
+                  // override marker on the audit row.
+                  ...(opts?.allowOverPartyCap ? { allowOverPartyCap: true } : {}),
                 });
                 const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);


### PR DESCRIPTION
## Summary

- bocconcini-49102 added a per-party cap recheck at `/approve` but salame-92103 only wired the `allowOverPartyCap` override into `/execute`. Approves above an exhausted cap (e.g. Abuja $30 on top of $625 paid) hit a hard 409 with no override path.
- Backend: `POST /:id/approve` accepts `allowOverPartyCap` in body (admin-class only — underbosses can never bypass). When set, skips `assertWithinPartyCap` and appends `[override: party cap]` to the audit row's note. The `autoExecute: true` branch forwards the flag into the inline `executePayout()` so USDC sends don't 409 at the per-party recheck inside execute either.
- Frontend `PayoutReviewModal`: mirrors the salame-92103 amber warning + ack `Checkbox` pattern (already in the Execute form) for the Approve transition. Approve button is disabled until the ack is ticked when `partyWouldExceedCap`; `allowOverPartyCap` flows through to `approveAdminPayout`.
- Frontend `SendPaymentModal`: removes the salame-92106 caveat (USDC autoExecute path now respects the ack) and forwards `allowOverPartyCap` on every approve call.

## Test plan

- [ ] Approve a payout where party cap is already met (e.g. $30 over a $625 cap with $625 paid) → amber per-party cap warning + ack Checkbox surface above the Approve button.
- [ ] Approve disabled until ack ticked; once ticked, click Approve → succeeds → audit row's note shows `[override: party cap]`.
- [ ] Same payout, do NOT tick ack → click Approve does nothing (button stays disabled); server returns 409 `PARTY_CAP_EXCEEDED` if the request reaches it.
- [ ] SendPaymentModal: pick a city already at/over cap, enter an amount > cap remaining, tick the per-party ack, select USDC → submit → approve+autoExecute succeeds (previously 409'd at approve time even with ack).
- [ ] SendPaymentModal: same flow with wire / mercury_card → still succeeds (approve + separate /execute, both honor override).
- [ ] Underboss tries to approve with `allowOverPartyCap: true` via curl → server still runs the cap check (admin-class gate is server-enforced).
- [ ] Per-submission ceiling ($675) still throws on amounts > $675 — override only bypasses the per-party cap.

Generated with [Claude Code](https://claude.com/claude-code)