### PR TITLE
fix(coppa-92105): duplicate receipts visibly excluded across all surfaces

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1659,10 +1659,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         // culatello-92104 (#2): admin-marked duplicates dim
                         // to 50% so the grid visually reflects the corrected
                         // payout at a glance.
-                        className={`relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group ${
-                          isDup ? 'opacity-50' : ''
+                        // coppa-92105: pair the dim with a red border so the
+                        // exclusion reads as "rejected" rather than just
+                        // "inactive". The diagonal-stripe overlay below
+                        // reinforces it further.
+                        className={`relative aspect-square rounded-lg overflow-hidden border group ${
+                          isDup
+                            ? 'opacity-50 border-red-500/60'
+                            : 'border-theme-stroke'
                         }`}
-                        title={doc.fileName}
+                        title={
+                          isDup
+                            ? `[DUPLICATE — excluded from totals] ${doc.fileName}`
+                            : doc.fileName
+                        }
                       >
                         {isVideoFile(doc) ? (
                           <>
@@ -1693,6 +1703,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         <span className="absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-amber-500 text-white">
                           receipt
                         </span>
+                        {/* coppa-92105: 8px alternating dark/transparent
+                            diagonal stripes laid over the thumbnail when
+                            marked duplicate. The opacity-50 dim alone reads
+                            as "inactive"; the stripes drive home "excluded
+                            from totals". Mirrors the by-city grid treatment. */}
+                        {isDup && (
+                          <span
+                            className="absolute inset-0 pointer-events-none"
+                            style={{
+                              backgroundImage:
+                                'repeating-linear-gradient(45deg, rgba(0,0,0,0.35) 0 4px, transparent 4px 8px)',
+                            }}
+                          />
+                        )}
                         {/* culatello-92104: DUPLICATE pill on the thumbnail
                             so admins see at a glance which receipts are
                             evidence-only. */}
@@ -2055,11 +2079,21 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       <li
                         key={r.id}
                         id={`receipt-row-${r.id}`}
+                        /* coppa-92105: the bare opacity-50 dim was too easy
+                            to read past — admins (Snax) reported missing
+                            it. Pair with a red left border + faint red
+                            background tint so the row visibly registers as
+                            "excluded from totals" rather than just
+                            "inactive". */
                         className={`text-sm rounded ${
                           isHighlighted
                             ? 'ring-2 ring-amber-400 animate-pulse'
                             : ''
-                        } ${isDup ? 'opacity-50' : ''}`}
+                        } ${
+                          isDup
+                            ? 'opacity-60 border-l-4 border-red-500/60 bg-red-500/5 pl-2 py-1'
+                            : ''
+                        }`}
                       >
                         <div className="flex items-center gap-2">
                           <span
@@ -3403,6 +3437,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         editorPane={lightboxEditorPane}
         onBeforeNavigate={lightboxOnBeforeNavigate}
         onDuplicateShortcut={lightboxOnDuplicateShortcut}
+        /* coppa-92105: paint the lightbox photo pane with a DUPLICATE banner +
+            diagonal-stripe overlay when the focused image is an admin-marked
+            duplicate. Only fires for the receipt bucket because lightboxReceipt
+            is null when navigating pizza/event photos. */
+        isDuplicate={lightboxReceipt?.isDuplicate === true}
       />
     </div>
   );

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -516,11 +516,22 @@ function CityExpansion({
   // shown in the panel (and we can hand-pick committed-cap semantics).
   const rollup = useMemo(() => {
     const payouts = row.payouts;
+    // coppa-92105: admin-marked duplicates are evidence-only — exclude their
+    // OCR amounts from the "Receipts collected" rollup so the by-city tile
+    // matches the per-payout modal's `ocrSum` semantics (which already
+    // filters duplicates) and the host PATCH `survivingOcrSum` recompute.
     const receiptUsdTotal = receiptEntries.reduce(
-      (s, e) => s + (Number(e.doc.ocrAmount) || 0),
+      (s, e) => s + (e.doc.isDuplicate ? 0 : (Number(e.doc.ocrAmount) || 0)),
       0,
     );
     const receiptCount = receiptEntries.length;
+    // coppa-92105: surface the duplicate count on the rollup so the tile can
+    // render "$X (N receipts, M duplicates excluded)" when M > 0. Visible
+    // proof the exclusion happened.
+    const duplicateCount = receiptEntries.reduce(
+      (n, e) => n + (e.doc.isDuplicate ? 1 : 0),
+      0,
+    );
 
     let approvedUsd = 0;
     let paidUsd = 0;
@@ -549,6 +560,7 @@ function CityExpansion({
     return {
       receiptUsdTotal,
       receiptCount,
+      duplicateCount,
       approvedUsd,
       paidUsd,
       outstandingUsd: Math.max(0, approvedUsd - paidUsd),
@@ -1142,7 +1154,15 @@ function CityExpansion({
         <RollupTile
           label="Receipts collected"
           value={formatUsd(rollup.receiptUsdTotal)}
-          sub={`${rollup.receiptCount} receipt${rollup.receiptCount === 1 ? '' : 's'}`}
+          /* coppa-92105: when duplicates exist, append "M duplicate(s) excluded"
+              so admins see at a glance that the USD total skipped them. The
+              culatello-92104 modal does the same on its "Sum of OCR amounts"
+              footer; this is the city-level mirror. */
+          sub={
+            rollup.duplicateCount > 0
+              ? `${rollup.receiptCount} receipt${rollup.receiptCount === 1 ? '' : 's'}, ${rollup.duplicateCount} duplicate${rollup.duplicateCount === 1 ? '' : 's'} excluded`
+              : `${rollup.receiptCount} receipt${rollup.receiptCount === 1 ? '' : 's'}`
+          }
           accent="text-theme-text"
         />
         <RollupTile
@@ -1256,35 +1276,64 @@ function CityExpansion({
             Receipts ({receiptEntries.length})
           </div>
           <div className="flex flex-wrap gap-2">
-            {receiptEntries.map((e, idx) => (
-              <button
-                key={e.doc.id}
-                type="button"
-                onClick={() => setLightbox({ bucket: 'receipt', index: idx })}
-                className="group relative w-16 h-16 rounded-md overflow-hidden border border-theme-stroke hover:border-theme-stroke-hover"
-                title={`${e.doc.fileName}${
-                  e.doc.uploadedByName || e.doc.uploadedByEmail
-                    ? ` — uploaded by ${e.doc.uploadedByName || e.doc.uploadedByEmail}`
-                    : ''
-                }${
-                  e.doc.ocrAmount != null
-                    ? ` · ${formatUsd(Number(e.doc.ocrAmount))}`
-                    : ''
-                }`}
-              >
-                <img
-                  src={e.doc.url}
-                  alt={e.doc.fileName}
-                  className="w-full h-full object-cover"
-                  loading="lazy"
-                />
-                {e.doc.ocrAmount != null && (
-                  <span className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-[10px] font-medium text-center py-0.5">
-                    {formatUsd(Number(e.doc.ocrAmount))}
-                  </span>
-                )}
-              </button>
-            ))}
+            {receiptEntries.map((e, idx) => {
+              // coppa-92105: dim + diagonal-stripe overlay + DUPLICATE pill on
+              // duplicate thumbnails so the by-city grid matches the per-
+              // payout modal's left-pane grid (culatello-92104) and admins
+              // can't miss that the receipt is excluded from the rollup.
+              const isDup = e.doc.isDuplicate === true;
+              return (
+                <button
+                  key={e.doc.id}
+                  type="button"
+                  onClick={() => setLightbox({ bucket: 'receipt', index: idx })}
+                  className={`group relative w-16 h-16 rounded-md overflow-hidden border hover:border-theme-stroke-hover ${
+                    isDup
+                      ? 'opacity-50 border-red-500/60'
+                      : 'border-theme-stroke'
+                  }`}
+                  title={`${isDup ? '[DUPLICATE — excluded from totals] ' : ''}${e.doc.fileName}${
+                    e.doc.uploadedByName || e.doc.uploadedByEmail
+                      ? ` — uploaded by ${e.doc.uploadedByName || e.doc.uploadedByEmail}`
+                      : ''
+                  }${
+                    e.doc.ocrAmount != null
+                      ? ` · ${formatUsd(Number(e.doc.ocrAmount))}`
+                      : ''
+                  }`}
+                >
+                  <img
+                    src={e.doc.url}
+                    alt={e.doc.fileName}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                  {/* coppa-92105: 8px alternating dark/transparent diagonal
+                      stripes laid over the thumbnail. Reinforces "do not
+                      count this" beyond the opacity-50 dim which alone reads
+                      as merely "inactive" rather than "excluded". */}
+                  {isDup && (
+                    <span
+                      className="absolute inset-0 pointer-events-none"
+                      style={{
+                        backgroundImage:
+                          'repeating-linear-gradient(45deg, rgba(0,0,0,0.35) 0 4px, transparent 4px 8px)',
+                      }}
+                    />
+                  )}
+                  {isDup && (
+                    <span className="absolute top-1 right-1 text-[8px] uppercase font-bold px-1 py-0.5 rounded bg-red-500 text-white">
+                      dup
+                    </span>
+                  )}
+                  {e.doc.ocrAmount != null && (
+                    <span className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-[10px] font-medium text-center py-0.5">
+                      {formatUsd(Number(e.doc.ocrAmount))}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
         </div>
       )}
@@ -1435,6 +1484,14 @@ function CityExpansion({
           lightbox?.bucket === 'receipt' && canEditReceipts
             ? lightboxOnDuplicateShortcut
             : undefined
+        }
+        /* coppa-92105: paint the lightbox photo pane with a DUPLICATE banner +
+            diagonal-stripe overlay when the focused receipt is an admin-marked
+            duplicate. Scoped to the receipt bucket (event/pizza photo lightboxes
+            never have an isDuplicate concept). */
+        isDuplicate={
+          lightbox?.bucket === 'receipt'
+          && lightboxReceipt?.isDuplicate === true
         }
       />
     </div>
@@ -1738,13 +1795,25 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
               // Compute Receipt total + Outstanding for the OUTER row from
               // the payouts already on the wire (mostarda-92103 unified
               // rollup — keep the outer cells in sync with the panel).
+              // coppa-92105: admin-marked duplicates are evidence-only —
+              // exclude their OCR amounts from the outer cell's USD total so
+              // it matches the in-panel "Receipts collected" rollup tile
+              // (which is itself the city-level mirror of the per-payout
+              // modal's `ocrSum`). We still count the duplicate row toward
+              // the receipt-attachment count so admins know the file exists;
+              // a "M duplicate(s) excluded" subtitle surfaces the exclusion.
               const payouts = row.payouts;
               let receiptUsdTotal = 0;
               let receiptCount = 0;
+              let receiptDuplicateCount = 0;
               for (const p of payouts) {
                 for (const d of p.documents || []) {
                   if (d.kind !== 'receipt') continue;
                   receiptCount += 1;
+                  if (d.isDuplicate === true) {
+                    receiptDuplicateCount += 1;
+                    continue;
+                  }
                   receiptUsdTotal += Number(d.ocrAmount) || 0;
                 }
               }
@@ -1862,6 +1931,16 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                       <div className="text-xs text-theme-text-muted inline-flex items-center gap-1">
                         <Paperclip size={11} />
                         {receiptCount} receipt{receiptCount === 1 ? '' : 's'}
+                        {/* coppa-92105: surface duplicate exclusion on the
+                            outer city row so admins reading the table without
+                            expanding can see the USD total skipped some
+                            receipts. Mirrors the in-panel "Receipts collected"
+                            tile subtitle. */}
+                        {receiptDuplicateCount > 0 && (
+                          <span className="ml-1 text-theme-text-faint">
+                            ({receiptDuplicateCount} dup excluded)
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -153,7 +153,29 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   const manualUsdMode = draft.manualUsdAmount !== undefined;
 
   return (
-    <div className="p-4 space-y-4 text-theme-text">
+    /* coppa-92105: when this receipt is admin-marked as a duplicate, paint
+        the entire editor pane with a red left border + faint red background
+        + DUPLICATE banner across the top so the admin can't miss that the
+        edits they're making are on an excluded row. The dim is intentionally
+        lighter than the thumbnail/right-row treatment (opacity-95 + tint)
+        because the editor is interactive — admins still need to read the
+        inputs to un-mark. */
+    <div
+      className={`p-4 space-y-4 text-theme-text ${
+        isDuplicate
+          ? 'border-l-4 border-red-500/60 bg-red-500/5'
+          : ''
+      }`}
+    >
+      {/* coppa-92105: DUPLICATE banner across the top of the editor when
+          marked. Heavier than the per-row pill so it can't be missed even on
+          a quick scan. */}
+      {isDuplicate && (
+        <div className="-mx-4 -mt-4 mb-2 px-4 py-2 bg-red-500/15 border-b border-red-500/40 text-red-300 text-xs font-bold uppercase tracking-wide flex items-center gap-2">
+          <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
+          Duplicate — excluded from all USD totals
+        </div>
+      )}
       {/* Header */}
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -68,6 +68,14 @@ interface ReceiptLightboxProps {
    * when admin context provides this prop.
    */
   onDuplicateShortcut?: () => void;
+  /**
+   * coppa-92105: when true, render a heavy DUPLICATE banner across the top
+   * of the photo + diagonal-stripe overlay across the image so admins can't
+   * confuse a duplicate receipt for a valid one while reviewing it
+   * full-screen. Parent decides per-image via the same onIndexChange hook
+   * used to pick `editorPane`. Pure visual — no behavior change.
+   */
+  isDuplicate?: boolean;
 }
 
 /** Some HEIC files come through with non-image/heic MIME types or no MIME at
@@ -90,6 +98,7 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   onIndexChange,
   onBeforeNavigate,
   onDuplicateShortcut,
+  isDuplicate = false,
 }) => {
   // Index lives in this component so callers only need to pass the starting
   // image. Reset whenever the lightbox is (re-)opened so each open starts
@@ -268,12 +277,30 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
         onClick={(e) => e.stopPropagation()}
       >
         <div
-          className={
+          className={`relative ${
             hasEditor
               ? 'flex items-center justify-center min-h-0'
               : 'flex items-center justify-center'
-          }
+          }`}
         >
+          {/* coppa-92105: heavy DUPLICATE banner + diagonal-stripe overlay
+              on the photo pane when the current receipt is admin-marked as
+              a duplicate. Pointer-events-none so the underlying photo / nav
+              controls stay interactive. */}
+          {isDuplicate && (
+            <>
+              <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 px-3 py-1 rounded-full bg-red-500 text-white text-xs font-bold uppercase tracking-wide shadow-lg pointer-events-none">
+                Duplicate — excluded from totals
+              </div>
+              <div
+                className="absolute inset-0 z-10 pointer-events-none"
+                style={{
+                  backgroundImage:
+                    'repeating-linear-gradient(45deg, rgba(239,68,68,0.18) 0 6px, transparent 6px 14px)',
+                }}
+              />
+            </>
+          )}
           {heic ? (
             <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
               <p className="text-sm font-semibold">Can't preview HEIC files</p>


### PR DESCRIPTION
## Summary

- **Audited every receipt-USD-sum call site** for the `isDuplicate` filter. Found and fixed: by-city "Receipts collected" rollup tile + outer table cell in `PayoutsByPartyTable.tsx` (both were summing every `ocrAmount` including duplicates).
- **Strengthened visual treatment** for marked duplicates so admins can't miss them:
  - Diagonal-stripe overlay (45-deg 8px alternating) on duplicate thumbnails in BOTH the per-payout modal grid and the by-city merged receipt grid.
  - Red left border + faint red bg-tint on the right-pane receipt row (previously bare `opacity-50`).
  - DUPLICATE banner across the top of `ReceiptEditor.tsx` so editor edits on excluded rows are visibly flagged.
  - DUPLICATE banner + red diagonal-stripe overlay on the `ReceiptLightbox.tsx` photo pane when the focused image is a marked duplicate (admin-only, scoped to receipt bucket).
- **Surfaces the exclusion in text** — the by-city rollup tile + outer-row receipts cell now render `'$X (N receipts, M duplicates excluded)'` when M > 0 (mirrors the per-payout modal's `(excludes 1 duplicate)` line).

### Surfaces covered (admin payments)

| Surface | File | Change |
|---|---|---|
| Per-payout modal — left-pane thumbnail grid | `PayoutReviewModal.tsx` | + diagonal stripes + red border |
| Per-payout modal — right-pane editor row | `PayoutReviewModal.tsx` | + red border-l + red bg tint |
| Per-payout modal — lightbox photo pane | via `ReceiptLightbox.tsx` | + banner + red diagonal stripes |
| By-city expansion — "Receipts collected" tile | `PayoutsByPartyTable.tsx` | excludes dup from USD; surfaces "M excluded" |
| By-city expansion — merged receipt grid | `PayoutsByPartyTable.tsx` | + diagonal stripes + red border + DUP pill |
| By-city outer table — receipts cell | `PayoutsByPartyTable.tsx` | excludes dup from USD; surfaces "M dup excluded" |
| Shared `ReceiptEditor` (used in lightbox) | `ReceiptEditor.tsx` | + banner + red border + bg tint |

### Backend audit — no changes needed

Verified the existing duplicate-aware sums in `payout.routes.ts` (host PATCH `survivingOcrSum`) and `admin-payout.routes.ts` (pizza-prices analytics) are correct. The by-party endpoint only ships a count (`totalReceiptCount`), not a USD sum — the frontend computes the rollup, which is what this PR fixed. POST path creates new docs with default `isDuplicate=false`, no filter needed there.

## Test plan

- [ ] Open per-payout modal: mark a receipt as duplicate. Verify: thumbnail in left-pane grid shows red border + diagonal stripes + DUPLICATE pill. Right-pane row shows red border-l + bg-tint.
- [ ] Open the lightbox on a duplicate-marked receipt: verify red DUPLICATE banner pinned at top + red diagonal stripes over the photo. ReceiptEditor pane in the right also shows the DUPLICATE banner + red treatment.
- [ ] Open `/payments` by-city expansion: mark a receipt as duplicate via the per-payout modal. Verify: "Receipts collected" tile shows `'$X (N receipts, 1 duplicate excluded)'`; merged-receipt grid thumbnail shows red border + diagonal stripes + `dup` pill.
- [ ] Verify outer city row (collapsed): `Receipts` cell shows `(1 dup excluded)` under the receipt-count line and the USD total is reduced by the duplicate amount.
- [ ] Un-mark the duplicate: all visual treatments revert; USD totals + count subtitle return to non-excluded form.
- [ ] `cd frontend && npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)