### PR TITLE
feat(gnocchi-92105): surface Mark paid + Send payment as standalone buttons

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -7,8 +7,9 @@ import {
   Paperclip,
   Flag,
   CheckCircle2,
-  MoreHorizontal,
+  MoreVertical,
   Coins,
+  DollarSign,
   XCircle,
   Plus,
   Send,
@@ -231,7 +232,23 @@ function collectReceipts(payouts: AdminPayout[]): Array<{
   return out;
 }
 
-/** City-row action menu — Mark paid/closed + Add external payment + scam flag. */
+/**
+ * City-row action cluster — gnocchi-92105 restructure.
+ *
+ * Before: a single "[⋯ Actions]" dropdown holding all four city-level
+ * actions (Mark paid · Add external · Flag scam · Send payment).
+ *
+ * After: the two most-used actions get promoted to inline buttons sitting
+ * next to a much smaller "⋮" three-dots icon menu that holds only the
+ * secondary record/flag actions:
+ *
+ *   [$ Mark paid] [💸 Send payment] [⋮]                                  →
+ *                                       Add external payment
+ *                                       Flag / Unflag possible scam
+ *
+ * All four handler props stay intact — we just slot them across two
+ * surfaces (inline buttons + dropdown) instead of one.
+ */
 function CityActionsMenu({
   onMarkPartyPaid,
   onAddExternalPayment,
@@ -257,114 +274,125 @@ function CityActionsMenu({
   isFlaggedScam: boolean;
   scamFlagBusy: boolean;
 }) {
-  const [open, setOpen] = useState(false);
-  // No actions to show? Render nothing.
-  if (
-    !canMarkPaid &&
-    !canAddExternal &&
-    !canSendPayment &&
-    !canToggleScamFlag
-  ) {
+  // Hooks-above-early-returns: declare useState before the no-actions guard
+  // so the conditional return can't reorder hooks on a re-render where the
+  // capability props flip. (feedback_hooks_above_early_returns)
+  const [menuOpen, setMenuOpen] = useState(false);
+  const hasMenuItems = canAddExternal || canToggleScamFlag;
+  // Nothing to show at all — render nothing.
+  if (!canMarkPaid && !canSendPayment && !hasMenuItems) {
     return null;
   }
 
   return (
-    <div className="relative inline-block" onClick={(e) => e.stopPropagation()}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-theme-stroke text-theme-text-secondary hover:bg-theme-surface-hover text-xs font-medium"
-        title="City actions"
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        <MoreHorizontal size={14} />
-        Actions
-      </button>
-      {open && (
-        <>
-          {/* click-out overlay */}
-          <div
-            className="fixed inset-0 z-40"
-            onClick={() => setOpen(false)}
-          />
-          <div
-            className="absolute right-0 mt-1 w-56 z-50 rounded-lg border border-theme-stroke bg-theme-surface shadow-lg py-1"
-            role="menu"
+    <div
+      className="inline-flex items-center gap-1.5"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Primary: Mark city paid (or Close city, depending on label). Same
+          handler as before; lifted out of the dropdown into a green button
+          per gnocchi-92105 so the most-used action is one click away. */}
+      {canMarkPaid && (
+        <button
+          type="button"
+          onClick={onMarkPartyPaid}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
+          title={markPaidLabel}
+        >
+          <DollarSign size={12} />
+          {markPaidLabel}
+        </button>
+      )}
+      {/* Secondary: Send payment — actively sends via Privy / wire / Mercury.
+          Same handler as the old menu item; pulled out to a secondary
+          (outline) button so it sits next to Mark paid. */}
+      {canSendPayment && (
+        <button
+          type="button"
+          onClick={onSendPayment}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-emerald-500/60 text-emerald-500 hover:bg-emerald-500/10 text-xs font-medium"
+          title="Send payment"
+        >
+          <Send size={12} />
+          Send payment
+        </button>
+      )}
+      {/* "⋮" three-dots — icon only, no "Actions" text. Holds the two
+          remaining secondary actions: Add external (record an off-platform
+          payment) and Flag/Unflag possible scam. Hidden entirely when
+          neither is available. */}
+      {hasMenuItems && (
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setMenuOpen((v) => !v)}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-theme-stroke text-theme-text-secondary hover:bg-theme-surface-hover"
+            title="More actions"
+            aria-label="More actions"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
           >
-            {canMarkPaid && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setOpen(false);
-                  onMarkPartyPaid?.();
-                }}
-                className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2"
+            <MoreVertical size={14} />
+          </button>
+          {menuOpen && (
+            <>
+              {/* click-out overlay */}
+              <div
+                className="fixed inset-0 z-40"
+                onClick={() => setMenuOpen(false)}
+              />
+              <div
+                className="absolute right-0 mt-1 w-56 z-50 rounded-lg border border-theme-stroke bg-theme-surface shadow-lg py-1"
+                role="menu"
               >
-                <Coins size={14} className="text-emerald-500" />
-                {markPaidLabel}
-              </button>
-            )}
-            {canAddExternal && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setOpen(false);
-                  onAddExternalPayment?.();
-                }}
-                className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2"
-              >
-                <Plus size={14} className="text-sky-500" />
-                Add external payment
-              </button>
-            )}
-            {/* salame-92106: actively SEND a payment from rsv.pizza's
-                infrastructure (USDC / wire / mercury) — distinct from the two
-                items above which only RECORD payments that happened elsewhere.
-                Slotted between Add-external and Flag-scam so the destructive-
-                action ordering stays: send → record → flag. */}
-            {canSendPayment && (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setOpen(false);
-                  onSendPayment?.();
-                }}
-                className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2"
-              >
-                <Send size={14} className="text-emerald-500" />
-                Send payment
-              </button>
-            )}
-            {/* bottarga-92104: flip the `possible-scam` tag on/off. Reversible
-                action — no confirm modal (feedback_reversible_actions_no_confirm).
-                Label flips with the current tag state. */}
-            {canToggleScamFlag && (
-              <button
-                type="button"
-                role="menuitem"
-                disabled={scamFlagBusy}
-                onClick={() => {
-                  setOpen(false);
-                  onToggleScamFlag?.();
-                }}
-                className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
-              >
-                {scamFlagBusy ? (
-                  <Loader2 size={14} className="animate-spin text-theme-text-muted" />
-                ) : isFlaggedScam ? (
-                  <CheckCircle2 size={14} className="text-emerald-500" />
-                ) : (
-                  <AlertTriangle size={14} className="text-red-500" />
+                {canAddExternal && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onAddExternalPayment?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2"
+                  >
+                    <Plus size={14} className="text-sky-500" />
+                    Add external payment
+                  </button>
                 )}
-                {isFlaggedScam ? 'Unflag possible scam' : 'Flag as possible scam'}
-              </button>
-            )}
-          </div>
-        </>
+                {/* bottarga-92104: flip the `possible-scam` tag on/off.
+                    Reversible — no confirm modal
+                    (feedback_reversible_actions_no_confirm). Label flips
+                    with the current tag state. */}
+                {canToggleScamFlag && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={scamFlagBusy}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onToggleScamFlag?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
+                  >
+                    {scamFlagBusy ? (
+                      <Loader2
+                        size={14}
+                        className="animate-spin text-theme-text-muted"
+                      />
+                    ) : isFlaggedScam ? (
+                      <CheckCircle2 size={14} className="text-emerald-500" />
+                    ) : (
+                      <AlertTriangle size={14} className="text-red-500" />
+                    )}
+                    {isFlaggedScam
+                      ? 'Unflag possible scam'
+                      : 'Flag as possible scam'}
+                  </button>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -51,8 +51,20 @@ const PER_SUBMISSION_MAX_USD = 675;
 interface SendPaymentModalProps {
   partyId: string;
   partyName: string;
-  /** Outstanding total (Approved + Paid - Paid) — defaults the amount field. */
+  /**
+   * Outstanding total (Approved - Paid). Kept for the helper-text display
+   * under the amount field, but no longer drives the default amount —
+   * gnocchi-92105 switched the pre-fill to receipts_total - paid_total so
+   * the admin sees "what the city actually spent minus what we've paid"
+   * rather than "what host claims add up to minus what's been paid."
+   */
   outstandingUsd: number;
+  /**
+   * gnocchi-92105: sum of non-duplicate receipt OCR USD values across the
+   * party's payouts. Together with `paidTotalUsd` this drives the default
+   * amount = max(0, receiptsTotal - paidTotal). No cap clamp.
+   */
+  receiptsTotalUsd: number;
   /** Optional — when present, drives the per-party cap warning + Mercury gate. */
   country: string | null;
   /** Optional — drives SWC-Hub warning via isSwcHubParty (country/tags). */
@@ -81,6 +93,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   partyId,
   partyName,
   outstandingUsd,
+  receiptsTotalUsd,
   country,
   eventTags,
   effectiveReimbursementCapUsd,
@@ -152,13 +165,16 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
     setRecipientUserId(next);
   }, [partyMeta, primaryHostUserId, recipientUserId]);
 
-  // Amount — defaults to Outstanding, clamped to per-submission max so the
-  // pre-filled value is never instantly invalid.
+  // gnocchi-92105: amount default is now receipts_total - paid_total —
+  // straight subtraction, NOT clamped by cap and NOT clamped by Outstanding.
+  // If negative (overpaid), defaults to $0. The per-submission ceiling is
+  // still enforced downstream via `exceedsPerSubmission`; we don't pre-clamp
+  // here because Snax wanted the raw subtraction visible.
   const defaultAmount = useMemo(() => {
-    const raw = outstandingUsd > 0 ? outstandingUsd : 0;
-    const clamped = Math.min(raw, PER_SUBMISSION_MAX_USD);
+    const raw = receiptsTotalUsd - paidTotalUsd;
+    const clamped = Math.max(0, raw);
     return clamped > 0 ? clamped.toFixed(2) : '';
-  }, [outstandingUsd]);
+  }, [receiptsTotalUsd, paidTotalUsd]);
   const [amountStr, setAmountStr] = useState(defaultAmount);
 
   const [method, setMethod] = useState<Method>('usdc_base');
@@ -453,8 +469,14 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
               required
             />
             <p className="text-xs text-theme-text-muted mt-1">
-              Defaults to outstanding (${outstandingUsd.toFixed(2)}). Edit
-              if you&apos;re sending a partial amount.
+              {/* gnocchi-92105: pre-fill = receipts - paid (no cap clamp).
+                  Outstanding is shown for context but isn't the default any
+                  more — Snax wanted the raw subtraction so admins can spot
+                  receipts that haven't been paid out yet. */}
+              Defaults to receipts − paid ($
+              {Math.max(0, receiptsTotalUsd - paidTotalUsd).toFixed(2)}).
+              Outstanding (Approved − Paid) for this city is $
+              {outstandingUsd.toFixed(2)}.
             </p>
             {exceedsPerSubmission && (
               <p className="text-xs text-red-500 mt-1">

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -228,6 +228,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         partyId: string;
         partyName: string;
         outstandingUsd: number;
+        // gnocchi-92105: sum of non-duplicate receipt OCR USD across the
+        // party's payouts. Drives the new "receipts - paid" default amount
+        // in SendPaymentModal (no cap clamp).
+        receiptsTotalUsd: number;
         country: string | null;
         eventTags: string[];
         effectiveReimbursementCapUsd: number | null;
@@ -1050,10 +1054,23 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
               const paidSumUsd =
                 row.aggregates.paidUsd + (row.aggregates.completedUsd ?? 0);
               const outstandingUsd = Math.max(0, approvedSumUsd - paidSumUsd);
+              // gnocchi-92105: tally non-duplicate receipt OCR USD across
+              // every payout on the party. Matches the coppa-92105 dedup
+              // semantics used by the by-city Receipt total cell so the
+              // modal default lines up with what the admin sees in the row.
+              let receiptsTotalUsd = 0;
+              for (const p of row.payouts) {
+                for (const d of p.documents || []) {
+                  if (d.kind !== 'receipt') continue;
+                  if (d.isDuplicate === true) continue;
+                  receiptsTotalUsd += Number(d.ocrAmount) || 0;
+                }
+              }
               setSendPaymentTarget({
                 partyId: row.party.id,
                 partyName: row.party.name,
                 outstandingUsd,
+                receiptsTotalUsd,
                 country: row.party.country,
                 eventTags: row.party.eventTags ?? [],
                 effectiveReimbursementCapUsd: row.party.effectiveReimbursementCapUsd,
@@ -1432,6 +1449,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             partyId={sendPaymentTarget.partyId}
             partyName={sendPaymentTarget.partyName}
             outstandingUsd={sendPaymentTarget.outstandingUsd}
+            receiptsTotalUsd={sendPaymentTarget.receiptsTotalUsd}
             country={sendPaymentTarget.country}
             eventTags={sendPaymentTarget.eventTags}
             effectiveReimbursementCapUsd={


### PR DESCRIPTION
## Summary

Restructures the city-row Actions menu on `/payments` (by-city view):

- **Mark city paid** and **Send payment** are now standalone buttons sitting inline next to the menu (no longer hidden behind an Actions dropdown).
- The Actions menu collapses to a **\"⋮\" three-dots icon** (no \"Actions\" text), holding only the two remaining record/flag actions:
  - Add external payment
  - Flag / Unflag possible scam
- **Send payment modal pre-fill** switched from `outstandingUsd` to `receipts_total - paid_total` (non-duplicate receipts, no cap clamp). If negative, defaults to \$0. Outstanding is still shown in the helper text for context.

## Why

Mark paid and Send payment are the two most-used city actions; one click is better than two. Pre-filling with receipts − paid surfaces \"what the city actually spent that we haven't covered yet\" rather than \"what host claims add up to\", so admins can spot unreimbursed receipts at a glance.

## Files

- `frontend/src/components/payments-admin/PayoutsByPartyTable.tsx` — rewrote `CityActionsMenu` as a button-cluster with a small \"⋮\" dropdown.
- `frontend/src/components/payments-admin/SendPaymentModal.tsx` — added `receiptsTotalUsd` prop, swapped default-amount logic, updated helper text.
- `frontend/src/pages/PaymentsAdminPage.tsx` — compute non-duplicate receipts sum from `row.payouts` and pass through to the modal.

## Test plan

- [ ] Open `/payments`, switch to by-city view, expand a city: the action area now shows `[$ Mark paid] [💸 Send payment] [⋮]` cluster.
- [ ] Click `⋮` → dropdown shows only **Add external payment** + **Flag/Unflag possible scam**.
- [ ] Click **Mark paid** → existing MarkPartyPaidModal opens.
- [ ] Click **Send payment** on a city with e.g. \$500 receipts + \$300 paid → modal pre-fills amount = `\$200.00`. Helper text reads \"Defaults to receipts − paid (\$200.00). Outstanding (Approved − Paid) for this city is \$X.\"
- [ ] City with paid > receipts → pre-fill defaults to empty (\$0).
- [ ] Underboss viewerRole → none of the new buttons render (admin-only gates preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)