### PR TITLE
feat(payments): add "Send wallet reminder" TG action

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -5449,6 +5449,88 @@ router.post(
   },
 );
 
+// POST /:partyId/tg-wallet-reminder
+//
+// Sibling of tg-receipts-reminder: DMs the primary host (when their Telegram
+// is linked) and posts to the city's GPP group chat, telling the host to
+// submit their payout wallet address on the host page's Payments tab. Same
+// per-channel send + skip-reason contract; the only differences are the
+// message text + target URL. We don't persist a "sent at" timestamp for this
+// one (no DB column), so unlike receipts there's no last-sent sub-label.
+router.post(
+  '/:partyId/tg-wallet-reminder',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: {
+          id: true,
+          customUrl: true,
+          inviteCode: true,
+          name: true,
+          hostTelegramChatId: true,
+        },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      const slug = party.customUrl || party.inviteCode;
+      const text = `Please submit your payout wallet address so we can reimburse you: rsv.pizza/host/${slug}/payments`;
+
+      let hostDmSent = false;
+      let hostDmReason: string | undefined;
+      if (party.hostTelegramChatId) {
+        const result = await sendTelegramMessage(
+          party.hostTelegramChatId.toString(),
+          text,
+        );
+        if (result.ok) {
+          hostDmSent = true;
+        } else {
+          hostDmReason = result.reason;
+        }
+      } else {
+        hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
+      }
+
+      const rawGroupChatId =
+        typeof req.body?.groupChatId === 'string' ? req.body.groupChatId.trim() : '';
+      let groupSent = false;
+      let groupReason: string | undefined;
+      if (rawGroupChatId) {
+        const result = await sendTelegramMessage(rawGroupChatId, text);
+        if (result.ok) {
+          groupSent = true;
+        } else {
+          groupReason = result.reason;
+        }
+      } else {
+        groupReason = 'no city TG group set';
+      }
+
+      console.log(
+        `[tg-wallet-reminder] party=${party.id} slug=${slug} host_dm=${
+          hostDmSent ? 'ok' : `skipped:${hostDmReason ?? 'unknown'}`
+        } group=${groupSent ? 'ok' : `skipped:${groupReason ?? 'unknown'}`}`,
+      );
+
+      res.json({
+        hostDmSent,
+        ...(hostDmReason ? { hostDmReason } : {}),
+        groupSent,
+        ...(groupReason ? { groupReason } : {}),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // ============================================
 // City-level payment approval. Admin can approve a total amount for the party
 // before sending payment. Shows as a thumbs-up button to the left of Send.

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -24,6 +24,7 @@ import {
   StickyNote,
   ThumbsUp,
   RotateCcw,
+  Wallet,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type {
@@ -52,6 +53,7 @@ import {
   flagPartyAsScam,
   POSSIBLE_SCAM_TAG,
   sendTgReceiptsReminder,
+  sendTgWalletReminder,
   setCityAdminNotes,
   approveCity,
   reopenParty,
@@ -166,6 +168,19 @@ interface PayoutsByPartyTableProps {
    * `window.alert`-free silent success (the menu still closes).
    */
   onTgReminderResult?: (
+    partyId: string,
+    result: {
+      hostDmSent: boolean;
+      hostDmReason?: string;
+      groupSent: boolean;
+      groupReason?: string;
+    } | { error: string },
+  ) => void;
+  /**
+   * Toast callback for the Send wallet reminder action — same per-channel
+   * success/skip shape as `onTgReminderResult`. The menu owns the API call.
+   */
+  onTgWalletReminderResult?: (
     partyId: string,
     result: {
       hostDmSent: boolean;
@@ -299,6 +314,7 @@ function CityActionsMenu({
   onSendPayment,
   onToggleScamFlag,
   onSendTgReminder,
+  onSendWalletReminder,
   onApproveCity,
   onReopen,
   canMarkPaid,
@@ -306,12 +322,14 @@ function CityActionsMenu({
   canSendPayment,
   canToggleScamFlag,
   canSendTgReminder,
+  canSendWalletReminder,
   canApproveCity,
   canReopen,
   markPaidLabel,
   isFlaggedScam,
   scamFlagBusy,
   tgReminderBusy,
+  walletReminderBusy,
   reopenBusy,
   approveBusy,
   receiptsReminderSentAt,
@@ -329,6 +347,11 @@ function CityActionsMenu({
    * Parent runs the API call and surfaces the toast.
    */
   onSendTgReminder?: () => void;
+  /**
+   * Fires after the second click on the Send wallet reminder menu item (same
+   * two-click confirm pattern as the receipts reminder).
+   */
+  onSendWalletReminder?: () => void;
   /** Approve city payment amount. Called with the amount to approve. */
   onApproveCity?: (amountUsd: number | null) => void;
   /** Reopen a closed city (undo the close). */
@@ -338,12 +361,14 @@ function CityActionsMenu({
   canSendPayment: boolean;
   canToggleScamFlag: boolean;
   canSendTgReminder: boolean;
+  canSendWalletReminder: boolean;
   canApproveCity: boolean;
   canReopen: boolean;
   markPaidLabel: string;
   isFlaggedScam: boolean;
   scamFlagBusy: boolean;
   tgReminderBusy: boolean;
+  walletReminderBusy: boolean;
   reopenBusy: boolean;
   approveBusy: boolean;
   receiptsReminderSentAt?: string | null;
@@ -361,8 +386,15 @@ function CityActionsMenu({
   // within the open menu actually fires. Resetting whenever the menu closes
   // prevents a stale confirm state carrying over to the next open.
   const [confirmTgReminder, setConfirmTgReminder] = useState(false);
+  // Same two-click confirm, separate state so the wallet + receipts items
+  // don't share a confirm flag.
+  const [confirmWalletReminder, setConfirmWalletReminder] = useState(false);
   const hasMenuItems =
-    canAddExternal || canToggleScamFlag || canSendTgReminder || canReopen;
+    canAddExternal ||
+    canToggleScamFlag ||
+    canSendTgReminder ||
+    canSendWalletReminder ||
+    canReopen;
   // Nothing to show at all — render nothing.
   if (!canMarkPaid && !canSendPayment && !canApproveCity && !hasMenuItems) {
     return null;
@@ -448,7 +480,10 @@ function CityActionsMenu({
                 // crocchetta-92106: closing the menu resets the TG-reminder
                 // confirm state so a stale "Click again to confirm" doesn't
                 // carry over to the next open.
-                if (!next) setConfirmTgReminder(false);
+                if (!next) {
+                  setConfirmTgReminder(false);
+                  setConfirmWalletReminder(false);
+                }
                 return next;
               });
             }}
@@ -468,6 +503,7 @@ function CityActionsMenu({
                 onClick={() => {
                   setMenuOpen(false);
                   setConfirmTgReminder(false);
+                  setConfirmWalletReminder(false);
                 }}
               />
               <div
@@ -589,6 +625,45 @@ function CityActionsMenu({
                         </span>
                       )}
                     </span>
+                  </button>
+                )}
+                {/* Send wallet reminder — sibling of the receipts reminder.
+                    DMs the host + posts to the city group telling them to
+                    submit their payout wallet address. Same two-click confirm
+                    (DMs can't be unsent). No last-sent sub-label (not
+                    persisted). */}
+                {canSendWalletReminder && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={walletReminderBusy}
+                    onClick={() => {
+                      if (!confirmWalletReminder) {
+                        setConfirmWalletReminder(true);
+                        return;
+                      }
+                      setMenuOpen(false);
+                      setConfirmWalletReminder(false);
+                      onSendWalletReminder?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
+                  >
+                    {walletReminderBusy ? (
+                      <Loader2
+                        size={14}
+                        className="animate-spin text-theme-text-muted"
+                      />
+                    ) : (
+                      <Wallet
+                        size={14}
+                        className={
+                          confirmWalletReminder ? 'text-amber-400' : 'text-sky-400'
+                        }
+                      />
+                    )}
+                    {confirmWalletReminder
+                      ? 'Click again to confirm'
+                      : 'Send wallet reminder'}
                   </button>
                 )}
               </div>
@@ -2206,6 +2281,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onSendPayment,
   onScamFlagChanged,
   onTgReminderResult,
+  onTgWalletReminderResult,
   cityGroupChatIds,
   viewerRole = 'admin',
   busyRowId,
@@ -2225,6 +2301,10 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // crocchetta-92106: per-row busy spinner for the Send receipts reminder
   // action. Avoids double-firing the POST while the bot is dispatching.
   const [tgReminderBusyPartyId, setTgReminderBusyPartyId] = useState<string | null>(null);
+  // Per-row busy spinner for the Send wallet reminder action.
+  const [walletReminderBusyPartyId, setWalletReminderBusyPartyId] = useState<
+    string | null
+  >(null);
   // City-level approval busy spinner.
   const [approveBusyPartyId, setApproveBusyPartyId] = useState<string | null>(null);
   // Per-row busy spinner for the Reopen city action.
@@ -2242,6 +2322,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // requireAnyAdminOrPaymentAdmin server-side; the UI gate just hides the
   // menu item for underbosses so they don't see a button that 403s.
   const canSendTgReminder = viewerRole === 'admin';
+  // Wallet reminder shares the same admin-only gate as the receipts reminder.
+  const canSendWalletReminder = viewerRole === 'admin';
   // City-level approval is admin-only.
   const canApproveCity = viewerRole === 'admin';
   // Reopen (undo a close) is admin-only — the endpoint enforces
@@ -2366,6 +2448,28 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   }
 
   /**
+   * Sibling of {@link handleSendTgReminder}: dispatch the wallet reminder POST
+   * and forward the per-channel outcome via `onTgWalletReminderResult`. Same
+   * city→group chat_id resolution.
+   */
+  async function handleSendWalletReminder(row: PartyPayoutsRow) {
+    const partyId = row.party.id;
+    const cityKey = stripGppPrefix(row.party.name).toLowerCase().trim();
+    const groupChatId = cityGroupChatIds?.get(cityKey);
+    setWalletReminderBusyPartyId(partyId);
+    try {
+      const result = await sendTgWalletReminder(partyId, groupChatId);
+      onTgWalletReminderResult?.(partyId, result);
+    } catch (err) {
+      onTgWalletReminderResult?.(partyId, {
+        error: (err as Error)?.message ?? 'Could not send reminder',
+      });
+    } finally {
+      setWalletReminderBusyPartyId((id) => (id === partyId ? null : id));
+    }
+  }
+
+  /**
    * City-level payment approval. Approves the receipts total as the payment
    * amount (or clears approval when amountUsd is null).
    */
@@ -2431,6 +2535,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
               const isFlaggedScam = effectiveTags.includes(POSSIBLE_SCAM_TAG);
               const scamFlagBusy = scamBusyPartyId === row.party.id;
               const tgReminderBusy = tgReminderBusyPartyId === row.party.id;
+              const walletReminderBusy =
+                walletReminderBusyPartyId === row.party.id;
               const hasInFlight =
                 row.aggregates.pendingCount + row.aggregates.approvedCount > 0;
               // pinsa-92103: ALSO show the button when the city has paid
@@ -2652,12 +2758,14 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           canSendPayment={canSendPayment}
                           canToggleScamFlag={canToggleScamFlag}
                           canSendTgReminder={canSendTgReminder}
+                          canSendWalletReminder={canSendWalletReminder}
                           canApproveCity={canApproveCity}
                           canReopen={isClosed && canReopenCap}
                           markPaidLabel={markPaidLabel}
                           isFlaggedScam={isFlaggedScam}
                           scamFlagBusy={scamFlagBusy}
                           tgReminderBusy={tgReminderBusy}
+                          walletReminderBusy={walletReminderBusy}
                           reopenBusy={reopenBusyPartyId === row.party.id}
                           approveBusy={approveBusyPartyId === row.party.id}
                           receiptsReminderSentAt={row.party.receiptsReminderSentAt}
@@ -2696,6 +2804,11 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           onSendTgReminder={
                             canSendTgReminder
                               ? () => handleSendTgReminder(row)
+                              : undefined
+                          }
+                          onSendWalletReminder={
+                            canSendWalletReminder
+                              ? () => handleSendWalletReminder(row)
                               : undefined
                           }
                           onReopen={

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -466,6 +466,27 @@ export async function sendTgReceiptsReminder(
 }
 
 /**
+ * Sibling of {@link sendTgReceiptsReminder}: sends a "submit your payout wallet
+ * address at rsv.pizza/host/<slug>/payments" reminder via the Molto Benny
+ * Telegram bot — DM to the primary host + post to the city's group chat. Same
+ * per-channel success + skip-reason contract. Unlike the receipts reminder this
+ * does NOT persist a sent-at timestamp.
+ */
+export async function sendTgWalletReminder(
+  partyId: string,
+  groupChatId?: string | null,
+): Promise<SendTgReceiptsReminderResponse> {
+  return apiRequest<SendTgReceiptsReminderResponse>(
+    `/api/admin/payouts/${partyId}/tg-wallet-reminder`,
+    {
+      method: 'POST',
+      requireAuth: true,
+      body: groupChatId ? { groupChatId } : undefined,
+    },
+  );
+}
+
+/**
  * mortadella-92106: set admin-only city notes on a party. Backed by the
  * dedicated `PATCH /api/admin/parties/:partyId/admin-notes` endpoint so
  * the generic host-accessible PATCH whitelist doesn't have to gate this

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1241,9 +1241,34 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 result.hostDmSent || result.groupSent ? 'success' : 'error';
               pushToast(`Reminder: ${hostLabel} | ${groupLabel}`, tone);
             }}
+            // Wallet reminder — same per-channel success/skip toast as the
+            // receipts reminder.
+            onTgWalletReminderResult={(_partyId, result) => {
+              if ('error' in result) {
+                pushToast(
+                  `Could not send wallet reminder: ${result.error}`,
+                  'error',
+                );
+                return;
+              }
+              const hostLabel = result.hostDmSent
+                ? 'DM ✓'
+                : `DM skipped${
+                    result.hostDmReason ? ` (${result.hostDmReason})` : ''
+                  }`;
+              const groupLabel = result.groupSent
+                ? 'Group ✓'
+                : `Group skipped${
+                    result.groupReason ? ` (${result.groupReason})` : ''
+                  }`;
+              const tone =
+                result.hostDmSent || result.groupSent ? 'success' : 'error';
+              pushToast(`Wallet reminder: ${hostLabel} | ${groupLabel}`, tone);
+            }}
             // crocchetta-92107: sheet-derived city → TG group chat_id map so
             // the Send-receipts-reminder action can post into the city's
-            // group chat (same source /underboss uses).
+            // group chat (same source /underboss uses). Reused by the wallet
+            // reminder too.
             cityGroupChatIds={cityGroupChatIds}
             viewerRole={viewerKind}
             busyRowId={rowBusyId}


### PR DESCRIPTION
## What

Adds a **Send wallet reminder** action to the payments admin by-city ⋮ menu — a sibling of the existing **Send receipts reminder**. It DMs the event's primary host via the Molto Benny Telegram bot and posts to the city's GPP group chat, telling the host to submit their payout wallet address at `rsv.pizza/host/<slug>/payments`.

## How

Mirrors the receipts-reminder feature at every layer:

- **Backend:** `POST /api/admin/payouts/:partyId/tg-wallet-reminder` — same auth (`requireAnyAdminOrPaymentAdmin`), same per-channel send + skip-reason response (`hostDmSent` / `groupSent` + reasons), reuses the `sendTelegramMessage` helper. Only the message text + target URL differ.
- **Frontend:** `sendTgWalletReminder()` API helper, a "Send wallet reminder" menu item with the same two-click confirm, a `Wallet` icon, busy spinner, and per-channel success/skip toast. Reuses the existing `cityGroupChatIds` sheet map.

## Difference from the receipts reminder

The receipts reminder stamps `parties.receipts_reminder_sent_at` and shows a "Sent <date>" sub-label. To keep this migration-free, the wallet reminder does **not** persist a sent-at timestamp, so it has no last-sent sub-label. Easy follow-up if we want it (adds a `wallet_reminder_sent_at` column + a prod migration).

## Test plan
- [ ] Backend + frontend typecheck clean (verified locally)
- [ ] On a city row, open ⋮ → "Send wallet reminder" → click again to confirm → toast shows `DM ✓ | Group ✓` (or accurate skip reasons)
- [ ] Host with linked Telegram receives the wallet-address DM; city group gets the post

🤖 Generated with [Claude Code](https://claude.com/claude-code)
