### PR TITLE
feat(provola-92106): mark receipts / line items as ineligible for reimbursement

### DIFF
--- a/backend/prisma/migrations/20260530000000_add_payout_documents_ineligible/migration.sql
+++ b/backend/prisma/migrations/20260530000000_add_payout_documents_ineligible/migration.sql
@@ -1,0 +1,23 @@
+-- provola-92106: per-receipt "ineligible for reimbursement" flag.
+-- Distinct from culatello-92104's `is_duplicate`: ineligible receipts are
+-- legitimate purchases the host paid for, but they don't qualify under the
+-- reimbursement policy (alcohol, tips, personal items). Visually treated
+-- with amber tint + 135° diagonal stripes + INELIGIBLE pill (distinct
+-- from duplicate's red 45° pattern). Same exclusion behavior as
+-- `is_duplicate`: excluded from the reviewer modal's OCR sum, the by-city
+-- `receiptUsdTotal`, the host PATCH `survivingOcrSum` recompute, and the
+-- pizza-prices analytics aggregate.
+--
+-- Independent flags — both columns can be true on the same row, though the
+-- UI prefers duplicate as the primary visual signal.
+--
+-- For per-LINE ineligibility, see the `ocrLineItems` jsonb column: each
+-- entry now accepts an optional `ineligible?: boolean` field. No schema
+-- change required there since the column is jsonb.
+ALTER TABLE "payout_documents"
+  ADD COLUMN IF NOT EXISTS "ineligible" boolean NOT NULL DEFAULT false;
+
+-- Column-level SELECT grant (project convention — see CLAUDE.md "Common
+-- Gotchas"). Without this, anon/authenticated queries that read the new
+-- column would 403 against the column-level RLS grant.
+GRANT SELECT ("ineligible") ON "payout_documents" TO anon, authenticated;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1819,6 +1819,17 @@ model PayoutDocument {
   // finalAmountUsd recompute path so admin edits propagate correctly. The
   // flag is reversible from the same toggle.
   isDuplicate      Boolean  @default(false) @map("is_duplicate")
+  // provola-92106: admin-flagged "ineligible for reimbursement" receipts.
+  // Semantically distinct from `isDuplicate` — this is a legitimate purchase
+  // (the host paid for it) that simply doesn't qualify under the reimbursement
+  // policy (alcohol, tips, personal items). Visually treated with amber tint +
+  // 135° diagonal stripes + INELIGIBLE pill (distinct from the duplicate's red
+  // 45° pattern). Same exclusion behavior as `isDuplicate`: excluded from the
+  // reviewer modal's OCR sum, the host PATCH `survivingOcrSum` recompute, the
+  // by-city `receiptUsdTotal`, and the pizza-prices analytics aggregate.
+  // Independent flags — both can be true on the same row but the UI prefers
+  // duplicate as the primary signal (duplicate pill wins on the thumbnail).
+  ineligible       Boolean  @default(false) @map("ineligible")
   createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   // napoletana-58210: thumbs-up voting on payout pizza photos surfaced in

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -608,6 +608,11 @@ function serializePayout(row: any): any {
       // dims these rows + excludes them from the OCR sum + the host PATCH
       // finalAmountUsd recompute path.
       isDuplicate: d.isDuplicate === true,
+      // provola-92106: admin-flagged "ineligible for reimbursement". Distinct
+      // from duplicate (legitimate purchase but doesn't qualify — alcohol,
+      // tips, personal items). Same exclusion semantics as `isDuplicate` —
+      // filtered out of every USD sum + the host recompute path.
+      ineligible: d.ineligible === true,
       // pancetta-37195: per-doc uploader attribution. Live name from the
       // join; cached email is the fallback if the User is later deleted.
       uploadedByUserId: d.uploadedByUserId ?? null,
@@ -4082,8 +4087,17 @@ router.post(
 //   // culatello-92104: admin-marked duplicate flag. Reversible. Excluded
 //   // from the reviewer modal's OCR sum, the host PATCH finalAmountUsd
 //   // recompute, and the pizza-prices analytics aggregate.
-//   isDuplicate?: boolean
+//   isDuplicate?: boolean,
+//   // provola-92106: admin-marked "ineligible for reimbursement" flag.
+//   // Distinct from `isDuplicate` — this is a legitimate purchase that
+//   // doesn't qualify for reimbursement under policy (alcohol, tips,
+//   // personal items). Same exclusion semantics as `isDuplicate`.
+//   ineligible?: boolean
 // }
+// Note: `ocrLineItems[*].ineligible` is supported in the same array — each
+// line item may carry an optional `ineligible?: boolean` field that excludes
+// only that line from sums. Stored alongside the existing fields in jsonb;
+// no schema change. Sanitized in `sanitizeLineItem` below.
 //   - null clears the field; undefined leaves it untouched.
 //   - ocrAmount must be finite (or null).
 //   - ocrCurrency must be a non-empty string ≤8 chars (or null).
@@ -4126,6 +4140,10 @@ router.patch(
           // culatello-92104: pull the old duplicate flag so the audit row
           // can record the transition (marked vs unmarked).
           isDuplicate: true,
+          // provola-92106: pull the old ineligible flag so the audit row can
+          // record the transition (marked vs unmarked) — same pattern as
+          // culatello-92104.
+          ineligible: true,
         },
       });
       if (!doc) {
@@ -4156,6 +4174,12 @@ router.patch(
         unitPrice: number;
         subtotal: number;
         category: (typeof ALLOWED_LINE_ITEM_CATEGORIES)[number];
+        // provola-92106: optional per-line "ineligible for reimbursement"
+        // flag. Stored alongside the other line-item fields in jsonb; no
+        // schema change. Only emitted when true so existing rows + admins
+        // who never touched the flag don't get a `false` sprinkled into
+        // every entry.
+        ineligible?: boolean;
       };
       function sanitizeLineItem(raw: unknown, idx: number): SanitizedLineItem {
         if (!raw || typeof raw !== 'object') {
@@ -4206,7 +4230,14 @@ router.patch(
             ? (rawCategory as SanitizedLineItem['category'])
             : 'other';
 
-        return { name, qty, unitPrice, subtotal, category };
+        // provola-92106: per-line "ineligible for reimbursement" flag. Only
+        // accept strict boolean; ignore anything else (matches the receipt-
+        // level isDuplicate / ineligible coercion stance — coercion would
+        // hide caller bugs). Only emit when true so admins who never touched
+        // it don't pollute every line with `ineligible:false`.
+        const out: SanitizedLineItem = { name, qty, unitPrice, subtotal, category };
+        if (e.ineligible === true) out.ineligible = true;
+        return out;
       }
 
       const data: {
@@ -4219,6 +4250,12 @@ router.patch(
         // culatello-92104: admin-only duplicate flag. Reversible — the same
         // toggle un-marks. Persisted to `payout_documents.is_duplicate`.
         isDuplicate?: boolean;
+        // provola-92106: admin-only "ineligible for reimbursement" flag.
+        // Distinct from `isDuplicate` — this is a legitimate purchase that
+        // doesn't qualify under policy (alcohol, tips, personal items).
+        // Reversible — same toggle un-marks. Persisted to
+        // `payout_documents.ineligible`.
+        ineligible?: boolean;
       } = {};
 
       if (body.ocrAmount !== undefined) {
@@ -4298,6 +4335,24 @@ router.patch(
           );
         }
         data.isDuplicate = body.isDuplicate;
+      }
+
+      // provola-92106: admin-toggleable "ineligible for reimbursement"
+      // flag. Strict boolean only (matches culatello-92104 `isDuplicate`
+      // semantics — coercion would hide caller bugs). Independent of the
+      // duplicate flag; both can be set on the same row. The reviewer
+      // modal's OCR sum + the host PATCH recompute path + the pizza-prices
+      // analytics aggregate all filter rows where this is true (same as
+      // they already do for `isDuplicate`).
+      if (body.ineligible !== undefined) {
+        if (typeof body.ineligible !== 'boolean') {
+          throw new AppError(
+            'ineligible must be a boolean',
+            400,
+            'VALIDATION_ERROR',
+          );
+        }
+        data.ineligible = body.ineligible;
       }
 
       // mortadella-92103 + caprino-92104: when admin changes the currency on a
@@ -4508,6 +4563,12 @@ router.patch(
             isDuplicate: data.isDuplicate === undefined
               ? undefined
               : data.isDuplicate,
+            // provola-92106: persist the ineligible-flag toggle. Independent
+            // of `isDuplicate` — both columns can be true on the same row,
+            // though the UI prefers duplicate as the primary visual signal.
+            ineligible: data.ineligible === undefined
+              ? undefined
+              : data.ineligible,
           },
         });
 
@@ -4600,6 +4661,33 @@ router.patch(
               },
             });
           }
+          // provola-92106: audit row for ineligible-flag transitions.
+          // Mirrors the culatello-92104 duplicate-audit precedent above —
+          // separate row per transition, only fires on actual value change.
+          // Uses the existing `edit_documents` action so it shows up in the
+          // forensics tools alongside the duplicate-flag toggles.
+          if (
+            data.ineligible !== undefined
+            && data.ineligible !== doc.ineligible
+          ) {
+            await tx.payoutAudit.create({
+              data: {
+                payoutId: doc.payoutId,
+                action: 'edit_documents',
+                actorEmail: actor.email,
+                actorKind: actor.actorKind,
+                note: JSON.stringify({
+                  scope: 'receipt',
+                  documentId: docId,
+                  message: data.ineligible
+                    ? 'marked ineligible'
+                    : 'unmarked ineligible',
+                  oldIneligible: doc.ineligible,
+                  newIneligible: data.ineligible,
+                }),
+              },
+            });
+          }
         }
 
         return row;
@@ -4627,6 +4715,9 @@ router.patch(
           ocrLineItems: Array.isArray(updated.ocrLineItems) ? updated.ocrLineItems : null,
           // culatello-92104: echo the persisted duplicate flag.
           isDuplicate: updated.isDuplicate === true,
+          // provola-92106: echo the persisted ineligible flag so the modal
+          // can update its optimistic override without a parent refetch.
+          ineligible: updated.ineligible === true,
           ocrError: updated.ocrError,
           sortOrder: updated.sortOrder,
           uploadedByUserId: updated.uploadedByUserId ?? null,
@@ -4699,6 +4790,11 @@ router.get(
           // exclude them from the analytics aggregate so the by-country
           // averages don't double-count the same purchase.
           isDuplicate: false,
+          // provola-92106: admin-marked ineligible receipts (alcohol, tips,
+          // personal items) aren't pizza prices either — same exclusion
+          // pattern. The aggregate should reflect what hosts actually paid
+          // for reimbursable items.
+          ineligible: false,
         },
         select: {
           id: true,

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -1810,10 +1810,14 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       // recompute sum so the admin's intent (these two receipts are the
       // same purchase) propagates back to the payout's finalAmountUsd on
       // the next host-side edit. Receipts persist for evidence either way.
+      // provola-92106: admin-flagged ineligible receipts (alcohol, tips,
+      // personal items) get the same exclusion treatment — distinct from
+      // duplicate but identical math. The reviewer modal's `ocrSum` already
+      // mirrors this filter; this keeps the host PATCH recompute consistent.
       const survivingOcrSum = survivingReceipts.reduce(
         (sum, d) =>
           sum
-          + (d.isDuplicate
+          + (d.isDuplicate || d.ineligible
             ? 0
             : d.ocrAmount != null
               ? Number(d.ocrAmount.toString())

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
 import { SwcHubWarning } from './SwcHubWarning';
 import { isSwcHubParty } from '../../utils/swcHub';
-import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, markReceiptDuplicate } from '../../lib/api';
+import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, markReceiptDuplicate, markReceiptIneligible } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
 import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal, ReceiptLineItem, ReceiptLineItemCategory } from '../../types';
@@ -427,6 +427,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     // culatello-92104: per-receipt duplicate flag override so the modal
     // reflects an in-flight toggle without waiting for parent refresh.
     isDuplicate?: boolean;
+    // provola-92106: per-receipt ineligible flag override. Independent of
+    // `isDuplicate` — both can be true on the same row. Same optimistic-
+    // override pattern.
+    ineligible?: boolean;
     // caprino-92104: post-FX-recompute fields so the lightbox editor's "USD
     // value" + "at rate X" display refreshes immediately on save.
     originalAmount?: number | null;
@@ -484,6 +488,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     unitPrice: string;
     subtotal: string;
     category: ReceiptLineItemCategory;
+    // provola-92106: per-line "ineligible for reimbursement" flag.
+    ineligible?: boolean;
   };
   const [lineItemsExpanded, setLineItemsExpanded] = useState<Record<string, boolean>>({});
   const [lineItemDrafts, setLineItemDrafts] = useState<Record<string, LineItemDraft[]>>({});
@@ -499,6 +505,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // above so a dup-toggle failure doesn't clobber the inline edit error.
   const [duplicateSavingId, setDuplicateSavingId] = useState<string | null>(null);
   const [duplicateSaveErrors, setDuplicateSaveErrors] = useState<Record<string, string>>({});
+  // provola-92106: per-row "Mark ineligible" loading + error state. Mirrors
+  // duplicate's scoping — separate buckets so a failure on one toggle
+  // doesn't clobber the other or the amount-edit error.
+  const [ineligibleSavingId, setIneligibleSavingId] = useState<string | null>(null);
+  const [ineligibleSaveErrors, setIneligibleSaveErrors] = useState<Record<string, string>>({});
 
   // Hooks must be declared above any early returns. There aren't any early
   // returns in this component today, but keeping all hooks grouped here makes
@@ -523,6 +534,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           // after PATCH without waiting for a parent refresh.
           // culatello-92104: same treatment for the duplicate flag so the
           // dim + pill update immediately on toggle.
+          // provola-92106: same again for the ineligible flag.
           return {
             ...d,
             ocrAmount: ov.ocrAmount,
@@ -531,6 +543,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               ov.ocrLineItems !== undefined ? ov.ocrLineItems : d.ocrLineItems,
             isDuplicate:
               ov.isDuplicate !== undefined ? ov.isDuplicate : d.isDuplicate,
+            ineligible:
+              ov.ineligible !== undefined ? ov.ineligible : d.ineligible,
             // caprino-92104: layer the FX recompute fields too so the
             // lightbox editor's "USD value" + rate display reflects the new
             // server-side values without a parent refetch.
@@ -696,6 +710,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           // through so a previous dup toggle isn't lost when amount/currency
           // is also edited.
           isDuplicate: updated.isDuplicate,
+          // provola-92106: same for the ineligible flag — server-authoritative.
+          ineligible: updated.ineligible,
           // caprino-92104: surface the recomputed FX details so the lightbox
           // editor's "USD value" display renders the new numbers without a
           // parent refetch.
@@ -789,6 +805,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       unitPrice: String(item.unitPrice ?? 0),
       subtotal: String(item.subtotal ?? 0),
       category: item.category ?? 'other',
+      // provola-92106: carry through the per-line ineligible flag. jsonb
+      // additive field — older items + items the admin never touched just
+      // omit it, mapping to "eligible" (default).
+      ineligible: item.ineligible === true ? true : undefined,
     };
   }
 
@@ -849,6 +869,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     if (!drafts) return 0;
     let sum = 0;
     for (const d of drafts) {
+      // provola-92106: skip lines the admin marked ineligible. Mirrors the
+      // shared ReceiptEditor's `draftSubtotalSum` helper so the live total
+      // shown in the right-pane editor matches the lightbox editor.
+      if (d.ineligible === true) continue;
       const n = Number(d.subtotal);
       if (Number.isFinite(n) && n >= 0) sum += n;
     }
@@ -900,13 +924,18 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         if (!Number.isFinite(subtotal) || subtotal < 0) {
           throw new Error(`Line ${idx + 1}: subtotal must be a non-negative number`);
         }
-        return {
+        // provola-92106: persist the per-line ineligible flag only when
+        // true so existing items + items the admin never touched don't
+        // sprout a `false` field. Backend sanitizer matches this stance.
+        const out: ReceiptLineItem = {
           name: d.name,
           qty,
           unitPrice,
           subtotal,
           category: d.category,
         };
+        if (d.ineligible === true) out.ineligible = true;
+        return out;
       });
       const updated = await updatePayoutDocument(docId, { ocrLineItems: items });
       setReceiptOverrides((m) => ({
@@ -917,6 +946,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           ocrLineItems: updated.ocrLineItems,
           // culatello-92104: see saveReceiptEdit comment.
           isDuplicate: updated.isDuplicate,
+          // provola-92106: same — carry the ineligible flag through.
+          ineligible: updated.ineligible,
         },
       }));
       // Re-seed the draft from the canonical saved array so the next render
@@ -1000,6 +1031,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             ocrCurrency: updated.ocrCurrency,
             ocrLineItems: updated.ocrLineItems,
             isDuplicate: updated.isDuplicate,
+            // provola-92106: carry through whatever the server has — keeps
+            // the two flags consistent if the server response includes both.
+            ineligible: updated.ineligible,
           },
         };
       });
@@ -1017,6 +1051,61 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       }));
     } finally {
       setDuplicateSavingId(null);
+    }
+  }
+
+  // provola-92106: toggle the per-receipt ineligible flag via the same
+  // PATCH /documents/:docId endpoint (passes `ineligible` instead of
+  // `isDuplicate`). Mirrors `toggleDuplicate` above — optimistic override,
+  // roll back on failure, server is authoritative on success. Independent
+  // of the duplicate flag (both can be true on the same row).
+  async function toggleIneligible(docId: string, nextValue: boolean) {
+    setIneligibleSavingId(docId);
+    setIneligibleSaveErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    const prior = receipts.find((r) => r.id === docId);
+    const priorIneligible = prior?.ineligible === true;
+    setReceiptOverrides((m) => {
+      const cur = m[docId] ?? {
+        ocrAmount: prior?.ocrAmount ?? null,
+        ocrCurrency: prior?.ocrCurrency ?? null,
+      };
+      return { ...m, [docId]: { ...cur, ineligible: nextValue } };
+    });
+    try {
+      const updated = await markReceiptIneligible(docId, nextValue);
+      setReceiptOverrides((m) => {
+        const cur = m[docId] ?? {
+          ocrAmount: updated.ocrAmount,
+          ocrCurrency: updated.ocrCurrency,
+        };
+        return {
+          ...m,
+          [docId]: {
+            ...cur,
+            ocrAmount: updated.ocrAmount,
+            ocrCurrency: updated.ocrCurrency,
+            ocrLineItems: updated.ocrLineItems,
+            isDuplicate: updated.isDuplicate,
+            ineligible: updated.ineligible,
+          },
+        };
+      });
+    } catch (err: any) {
+      setReceiptOverrides((m) => {
+        const cur = m[docId];
+        if (!cur) return m;
+        return { ...m, [docId]: { ...cur, ineligible: priorIneligible } };
+      });
+      setIneligibleSaveErrors((m) => ({
+        ...m,
+        [docId]: err?.message || 'Failed to update ineligible flag',
+      }));
+    } finally {
+      setIneligibleSavingId(null);
     }
   }
 
@@ -1086,7 +1175,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           a.qty !== b.qty ||
           a.unitPrice !== b.unitPrice ||
           a.subtotal !== b.subtotal ||
-          a.category !== b.category
+          a.category !== b.category ||
+          // provola-92106: per-line ineligible flag is dirty-trackable too.
+          // Normalize to boolean so undefined !== false doesn't false-positive.
+          (a.ineligible === true) !== (b.ineligible === true)
         ) {
           return true;
         }
@@ -1173,6 +1265,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         dupSaving={duplicateSavingId === r.id}
         dupError={duplicateSaveErrors[r.id]}
         onToggleDuplicate={() => toggleDuplicate(r.id, !(r.isDuplicate === true))}
+        isIneligible={r.ineligible === true}
+        ineligibleSaving={ineligibleSavingId === r.id}
+        ineligibleError={ineligibleSaveErrors[r.id]}
+        onToggleIneligible={() => toggleIneligible(r.id, !(r.ineligible === true))}
         lineItemDrafts={liDrafts}
         lineItemsSaving={lineItemsSavingId === r.id}
         lineItemsSaveError={lineItemsSaveErrors[r.id]}
@@ -1223,6 +1319,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     receiptSaveErrorCodes,
     duplicateSavingId,
     duplicateSaveErrors,
+    ineligibleSavingId,
+    ineligibleSaveErrors,
     lineItemDrafts,
     lineItemsSavingId,
     lineItemsSaveErrors,
@@ -1234,12 +1332,25 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // culatello-92104: duplicates are evidence-only — exclude their OCR
   // amounts from the receipt sum so admins see the corrected total. The
   // host PATCH recompute path (backend/payout.routes.ts) does the same.
+  // provola-92106: same exclusion for the ineligible flag. Both are
+  // independent toggles but identical math — the sum reflects only rows
+  // that count toward reimbursement.
   const ocrSum = receipts.reduce(
-    (sum, r) => sum + (r.isDuplicate ? 0 : (Number(r.ocrAmount) || 0)),
+    (sum, r) =>
+      sum + (r.isDuplicate || r.ineligible ? 0 : (Number(r.ocrAmount) || 0)),
     0,
   );
   const duplicateCount = receipts.reduce(
     (n, r) => n + (r.isDuplicate ? 1 : 0),
+    0,
+  );
+  // provola-92106: surface ineligible count separately so the sum line
+  // can render "($X dup excluded, $Y ineligible excluded)". Note: a row
+  // that's BOTH duplicate AND ineligible counts toward `duplicateCount`
+  // only (duplicate wins as the primary signal — same convention used by
+  // the thumbnail pill below).
+  const ineligibleCount = receipts.reduce(
+    (n, r) => n + (!r.isDuplicate && r.ineligible ? 1 : 0),
     0,
   );
 
@@ -1260,7 +1371,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         // culatello-92104: exclude admin-marked duplicates from the
         // original-currency totals + the extracted USD sum so the summary
         // line reflects the corrected payout.
+        // provola-92106: same for the ineligible flag — both feed the
+        // recomputed reimbursable total.
         !r.isDuplicate &&
+        !r.ineligible &&
         r.originalCurrency != null &&
         r.originalCurrency !== '' &&
         r.originalAmount != null &&
@@ -1663,6 +1777,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     // payment-app pizzas in the merged carousel.
                     const carouselIdx = pizzas.length + idx;
                     const isDup = doc.isDuplicate === true;
+                    // provola-92106: ineligible-but-not-duplicate gets its
+                    // own amber treatment. When BOTH flags are true, the
+                    // duplicate visual wins (red border + 45° stripes +
+                    // DUPLICATE pill) so the grid stays scannable. Admin
+                    // can still un-toggle either flag from the editor.
+                    const isIne = doc.ineligible === true && !isDup;
                     return (
                       <button
                         key={doc.id}
@@ -1684,15 +1804,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         // exclusion reads as "rejected" rather than just
                         // "inactive". The diagonal-stripe overlay below
                         // reinforces it further.
+                        // provola-92106: amber variant for ineligible.
                         className={`relative aspect-square rounded-lg overflow-hidden border group ${
                           isDup
                             ? 'opacity-50 border-red-500/60'
-                            : 'border-theme-stroke'
+                            : isIne
+                              ? 'opacity-60 border-amber-500/60'
+                              : 'border-theme-stroke'
                         }`}
                         title={
                           isDup
                             ? `[DUPLICATE — excluded from totals] ${doc.fileName}`
-                            : doc.fileName
+                            : isIne
+                              ? `[INELIGIBLE — excluded from totals] ${doc.fileName}`
+                              : doc.fileName
                         }
                       >
                         {isVideoFile(doc) ? (
@@ -1744,6 +1869,29 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         {isDup && (
                           <span className="absolute top-1 right-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-red-500 text-white">
                             duplicate
+                          </span>
+                        )}
+                        {/* provola-92106: 135° amber stripes on ineligible
+                            (but not duplicate) thumbnails. The angle is
+                            opposite the duplicate's 45° pattern so admins
+                            scanning the grid can tell at a glance which
+                            flag is on each excluded receipt. */}
+                        {isIne && (
+                          <span
+                            className="absolute inset-0 pointer-events-none"
+                            style={{
+                              backgroundImage:
+                                'repeating-linear-gradient(135deg, rgba(245,158,11,0.35) 0 4px, transparent 4px 8px)',
+                            }}
+                          />
+                        )}
+                        {/* provola-92106: INELIGIBLE pill mirrors duplicate's
+                            position so admins know what they're looking at
+                            without hovering. Amber background to match the
+                            rest of the ineligible treatment. */}
+                        {isIne && (
+                          <span className="absolute top-1 right-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-amber-500 text-white">
+                            ineligible
                           </span>
                         )}
                       </button>
@@ -2093,9 +2241,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     // culatello-92104: dim the row when marked duplicate +
                     // amber outline + pulse when admin clicked its thumbnail.
                     const isDup = r.isDuplicate === true;
+                    // provola-92106: amber row treatment for ineligible-but-
+                    // not-duplicate (duplicate's red wins when both).
+                    const isIne = r.ineligible === true && !isDup;
                     const isHighlighted = highlightedReceiptId === r.id;
                     const dupSaving = duplicateSavingId === r.id;
                     const dupError = duplicateSaveErrors[r.id];
+                    const ineSaving = ineligibleSavingId === r.id;
+                    const ineError = ineligibleSaveErrors[r.id];
                     return (
                       <li
                         key={r.id}
@@ -2105,7 +2258,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                             it. Pair with a red left border + faint red
                             background tint so the row visibly registers as
                             "excluded from totals" rather than just
-                            "inactive". */
+                            "inactive".
+                            provola-92106: amber variant for ineligible. */
                         className={`text-sm rounded ${
                           isHighlighted
                             ? 'ring-2 ring-amber-400 animate-pulse'
@@ -2113,7 +2267,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         } ${
                           isDup
                             ? 'opacity-60 border-l-4 border-red-500/60 bg-red-500/5 pl-2 py-1'
-                            : ''
+                            : isIne
+                              ? 'opacity-70 border-l-4 border-amber-500/60 bg-amber-500/5 pl-2 py-1'
+                              : ''
                         }`}
                       >
                         <div className="flex items-center gap-2">
@@ -2224,6 +2380,37 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                 )}
                                 {isDup ? 'Unmark duplicate' : 'Mark duplicate'}
                               </button>
+                              {/* provola-92106: per-row "Mark ineligible"
+                                  toggle. Same mechanics as the duplicate
+                                  button next to it — reversible, optimistic-
+                                  friendly, errors surface below. Distinct
+                                  from duplicate (legitimate purchase that
+                                  doesn't qualify for reimbursement — alcohol,
+                                  tips, personal items). Excluded from the
+                                  receipt OCR sum and the host PATCH
+                                  recompute path. */}
+                              <button
+                                type="button"
+                                onClick={() => toggleIneligible(r.id, !(r.ineligible === true))}
+                                disabled={ineSaving}
+                                className={`px-2 py-1 rounded text-xs disabled:opacity-40 inline-flex items-center gap-1 ${
+                                  r.ineligible === true
+                                    ? 'border border-amber-500 text-amber-500 hover:bg-amber-500/10'
+                                    : 'border border-theme-stroke text-theme-text hover:bg-theme-surface'
+                                }`}
+                                title={
+                                  r.ineligible === true
+                                    ? 'Un-mark this receipt as ineligible'
+                                    : 'Mark this receipt as ineligible for reimbursement (alcohol, tips, personal items — excluded from sums)'
+                                }
+                              >
+                                {ineSaving ? (
+                                  <Loader2 size={12} className="animate-spin" />
+                                ) : (
+                                  <AlertTriangle size={12} />
+                                )}
+                                {r.ineligible === true ? 'Unmark ineligible' : 'Mark ineligible'}
+                              </button>
                               {conf > 0 && (
                                 <span className={`text-xs ${lowConf ? 'text-amber-600' : 'text-theme-text-faint'}`}>
                                   {(conf * 100).toFixed(0)}%
@@ -2276,6 +2463,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                             separately from amount/currency save errors. */}
                         {dupError && (
                           <div className="text-xs text-red-600 mt-0.5 ml-4">{dupError}</div>
+                        )}
+                        {/* provola-92106: ineligible-toggle error. Amber
+                            instead of red to match the rest of the
+                            ineligible visual language. */}
+                        {ineError && (
+                          <div className="text-xs text-amber-600 mt-0.5 ml-4">{ineError}</div>
                         )}
                         {/* taralli-92104: collapsed line item editor. Caret
                             toggles expansion; on expand we seed the drafts
@@ -2470,6 +2663,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   {duplicateCount > 0 && (
                     <span className="ml-1 text-theme-text-faint">
                       (excludes {duplicateCount} duplicate{duplicateCount === 1 ? '' : 's'})
+                    </span>
+                  )}
+                  {/* provola-92106: parallel hint for ineligible exclusions.
+                      Rendered separately from duplicate so the two flags
+                      stay legible in the rare both-set case. */}
+                  {ineligibleCount > 0 && (
+                    <span className="ml-1 text-amber-400">
+                      (excludes {ineligibleCount} ineligible{ineligibleCount === 1 ? '' : 's'})
                     </span>
                   )}
                   {canEditReceipts && (
@@ -3513,6 +3714,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             duplicate. Only fires for the receipt bucket because lightboxReceipt
             is null when navigating pizza/event photos. */
         isDuplicate={lightboxReceipt?.isDuplicate === true}
+        /* provola-92106: parallel amber INELIGIBLE banner. Gated to NOT-also-
+            duplicate so the two banners don't fight (duplicate wins as the
+            primary signal when both are on — same convention used by the
+            thumbnail pill above). */
+        isIneligible={
+          lightboxReceipt?.ineligible === true
+          && lightboxReceipt?.isDuplicate !== true
+        }
       />
     </div>
   );

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -40,6 +40,7 @@ import { isVideoFile } from '../../lib/mediaUtils';
 import {
   updatePayoutDocument,
   markReceiptDuplicate,
+  markReceiptIneligible,
   retryPayoutDocumentOcr,
   flagPartyAsScam,
   POSSIBLE_SCAM_TAG,
@@ -460,6 +461,9 @@ function CityExpansion({
     ocrCurrency: string | null;
     ocrLineItems?: ReceiptLineItem[] | null;
     isDuplicate?: boolean;
+    // provola-92106: per-receipt ineligible flag override. Independent of
+    // `isDuplicate` — both can be true on the same row.
+    ineligible?: boolean;
     // caprino-92104: persist the FX recompute details so the lightbox
     // editor's "USD value @ rate" line refreshes immediately on save.
     originalAmount?: number | null;
@@ -477,6 +481,10 @@ function CityExpansion({
   // Mark-duplicate state.
   const [duplicateSavingId, setDuplicateSavingId] = useState<string | null>(null);
   const [duplicateSaveErrors, setDuplicateSaveErrors] = useState<Record<string, string>>({});
+  // provola-92106: Mark-ineligible state. Mirrors duplicate's scoping —
+  // separate buckets so a toggle failure on one doesn't clobber the other.
+  const [ineligibleSavingId, setIneligibleSavingId] = useState<string | null>(null);
+  const [ineligibleSaveErrors, setIneligibleSaveErrors] = useState<Record<string, string>>({});
   // Line-item editor state.
   const [lineItemDrafts, setLineItemDrafts] = useState<Record<string, LineItemDraft[]>>({});
   const [lineItemsSavingId, setLineItemsSavingId] = useState<string | null>(null);
@@ -507,6 +515,9 @@ function CityExpansion({
             ov.ocrLineItems !== undefined ? ov.ocrLineItems : e.doc.ocrLineItems,
           isDuplicate:
             ov.isDuplicate !== undefined ? ov.isDuplicate : e.doc.isDuplicate,
+          // provola-92106: layer in the ineligible override too.
+          ineligible:
+            ov.ineligible !== undefined ? ov.ineligible : e.doc.ineligible,
           // caprino-92104: layer the FX recompute fields so the lightbox
           // editor's "USD value @ rate" row refreshes without a refetch.
           originalAmount:
@@ -548,8 +559,14 @@ function CityExpansion({
     // OCR amounts from the "Receipts collected" rollup so the by-city tile
     // matches the per-payout modal's `ocrSum` semantics (which already
     // filters duplicates) and the host PATCH `survivingOcrSum` recompute.
+    // provola-92106: same exclusion for the ineligible flag — both filters
+    // share the same math.
     const receiptUsdTotal = receiptEntries.reduce(
-      (s, e) => s + (e.doc.isDuplicate ? 0 : (Number(e.doc.ocrAmount) || 0)),
+      (s, e) =>
+        s
+        + (e.doc.isDuplicate || e.doc.ineligible
+          ? 0
+          : (Number(e.doc.ocrAmount) || 0)),
       0,
     );
     const receiptCount = receiptEntries.length;
@@ -558,6 +575,14 @@ function CityExpansion({
     // proof the exclusion happened.
     const duplicateCount = receiptEntries.reduce(
       (n, e) => n + (e.doc.isDuplicate ? 1 : 0),
+      0,
+    );
+    // provola-92106: ineligible-but-not-also-duplicate count. The thumbnail
+    // pill + the rollup subtitle prefer duplicate as the primary signal
+    // when both flags are set, so this stays exclusive of the duplicate
+    // bucket to avoid double-counting in the "M dup + K ineligible" string.
+    const ineligibleCount = receiptEntries.reduce(
+      (n, e) => n + (!e.doc.isDuplicate && e.doc.ineligible ? 1 : 0),
       0,
     );
 
@@ -589,6 +614,7 @@ function CityExpansion({
       receiptUsdTotal,
       receiptCount,
       duplicateCount,
+      ineligibleCount,
       approvedUsd,
       paidUsd,
       outstandingUsd: Math.max(0, approvedUsd - paidUsd),
@@ -756,6 +782,10 @@ function CityExpansion({
           ocrCurrency: updated.ocrCurrency,
           ocrLineItems: updated.ocrLineItems,
           isDuplicate: updated.isDuplicate,
+          // provola-92106: carry through the server-authoritative ineligible
+          // flag so a prior toggle isn't lost when amount/currency is also
+          // edited.
+          ineligible: updated.ineligible,
           originalAmount: updated.originalAmount,
           originalCurrency: updated.originalCurrency,
           exchangeRate: updated.exchangeRate,
@@ -815,6 +845,8 @@ function CityExpansion({
             ocrCurrency: updated.ocrCurrency,
             ocrLineItems: updated.ocrLineItems,
             isDuplicate: updated.isDuplicate,
+            // provola-92106: server is authoritative on both flags.
+            ineligible: updated.ineligible,
           },
         };
       });
@@ -834,6 +866,62 @@ function CityExpansion({
       }));
     } finally {
       setDuplicateSavingId(null);
+    }
+  }, [receiptEntries]);
+
+  // provola-92106: toggle the per-receipt ineligible flag via the same
+  // PATCH /documents/:docId endpoint. Mirrors `toggleDuplicate` above —
+  // optimistic override, roll back on failure. Independent of the duplicate
+  // flag.
+  const toggleIneligible = useCallback(async (docId: string, nextValue: boolean) => {
+    setIneligibleSavingId(docId);
+    setIneligibleSaveErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    const prior = receiptEntries.find((e) => e.doc.id === docId)?.doc;
+    setReceiptOverrides((m) => {
+      const cur = m[docId] ?? {
+        ocrAmount: prior?.ocrAmount ?? null,
+        ocrCurrency: prior?.ocrCurrency ?? null,
+      };
+      return { ...m, [docId]: { ...cur, ineligible: nextValue } };
+    });
+    try {
+      const updated = await markReceiptIneligible(docId, nextValue);
+      setReceiptOverrides((m) => {
+        const cur = m[docId] ?? {
+          ocrAmount: updated.ocrAmount,
+          ocrCurrency: updated.ocrCurrency,
+        };
+        return {
+          ...m,
+          [docId]: {
+            ...cur,
+            ocrAmount: updated.ocrAmount,
+            ocrCurrency: updated.ocrCurrency,
+            ocrLineItems: updated.ocrLineItems,
+            isDuplicate: updated.isDuplicate,
+            ineligible: updated.ineligible,
+          },
+        };
+      });
+    } catch (err: any) {
+      setReceiptOverrides((m) => {
+        const cur = m[docId];
+        if (!cur) return m;
+        return {
+          ...m,
+          [docId]: { ...cur, ineligible: prior?.ineligible === true },
+        };
+      });
+      setIneligibleSaveErrors((m) => ({
+        ...m,
+        [docId]: err?.message || 'Failed to mark ineligible',
+      }));
+    } finally {
+      setIneligibleSavingId(null);
     }
   }, [receiptEntries]);
 
@@ -870,6 +958,8 @@ function CityExpansion({
     const drafts = lineItemDrafts[docId] ?? [];
     let sum = 0;
     for (const d of drafts) {
+      // provola-92106: ineligible lines stay out of the rolled-up amount.
+      if (d.ineligible === true) continue;
       const n = Number(d.subtotal);
       if (Number.isFinite(n) && n >= 0) sum += n;
     }
@@ -910,13 +1000,16 @@ function CityExpansion({
         if (!Number.isFinite(subtotal) || subtotal < 0) {
           throw new Error(`Line ${idx + 1}: subtotal must be a non-negative number`);
         }
-        return {
+        // provola-92106: persist per-line ineligible only when true.
+        const out: ReceiptLineItem = {
           name: d.name,
           qty,
           unitPrice,
           subtotal,
           category: d.category,
         };
+        if (d.ineligible === true) out.ineligible = true;
+        return out;
       });
       const updated = await updatePayoutDocument(docId, { ocrLineItems: items });
       setReceiptOverrides((m) => ({
@@ -926,6 +1019,8 @@ function CityExpansion({
           ocrCurrency: updated.ocrCurrency,
           ocrLineItems: updated.ocrLineItems,
           isDuplicate: updated.isDuplicate,
+          // provola-92106: carry through the ineligible flag too.
+          ineligible: updated.ineligible,
         },
       }));
       setLineItemDrafts((m) => ({
@@ -1003,7 +1098,11 @@ function CityExpansion({
           a.qty !== b.qty ||
           a.unitPrice !== b.unitPrice ||
           a.subtotal !== b.subtotal ||
-          a.category !== b.category
+          a.category !== b.category ||
+          // provola-92106: per-line ineligible flag is dirty-trackable too.
+          // Normalize both sides to boolean so undefined === false comparisons
+          // don't false-positive.
+          (a.ineligible === true) !== (b.ineligible === true)
         ) {
           return true;
         }
@@ -1073,6 +1172,10 @@ function CityExpansion({
         dupSaving={duplicateSavingId === r.id}
         dupError={duplicateSaveErrors[r.id]}
         onToggleDuplicate={() => toggleDuplicate(r.id, !(r.isDuplicate === true))}
+        isIneligible={r.ineligible === true}
+        ineligibleSaving={ineligibleSavingId === r.id}
+        ineligibleError={ineligibleSaveErrors[r.id]}
+        onToggleIneligible={() => toggleIneligible(r.id, !(r.ineligible === true))}
         lineItemDrafts={liDrafts}
         lineItemsSaving={lineItemsSavingId === r.id}
         lineItemsSaveError={lineItemsSaveErrors[r.id]}
@@ -1124,6 +1227,8 @@ function CityExpansion({
     receiptSaveErrorCodes,
     duplicateSavingId,
     duplicateSaveErrors,
+    ineligibleSavingId,
+    ineligibleSaveErrors,
     lineItemDrafts,
     lineItemsSavingId,
     lineItemsSaveErrors,
@@ -1185,12 +1290,20 @@ function CityExpansion({
           /* coppa-92105: when duplicates exist, append "M duplicate(s) excluded"
               so admins see at a glance that the USD total skipped them. The
               culatello-92104 modal does the same on its "Sum of OCR amounts"
-              footer; this is the city-level mirror. */
-          sub={
-            rollup.duplicateCount > 0
-              ? `${rollup.receiptCount} receipt${rollup.receiptCount === 1 ? '' : 's'}, ${rollup.duplicateCount} duplicate${rollup.duplicateCount === 1 ? '' : 's'} excluded`
-              : `${rollup.receiptCount} receipt${rollup.receiptCount === 1 ? '' : 's'}`
-          }
+              footer; this is the city-level mirror.
+              provola-92106: parallel "K ineligible excluded" hint. Both
+              counts can appear in the same string when the city has a mix. */
+          sub={(() => {
+            const base = `${rollup.receiptCount} receipt${rollup.receiptCount === 1 ? '' : 's'}`;
+            const parts: string[] = [base];
+            if (rollup.duplicateCount > 0) {
+              parts.push(`${rollup.duplicateCount} duplicate${rollup.duplicateCount === 1 ? '' : 's'} excluded`);
+            }
+            if (rollup.ineligibleCount > 0) {
+              parts.push(`${rollup.ineligibleCount} ineligible excluded`);
+            }
+            return parts.join(', ');
+          })()}
           accent="text-theme-text"
         />
         <RollupTile
@@ -1309,7 +1422,10 @@ function CityExpansion({
               // duplicate thumbnails so the by-city grid matches the per-
               // payout modal's left-pane grid (culatello-92104) and admins
               // can't miss that the receipt is excluded from the rollup.
+              // provola-92106: amber variant for ineligible (135° stripes +
+              // INELIGIBLE pill, but duplicate wins when both are on).
               const isDup = e.doc.isDuplicate === true;
+              const isIne = e.doc.ineligible === true && !isDup;
               return (
                 <button
                   key={e.doc.id}
@@ -1318,9 +1434,11 @@ function CityExpansion({
                   className={`group relative w-16 h-16 rounded-md overflow-hidden border hover:border-theme-stroke-hover ${
                     isDup
                       ? 'opacity-50 border-red-500/60'
-                      : 'border-theme-stroke'
+                      : isIne
+                        ? 'opacity-60 border-amber-500/60'
+                        : 'border-theme-stroke'
                   }`}
-                  title={`${isDup ? '[DUPLICATE — excluded from totals] ' : ''}${e.doc.fileName}${
+                  title={`${isDup ? '[DUPLICATE — excluded from totals] ' : isIne ? '[INELIGIBLE — excluded from totals] ' : ''}${e.doc.fileName}${
                     e.doc.uploadedByName || e.doc.uploadedByEmail
                       ? ` — uploaded by ${e.doc.uploadedByName || e.doc.uploadedByEmail}`
                       : ''
@@ -1352,6 +1470,24 @@ function CityExpansion({
                   {isDup && (
                     <span className="absolute top-1 right-1 text-[8px] uppercase font-bold px-1 py-0.5 rounded bg-red-500 text-white">
                       dup
+                    </span>
+                  )}
+                  {/* provola-92106: 135° amber stripes (opposite angle from
+                      duplicate's 45°) + INE pill so admins can scan the grid
+                      and tell at a glance which flag is on each excluded
+                      thumbnail. */}
+                  {isIne && (
+                    <span
+                      className="absolute inset-0 pointer-events-none"
+                      style={{
+                        backgroundImage:
+                          'repeating-linear-gradient(135deg, rgba(245,158,11,0.35) 0 4px, transparent 4px 8px)',
+                      }}
+                    />
+                  )}
+                  {isIne && (
+                    <span className="absolute top-1 right-1 text-[8px] uppercase font-bold px-1 py-0.5 rounded bg-amber-500 text-white">
+                      ine
                     </span>
                   )}
                   {e.doc.ocrAmount != null && (
@@ -1520,6 +1656,13 @@ function CityExpansion({
         isDuplicate={
           lightbox?.bucket === 'receipt'
           && lightboxReceipt?.isDuplicate === true
+        }
+        /* provola-92106: amber INELIGIBLE banner — gated to NOT-also-duplicate
+            so the two banners don't fight. Same bucket scoping as isDuplicate. */
+        isIneligible={
+          lightbox?.bucket === 'receipt'
+          && lightboxReceipt?.ineligible === true
+          && lightboxReceipt?.isDuplicate !== true
         }
       />
     </div>
@@ -1834,12 +1977,22 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
               let receiptUsdTotal = 0;
               let receiptCount = 0;
               let receiptDuplicateCount = 0;
+              // provola-92106: parallel "K ineligible excluded" counter for
+              // the outer cell subtitle. Counts ineligibles that aren't ALSO
+              // duplicate so the dup + ine counts don't overlap (duplicate
+              // wins as the primary signal — same convention used in the
+              // rollup tile + the per-payout modal sum line).
+              let receiptIneligibleCount = 0;
               for (const p of payouts) {
                 for (const d of p.documents || []) {
                   if (d.kind !== 'receipt') continue;
                   receiptCount += 1;
                   if (d.isDuplicate === true) {
                     receiptDuplicateCount += 1;
+                    continue;
+                  }
+                  if (d.ineligible === true) {
+                    receiptIneligibleCount += 1;
                     continue;
                   }
                   receiptUsdTotal += Number(d.ocrAmount) || 0;
@@ -1967,6 +2120,15 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                         {receiptDuplicateCount > 0 && (
                           <span className="ml-1 text-theme-text-faint">
                             ({receiptDuplicateCount} dup excluded)
+                          </span>
+                        )}
+                        {/* provola-92106: parallel hint for ineligible
+                            exclusions. Amber so admins reading the outer row
+                            can tell which type of exclusion happened without
+                            expanding. */}
+                        {receiptIneligibleCount > 0 && (
+                          <span className="ml-1 text-amber-400">
+                            ({receiptIneligibleCount} ine excluded)
                           </span>
                         )}
                       </div>

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -50,6 +50,11 @@ export type LineItemDraft = {
   unitPrice: string;
   subtotal: string;
   category: ReceiptLineItemCategory;
+  // provola-92106: per-line "ineligible for reimbursement" flag. When true
+  // the row strikes through + tints amber + is excluded from the live line
+  // sum + the "Use line sum" button output. Optional so admins who never
+  // touched the flag don't carry `false` through every line.
+  ineligible?: boolean;
 };
 
 interface ReceiptEditorProps {
@@ -71,6 +76,19 @@ interface ReceiptEditorProps {
   dupSaving: boolean;
   dupError?: string;
   onToggleDuplicate: () => void;
+
+  /**
+   * provola-92106: Mark-ineligible state. Mirrors the duplicate toggle —
+   * reversible, optimistic-friendly, errors surfaced inline. Distinct from
+   * duplicate (legitimate purchase but doesn't qualify for reimbursement
+   * — alcohol, tips, personal items). Both flags can be true on the same
+   * row; the UI prefers duplicate as the primary visual signal when both
+   * are set.
+   */
+  isIneligible: boolean;
+  ineligibleSaving: boolean;
+  ineligibleError?: string;
+  onToggleIneligible: () => void;
 
   /** Line items editor. */
   lineItemDrafts: LineItemDraft[] | undefined;
@@ -97,6 +115,10 @@ function draftSubtotalSum(drafts: LineItemDraft[] | undefined): number {
   if (!drafts) return 0;
   let sum = 0;
   for (const d of drafts) {
+    // provola-92106: skip lines the admin marked ineligible (alcohol, tips,
+    // personal items). The live sum + "Use line sum" button both rely on
+    // this helper so the receipt total reflects only reimbursable items.
+    if (d.ineligible === true) continue;
     const n = Number(d.subtotal);
     if (Number.isFinite(n) && n >= 0) sum += n;
   }
@@ -115,6 +137,10 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   dupSaving,
   dupError,
   onToggleDuplicate,
+  isIneligible,
+  ineligibleSaving,
+  ineligibleError,
+  onToggleIneligible,
   lineItemDrafts,
   lineItemsSaving,
   lineItemsSaveError,
@@ -159,14 +185,40 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
         edits they're making are on an excluded row. The dim is intentionally
         lighter than the thumbnail/right-row treatment (opacity-95 + tint)
         because the editor is interactive — admins still need to read the
-        inputs to un-mark. */
+        inputs to un-mark.
+
+        provola-92106: same treatment for the ineligible flag but in amber
+        (visually distinct from duplicate's red). When BOTH flags are set,
+        the duplicate styling wins as the primary signal — admins can still
+        un-toggle the ineligible flag from the checkbox below.
+    */
     <div
-      className={`p-4 space-y-4 text-theme-text ${
+      className={`relative p-4 space-y-4 text-theme-text ${
         isDuplicate
           ? 'border-l-4 border-red-500/60 bg-red-500/5'
-          : ''
+          : isIneligible
+            ? 'border-l-4 border-amber-500/60 bg-amber-500/5'
+            : ''
       }`}
     >
+      {/* provola-92106: 135° amber diagonal stripes overlay when the
+          receipt is admin-marked ineligible. Distinct from duplicate's
+          45° red stripes (the by-city + modal thumbnails use 45° / red);
+          the angle difference is intentional so admins can tell the two
+          flags apart at a glance even in dense grids. Pointer-events-none
+          + low opacity so admins can still interact with the inputs below.
+          Only renders when ineligible AND NOT duplicate so the two
+          patterns don't fight each other when both flags are on. */}
+      {isIneligible && !isDuplicate && (
+        <span
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              'repeating-linear-gradient(135deg, rgba(245,158,11,0.08) 0 6px, transparent 6px 14px)',
+          }}
+          aria-hidden="true"
+        />
+      )}
       {/* coppa-92105: DUPLICATE banner across the top of the editor when
           marked. Heavier than the per-row pill so it can't be missed even on
           a quick scan. */}
@@ -174,6 +226,17 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
         <div className="-mx-4 -mt-4 mb-2 px-4 py-2 bg-red-500/15 border-b border-red-500/40 text-red-300 text-xs font-bold uppercase tracking-wide flex items-center gap-2">
           <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
           Duplicate — excluded from all USD totals
+        </div>
+      )}
+      {/* provola-92106: INELIGIBLE banner — amber, distinct from duplicate's
+          red. Only shown when the receipt is NOT also marked duplicate
+          (duplicate wins as the primary signal so the banner area doesn't
+          get crowded; the admin can still see + un-toggle the ineligible
+          checkbox below). */}
+      {isIneligible && !isDuplicate && (
+        <div className="-mx-4 -mt-4 mb-2 px-4 py-2 bg-amber-500/15 border-b border-amber-500/40 text-amber-300 text-xs font-bold uppercase tracking-wide flex items-center gap-2">
+          <span className="inline-block w-2 h-2 rounded-full bg-amber-500" />
+          Ineligible — legitimate purchase, does not qualify for reimbursement
         </div>
       )}
       {/* Header */}
@@ -336,6 +399,41 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
         </div>
       )}
 
+      {/* provola-92106: Mark-ineligible row. Distinct from the duplicate
+          checkbox above — duplicates are bookkeeping deduplication;
+          ineligibles are legitimate purchases that don't qualify under the
+          reimbursement policy (alcohol, tips, personal items). Same
+          exclusion math, different visual + semantic. Helper text spells
+          out the difference inline so admins picking between the two flags
+          don't have to guess. */}
+      <div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Checkbox
+            checked={isIneligible}
+            onChange={onToggleIneligible}
+            label={
+              isIneligible
+                ? 'Marked as ineligible for reimbursement'
+                : 'Mark as ineligible for reimbursement'
+            }
+            disabled={ineligibleSaving}
+          />
+          {ineligibleSaving && (
+            <Loader2 size={12} className="animate-spin text-theme-text-muted" />
+          )}
+        </div>
+        <p className="text-xs text-white/40 mt-1">
+          Not a duplicate — this receipt is legitimate but doesn't qualify
+          (e.g. alcohol, tips, personal items). Excluded from all USD totals.
+        </p>
+        {ineligibleError && (
+          <div className="text-xs text-amber-300 flex items-start gap-1.5 mt-1">
+            <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
+            <span>{ineligibleError}</span>
+          </div>
+        )}
+      </div>
+
       {/* OCR retry — only visible when the doc errored. Keeps parity with
           the right-pane row's per-row retry affordance (pancetta-92104). */}
       {hasOcrError && onRetryOcr && (
@@ -371,6 +469,19 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
           </h4>
           <span className="text-xs text-theme-text-muted">
             Sum: {sumCurrency} {lineSum.toFixed(2)}
+            {/* provola-92106: when ineligible lines exist, note how many
+                were excluded from the live sum so admins see the math is
+                doing what they expect. */}
+            {(() => {
+              const ineligibleCount = (lineItemDrafts ?? []).filter(
+                (li) => li.ineligible === true,
+              ).length;
+              return ineligibleCount > 0 ? (
+                <span className="ml-1 text-amber-400">
+                  ({ineligibleCount} ineligible excluded)
+                </span>
+              ) : null;
+            })()}
           </span>
         </div>
         <div className="rounded-lg border border-theme-stroke bg-theme-bg p-2 space-y-1.5">
@@ -379,90 +490,127 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
               No line items yet. Click <span className="font-semibold">Add line</span> to start.
             </p>
           )}
-          {(lineItemDrafts ?? []).map((d, idx) => (
-            <div
-              key={idx}
-              className="flex flex-wrap items-center gap-1.5 sm:flex-nowrap"
-            >
-              {/*
-                taralli-92104 precedent: line-item rows are data-grid cells,
-                not form fields. Raw inputs keep the layout tight enough to
-                show all 5 columns + remove on one row. */}
-              <input
-                type="text"
-                value={d.name}
-                placeholder="name"
-                onChange={(e) =>
-                  onLineItemDraftChange(idx, { name: e.target.value })
-                }
-                className="flex-1 min-w-[120px] px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
-              />
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                inputMode="decimal"
-                value={d.qty}
-                placeholder="qty"
-                onChange={(e) =>
-                  onLineItemDraftChange(idx, { qty: e.target.value })
-                }
-                className="w-14 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
-              />
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                inputMode="decimal"
-                value={d.unitPrice}
-                placeholder="unit"
-                onChange={(e) =>
-                  onLineItemDraftChange(idx, { unitPrice: e.target.value })
-                }
-                className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
-              />
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                inputMode="decimal"
-                value={d.subtotal}
-                placeholder="subtotal"
-                onChange={(e) =>
-                  onLineItemDraftChange(idx, { subtotal: e.target.value })
-                }
-                className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
-              />
-              <select
-                value={d.category}
-                onChange={(e) =>
-                  onLineItemDraftChange(idx, {
-                    category: e.target.value as ReceiptLineItemCategory,
-                  })
-                }
-                className="px-1 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
-                title="Category — pizza-prices analytics filters on 'pizza'"
+          {(lineItemDrafts ?? []).map((d, idx) => {
+            // provola-92106: when admin unchecks the Eligible box for this
+            // line, strike through the row + tint amber so it's visually
+            // distinct from active lines. Reuses the same amber palette the
+            // receipt-level ineligible flag uses for consistency. The live
+            // sum + "Use line sum" both already exclude ineligible lines via
+            // `draftSubtotalSum`.
+            const lineIneligible = d.ineligible === true;
+            return (
+              <div
+                key={idx}
+                className={`flex flex-wrap items-center gap-1.5 sm:flex-nowrap rounded ${
+                  lineIneligible
+                    ? 'bg-amber-500/10 line-through text-theme-text-muted'
+                    : ''
+                }`}
               >
-                <option value="pizza">pizza</option>
-                <option value="beverage">beverage</option>
-                <option value="topping">topping</option>
-                <option value="side">side</option>
-                <option value="dessert">dessert</option>
-                <option value="tax">tax</option>
-                <option value="tip">tip</option>
-                <option value="fee">fee</option>
-                <option value="other">other</option>
-              </select>
-              <button
-                type="button"
-                onClick={() => onRemoveLineItem(idx)}
-                className="p-1 rounded text-theme-text-muted hover:text-red-500 hover:bg-red-50"
-                title="Remove this line"
-              >
-                <Trash2 size={12} />
-              </button>
-            </div>
-          ))}
+                {/*
+                  taralli-92104 precedent: line-item rows are data-grid cells,
+                  not form fields. Raw inputs keep the layout tight enough to
+                  show all 5 columns + remove on one row. */}
+                <input
+                  type="text"
+                  value={d.name}
+                  placeholder="name"
+                  onChange={(e) =>
+                    onLineItemDraftChange(idx, { name: e.target.value })
+                  }
+                  className="flex-1 min-w-[120px] px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
+                />
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  inputMode="decimal"
+                  value={d.qty}
+                  placeholder="qty"
+                  onChange={(e) =>
+                    onLineItemDraftChange(idx, { qty: e.target.value })
+                  }
+                  className="w-14 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                />
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  inputMode="decimal"
+                  value={d.unitPrice}
+                  placeholder="unit"
+                  onChange={(e) =>
+                    onLineItemDraftChange(idx, { unitPrice: e.target.value })
+                  }
+                  className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                />
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  inputMode="decimal"
+                  value={d.subtotal}
+                  placeholder="subtotal"
+                  onChange={(e) =>
+                    onLineItemDraftChange(idx, { subtotal: e.target.value })
+                  }
+                  className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                />
+                <select
+                  value={d.category}
+                  onChange={(e) =>
+                    onLineItemDraftChange(idx, {
+                      category: e.target.value as ReceiptLineItemCategory,
+                    })
+                  }
+                  className="px-1 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs"
+                  title="Category — pizza-prices analytics filters on 'pizza'"
+                >
+                  <option value="pizza">pizza</option>
+                  <option value="beverage">beverage</option>
+                  <option value="topping">topping</option>
+                  <option value="side">side</option>
+                  <option value="dessert">dessert</option>
+                  <option value="tax">tax</option>
+                  <option value="tip">tip</option>
+                  <option value="fee">fee</option>
+                  <option value="other">other</option>
+                </select>
+                {/* provola-92106: per-line Eligible checkbox. Inverted
+                    semantics from the persisted `ineligible` flag — admin
+                    sees "Eligible (checked = included)" instead of "mark
+                    ineligible". Checked by default for existing items so the
+                    UI matches the historical behavior (everything counts
+                    until admin says otherwise). Tooltip clarifies what
+                    unchecking does. */}
+                <label
+                  className="inline-flex items-center gap-1 text-[10px] text-theme-text-muted px-1"
+                  title="Uncheck to exclude this line from reimbursement (alcohol, tip, personal item, etc.)"
+                >
+                  <input
+                    type="checkbox"
+                    checked={!lineIneligible}
+                    onChange={(e) =>
+                      onLineItemDraftChange(idx, {
+                        ineligible: !e.target.checked,
+                      })
+                    }
+                    className="rounded border-theme-stroke-hover"
+                    aria-label="Eligible for reimbursement"
+                  />
+                  Eligible
+                </label>
+                <button
+                  type="button"
+                  onClick={() => onRemoveLineItem(idx)}
+                  className="p-1 rounded text-theme-text-muted hover:text-red-500 hover:bg-red-50"
+                  title="Remove this line"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            );
+          })}
           <div className="flex flex-wrap items-center gap-2 pt-1">
             <button
               type="button"
@@ -518,6 +666,10 @@ export function lineItemToDraft(item: ReceiptLineItem): LineItemDraft {
     unitPrice: String(item.unitPrice ?? 0),
     subtotal: String(item.subtotal ?? 0),
     category: item.category ?? 'other',
+    // provola-92106: carry through the per-line ineligible flag (jsonb
+    // additive field — older items + items the admin never touched just
+    // omit it, which maps to "eligible").
+    ineligible: item.ineligible === true ? true : undefined,
   };
 }
 

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -76,6 +76,13 @@ interface ReceiptLightboxProps {
    * used to pick `editorPane`. Pure visual — no behavior change.
    */
   isDuplicate?: boolean;
+  /**
+   * provola-92106: same as `isDuplicate` but for the ineligible flag —
+   * amber INELIGIBLE banner + 135° amber stripe overlay. When both flags
+   * are true, the duplicate visual wins (parent should pass `isIneligible`
+   * as false when also passing `isDuplicate=true`). Pure visual.
+   */
+  isIneligible?: boolean;
 }
 
 /** Some HEIC files come through with non-image/heic MIME types or no MIME at
@@ -99,6 +106,7 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   onBeforeNavigate,
   onDuplicateShortcut,
   isDuplicate = false,
+  isIneligible = false,
 }) => {
   // Index lives in this component so callers only need to pass the starting
   // image. Reset whenever the lightbox is (re-)opened so each open starts
@@ -297,6 +305,24 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
                 style={{
                   backgroundImage:
                     'repeating-linear-gradient(45deg, rgba(239,68,68,0.18) 0 6px, transparent 6px 14px)',
+                }}
+              />
+            </>
+          )}
+          {/* provola-92106: parallel INELIGIBLE banner — amber, 135° stripes
+              (distinct from duplicate's red / 45°). Rendered only when NOT
+              also duplicate so the two patterns don't fight when both are
+              on (duplicate wins as the primary signal per task spec). */}
+          {isIneligible && !isDuplicate && (
+            <>
+              <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 px-3 py-1 rounded-full bg-amber-500 text-white text-xs font-bold uppercase tracking-wide shadow-lg pointer-events-none">
+                Ineligible — excluded from totals
+              </div>
+              <div
+                className="absolute inset-0 z-10 pointer-events-none"
+                style={{
+                  backgroundImage:
+                    'repeating-linear-gradient(135deg, rgba(245,158,11,0.18) 0 6px, transparent 6px 14px)',
                 }}
               />
             </>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4317,6 +4317,11 @@ export async function updatePayoutDocument(
     ocrLineItems?: ReceiptLineItem[] | null;
     // culatello-92104: admin-toggleable duplicate flag. Reversible.
     isDuplicate?: boolean;
+    // provola-92106: admin-toggleable "ineligible for reimbursement" flag.
+    // Distinct from `isDuplicate` (legitimate purchase but doesn't qualify
+    // under policy — alcohol, tips, personal items). Reversible. Same
+    // exclusion semantics as `isDuplicate` everywhere it's read.
+    ineligible?: boolean;
   },
 ): Promise<{
   id: string;
@@ -4333,6 +4338,9 @@ export async function updatePayoutDocument(
   exchangeRate: number | null;
   ocrLineItems: ReceiptLineItem[] | null;
   isDuplicate: boolean;
+  // provola-92106: echoed back so callers can sync their optimistic
+  // override against the server-authoritative value after PATCH.
+  ineligible: boolean;
   ocrError: string | null;
   sortOrder: number;
   uploadedByUserId: string | null;
@@ -4355,6 +4363,22 @@ export async function markReceiptDuplicate(
   isDuplicate: boolean,
 ) {
   return updatePayoutDocument(docId, { isDuplicate });
+}
+
+/**
+ * provola-92106: typed wrapper for the per-receipt "Mark ineligible" toggle.
+ * Mirrors `markReceiptDuplicate` above. Semantically distinct from duplicate
+ * — ineligibles are legitimate purchases the host paid for that don't
+ * qualify under the reimbursement policy (alcohol, tips, personal items).
+ * Reversible — pass `false` to un-mark. Independent of `isDuplicate` (both
+ * flags can be true on the same row, though the UI prefers duplicate as the
+ * primary visual signal).
+ */
+export async function markReceiptIneligible(
+  docId: string,
+  ineligible: boolean,
+) {
+  return updatePayoutDocument(docId, { ineligible });
 }
 
 /**

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1686,6 +1686,12 @@ export interface PayoutDocument {
   // the host PATCH finalAmountUsd recompute path. Optional on the wire so
   // older cached payloads still type-check.
   isDuplicate?: boolean;
+  // provola-92106: admin-marked "ineligible for reimbursement" flag.
+  // Distinct from `isDuplicate` — this is a legitimate purchase that
+  // doesn't qualify under policy (alcohol, tips, personal items). Same
+  // exclusion semantics as `isDuplicate` (USD sums + recompute paths).
+  // Optional on the wire so older cached payloads still type-check.
+  ineligible?: boolean;
   ocrError: string | null;
   sortOrder: number;
   // pancetta-37195: per-doc uploader attribution. Null on historical rows
@@ -1719,6 +1725,13 @@ export interface ReceiptLineItem {
   unitPrice: number;
   subtotal: number;
   category: ReceiptLineItemCategory;
+  // provola-92106: per-line "ineligible for reimbursement" flag. Stored
+  // alongside the other fields in the `payout_documents.ocr_line_items`
+  // jsonb column (no schema change). When true the row is excluded from
+  // the receipt's live line sum + the "Use line sum" button. Optional on
+  // the wire — older cached payloads + items the admin never touched
+  // simply omit the field instead of carrying `false`.
+  ineligible?: boolean;
 }
 
 export interface BankDetails {

--- a/scripts/apply-provola-92106-migration.cjs
+++ b/scripts/apply-provola-92106-migration.cjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * provola-92106: add `ineligible boolean` to payout_documents +
+ * grant column-level SELECT to anon/authenticated. Mirrors the
+ * culatello-92104 `is_duplicate` migration pattern.
+ *
+ * Run from rsvpizza root:
+ *   DATABASE_URL=... node .claude/worktrees/agent-a4ff5cee72ace5cb3/scripts/apply-provola-92106-migration.cjs
+ *
+ * Idempotent — uses IF NOT EXISTS for the column add and re-grants are no-ops.
+ */
+const { Client } = require('pg');
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+  const client = new Client({ connectionString: url });
+  await client.connect();
+
+  try {
+    console.log('-- Adding payout_documents.ineligible ...');
+    await client.query(`
+      ALTER TABLE payout_documents
+      ADD COLUMN IF NOT EXISTS ineligible boolean NOT NULL DEFAULT false;
+    `);
+
+    console.log('-- Granting column-level SELECT to anon, authenticated ...');
+    await client.query(`
+      GRANT SELECT (ineligible) ON payout_documents TO anon, authenticated;
+    `);
+
+    const { rows } = await client.query(`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_name = 'payout_documents'
+        AND column_name = 'ineligible';
+    `);
+    console.log('-- post-migration:', rows);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds two new exclusion flags distinct from duplicate (culatello-92104): `payout_documents.ineligible` (whole receipt) and `ocr_line_items[].ineligible` (per-line). Semantically not a dup — a legitimate purchase that doesn't qualify (alcohol, tips, personal items).
- Visual: amber tint + 135 deg diagonal stripes + INELIGIBLE pill (distinct from duplicate's red 45 deg pattern). When BOTH flags are on, duplicate wins as the primary signal.
- Excluded everywhere duplicate is excluded: reviewer modal `ocrSum`, by-city `receiptUsdTotal`, host PATCH `survivingOcrSum` recompute, pizza-prices analytics, line-item sums + "Use line sum" button.

## Schema
- New column `payout_documents.ineligible boolean NOT NULL DEFAULT false` (migration `20260530000000_add_payout_documents_ineligible`, already applied to prod via `scripts/apply-provola-92106-migration.cjs`).
- Column-level `GRANT SELECT (ineligible) ON payout_documents TO anon, authenticated`.
- Per-line flag is a jsonb additive field on `ocr_line_items` — no schema change.

## Backend
- `PATCH /api/admin/payouts/documents/:docId` accepts `ineligible: boolean` and persists it (strict-boolean validation, audit row on transitions, `edit_documents` action).
- Same endpoint's `sanitizeLineItem` accepts `ineligible?: boolean` per-line (only emitted when true).
- `survivingOcrSum` in `payout.routes.ts` host PATCH path filters `isDuplicate || ineligible`.
- Pizza-prices analytics `where` clause adds `ineligible: false`.
- Host-side serializer untouched — admin-only state (same convention as `isDuplicate`).

## Frontend
- `ReceiptEditor` adds receipt-level "Mark as ineligible for reimbursement" checkbox + helper text; per-line "Eligible" checkbox (default checked, unchecking strikes the row + tints amber + excludes from live sum).
- `PayoutReviewModal` + `PayoutsByPartyTable` mirror the duplicate state pattern: `ineligibleSavingId` + `ineligibleSaveErrors`, `toggleIneligible` callback (optimistic + rollback), per-row "Mark ineligible" button, amber row tint, INE/INELIGIBLE pill on thumbnails, "K ineligible excluded" subtitle on the rollup tile + outer city row + sum line.
- `ReceiptLightbox` adds `isIneligible` prop — amber 135 deg stripe overlay + INELIGIBLE banner, gated to NOT-also-duplicate so the two banners don't fight.
- API: `markReceiptIneligible(docId, ineligible)` typed wrapper.

## Test plan
- [ ] Mark a receipt ineligible from the reviewer modal -> amber tint + pill -> sum line + parent finalAmountUsd recompute exclude it.
- [ ] Mark a single line item ineligible (uncheck Eligible) -> row strikes through + tints amber -> live sum + "Use line sum" updates.
- [ ] Receipt that's BOTH duplicate AND ineligible -> duplicate visual wins on thumbnails / lightbox; admin can still un-toggle either flag from the editor.
- [ ] By-city expansion: "Receipts collected" tile shows "N receipts, M duplicate(s) excluded, K ineligible excluded" with the correct counts.
- [ ] Outer city row receipt cell shows "(M dup excluded) (K ine excluded)" hint when applicable.
- [ ] Pizza-prices `/api/admin/payouts/pizza-prices` excludes both duplicate and ineligible rows.