### PR TITLE
Relabel checklist item to "Submit Estimated Attendance"

### DIFF
--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -93,6 +93,13 @@ export const GPPDashboardTab: React.FC = () => {
     'Estimated Attendance': Users,
   };
 
+  // Display-label overrides — the DB `name` stays the stable key (matched for
+  // the icon, the modal click handler, and the `attendance_estimated`
+  // auto-rule); only the rendered text differs.
+  const LABEL_OVERRIDES: Record<string, string> = {
+    'Estimated Attendance': 'Submit Estimated Attendance',
+  };
+
   const goToTab = (tab: string) => {
     if (tab === 'details') {
       navigate(`/host/${inviteCode}`);
@@ -126,7 +133,7 @@ export const GPPDashboardTab: React.FC = () => {
         id: item.id,
         isAuto: item.isAuto,
         autoRule: item.autoRule,
-        label: item.name,
+        label: LABEL_OVERRIDES[item.name] ?? item.name,
         done,
         tab: item.linkTab,
         onClick: item.name === 'Build a Team' ? () => setHostsExpanded(prev => !prev) :


### PR DESCRIPTION
Changes the GPP dashboard checklist label from **Estimated Attendance** to **Submit Estimated Attendance**.

Display-only override (`LABEL_OVERRIDES` in `GPPDashboardTab.tsx`). The DB checklist `name` stays `Estimated Attendance` so the icon lookup, attendance-modal click handler, and the `attendance_estimated` auto-rule continue to match. Frontend-only — no DB/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)