### PR TITLE
fix(bocconcino-92105): opaque ⋮ dropdown in by-city actions

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -342,7 +342,7 @@ function CityActionsMenu({
                 onClick={() => setMenuOpen(false)}
               />
               <div
-                className="absolute right-0 mt-1 w-56 z-50 rounded-lg border border-theme-stroke bg-theme-surface shadow-lg py-1"
+                className="absolute right-0 mt-1 w-56 z-50 rounded-lg border border-theme-stroke bg-[#1a1a2e] shadow-xl py-1"
                 role="menu"
               >
                 {canAddExternal && (


### PR DESCRIPTION
## Summary

The new gnocchi-92105 ⋮ dropdown menu in `CityActionsMenu` (PayoutsByPartyTable) was rendering with a translucent background (`bg-theme-surface` = `rgba(255,255,255,0.05)`), so content from the row below showed through the menu items.

- Swapped `bg-theme-surface` → `bg-[#1a1a2e]` (matches `--bg-header`, the project's solid card pattern used by Drawer + PartnerIntakePage).
- Kept the existing `z-50`, `border border-theme-stroke`.
- Bumped `shadow-lg` → `shadow-xl` for extra visual lift over the row below.

One-line CSS change. No handlers/items/trigger touched.

## Test plan

- [ ] `cd frontend && npx tsc --noEmit` — clean.
- [ ] Open `/underboss` payouts → By-city tab → click ⋮ on a city row that has another row directly underneath → menu items render solid; no see-through to the row below.
- [ ] Both menu items (Add external payment, Flag/Unflag possible scam) still click through to their handlers.