### PR TITLE
Pre-fill Send payment wallet from host's submitted address

### DIFF
--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -75,6 +75,13 @@ interface SendPaymentModalProps {
   paidTotalUsd: number;
   /** Optional — primary host User id (parties.userId). Pre-selects recipient. */
   primaryHostUserId?: string | null;
+  /**
+   * Map of recipient User id -> the USDC wallet that host submitted on their
+   * receipt payouts for this city (ENS input preferred over the resolved 0x).
+   * Used to pre-fill the wallet field when a recipient is selected so the
+   * admin doesn't have to re-type the address the host already gave us.
+   */
+  hostWalletByUserId?: Record<string, string>;
   onClose: () => void;
   /**
    * Called on a successful send. Receives the city name + method + amount so
@@ -99,6 +106,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   effectiveReimbursementCapUsd,
   paidTotalUsd,
   primaryHostUserId,
+  hostWalletByUserId,
   onClose,
   onSent,
 }) => {
@@ -186,6 +194,17 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   const [mercuryCardLast4, setMercuryCardLast4] = useState('');
   const [mercuryCardId, setMercuryCardId] = useState('');
   const [wireReference, setWireReference] = useState('');
+
+  // Pre-fill the USDC wallet with the address the selected host submitted on
+  // their receipt payouts for this city (passed down per-recipient by the
+  // parent). Re-runs whenever the recipient changes so switching hosts pulls
+  // in that host's wallet; an empty mapping clears the field. `hostWalletByUserId`
+  // is a stable snapshot for the modal's lifetime, so this only fires on an
+  // actual recipient change — a manual edit for the same recipient is kept.
+  useEffect(() => {
+    if (!recipientUserId) return;
+    setWalletAddress(hostWalletByUserId?.[recipientUserId] ?? '');
+  }, [recipientUserId, hostWalletByUserId]);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -238,6 +238,11 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         effectiveReimbursementCapUsd: number | null;
         paidTotalUsd: number;
         primaryHostUserId: string | null;
+        // Map of recipient User id -> the USDC wallet that host submitted on
+        // their most recent receipt payout for this city (ENS input preferred
+        // over the resolved 0x). Lets SendPaymentModal pre-fill the wallet
+        // field per selected recipient instead of making the admin re-type it.
+        hostWalletByUserId: Record<string, string>;
       }
     | null
   >(null);
@@ -1099,6 +1104,21 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                   receiptsTotalUsd += Number(d.ocrAmount) || 0;
                 }
               }
+              // Pull in each host's submitted USDC wallet so the modal can
+              // pre-fill it per recipient. Walk payouts newest-first (ISO
+              // createdAt sorts lexically) and keep the first non-empty wallet
+              // per recipient — preferring the original ENS input over the
+              // resolved 0x (caciotta-92104). Only usdc_base payouts carry a
+              // wallet, so presence is the filter.
+              const hostWalletByUserId: Record<string, string> = {};
+              const payoutsNewestFirst = [...row.payouts].sort((a, b) =>
+                b.createdAt.localeCompare(a.createdAt),
+              );
+              for (const p of payoutsNewestFirst) {
+                if (!p.hostUserId || hostWalletByUserId[p.hostUserId]) continue;
+                const wallet = (p.payoutWalletInput || p.payoutWalletAddress || '').trim();
+                if (wallet) hostWalletByUserId[p.hostUserId] = wallet;
+              }
               setSendPaymentTarget({
                 partyId: row.party.id,
                 partyName: row.party.name,
@@ -1109,6 +1129,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 effectiveReimbursementCapUsd: row.party.effectiveReimbursementCapUsd,
                 paidTotalUsd: paidSumUsd,
                 primaryHostUserId: row.party.userId ?? null,
+                hostWalletByUserId,
               });
             }}
             // bottarga-92104: after the table toggles the `possible-scam` tag,
@@ -1521,6 +1542,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             }
             paidTotalUsd={sendPaymentTarget.paidTotalUsd}
             primaryHostUserId={sendPaymentTarget.primaryHostUserId}
+            hostWalletByUserId={sendPaymentTarget.hostWalletByUserId}
             onClose={() => setSendPaymentTarget(null)}
             onSent={async ({ partyName: sentTo, method, amountUsd }) => {
               const methodLabel =


### PR DESCRIPTION
## What
The **Send payment to {city}** admin modal left the *USDC wallet address or ENS* field empty, forcing admins to re-type an address the host had already submitted. Now selecting a recipient pulls in the wallet that host submitted on their receipt payouts for this city.

## How
- `PaymentsAdminPage.tsx` — builds a `hostWalletByUserId` map from the by-city payouts already loaded client-side, walking newest-first and keeping each recipient's most recent non-empty wallet (preferring the original ENS input over the resolved `0x`). Passed to the modal in the `sendPaymentTarget` snapshot.
- `SendPaymentModal.tsx` — new `hostWalletByUserId` prop + an effect that prefills the wallet field on recipient change. Switching recipients pulls that host's wallet; clears if they never submitted one. Manual edits for the same recipient are preserved.

## Notes
- Frontend-only. No new backend endpoint, no DB/migration — reads existing `payoutWalletAddress` / `payoutWalletInput` fields. Safe on preview (shared prod backend/DB).
- ENS names pull in as typed and still resolve server-side at send time.
- Edge: a recipient with multiple receipts using different wallets gets the most recent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)