### PR TITLE
feat(salame-92107): add MWK + XOF + XAF currencies

### DIFF
--- a/backend/scripts/backfill-misclassified-usd-receipts.cjs
+++ b/backend/scripts/backfill-misclassified-usd-receipts.cjs
@@ -83,6 +83,15 @@ const COUNTRY_NAME_TO_ISO2 = {
   'uruguay': 'UY', 'venezuela': 'VE', 'vietnam': 'VN', 'zambia': 'ZM',
   'zimbabwe': 'ZW', 'puerto rico': 'PR', 'antigua and barbuda': 'AG',
   'bahrain': 'BH',
+  // salame-92107: MWK + XOF (UEMOA) + XAF (CEMAC) country members.
+  // (Côte d'Ivoire is already mapped above.)
+  'malawi': 'MW',
+  'togo': 'TG', 'benin': 'BJ', 'burkina faso': 'BF', 'ivory coast': 'CI',
+  'mali': 'ML', 'senegal': 'SN',
+  'guinea-bissau': 'GW', 'guinea bissau': 'GW', 'niger': 'NE',
+  'cameroon': 'CM', 'gabon': 'GA', 'chad': 'TD',
+  'central african republic': 'CF', 'equatorial guinea': 'GQ',
+  'republic of the congo': 'CG', 'congo-brazzaville': 'CG', 'congo': 'CG',
 };
 
 function normalizeCountryToIso2(raw) {
@@ -114,7 +123,11 @@ const COUNTRY_TO_PRIMARY_CURRENCY = {
   AU: 'AUD', NZ: 'NZD', PK: 'PKR', BD: 'BDT', LK: 'LKR',
   AE: 'AED', SA: 'SAR', IL: 'ILS', QA: 'QAR', KW: 'KWD', BH: 'BHD',
   EG: 'EGP', NG: 'NGN', ZA: 'ZAR', KE: 'KES', GH: 'GHS', MA: 'MAD',
-  TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS',
+  TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS', MW: 'MWK',
+  // salame-92107: XOF (UEMOA) + XAF (CEMAC).
+  BJ: 'XOF', BF: 'XOF', CI: 'XOF', GW: 'XOF', ML: 'XOF', NE: 'XOF',
+  SN: 'XOF', TG: 'XOF',
+  CM: 'XAF', CF: 'XAF', TD: 'XAF', GQ: 'XAF', GA: 'XAF', CG: 'XAF',
 };
 
 // Minimal FX fallback rates (mirrored from fx.service.ts). Kept here so the
@@ -134,6 +147,8 @@ const FALLBACK_RATES_TO_USD = {
   AED: 0.27, SAR: 0.27, ILS: 0.27, QAR: 0.27, KWD: 3.25, BHD: 2.65,
   EGP: 0.020, KES: 0.0078, GHS: 0.063, MAD: 0.10, TND: 0.32,
   ETB: 0.018, UGX: 0.00027, TZS: 0.00039,
+  // salame-92107: MWK + XOF/XAF (both pegged to EUR via 655.957/€1).
+  MWK: 0.00058, XOF: 0.0016, XAF: 0.0016,
 };
 
 async function fetchRate(currency) {

--- a/backend/src/services/fx.service.ts
+++ b/backend/src/services/fx.service.ts
@@ -51,6 +51,11 @@ export const FALLBACK_RATES_TO_USD: Record<string, number> = {
   KRW: 0.00075,
   CNY: 0.14,
   ZAR: 0.055,
+  // salame-92107: MWK ~1730/USD (2026), XOF + XAF both pegged to EUR
+  // (655.957/€1) so ~615/USD with EUR ≈ 1.07.
+  MWK: 0.00058,
+  XOF: 0.0016,
+  XAF: 0.0016,
 };
 
 export type FxSource =

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -85,7 +85,12 @@ export const COUNTRY_TO_PRIMARY_CURRENCY: Record<string, string> = {
   AE: 'AED', SA: 'SAR', IL: 'ILS', QA: 'QAR', KW: 'KWD', BH: 'BHD',
   // Africa
   EG: 'EGP', NG: 'NGN', ZA: 'ZAR', KE: 'KES', GH: 'GHS', MA: 'MAD',
-  TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS',
+  TN: 'TND', ET: 'ETB', UG: 'UGX', TZ: 'TZS', MW: 'MWK',
+  // salame-92107: West African CFA franc (XOF) — 8 UEMOA members.
+  BJ: 'XOF', BF: 'XOF', CI: 'XOF', GW: 'XOF', ML: 'XOF', NE: 'XOF',
+  SN: 'XOF', TG: 'XOF',
+  // salame-92107: Central African CFA franc (XAF) — 6 CEMAC members.
+  CM: 'XAF', CF: 'XAF', TD: 'XAF', GQ: 'XAF', GA: 'XAF', CG: 'XAF',
 };
 
 function buildSystemPrompt(partyCountry?: string | null): string {

--- a/frontend/src/utils/currencies.ts
+++ b/frontend/src/utils/currencies.ts
@@ -71,6 +71,29 @@ export const SUPPORTED_CURRENCIES: CurrencyOption[] = [
   { code: 'GHS', name: 'Ghanaian Cedi', country: 'Ghana', flag: '🇬🇭' },
   { code: 'MAD', name: 'Moroccan Dirham', country: 'Morocco', flag: '🇲🇦' },
   { code: 'ETB', name: 'Ethiopian Birr', country: 'Ethiopia', flag: '🇪🇹' },
+  { code: 'MWK', name: 'Malawian Kwacha', country: 'Malawi', flag: '🇲🇼' },
+  {
+    code: 'XOF',
+    name: 'West African CFA franc',
+    country: 'Togo',
+    flag: '🇹🇬',
+    aliases: [
+      'Benin', 'Burkina Faso', "Côte d'Ivoire", 'Cote d Ivoire', 'Ivory Coast',
+      'Guinea-Bissau', 'Guinea Bissau', 'Mali', 'Niger', 'Senegal',
+      'CFA', 'West Africa', 'WAEMU', 'UEMOA',
+    ],
+  },
+  {
+    code: 'XAF',
+    name: 'Central African CFA franc',
+    country: 'Cameroon',
+    flag: '🇨🇲',
+    aliases: [
+      'Central African Republic', 'Chad', 'Equatorial Guinea', 'Gabon',
+      'Republic of the Congo', 'Congo-Brazzaville', 'Congo',
+      'CFA', 'Central Africa', 'CEMAC',
+    ],
+  },
 
   // Middle East
   { code: 'AED', name: 'UAE Dirham', country: 'United Arab Emirates', flag: '🇦🇪', aliases: ['UAE', 'Dubai', 'Abu Dhabi'] },


### PR DESCRIPTION
## Summary
- Adds **MWK** (Malawian Kwacha), **XOF** (West African CFA franc), and **XAF** (Central African CFA franc) to the four parallel currency catalogs that caprino-92104 / mortadella-92103 set up.
- Picker now includes country aliases so searching by Benin / Burkina Faso / Côte d'Ivoire / Guinea-Bissau / Mali / Niger / Senegal / Togo finds XOF, and Cameroon / CAR / Chad / Equatorial Guinea / Gabon / Republic of the Congo finds XAF.
- Backend FX fallback rates and the OCR country-prior map updated to match; mortadella backfill script's embedded copy mirrored.

## Files
- `frontend/src/utils/currencies.ts` — three new `CurrencyOption` entries with country aliases.
- `backend/src/services/fx.service.ts` — `FALLBACK_RATES_TO_USD` adds MWK (0.00058), XOF (0.0016), XAF (0.0016).
- `backend/src/services/ocr.service.ts` — `COUNTRY_TO_PRIMARY_CURRENCY` adds MW + 8 UEMOA members (XOF) + 6 CEMAC members (XAF).
- `backend/scripts/backfill-misclassified-usd-receipts.cjs` — mirrors both maps, plus new `COUNTRY_NAME_TO_ISO2` entries for the historical full-name `parties.country` rows.

## Test plan
- [ ] `cd frontend && npx tsc --noEmit` clean (verified locally)
- [ ] `cd backend && npx tsc --noEmit` no NEW errors (verified — only pre-existing missing-dep errors remain)
- [ ] Open the receipt currency picker on a payout, type "Malawi" → MWK shows; type "Togo" → XOF top hit; type "Senegal" → XOF via alias; type "Cameroon" → XAF top hit.
- [ ] OCR run on a receipt from a party with `country = 'CM'` should now apply the XAF country prior in the system prompt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>