### PR TITLE
feat(nduja-58296): 25MB photo cap + 30/user/event limit

### DIFF
--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -1,4 +1,5 @@
 import { Router, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
 import { requireAuth, optionalAuth, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
@@ -489,11 +490,11 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
 
     const isVideo = allowedVideoTypes.includes(mimeType);
 
-    // Validate file size: 10MB for images, 50MB for videos
-    const maxSize = isVideo ? 50 * 1024 * 1024 : 10 * 1024 * 1024;
+    // Validate file size: 25MB for images, 50MB for videos
+    const maxSize = isVideo ? 50 * 1024 * 1024 : 25 * 1024 * 1024;
     if (fileSize > maxSize) {
       throw new AppError(
-        isVideo ? 'File too large. Maximum video size is 50MB' : 'File too large. Maximum size is 10MB',
+        isVideo ? 'File too large. Maximum video size is 50MB' : 'File too large. Maximum size is 25MB',
         400,
         'FILE_TOO_LARGE'
       );
@@ -548,6 +549,38 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
           include: { guest: { select: { id: true, name: true } } },
         });
         return res.status(200).json({ photo: dedupedPhoto, deduped: true });
+      }
+    }
+
+    // nduja-58296: per-user 30-photo cap per event. Identify the uploader by
+    // userId, guestId, or lowercased email — any match counts. Pending +
+    // approved count; rejected photos do not (so a host can clean up bad
+    // uploads to make room). If we can't identify the uploader at all, skip
+    // the check rather than reject an otherwise valid upload.
+    const PHOTO_LIMIT_PER_USER_PER_EVENT = 30;
+    const uploaderUserId = req.userId || null;
+    const uploaderGuestId = verifiedGuestId || null;
+    const uploaderEmailLower = (uploaderEmail || '').toLowerCase() || null;
+
+    const uploaderClauses: Prisma.PhotoWhereInput[] = [];
+    if (uploaderUserId) uploaderClauses.push({ reviewedBy: uploaderUserId });
+    if (uploaderGuestId) uploaderClauses.push({ uploadedBy: uploaderGuestId });
+    if (uploaderEmailLower) uploaderClauses.push({ uploaderEmail: uploaderEmailLower });
+
+    if (uploaderClauses.length > 0) {
+      const existingCount = await prisma.photo.count({
+        where: {
+          partyId,
+          status: { not: 'rejected' },
+          OR: uploaderClauses,
+        },
+      });
+      if (existingCount >= PHOTO_LIMIT_PER_USER_PER_EVENT) {
+        throw new AppError(
+          '30 photo limit per user. Remove photos to make room',
+          400,
+          'PHOTO_LIMIT_REACHED'
+        );
       }
     }
 

--- a/frontend/src/components/photos/PhotoUpload.tsx
+++ b/frontend/src/components/photos/PhotoUpload.tsx
@@ -80,7 +80,7 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
       if (!isImage && !isVideo) continue;
 
       // Client-side size validation
-      if (isImage && file.size > 10 * 1024 * 1024) continue;
+      if (isImage && file.size > 25 * 1024 * 1024) continue;
       if (isVideo && file.size > 50 * 1024 * 1024) continue;
 
       // Client-side duration validation for videos
@@ -216,15 +216,19 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
         onUploadComplete?.(result.photo);
       } catch (error) {
         console.error('Upload error:', error);
+        // Surface the 30-photo limit message verbatim (snax requested exact copy)
+        const message = error instanceof Error ? error.message : String(error);
         setFiles(prev => {
           const newFiles = [...prev];
           newFiles[fileIndex] = {
             ...newFiles[fileIndex],
             status: 'error',
-            error: error instanceof Error ? error.message : 'Upload failed',
+            error: message.includes('30 photo limit') ? message : (message || 'Upload failed'),
           };
           return newFiles;
         });
+        // If hit the per-user limit, stop trying further files (they'd all fail)
+        if (message.includes('30 photo limit')) break;
       }
     }
   };
@@ -276,7 +280,7 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
         <Upload className="w-10 h-10 text-theme-text-muted mx-auto mb-3" />
         <p className="text-theme-text-secondary mb-1">Drag and drop photos or videos here</p>
         <p className="text-theme-text-muted text-sm">or click to select files</p>
-        <p className="text-theme-text-faint text-xs mt-2">Max 10MB per photo, 50MB per video (5 min). JPEG, PNG, WebP, GIF, MP4, WebM, MOV</p>
+        <p className="text-theme-text-faint text-xs mt-2">Max 25 MB per photo, 50MB per video (5 min). JPEG, PNG, WebP, GIF, MP4, WebM, MOV</p>
       </div>
 
       {/* Caption Input */}

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -450,8 +450,8 @@ export async function uploadEventPhoto(
       return null;
     }
 
-    // Validate file size (10MB max)
-    if (file.size > 10 * 1024 * 1024) {
+    // Validate file size (25MB max)
+    if (file.size > 25 * 1024 * 1024) {
       console.error('File too large:', file.size);
       return null;
     }

--- a/supabase/migrations/20260531000000_nduja_58296_bump_event_photos_25mb.sql
+++ b/supabase/migrations/20260531000000_nduja_58296_bump_event_photos_25mb.sql
@@ -1,0 +1,5 @@
+-- nduja-58296: bump event-photos bucket file_size_limit from 10MB to 25MB
+-- Snax requested this to accommodate DSLR/event-photographer JPEGs and modern smartphone high-MP modes.
+-- The 10MB limit was rejecting most pro shots.
+UPDATE storage.buckets SET file_size_limit = 26214400 WHERE id = 'event-photos';
+-- 26214400 = 25 * 1024 * 1024 = 25 MiB


### PR DESCRIPTION
## Changes
- **25MB cap** for /event-photos uploads (was 10MB). Bucket migration + client check + PhotoUpload constant.
- **30 photos per user per event** limit. 31st upload throws PHOTO_LIMIT_REACHED with message: \"30 photo limit per user. Remove photos to make room\". Counts non-rejected photos. Identifies user by userId / guestId / uploaderEmail.

## Deploy order
1. Apply bucket migration to prod (\`UPDATE storage.buckets SET file_size_limit = 26214400 WHERE id = 'event-photos'\`)
2. Merge -> backend redeploys with per-user check
3. Frontend redeploys with 25MB client check + error display

## Test plan
- [ ] Upload 20MB photo -> succeeds (was rejected with 10MB cap)
- [ ] Upload 30MB photo -> still rejected (above 25MB)
- [ ] Same user uploads 30 photos -> all succeed
- [ ] User tries 31st upload -> \"30 photo limit per user. Remove photos to make room\" shown
- [ ] After deleting one of their photos -> 31st upload succeeds

Generated with [Claude Code](https://claude.com/claude-code)