### PR TITLE
feat(mortadella-92106): city-level admin notes

### DIFF
--- a/backend/prisma/migrations/20260530143011_add_party_admin_notes/migration.sql
+++ b/backend/prisma/migrations/20260530143011_add_party_admin_notes/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable: mortadella-92106 — admin-only city-level notes on parties.
+-- Free-text scratchpad for the /payments by-city expansion. Distinct from
+-- per-payout `payouts.admin_notes` (which is on the Payout model) and from
+-- `parties.underboss_notes` (visible to underbosses). This column is gated
+-- to admins on read AND write.
+--
+-- GRANT SELECT only to `authenticated`, NOT to `anon`. Server-side admin
+-- gating in the route handler + serializer is the primary protection;
+-- this is defense-in-depth.
+ALTER TABLE "parties" ADD COLUMN "admin_notes" TEXT;
+
+GRANT SELECT ("admin_notes") ON "parties" TO authenticated;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -199,6 +199,13 @@ model Party {
   statusAudit     PartyStatusAudit[]
   hostTags        Json               @default("[]") @map("host_tags")
   underbossNotes  String?            @map("underboss_notes")
+  // mortadella-92106: admin-only city-level notes shown on the /payments
+  // by-city expansion. Free-text scratchpad for context like "host
+  // unresponsive", "follow up with city org", "claim disputed", etc.
+  // Distinct from per-payout `Payout.adminNotes` and from `underbossNotes`
+  // (visible to underbosses). Read AND write are gated to admins; the
+  // by-party serializer omits this field for underboss viewers.
+  adminNotes      String?            @map("admin_notes")
 
   // GPP (Global Pizza Party/Previous year) photo management
   hiddenGppPhotos Json @default("[]") @map("hidden_gpp_photos") // Array of hidden app.gpp.day photo src paths
@@ -287,15 +294,15 @@ model Party {
 // keyed on guestId (unique). EXPLICIT @@map so Prisma uses the actual table
 // name instead of inferring it.
 model SurveyResponse {
-  id                 String   @id @default(uuid()) @db.Uuid
-  partyId            String   @map("party_id") @db.Uuid
-  party              Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  guestId            String   @unique @map("guest_id") @db.Uuid
-  guest              Guest    @relation(fields: [guestId], references: [id], onDelete: Cascade)
+  id                 String    @id @default(uuid()) @db.Uuid
+  partyId            String    @map("party_id") @db.Uuid
+  party              Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  guestId            String    @unique @map("guest_id") @db.Uuid
+  guest              Guest     @relation(fields: [guestId], references: [id], onDelete: Cascade)
   email              String
-  questionSetVersion Int      @map("question_set_version")
+  questionSetVersion Int       @map("question_set_version")
   answers            Json
-  submittedAt        DateTime @default(now()) @map("submitted_at") @db.Timestamptz
+  submittedAt        DateTime  @default(now()) @map("submitted_at") @db.Timestamptz
   updatedAt          DateTime? @map("updated_at") @db.Timestamptz
 
   @@index([partyId])
@@ -1765,38 +1772,38 @@ model PartyPaymentOptIn {
 }
 
 model PayoutDocument {
-  id               String   @id @default(uuid()) @db.Uuid
+  id               String    @id @default(uuid()) @db.Uuid
   // agnolotti-58291: receipts are now PARTY-level. `partyId` is the canonical
   // owner (NOT NULL, CASCADE on party delete). `payoutId` is optional and is
   // the submission this receipt was uploaded with; it goes NULL via SET NULL
   // cascade if the payout row is later hard-deleted, so receipts survive.
-  partyId          String   @map("party_id") @db.Uuid
-  party            Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
-  payoutId         String?  @map("payout_id") @db.Uuid
-  payout           Payout?  @relation(fields: [payoutId], references: [id], onDelete: SetNull)
+  partyId          String    @map("party_id") @db.Uuid
+  party            Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  payoutId         String?   @map("payout_id") @db.Uuid
+  payout           Payout?   @relation(fields: [payoutId], references: [id], onDelete: SetNull)
   kind             String // 'pizza' | 'receipt'
   url              String
-  fileName         String   @map("file_name")
-  fileSize         Int      @map("file_size")
-  mimeType         String   @map("mime_type")
-  ocrAmount        Decimal? @map("ocr_amount") @db.Decimal(12, 2)
-  ocrCurrency      String?  @map("ocr_currency")
-  ocrConfidence    Decimal? @map("ocr_confidence") @db.Decimal(3, 2)
+  fileName         String    @map("file_name")
+  fileSize         Int       @map("file_size")
+  mimeType         String    @map("mime_type")
+  ocrAmount        Decimal?  @map("ocr_amount") @db.Decimal(12, 2)
+  ocrCurrency      String?   @map("ocr_currency")
+  ocrConfidence    Decimal?  @map("ocr_confidence") @db.Decimal(3, 2)
   // mortadella-92103: per-receipt FX persistence so non-USD receipts can be
   // re-converted in-place when the admin corrects the currency, and so the
   // reviewer modal can render the original-currency amount per receipt
   // without re-parsing ocrRaw. ocrAmount stays the USD-converted value.
-  originalAmount   Decimal? @map("original_amount") @db.Decimal(14, 4)
-  originalCurrency String?  @map("original_currency") @db.Char(3)
-  exchangeRate     Decimal? @map("exchange_rate") @db.Decimal(18, 8)
-  ocrRaw           Json?    @map("ocr_raw")
+  originalAmount   Decimal?  @map("original_amount") @db.Decimal(14, 4)
+  originalCurrency String?   @map("original_currency") @db.Char(3)
+  exchangeRate     Decimal?  @map("exchange_rate") @db.Decimal(18, 8)
+  ocrRaw           Json?     @map("ocr_raw")
   // formaggi-89172: structured per-line items extracted from the receipt OCR.
   // Schema is OcrLineItem[] (see backend/src/services/ocr.service.ts) — each
   // entry has name, qty, unitPrice, subtotal, category. Stored as JSONB with a
   // GIN index (`idx_payout_documents_ocr_line_items`) to support future
   // analytics queries (e.g. average pizza prices by country/city).
-  ocrLineItems     Json?    @map("ocr_line_items")
-  ocrError         String?  @map("ocr_error")
+  ocrLineItems     Json?     @map("ocr_line_items")
+  ocrError         String?   @map("ocr_error")
   // pancetta-92104: timestamp + attempt-count for the line-items backfill
   // loop. The backfill used to query `ocr_line_items IS NULL` candidates
   // unconditionally, so docs whose `analyzeReceipt` threw (OpenAI 429, bad
@@ -1810,10 +1817,10 @@ model PayoutDocument {
   // pancetta-37195: per-receipt uploader attribution. Both nullable so
   // historical rows are valid. uploadedByEmail caches the email at upload
   // time so display still works if the User is later deleted.
-  uploadedByUserId String?  @map("uploaded_by_user_id")
-  uploadedByEmail  String?  @map("uploaded_by_email")
-  uploadedBy       User?    @relation("PayoutDocumentUploadedBy", fields: [uploadedByUserId], references: [id], onDelete: SetNull)
-  sortOrder        Int      @default(0) @map("sort_order")
+  uploadedByUserId String?   @map("uploaded_by_user_id")
+  uploadedByEmail  String?   @map("uploaded_by_email")
+  uploadedBy       User?     @relation("PayoutDocumentUploadedBy", fields: [uploadedByUserId], references: [id], onDelete: SetNull)
+  sortOrder        Int       @default(0) @map("sort_order")
   // culatello-92104: admin-flagged duplicate receipts. Visually dimmed in the
   // reviewer modal, excluded from the OCR sum, and ignored by the host PATCH
   // finalAmountUsd recompute path so admin edits propagate correctly. The

--- a/backend/src/routes/admin-party.routes.ts
+++ b/backend/src/routes/admin-party.routes.ts
@@ -330,4 +330,93 @@ router.post(
   },
 );
 
+/**
+ * PATCH /api/admin/parties/:partyId/admin-notes — mortadella-92106
+ *
+ * Free-text admin-only city notes used on the /payments by-city expansion.
+ * Distinct from per-payout `payouts.admin_notes` (per-row, scoped to one
+ * payout) and `parties.underboss_notes` (visible to underbosses). Examples:
+ * "host is unresponsive", "follow up with city org", "claim disputed",
+ * "needs translator".
+ *
+ * Auth: admin / super_admin / payment_admin only. Underbosses never see the
+ * column on read (stripped in the by-party serializer) and cannot write here.
+ *
+ * Body: { notes: string | null }  — null or empty string clears the field.
+ *
+ * Audit: lightweight console.log (mirrors the bottarga-92104 `possible-scam`
+ * audit pattern) — the column itself + git/log retention is the durable
+ * signal, and city-notes edits are reversible.
+ */
+router.patch(
+  '/:partyId/admin-notes',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const raw = (req.body ?? {}).notes;
+
+      if (raw !== null && raw !== undefined && typeof raw !== 'string') {
+        throw new AppError('notes must be a string or null', 400, 'VALIDATION_ERROR');
+      }
+
+      // Trim + treat empty as null so the DB column stays clean (no "" rows).
+      // Cap at 4000 chars — generous for context but bounded so we don't ship
+      // novels through PATCH.
+      let nextValue: string | null;
+      if (raw === null || raw === undefined) {
+        nextValue = null;
+      } else {
+        const trimmed = raw.trim();
+        if (trimmed.length === 0) {
+          nextValue = null;
+        } else if (trimmed.length > 4000) {
+          throw new AppError(
+            'notes must be 4000 characters or fewer',
+            400,
+            'VALIDATION_ERROR',
+          );
+        } else {
+          nextValue = trimmed;
+        }
+      }
+
+      // Verify the party exists before updating so we 404 cleanly instead of
+      // surfacing a Prisma RecordNotFound.
+      const existing = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { id: true, adminNotes: true },
+      });
+      if (!existing) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      const updated = await prisma.party.update({
+        where: { id: partyId },
+        data: { adminNotes: nextValue },
+        select: { id: true, adminNotes: true },
+      });
+
+      console.log(
+        `[mortadella-92106][city-admin-notes] party=${partyId} actor=${
+          req.userEmail ?? 'unknown'
+        } prev_len=${existing.adminNotes?.length ?? 0} next_len=${
+          updated.adminNotes?.length ?? 0
+        } at=${new Date().toISOString()}`,
+      );
+
+      res.json({
+        ok: true,
+        party: {
+          id: updated.id,
+          adminNotes: updated.adminNotes,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 export default router;

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -121,6 +121,10 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   // ✓ Closed pill on the by-city table + hides the Mark Paid affordance for
   // already-closed parties.
   paymentsClosedAt: true,
+  // mortadella-92106: admin-only city notes. Surfaced in the by-city
+  // expansion for admin viewers and stripped from the response for
+  // underbosses (see serializer below).
+  adminNotes: true,
   _count: {
     select: {
       guests: {
@@ -1813,6 +1817,14 @@ router.get(
             paymentsClosedAt: b.partyMeta.paymentsClosedAt
               ? b.partyMeta.paymentsClosedAt.toISOString()
               : null,
+            // mortadella-92106: admin-only city notes. Stripped to null for
+            // underboss viewers so they never see the text — both the input
+            // and the gating on the frontend are belt-and-braces but this
+            // is the canonical server-side gate.
+            adminNotes:
+              req.viewerRole === 'admin'
+                ? (b.partyMeta.adminNotes ?? null)
+                : null,
           },
           aggregates: {
             pendingCount: b.pendingCount,

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -19,7 +19,11 @@ import {
   Play,
   AlertTriangle,
   MessageCircle,
+  Check,
+  AlertCircle,
+  StickyNote,
 } from 'lucide-react';
+import { IconInput } from '../IconInput';
 import type {
   AdminPayout,
   AdminPayoutEventPhoto,
@@ -46,6 +50,7 @@ import {
   flagPartyAsScam,
   POSSIBLE_SCAM_TAG,
   sendTgReceiptsReminder,
+  setCityAdminNotes,
 } from '../../lib/api';
 import {
   ReceiptEditor,
@@ -517,6 +522,7 @@ function CityExpansion({
   onRowClick,
   busyRowId,
   canEditReceipts,
+  canEditAdminNotes,
 }: {
   row: PartyPayoutsRow;
   selectedIds: Set<string>;
@@ -529,6 +535,13 @@ function CityExpansion({
    * the plain photo-only lightbox.
    */
   canEditReceipts: boolean;
+  /**
+   * mortadella-92106: gates the city-level admin notes textarea (read AND
+   * write). True for admin / super_admin / payment_admin. Underbosses don't
+   * see the input at all — they also receive `row.party.adminNotes === null`
+   * from the server, so this is belt-and-braces.
+   */
+  canEditAdminNotes: boolean;
 }) {
   // Hooks-above-early-returns: all useState / useMemo / useCallback live up
   // front so adding a conditional return below can't change hook order.
@@ -592,6 +605,21 @@ function CityExpansion({
   // Tracks which receipt index in the bucket carousel is currently displayed
   // so we can rebuild the editor pane for the right doc on arrow-key nav.
   const [lightboxCurrentIndex, setLightboxCurrentIndex] = useState<number | null>(null);
+
+  // mortadella-92106: city-level admin notes state. `noteDraft` is the
+  // working value the textarea binds to so the admin can type freely before
+  // the autosave-on-blur fires. Initial value comes from `row.party.adminNotes`
+  // (server-supplied; null for underbosses). `noteSaveStatus` drives the
+  // inline "Saved" / "Saving…" / "Save failed" indicator and is intentionally
+  // unionized like PaymentDetailsCard so the same render branches work.
+  const [noteDraft, setNoteDraft] = useState<string>(row.party.adminNotes ?? '');
+  const [noteSaveStatus, setNoteSaveStatus] = useState<
+    'idle' | 'saving' | 'saved' | 'error'
+  >('idle');
+  const [noteSaveError, setNoteSaveError] = useState<string | null>(null);
+  // Last value that was successfully persisted — used to detect "no-op on
+  // blur" so we don't fire a PATCH when the admin tabs away without editing.
+  const [noteSaved, setNoteSaved] = useState<string>(row.party.adminNotes ?? '');
 
   // Merge receipts across all payouts on the party — multi-host pot. Layers
   // `receiptOverrides` (pesto-92105) on top so saves reflect immediately.
@@ -1220,6 +1248,37 @@ function CityExpansion({
     toggleDuplicate(lightboxReceipt.id, !(lightboxReceipt.isDuplicate === true));
   }, [lightboxReceipt, toggleDuplicate]);
 
+  // mortadella-92106: autosave-on-blur for the city-level admin notes.
+  // Optimistic — the textarea binds to `noteDraft` and the typed value is
+  // visible immediately. On blur we PATCH only when the draft differs from
+  // the last-saved value; on failure we surface an inline error and roll the
+  // local "saved" anchor back to `noteSaved` (no rollback of the textarea
+  // contents — the admin can fix and re-blur to retry).
+  const handleSaveAdminNotes = useCallback(async () => {
+    if (!canEditAdminNotes) return;
+    const trimmed = noteDraft.trim();
+    const next = trimmed.length === 0 ? null : trimmed;
+    const prev = noteSaved.trim().length === 0 ? null : noteSaved;
+    if (next === prev) {
+      // No-op blur (admin tabbed away without editing) — don't fire a PATCH.
+      return;
+    }
+    setNoteSaveStatus('saving');
+    setNoteSaveError(null);
+    try {
+      const result = await setCityAdminNotes(row.party.id, next);
+      setNoteSaved(result.adminNotes ?? '');
+      setNoteSaveStatus('saved');
+      // Clear the "Saved" badge after a moment so it doesn't stick.
+      window.setTimeout(() => {
+        setNoteSaveStatus((s) => (s === 'saved' ? 'idle' : s));
+      }, 1800);
+    } catch (err: any) {
+      setNoteSaveStatus('error');
+      setNoteSaveError(err?.message || 'Failed to save city notes');
+    }
+  }, [canEditAdminNotes, noteDraft, noteSaved, row.party.id]);
+
   // pesto-92105: build the editor pane for the lightbox. Gated to receipt
   // bucket + admin viewer; null for event/pizza photos and underbosses (the
   // lightbox then renders its plain photo-only layout).
@@ -1375,6 +1434,55 @@ function CityExpansion({
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {/*
+        mortadella-92106: city-level admin notes (admin-only). Free-text
+        scratchpad for context that doesn't fit per-payout notes:
+        "host unresponsive", "follow up with city org", "claim disputed",
+        "needs translator", etc. Autosave on blur, optimistic UI, surfaced
+        only for admin viewers (underbosses also receive `adminNotes = null`
+        from the server so this is belt-and-braces).
+      */}
+      {canEditAdminNotes && (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between gap-3">
+            <span className="inline-flex items-center gap-1 text-theme-text-muted text-xs uppercase tracking-wide">
+              <StickyNote size={12} />
+              City notes (admin only)
+            </span>
+            <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+              {noteSaveStatus === 'saving' && (
+                <>
+                  <Loader2 size={12} className="animate-spin text-theme-text-muted" />
+                  <span className="text-theme-text-muted">Saving…</span>
+                </>
+              )}
+              {noteSaveStatus === 'saved' && (
+                <>
+                  <Check size={12} className="text-emerald-500" />
+                  <span className="text-emerald-500">Saved</span>
+                </>
+              )}
+              {noteSaveStatus === 'error' && (
+                <>
+                  <AlertCircle size={12} className="text-[#ff393a]" />
+                  <span className="text-[#ff393a]">{noteSaveError || 'Save failed'}</span>
+                </>
+              )}
+            </div>
+          </div>
+          <IconInput
+            multiline
+            rows={3}
+            value={noteDraft}
+            onChange={(e) => setNoteDraft(e.target.value)}
+            onBlur={handleSaveAdminNotes}
+            placeholder="Internal notes about this city... (admin only)"
+            className="input"
+            maxLength={4000}
+          />
         </div>
       )}
 
@@ -1953,6 +2061,10 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // `canEditReceipts` (admin / super_admin / payment_admin). Underbosses get
   // the plain photo-only lightbox.
   const canEditReceipts = viewerRole === 'admin';
+  // mortadella-92106: same admin-only gate for the city-level notes textarea.
+  // Backend strips `adminNotes` to null for underbosses; this hides the input
+  // wholesale so they don't even see the section heading.
+  const canEditAdminNotes = viewerRole === 'admin';
 
   function toggleExpanded(partyId: string) {
     setExpanded((prev) => {
@@ -2356,6 +2468,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                             onRowClick={onRowClick}
                             busyRowId={busyRowId}
                             canEditReceipts={canEditReceipts}
+                            canEditAdminNotes={canEditAdminNotes}
                           />
                         </div>
                       </td>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -464,6 +464,30 @@ export async function sendTgReceiptsReminder(
 }
 
 /**
+ * mortadella-92106: set admin-only city notes on a party. Backed by the
+ * dedicated `PATCH /api/admin/parties/:partyId/admin-notes` endpoint so
+ * the generic host-accessible PATCH whitelist doesn't have to gate this
+ * admin-only field.
+ *
+ * Pass `null` (or an empty string — the server normalizes) to clear the
+ * column. Returns the persisted value so the caller can reconcile against
+ * any concurrent edit.
+ */
+export async function setCityAdminNotes(
+  partyId: string,
+  notes: string | null,
+): Promise<{ adminNotes: string | null }> {
+  const res = await apiRequest<{ ok: boolean; party: { id: string; adminNotes: string | null } }>(
+    `/api/admin/parties/${partyId}/admin-notes`,
+    {
+      method: 'PATCH',
+      body: { notes },
+    },
+  );
+  return { adminNotes: res.party.adminNotes };
+}
+
+/**
  * quattro-71244: Fetches this party's rank against peer GPP events.
  * Returns null on 401/403/404/network failure so callers (the LeaderboardPill)
  * can gracefully hide instead of crashing the dashboard.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2242,6 +2242,13 @@ export interface PartyPayoutsRow {
      * cached payloads during a rolling deploy.
      */
     paymentsClosedAt?: string | null;
+    /**
+     * mortadella-92106: admin-only city notes. Free-text scratchpad on the
+     * by-city expansion. Always `null` for underboss viewers (server-side
+     * gate strips the value). Optional for backward-compat with cached
+     * payloads during a rolling deploy.
+     */
+    adminNotes?: string | null;
   };
   aggregates: {
     pendingCount: number;


### PR DESCRIPTION
## Summary

- Adds `parties.admin_notes` column + admin-only editable textarea in the `/payments` by-city expansion.
- Free-text for city-wide context that doesn't fit per-payout `Payout.admin_notes`: "host unresponsive", "follow up with city org", "claim disputed", "needs translator", etc.
- Autosave on blur with optimistic UI + "Saved" / "Saving" / "Save failed" inline indicator (mirrors `PaymentDetailsCard`).
- Read AND write are admin-only: backend strips `adminNotes` to `null` for underboss viewers in the by-party serializer; the new `PATCH /api/admin/parties/:partyId/admin-notes` endpoint is gated by `requireAnyAdminOrPaymentAdmin`. Underbosses don't see the textarea at all.

## Implementation

- **DB**: `parties.admin_notes TEXT NULL` (applied via pg; migration file checked in for reference). `GRANT SELECT ("admin_notes") ON "parties" TO authenticated` — not `anon` — defense in depth on top of route-level admin gating.
- **Backend**:
  - `Party.adminNotes` added to Prisma schema (separate from existing `Payout.adminNotes` per-row column and `Party.underbossNotes`).
  - `PAYOUT_PARTY_SELECT` extended; by-party serializer surfaces `adminNotes` for admins, `null` for underbosses.
  - New `PATCH /api/admin/parties/:partyId/admin-notes` accepts `{ notes: string | null }`, normalizes empty/whitespace to `null`, caps at 4000 chars, console-logs an audit line (mirrors the `bottarga-92104` `possible-scam` audit pattern).
- **Frontend**:
  - `setCityAdminNotes(partyId, notes)` typed wrapper in `lib/api.ts`.
  - `PartyPayoutsRow.party.adminNotes?: string | null` added to `types.ts`.
  - New "City notes (admin only)" section in `CityExpansion` rendered right after the hosts+tags strip, before the rollup tiles. Uses `IconInput` with `multiline rows={3}`, placeholder `"Internal notes about this city... (admin only)"`. Autosave fires on blur only when the trimmed value differs from the last-saved value.
  - All hooks declared above any early returns (`feedback_hooks_above_early_returns`).

## Test plan

- [ ] Migration confirmed live on prod DB (`parties.admin_notes` column exists with grant to `authenticated`).
- [ ] As admin: open `/payments`, expand a city row, see the new "City notes (admin only)" section under hosts/tags.
- [ ] Type a note, click outside → "Saved" badge appears briefly. Reload the page, re-expand → text persists.
- [ ] Clear the note (delete all text), blur → "Saved" badge, reload → field is empty.
- [ ] Type 4001+ chars → save fails with validation error inline.
- [ ] As underboss (e.g. via `?regions=...` LATAM portal): expand a city row, confirm the "City notes" section is NOT visible.
- [ ] Per-payout `admin_notes` on `PayoutReviewModal` still works independently and is unaffected.