### PR TITLE
fix(marinara-92106): persist country from LocationAutocomplete to party

### DIFF
--- a/frontend/src/components/LocationAutocomplete.tsx
+++ b/frontend/src/components/LocationAutocomplete.tsx
@@ -190,8 +190,13 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
             onLocationSelectedRef.current(null);
           }
 
-          // Parse city data from address_components
-          if (onCitySelectedRef.current && place.address_components && place.geometry?.location) {
+          // Parse city data from address_components.
+          // marinara-92106: fire onCitySelected whenever ANY of city OR country
+          // is available, not only when city+geometry are both present. Country
+          // alone is enough to persist parties.country (74 prod rows had NULL
+          // country because the previous guard short-circuited any pick that
+          // lacked a locality, e.g. street-only or establishment picks).
+          if (onCitySelectedRef.current && place.address_components) {
             const components = place.address_components;
             const getComponent = (type: string) =>
               components.find(c => c.types.includes(type));
@@ -200,14 +205,16 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
             const countryComponent = getComponent('country');
             const stateComponent = getComponent('administrative_area_level_1');
 
-            if (cityComponent) {
+            if (cityComponent || countryComponent) {
+              const lat = place.geometry?.location?.lat();
+              const lng = place.geometry?.location?.lng();
               onCitySelectedRef.current({
-                cityName: cityComponent.long_name,
+                cityName: cityComponent?.long_name || '',
                 country: countryComponent?.long_name || '',
                 countryCode: countryComponent?.short_name || '',
                 state: stateComponent?.short_name,
-                lat: place.geometry.location.lat(),
-                lng: place.geometry.location.lng(),
+                lat: typeof lat === 'number' ? lat : 0,
+                lng: typeof lng === 'number' ? lng : 0,
                 formattedName: selectedAddress,
               });
             }


### PR DESCRIPTION
## Summary

74 prod parties had `country IS NULL` because `LocationAutocomplete.onCitySelected` short-circuited any place pick that didn't include a `locality`/`sublocality`/`administrative_area_level_1` component AND `place.geometry`. Country-only picks, establishment picks, and addresses with sparse `address_components` silently dropped the country even when `address_components` contained it.

The full audit confirmed the rest of the chain is wired correctly on `master`:

| Site | Country wired? | Notes |
|------|----------------|-------|
| `LocationAutocomplete.tsx` extraction | **fixed in this PR** | now fires when EITHER city OR country is present |
| `EventForm.tsx` capture + pass | yes (calzone-71208, PR #...) | `pendingCountry`/state + `onCitySelected` wired |
| `EventDetailsTab.tsx` capture + pass | yes | `pendingCountryRef` -> `saveLocation` -> `updateParty.country` |
| `createPartyApi` POST body | yes (calzone-71208) | `country` in body |
| `updatePartyApi` PATCH body | yes | `country` in body |
| Backend `POST /api/parties` | yes (calzone-71208) | destructures + persists `country` |
| Backend `PATCH /api/parties/:id` | yes | `...(country !== undefined && { country: country || null })` |
| Prisma `Party.country` column | yes | `String?` + `GRANT SELECT (country)` since arugula-29881 |
| `dbPartyToParty` mapper | yes | `country: dbParty.country || null` |
| `SAFE_PARTY_COLUMNS` SELECT list | yes | listed |

## Changes

Single-file change in `frontend/src/components/LocationAutocomplete.tsx`:
- Drop the `place.geometry?.location` guard from the `onCitySelected` precondition (geometry is no longer required to surface country).
- Drop the `cityComponent` requirement; require EITHER `cityComponent` OR `countryComponent`.
- `cityName` falls back to `''`, lat/lng fall back to 0 when geometry is missing. In-repo consumers either use the separate `onLocationSelected` callback for coords (EventForm, EventDetailsTab) or pin `types: ['(cities)']` which always have geometry (GPPLandingPage), so the 0/0 fallback is unreachable in practice.

## Test plan
- [ ] `cd frontend && npx tsc --noEmit` clean (verified locally)
- [ ] Backend tsc unchanged (pre-existing errors in `sharp`/`openai`/`archiver`/`jwt` test mocks are unrelated)
- [ ] Manual: on Vercel preview, create a new event, pick a Nigerian street address via autocomplete -> verify saved party has `country='Nigeria'`
- [ ] Manual: edit an existing event's location, pick a country-only result -> verify country updates
- [ ] Manual: pick a named establishment (e.g. "Eiffel Tower") -> verify country='France' is captured
- [ ] Manual: type a free-form address without picking -> reasonable fallback (country stays NULL, no crash)

## Followup
- Snax to run a one-off backfill against the existing 74 NULL-country parties (re-geocode via stored `place_id` where available, fall back to address parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)