### PR TITLE
feat(payments): reopen mistakenly-closed cities + drop "mark all as paid"

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -6122,3 +6122,101 @@ partyMarkPaidRouter.post(
     }
   },
 );
+
+// ============================================
+// POST /api/admin/parties/:partyId/reopen
+//
+// Undo an accidental city close. Clears `payments_closed_at` and reverts the
+// payouts the close flipped to `completed` back to their pre-close status.
+//
+// The `mark_pending_complete` path of Mark Party Paid stamps the close
+// timestamp AND flips pending/approved/queued rows to `completed` in one
+// transaction, so a clean undo has to do both. We identify which rows the close
+// touched by their most-recent `new_status='completed'` audit landing at/after
+// `payments_closed_at`, and restore each to that audit's `old_status`. Rows
+// that became `completed` in an EARLIER action (before this close) are left
+// untouched — they weren't part of the mistake.
+//
+// A pure close-out (no in-flight rows, just a stamped timestamp) reverts
+// nothing — only the timestamp is cleared.
+//
+// Idempotent: 400 NOT_CLOSED if the city isn't currently closed.
+// ============================================
+partyMarkPaidRouter.post(
+  '/:partyId/reopen',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+      const actor = await loadActor(req);
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { id: true, name: true, paymentsClosedAt: true },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+      if (!party.paymentsClosedAt) {
+        throw new AppError('City is not closed', 400, 'NOT_CLOSED');
+      }
+      const closedAt = party.paymentsClosedAt;
+
+      const body = req.body || {};
+      const note =
+        typeof body.note === 'string' && body.note.trim() ? body.note.trim() : null;
+
+      const reopenedIds: string[] = [];
+      await prisma.$transaction(async (tx) => {
+        const completed = await tx.payout.findMany({
+          where: { partyId, status: 'completed' },
+          select: { id: true },
+        });
+        for (const p of completed) {
+          // The transition INTO 'completed' carries the pre-close status in
+          // its old_status. Only undo rows the close itself flipped (audit
+          // at/after the close stamp); skip rows completed in an earlier pass.
+          const lastComplete = await tx.payoutAudit.findFirst({
+            where: { payoutId: p.id, newStatus: 'completed' },
+            orderBy: { createdAt: 'desc' },
+            select: { oldStatus: true, createdAt: true },
+          });
+          if (!lastComplete || lastComplete.createdAt < closedAt) continue;
+          const restoreTo = lastComplete.oldStatus || 'approved';
+          await tx.payout.update({
+            where: { id: p.id },
+            data: { status: restoreTo },
+          });
+          await tx.payoutAudit.create({
+            data: {
+              payoutId: p.id,
+              action: 'unmark_paid',
+              oldStatus: 'completed',
+              newStatus: restoreTo,
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: note
+                ? `Reopened city; ${note}`
+                : 'Reopened city — reverted completed close-out to pre-close status',
+            },
+          });
+          reopenedIds.push(p.id);
+        }
+
+        await tx.party.update({
+          where: { id: partyId },
+          data: { paymentsClosedAt: null },
+        });
+      });
+
+      res.json({
+        party: { id: party.id, name: party.name, paymentsClosedAt: null },
+        reopenedCount: reopenedIds.length,
+        payoutIds: reopenedIds,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);

--- a/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
+++ b/frontend/src/components/payments-admin/MarkPartyPaidModal.tsx
@@ -7,11 +7,15 @@ import {
   markPartyPaid,
   type MarkPartyPaidPreviewResponse,
 } from '../../lib/api';
-import type { PayoutMethod } from '../../types';
 
 // provolone-92103: 'mark_pending_complete' replaces caciotta's
 // 'withdraw_pending' — the close-out terminal state is now `'completed'`
 // (city paid in full, this claim done) instead of `'withdrawn'` (claim invalid).
+//
+// The legacy 'mark_paid' close path (which created brand-new paid records) was
+// removed from this modal — closing a city always uses 'mark_pending_complete'
+// now. The union is kept for the onSuccess summary `mode` field the server can
+// still echo back for older payloads.
 type MarkPaidMode = 'mark_paid' | 'mark_pending_complete';
 
 /**
@@ -22,16 +26,6 @@ type MarkPaidMode = 'mark_paid' | 'mark_pending_complete';
 function stripGppPrefix(name: string): string {
   return name.replace(/^Global Pizza Party\s+/i, '');
 }
-
-type PaidMethodChoice = PayoutMethod | 'external' | 'unchanged';
-
-const METHOD_LABELS: Record<PaidMethodChoice, string> = {
-  unchanged: 'Leave method unchanged',
-  mercury_card: 'Mercury virtual card',
-  wire: 'Wire transfer',
-  usdc_base: 'USDC on Base',
-  external: 'External / off-platform',
-};
 
 interface MarkPartyPaidModalProps {
   partyId: string;
@@ -89,9 +83,9 @@ interface MarkPartyPaidModalProps {
  * mark paid" notice and disables the destructive button.
  *
  * The shared `note` is appended (with timestamp) to each row's `admin_notes`
- * and also written to the per-row payout_audit entry. Optional `paidMethod`
- * stamps on each payout's `payout_method` ONLY when currently null — existing
- * methods are preserved server-side.
+ * and also written to the per-row payout_audit entry. In-flight rows are always
+ * closed out as `completed` (provolone-92103) — the legacy "Mark all as paid"
+ * mode (new paid records + payout_method stamping) was removed from this modal.
  *
  * Reversible: each row can be flipped back via the existing PayoutReviewModal
  * "Revert to Pending" path (caprino-92103) — no confirm step here per project
@@ -110,10 +104,10 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
 
   const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
   const [note, setNote] = useState<string>(() => `Marked paid in bulk on ${today}`);
-  const [method, setMethod] = useState<PaidMethodChoice>('unchanged');
   /**
-   * caciotta-92103: mode selector. `null` until the preview lands; then we
-   * default to the server's suggestedMode. Admin can override either way.
+   * Closing a city always uses 'mark_pending_complete' — the "Mark all as
+   * paid" path (new paid records) was removed. `null` until the preview lands
+   * so canSubmit gates on a loaded preview.
    */
   const [mode, setMode] = useState<MarkPaidMode | null>(null);
 
@@ -148,9 +142,9 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
       .then((res) => {
         if (cancelled) return;
         setPreview(res);
-        // caciotta-92103: default-select the server's recommendation. Admin
-        // can still override before submitting.
-        setMode(res.suggestedMode);
+        // Always close out via mark_pending_complete — the legacy "Mark all as
+        // paid" mode is no longer offered.
+        setMode('mark_pending_complete');
       })
       .catch((err) => {
         if (cancelled) return;
@@ -206,20 +200,13 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
       const trimmedNote = note.trim();
       const body: {
         note?: string;
-        paidMethod?: PayoutMethod | 'external';
         mode?: MarkPaidMode;
       } = {};
       if (trimmedNote) body.note = trimmedNote;
-      // payout_method is meaningful for mark_paid only; skip it for
-      // mark_pending_complete (provolone) and for close-out mode (pinsa)
-      // since neither path touches payout_method on existing rows.
-      if (!isCloseOutMode && mode === 'mark_paid' && method !== 'unchanged') {
-        body.paidMethod = method;
-      }
-      // caciotta-92103 + provolone-92103: send the resolved mode when there's
-      // something to act on. In close-out mode we leave it unset and let the
-      // server pick the pure close-out path.
-      if (!isCloseOutMode && mode) body.mode = mode;
+      // provolone-92103: in-flight rows are always closed out as completed.
+      // In close-out mode (no in-flight rows) we leave mode unset and let the
+      // server take the pure close-out path (stamp paymentsClosedAt only).
+      if (!isCloseOutMode) body.mode = 'mark_pending_complete';
       const res = await markPartyPaid(partyId, body);
       onSuccess({
         count: res.count,
@@ -389,54 +376,28 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
             </div>
           )}
 
-          {/* caciotta-92103 + provolone-92103: mode selector — Mark all as
-              paid (legacy) vs Mark pending complete (new). Default-selected
-              radio mirrors the server's suggestedMode so the safe action is
-              one-click in the common "I already paid externally and recorded
-              it" case. */}
-          {preview && !previewLoading && count > 0 && mode !== null && (
-            <div>
-              <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
-                What should happen to these {count} payment{count === 1 ? '' : 's'}?
-              </div>
-              <div className="space-y-2">
-                {(['mark_paid', 'mark_pending_complete'] as MarkPaidMode[]).map((m) => {
-                  const active = mode === m;
-                  const isMarkPaid = m === 'mark_paid';
-                  const title = isMarkPaid
-                    ? 'Mark all as paid'
-                    : 'Mark pending complete (city fully paid)';
-                  const explanation = isMarkPaid
-                    ? `Creates ${count} new paid record${count === 1 ? '' : 's'} summing to $${totalUsd.toFixed(2)}. Use this if you actually paid out additionally.`
-                    : `Closes out ${count} pending claim${count === 1 ? '' : 's'} as completed without creating new paid records. The city is fully paid even if the org paid less than the requested amount.`;
-                  return (
-                    <label
-                      key={m}
-                      className={`flex items-start gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-colors ${
-                        active
-                          ? 'border-emerald-500 bg-emerald-500/10'
-                          : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="markPaidMode"
-                        value={m}
-                        checked={active}
-                        onChange={() => setMode(m)}
-                        className="mt-1"
-                      />
-                      <span className="flex-1 min-w-0">
-                        <span className="block text-sm text-theme-text font-medium">
-                          {title}
-                        </span>
-                        <span className="block text-xs text-theme-text-muted mt-0.5">
-                          {explanation}
-                        </span>
-                      </span>
-                    </label>
-                  );
-                })}
+          {/* provolone-92103: closing a city always closes out its in-flight
+              claims as completed (no new paid records). The legacy "Mark all
+              as paid" option was removed — this panel just explains what the
+              one remaining action does. */}
+          {preview && !previewLoading && count > 0 && (
+            <div className="rounded-lg border border-teal-500/40 bg-teal-500/5 p-3">
+              <div className="flex items-start gap-2">
+                <CheckCircle2
+                  size={16}
+                  className="text-teal-400 mt-0.5 flex-shrink-0"
+                />
+                <div className="text-sm text-theme-text">
+                  <p>
+                    Closes out {count} pending claim{count === 1 ? '' : 's'} as
+                    completed without creating new paid records.
+                  </p>
+                  <p className="text-xs text-theme-text-muted mt-1">
+                    The city is marked fully paid even if the org paid less than
+                    the requested ${totalUsd.toFixed(2)}. Existing paid records
+                    stay unchanged.
+                  </p>
+                </div>
               </div>
             </div>
           )}
@@ -451,47 +412,6 @@ export const MarkPartyPaidModal: React.FC<MarkPartyPaidModalProps> = ({
             onChange={(e) => setNote(e.target.value)}
             maxLength={500}
           />
-
-          {/* Optional method override.
-              caciotta-92103 + provolone-92103: only meaningful for mark_paid;
-              mark_pending_complete never stamps payout_method.
-              pinsa-92103: hidden in close-out mode — there are no in-flight
-              rows for the method to stamp, so the choice is meaningless. */}
-          {!isCloseOutMode && mode === 'mark_paid' && (
-            <div>
-              <div className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">
-                Payout method (optional)
-              </div>
-              <div className="space-y-1.5">
-                {(Object.keys(METHOD_LABELS) as PaidMethodChoice[]).map((k) => {
-                  const active = method === k;
-                  return (
-                    <label
-                      key={k}
-                      className={`flex items-center gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-colors ${
-                        active
-                          ? 'border-emerald-500 bg-emerald-500/10'
-                          : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="paidMethod"
-                        value={k}
-                        checked={active}
-                        onChange={() => setMethod(k)}
-                      />
-                      <span className="text-sm text-theme-text">{METHOD_LABELS[k]}</span>
-                    </label>
-                  );
-                })}
-              </div>
-              <p className="text-xs text-theme-text-muted mt-1">
-                Only stamps the method on payouts that don't already have one —
-                existing methods are preserved.
-              </p>
-            </div>
-          )}
 
           {submitError && (
             <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/40 text-xs text-red-300 flex items-start gap-2">

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -23,6 +23,7 @@ import {
   AlertCircle,
   StickyNote,
   ThumbsUp,
+  RotateCcw,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type {
@@ -53,6 +54,7 @@ import {
   sendTgReceiptsReminder,
   setCityAdminNotes,
   approveCity,
+  reopenParty,
 } from '../../lib/api';
 import {
   ReceiptEditor,
@@ -128,6 +130,13 @@ interface PayoutsByPartyTableProps {
    * paid, close out a fully-paid city, etc. Hidden for underbosses.
    */
   onMarkPartyPaid?: (partyId: string) => void;
+  /**
+   * Refresh hook called after a closed city is reopened. The table owns the
+   * `reopenParty` API call + busy spinner (mirrors the scam-flag pattern); the
+   * parent uses this to re-fetch the by-party feed (statuses + close pill
+   * change) and flash a toast. Admin-only via the viewerRole gate on the menu.
+   */
+  onReopened?: (partyId: string, reopenedCount: number) => void;
   /**
    * mostarda-92103: opens the Add External Payment modal pre-targeted at
    * this city. Hidden for underbosses (admins only).
@@ -291,16 +300,19 @@ function CityActionsMenu({
   onToggleScamFlag,
   onSendTgReminder,
   onApproveCity,
+  onReopen,
   canMarkPaid,
   canAddExternal,
   canSendPayment,
   canToggleScamFlag,
   canSendTgReminder,
   canApproveCity,
+  canReopen,
   markPaidLabel,
   isFlaggedScam,
   scamFlagBusy,
   tgReminderBusy,
+  reopenBusy,
   approveBusy,
   receiptsReminderSentAt,
   paymentsApprovedUsd,
@@ -319,16 +331,20 @@ function CityActionsMenu({
   onSendTgReminder?: () => void;
   /** Approve city payment amount. Called with the amount to approve. */
   onApproveCity?: (amountUsd: number | null) => void;
+  /** Reopen a closed city (undo the close). */
+  onReopen?: () => void;
   canMarkPaid: boolean;
   canAddExternal: boolean;
   canSendPayment: boolean;
   canToggleScamFlag: boolean;
   canSendTgReminder: boolean;
   canApproveCity: boolean;
+  canReopen: boolean;
   markPaidLabel: string;
   isFlaggedScam: boolean;
   scamFlagBusy: boolean;
   tgReminderBusy: boolean;
+  reopenBusy: boolean;
   approveBusy: boolean;
   receiptsReminderSentAt?: string | null;
   paymentsApprovedUsd?: number | null;
@@ -345,7 +361,8 @@ function CityActionsMenu({
   // within the open menu actually fires. Resetting whenever the menu closes
   // prevents a stale confirm state carrying over to the next open.
   const [confirmTgReminder, setConfirmTgReminder] = useState(false);
-  const hasMenuItems = canAddExternal || canToggleScamFlag || canSendTgReminder;
+  const hasMenuItems =
+    canAddExternal || canToggleScamFlag || canSendTgReminder || canReopen;
   // Nothing to show at all — render nothing.
   if (!canMarkPaid && !canSendPayment && !canApproveCity && !hasMenuItems) {
     return null;
@@ -457,6 +474,29 @@ function CityActionsMenu({
                 className="absolute right-0 mt-1 w-56 z-50 rounded-lg border border-theme-stroke bg-[#1a1a2e] shadow-xl py-1"
                 role="menu"
               >
+                {/* Reopen a city that was closed by mistake. Reverts the
+                    payouts the close flipped to completed + clears the close
+                    flag. Reversible (re-close) — no confirm. Listed first
+                    since it's the relevant action on a closed row. */}
+                {canReopen && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={reopenBusy}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onReopen?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
+                  >
+                    {reopenBusy ? (
+                      <Loader2 size={14} className="animate-spin text-theme-text-muted" />
+                    ) : (
+                      <RotateCcw size={14} className="text-amber-400" />
+                    )}
+                    Reopen city
+                  </button>
+                )}
                 {canAddExternal && (
                   <button
                     type="button"
@@ -2161,6 +2201,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onExecute,
   onMarkPaid,
   onMarkPartyPaid,
+  onReopened,
   onAddExternalPayment,
   onSendPayment,
   onScamFlagChanged,
@@ -2186,6 +2227,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   const [tgReminderBusyPartyId, setTgReminderBusyPartyId] = useState<string | null>(null);
   // City-level approval busy spinner.
   const [approveBusyPartyId, setApproveBusyPartyId] = useState<string | null>(null);
+  // Per-row busy spinner for the Reopen city action.
+  const [reopenBusyPartyId, setReopenBusyPartyId] = useState<string | null>(null);
 
   const canMarkPartyPaid = viewerRole === 'admin' && !!onMarkPartyPaid;
   const canAddExternal = viewerRole === 'admin' && !!onAddExternalPayment;
@@ -2201,6 +2244,10 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   const canSendTgReminder = viewerRole === 'admin';
   // City-level approval is admin-only.
   const canApproveCity = viewerRole === 'admin';
+  // Reopen (undo a close) is admin-only — the endpoint enforces
+  // requireAnyAdminOrPaymentAdmin server-side; the per-row gate also requires
+  // the city to be closed (computed in the row render).
+  const canReopenCap = viewerRole === 'admin';
   // pesto-92105: same gate the per-payout PayoutReviewModal applies for
   // `canEditReceipts` (admin / super_admin / payment_admin). Underbosses get
   // the plain photo-only lightbox.
@@ -2264,6 +2311,29 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
       );
     } finally {
       setScamBusyPartyId((id) => (id === partyId ? null : id));
+    }
+  }
+
+  /**
+   * Undo an accidental city close. Calls the reopen endpoint (clears the close
+   * flag + reverts the payouts the close flipped to `completed`) and asks the
+   * parent to refresh + toast. Reversible — no confirm step per project
+   * convention (feedback_reversible_actions_no_confirm). Errors surface via a
+   * minimal alert, matching the scam-flag path.
+   */
+  async function handleReopen(row: PartyPayoutsRow) {
+    const partyId = row.party.id;
+    setReopenBusyPartyId(partyId);
+    try {
+      const { reopenedCount } = await reopenParty(partyId);
+      onReopened?.(partyId, reopenedCount);
+    } catch (err) {
+      // eslint-disable-next-line no-alert
+      window.alert(
+        `Could not reopen this city: ${(err as Error)?.message ?? 'unknown error'}`,
+      );
+    } finally {
+      setReopenBusyPartyId((id) => (id === partyId ? null : id));
     }
   }
 
@@ -2583,10 +2653,12 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           canToggleScamFlag={canToggleScamFlag}
                           canSendTgReminder={canSendTgReminder}
                           canApproveCity={canApproveCity}
+                          canReopen={isClosed && canReopenCap}
                           markPaidLabel={markPaidLabel}
                           isFlaggedScam={isFlaggedScam}
                           scamFlagBusy={scamFlagBusy}
                           tgReminderBusy={tgReminderBusy}
+                          reopenBusy={reopenBusyPartyId === row.party.id}
                           approveBusy={approveBusyPartyId === row.party.id}
                           receiptsReminderSentAt={row.party.receiptsReminderSentAt}
                           paymentsApprovedUsd={row.party.paymentsApprovedUsd}
@@ -2624,6 +2696,11 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           onSendTgReminder={
                             canSendTgReminder
                               ? () => handleSendTgReminder(row)
+                              : undefined
+                          }
+                          onReopen={
+                            isClosed && canReopenCap
+                              ? () => handleReopen(row)
                               : undefined
                           }
                         />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4854,6 +4854,31 @@ export async function markPartyPaid(
 }
 
 /**
+ * Undo an accidental city close. Clears `payments_closed_at` and reverts the
+ * payouts the close flipped to `completed` back to their pre-close status
+ * (pending / approved / queued). Returns the cleared party + how many payouts
+ * were reverted. Throws 400 NOT_CLOSED if the city isn't currently closed.
+ */
+export interface ReopenPartyResponse {
+  party: { id: string; name: string; paymentsClosedAt: string | null };
+  reopenedCount: number;
+  payoutIds: string[];
+}
+
+export async function reopenParty(
+  partyId: string,
+  note?: string,
+): Promise<ReopenPartyResponse> {
+  return apiRequest<ReopenPartyResponse>(
+    `/api/admin/parties/${partyId}/reopen`,
+    {
+      method: 'POST',
+      body: note ? { note } : {},
+    },
+  );
+}
+
+/**
  * Execute an approved payout (PR 5). Body shape is method-specific:
  *   - usdc_base    → no body required; server sends via Privy server-wallet
  *   - wire         → { wireReference: string } REQUIRED

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1094,6 +1094,23 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 isSwcHub: isSwcHubParty(row?.party),
               });
             }}
+            // Undo an accidental close. The table owns the reopenParty call +
+            // busy spinner; we just refresh the feeds (statuses + close pill
+            // changed) and flash a toast.
+            onReopened={async (partyId, reopenedCount) => {
+              const row = byPartyRows.find((r) => r.party.id === partyId);
+              const name = (row?.party.name ?? 'City').replace(
+                /^Global Pizza Party\s+/i,
+                '',
+              );
+              pushToast(
+                reopenedCount > 0
+                  ? `Reopened ${name} — ${reopenedCount} payment${reopenedCount === 1 ? '' : 's'} restored to in-flight`
+                  : `Reopened ${name}`,
+                'success',
+              );
+              await Promise.all([refresh(), loadPrepayQueue()]);
+            }}
             // mostarda-92103: city-level "Add external payment" — opens the
             // ExternalPaymentModal with the city name seeded in the party
             // picker so the admin can confirm-and-go. Admin-only via the


### PR DESCRIPTION
## What

Two related changes to the city close-out flow in payments admin.

### 1. Reopen a city closed by mistake
- **Backend:** new `POST /api/admin/parties/:partyId/reopen`. Clears `payments_closed_at` **and** reverts the payouts the close flipped to `completed` back to their pre-close status. It scopes the undo to rows whose most-recent into-`completed` audit landed at/after the close timestamp, restoring each to that audit's `old_status` (rows completed in an earlier pass are left alone). A pure close-out (just a timestamp, no in-flight rows) reverts nothing. Idempotent: `400 NOT_CLOSED` if the city isn't closed.
- **Frontend:** "Reopen city" item in the by-city actions menu, shown only on closed rows (admin-only, reversible → no confirm). Refreshes the feed + toasts the count restored.

### 2. Remove "Mark all as paid" from the close modal
Closing a city with in-flight rows now always uses **Mark pending complete** (closes claims out as `completed`, no new paid records). The legacy paid-record path and the payout-method override were removed from `MarkPartyPaidModal`. The count=0 "Close city" path is unchanged.

## ⚠️ Deploy note
The backend only deploys from `master`, so the **Reopen** action will 404 on preview branches until this merges. The modal change is frontend-only and works on preview now.

## Related
The same logic was applied as a one-off to undo the accidental close of **Global Pizza Party Karachi** (3 payouts reverted from `completed` → pending/approved, close flag cleared).

## Test plan
- [ ] Backend + frontend typecheck clean (verified locally)
- [ ] Close a test city, confirm it shows "Closed", reopen it, confirm statuses + pill restored
- [ ] Confirm the close modal only offers "Mark pending complete"

🤖 Generated with [Claude Code](https://claude.com/claude-code)