### PR TITLE
feat(crocchetta-92106): receipts reminder via Molto Benny TG

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -5141,7 +5141,7 @@ router.post(
 );
 
 // ============================================
-// crocchetta-92106: Telegram receipts reminder.
+// crocchetta-92106 + crocchetta-92107: Telegram receipts reminder.
 //
 // Sends a Telegram nudge via the Molto Benny bot (`TELEGRAM_BOT_TOKEN`) to:
 //   1. The host's private DM, using `parties.host_telegram_chat_id` — set
@@ -5149,11 +5149,14 @@ router.post(
 //      backend/src/routes/telegram-webhook.routes.ts). When null, the host
 //      DM is silently skipped and `hostDmSent=false` with a reason returned
 //      to the caller.
-//   2. The shared GPP group chat — `GPP_GROUP_TG_CHAT_ID` env var. When
-//      unset (it's a new env var introduced by this task), the group send is
-//      skipped and `groupSent=false` with a reason returned to the caller.
-//      Kept separate from the existing `PAYMENTS_TEAM_TG_CHAT_ID` so the
-//      payments-team feed isn't spammed with host reminders.
+//   2. The city's Telegram group chat — chat_id passed in the request body
+//      as `groupChatId`, resolved client-side from the same GPP sheet that
+//      powers the /underboss broadcast tooling (`fetchSheetCities` →
+//      `SheetCity.groupId`). When the party's city has no group_id on file,
+//      the frontend omits the field and the backend skips the group post
+//      with `groupReason: 'no city TG group set'`. This mirrors the
+//      per-row chat_id pattern used by /api/telegram/broadcast — the
+//      backend never fetches the sheet itself.
 //
 // Both messages carry the same body:
 //   "Make sure you've uploaded receipts and photos to rsv.pizza/<custom_url>"
@@ -5252,19 +5255,24 @@ router.post(
         hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
       }
 
-      // Group chat — only when GPP_GROUP_TG_CHAT_ID is configured.
-      const groupChatId = process.env.GPP_GROUP_TG_CHAT_ID;
+      // Group chat — per-city chat_id supplied by the caller. The frontend
+      // resolves it from the GPP sheet (`SheetCity.groupId`) using the same
+      // city→chat_id map that /underboss uses for its broadcast tooling. We
+      // intentionally don't fetch the sheet from the backend; mirrors the
+      // `/api/telegram/broadcast` contract where the client supplies chatIds.
+      const rawGroupChatId =
+        typeof req.body?.groupChatId === 'string' ? req.body.groupChatId.trim() : '';
       let groupSent = false;
       let groupReason: string | undefined;
-      if (groupChatId && groupChatId.trim()) {
-        const result = await sendTelegramMessage(groupChatId.trim(), text);
+      if (rawGroupChatId) {
+        const result = await sendTelegramMessage(rawGroupChatId, text);
         if (result.ok) {
           groupSent = true;
         } else {
           groupReason = result.reason;
         }
       } else {
-        groupReason = 'GPP_GROUP_TG_CHAT_ID env var not configured';
+        groupReason = 'no city TG group set';
       }
 
       // Grep-marker audit line (no DB row per task spec). Includes party id,

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -5140,6 +5140,154 @@ router.post(
   },
 );
 
+// ============================================
+// crocchetta-92106: Telegram receipts reminder.
+//
+// Sends a Telegram nudge via the Molto Benny bot (`TELEGRAM_BOT_TOKEN`) to:
+//   1. The host's private DM, using `parties.host_telegram_chat_id` — set
+//      when the host links Telegram via the `/start <token>` deeplink (see
+//      backend/src/routes/telegram-webhook.routes.ts). When null, the host
+//      DM is silently skipped and `hostDmSent=false` with a reason returned
+//      to the caller.
+//   2. The shared GPP group chat — `GPP_GROUP_TG_CHAT_ID` env var. When
+//      unset (it's a new env var introduced by this task), the group send is
+//      skipped and `groupSent=false` with a reason returned to the caller.
+//      Kept separate from the existing `PAYMENTS_TEAM_TG_CHAT_ID` so the
+//      payments-team feed isn't spammed with host reminders.
+//
+// Both messages carry the same body:
+//   "Make sure you've uploaded receipts and photos to rsv.pizza/<custom_url>"
+//
+// No DB writes — we surface success/failure per channel in the response and
+// emit a single console line with the `[crocchetta-92106][tg-reminder]`
+// marker for grep-driven audit recovery.
+//
+// Auth: admin / super_admin / payment_admin via
+// `requireAnyAdminOrPaymentAdmin` — same gate as the other by-city actions
+// (Mark party paid, Send payment, Flag scam). Regional underbosses don't see
+// the menu item.
+// ============================================
+
+async function sendTelegramMessage(
+  chatId: string,
+  text: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    return { ok: false, reason: 'TELEGRAM_BOT_TOKEN not configured' };
+  }
+  try {
+    const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!resp.ok) {
+      let detail = '';
+      try {
+        const body = await resp.text();
+        detail = body.slice(0, 200);
+      } catch {
+        // ignore — surface just the status
+      }
+      return {
+        ok: false,
+        reason: `Telegram API returned ${resp.status}${detail ? `: ${detail}` : ''}`,
+      };
+    }
+    return { ok: true };
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: `Telegram fetch failed: ${err?.message || String(err)}`,
+    };
+  }
+}
+
+router.post(
+  '/:partyId/tg-receipts-reminder',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: {
+          id: true,
+          customUrl: true,
+          inviteCode: true,
+          name: true,
+          hostTelegramChatId: true,
+        },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      // Prefer custom_url for the public link; fall back to invite_code so
+      // the URL always resolves even on parties without a custom slug.
+      const slug = party.customUrl || party.inviteCode;
+      const text = `Make sure you've uploaded receipts and photos to rsv.pizza/${slug}`;
+
+      // Host DM — only when the party has a linked Telegram chat id.
+      let hostDmSent = false;
+      let hostDmReason: string | undefined;
+      if (party.hostTelegramChatId) {
+        const result = await sendTelegramMessage(
+          party.hostTelegramChatId.toString(),
+          text,
+        );
+        if (result.ok) {
+          hostDmSent = true;
+        } else {
+          hostDmReason = result.reason;
+        }
+      } else {
+        hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
+      }
+
+      // Group chat — only when GPP_GROUP_TG_CHAT_ID is configured.
+      const groupChatId = process.env.GPP_GROUP_TG_CHAT_ID;
+      let groupSent = false;
+      let groupReason: string | undefined;
+      if (groupChatId && groupChatId.trim()) {
+        const result = await sendTelegramMessage(groupChatId.trim(), text);
+        if (result.ok) {
+          groupSent = true;
+        } else {
+          groupReason = result.reason;
+        }
+      } else {
+        groupReason = 'GPP_GROUP_TG_CHAT_ID env var not configured';
+      }
+
+      // Grep-marker audit line (no DB row per task spec). Includes party id,
+      // slug, and per-channel outcome so post-hoc recovery is one `vercel
+      // logs | grep` away.
+      console.log(
+        `[crocchetta-92106][tg-reminder] party=${party.id} slug=${slug} host_dm=${
+          hostDmSent ? 'ok' : `skipped:${hostDmReason ?? 'unknown'}`
+        } group=${groupSent ? 'ok' : `skipped:${groupReason ?? 'unknown'}`}`,
+      );
+
+      res.json({
+        hostDmSent,
+        ...(hostDmReason ? { hostDmReason } : {}),
+        groupSent,
+        ...(groupReason ? { groupReason } : {}),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // Re-export the helper so other backend code (e.g. PR 5 execute route) can
 // reuse the composed guard without re-deriving it.
 export { requireAnyAdminOrPaymentAdmin, isFullAdmin };

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -157,6 +157,15 @@ interface PayoutsByPartyTableProps {
       groupReason?: string;
     } | { error: string },
   ) => void;
+  /**
+   * crocchetta-92107: per-city Telegram group chat_id map keyed by the
+   * lower-cased, trimmed city name (with the "Global Pizza Party " prefix
+   * stripped). Populated by the parent from `fetchSheetCities()` —
+   * `SheetCity.groupId` — the same source /underboss uses for its broadcast
+   * tooling. When a row's city is missing from the map, the group post is
+   * skipped server-side with `groupReason: 'no city TG group set'`.
+   */
+  cityGroupChatIds?: Map<string, string>;
   viewerRole?: 'admin' | 'underboss';
   busyRowId?: string | null;
   loading?: boolean;
@@ -1765,6 +1774,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onSendPayment,
   onScamFlagChanged,
   onTgReminderResult,
+  cityGroupChatIds,
   viewerRole = 'admin',
   busyRowId,
   loading,
@@ -1859,17 +1869,23 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   }
 
   /**
-   * crocchetta-92106: dispatch the Send-receipts-reminder POST and surface
-   * the per-channel outcome to the parent via `onTgReminderResult` so the
-   * page-level toast stack renders the right message. Errors are caught and
-   * forwarded with an `error` shape so the parent can flash a failure toast
-   * without the table needing its own alert path.
+   * crocchetta-92106 + crocchetta-92107: dispatch the Send-receipts-reminder
+   * POST and surface the per-channel outcome to the parent via
+   * `onTgReminderResult` so the page-level toast stack renders the right
+   * message. The per-city Telegram group chat_id is resolved from
+   * `cityGroupChatIds` (a sheet-derived map keyed by the stripped,
+   * lower-cased city name); when the map has no entry the request omits the
+   * field and the backend marks the group post skipped. Errors are caught
+   * and forwarded with an `error` shape so the parent can flash a failure
+   * toast without the table needing its own alert path.
    */
   async function handleSendTgReminder(row: PartyPayoutsRow) {
     const partyId = row.party.id;
+    const cityKey = stripGppPrefix(row.party.name).toLowerCase().trim();
+    const groupChatId = cityGroupChatIds?.get(cityKey);
     setTgReminderBusyPartyId(partyId);
     try {
-      const result = await sendTgReceiptsReminder(partyId);
+      const result = await sendTgReceiptsReminder(partyId, groupChatId);
       onTgReminderResult?.(partyId, result);
     } catch (err) {
       onTgReminderResult?.(partyId, {

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -18,6 +18,7 @@ import {
   User as UserIcon,
   Play,
   AlertTriangle,
+  MessageCircle,
 } from 'lucide-react';
 import type {
   AdminPayout,
@@ -43,6 +44,7 @@ import {
   retryPayoutDocumentOcr,
   flagPartyAsScam,
   POSSIBLE_SCAM_TAG,
+  sendTgReceiptsReminder,
 } from '../../lib/api';
 import {
   ReceiptEditor,
@@ -139,6 +141,22 @@ interface PayoutsByPartyTableProps {
    * the viewerRole gate on the menu.
    */
   onScamFlagChanged?: (partyId: string, nextTags: string[]) => void;
+  /**
+   * crocchetta-92106: toast callback used by the Send receipts reminder
+   * action. Called after the backend POST resolves; the menu owns the API
+   * call so the parent only needs to render the message (mirrors the
+   * gnocchi-92104 pattern). When omitted, the table falls back to a
+   * `window.alert`-free silent success (the menu still closes).
+   */
+  onTgReminderResult?: (
+    partyId: string,
+    result: {
+      hostDmSent: boolean;
+      hostDmReason?: string;
+      groupSent: boolean;
+      groupReason?: string;
+    } | { error: string },
+  ) => void;
   viewerRole?: 'admin' | 'underboss';
   busyRowId?: string | null;
   loading?: boolean;
@@ -254,31 +272,47 @@ function CityActionsMenu({
   onAddExternalPayment,
   onSendPayment,
   onToggleScamFlag,
+  onSendTgReminder,
   canMarkPaid,
   canAddExternal,
   canSendPayment,
   canToggleScamFlag,
+  canSendTgReminder,
   markPaidLabel,
   isFlaggedScam,
   scamFlagBusy,
+  tgReminderBusy,
 }: {
   onMarkPartyPaid?: () => void;
   onAddExternalPayment?: () => void;
   onSendPayment?: () => void;
   onToggleScamFlag?: () => void;
+  /**
+   * crocchetta-92106: fires after the second click on the Send receipts
+   * reminder menu item (two-click confirm pattern — DMs aren't reversible).
+   * Parent runs the API call and surfaces the toast.
+   */
+  onSendTgReminder?: () => void;
   canMarkPaid: boolean;
   canAddExternal: boolean;
   canSendPayment: boolean;
   canToggleScamFlag: boolean;
+  canSendTgReminder: boolean;
   markPaidLabel: string;
   isFlaggedScam: boolean;
   scamFlagBusy: boolean;
+  tgReminderBusy: boolean;
 }) {
   // Hooks-above-early-returns: declare useState before the no-actions guard
   // so the conditional return can't reorder hooks on a re-render where the
   // capability props flip. (feedback_hooks_above_early_returns)
   const [menuOpen, setMenuOpen] = useState(false);
-  const hasMenuItems = canAddExternal || canToggleScamFlag;
+  // crocchetta-92106: two-click confirm for the TG reminder action. The
+  // first click flips the label to "Click again to confirm"; a second click
+  // within the open menu actually fires. Resetting whenever the menu closes
+  // prevents a stale confirm state carrying over to the next open.
+  const [confirmTgReminder, setConfirmTgReminder] = useState(false);
+  const hasMenuItems = canAddExternal || canToggleScamFlag || canSendTgReminder;
   // Nothing to show at all — render nothing.
   if (!canMarkPaid && !canSendPayment && !hasMenuItems) {
     return null;
@@ -325,7 +359,16 @@ function CityActionsMenu({
         <div className="relative">
           <button
             type="button"
-            onClick={() => setMenuOpen((v) => !v)}
+            onClick={() => {
+              setMenuOpen((v) => {
+                const next = !v;
+                // crocchetta-92106: closing the menu resets the TG-reminder
+                // confirm state so a stale "Click again to confirm" doesn't
+                // carry over to the next open.
+                if (!next) setConfirmTgReminder(false);
+                return next;
+              });
+            }}
             className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-theme-stroke text-theme-text-secondary hover:bg-theme-surface-hover"
             title="More actions"
             aria-label="More actions"
@@ -339,7 +382,10 @@ function CityActionsMenu({
               {/* click-out overlay */}
               <div
                 className="fixed inset-0 z-40"
-                onClick={() => setMenuOpen(false)}
+                onClick={() => {
+                  setMenuOpen(false);
+                  setConfirmTgReminder(false);
+                }}
               />
               <div
                 className="absolute right-0 mt-1 w-56 z-50 rounded-lg border border-theme-stroke bg-[#1a1a2e] shadow-xl py-1"
@@ -387,6 +433,47 @@ function CityActionsMenu({
                     {isFlaggedScam
                       ? 'Unflag possible scam'
                       : 'Flag as possible scam'}
+                  </button>
+                )}
+                {/* crocchetta-92106: Send receipts reminder via Molto Benny
+                    Telegram bot. DMs the primary host (when their TG is
+                    linked) and posts to the shared GPP group chat. Two-click
+                    confirm — first click flips the label to "Click again to
+                    confirm" because a DM can't be unsent (reversible-action
+                    convention DOESN'T apply here per
+                    feedback_reversible_actions_no_confirm). */}
+                {canSendTgReminder && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={tgReminderBusy}
+                    onClick={() => {
+                      if (!confirmTgReminder) {
+                        setConfirmTgReminder(true);
+                        return;
+                      }
+                      setMenuOpen(false);
+                      setConfirmTgReminder(false);
+                      onSendTgReminder?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
+                  >
+                    {tgReminderBusy ? (
+                      <Loader2
+                        size={14}
+                        className="animate-spin text-theme-text-muted"
+                      />
+                    ) : (
+                      <MessageCircle
+                        size={14}
+                        className={
+                          confirmTgReminder ? 'text-amber-400' : 'text-sky-400'
+                        }
+                      />
+                    )}
+                    {confirmTgReminder
+                      ? 'Click again to confirm'
+                      : 'Send receipts reminder'}
                   </button>
                 )}
               </div>
@@ -1677,6 +1764,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onAddExternalPayment,
   onSendPayment,
   onScamFlagChanged,
+  onTgReminderResult,
   viewerRole = 'admin',
   busyRowId,
   loading,
@@ -1692,6 +1780,9 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // Per-row busy spinner state for the scam-flag toggle. Avoids double-clicks
   // during the PATCH round-trip.
   const [scamBusyPartyId, setScamBusyPartyId] = useState<string | null>(null);
+  // crocchetta-92106: per-row busy spinner for the Send receipts reminder
+  // action. Avoids double-firing the POST while the bot is dispatching.
+  const [tgReminderBusyPartyId, setTgReminderBusyPartyId] = useState<string | null>(null);
 
   const canMarkPartyPaid = viewerRole === 'admin' && !!onMarkPartyPaid;
   const canAddExternal = viewerRole === 'admin' && !!onAddExternalPayment;
@@ -1701,6 +1792,10 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // bottarga-92104: same admin gate as the other two menu items. Underbosses
   // never see the scam-flag action.
   const canToggleScamFlag = viewerRole === 'admin';
+  // crocchetta-92106: TG reminder is admin-only. The endpoint itself enforces
+  // requireAnyAdminOrPaymentAdmin server-side; the UI gate just hides the
+  // menu item for underbosses so they don't see a button that 403s.
+  const canSendTgReminder = viewerRole === 'admin';
   // pesto-92105: same gate the per-payout PayoutReviewModal applies for
   // `canEditReceipts` (admin / super_admin / payment_admin). Underbosses get
   // the plain photo-only lightbox.
@@ -1763,6 +1858,28 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
     }
   }
 
+  /**
+   * crocchetta-92106: dispatch the Send-receipts-reminder POST and surface
+   * the per-channel outcome to the parent via `onTgReminderResult` so the
+   * page-level toast stack renders the right message. Errors are caught and
+   * forwarded with an `error` shape so the parent can flash a failure toast
+   * without the table needing its own alert path.
+   */
+  async function handleSendTgReminder(row: PartyPayoutsRow) {
+    const partyId = row.party.id;
+    setTgReminderBusyPartyId(partyId);
+    try {
+      const result = await sendTgReceiptsReminder(partyId);
+      onTgReminderResult?.(partyId, result);
+    } catch (err) {
+      onTgReminderResult?.(partyId, {
+        error: (err as Error)?.message ?? 'Could not send reminder',
+      });
+    } finally {
+      setTgReminderBusyPartyId((id) => (id === partyId ? null : id));
+    }
+  }
+
   return (
     <div className="bg-theme-surface border border-theme-stroke rounded-xl overflow-hidden">
       <div className="overflow-x-auto">
@@ -1807,6 +1924,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                 tagOverrides[row.party.id] ?? row.party.eventTags ?? [];
               const isFlaggedScam = effectiveTags.includes(POSSIBLE_SCAM_TAG);
               const scamFlagBusy = scamBusyPartyId === row.party.id;
+              const tgReminderBusy = tgReminderBusyPartyId === row.party.id;
               const hasInFlight =
                 row.aggregates.pendingCount + row.aggregates.approvedCount > 0;
               // pinsa-92103: ALSO show the button when the city has paid
@@ -2008,9 +2126,11 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           canAddExternal={canAddExternal}
                           canSendPayment={canSendPayment}
                           canToggleScamFlag={canToggleScamFlag}
+                          canSendTgReminder={canSendTgReminder}
                           markPaidLabel={markPaidLabel}
                           isFlaggedScam={isFlaggedScam}
                           scamFlagBusy={scamFlagBusy}
+                          tgReminderBusy={tgReminderBusy}
                           onMarkPartyPaid={
                             showMarkPartyPaid && onMarkPartyPaid
                               ? () => onMarkPartyPaid(row.party.id)
@@ -2033,6 +2153,11 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           onToggleScamFlag={
                             canToggleScamFlag
                               ? () => handleToggleScamFlag(row)
+                              : undefined
+                          }
+                          onSendTgReminder={
+                            canSendTgReminder
+                              ? () => handleSendTgReminder(row)
                               : undefined
                           }
                         />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -425,6 +425,39 @@ export async function flagPartyAsScam(
 }
 
 /**
+ * crocchetta-92106: Send the "Make sure you've uploaded receipts and photos
+ * to rsv.pizza/<custom_url>" reminder via the Molto Benny Telegram bot.
+ *
+ * Two messages, same body:
+ *   1. DM to the primary host (uses `parties.host_telegram_chat_id`; skipped
+ *      with a reason when the host hasn't linked Telegram).
+ *   2. Post to the GPP-wide group chat (uses `GPP_GROUP_TG_CHAT_ID` env;
+ *      skipped with a reason when the env var isn't configured yet).
+ *
+ * Backend returns per-channel success + skip reason so the UI can render an
+ * accurate partial-success toast. Triggered from the /payments by-city ⋮
+ * menu (PayoutsByPartyTable).
+ */
+export interface SendTgReceiptsReminderResponse {
+  hostDmSent: boolean;
+  hostDmReason?: string;
+  groupSent: boolean;
+  groupReason?: string;
+}
+
+export async function sendTgReceiptsReminder(
+  partyId: string,
+): Promise<SendTgReceiptsReminderResponse> {
+  return apiRequest<SendTgReceiptsReminderResponse>(
+    `/api/admin/payouts/${partyId}/tg-receipts-reminder`,
+    {
+      method: 'POST',
+      requireAuth: true,
+    },
+  );
+}
+
+/**
  * quattro-71244: Fetches this party's rank against peer GPP events.
  * Returns null on 401/403/404/network failure so callers (the LeaderboardPill)
  * can gracefully hide instead of crashing the dashboard.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -425,14 +425,18 @@ export async function flagPartyAsScam(
 }
 
 /**
- * crocchetta-92106: Send the "Make sure you've uploaded receipts and photos
- * to rsv.pizza/<custom_url>" reminder via the Molto Benny Telegram bot.
+ * crocchetta-92106 + crocchetta-92107: Send the "Make sure you've uploaded
+ * receipts and photos to rsv.pizza/<custom_url>" reminder via the Molto
+ * Benny Telegram bot.
  *
  * Two messages, same body:
  *   1. DM to the primary host (uses `parties.host_telegram_chat_id`; skipped
  *      with a reason when the host hasn't linked Telegram).
- *   2. Post to the GPP-wide group chat (uses `GPP_GROUP_TG_CHAT_ID` env;
- *      skipped with a reason when the env var isn't configured yet).
+ *   2. Post to the **city's** Telegram group chat. The caller resolves the
+ *      chat_id from the GPP sheet (same `SheetCity.groupId` field that
+ *      powers /underboss broadcasts) and passes it in `groupChatId`. When
+ *      omitted/empty, the backend skips with `groupReason: 'no city TG
+ *      group set'` (per-party, not a global env var).
  *
  * Backend returns per-channel success + skip reason so the UI can render an
  * accurate partial-success toast. Triggered from the /payments by-city ⋮
@@ -447,12 +451,14 @@ export interface SendTgReceiptsReminderResponse {
 
 export async function sendTgReceiptsReminder(
   partyId: string,
+  groupChatId?: string | null,
 ): Promise<SendTgReceiptsReminderResponse> {
   return apiRequest<SendTgReceiptsReminderResponse>(
     `/api/admin/payouts/${partyId}/tg-receipts-reminder`,
     {
       method: 'POST',
       requireAuth: true,
+      body: groupChatId ? { groupChatId } : undefined,
     },
   );
 }

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -36,6 +36,7 @@ import type {
 import { formatUsd } from '../components/payments-shared';
 import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
 import { isSwcHubParty } from '../utils/swcHub';
+import { fetchSheetCities } from '../lib/cities';
 import {
   PayoutsFilterBar,
   PayoutsTable,
@@ -286,6 +287,37 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     },
     [],
   );
+
+  // crocchetta-92107: city-name → Telegram group chat_id map, sourced from
+  // the same GPP sheet (`fetchSheetCities` → `SheetCity.groupId`) that
+  // /underboss uses for its broadcast tooling. Drives the per-city group
+  // post on the Send-receipts-reminder action; rows without a matching city
+  // entry skip the group post server-side. Fetched once on mount; failures
+  // collapse to an empty map (the host DM still goes out).
+  const [cityGroupChatIds, setCityGroupChatIds] = useState<Map<string, string>>(
+    new Map(),
+  );
+  useEffect(() => {
+    let cancelled = false;
+    fetchSheetCities()
+      .then((cities) => {
+        if (cancelled) return;
+        const map = new Map<string, string>();
+        for (const c of cities) {
+          if (c.groupId) {
+            map.set(c.city.toLowerCase().trim(), c.groupId);
+          }
+        }
+        setCityGroupChatIds(map);
+      })
+      .catch(() => {
+        // Sheet fetch is best-effort — silently collapse on failure. The DM
+        // path still runs and the toast surfaces "no city TG group set".
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const loadPrepayQueue = useCallback(async () => {
     try {
@@ -1127,6 +1159,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 result.hostDmSent || result.groupSent ? 'success' : 'error';
               pushToast(`Reminder: ${hostLabel} | ${groupLabel}`, tone);
             }}
+            // crocchetta-92107: sheet-derived city → TG group chat_id map so
+            // the Send-receipts-reminder action can post into the city's
+            // group chat (same source /underboss uses).
+            cityGroupChatIds={cityGroupChatIds}
             viewerRole={viewerKind}
             busyRowId={rowBusyId}
             loading={loading}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1100,6 +1100,33 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 'success',
               );
             }}
+            // crocchetta-92106: Send-receipts-reminder result toast. The
+            // backend returns per-channel success + skip reason; we render
+            // each channel as a "✓"/"–" so the admin can see at a glance
+            // whether both messages went out, or just the group post when
+            // the host hasn't linked TG yet.
+            onTgReminderResult={(_partyId, result) => {
+              if ('error' in result) {
+                pushToast(
+                  `Could not send reminder: ${result.error}`,
+                  'error',
+                );
+                return;
+              }
+              const hostLabel = result.hostDmSent
+                ? 'DM ✓'
+                : `DM skipped${
+                    result.hostDmReason ? ` (${result.hostDmReason})` : ''
+                  }`;
+              const groupLabel = result.groupSent
+                ? 'Group ✓'
+                : `Group skipped${
+                    result.groupReason ? ` (${result.groupReason})` : ''
+                  }`;
+              const tone =
+                result.hostDmSent || result.groupSent ? 'success' : 'error';
+              pushToast(`Reminder: ${hostLabel} | ${groupLabel}`, tone);
+            }}
             viewerRole={viewerKind}
             busyRowId={rowBusyId}
             loading={loading}


### PR DESCRIPTION
## Summary

- Adds a new **Send receipts reminder** item to the /payments by-city ⋮ menu (after Flag/Unflag possible scam) that dispatches a Telegram nudge via the existing Molto Benny bot.
- One click → "Click again to confirm" (DMs can't be unsent so a tiny inline confirm is appropriate per [[feedback_reversible_actions_no_confirm]]); second click POSTs to the new endpoint and a toast renders per-channel outcome.
- Backend endpoint `POST /api/admin/payouts/:partyId/tg-receipts-reminder` is admin-only (`requireAnyAdminOrPaymentAdmin`) and sends to:
  1. **Host DM** — `parties.host_telegram_chat_id` (set when the host links Telegram via the `/start <token>` deeplink). Silently skipped when null; reason returned to the caller.
  2. **City TG group chat** (crocchetta-92107 follow-up) — chat_id resolved per-party from the same GPP Google Sheet that powers /underboss broadcasts (`fetchSheetCities` → `SheetCity.groupId`). The frontend fetches the sheet once on mount, builds a city → groupId map, and passes the resolved chat_id in the POST body. When the row's city has no group_id on the sheet, the backend skips with `groupReason: "no city TG group set"`. Mirrors the `/api/telegram/broadcast` contract — the backend never fetches the sheet itself.

Both messages carry the same body:

```
Make sure you've uploaded receipts and photos to rsv.pizza/{custom_url}
```

No DB migration — each call emits a `[crocchetta-92106][tg-reminder]` grep marker so post-hoc audit recovery is a single `vercel logs | grep` away.

## Env vars

- **Existing** (already set on backend Vercel): `TELEGRAM_BOT_TOKEN` — Molto Benny bot's HTTP-API token. Required for both channels.
- **No new env vars.** The group chat_id is per-city via the GPP Google Sheet (`SheetCity.groupId`), same source /underboss uses. Edit the sheet row's group_id column to wire a city up; no deploy needed.
- **Untouched**: `PAYMENTS_TEAM_TG_CHAT_ID` stays exclusive to the existing payments-team approval/flag-ready notifications.

## Test plan

- [ ] On Vercel preview, open `/payments` as an admin, switch to By city view.
- [ ] Click `⋮` on a city whose primary host has linked TG AND whose city row in the GPP sheet has a `group_id`.
- [ ] Confirm the new `Send receipts reminder` row appears below `Flag as possible scam` with a sky-blue chat icon.
- [ ] Click once — label flips to `Click again to confirm`; icon turns amber.
- [ ] Click again — spinner shows, then toast renders `Reminder: DM ✓ | Group ✓`.
- [ ] Confirm host receives `Make sure you've uploaded receipts and photos to rsv.pizza/<their-slug>` DM from Molto Benny.
- [ ] Confirm the city's TG group also receives the same body.
- [ ] Try on a city whose host has NOT linked TG — toast reads `Reminder: DM skipped (Host has not linked Telegram …) | Group ✓`.
- [ ] Try on a city WITHOUT a TG group id on the sheet — toast reads `Reminder: DM ✓ | Group skipped (no city TG group set)`.
- [ ] Confirm regional underbosses (e.g. `/payments/latam`) don't see the menu item (admin-only gate).
- [ ] Confirm backend logs include the grep marker line `[crocchetta-92106][tg-reminder] party=… slug=… host_dm=… group=…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)