### PR TITLE
fix(taleggio-58917): SWC Canada newsletter signups download

### DIFF
--- a/backend/src/lib/consolidatedReport.ts
+++ b/backend/src/lib/consolidatedReport.ts
@@ -21,7 +21,7 @@ export const NEWSLETTER_OPTIN_FIELD: Record<
   'swcOptIn' | 'swcCaOptIn' | 'swcAuOptIn' | 'swcEuOptIn' | 'swcUkOptIn' | 'swcBrOptIn' | 'ethconfOptIn'
 > = {
   swc: 'swcOptIn',
-  swcca: 'swcCaOptIn',
+  swccanada: 'swcCaOptIn',
   swcau: 'swcAuOptIn',
   swceu: 'swcEuOptIn',
   swcuk: 'swcUkOptIn',

--- a/backend/src/routes/sponsor-user.routes.ts
+++ b/backend/src/routes/sponsor-user.routes.ts
@@ -1113,7 +1113,7 @@ sponsorDashboardRouter.get('/events/timeseries', requireAuth, requireSponsorAuth
 // Guest model. The consolidated report's "newsletter signups" tile counts only
 // these (never PizzaDAO's mailingListOptIn) and is hidden for any other tag.
 const NEWSLETTER_OPTIN_FIELD: Record<string, 'swcOptIn' | 'swcCaOptIn' | 'swcAuOptIn' | 'swcEuOptIn' | 'swcUkOptIn' | 'swcBrOptIn' | 'ethconfOptIn'> = {
-  swc: 'swcOptIn', swcca: 'swcCaOptIn', swcau: 'swcAuOptIn', swceu: 'swcEuOptIn', swcuk: 'swcUkOptIn', swcbr: 'swcBrOptIn', ethconf: 'ethconfOptIn',
+  swc: 'swcOptIn', swccanada: 'swcCaOptIn', swcau: 'swcAuOptIn', swceu: 'swcEuOptIn', swcuk: 'swcUkOptIn', swcbr: 'swcBrOptIn', ethconf: 'ethconfOptIn',
 };
 
 // scamorza-71819: per-partner AI-share token endpoints.


### PR DESCRIPTION
Backend-only fix. The `NEWSLETTER_OPTIN_FIELD` map keyed SWC Canada as `swcca`, but the SWC Canada sponsor tag and `event_tags` value are both `swccanada`. The mismatched key made the lookup return `undefined`, so the consolidated report's Newsletter signups count came back null -- hiding the tile and its CSV download link.

Changed the key `swcca` -> `swccanada` in both duplicated `NEWSLETTER_OPTIN_FIELD` definitions (`backend/src/lib/consolidatedReport.ts` and `backend/src/routes/sponsor-user.routes.ts`). Value (`'swcCaOptIn'`) unchanged.

The 167 `swc_ca_opt_in` signups will now be counted and downloadable. No frontend changes, no migrations. Deploys from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)