### PR TITLE
provolone-49301: run receipt OCR once (trust preview, re-lock FX)

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -578,6 +578,13 @@ router.post(
         exchangeRate: unresolved ? 0 : (fx.exchangeRate ?? 0),
         confidence: ocr.confidence,
         items: ocr.items,
+        // provolone-49301: expose the structured line items + raw OCR payload
+        // (already computed in this same analyzeReceipt call — zero extra
+        // compute) so the frontend can forward them at submit. POST /payouts
+        // then persists them and SKIPS a second gpt-4o pass, while still
+        // re-running the free convertToUSD to re-lock FX authoritatively.
+        lineItems: ocr.lineItems ?? null,
+        ocrRaw: ocr.raw ?? null,
         fxSource: fx.source,
         conversionNote: unresolved
           ? `Currency could not be determined automatically — please pick the correct currency to convert ${fx.originalAmount.toLocaleString()} to USD.`
@@ -678,6 +685,18 @@ interface IncomingDocument {
   fileName?: string;
   fileSize?: number;
   mimeType?: string;
+  // provolone-49301: optional preview-OCR payload forwarded from the host
+  // upload step (ocr-preview ran gpt-4o once already). When a valid
+  // ocrOriginalAmount is present we trust the original-currency OCR fields
+  // and SKIP a second analyzeReceipt pass, still re-running the free
+  // convertToUSD to re-lock FX server-side. We NEVER trust a client-supplied
+  // USD amount or exchange rate — those always come from convertToUSD.
+  ocrOriginalAmount?: number;
+  ocrOriginalCurrency?: string | null;
+  ocrConfidence?: number;
+  ocrLineItems?: unknown;
+  ocrRaw?: unknown;
+  ocrError?: string | null;
 }
 
 router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: NextFunction) => {
@@ -917,6 +936,24 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       : await Promise.allSettled(
           (receiptPhotos as IncomingDocument[]).map(async (r) => {
             try {
+              // provolone-49301: when the frontend forwards the preview-OCR
+              // payload (gpt-4o already ran once on upload), trust the
+              // original-currency fields and SKIP a second analyzeReceipt
+              // pass. We still re-run the FREE convertToUSD below to re-lock
+              // FX authoritatively — the USD amount + exchange rate ALWAYS
+              // come from the server, never from the client.
+              if (Number.isFinite(r.ocrOriginalAmount) && (r.ocrOriginalAmount as number) >= 0) {
+                const ocr = {
+                  amount: r.ocrOriginalAmount as number,
+                  currency: (typeof r.ocrOriginalCurrency === 'string' && r.ocrOriginalCurrency.trim()) ? r.ocrOriginalCurrency.trim().slice(0, 8) : null,
+                  confidence: Math.min(1, Math.max(0, Number(r.ocrConfidence) || 0)),
+                  lineItems: Array.isArray(r.ocrLineItems) ? (r.ocrLineItems as any[]).slice(0, 100) : undefined,
+                  raw: r.ocrRaw ?? null,
+                };
+                const fx = await convertToUSD(ocr.amount, ocr.currency);
+                return { ok: true as const, doc: r, ocr, fx };
+              }
+              // Fallback (no forwarded payload, e.g. old clients): OCR here.
               // bocconcino-92104: PDFs are OCR'd via their `.thumb.png` sibling.
               const ocr = await analyzeReceipt({
                 imageUrl: deriveOcrUrl(r),
@@ -1675,6 +1712,21 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       : await Promise.allSettled(
           newReceipts.map(async (r) => {
             try {
+              // provolone-49301: trust the forwarded preview-OCR payload and
+              // skip a second analyzeReceipt pass when present (parity with
+              // POST /payouts). USD + rate still come from convertToUSD.
+              if (Number.isFinite(r.ocrOriginalAmount) && (r.ocrOriginalAmount as number) >= 0) {
+                const ocr = {
+                  amount: r.ocrOriginalAmount as number,
+                  currency: (typeof r.ocrOriginalCurrency === 'string' && r.ocrOriginalCurrency.trim()) ? r.ocrOriginalCurrency.trim().slice(0, 8) : null,
+                  confidence: Math.min(1, Math.max(0, Number(r.ocrConfidence) || 0)),
+                  lineItems: Array.isArray(r.ocrLineItems) ? (r.ocrLineItems as any[]).slice(0, 100) : undefined,
+                  raw: r.ocrRaw ?? null,
+                };
+                const fx = await convertToUSD(ocr.amount, ocr.currency);
+                return { ok: true as const, doc: r, ocr, fx };
+              }
+              // Fallback (no forwarded payload): OCR here.
               // bocconcino-92104: PDFs are OCR'd via their `.thumb.png` sibling.
               const ocr = await analyzeReceipt({
                 imageUrl: deriveOcrUrl(r),

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -231,6 +231,19 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             fileName: r.fileName,
             fileSize: r.fileSize,
             mimeType: r.mimeType,
+            // provolone-49301: forward the preview-OCR payload so the backend
+            // skips a second gpt-4o pass. These already reflect any host
+            // currency override (CurrencyOverrideSelect mutates r.ocr in
+            // place). USD amount/rate are intentionally NOT sent — the backend
+            // re-locks FX via convertToUSD. Include the CURRENCY_UNRESOLVED
+            // case too (originalAmount is still set) so the backend treats it
+            // as forwarded and doesn't re-OCR.
+            ocrOriginalAmount: r.ocr?.originalAmount,
+            ocrOriginalCurrency: r.ocr?.originalCurrency,
+            ocrConfidence: r.ocr?.confidence,
+            ocrLineItems: r.ocr?.lineItems,
+            ocrRaw: r.ocr?.ocrRaw,
+            ocrError: r.ocr?.ocrError,
           })),
         pizzaPhotos: pizzaPhotos
           .filter(p => p.status === 'done' && p.url)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5172,6 +5172,17 @@ export interface CreatePayoutPhotoInput {
   fileName?: string;
   fileSize?: number;
   mimeType?: string;
+  // provolone-49301: optional forwarded preview-OCR payload for receipts.
+  // ocr-preview already ran gpt-4o once on upload; forwarding the
+  // original-currency result lets the backend SKIP a second pass while still
+  // re-locking FX server-side. USD amount/rate are never sent — the server
+  // recomputes them via convertToUSD. Ignored for pizza photos.
+  ocrOriginalAmount?: number;
+  ocrOriginalCurrency?: string | null;
+  ocrConfidence?: number;
+  ocrLineItems?: unknown;
+  ocrRaw?: unknown;
+  ocrError?: string | null;
 }
 
 export interface CreatePayoutData {
@@ -5273,6 +5284,15 @@ export interface UpdatePayoutData {
     fileName: string;
     fileSize: number;
     mimeType: string;
+    // provolone-49301: optional forwarded preview-OCR payload (parity with
+    // createPayout). When present the backend skips a second analyzeReceipt
+    // pass and re-locks FX via convertToUSD.
+    ocrOriginalAmount?: number;
+    ocrOriginalCurrency?: string | null;
+    ocrConfidence?: number;
+    ocrLineItems?: unknown;
+    ocrRaw?: unknown;
+    ocrError?: string | null;
   }>;
   pizzaPhotos?: Array<{
     url: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2193,6 +2193,18 @@ export interface PrepayQueueRow {
   partyPaidCount: number;
 }
 
+// provolone-49301: one structured receipt line item, as returned by the
+// backend OCR service. Kept intentionally loose — every field is optional so
+// it tolerates partial/legacy payloads. Forwarded verbatim back to the
+// backend at submit so it can be persisted without a second gpt-4o pass.
+export interface OcrLineItem {
+  name?: string;
+  qty?: number;
+  unitPrice?: number;
+  subtotal?: number;
+  category?: string;
+}
+
 export interface OcrPreviewResult {
   amount: number;             // USD-converted total (0 when ocrError='CURRENCY_UNRESOLVED')
   currency: 'USD';
@@ -2201,6 +2213,11 @@ export interface OcrPreviewResult {
   exchangeRate: number;
   confidence: number;
   items?: string[];
+  // provolone-49301: structured per-line items + raw OCR payload, exposed by
+  // ocr-preview (already computed in the same analyzeReceipt call). Forwarded
+  // at submit so POST /payouts can persist them and skip a second OCR pass.
+  lineItems?: OcrLineItem[];
+  ocrRaw?: unknown;
   // mortadella-92103: 'unresolved' is the new source for "OCR could not
   // determine currency and no country prior was strong enough to pick one
   // automatically". Host must override via CurrencyOverrideSelect.


### PR DESCRIPTION
## Problem
Receipts were OCR'd by gpt-4o twice — once on host upload (ocr-preview) and again at POST /payouts, because NewPayoutForm dropped the preview OCR result.

## Fix
Forward the preview OCR payload at submit; backend persists it and skips analyzeReceipt, still re-running the free convertToUSD to re-lock FX authoritatively. Falls back to analyzeReceipt when the payload is absent (deploy-order-safe). Exposes lineItems+raw in the ocr-preview response (already computed in the same call) to preserve pizza-price analytics + forensics. USD amount/rate always come from server-side convertToUSD — no client USD trusted.

## Note
Backend deploys from master only, so the OCR-skip path is NOT exercisable on the Vercel preview (previews hit the prod backend). Frontend forwarding is harmless on prod until the backend lands.

Preview: https://rsvpizza-git-provolone-49301-ocr-once-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)