### PR TITLE
feat(salame-92110): host tax-form upload (W-9 / W-8BEN / W-8BEN-E)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "jsonwebtoken": "^9.0.2",
     "nanoid": "^5.0.5",
     "openai": "^6.38.0",
+    "pdf-lib": "^1.17.1",
     "pg": "^8.21.0",
     "sharp": "^0.33.5",
     "swagger-jsdoc": "^6.2.8",

--- a/backend/prisma/migrations/20260531_tax_forms/migration.sql
+++ b/backend/prisma/migrations/20260531_tax_forms/migration.sql
@@ -1,0 +1,61 @@
+-- salame-92110: host tax-form upload (W-9 / W-8BEN / W-8BEN-E).
+--
+-- Hosts must submit a tax form before admin can Approve their payouts.
+-- US W-9 is required at $600 YTD; foreign W-8BEN / W-8BEN-E are required
+-- for every payment (the IRS has no small-payment exception for foreign).
+--
+-- `tax_forms.form_data` is a JSONB blob holding the per-form fields used to
+-- generate the PDF (name/address/TIN/etc.). The generated PDF is uploaded to
+-- the existing `event-images` bucket (10MB cap + application/pdf allowlist
+-- already in place from bocconcino-92104).
+--
+-- `payouts.tax_form_id` snapshots the form used at submission time so
+-- historical immutability survives the host editing or replacing their form
+-- later. ON DELETE SET NULL — deleting a tax form unsets the link but does
+-- not cascade-destroy historical payouts.
+
+CREATE TABLE "tax_forms" (
+  "id"              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"         TEXT         NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "form_type"       TEXT         NOT NULL CHECK ("form_type" IN ('w9', 'w8ben', 'w8bene')),
+  "status"          TEXT         NOT NULL DEFAULT 'draft'
+                                  CHECK ("status" IN ('draft', 'submitted', 'verified', 'rejected')),
+  "form_data"       JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  "pdf_url"         TEXT,
+  "pdf_thumb_url"   TEXT,
+  "signed_at"       TIMESTAMPTZ,
+  "expires_at"      TIMESTAMPTZ,
+  "verified_at"     TIMESTAMPTZ,
+  "verified_by"     TEXT,
+  "rejected_reason" TEXT,
+  "created_at"      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  "updated_at"      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "idx_tax_forms_user_id"    ON "tax_forms"("user_id");
+CREATE INDEX "idx_tax_forms_status"     ON "tax_forms"("status");
+CREATE INDEX "idx_tax_forms_expires_at" ON "tax_forms"("expires_at") WHERE "expires_at" IS NOT NULL;
+
+ALTER TABLE "payouts" ADD COLUMN "tax_form_id" UUID REFERENCES "tax_forms"("id") ON DELETE SET NULL;
+CREATE INDEX "idx_payouts_tax_form_id" ON "payouts"("tax_form_id");
+
+-- Column-level SELECT grants. `form_data` is intentionally NOT granted to
+-- authenticated — the route handler's admin-only detail endpoint returns it
+-- via the service-role Prisma client. Host-side endpoints surface the PDF
+-- URL + thumbnail + status only.
+GRANT SELECT (
+  "id",
+  "user_id",
+  "form_type",
+  "status",
+  "pdf_url",
+  "pdf_thumb_url",
+  "signed_at",
+  "expires_at",
+  "verified_at",
+  "rejected_reason",
+  "created_at",
+  "updated_at"
+) ON "tax_forms" TO authenticated;
+
+GRANT SELECT ("tax_form_id") ON "payouts" TO anon, authenticated;

--- a/backend/prisma/migrations/20260531_tax_forms/migration.sql
+++ b/backend/prisma/migrations/20260531_tax_forms/migration.sql
@@ -59,3 +59,13 @@ GRANT SELECT (
 ) ON "tax_forms" TO authenticated;
 
 GRANT SELECT ("tax_form_id") ON "payouts" TO anon, authenticated;
+
+-- culatello-92106: per-event admin-controlled gate for the tax-form
+-- requirement. The salame-92110 host-side TaxFormSection only renders + the
+-- backend TAX_FORM_REQUIRED 400 only fires when this flag is true. Default
+-- false so existing events do NOT regress into requiring a form — admin
+-- explicitly flips the flag for events that should be gated. Hosts cannot
+-- toggle this; the admin checkbox lives on /payments (PayoutReviewModal +
+-- PayoutsByPartyTable city expansion).
+ALTER TABLE parties ADD COLUMN tax_form_required boolean NOT NULL DEFAULT false;
+GRANT SELECT (tax_form_required) ON parties TO anon, authenticated;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -236,6 +236,13 @@ model Party {
   // events. Cron worker skips parties where this is false.
   remindersEnabled Boolean @default(true) @map("reminders_enabled")
 
+  // culatello-92106: per-event gate for the salame-92110 host tax-form
+  // requirement. When false (default) the host-side TaxFormSection is hidden
+  // and the backend TAX_FORM_REQUIRED 400 is skipped. Flipped per-event by an
+  // admin on /payments (PayoutReviewModal + PayoutsByPartyTable city
+  // expansion). Hosts cannot toggle this flag.
+  taxFormRequired Boolean @default(false) @map("tax_form_required")
+
   // Reimbursement cap (arugula-38633 v2) — set by underboss after validating
   // the city-tier × RSVP heuristic. NULL = not yet validated (banner hidden).
   reimbursementCapUsd        Decimal?  @map("reimbursement_cap_usd") @db.Decimal(10, 2)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,6 +46,7 @@ model User {
   uploadedPayoutDocuments          PayoutDocument[]         @relation("PayoutDocumentUploadedBy")
   reimbursementCapAppealsSubmitted ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsByHost")
   reimbursementCapAppealsReviewed  ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsReviewedBy")
+  taxForms                         TaxForm[]
 }
 
 model Party {
@@ -1738,6 +1739,14 @@ model Payout {
   wireReference    String? @map("wire_reference")
   externalProofUrl String? @map("external_proof_url")
 
+  // salame-92110: snapshot of the host's tax form at the time this payout was
+  // submitted. Set on POST when the host has a `status='submitted'` form on
+  // file. NULL on payouts created before the tax-form feature shipped, and on
+  // shipping-coordinator receipts that don't require a form. ON DELETE SET
+  // NULL — historical payouts survive a form being deleted.
+  taxFormId String?  @map("tax_form_id") @db.Uuid
+  taxForm   TaxForm? @relation(fields: [taxFormId], references: [id], onDelete: SetNull)
+
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
@@ -1748,7 +1757,49 @@ model Payout {
   @@index([hostUserId])
   @@index([status])
   @@index([createdAt(sort: Desc)])
+  @@index([taxFormId])
   @@map("payouts")
+}
+
+// ============================================
+// Host tax forms (salame-92110)
+// ============================================
+// Per-user W-9 (US individuals/entities), W-8BEN (foreign individuals), or
+// W-8BEN-E (foreign entities). `form_data` is a JSONB blob holding the
+// per-form fields used to render the PDF; the canonical PDF lives in
+// Supabase Storage (`event-images` bucket) and `pdf_url` references it.
+//
+// One submitted form per user per type is the typical case; we store all
+// historical drafts/submissions so admins can audit changes. The form used
+// at payout time is snapshotted onto `payouts.tax_form_id`.
+model TaxForm {
+  id             String    @id @default(uuid()) @db.Uuid
+  userId         String    @map("user_id")
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // 'w9' | 'w8ben' | 'w8bene' — enforced by DB CHECK constraint.
+  formType       String    @map("form_type")
+  // 'draft' | 'submitted' | 'verified' | 'rejected' — enforced by DB CHECK.
+  status         String    @default("draft")
+  formData       Json      @default("{}") @map("form_data")
+  pdfUrl         String?   @map("pdf_url")
+  pdfThumbUrl    String?   @map("pdf_thumb_url")
+  signedAt       DateTime? @map("signed_at") @db.Timestamptz
+  // W-9: NULL (no expiry). W-8 forms: signed_at + 3 years and last day of the
+  // third calendar year per IRS rules — we use a simpler "signed_at + 3y11m"
+  // for now (re-validated by the phase-2 expiry cron).
+  expiresAt      DateTime? @map("expires_at") @db.Timestamptz
+  verifiedAt     DateTime? @map("verified_at") @db.Timestamptz
+  verifiedBy     String?   @map("verified_by")
+  rejectedReason String?   @map("rejected_reason")
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+
+  payouts Payout[]
+
+  @@index([userId])
+  @@index([status])
+  @@index([expiresAt])
+  @@map("tax_forms")
 }
 
 // ============================================

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -67,6 +67,7 @@ import resendWebhookRouter from './routes/webhooks.resend.routes.js';
 import ensRoutes from './routes/ens.routes.js';
 import { surveyPublicRouter, surveyHostRouter, cronRouter } from './routes/survey.routes.js';
 import reminderRoutes from './routes/reminder.routes.js';
+import { taxFormRouter, adminTaxFormRouter } from './routes/tax-form.routes.js';
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -139,6 +140,7 @@ app.use('/api/rsvp', rsvpLimiter);
 
 // Routes
 app.use('/api/admin/logo-bg-audit', logoAuditRoutes); // Graphics-admin logo cleanup (before /api/admin catch-all)
+app.use('/api/admin/tax-forms', adminTaxFormRouter); // salame-92110: admin tax-form review (before /api/admin catch-all)
 app.use('/api/admin/payouts', adminPayoutRoutes); // Host payouts admin dashboard (before /api/admin catch-all)
 app.use('/api/admin/payout-wallet', payoutWalletRouter); // coppa-91827: hot wallet address + balances (before /api/admin catch-all)
 app.use('/api/admin/parties', partyMarkPaidRouter); // panettone-92103: party-level "mark party paid" bulk action — before /api/admin catch-all
@@ -156,6 +158,7 @@ app.use('/api/sponsor-users', quizTemplateRoutes); // Quiz template CRUD (admin)
 app.use('/api/sponsor/report/ai', partnerAiShareRouter);
 app.use('/api/sponsor', sponsorDashboardRouter); // Sponsor dashboard (login-based auth)
 app.use('/api/shipping', shippingRoutes); // Shipping coordinator dashboard
+app.use('/api/tax-forms', taxFormRouter); // salame-92110: host tax-form upload (W-9 / W-8BEN / W-8BEN-E)
 app.use('/api/auth', authRoutes);
 app.use('/api/photos', photoFeedRoutes); // margherita-43821: public global photos feed
 app.use('/api/payouts', payoutDocumentVoteRoutes); // napoletana-58210: vote on payout-sourced pizza photos

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -267,6 +267,10 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   // ✓ Closed pill on the by-city table + hides the Mark Paid affordance for
   // already-closed parties.
   paymentsClosedAt: true,
+  // culatello-92106: per-event tax-form gate. Surfaced on /payments so admin
+  // can flip it via the PayoutReviewModal checkbox + the city-expansion
+  // pill — drives whether the host-side TaxFormSection renders.
+  taxFormRequired: true,
   // mortadella-92106: admin-only city notes. Surfaced in the by-city
   // expansion for admin viewers and stripped from the response for
   // underbosses (see serializer below).
@@ -833,6 +837,9 @@ function serializePayout(row: any): any {
           paymentsClosedAt: row.party.paymentsClosedAt
             ? row.party.paymentsClosedAt.toISOString()
             : null,
+          // culatello-92106: per-event tax-form gate. Drives the admin
+          // checkbox in PayoutReviewModal + the pill in PayoutsByPartyTable.
+          taxFormRequired: row.party.taxFormRequired === true,
         }
       : undefined,
     host: row.host
@@ -2034,6 +2041,10 @@ router.get(
             paymentsClosedAt: b.partyMeta.paymentsClosedAt
               ? b.partyMeta.paymentsClosedAt.toISOString()
               : null,
+            // culatello-92106: per-event tax-form gate. Surfaced on the
+            // outer city row so PayoutsByPartyTable can render the pill
+            // before the admin expands the row.
+            taxFormRequired: b.partyMeta.taxFormRequired === true,
             // mortadella-92106: admin-only city notes. Stripped to null for
             // underboss viewers so they never see the text — both the input
             // and the gating on the frontend are belt-and-braces but this

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -500,6 +500,10 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       wifiInfo,
       parkingNotes,
       reimbursementCapUsd,
+      // culatello-92106: admin-only per-event tax-form gate. Hosts who
+      // attempt to PATCH this field get silently dropped from the update
+      // (rather than 403'd) so the rest of their save still succeeds.
+      taxFormRequired,
       // quattro-71244: gamified dashboard goals (JSONB) — per-KPI host targets.
       hostGoals,
       // porchetta-81402: host can edit the free-text cancellation reason
@@ -653,6 +657,20 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
     }
 
+    // culatello-92106: taxFormRequired is admin-only (admin / super_admin /
+    // payment_admin via isPaymentAdmin — same gate used for the 'go' tag
+    // above). Hosts who try to set it via this generic PATCH get silently
+    // dropped from the update (rather than 403'd) so the rest of their save
+    // still succeeds. We coerce to a strict boolean so a stray "true" / 0 /
+    // null doesn't write garbage into a NOT NULL column.
+    let taxFormRequiredToWrite: boolean | undefined = undefined;
+    if (taxFormRequired !== undefined) {
+      const allowed = await isPaymentAdmin(req.userEmail);
+      if (allowed) {
+        taxFormRequiredToWrite = taxFormRequired === true || taxFormRequired === 'true';
+      }
+    }
+
     // fennel-49102: snapshot the prior cap value so we can log only real
     // changes to reimbursement_cap_audit. Skipped when the request doesn't
     // touch the cap (either field omitted or caller wasn't authorized to
@@ -762,6 +780,7 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(wifiInfo !== undefined && { wifiInfo: wifiInfo || null }),
         ...(parkingNotes !== undefined && { parkingNotes: parkingNotes || null }),
         ...(reimbursementCapUsdToWrite !== undefined && { reimbursementCapUsd: reimbursementCapUsdToWrite }),
+        ...(taxFormRequiredToWrite !== undefined && { taxFormRequired: taxFormRequiredToWrite }),
         ...(hostGoalsToWrite !== undefined && { hostGoals: hostGoalsToWrite }),
         // porchetta-81402: allow editing the cancellation reason (truncated to
         // 500 chars to match the cancel-handler limit). Empty string clears it.

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -837,17 +837,21 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       await assertUserHasValidPayoutMethod(req.userId);
     }
 
-    // salame-92110: tax-form gate. We snapshot the recipient host's latest
-    // submitted/verified tax form onto the new payout. Phase 1 keeps the
-    // required-vs-not decision host-driven — the host picks the form type
-    // (W-9, W-8BEN, W-8BEN-E) from a 3-card picker on the payout form; we
-    // don't auto-infer US vs foreign from User / Party fields.
+    // salame-92110 + culatello-92106: tax-form gate.
     //
-    // Required when:
-    //   - any tax form has ever been submitted (host is in the system), OR
-    //   - projected YTD payout total is at or above the $600 W-9 floor.
+    // culatello-92106 moved the required-vs-not decision behind a per-event
+    // admin-controlled flag (`parties.tax_form_required`). When the flag is
+    // false (the default) the gate is skipped entirely — the host can submit
+    // payouts without a tax form. When admin has flipped the flag to true on
+    // /payments, the salame-92110 logic runs: a W-9 / W-8BEN / W-8BEN-E must
+    // exist before the receipt can be submitted, and the latest form is
+    // snapshotted onto the resulting payout.
     //
-    // Skipped entirely when:
+    // Inside the flagged-on branch, the salame-92110 required-vs-not logic
+    // still applies (latest form OR projected YTD ≥ $600), but in practice
+    // both reduce to "form must exist" because the flag itself is the gate.
+    //
+    // Skipped entirely (regardless of party flag) when:
     //   - purpose='shipping' (shipping coordinators don't take taxable income
     //     via this flow), OR
     //   - an admin is prepaying on behalf of a cohost.
@@ -859,28 +863,49 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     let taxFormSnapshotId: string | null = null;
     const skipTaxFormGate = isShippingPurpose || adminPrepayingForCohost;
     if (!skipTaxFormGate) {
+      // culatello-92106: read the per-event flag before doing anything else.
+      // We always still snapshot the latest form onto the payout when one
+      // exists (so admin can review historical submissions even if the flag
+      // later flips off), but we only THROW when the flag is on.
+      const partyForTaxGate = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { taxFormRequired: true },
+      });
+      const partyTaxFormRequired = partyForTaxGate?.taxFormRequired === true;
       const gateRecipientUserId =
         recipientOverrideRequested && typeof recipientHostUserId === 'string'
           ? recipientHostUserId.trim()
           : req.userId;
       if (gateRecipientUserId) {
-        const [latestForm, ytdTotal] = await Promise.all([
-          getLatestSubmittedTaxFormForUser(gateRecipientUserId),
-          getYtdPayoutTotalUsd(gateRecipientUserId),
-        ]);
-        const incomingAmount =
-          typeof finalAmountUsd === 'number' && finalAmountUsd > 0 ? finalAmountUsd : 0;
-        const projectedYtd = ytdTotal + incomingAmount;
-        const required = latestForm != null || projectedYtd >= US_W9_YTD_THRESHOLD_USD;
-        if (required && !latestForm) {
-          throw new AppError(
-            'A tax form (W-9, W-8BEN, or W-8BEN-E) is required before this payment can be submitted.',
-            400,
-            'TAX_FORM_REQUIRED',
-          );
-        }
-        if (latestForm) {
-          taxFormSnapshotId = latestForm.id;
+        if (partyTaxFormRequired) {
+          // Per-event flag is ON — enforce salame-92110 gate.
+          const [latestForm, ytdTotal] = await Promise.all([
+            getLatestSubmittedTaxFormForUser(gateRecipientUserId),
+            getYtdPayoutTotalUsd(gateRecipientUserId),
+          ]);
+          const incomingAmount =
+            typeof finalAmountUsd === 'number' && finalAmountUsd > 0 ? finalAmountUsd : 0;
+          const projectedYtd = ytdTotal + incomingAmount;
+          const required = latestForm != null || projectedYtd >= US_W9_YTD_THRESHOLD_USD;
+          if (required && !latestForm) {
+            throw new AppError(
+              'A tax form (W-9, W-8BEN, or W-8BEN-E) is required before this payment can be submitted.',
+              400,
+              'TAX_FORM_REQUIRED',
+            );
+          }
+          if (latestForm) {
+            taxFormSnapshotId = latestForm.id;
+          }
+        } else {
+          // Per-event flag is OFF — skip the throw, but still snapshot the
+          // form when the host has one on file so admin's TaxFormReviewPanel
+          // keeps working (and so flipping the flag on later doesn't lose the
+          // attribution to past payouts).
+          const latestForm = await getLatestSubmittedTaxFormForUser(gateRecipientUserId);
+          if (latestForm) {
+            taxFormSnapshotId = latestForm.id;
+          }
         }
       }
     }

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -26,6 +26,11 @@ import { convertToUSD } from '../services/fx.service.js';
 import { looksLikeEnsName, resolveWalletInput, resolveWalletInputWithMeta } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
+import {
+  getLatestSubmittedTaxFormForUser,
+  getYtdPayoutTotalUsd,
+  US_W9_YTD_THRESHOLD_USD,
+} from './tax-form.routes.js';
 
 const router = Router();
 
@@ -106,6 +111,9 @@ function serializePayout(p: any) {
     transactionHash: p.transactionHash ?? null,
     wireReference: p.wireReference ?? null,
     externalProofUrl: p.externalProofUrl ?? null,
+    // salame-92110: snapshot of the host's tax form at submission time.
+    // Null on pre-feature payouts and on shipping-coordinator receipts.
+    taxFormId: p.taxFormId ?? null,
     createdAt: p.createdAt.toISOString(),
     updatedAt: p.updatedAt.toISOString(),
     documents: Array.isArray(p.documents) ? p.documents.map(serializeDocument) : undefined,
@@ -829,6 +837,54 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       await assertUserHasValidPayoutMethod(req.userId);
     }
 
+    // salame-92110: tax-form gate. We snapshot the recipient host's latest
+    // submitted/verified tax form onto the new payout. Phase 1 keeps the
+    // required-vs-not decision host-driven — the host picks the form type
+    // (W-9, W-8BEN, W-8BEN-E) from a 3-card picker on the payout form; we
+    // don't auto-infer US vs foreign from User / Party fields.
+    //
+    // Required when:
+    //   - any tax form has ever been submitted (host is in the system), OR
+    //   - projected YTD payout total is at or above the $600 W-9 floor.
+    //
+    // Skipped entirely when:
+    //   - purpose='shipping' (shipping coordinators don't take taxable income
+    //     via this flow), OR
+    //   - an admin is prepaying on behalf of a cohost.
+    //
+    // The recipient for the gate is the admin-overridden `recipientHostUserId`
+    // when applicable, else the authenticated submitter. We collapse the
+    // admin-override resolution here (a couple of lines below the same logic
+    // runs for `effectiveHostUserId`).
+    let taxFormSnapshotId: string | null = null;
+    const skipTaxFormGate = isShippingPurpose || adminPrepayingForCohost;
+    if (!skipTaxFormGate) {
+      const gateRecipientUserId =
+        recipientOverrideRequested && typeof recipientHostUserId === 'string'
+          ? recipientHostUserId.trim()
+          : req.userId;
+      if (gateRecipientUserId) {
+        const [latestForm, ytdTotal] = await Promise.all([
+          getLatestSubmittedTaxFormForUser(gateRecipientUserId),
+          getYtdPayoutTotalUsd(gateRecipientUserId),
+        ]);
+        const incomingAmount =
+          typeof finalAmountUsd === 'number' && finalAmountUsd > 0 ? finalAmountUsd : 0;
+        const projectedYtd = ytdTotal + incomingAmount;
+        const required = latestForm != null || projectedYtd >= US_W9_YTD_THRESHOLD_USD;
+        if (required && !latestForm) {
+          throw new AppError(
+            'A tax form (W-9, W-8BEN, or W-8BEN-E) is required before this payment can be submitted.',
+            400,
+            'TAX_FORM_REQUIRED',
+          );
+        }
+        if (latestForm) {
+          taxFormSnapshotId = latestForm.id;
+        }
+      }
+    }
+
     // Validate optional one-shot attendance setup. Only persisted to the party
     // below if the party's current expectedGuests is null (see updateMany call).
     let validatedAttendance: number | null = null;
@@ -1272,6 +1328,10 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           // bismarck-92103: admin-supplied adminNotes (e.g. "Prepayment for X")
           // when an admin creates a prepayment on behalf of a cohost.
           adminNotes: initialAdminNotes,
+          // salame-92110: snapshot of the recipient host's tax form at submit
+          // time (W-9 / W-8BEN / W-8BEN-E). Null on shipping-purpose receipts
+          // and on admin-prepay rows where the gate is skipped.
+          taxFormId: taxFormSnapshotId,
           documents: { create: docsToCreateStamped },
         },
         include: {

--- a/backend/src/routes/tax-form.routes.ts
+++ b/backend/src/routes/tax-form.routes.ts
@@ -1,0 +1,458 @@
+/**
+ * salame-92110: host-facing + admin endpoints for tax forms (W-9 / W-8BEN /
+ * W-8BEN-E).
+ *
+ * Host endpoints (authed):
+ *   GET    /api/tax-forms/me                   List my tax forms (latest first)
+ *   POST   /api/tax-forms/draft                Upsert my draft for a form type
+ *   POST   /api/tax-forms/submit               Finalize current draft → generate PDF → status='submitted'
+ *
+ * Admin endpoints (admin / payment_admin / super_admin):
+ *   GET    /api/admin/tax-forms                List with filters (status, form_type, user_id, expiring)
+ *   GET    /api/admin/tax-forms/:id            Detail (includes form_data jsonb)
+ *   POST   /api/admin/tax-forms/:id/verify     Stamp verified_at + verified_by
+ *   POST   /api/admin/tax-forms/:id/reject     Set status='rejected' + rejected_reason
+ *
+ * Phase 1 scope: no expiry cron, no 1099-NEC year-end generator. Those land
+ * in phase 2.
+ */
+import { Router, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isPaymentAdmin } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import {
+  generateW9PDF,
+  generateW8BENPDF,
+  generateW8BENEPDF,
+  W9FormData,
+  W8BENFormData,
+  W8BENEFormData,
+} from '../services/taxFormPdf.service.js';
+import { uploadTaxFormPdf, TaxFormType } from '../services/taxFormStorage.service.js';
+
+export const taxFormRouter = Router();
+export const adminTaxFormRouter = Router();
+
+const FORM_TYPES: ReadonlyArray<TaxFormType> = ['w9', 'w8ben', 'w8bene'] as const;
+const STATUSES = ['draft', 'submitted', 'verified', 'rejected'] as const;
+type TaxFormStatus = (typeof STATUSES)[number];
+
+// ---------- helpers ----------
+
+function isValidFormType(v: unknown): v is TaxFormType {
+  return typeof v === 'string' && (FORM_TYPES as ReadonlyArray<string>).includes(v);
+}
+
+function serializeTaxForm(t: any, includeFormData: boolean) {
+  return {
+    id: t.id,
+    userId: t.userId,
+    formType: t.formType,
+    status: t.status,
+    pdfUrl: t.pdfUrl ?? null,
+    pdfThumbUrl: t.pdfThumbUrl ?? null,
+    signedAt: t.signedAt ? t.signedAt.toISOString() : null,
+    expiresAt: t.expiresAt ? t.expiresAt.toISOString() : null,
+    verifiedAt: t.verifiedAt ? t.verifiedAt.toISOString() : null,
+    verifiedBy: t.verifiedBy ?? null,
+    rejectedReason: t.rejectedReason ?? null,
+    createdAt: t.createdAt.toISOString(),
+    updatedAt: t.updatedAt.toISOString(),
+    ...(includeFormData ? { formData: t.formData ?? {} } : {}),
+    ...(t.user ? { user: { id: t.user.id, name: t.user.name ?? null, email: t.user.email ?? null } } : {}),
+  };
+}
+
+/**
+ * Validate the minimal required fields per form type before generating a PDF.
+ * Throws AppError(400, 'INVALID_FORM_DATA') with a human-readable message
+ * naming the missing field.
+ */
+function assertSubmitValid(formType: TaxFormType, data: any): void {
+  function requireField(field: string) {
+    if (!data || typeof data[field] !== 'string' || !data[field].trim()) {
+      throw new AppError(
+        `Missing required field: ${field}`,
+        400,
+        'INVALID_FORM_DATA',
+      );
+    }
+  }
+  if (formType === 'w9') {
+    requireField('name');
+    requireField('taxClassification');
+    requireField('address');
+    requireField('cityStateZip');
+    requireField('signature');
+    requireField('date');
+    // Exactly one of SSN / EIN must be present.
+    const hasSsn = typeof data.ssn === 'string' && data.ssn.trim();
+    const hasEin = typeof data.ein === 'string' && data.ein.trim();
+    if (!hasSsn && !hasEin) {
+      throw new AppError(
+        'Either SSN or EIN is required on the W-9',
+        400,
+        'INVALID_FORM_DATA',
+      );
+    }
+  } else if (formType === 'w8ben') {
+    requireField('name');
+    requireField('citizenship');
+    requireField('permanentAddress');
+    requireField('permanentCity');
+    requireField('permanentCountry');
+    requireField('dateOfBirth');
+    requireField('signature');
+    requireField('date');
+  } else if (formType === 'w8bene') {
+    requireField('entityName');
+    requireField('countryOfIncorporation');
+    requireField('entityType');
+    requireField('chapter4Status');
+    requireField('permanentAddress');
+    requireField('permanentCity');
+    requireField('permanentCountry');
+    requireField('signature');
+    requireField('date');
+    if (data.chapter4Status === 'ffi') {
+      // FFI requires the long-form FATCA classification we don't render.
+      throw new AppError(
+        'FFI entities require a paper W-8BEN-E — please contact an admin',
+        400,
+        'FFI_PAPER_FORM_REQUIRED',
+      );
+    }
+  }
+}
+
+/**
+ * Compute the IRS expiry for a W-8 form: signed_at + 3 years and the rest of
+ * the calendar year. Simplified to "signed_at + 3 years 11 months" — phase 2
+ * cron refines this if needed.
+ *
+ * W-9 has no expiry (returns null).
+ */
+function computeExpiry(formType: TaxFormType, signedAt: Date): Date | null {
+  if (formType === 'w9') return null;
+  const d = new Date(signedAt);
+  d.setUTCMonth(d.getUTCMonth() + 47); // 3 years 11 months
+  return d;
+}
+
+// ============================================================================
+// Host endpoints
+// ============================================================================
+
+taxFormRouter.use(requireAuth);
+
+// GET /api/tax-forms/me — list authed user's tax forms (latest first)
+taxFormRouter.get('/me', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.userId) throw new AppError('No user id on request', 500, 'NO_USER_ID');
+    const forms = await prisma.taxForm.findMany({
+      where: { userId: req.userId },
+      orderBy: [{ updatedAt: 'desc' }],
+    });
+    res.json({ taxForms: forms.map((t) => serializeTaxForm(t, /* includeFormData */ true)) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/tax-forms/draft — create/update draft for a form type
+// Body: { formType: 'w9'|'w8ben'|'w8bene', formData: {...} }
+// Idempotent per (user, form_type) — upserts the user's existing draft if
+// one exists, otherwise creates a new row. Replacing a submitted form
+// requires posting a new draft of the same type (which appears alongside).
+taxFormRouter.post('/draft', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.userId) throw new AppError('No user id on request', 500, 'NO_USER_ID');
+    const { formType, formData } = (req.body || {}) as {
+      formType?: unknown;
+      formData?: unknown;
+    };
+    if (!isValidFormType(formType)) {
+      throw new AppError('formType must be w9|w8ben|w8bene', 400, 'INVALID_FORM_TYPE');
+    }
+    if (formData == null || typeof formData !== 'object') {
+      throw new AppError('formData must be an object', 400, 'INVALID_FORM_DATA');
+    }
+
+    // Look for an existing draft of this type for this user. If found, update
+    // in place (so editing the form before submit doesn't pile up rows).
+    const existingDraft = await prisma.taxForm.findFirst({
+      where: { userId: req.userId, formType, status: 'draft' },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    const data = formData as Prisma.InputJsonValue;
+
+    let row;
+    if (existingDraft) {
+      row = await prisma.taxForm.update({
+        where: { id: existingDraft.id },
+        data: { formData: data },
+      });
+    } else {
+      row = await prisma.taxForm.create({
+        data: {
+          userId: req.userId,
+          formType,
+          status: 'draft',
+          formData: data,
+        },
+      });
+    }
+
+    res.status(existingDraft ? 200 : 201).json({ taxForm: serializeTaxForm(row, true) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/tax-forms/submit — finalize draft (or submit new) → PDF → store
+// Body: { formType: 'w9'|'w8ben'|'w8bene', formData?: {...} }
+//   - If formData is provided, the draft is updated to that data first.
+//   - Validates required fields, generates the PDF, uploads it, then writes:
+//       status='submitted', signed_at=now(), expires_at, pdf_url.
+taxFormRouter.post('/submit', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.userId) throw new AppError('No user id on request', 500, 'NO_USER_ID');
+    const { formType, formData } = (req.body || {}) as {
+      formType?: unknown;
+      formData?: unknown;
+    };
+    if (!isValidFormType(formType)) {
+      throw new AppError('formType must be w9|w8ben|w8bene', 400, 'INVALID_FORM_TYPE');
+    }
+
+    // Locate the current draft for this type; either we're submitting one
+    // the host already saved, or we'll create a fresh row.
+    let draft = await prisma.taxForm.findFirst({
+      where: { userId: req.userId, formType, status: 'draft' },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    // Merge incoming formData over the saved draft (or use it standalone).
+    const dataToValidate = formData && typeof formData === 'object'
+      ? { ...(draft?.formData as any || {}), ...(formData as any) }
+      : (draft?.formData as any || {});
+
+    assertSubmitValid(formType, dataToValidate);
+
+    // Render the PDF — use a stable shortish reference id for the PDF footer.
+    // We use the draft id when available, otherwise a placeholder until insert.
+    const refIdForPdf = draft?.id || `${formType}-${Date.now()}`;
+    let pdf: Buffer;
+    if (formType === 'w9') {
+      pdf = await generateW9PDF(dataToValidate as W9FormData, refIdForPdf.slice(0, 8));
+    } else if (formType === 'w8ben') {
+      pdf = await generateW8BENPDF(dataToValidate as W8BENFormData, refIdForPdf.slice(0, 8));
+    } else {
+      pdf = await generateW8BENEPDF(dataToValidate as W8BENEFormData, refIdForPdf.slice(0, 8));
+    }
+
+    // Upload to storage.
+    const { url, thumbUrl } = await uploadTaxFormPdf(pdf, req.userId, formType);
+
+    // Persist as submitted.
+    const now = new Date();
+    const expiresAt = computeExpiry(formType, now);
+    let row;
+    if (draft) {
+      row = await prisma.taxForm.update({
+        where: { id: draft.id },
+        data: {
+          formData: dataToValidate as Prisma.InputJsonValue,
+          status: 'submitted',
+          pdfUrl: url,
+          pdfThumbUrl: thumbUrl,
+          signedAt: now,
+          expiresAt,
+          // Clear any prior rejection state if the host re-submits.
+          rejectedReason: null,
+        },
+      });
+    } else {
+      row = await prisma.taxForm.create({
+        data: {
+          userId: req.userId,
+          formType,
+          status: 'submitted',
+          formData: dataToValidate as Prisma.InputJsonValue,
+          pdfUrl: url,
+          pdfThumbUrl: thumbUrl,
+          signedAt: now,
+          expiresAt,
+        },
+      });
+    }
+
+    res.status(200).json({ taxForm: serializeTaxForm(row, true) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ============================================================================
+// Admin endpoints
+// ============================================================================
+
+adminTaxFormRouter.use(requireAuth);
+
+async function requireAnyAdmin(req: AuthRequest, _res: Response, next: NextFunction) {
+  try {
+    if (!(await isPaymentAdmin(req.userEmail))) {
+      throw new AppError('Forbidden', 403, 'FORBIDDEN');
+    }
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+adminTaxFormRouter.use(requireAnyAdmin);
+
+// GET /api/admin/tax-forms?status=&formType=&userId=&expiringWithinDays=
+adminTaxFormRouter.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { status, formType, userId, expiringWithinDays } = req.query;
+    const where: Prisma.TaxFormWhereInput = {};
+    if (typeof status === 'string' && (STATUSES as ReadonlyArray<string>).includes(status)) {
+      where.status = status;
+    }
+    if (isValidFormType(formType)) {
+      where.formType = formType;
+    }
+    if (typeof userId === 'string' && userId.trim()) {
+      where.userId = userId.trim();
+    }
+    if (typeof expiringWithinDays === 'string') {
+      const n = Number(expiringWithinDays);
+      if (Number.isFinite(n) && n > 0) {
+        const cutoff = new Date();
+        cutoff.setUTCDate(cutoff.getUTCDate() + n);
+        where.expiresAt = { not: null, lte: cutoff };
+      }
+    }
+
+    const rows = await prisma.taxForm.findMany({
+      where,
+      orderBy: [{ updatedAt: 'desc' }],
+      include: { user: { select: { id: true, name: true, email: true } } },
+      take: 500,
+    });
+
+    // Tight payload — omit form_data on the list (it's only fetched on detail).
+    res.json({ taxForms: rows.map((t) => serializeTaxForm(t, /* includeFormData */ false)) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/admin/tax-forms/:id — full detail incl. form_data jsonb
+adminTaxFormRouter.get('/:id', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const row = await prisma.taxForm.findUnique({
+      where: { id: req.params.id },
+      include: { user: { select: { id: true, name: true, email: true } } },
+    });
+    if (!row) throw new AppError('Tax form not found', 404, 'NOT_FOUND');
+    res.json({ taxForm: serializeTaxForm(row, /* includeFormData */ true) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/admin/tax-forms/:id/verify
+adminTaxFormRouter.post(
+  '/:id/verify',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const row = await prisma.taxForm.findUnique({ where: { id: req.params.id } });
+      if (!row) throw new AppError('Tax form not found', 404, 'NOT_FOUND');
+      if (row.status !== 'submitted') {
+        throw new AppError(
+          'Only submitted forms can be verified',
+          400,
+          'INVALID_STATUS_TRANSITION',
+        );
+      }
+      const updated = await prisma.taxForm.update({
+        where: { id: row.id },
+        data: {
+          status: 'verified',
+          verifiedAt: new Date(),
+          verifiedBy: req.userEmail || null,
+          rejectedReason: null,
+        },
+        include: { user: { select: { id: true, name: true, email: true } } },
+      });
+      res.json({ taxForm: serializeTaxForm(updated, true) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// POST /api/admin/tax-forms/:id/reject  Body: { reason: string }
+adminTaxFormRouter.post(
+  '/:id/reject',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { reason } = (req.body || {}) as { reason?: unknown };
+      if (typeof reason !== 'string' || !reason.trim()) {
+        throw new AppError('reason is required', 400, 'REASON_REQUIRED');
+      }
+      const row = await prisma.taxForm.findUnique({ where: { id: req.params.id } });
+      if (!row) throw new AppError('Tax form not found', 404, 'NOT_FOUND');
+      const updated = await prisma.taxForm.update({
+        where: { id: row.id },
+        data: {
+          status: 'rejected',
+          rejectedReason: reason.trim(),
+          verifiedAt: null,
+          verifiedBy: null,
+        },
+        include: { user: { select: { id: true, name: true, email: true } } },
+      });
+      res.json({ taxForm: serializeTaxForm(updated, true) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// Convenience helper exported for use in the payout-submission gate.
+export async function getLatestSubmittedTaxFormForUser(userId: string) {
+  return prisma.taxForm.findFirst({
+    where: {
+      userId,
+      status: { in: ['submitted', 'verified'] },
+    },
+    orderBy: [{ updatedAt: 'desc' }],
+  });
+}
+
+// US YTD payout threshold — W-9 required at or above this.
+export const US_W9_YTD_THRESHOLD_USD = 600;
+
+/**
+ * Sum paid + approved + queued payouts for a user in the current calendar
+ * year. Used by the payout-submission gate to decide whether the W-9 floor
+ * has been crossed.
+ */
+export async function getYtdPayoutTotalUsd(userId: string): Promise<number> {
+  const start = new Date();
+  start.setUTCMonth(0, 1);
+  start.setUTCHours(0, 0, 0, 0);
+  const rows = await prisma.payout.findMany({
+    where: {
+      hostUserId: userId,
+      status: { in: ['paid', 'approved', 'queued', 'completed'] },
+      createdAt: { gte: start },
+    },
+    select: { finalAmountUsd: true },
+  });
+  return rows.reduce((s, r) => s + Number(r.finalAmountUsd), 0);
+}

--- a/backend/src/services/taxFormPdf.service.ts
+++ b/backend/src/services/taxFormPdf.service.ts
@@ -1,0 +1,1093 @@
+/**
+ * salame-92110: PDF generators for host tax forms (W-9 / W-8BEN / W-8BEN-E).
+ *
+ * Ported from the standalone tax-form repo (src/pdf-generator.js, pdf-lib
+ * based). W-9 + W-8BEN are direct ports; W-8BEN-E is new — copies the W-8BEN
+ * structure and adds entity-specific fields (entity name, country of
+ * incorporation, chapter 3/4 status, GIIN). Parts II–XXVIII (advanced FATCA
+ * classifications) are intentionally skipped; complex cases fall back to a
+ * paper form (admin override).
+ *
+ * Each generator returns a `Buffer` so the caller can hand it straight to the
+ * storage service.
+ */
+import { PDFDocument, PDFFont, PDFPage, StandardFonts, rgb } from 'pdf-lib';
+
+// ---------- helpers ----------
+
+interface FieldOpts {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label?: string;
+  value?: string;
+  font: PDFFont;
+  boldFont?: PDFFont;
+  fontSize?: number;
+}
+
+function drawField(page: PDFPage, opts: FieldOpts) {
+  const { x, y, width, height, label, value, font, boldFont, fontSize = 10 } = opts;
+  // Box border
+  page.drawRectangle({
+    x,
+    y: y - height,
+    width,
+    height,
+    borderColor: rgb(0, 0, 0),
+    borderWidth: 0.5,
+    color: rgb(1, 1, 1),
+  });
+  // Label (small, gray)
+  if (label) {
+    page.drawText(label, {
+      x: x + 3,
+      y: y - 10,
+      size: 7,
+      font: boldFont || font,
+      color: rgb(0.3, 0.3, 0.3),
+    });
+  }
+  // Value
+  if (value) {
+    const valueY = label ? y - height + 6 : y - height + 10;
+    page.drawText(String(value), {
+      x: x + 4,
+      y: valueY,
+      size: fontSize,
+      font,
+      color: rgb(0, 0, 0),
+    });
+  }
+}
+
+interface CheckboxOpts {
+  x: number;
+  y: number;
+  checked: boolean;
+  label?: string;
+  font: PDFFont;
+}
+
+function drawCheckbox(page: PDFPage, opts: CheckboxOpts) {
+  const { x, y, checked, label, font } = opts;
+  page.drawRectangle({
+    x,
+    y: y - 10,
+    width: 10,
+    height: 10,
+    borderColor: rgb(0, 0, 0),
+    borderWidth: 0.5,
+    color: rgb(1, 1, 1),
+  });
+  if (checked) {
+    page.drawText('X', { x: x + 1.5, y: y - 9, size: 9, font, color: rgb(0, 0, 0) });
+  }
+  if (label) {
+    page.drawText(label, { x: x + 14, y: y - 9, size: 8, font, color: rgb(0, 0, 0) });
+  }
+}
+
+/** Wrap a long string to fit `maxWidth` at `size` using the given font. */
+function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
+  const words = text.split(' ');
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const test = current ? `${current} ${word}` : word;
+    if (font.widthOfTextAtSize(test, size) > maxWidth) {
+      if (current) lines.push(current);
+      current = word;
+    } else {
+      current = test;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+function todayIso(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+// ---------- W-9 ----------
+
+export interface W9FormData {
+  name: string;
+  businessName?: string;
+  taxClassification:
+    | 'individual'
+    | 'c_corp'
+    | 's_corp'
+    | 'partnership'
+    | 'trust_estate'
+    | 'llc_c'
+    | 'llc_s'
+    | 'llc_p'
+    | 'other';
+  exemptPayeeCode?: string;
+  fatcaCode?: string;
+  address: string;
+  cityStateZip: string;
+  accountNumbers?: string;
+  ssn?: string;
+  ein?: string;
+  signature: string;
+  date: string;
+}
+
+export async function generateW9PDF(data: W9FormData, refId: string): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([612, 792]); // US Letter
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const W = 612;
+
+  // Header
+  page.drawRectangle({ x: 0, y: 740, width: W, height: 52, color: rgb(0.15, 0.15, 0.15) });
+  page.drawText('Form W-9', { x: 30, y: 762, size: 22, font: bold, color: rgb(1, 1, 1) });
+  page.drawText('Request for Taxpayer Identification Number and Certification', {
+    x: 30,
+    y: 748,
+    size: 9,
+    font,
+    color: rgb(0.85, 0.85, 0.85),
+  });
+  page.drawText('Department of the Treasury — Internal Revenue Service', {
+    x: 340,
+    y: 762,
+    size: 8,
+    font,
+    color: rgb(0.85, 0.85, 0.85),
+  });
+  page.drawText('Rev. October 2018', {
+    x: 340,
+    y: 748,
+    size: 8,
+    font,
+    color: rgb(0.7, 0.7, 0.7),
+  });
+
+  let y = 730;
+
+  // Line 1 - Name
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '1  Name (as shown on your income tax return). Name is required; do not leave blank.',
+    value: data.name,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  // Line 2 - Business name
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '2  Business name/disregarded entity name, if different from above',
+    value: data.businessName || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  // Line 3 - Tax classification
+  page.drawText(
+    '3  Check appropriate box for federal tax classification of the person whose name is entered on line 1:',
+    { x: 33, y: y - 2, size: 7, font: bold, color: rgb(0.3, 0.3, 0.3) },
+  );
+  y -= 16;
+
+  const classifications: Array<{
+    key: W9FormData['taxClassification'];
+    label: string;
+  }> = [
+    { key: 'individual', label: 'Individual/Sole prop.' },
+    { key: 'c_corp', label: 'C Corp' },
+    { key: 's_corp', label: 'S Corp' },
+    { key: 'partnership', label: 'Partnership' },
+    { key: 'trust_estate', label: 'Trust/Estate' },
+    { key: 'llc_c', label: 'LLC' },
+    { key: 'other', label: 'Other' },
+  ];
+  let cx = 33;
+  for (const cls of classifications) {
+    const checked =
+      data.taxClassification === cls.key
+      || (cls.key === 'llc_c' && ['llc_c', 'llc_s', 'llc_p'].includes(data.taxClassification));
+    drawCheckbox(page, { x: cx, y, checked, label: cls.label, font });
+    cx += font.widthOfTextAtSize(cls.label, 8) + 28;
+  }
+  y -= 18;
+
+  // Line 4 - Exemptions
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '4  Exempt payee code (if any)',
+    value: data.exemptPayeeCode || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '    FATCA reporting code (if any)',
+    value: data.fatcaCode || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  // Line 5 - Address
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '5  Address (number, street, and apt. or suite no.)',
+    value: data.address,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  // Line 6 - City, state, ZIP
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '6  City, state, and ZIP code',
+    value: data.cityStateZip,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  // Line 7 - Account numbers
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '7  List account number(s) here (optional)',
+    value: data.accountNumbers || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 50;
+
+  // Part I - TIN
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: rgb(0.15, 0.15, 0.15) });
+  y -= 6;
+  page.drawText('Part I', { x: 33, y: y - 4, size: 10, font: bold, color: rgb(0.15, 0.15, 0.15) });
+  page.drawText('Taxpayer Identification Number (TIN)', {
+    x: 80,
+    y: y - 4,
+    size: 10,
+    font,
+    color: rgb(0.15, 0.15, 0.15),
+  });
+  y -= 18;
+
+  page.drawText(
+    'Enter your TIN in the appropriate box. For individuals, this is generally your social security number (SSN).',
+    { x: 33, y: y - 2, size: 7.5, font, color: rgb(0.3, 0.3, 0.3) },
+  );
+  y -= 14;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 36,
+    label: 'Social security number (SSN)',
+    value: data.ssn || '',
+    font,
+    boldFont: bold,
+    fontSize: 13,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 36,
+    label: 'Employer identification number (EIN)',
+    value: data.ein || '',
+    font,
+    boldFont: bold,
+    fontSize: 13,
+  });
+  y -= 50;
+
+  // Part II - Certification
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: rgb(0.15, 0.15, 0.15) });
+  y -= 6;
+  page.drawText('Part II', { x: 33, y: y - 4, size: 10, font: bold, color: rgb(0.15, 0.15, 0.15) });
+  page.drawText('Certification', {
+    x: 80,
+    y: y - 4,
+    size: 10,
+    font,
+    color: rgb(0.15, 0.15, 0.15),
+  });
+  y -= 18;
+
+  const certText =
+    'Under penalties of perjury, I certify that: (1) The number shown on this form is my correct taxpayer identification number, (2) I am not subject to backup withholding, (3) I am a U.S. citizen or other U.S. person, and (4) The FATCA code(s) entered on this form (if any) indicating that I am exempt from FATCA reporting is correct.';
+  for (const line of wrapText(certText, font, 7.5, 540)) {
+    page.drawText(line, { x: 33, y: y - 2, size: 7.5, font, color: rgb(0.3, 0.3, 0.3) });
+    y -= 10;
+  }
+  y -= 10;
+
+  // Signature line
+  page.drawRectangle({ x: 30, y: y - 1, width: 552, height: 1, color: rgb(0, 0, 0) });
+  y -= 4;
+  drawField(page, {
+    x: 30,
+    y,
+    width: 380,
+    height: 32,
+    label: 'Signature of U.S. person',
+    value: data.signature,
+    font,
+    boldFont: bold,
+    fontSize: 13,
+  });
+  drawField(page, {
+    x: 410,
+    y,
+    width: 172,
+    height: 32,
+    label: 'Date',
+    value: data.date,
+    font,
+    boldFont: bold,
+  });
+
+  // Footer
+  page.drawText(`Generated ${todayIso()}  |  Submission #${refId}`, {
+    x: 30,
+    y: 30,
+    size: 7,
+    font,
+    color: rgb(0.6, 0.6, 0.6),
+  });
+
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+// ---------- W-8BEN ----------
+
+export interface W8BENFormData {
+  name: string;
+  citizenship: string;
+  permanentAddress: string;
+  permanentCity: string;
+  permanentCountry: string;
+  mailingAddress?: string;
+  mailingCity?: string;
+  mailingCountry?: string;
+  usTin?: string;
+  foreignTin?: string;
+  referenceNumbers?: string;
+  dateOfBirth: string;
+  treatyCountry?: string;
+  articleParagraph?: string;
+  withholdingRate?: string;
+  incomeType?: string;
+  treatyExplanation?: string;
+  signature: string;
+  date: string;
+}
+
+export async function generateW8BENPDF(data: W8BENFormData, refId: string): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([612, 792]);
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const W = 612;
+  const HEADER = rgb(0.05, 0.25, 0.45);
+
+  // Header
+  page.drawRectangle({ x: 0, y: 740, width: W, height: 52, color: HEADER });
+  page.drawText('Form W-8BEN', { x: 30, y: 762, size: 20, font: bold, color: rgb(1, 1, 1) });
+  page.drawText('Certificate of Foreign Status of Beneficial Owner', {
+    x: 30,
+    y: 748,
+    size: 8,
+    font,
+    color: rgb(0.8, 0.85, 0.95),
+  });
+  page.drawText('Department of the Treasury — Internal Revenue Service', {
+    x: 340,
+    y: 762,
+    size: 8,
+    font,
+    color: rgb(0.8, 0.85, 0.95),
+  });
+  page.drawText('Rev. October 2021', {
+    x: 340,
+    y: 748,
+    size: 8,
+    font,
+    color: rgb(0.6, 0.7, 0.8),
+  });
+
+  let y = 725;
+
+  // Part I header
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: HEADER });
+  y -= 6;
+  page.drawText('Part I', { x: 33, y: y - 4, size: 10, font: bold, color: HEADER });
+  page.drawText('Identification of Beneficial Owner', {
+    x: 80,
+    y: y - 4,
+    size: 10,
+    font,
+    color: HEADER,
+  });
+  y -= 20;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '1  Name of individual who is the beneficial owner',
+    value: data.name,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '2  Country of citizenship',
+    value: data.citizenship,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '3  Permanent residence address (street, apt. or suite no., or rural route)',
+    value: data.permanentAddress,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '    City or town',
+    value: data.permanentCity,
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '    Country',
+    value: data.permanentCountry,
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '4  Mailing address (if different from above)',
+    value: data.mailingAddress || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  if (data.mailingCity || data.mailingCountry) {
+    drawField(page, {
+      x: 30,
+      y,
+      width: 276,
+      height: 32,
+      label: '    City or town',
+      value: data.mailingCity || '',
+      font,
+      boldFont: bold,
+    });
+    drawField(page, {
+      x: 306,
+      y,
+      width: 276,
+      height: 32,
+      label: '    Country',
+      value: data.mailingCountry || '',
+      font,
+      boldFont: bold,
+    });
+    y -= 36;
+  }
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '5  U.S. taxpayer identification number (SSN or ITIN)',
+    value: data.usTin || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '6  Foreign tax identifying number (FTIN)',
+    value: data.foreignTin || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '7  Reference number(s)',
+    value: data.referenceNumbers || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '8  Date of birth (MM-DD-YYYY)',
+    value: data.dateOfBirth,
+    font,
+    boldFont: bold,
+  });
+  y -= 44;
+
+  // Part II - Treaty Benefits
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: HEADER });
+  y -= 6;
+  page.drawText('Part II', { x: 33, y: y - 4, size: 10, font: bold, color: HEADER });
+  page.drawText('Claim of Tax Treaty Benefits (for chapter 3 purposes only)', {
+    x: 80,
+    y: y - 4,
+    size: 10,
+    font,
+    color: HEADER,
+  });
+  y -= 20;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 32,
+    label: '9  I certify that the beneficial owner is a resident of:',
+    value: data.treatyCountry || 'N/A',
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '10  Article and paragraph',
+    value: data.articleParagraph || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 136,
+    height: 32,
+    label: '    Withholding rate (%)',
+    value: data.withholdingRate || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 442,
+    y,
+    width: 140,
+    height: 32,
+    label: '    Type of income',
+    value: data.incomeType || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  if (data.treatyExplanation) {
+    drawField(page, {
+      x: 30,
+      y,
+      width: 552,
+      height: 40,
+      label: '    Explanation',
+      value: data.treatyExplanation,
+      font,
+      boldFont: bold,
+      fontSize: 8,
+    });
+    y -= 44;
+  }
+
+  y -= 8;
+
+  // Part III - Certification
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: HEADER });
+  y -= 6;
+  page.drawText('Part III', { x: 33, y: y - 4, size: 10, font: bold, color: HEADER });
+  page.drawText('Certification', { x: 85, y: y - 4, size: 10, font, color: HEADER });
+  y -= 18;
+
+  const certText =
+    'Under penalties of perjury, I declare that I have examined the information on this form and to the best of my knowledge and belief it is true, correct, and complete. I further certify under penalties of perjury that I am the individual that is the beneficial owner (or am authorized to sign for the individual that is the beneficial owner) of all the income to which this form relates, that I am not a U.S. person, and that I am a resident of the treaty country listed above (if any).';
+  for (const line of wrapText(certText, font, 7.5, 540)) {
+    page.drawText(line, { x: 33, y: y - 2, size: 7.5, font, color: rgb(0.3, 0.3, 0.3) });
+    y -= 10;
+  }
+  y -= 10;
+
+  page.drawRectangle({ x: 30, y: y - 1, width: 552, height: 1, color: rgb(0, 0, 0) });
+  y -= 4;
+  drawField(page, {
+    x: 30,
+    y,
+    width: 380,
+    height: 32,
+    label: 'Sign here — Signature of beneficial owner (or individual authorized to sign)',
+    value: data.signature,
+    font,
+    boldFont: bold,
+    fontSize: 13,
+  });
+  drawField(page, {
+    x: 410,
+    y,
+    width: 172,
+    height: 32,
+    label: 'Date (MM-DD-YYYY)',
+    value: data.date,
+    font,
+    boldFont: bold,
+  });
+
+  page.drawText(`Generated ${todayIso()}  |  Submission #${refId}`, {
+    x: 30,
+    y: 30,
+    size: 7,
+    font,
+    color: rgb(0.6, 0.6, 0.6),
+  });
+
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+// ---------- W-8BEN-E ----------
+
+export type W8BENEEntityType =
+  | 'corporation'
+  | 'partnership'
+  | 'simple_trust'
+  | 'grantor_trust'
+  | 'complex_trust'
+  | 'estate'
+  | 'government'
+  | 'central_bank'
+  | 'tax_exempt_org'
+  | 'private_foundation'
+  | 'international_org';
+
+export type W8BENEChapter4Status = 'active_nffe' | 'passive_nffe' | 'ffi';
+
+export interface W8BENEFormData {
+  // Part I — Identification
+  entityName: string;
+  countryOfIncorporation: string;
+  disregardedEntityName?: string;
+  entityType: W8BENEEntityType;
+  chapter4Status: W8BENEChapter4Status;
+  permanentAddress: string;
+  permanentCity: string;
+  permanentCountry: string;
+  mailingAddress?: string;
+  mailingCity?: string;
+  mailingCountry?: string;
+  usTin?: string;
+  giin?: string;
+  foreignTin?: string;
+  referenceNumbers?: string;
+  // Part XXIX — Certification
+  signature: string;
+  signerCapacity?: string;
+  date: string;
+}
+
+export async function generateW8BENEPDF(data: W8BENEFormData, refId: string): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([612, 792]);
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const W = 612;
+  // Slightly darker blue than W-8BEN so the two foreign forms are visually
+  // distinguishable at a glance in the admin reviewer.
+  const HEADER = rgb(0.04, 0.18, 0.36);
+
+  page.drawRectangle({ x: 0, y: 740, width: W, height: 52, color: HEADER });
+  page.drawText('Form W-8BEN-E', { x: 30, y: 762, size: 20, font: bold, color: rgb(1, 1, 1) });
+  page.drawText('Certificate of Status of Beneficial Owner for U.S. Tax Withholding (Entities)', {
+    x: 30,
+    y: 748,
+    size: 8,
+    font,
+    color: rgb(0.8, 0.85, 0.95),
+  });
+  page.drawText('Department of the Treasury — Internal Revenue Service', {
+    x: 340,
+    y: 762,
+    size: 8,
+    font,
+    color: rgb(0.8, 0.85, 0.95),
+  });
+  page.drawText('Rev. October 2021', {
+    x: 340,
+    y: 748,
+    size: 8,
+    font,
+    color: rgb(0.6, 0.7, 0.8),
+  });
+
+  let y = 725;
+
+  // Part I header
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: HEADER });
+  y -= 6;
+  page.drawText('Part I', { x: 33, y: y - 4, size: 10, font: bold, color: HEADER });
+  page.drawText('Identification of Beneficial Owner', {
+    x: 80,
+    y: y - 4,
+    size: 10,
+    font,
+    color: HEADER,
+  });
+  y -= 20;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '1  Name of organization that is the beneficial owner',
+    value: data.entityName,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 36,
+    label: '2  Country of incorporation or organization',
+    value: data.countryOfIncorporation,
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 36,
+    label: '3  Name of disregarded entity (if any)',
+    value: data.disregardedEntityName || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  // Line 4 - Entity (chapter 3) status — render as a vertical-ish list of
+  // checkboxes inside a labeled box. Keep it scannable for an admin reviewer.
+  page.drawText('4  Chapter 3 Status (entity type)', {
+    x: 33,
+    y: y - 2,
+    size: 7,
+    font: bold,
+    color: rgb(0.3, 0.3, 0.3),
+  });
+  y -= 14;
+
+  const entityTypes: Array<{ key: W8BENEEntityType; label: string }> = [
+    { key: 'corporation', label: 'Corporation' },
+    { key: 'partnership', label: 'Partnership' },
+    { key: 'simple_trust', label: 'Simple trust' },
+    { key: 'grantor_trust', label: 'Grantor trust' },
+    { key: 'complex_trust', label: 'Complex trust' },
+    { key: 'estate', label: 'Estate' },
+    { key: 'government', label: 'Government' },
+    { key: 'central_bank', label: 'Central bank of issue' },
+    { key: 'tax_exempt_org', label: 'Tax-exempt organization' },
+    { key: 'private_foundation', label: 'Private foundation' },
+    { key: 'international_org', label: 'International organization' },
+  ];
+  // Two columns of checkboxes
+  const colWidth = 270;
+  let col = 0;
+  let rowYCursor = y;
+  for (const et of entityTypes) {
+    const cx = 33 + col * colWidth;
+    drawCheckbox(page, { x: cx, y: rowYCursor, checked: data.entityType === et.key, label: et.label, font });
+    if (col === 0) {
+      col = 1;
+    } else {
+      col = 0;
+      rowYCursor -= 14;
+    }
+  }
+  // Account for final row if odd-count list left col=1 unfilled
+  if (col === 1) rowYCursor -= 14;
+  y = rowYCursor - 6;
+
+  // Line 5 - Chapter 4 (FATCA) status — simplified to the 3 buckets we
+  // actually support; FFI surfaces a "contact admin" warning on the UI.
+  page.drawText('5  Chapter 4 Status (FATCA status)', {
+    x: 33,
+    y: y - 2,
+    size: 7,
+    font: bold,
+    color: rgb(0.3, 0.3, 0.3),
+  });
+  y -= 14;
+
+  const ch4: Array<{ key: W8BENEChapter4Status; label: string }> = [
+    { key: 'active_nffe', label: 'Active NFFE' },
+    { key: 'passive_nffe', label: 'Passive NFFE' },
+    { key: 'ffi', label: 'FFI (contact admin — paper form required)' },
+  ];
+  let ch4cx = 33;
+  for (const c of ch4) {
+    drawCheckbox(page, { x: ch4cx, y, checked: data.chapter4Status === c.key, label: c.label, font });
+    ch4cx += font.widthOfTextAtSize(c.label, 8) + 28;
+  }
+  y -= 18;
+
+  // Line 6 - Permanent address
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '6  Permanent residence address (street, apt. or suite no., or rural route)',
+    value: data.permanentAddress,
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '    City or town',
+    value: data.permanentCity,
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '    Country',
+    value: data.permanentCountry,
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  // Line 7 - Mailing address
+  drawField(page, {
+    x: 30,
+    y,
+    width: 552,
+    height: 36,
+    label: '7  Mailing address (if different from above)',
+    value: data.mailingAddress || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 40;
+
+  if (data.mailingCity || data.mailingCountry) {
+    drawField(page, {
+      x: 30,
+      y,
+      width: 276,
+      height: 32,
+      label: '    City or town',
+      value: data.mailingCity || '',
+      font,
+      boldFont: bold,
+    });
+    drawField(page, {
+      x: 306,
+      y,
+      width: 276,
+      height: 32,
+      label: '    Country',
+      value: data.mailingCountry || '',
+      font,
+      boldFont: bold,
+    });
+    y -= 36;
+  }
+
+  // Line 8 - U.S. TIN (optional for entities)
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '8  U.S. taxpayer identification number (EIN) — if any',
+    value: data.usTin || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '9  GIIN (if applicable)',
+    value: data.giin || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 36;
+
+  drawField(page, {
+    x: 30,
+    y,
+    width: 276,
+    height: 32,
+    label: '9b  Foreign TIN',
+    value: data.foreignTin || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 306,
+    y,
+    width: 276,
+    height: 32,
+    label: '10  Reference number(s)',
+    value: data.referenceNumbers || '',
+    font,
+    boldFont: bold,
+  });
+  y -= 44;
+
+  // Part XXIX - Certification (we skip the intermediate FATCA-classification
+  // parts II–XXVIII; complex cases use a paper form).
+  page.drawRectangle({ x: 30, y: y - 2, width: 552, height: 2, color: HEADER });
+  y -= 6;
+  page.drawText('Part XXIX', { x: 33, y: y - 4, size: 10, font: bold, color: HEADER });
+  page.drawText('Certification', { x: 95, y: y - 4, size: 10, font, color: HEADER });
+  y -= 18;
+
+  const certText =
+    'Under penalties of perjury, I declare that I have examined the information on this form and to the best of my knowledge and belief it is true, correct, and complete. I further certify under penalties of perjury that the entity identified on line 1 of this form is the beneficial owner of all the income to which this form relates, is using this form to certify its status for chapter 4 purposes, and is not a U.S. person. I agree that I will submit a new form within 30 days if any certification on this form becomes incorrect.';
+  for (const line of wrapText(certText, font, 7.5, 540)) {
+    page.drawText(line, { x: 33, y: y - 2, size: 7.5, font, color: rgb(0.3, 0.3, 0.3) });
+    y -= 10;
+  }
+  y -= 10;
+
+  page.drawRectangle({ x: 30, y: y - 1, width: 552, height: 1, color: rgb(0, 0, 0) });
+  y -= 4;
+  drawField(page, {
+    x: 30,
+    y,
+    width: 280,
+    height: 32,
+    label: 'Sign here — Signature of person authorized to sign for the beneficial owner',
+    value: data.signature,
+    font,
+    boldFont: bold,
+    fontSize: 13,
+  });
+  drawField(page, {
+    x: 310,
+    y,
+    width: 130,
+    height: 32,
+    label: 'Capacity (e.g. Director)',
+    value: data.signerCapacity || '',
+    font,
+    boldFont: bold,
+  });
+  drawField(page, {
+    x: 440,
+    y,
+    width: 142,
+    height: 32,
+    label: 'Date (MM-DD-YYYY)',
+    value: data.date,
+    font,
+    boldFont: bold,
+  });
+
+  page.drawText(`Generated ${todayIso()}  |  Submission #${refId}`, {
+    x: 30,
+    y: 30,
+    size: 7,
+    font,
+    color: rgb(0.6, 0.6, 0.6),
+  });
+
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}

--- a/backend/src/services/taxFormStorage.service.ts
+++ b/backend/src/services/taxFormStorage.service.ts
@@ -1,0 +1,68 @@
+/**
+ * salame-92110: storage helpers for host tax-form PDFs.
+ *
+ * PDFs are uploaded to the existing `event-images` Supabase Storage bucket
+ * (10MB cap + application/pdf allowlist already in place from bocconcino-92104).
+ * Path: `tax-forms/{userId}/{formType}-{timestamp}.pdf`.
+ *
+ * Thumbnails: phase 1 skips server-side PDF→PNG rendering. We surface the
+ * PDF URL directly; the admin reviewer modal renders it via <embed>. A future
+ * iteration can add `pdfjs-dist` to the backend if a real thumbnail becomes
+ * necessary — for the foundational PR that's overkill.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const BUCKET = 'event-images';
+
+let _client: ReturnType<typeof createClient> | null = null;
+function getSupabaseAdmin() {
+  if (_client) return _client;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set to upload tax forms');
+  }
+  _client = createClient(url, key);
+  return _client;
+}
+
+export type TaxFormType = 'w9' | 'w8ben' | 'w8bene';
+
+export interface UploadTaxFormPdfResult {
+  url: string;
+  /** Currently null — phase 1 skips thumbnail generation (PDF embed used). */
+  thumbUrl: string | null;
+}
+
+/**
+ * Upload a generated tax-form PDF buffer to Supabase Storage and return the
+ * public URL + (currently null) thumbnail URL. Throws on upload failure.
+ */
+export async function uploadTaxFormPdf(
+  buffer: Buffer,
+  userId: string,
+  formType: TaxFormType,
+): Promise<UploadTaxFormPdfResult> {
+  const supabase = getSupabaseAdmin();
+  const ts = Date.now();
+  const path = `tax-forms/${userId}/${formType}-${ts}.pdf`;
+
+  const { error } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, buffer, {
+      cacheControl: '3600',
+      upsert: false,
+      contentType: 'application/pdf',
+    });
+
+  if (error) {
+    throw new Error(`Tax form PDF upload failed: ${error.message}`);
+  }
+
+  const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+
+  return {
+    url: urlData.publicUrl,
+    thumbUrl: null,
+  };
+}

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -300,6 +300,40 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     await saveTags(nextTags);
   }
 
+  // culatello-92106: per-event tax-form gate. Full admins (admin / super_admin
+  // / payment_admin — same gate as the backend) can flip the
+  // `parties.tax_form_required` boolean. Optimistic local state; on failure we
+  // revert + surface the error inline. Hooks declared above any early return
+  // per project convention.
+  const canEditTaxFormRequired =
+    adminRole === 'admin' || adminRole === 'super_admin' || adminRole === 'payment_admin';
+  const [taxFormRequired, setTaxFormRequired] = useState<boolean>(
+    payout.party.taxFormRequired === true,
+  );
+  const [taxFormRequiredSaving, setTaxFormRequiredSaving] = useState(false);
+  const [taxFormRequiredError, setTaxFormRequiredError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setTaxFormRequired(payout.party.taxFormRequired === true);
+  }, [payout.id, payout.party.taxFormRequired]);
+
+  async function handleToggleTaxFormRequired(next: boolean) {
+    if (!canEditTaxFormRequired) return;
+    const prev = taxFormRequired;
+    setTaxFormRequired(next);
+    setTaxFormRequiredSaving(true);
+    setTaxFormRequiredError(null);
+    try {
+      await updatePartyApi(payout.partyId, { taxFormRequired: next });
+    } catch (err: any) {
+      // Roll back the optimistic flip.
+      setTaxFormRequired(prev);
+      setTaxFormRequiredError(err?.message || 'Failed to update tax-form gate');
+    } finally {
+      setTaxFormRequiredSaving(false);
+    }
+  }
+
   const [editingAmount, setEditingAmount] = useState(false);
   const [draftAmount, setDraftAmount] = useState(String(payout.finalAmountUsd));
   const [adminNotes, setAdminNotes] = useState(payout.adminNotes ?? '');
@@ -2157,6 +2191,35 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 )}
                 {tagError && (
                   <div className="mt-2 text-xs text-red-300">{tagError}</div>
+                )}
+              </div>
+            )}
+
+            {/* culatello-92106: per-event tax-form gate.
+                Admin checkbox flips `parties.tax_form_required`. When OFF
+                (default) the host's NewPayoutForm hides TaxFormSection and
+                the backend skips the TAX_FORM_REQUIRED 400. When ON, hosts
+                see TaxFormSection and must submit a W-9 / W-8BEN / W-8BEN-E
+                before they can submit a payout. The TaxFormReviewPanel
+                below still surfaces any historical snapshot regardless of
+                this flag. */}
+            {(canEditTaxFormRequired || taxFormRequired) && (
+              <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+                <Checkbox
+                  checked={taxFormRequired}
+                  onChange={() => handleToggleTaxFormRequired(!taxFormRequired)}
+                  disabled={!canEditTaxFormRequired || taxFormRequiredSaving}
+                  label="Tax forms required for this event"
+                />
+                <p className="mt-1 ml-7 text-xs text-theme-text-muted">
+                  When checked, the host must submit a tax form (W-9, W-8BEN,
+                  or W-8BEN-E) before any payout on this event can be
+                  submitted.
+                </p>
+                {taxFormRequiredError && (
+                  <div className="mt-2 ml-7 text-xs text-red-300">
+                    {taxFormRequiredError}
+                  </div>
                 )}
               </div>
             )}

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -18,6 +18,7 @@ import {
   ReceiptLightbox,
 } from '../payments-shared';
 import { ReceiptEditor } from './ReceiptEditor';
+import { TaxFormReviewPanel } from './TaxFormReviewPanel';
 
 /**
  * parmigiana-58291: strip the "Global Pizza Party " prefix from event names so
@@ -2159,6 +2160,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 )}
               </div>
             )}
+
+            {/* salame-92110: Tax form review panel (above Receipts). Shows the
+                W-9 / W-8BEN / W-8BEN-E snapshotted onto the payout, with
+                Verify / Reject. When `payout.taxFormId` is null we render an
+                amber "host has not submitted a tax form" banner. */}
+            <TaxFormReviewPanel taxFormId={payout.taxFormId ?? null} />
 
             {/* Per-receipt OCR */}
             {receipts.length > 0 && (

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -57,6 +57,9 @@ import {
   setCityAdminNotes,
   approveCity,
   reopenParty,
+  // culatello-92106: per-event tax-form gate toggle. Same PATCH backend uses
+  // for tags + reimbursement cap; whitelisted with admin-only gating server-side.
+  updatePartyApi,
 } from '../../lib/api';
 import {
   ReceiptEditor,
@@ -2416,6 +2419,16 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // Per-row busy spinner state for the scam-flag toggle. Avoids double-clicks
   // during the PATCH round-trip.
   const [scamBusyPartyId, setScamBusyPartyId] = useState<string | null>(null);
+  // culatello-92106: optimistic-override map for `taxFormRequired` so the pill
+  // flips immediately on click without waiting for a parent refetch. Keyed on
+  // partyId; mirrors the `tagOverrides` pattern. Cleared on a parent refresh.
+  const [taxFormRequiredOverrides, setTaxFormRequiredOverrides] = useState<
+    Record<string, boolean>
+  >({});
+  // Per-row busy spinner so we don't double-click the pill mid-PATCH.
+  const [taxFormRequiredBusyPartyId, setTaxFormRequiredBusyPartyId] = useState<
+    string | null
+  >(null);
   // crocchetta-92106: per-row busy spinner for the Send receipts reminder
   // action. Avoids double-firing the POST while the bot is dispatching.
   const [tgReminderBusyPartyId, setTgReminderBusyPartyId] = useState<string | null>(null);
@@ -2440,6 +2453,10 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   // requireAnyAdminOrPaymentAdmin server-side; the UI gate just hides the
   // menu item for underbosses so they don't see a button that 403s.
   const canSendTgReminder = viewerRole === 'admin';
+  // culatello-92106: tax-form gate toggle — admin-only. Backend gate is
+  // payment_admin / admin / super_admin (isPaymentAdmin); UI mirrors the same
+  // "admin" viewer role used by the rest of this table for underboss hiding.
+  const canToggleTaxFormRequired = viewerRole === 'admin';
   // Wallet reminder shares the same admin-only gate as the receipts reminder.
   const canSendWalletReminder = viewerRole === 'admin';
   // City-level approval is admin-only.
@@ -2511,6 +2528,43 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
       );
     } finally {
       setScamBusyPartyId((id) => (id === partyId ? null : id));
+    }
+  }
+
+  /**
+   * culatello-92106: toggle `parties.tax_form_required` for a city.
+   * Optimistic — flips the override map immediately so the pill state updates
+   * without waiting for the PATCH. Reversible (one click flips back) so no
+   * confirm step per project convention. Failures roll the override back and
+   * surface via a minimal alert, matching the scam-flag path.
+   */
+  async function handleToggleTaxFormRequired(row: PartyPayoutsRow) {
+    if (!canToggleTaxFormRequired) return;
+    const partyId = row.party.id;
+    const current =
+      taxFormRequiredOverrides[partyId] !== undefined
+        ? taxFormRequiredOverrides[partyId]
+        : row.party.taxFormRequired === true;
+    const next = !current;
+    setTaxFormRequiredOverrides((m) => ({ ...m, [partyId]: next }));
+    setTaxFormRequiredBusyPartyId(partyId);
+    try {
+      await updatePartyApi(partyId, { taxFormRequired: next });
+    } catch (err) {
+      // Roll back the optimistic flip.
+      setTaxFormRequiredOverrides((m) => {
+        const nextMap = { ...m };
+        delete nextMap[partyId];
+        return nextMap;
+      });
+      // eslint-disable-next-line no-alert
+      window.alert(
+        `Could not ${next ? 'require' : 'un-require'} tax forms for this city: ${
+          (err as Error)?.message ?? 'unknown error'
+        }`,
+      );
+    } finally {
+      setTaxFormRequiredBusyPartyId((id) => (id === partyId ? null : id));
     }
   }
 
@@ -2652,6 +2706,15 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                 tagOverrides[row.party.id] ?? row.party.eventTags ?? [];
               const isFlaggedScam = effectiveTags.includes(POSSIBLE_SCAM_TAG);
               const scamFlagBusy = scamBusyPartyId === row.party.id;
+              // culatello-92106: same optimistic-override pattern as the scam
+              // tag — when present the override wins so the pill reflects the
+              // user's last click without waiting for the parent to refetch.
+              const effectiveTaxFormRequired =
+                taxFormRequiredOverrides[row.party.id] !== undefined
+                  ? taxFormRequiredOverrides[row.party.id]
+                  : row.party.taxFormRequired === true;
+              const taxFormRequiredBusy =
+                taxFormRequiredBusyPartyId === row.party.id;
               const tgReminderBusy = tgReminderBusyPartyId === row.party.id;
               const walletReminderBusy =
                 walletReminderBusyPartyId === row.party.id;
@@ -2777,6 +2840,42 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                             <CheckCircle2 size={11} />
                             Closed
                           </span>
+                        )}
+                        {/* culatello-92106: tax-form gate pill. Visible
+                            whenever the gate is ON for the city; admins can
+                            also see + click an off-state pill via the same
+                            optimistic toggle pattern as the scam flag. Hidden
+                            entirely for non-admin viewers when the gate is
+                            off (no useful info). */}
+                        {(effectiveTaxFormRequired || canToggleTaxFormRequired) && (
+                          <button
+                            type="button"
+                            disabled={taxFormRequiredBusy || !canToggleTaxFormRequired}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (!canToggleTaxFormRequired) return;
+                              handleToggleTaxFormRequired(row);
+                            }}
+                            className={
+                              effectiveTaxFormRequired
+                                ? 'inline-flex items-center gap-1 text-[11px] text-sky-300 px-1.5 py-0.5 rounded-full bg-sky-500/10 border border-sky-500/40 hover:bg-sky-500/20 disabled:opacity-60 disabled:cursor-not-allowed'
+                                : 'inline-flex items-center gap-1 text-[11px] text-theme-text-muted px-1.5 py-0.5 rounded-full border border-theme-stroke hover:bg-theme-surface-hover disabled:opacity-60 disabled:cursor-not-allowed'
+                            }
+                            title={
+                              !canToggleTaxFormRequired
+                                ? 'Tax forms required for this event'
+                                : effectiveTaxFormRequired
+                                ? 'Click to stop requiring tax forms for this event'
+                                : 'Click to require tax forms for this event'
+                            }
+                          >
+                            {taxFormRequiredBusy ? (
+                              <Loader2 size={11} className="animate-spin" />
+                            ) : null}
+                            {effectiveTaxFormRequired
+                              ? 'Tax forms required'
+                              : 'Tax forms: off'}
+                          </button>
                         )}
                         {/* bottarga-92104: red "Possible scam" pill — visible
                             in the city header next to other status pills when

--- a/frontend/src/components/payments-admin/TaxFormReviewPanel.tsx
+++ b/frontend/src/components/payments-admin/TaxFormReviewPanel.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, ShieldCheck, AlertTriangle, FileText, XCircle, CheckCircle2 } from 'lucide-react';
+import { TaxForm, TaxFormType } from '../../types';
+import { getAdminTaxForm, verifyTaxForm, rejectTaxForm } from '../../lib/api';
+import { IconInput } from '../IconInput';
+
+interface TaxFormReviewPanelProps {
+  /** UUID of the snapshotted tax form on the payout (`payouts.tax_form_id`). */
+  taxFormId: string | null;
+}
+
+const FORM_LABEL: Record<TaxFormType, string> = {
+  w9: 'W-9',
+  w8ben: 'W-8BEN',
+  w8bene: 'W-8BEN-E',
+};
+
+/**
+ * salame-92110: admin panel rendered above Receipts in PayoutReviewModal.
+ * Shows the host's tax form (W-9 / W-8BEN / W-8BEN-E) with PDF embed +
+ * Verify / Reject actions. Renders an amber banner when the payout has no
+ * tax form on file (most pre-feature payouts).
+ */
+export const TaxFormReviewPanel: React.FC<TaxFormReviewPanelProps> = ({ taxFormId }) => {
+  // Hooks BEFORE early returns (react-hooks rule).
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState<TaxForm | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!taxFormId) {
+      setForm(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getAdminTaxForm(taxFormId)
+      .then((f) => {
+        if (!cancelled) setForm(f);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e?.message || 'Failed to load tax form');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [taxFormId]);
+
+  const handleVerify = async () => {
+    if (!form) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const updated = await verifyTaxForm(form.id);
+      setForm(updated);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to verify form');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!form || !reason.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const updated = await rejectTaxForm(form.id, reason.trim());
+      setForm(updated);
+      setRejectOpen(false);
+      setReason('');
+    } catch (e: any) {
+      setError(e?.message || 'Failed to reject form');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // ----- render -----
+  if (!taxFormId) {
+    return (
+      <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-3">
+        <div className="flex items-start gap-2 text-xs text-amber-100">
+          <AlertTriangle size={14} className="mt-0.5 flex-shrink-0 text-amber-300" />
+          <div>
+            <span className="font-semibold">Tax form</span> — host has not submitted a tax form for this payment.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-theme-text inline-flex items-center gap-1.5">
+          <FileText size={14} />
+          Tax form
+        </h3>
+        {form && (
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center rounded-full bg-theme-surface-hover px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-theme-text-secondary">
+              {FORM_LABEL[form.formType]}
+            </span>
+            <StatusPill status={form.status} />
+          </div>
+        )}
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-xs text-theme-text-muted">
+          <Loader2 size={14} className="animate-spin" />
+          Loading form…
+        </div>
+      )}
+
+      {error && (
+        <div className="text-xs text-red-300 mb-2">{error}</div>
+      )}
+
+      {form && (
+        <div className="space-y-2">
+          <div className="text-xs text-theme-text-muted">
+            {form.user?.name || form.user?.email || form.userId}
+            {form.signedAt && (
+              <> · signed {new Date(form.signedAt).toLocaleDateString()}</>
+            )}
+            {form.expiresAt && (
+              <> · expires {new Date(form.expiresAt).toLocaleDateString()}</>
+            )}
+          </div>
+          {form.pdfUrl ? (
+            <div className="rounded-lg overflow-hidden border border-theme-stroke">
+              <embed src={form.pdfUrl} type="application/pdf" className="w-full h-64" />
+              <a
+                href={form.pdfUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block px-2 py-1 text-xs text-theme-text underline underline-offset-2 hover:text-[#ff393a] bg-theme-surface-hover"
+              >
+                Open full PDF →
+              </a>
+            </div>
+          ) : (
+            <div className="text-xs text-theme-text-muted">No PDF available.</div>
+          )}
+          {form.status === 'rejected' && form.rejectedReason && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200">
+              Rejection reason: {form.rejectedReason}
+            </div>
+          )}
+
+          {form.status === 'submitted' && (
+            <div className="flex gap-2 pt-1">
+              <button
+                type="button"
+                className="btn-primary inline-flex items-center gap-2"
+                onClick={handleVerify}
+                disabled={submitting}
+              >
+                {submitting ? <Loader2 size={14} className="animate-spin" /> : <CheckCircle2 size={14} />}
+                Verify
+              </button>
+              <button
+                type="button"
+                className="btn-secondary inline-flex items-center gap-2"
+                onClick={() => setRejectOpen((v) => !v)}
+                disabled={submitting}
+              >
+                <XCircle size={14} />
+                Reject
+              </button>
+            </div>
+          )}
+
+          {form.status === 'verified' && (
+            <div className="flex items-center gap-2 text-xs text-emerald-300">
+              <ShieldCheck size={14} />
+              Verified
+              {form.verifiedBy && <span className="text-theme-text-muted">by {form.verifiedBy}</span>}
+            </div>
+          )}
+
+          {rejectOpen && form.status === 'submitted' && (
+            <div className="mt-2 space-y-2 rounded-lg border border-theme-stroke bg-theme-input p-2">
+              <IconInput
+                multiline
+                rows={2}
+                placeholder="Reason for rejection (visible to host)"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  className="btn-secondary text-xs"
+                  onClick={() => {
+                    setRejectOpen(false);
+                    setReason('');
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn-primary text-xs"
+                  onClick={handleReject}
+                  disabled={submitting || !reason.trim()}
+                >
+                  {submitting && <Loader2 size={12} className="animate-spin mr-1" />}
+                  Reject
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const StatusPill: React.FC<{ status: TaxForm['status'] }> = ({ status }) => {
+  const styles: Record<TaxForm['status'], string> = {
+    draft: 'bg-theme-surface-hover text-theme-text-muted',
+    submitted: 'bg-blue-500/15 text-blue-200',
+    verified: 'bg-emerald-500/15 text-emerald-200',
+    rejected: 'bg-red-500/15 text-red-200',
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${styles[status]}`}
+    >
+      {status}
+    </span>
+  );
+};

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -10,6 +10,8 @@ import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { PayoutAmountSummary } from './PayoutAmountSummary';
 import { AppealCapModal } from './AppealCapModal';
+import { TaxFormSection } from './TaxFormSection';
+import { TaxFormType } from '../../types';
 
 /**
  * speck-89172: the $675 per-payment hard ceiling is still informative — USDC
@@ -131,6 +133,11 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // salame-92110: when the backend returns TAX_FORM_REQUIRED, we surface a
+  // pointer at the TaxFormSection above and (optionally) auto-open a form
+  // type if the host has indicated one. Phase 1 doesn't auto-infer US vs
+  // foreign, so we leave the type null and the host picks.
+  const [taxFormAutoOpen, setTaxFormAutoOpen] = useState<TaxFormType | null>(null);
 
   // mortadella-92103: exclude receipts whose currency couldn't be resolved
   // (the `$` ambiguity in non-USD countries) from the auto-sum. They keep
@@ -263,7 +270,24 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       });
       onCreated(created);
     } catch (err: any) {
-      setSubmitError(err?.message || 'Failed to submit receipt');
+      // salame-92110: when the backend says a tax form is required, scroll
+      // the host up to the TaxFormSection instead of just showing a red error.
+      if (err?.code === 'TAX_FORM_REQUIRED') {
+        const requiredType: TaxFormType | null = err?.requiredFormType ?? null;
+        setTaxFormAutoOpen(requiredType);
+        setSubmitError(
+          'A tax form is required before this payment can be submitted. Please complete the tax form above.',
+        );
+        // Scroll to the section the next tick after state has propagated.
+        setTimeout(() => {
+          document.getElementById('tax-form-section')?.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start',
+          });
+        }, 0);
+      } else {
+        setSubmitError(err?.message || 'Failed to submit receipt');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -410,6 +434,9 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           onOverrideChange={setOverrideAmount}
         />
       </div>
+
+      {/* 4b. Tax form (salame-92110). Required before admin approval. */}
+      <TaxFormSection autoOpenFormType={taxFormAutoOpen} />
 
       {/* 5. Submit */}
       {submitError && (

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -435,8 +435,15 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         />
       </div>
 
-      {/* 4b. Tax form (salame-92110). Required before admin approval. */}
-      <TaxFormSection autoOpenFormType={taxFormAutoOpen} />
+      {/* 4b. Tax form (salame-92110).
+          culatello-92106: only rendered when admin has flipped the per-event
+          `taxFormRequired` flag. When the flag is off (default for all events)
+          the section is hidden and the host can submit payouts without a form.
+          When the flag is on, the section is required + backend enforces
+          TAX_FORM_REQUIRED before the payout is accepted. */}
+      {party?.taxFormRequired === true && (
+        <TaxFormSection autoOpenFormType={taxFormAutoOpen} />
+      )}
 
       {/* 5. Submit */}
       {submitError && (

--- a/frontend/src/components/payouts/TaxFormSection.tsx
+++ b/frontend/src/components/payouts/TaxFormSection.tsx
@@ -1,0 +1,337 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2, FileText, Loader2, ShieldCheck, AlertTriangle, XCircle } from 'lucide-react';
+import { TaxForm, TaxFormType } from '../../types';
+import {
+  getMyTaxForms,
+  saveTaxFormDraft,
+  submitTaxForm,
+} from '../../lib/api';
+import { TaxFormPicker } from './tax/TaxFormPicker';
+import { W9Form, W9FormData } from './tax/W9Form';
+import { W8BENForm, W8BENFormData } from './tax/W8BENForm';
+import { W8BENEForm, W8BENEFormData } from './tax/W8BENEForm';
+
+interface TaxFormSectionProps {
+  /**
+   * If set, force the picker open onto this form type — used when the
+   * payout-submit endpoint returns `TAX_FORM_REQUIRED` so we can guide the
+   * host to fill the right form immediately.
+   */
+  autoOpenFormType?: TaxFormType | null;
+}
+
+const FORM_TYPE_LABEL: Record<TaxFormType, string> = {
+  w9: 'W-9',
+  w8ben: 'W-8BEN',
+  w8bene: 'W-8BEN-E',
+};
+
+/**
+ * salame-92110: Tax-form section shown on the NewPayoutForm between Payment
+ * method and Submit. Self-contained — fetches the host's tax forms, picks the
+ * "current" one (latest draft / submitted of any type), and routes to the
+ * appropriate editor.
+ */
+export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType = null }) => {
+  // ----- hooks (declared above any early returns per react-hooks rules) -----
+  const sectionRef = useRef<HTMLDivElement | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [forms, setForms] = useState<TaxForm[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [editingType, setEditingType] = useState<TaxFormType | null>(null);
+  const [draftData, setDraftData] = useState<Record<string, any>>({});
+  const [saving, setSaving] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  // Pick the "current" form: the latest non-draft (submitted/verified/rejected)
+  // OR the latest draft if no live form exists.
+  const currentForm = useMemo(() => {
+    const live = forms.find((f) => f.status === 'submitted' || f.status === 'verified');
+    if (live) return live;
+    return forms[0] || null;
+  }, [forms]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await getMyTaxForms();
+      setForms(list);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load tax forms');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // When the parent flags TAX_FORM_REQUIRED with a type hint, scroll and open
+  // the editor pre-set to that type.
+  useEffect(() => {
+    if (!autoOpenFormType) return;
+    setEditingType(autoOpenFormType);
+    setPickerOpen(false);
+    sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [autoOpenFormType]);
+
+  // Seed the editor with existing draft/submitted data when entering edit mode.
+  useEffect(() => {
+    if (!editingType) return;
+    const existing = forms.find((f) => f.formType === editingType);
+    setDraftData((existing?.formData as Record<string, any>) || {});
+  }, [editingType, forms]);
+
+  const handlePick = (formType: TaxFormType) => {
+    setEditingType(formType);
+    setPickerOpen(false);
+  };
+
+  const handleSaveDraft = async () => {
+    if (!editingType) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await saveTaxFormDraft(editingType, draftData);
+      setStatusMessage('Draft saved.');
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to save draft');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!editingType) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitTaxForm(editingType, draftData);
+      setStatusMessage('Tax form submitted.');
+      setEditingType(null);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to submit tax form');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // ----- early renders (after hooks) -----
+  if (loading) {
+    return (
+      <div ref={sectionRef} className="card p-6 flex items-center gap-2 text-sm text-theme-text-muted">
+        <Loader2 size={16} className="animate-spin" />
+        Loading tax forms…
+      </div>
+    );
+  }
+
+  const renderEditor = () => {
+    if (!editingType) return null;
+    const editorBody =
+      editingType === 'w9' ? (
+        <W9Form value={draftData as W9FormData} onChange={(v) => setDraftData(v)} />
+      ) : editingType === 'w8ben' ? (
+        <W8BENForm value={draftData as W8BENFormData} onChange={(v) => setDraftData(v)} />
+      ) : (
+        <W8BENEForm value={draftData as W8BENEFormData} onChange={(v) => setDraftData(v)} />
+      );
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="text-sm font-semibold text-theme-text">
+            {FORM_TYPE_LABEL[editingType]} form
+          </div>
+          <button
+            type="button"
+            className="text-xs text-theme-text-muted underline underline-offset-2 hover:text-theme-text"
+            onClick={() => {
+              setEditingType(null);
+              setPickerOpen(true);
+            }}
+          >
+            Change form type
+          </button>
+        </div>
+        {editorBody}
+        {error && (
+          <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10 text-xs text-red-200">
+            {error}
+          </div>
+        )}
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={handleSaveDraft}
+            disabled={saving || submitting}
+          >
+            {saving && <Loader2 size={14} className="animate-spin mr-2" />}
+            Save draft
+          </button>
+          <button
+            type="button"
+            className="btn-primary inline-flex items-center gap-2 justify-center"
+            onClick={handleSubmit}
+            disabled={saving || submitting}
+          >
+            {submitting && <Loader2 size={14} className="animate-spin" />}
+            Submit tax form
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderSummary = () => {
+    if (!currentForm) {
+      return (
+        <div className="space-y-3">
+          <div className="text-sm text-theme-text-muted">
+            No tax form on file. Pick the form type that applies to you.
+          </div>
+          <TaxFormPicker value={null} onChange={handlePick} />
+        </div>
+      );
+    }
+    if (currentForm.status === 'draft') {
+      return (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm text-theme-text">
+            <FileText size={16} className="text-theme-text-muted" />
+            {FORM_TYPE_LABEL[currentForm.formType]} draft saved — not submitted yet.
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => setEditingType(currentForm.formType)}
+            >
+              Continue editing
+            </button>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => setPickerOpen(true)}
+            >
+              Change type
+            </button>
+          </div>
+          {pickerOpen && (
+            <div className="mt-2">
+              <TaxFormPicker value={currentForm.formType} onChange={handlePick} />
+            </div>
+          )}
+        </div>
+      );
+    }
+    // submitted | verified | rejected
+    const verified = currentForm.status === 'verified';
+    const rejected = currentForm.status === 'rejected';
+    return (
+      <div className="space-y-3">
+        <div
+          className={[
+            'rounded-xl p-3 flex items-start gap-3',
+            rejected
+              ? 'bg-red-500/10 border border-red-500/30'
+              : verified
+              ? 'bg-emerald-500/10 border border-emerald-500/30'
+              : 'bg-theme-input border border-theme-stroke',
+          ].join(' ')}
+        >
+          {rejected ? (
+            <XCircle size={18} className="text-red-300 mt-0.5 flex-shrink-0" />
+          ) : verified ? (
+            <ShieldCheck size={18} className="text-emerald-300 mt-0.5 flex-shrink-0" />
+          ) : (
+            <CheckCircle2 size={18} className="text-emerald-300 mt-0.5 flex-shrink-0" />
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-theme-text">
+              {FORM_TYPE_LABEL[currentForm.formType]} —{' '}
+              {verified
+                ? 'verified by admin'
+                : rejected
+                ? 'rejected — please resubmit'
+                : 'submitted'}
+            </div>
+            {currentForm.signedAt && (
+              <div className="text-xs text-theme-text-muted mt-0.5">
+                Signed {new Date(currentForm.signedAt).toLocaleDateString()}
+                {currentForm.expiresAt && (
+                  <> · expires {new Date(currentForm.expiresAt).toLocaleDateString()}</>
+                )}
+              </div>
+            )}
+            {rejected && currentForm.rejectedReason && (
+              <div className="text-xs text-red-200 mt-1">
+                Reason: {currentForm.rejectedReason}
+              </div>
+            )}
+            {currentForm.pdfUrl && (
+              <a
+                href={currentForm.pdfUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block text-xs text-theme-text underline underline-offset-2 mt-1"
+              >
+                View PDF
+              </a>
+            )}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => setEditingType(currentForm.formType)}
+          >
+            Edit / resubmit
+          </button>
+          <button
+            type="button"
+            className="text-xs text-theme-text-muted underline underline-offset-2 hover:text-theme-text"
+            onClick={() => setPickerOpen((v) => !v)}
+          >
+            {pickerOpen ? 'Cancel' : 'Change type'}
+          </button>
+        </div>
+        {pickerOpen && (
+          <div className="mt-2">
+            <TaxFormPicker value={currentForm.formType} onChange={handlePick} />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div ref={sectionRef} className="card p-6 space-y-3" id="tax-form-section">
+      <div>
+        <h3 className="text-base font-semibold text-theme-text">Tax form</h3>
+        <p className="text-xs text-theme-text-muted mt-0.5">
+          Required before admin can approve your payouts. US hosts file a W-9; non-US individuals file W-8BEN; non-US organizations file W-8BEN-E.
+        </p>
+      </div>
+      {error && !editingType && (
+        <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10">
+          <div className="flex items-start gap-2 text-xs text-red-200">
+            <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
+            <div>{error}</div>
+          </div>
+        </div>
+      )}
+      {statusMessage && !editingType && (
+        <div className="text-xs text-emerald-300">{statusMessage}</div>
+      )}
+      {editingType ? renderEditor() : renderSummary()}
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/tax/TaxFormPicker.tsx
+++ b/frontend/src/components/payouts/tax/TaxFormPicker.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Flag, Globe, Building2 } from 'lucide-react';
+import { TaxFormType } from '../../../types';
+
+interface TaxFormPickerProps {
+  value: TaxFormType | null;
+  onChange: (formType: TaxFormType) => void;
+  disabled?: boolean;
+}
+
+interface CardSpec {
+  type: TaxFormType;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  title: string;
+  desc: string;
+}
+
+const CARDS: CardSpec[] = [
+  {
+    type: 'w9',
+    icon: Flag,
+    title: 'US individual or business (W-9)',
+    desc: 'Use this if you live in the US or your business is registered in the US.',
+  },
+  {
+    type: 'w8ben',
+    icon: Globe,
+    title: 'Individual outside the US (W-8BEN)',
+    desc: 'Use this if you are a non-US individual.',
+  },
+  {
+    type: 'w8bene',
+    icon: Building2,
+    title: 'Organization outside the US (W-8BEN-E)',
+    desc: 'Use this if your organization is registered outside the US.',
+  },
+];
+
+/**
+ * salame-92110: 3-card picker for the host's tax-form type. The host picks
+ * one explicitly — we don't auto-infer US vs foreign from User.country /
+ * Party.country in phase 1 to keep the cohost-shared-party flow simple.
+ */
+export const TaxFormPicker: React.FC<TaxFormPickerProps> = ({ value, onChange, disabled }) => {
+  return (
+    <div className="space-y-3">
+      {CARDS.map((card) => {
+        const Icon = card.icon;
+        const active = value === card.type;
+        return (
+          <button
+            key={card.type}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(card.type)}
+            className={[
+              'w-full text-left rounded-xl border p-4 transition-colors',
+              'flex items-start gap-3',
+              active
+                ? 'border-[#ff393a] bg-[#ff393a]/10'
+                : 'border-theme-stroke hover:border-theme-text-muted',
+              disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+            ].join(' ')}
+          >
+            <Icon size={20} className={active ? 'text-[#ff393a]' : 'text-theme-text-muted'} />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-semibold text-theme-text">{card.title}</div>
+              <div className="text-xs text-theme-text-muted mt-0.5">{card.desc}</div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { Building2, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle } from 'lucide-react';
+import { IconInput } from '../../IconInput';
+import { Checkbox } from '../../Checkbox';
+
+export type W8BENEEntityType =
+  | 'corporation'
+  | 'partnership'
+  | 'simple_trust'
+  | 'grantor_trust'
+  | 'complex_trust'
+  | 'estate'
+  | 'government'
+  | 'central_bank'
+  | 'tax_exempt_org'
+  | 'private_foundation'
+  | 'international_org';
+
+export type W8BENEChapter4Status = 'active_nffe' | 'passive_nffe' | 'ffi';
+
+export interface W8BENEFormData {
+  entityName?: string;
+  countryOfIncorporation?: string;
+  disregardedEntityName?: string;
+  entityType?: W8BENEEntityType;
+  chapter4Status?: W8BENEChapter4Status;
+  permanentAddress?: string;
+  permanentCity?: string;
+  permanentCountry?: string;
+  mailingAddress?: string;
+  mailingCity?: string;
+  mailingCountry?: string;
+  usTin?: string;
+  giin?: string;
+  foreignTin?: string;
+  referenceNumbers?: string;
+  certify?: boolean;
+  signature?: string;
+  signerCapacity?: string;
+  date?: string;
+}
+
+interface W8BENEFormProps {
+  value: W8BENEFormData;
+  onChange: (next: W8BENEFormData) => void;
+  disabled?: boolean;
+}
+
+const ENTITY_TYPES: Array<{ value: W8BENEEntityType; label: string }> = [
+  { value: 'corporation', label: 'Corporation' },
+  { value: 'partnership', label: 'Partnership' },
+  { value: 'simple_trust', label: 'Simple trust' },
+  { value: 'grantor_trust', label: 'Grantor trust' },
+  { value: 'complex_trust', label: 'Complex trust' },
+  { value: 'estate', label: 'Estate' },
+  { value: 'government', label: 'Government' },
+  { value: 'central_bank', label: 'Central bank of issue' },
+  { value: 'tax_exempt_org', label: 'Tax-exempt organization' },
+  { value: 'private_foundation', label: 'Private foundation' },
+  { value: 'international_org', label: 'International organization' },
+];
+
+const CHAPTER4: Array<{ value: W8BENEChapter4Status; label: string; hint?: string }> = [
+  { value: 'active_nffe', label: 'Active NFFE', hint: 'Most non-financial entities with substantial active business.' },
+  { value: 'passive_nffe', label: 'Passive NFFE', hint: 'Holding companies, investment vehicles.' },
+  { value: 'ffi', label: 'FFI', hint: 'Foreign financial institution — paper form required.' },
+];
+
+export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disabled }) => {
+  const set = <K extends keyof W8BENEFormData>(key: K, v: W8BENEFormData[K]) =>
+    onChange({ ...value, [key]: v });
+
+  const showFfiNotice = value.chapter4Status === 'ffi';
+
+  return (
+    <div className="space-y-4">
+      <IconInput
+        icon={Building2}
+        type="text"
+        placeholder="Name of organization"
+        value={value.entityName ?? ''}
+        onChange={(e) => set('entityName', e.target.value)}
+        disabled={disabled}
+        required
+      />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Globe}
+          type="text"
+          placeholder="Country of incorporation"
+          value={value.countryOfIncorporation ?? ''}
+          onChange={(e) => set('countryOfIncorporation', e.target.value)}
+          disabled={disabled}
+          required
+        />
+        <IconInput
+          icon={Building2}
+          type="text"
+          placeholder="Disregarded entity name (if any)"
+          value={value.disregardedEntityName ?? ''}
+          onChange={(e) => set('disregardedEntityName', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div>
+        <p className="text-xs text-theme-text-muted mb-1">Entity type (Chapter 3)</p>
+        <select
+          value={value.entityType ?? ''}
+          onChange={(e) =>
+            set('entityType', (e.target.value || undefined) as W8BENEEntityType | undefined)
+          }
+          disabled={disabled}
+          className="w-full px-3 py-2 rounded-md bg-theme-input border border-theme-stroke text-sm text-theme-text"
+        >
+          <option value="">Select entity type…</option>
+          {ENTITY_TYPES.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <p className="text-xs text-theme-text-muted mb-1">FATCA status (Chapter 4)</p>
+        <div className="space-y-1.5">
+          {CHAPTER4.map((c) => {
+            const active = value.chapter4Status === c.value;
+            return (
+              <button
+                key={c.value}
+                type="button"
+                disabled={disabled}
+                onClick={() => set('chapter4Status', c.value)}
+                className={[
+                  'w-full text-left rounded-lg border px-3 py-2 transition-colors',
+                  active
+                    ? 'border-[#ff393a] bg-[#ff393a]/10'
+                    : 'border-theme-stroke hover:border-theme-text-muted',
+                ].join(' ')}
+              >
+                <div className="text-sm font-medium text-theme-text">{c.label}</div>
+                {c.hint && <div className="text-xs text-theme-text-muted">{c.hint}</div>}
+              </button>
+            );
+          })}
+        </div>
+        {showFfiNotice && (
+          <div className="mt-2 card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+            <div className="flex items-start gap-2.5">
+              <AlertTriangle size={16} className="text-amber-300 mt-0.5 flex-shrink-0" />
+              <div className="text-xs text-amber-100">
+                FFI entities require a paper W-8BEN-E with the full FATCA classification. Please reach out to an admin.
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-muted">Permanent residence address</p>
+        <IconInput
+          icon={MapPin}
+          type="text"
+          placeholder="Street, apt / suite"
+          value={value.permanentAddress ?? ''}
+          onChange={(e) => set('permanentAddress', e.target.value)}
+          disabled={disabled}
+          required
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="City or town"
+            value={value.permanentCity ?? ''}
+            onChange={(e) => set('permanentCity', e.target.value)}
+            disabled={disabled}
+            required
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Country"
+            value={value.permanentCountry ?? ''}
+            onChange={(e) => set('permanentCountry', e.target.value)}
+            disabled={disabled}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-muted">Mailing address (if different)</p>
+        <IconInput
+          icon={MapPin}
+          type="text"
+          placeholder="Street, apt / suite"
+          value={value.mailingAddress ?? ''}
+          onChange={(e) => set('mailingAddress', e.target.value)}
+          disabled={disabled}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="City or town"
+            value={value.mailingCity ?? ''}
+            onChange={(e) => set('mailingCity', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Country"
+            value={value.mailingCountry ?? ''}
+            onChange={(e) => set('mailingCountry', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="US EIN (optional)"
+          value={value.usTin ?? ''}
+          onChange={(e) => set('usTin', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="GIIN (if applicable)"
+          value={value.giin ?? ''}
+          onChange={(e) => set('giin', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Foreign TIN"
+          value={value.foreignTin ?? ''}
+          onChange={(e) => set('foreignTin', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Reference number(s)"
+          value={value.referenceNumbers ?? ''}
+          onChange={(e) => set('referenceNumbers', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="pt-2">
+        <Checkbox
+          checked={!!value.certify}
+          onChange={() => set('certify', !value.certify)}
+          label="I declare under penalties of perjury that the entity above is the beneficial owner, that the information is true, and that I am authorized to sign for it."
+          labelClassName="text-xs text-theme-text"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <IconInput
+          icon={FileSignature}
+          type="text"
+          placeholder="Signature (type your full name)"
+          value={value.signature ?? ''}
+          onChange={(e) => set('signature', e.target.value)}
+          disabled={disabled}
+          required
+        />
+        <IconInput
+          icon={Building2}
+          type="text"
+          placeholder="Capacity (e.g. Director)"
+          value={value.signerCapacity ?? ''}
+          onChange={(e) => set('signerCapacity', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={CalendarDays}
+          type="date"
+          placeholder="Date"
+          value={value.date ?? ''}
+          onChange={(e) => set('date', e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -1,0 +1,240 @@
+import React from 'react';
+import { User, Globe, MapPin, Hash, FileSignature, CalendarDays } from 'lucide-react';
+import { IconInput } from '../../IconInput';
+import { Checkbox } from '../../Checkbox';
+
+export interface W8BENFormData {
+  name?: string;
+  citizenship?: string;
+  permanentAddress?: string;
+  permanentCity?: string;
+  permanentCountry?: string;
+  mailingAddress?: string;
+  mailingCity?: string;
+  mailingCountry?: string;
+  usTin?: string;
+  foreignTin?: string;
+  referenceNumbers?: string;
+  dateOfBirth?: string;
+  treatyCountry?: string;
+  articleParagraph?: string;
+  withholdingRate?: string;
+  incomeType?: string;
+  treatyExplanation?: string;
+  certify?: boolean;
+  signature?: string;
+  date?: string;
+}
+
+interface W8BENFormProps {
+  value: W8BENFormData;
+  onChange: (next: W8BENFormData) => void;
+  disabled?: boolean;
+}
+
+export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled }) => {
+  const set = <K extends keyof W8BENFormData>(key: K, v: W8BENFormData[K]) =>
+    onChange({ ...value, [key]: v });
+
+  return (
+    <div className="space-y-4">
+      <IconInput
+        icon={User}
+        type="text"
+        placeholder="Full legal name"
+        value={value.name ?? ''}
+        onChange={(e) => set('name', e.target.value)}
+        disabled={disabled}
+        required
+      />
+      <IconInput
+        icon={Globe}
+        type="text"
+        placeholder="Country of citizenship"
+        value={value.citizenship ?? ''}
+        onChange={(e) => set('citizenship', e.target.value)}
+        disabled={disabled}
+        required
+      />
+
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-muted">Permanent residence address</p>
+        <IconInput
+          icon={MapPin}
+          type="text"
+          placeholder="Street, apt / suite"
+          value={value.permanentAddress ?? ''}
+          onChange={(e) => set('permanentAddress', e.target.value)}
+          disabled={disabled}
+          required
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="City or town"
+            value={value.permanentCity ?? ''}
+            onChange={(e) => set('permanentCity', e.target.value)}
+            disabled={disabled}
+            required
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Country"
+            value={value.permanentCountry ?? ''}
+            onChange={(e) => set('permanentCountry', e.target.value)}
+            disabled={disabled}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-muted">Mailing address (if different)</p>
+        <IconInput
+          icon={MapPin}
+          type="text"
+          placeholder="Street, apt / suite"
+          value={value.mailingAddress ?? ''}
+          onChange={(e) => set('mailingAddress', e.target.value)}
+          disabled={disabled}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="City or town"
+            value={value.mailingCity ?? ''}
+            onChange={(e) => set('mailingCity', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Country"
+            value={value.mailingCountry ?? ''}
+            onChange={(e) => set('mailingCountry', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="US TIN (SSN / ITIN, optional)"
+          value={value.usTin ?? ''}
+          onChange={(e) => set('usTin', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Foreign TIN"
+          value={value.foreignTin ?? ''}
+          onChange={(e) => set('foreignTin', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Reference number(s)"
+          value={value.referenceNumbers ?? ''}
+          onChange={(e) => set('referenceNumbers', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={CalendarDays}
+          type="date"
+          placeholder="Date of birth"
+          value={value.dateOfBirth ?? ''}
+          onChange={(e) => set('dateOfBirth', e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-muted">Tax treaty claim (optional)</p>
+        <IconInput
+          icon={Globe}
+          type="text"
+          placeholder="Country for tax treaty claim"
+          value={value.treatyCountry ?? ''}
+          onChange={(e) => set('treatyCountry', e.target.value)}
+          disabled={disabled}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <IconInput
+            icon={Hash}
+            type="text"
+            placeholder="Article + paragraph"
+            value={value.articleParagraph ?? ''}
+            onChange={(e) => set('articleParagraph', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={Hash}
+            type="text"
+            placeholder="Withholding rate (%)"
+            value={value.withholdingRate ?? ''}
+            onChange={(e) => set('withholdingRate', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={Hash}
+            type="text"
+            placeholder="Type of income"
+            value={value.incomeType ?? ''}
+            onChange={(e) => set('incomeType', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+        <IconInput
+          icon={Hash}
+          multiline
+          rows={2}
+          placeholder="Explanation for treaty claim (optional)"
+          value={value.treatyExplanation ?? ''}
+          onChange={(e) => set('treatyExplanation', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="pt-2">
+        <Checkbox
+          checked={!!value.certify}
+          onChange={() => set('certify', !value.certify)}
+          label="I certify that I am the beneficial owner of all income to which this form relates, that I am not a U.S. person, and the information above is true and correct."
+          labelClassName="text-xs text-theme-text"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={FileSignature}
+          type="text"
+          placeholder="Signature (type your full name)"
+          value={value.signature ?? ''}
+          onChange={(e) => set('signature', e.target.value)}
+          disabled={disabled}
+          required
+        />
+        <IconInput
+          icon={CalendarDays}
+          type="date"
+          placeholder="Date"
+          value={value.date ?? ''}
+          onChange={(e) => set('date', e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { User, Building2, MapPin, Hash, FileSignature, CalendarDays } from 'lucide-react';
+import { IconInput } from '../../IconInput';
+import { Checkbox } from '../../Checkbox';
+
+export interface W9FormData {
+  name?: string;
+  businessName?: string;
+  taxClassification?:
+    | 'individual'
+    | 'c_corp'
+    | 's_corp'
+    | 'partnership'
+    | 'trust_estate'
+    | 'llc_c'
+    | 'llc_s'
+    | 'llc_p'
+    | 'other';
+  exemptPayeeCode?: string;
+  fatcaCode?: string;
+  address?: string;
+  cityStateZip?: string;
+  accountNumbers?: string;
+  ssn?: string;
+  ein?: string;
+  certify?: boolean;
+  signature?: string;
+  date?: string;
+}
+
+interface W9FormProps {
+  value: W9FormData;
+  onChange: (next: W9FormData) => void;
+  disabled?: boolean;
+}
+
+const TAX_CLASS_OPTIONS: Array<{ value: NonNullable<W9FormData['taxClassification']>; label: string }> = [
+  { value: 'individual', label: 'Individual / sole proprietor / single-member LLC' },
+  { value: 'c_corp', label: 'C Corporation' },
+  { value: 's_corp', label: 'S Corporation' },
+  { value: 'partnership', label: 'Partnership' },
+  { value: 'trust_estate', label: 'Trust / estate' },
+  { value: 'llc_c', label: 'LLC taxed as C corporation' },
+  { value: 'llc_s', label: 'LLC taxed as S corporation' },
+  { value: 'llc_p', label: 'LLC taxed as Partnership' },
+  { value: 'other', label: 'Other' },
+];
+
+/**
+ * W-9 host form. All fields are controlled; the parent passes `value` /
+ * `onChange` so the draft can be saved as you type. Required-field validation
+ * lives on the backend (POST /api/tax-forms/submit) — the submit button is
+ * the place to surface failures.
+ */
+export const W9Form: React.FC<W9FormProps> = ({ value, onChange, disabled }) => {
+  const set = <K extends keyof W9FormData>(key: K, v: W9FormData[K]) =>
+    onChange({ ...value, [key]: v });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <IconInput
+          icon={User}
+          type="text"
+          placeholder="Full legal name (as on your tax return)"
+          value={value.name ?? ''}
+          onChange={(e) => set('name', e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+      <div>
+        <IconInput
+          icon={Building2}
+          type="text"
+          placeholder="Business name (if different from above)"
+          value={value.businessName ?? ''}
+          onChange={(e) => set('businessName', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div>
+        <p className="text-xs text-theme-text-muted mb-1">Federal tax classification</p>
+        <select
+          value={value.taxClassification ?? ''}
+          onChange={(e) =>
+            set('taxClassification', (e.target.value || undefined) as W9FormData['taxClassification'])
+          }
+          disabled={disabled}
+          className="w-full px-3 py-2 rounded-md bg-theme-input border border-theme-stroke text-sm text-theme-text"
+        >
+          <option value="">Select classification…</option>
+          {TAX_CLASS_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Exempt payee code (optional)"
+          value={value.exemptPayeeCode ?? ''}
+          onChange={(e) => set('exemptPayeeCode', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="FATCA reporting code (optional)"
+          value={value.fatcaCode ?? ''}
+          onChange={(e) => set('fatcaCode', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <IconInput
+        icon={MapPin}
+        type="text"
+        placeholder="Address (number, street, apt / suite)"
+        value={value.address ?? ''}
+        onChange={(e) => set('address', e.target.value)}
+        disabled={disabled}
+        required
+      />
+      <IconInput
+        icon={MapPin}
+        type="text"
+        placeholder="City, state, and ZIP code"
+        value={value.cityStateZip ?? ''}
+        onChange={(e) => set('cityStateZip', e.target.value)}
+        disabled={disabled}
+        required
+      />
+      <IconInput
+        icon={Hash}
+        type="text"
+        placeholder="Account number(s) (optional)"
+        value={value.accountNumbers ?? ''}
+        onChange={(e) => set('accountNumbers', e.target.value)}
+        disabled={disabled}
+      />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Social Security Number (XXX-XX-XXXX)"
+          value={value.ssn ?? ''}
+          onChange={(e) => set('ssn', e.target.value)}
+          disabled={disabled}
+        />
+        <IconInput
+          icon={Hash}
+          type="text"
+          placeholder="Employer ID Number (XX-XXXXXXX)"
+          value={value.ein ?? ''}
+          onChange={(e) => set('ein', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+      <p className="text-xs text-theme-text-muted">Enter one of SSN or EIN.</p>
+
+      <div className="pt-2">
+        <Checkbox
+          checked={!!value.certify}
+          onChange={() => set('certify', !value.certify)}
+          label="I certify, under penalties of perjury, that the information above is correct and I am a U.S. person."
+          labelClassName="text-xs text-theme-text"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <IconInput
+          icon={FileSignature}
+          type="text"
+          placeholder="Signature (type your full name)"
+          value={value.signature ?? ''}
+          onChange={(e) => set('signature', e.target.value)}
+          disabled={disabled}
+          required
+        />
+        <IconInput
+          icon={CalendarDays}
+          type="date"
+          placeholder="Date"
+          value={value.date ?? ''}
+          onChange={(e) => set('date', e.target.value)}
+          disabled={disabled}
+          required
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -184,6 +184,9 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     }),
     reimbursementCapAppealNote: dbParty.reimbursement_cap_appeal_note ?? null,
     reimbursementCapAppealedAt: dbParty.reimbursement_cap_appealed_at ?? null,
+    // culatello-92106: per-event tax-form gate. Default false so existing
+    // events without the column don't accidentally enforce the gate.
+    taxFormRequired: dbParty.tax_form_required === true,
     // Day-of logistics (pepperoni-58341)
     wifiInfo: dbParty.wifi_info ?? null,
     parkingNotes: dbParty.parking_notes ?? null,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem, TaxForm, TaxFormType, TaxFormStatus } from '../types';
 // pancetta-92103: region portal → underlying parties.region slug map. Used by
 // `buildPayoutQuery` to expand the /payments admin Regions multi-select into
 // the existing `?regions=` query the backend already accepts.
@@ -5811,4 +5811,86 @@ export async function getSurveyResults(partyId: string): Promise<SurveyResults> 
     method: 'GET',
     requireAuth: true,
   });
+}
+
+// ============================================
+// Tax forms (salame-92110)
+// ============================================
+
+export async function getMyTaxForms(): Promise<TaxForm[]> {
+  const res = await apiRequest<{ taxForms: TaxForm[] }>(`/api/tax-forms/me`, {
+    requireAuth: true,
+  });
+  return res.taxForms;
+}
+
+export async function saveTaxFormDraft(
+  formType: TaxFormType,
+  formData: Record<string, any>,
+): Promise<TaxForm> {
+  const res = await apiRequest<{ taxForm: TaxForm }>(`/api/tax-forms/draft`, {
+    method: 'POST',
+    body: { formType, formData },
+    requireAuth: true,
+  });
+  return res.taxForm;
+}
+
+export async function submitTaxForm(
+  formType: TaxFormType,
+  formData?: Record<string, any>,
+): Promise<TaxForm> {
+  const res = await apiRequest<{ taxForm: TaxForm }>(`/api/tax-forms/submit`, {
+    method: 'POST',
+    body: formData ? { formType, formData } : { formType },
+    requireAuth: true,
+  });
+  return res.taxForm;
+}
+
+export interface ListAdminTaxFormsFilters {
+  status?: TaxFormStatus;
+  formType?: TaxFormType;
+  userId?: string;
+  expiringWithinDays?: number;
+}
+
+export async function listAdminTaxForms(
+  filters: ListAdminTaxFormsFilters = {},
+): Promise<TaxForm[]> {
+  const params = new URLSearchParams();
+  if (filters.status) params.set('status', filters.status);
+  if (filters.formType) params.set('formType', filters.formType);
+  if (filters.userId) params.set('userId', filters.userId);
+  if (filters.expiringWithinDays != null)
+    params.set('expiringWithinDays', String(filters.expiringWithinDays));
+  const qs = params.toString();
+  const res = await apiRequest<{ taxForms: TaxForm[] }>(
+    `/api/admin/tax-forms${qs ? `?${qs}` : ''}`,
+    { requireAuth: true },
+  );
+  return res.taxForms;
+}
+
+export async function getAdminTaxForm(id: string): Promise<TaxForm> {
+  const res = await apiRequest<{ taxForm: TaxForm }>(`/api/admin/tax-forms/${id}`, {
+    requireAuth: true,
+  });
+  return res.taxForm;
+}
+
+export async function verifyTaxForm(id: string): Promise<TaxForm> {
+  const res = await apiRequest<{ taxForm: TaxForm }>(
+    `/api/admin/tax-forms/${id}/verify`,
+    { method: 'POST', requireAuth: true },
+  );
+  return res.taxForm;
+}
+
+export async function rejectTaxForm(id: string, reason: string): Promise<TaxForm> {
+  const res = await apiRequest<{ taxForm: TaxForm }>(
+    `/api/admin/tax-forms/${id}/reject`,
+    { method: 'POST', body: { reason }, requireAuth: true },
+  );
+  return res.taxForm;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -240,6 +240,9 @@ export interface UpdatePartyData {
   // margherita-58471: T-4h reminder opt-out at the party level.
   remindersEnabled?: boolean;
   reimbursementCapUsd?: number | null;
+  // culatello-92106: admin-only per-event gate for the salame-92110 tax-form
+  // requirement. Hosts who PATCH this get silently dropped (backend gate).
+  taxFormRequired?: boolean;
   // Day-of logistics (pepperoni-58341)
   wifiInfo?: string | null;
   parkingNotes?: string | null;
@@ -365,6 +368,7 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       surveyEnabled: data.surveyEnabled,
       remindersEnabled: data.remindersEnabled,
       reimbursementCapUsd: data.reimbursementCapUsd,
+      taxFormRequired: data.taxFormRequired,
       // Day-of logistics (pepperoni-58341)
       wifiInfo: data.wifiInfo,
       parkingNotes: data.parkingNotes,

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -835,6 +835,9 @@ export interface DbParty {
   reimbursement_cap_usd?: number | null;
   reimbursement_cap_appeal_note?: string | null;
   reimbursement_cap_appealed_at?: string | null;
+  // culatello-92106: per-event tax-form gate. When true the host-side
+  // TaxFormSection renders + backend payout submission enforces salame-92110.
+  tax_form_required?: boolean;
   // quattro-71244: gamified-dashboard goal targets (JSONB on parties).
   host_goals?: HostGoals | null;
   // porchetta-81402: soft-cancel columns. cancelledAt null = active event.
@@ -913,6 +916,7 @@ export const SAFE_PARTY_COLUMNS = `
   poster_image_url, poster_generated_at,
   rollup_image_url, rollup_generated_at,
   reimbursement_cap_usd, reimbursement_cap_appeal_note, reimbursement_cap_appealed_at,
+  tax_form_required,
   cancelled_at, cancelled_by, cancellation_reason
 `;
 
@@ -1997,6 +2001,8 @@ export async function updateParty(
     survey_enabled?: boolean;
     reminders_enabled?: boolean;
     reimbursement_cap_usd?: number | null;
+    // culatello-92106: admin-only per-event tax-form gate.
+    tax_form_required?: boolean;
     // quattro-71244: gamified-dashboard goal targets.
     host_goals?: HostGoals | null;
     // porchetta-81402: edit cancellation reason via PATCH. Cancel/reinstate
@@ -2082,6 +2088,7 @@ export async function updateParty(
         surveyEnabled: updates.survey_enabled,
         remindersEnabled: updates.reminders_enabled,
         reimbursementCapUsd: updates.reimbursement_cap_usd,
+        taxFormRequired: updates.tax_form_required,
         // Day-of logistics (pepperoni-58341)
         wifiInfo: updates.wifi_info,
         parkingNotes: updates.parking_notes,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1831,6 +1831,40 @@ export interface Payout {
   createdAt: string;
   updatedAt: string;
   documents: PayoutDocument[];
+  /**
+   * salame-92110: snapshot of the host's tax form (W-9 / W-8BEN / W-8BEN-E)
+   * captured at submission time. Null on payouts created before the tax-form
+   * feature shipped and on shipping-coordinator receipts.
+   */
+  taxFormId?: string | null;
+}
+
+// ============================================
+// Tax forms (salame-92110)
+// ============================================
+
+export type TaxFormType = 'w9' | 'w8ben' | 'w8bene';
+export type TaxFormStatus = 'draft' | 'submitted' | 'verified' | 'rejected';
+
+export interface TaxForm {
+  id: string;
+  userId: string;
+  formType: TaxFormType;
+  status: TaxFormStatus;
+  pdfUrl: string | null;
+  pdfThumbUrl: string | null;
+  signedAt: string | null;
+  /** Null for W-9, set for W-8BEN/W-8BEN-E (signed_at + ~3y11m). */
+  expiresAt: string | null;
+  verifiedAt: string | null;
+  verifiedBy: string | null;
+  rejectedReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  /** Only present for drafts + the host's own /me endpoint + admin detail. */
+  formData?: Record<string, any>;
+  /** Hydrated on admin endpoints. */
+  user?: { id: string; name: string | null; email: string | null };
 }
 
 /**

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -353,6 +353,10 @@ export interface Party {
   effectiveReimbursementCapUsd?: number | null;
   reimbursementCapAppealNote?: string | null;
   reimbursementCapAppealedAt?: string | null;
+  // culatello-92106: per-event tax-form gate. Admin-only flag; when true the
+  // host-side TaxFormSection renders + backend payout submission enforces
+  // the salame-92110 TAX_FORM_REQUIRED check. Default false.
+  taxFormRequired?: boolean;
   // quattro-71244: Gamified host dashboard KPIs — host-private goal targets
   // keyed by ReportKPIs stat key. Lives in the `host_goals` JSONB column.
   hostGoals?: HostGoals | null;
@@ -2022,6 +2026,14 @@ export interface AdminPayout extends Payout, FlaggedReadyFields {
      * for backward-compat with cached payloads during a rolling deploy.
      */
     paymentsClosedAt?: string | null;
+    /**
+     * culatello-92106: per-event tax-form gate. When true, hosts must submit
+     * a W-9 / W-8BEN / W-8BEN-E (salame-92110) before they can submit a
+     * payout. Toggled by admins via PATCH /api/parties/:id with
+     * `taxFormRequired: boolean`. Optional for backward-compat with cached
+     * payloads during a rolling deploy.
+     */
+    taxFormRequired?: boolean;
   };
   host: {
     id: string;
@@ -2279,6 +2291,14 @@ export interface PartyPayoutsRow {
      * cached payloads during a rolling deploy.
      */
     paymentsClosedAt?: string | null;
+    /**
+     * culatello-92106: per-event tax-form gate. When true, hosts must submit
+     * a W-9 / W-8BEN / W-8BEN-E (salame-92110) before they can submit a
+     * payout. Toggled from the by-city expansion or PayoutReviewModal.
+     * Optional for backward-compat with cached payloads during a rolling
+     * deploy.
+     */
+    taxFormRequired?: boolean;
     /**
      * mortadella-92106: admin-only city notes. Free-text scratchpad on the
      * by-city expansion. Always `null` for underboss viewers (server-side

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "jsonwebtoken": "^9.0.2",
         "nanoid": "^5.0.5",
         "openai": "^6.38.0",
+        "pdf-lib": "^1.17.1",
         "pg": "^8.21.0",
         "sharp": "^0.33.5",
         "swagger-jsdoc": "^6.2.8",
@@ -3751,6 +3752,24 @@
       "license": "(MIT OR Apache-2.0)",
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -17638,6 +17657,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -17796,6 +17821,24 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pdfjs-dist": {
       "version": "5.7.284",


### PR DESCRIPTION
## Summary

Hosts must submit a tax form before admin can Approve their payouts, **but only on events where an admin has flipped the per-event `tax_form_required` flag** (culatello-92106). Three form types:

- **W-9** — US individuals / entities
- **W-8BEN** — non-US individuals
- **W-8BEN-E** — non-US organizations

The salame-92110 US-$600 + foreign-always heuristic still runs inside the gate, but it only fires when admin has decided this specific event needs tax-form collection. Default-off for every existing event.

## culatello-92106: per-event admin gate

The `parties.tax_form_required` boolean (default `false`) is the canonical gate:

- **Host side**: `NewPayoutForm` only renders `TaxFormSection` when `party.taxFormRequired === true`. Hosts on un-gated events see no tax-form UI at all.
- **Backend**: `POST /api/parties/:partyId/payouts` reads `parties.tax_form_required`; when `false`, the `TAX_FORM_REQUIRED` 400 is skipped entirely (a form snapshot is still taken if one happens to be on file). When `true`, the salame-92110 enforcement applies.
- **Admin flip**: A Checkbox in `PayoutReviewModal` + a clickable pill in the `PayoutsByPartyTable` city header both PATCH `/api/parties/:id` with `taxFormRequired: boolean`. Backend gates the field write to admin / payment_admin / super_admin (`isPaymentAdmin`).

The admin `TaxFormReviewPanel` still surfaces historical form snapshots regardless of the flag — flipping the gate off doesn't lose attribution on already-submitted payouts.

## Architecture

- **Backend**: `pdf-lib` generators ported from the standalone `tax-form/` repo for W-9 + W-8BEN. W-8BEN-E is new (entity-name, country of incorporation, Chapter 3 entity type, simplified Chapter 4 FATCA status with an FFI → paper-form escape hatch).
- **Storage**: existing `event-images` bucket (`application/pdf` allowlist + 10MB cap already in place from bocconcino-92104). Path: `tax-forms/{userId}/{formType}-{timestamp}.pdf`. No new bucket required.
- **Snapshot model**: `payouts.tax_form_id` is set at submission time so historical immutability survives the host editing or replacing their form later.

## DB migration — NOT yet applied

Migration file: `backend/prisma/migrations/20260531_tax_forms/migration.sql`

**Snax must run this manually before merging.** The file:

- Creates `tax_forms` (uuid PK, FK to `User(id)` CASCADE, JSONB `form_data`, CHECK constraints on `form_type` + `status`)
- Adds `payouts.tax_form_id` (uuid FK, ON DELETE SET NULL) + index
- **(culatello-92106)** Adds `parties.tax_form_required boolean NOT NULL DEFAULT false` + `GRANT SELECT (tax_form_required)` to anon, authenticated
- Sets column-level `GRANT SELECT` for `authenticated` on `tax_forms` (omits `form_data` — admin route returns it via service-role)
- Grants `SELECT (tax_form_id)` on `payouts` to anon, authenticated

## Endpoints

Host (authed):
- `GET    /api/tax-forms/me`        list my forms (latest first; includes `formData`)
- `POST   /api/tax-forms/draft`     upsert my draft for `{ formType, formData }`
- `POST   /api/tax-forms/submit`    finalize → validate → generate PDF → upload → `status='submitted'`

Admin (admin / payment_admin / super_admin):
- `GET    /api/admin/tax-forms`           list with `?status=&formType=&userId=&expiringWithinDays=` (no `formData` on list)
- `GET    /api/admin/tax-forms/:id`       single form incl. `formData`
- `POST   /api/admin/tax-forms/:id/verify`
- `POST   /api/admin/tax-forms/:id/reject` body `{ reason }`
- `PATCH  /api/parties/:id` now accepts `taxFormRequired: boolean` (admin-gated; hosts dropped silently — culatello-92106)

## UI

- **Host**: new `TaxFormSection` rendered inside `NewPayoutForm` between Amount and Submit, **only when `party.taxFormRequired === true`**. States: no-form → 3-card picker; draft → editor with Save Draft + Submit; submitted → green-check card with PDF link + Edit; verified → green "Verified by admin" badge; rejected → reason + resubmit.
- **Admin**: new `TaxFormReviewPanel` in `PayoutReviewModal` above Receipts (shows historical snapshots regardless of the per-event flag). A new "Tax forms required for this event" Checkbox sits above the panel and PATCHes the per-event flag. The `/payments` `PayoutsByPartyTable` city header gets a clickable "Tax forms required" / "Tax forms: off" pill that flips the same flag (optimistic, reversible, no confirm).
- `NewPayoutForm` catches `TAX_FORM_REQUIRED` from the submit response, scrolls to the section, and auto-opens any provided form type.

## Out of scope (phase 2)

- Expiry tracking cron (W-8 expires after ~3 years; the column is populated but no nag email yet)
- Year-end 1099-NEC generator
- e-signature / TIN-matching integrations
- Auto-infer US vs foreign from User.country / Party.country (now superseded by the admin per-event flag)

## Test plan

- [ ] **DB**: Snax runs `backend/prisma/migrations/20260531_tax_forms/migration.sql` against prod via Supabase MCP (verify `User` table FK resolves — capital singular per `[[feedback_prisma_table_name_verify]]`)
- [ ] **Backend deploy**: master deploy via `rsvpizza-master-deploy` worktree picks up the new `pdf-lib` dep + new routes
- [ ] **Flag default**: open any existing event's Payments tab → no TaxFormSection rendered (flag is `false`)
- [ ] **Admin flip**: open PayoutReviewModal on an event → tick "Tax forms required for this event" → host's Payments tab now shows TaxFormSection
- [ ] **By-city pill**: `/payments` table → click the "Tax forms: off" pill on a city → it flips to "Tax forms required" optimistically + persists on refresh
- [ ] **Smoke W-9** (on a flagged event): fill all required fields → Save draft → reload → Continue editing → Submit → PDF opens in new tab → admin sees Submitted pill in PayoutReviewModal
- [ ] **Smoke W-8BEN** (on a flagged event): same flow; verify expiry shows ~3y11m out
- [ ] **Smoke W-8BEN-E** (on a flagged event): pick FFI → see paper-form amber warning; pick Active NFFE → submit → PDF renders
- [ ] **Gate**: on a flagged event, brand-new host submits a $700 payout without a form → 400 TAX_FORM_REQUIRED → section opens
- [ ] **No-gate**: on an un-flagged event, brand-new host submits a $700 payout without a form → succeeds, no TAX_FORM_REQUIRED error
- [ ] **Snapshot**: submit a payout, then host edits the form → admin reviewing the OLD payout still sees the original snapshot via `payouts.tax_form_id`
- [ ] **Admin verify** → status flips to verified; **Reject** with reason → status flips, host sees rejection message on TaxFormSection
- [ ] **Host can't flip the flag**: hit `PATCH /api/parties/:id` with `taxFormRequired: true` as the host → field silently dropped, rest of the PATCH still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)