### PR TITLE
taleggio-49312: show all-time Paid total in /payments stats

### DIFF
--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DollarSign, Calendar, TrendingUp, Inbox, CheckCircle2 } from 'lucide-react';
+import { DollarSign, TrendingUp, Inbox, CheckCircle2 } from 'lucide-react';
 import type { AdminPayoutTotals } from '../../types';
 import { formatUsd } from '../payments-shared';
 
@@ -51,9 +51,9 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
         tone="amber"
       />
       <StatCard
-        icon={<Calendar size={14} />}
-        label="Paid this month"
-        value={formatUsd(totals.totalUsdThisMonth)}
+        icon={<CheckCircle2 size={14} />}
+        label="Paid"
+        value={formatUsd(totals.totalUsdPaid)}
         tone="emerald"
       />
       <StatCard


### PR DESCRIPTION
Swap the admin /payments "Paid this month" KPI to "Paid", backed by the all-time, proof-gated `totals.totalUsdPaid` instead of `totals.totalUsdThisMonth`. The Calendar icon (read as "this month") becomes CheckCircle2 since the figure is no longer month-scoped, and the now-unused Calendar import is removed.

`totalUsdPaid` already exists in `AdminPayoutTotals` and is returned by the stats endpoint, so this is frontend-only and works on preview immediately (no backend/DB change).

Preview: https://rsvpizza-git-taleggio-49312-paid-all-time-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)