### PR TITLE
bresaola-49340: proof-gate completed rows in Paid totals

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1926,8 +1926,17 @@ router.get(
         // provolone-92103: terminal close-out status for "city paid in full"
         // mark-pending-complete flow. Tracked separately from 'paid' so the
         // admin UI can show "X paid + Y completed" distinct rollups.
+        // completedCount/completedUsd count ALL completed rows (proven or not)
+        // for backward compatibility with existing consumers.
         completedCount: number;
         completedUsd: number;
+        // bresaola-49340: subset of completed rows that lack per-row proof
+        // (the proofless mark_pending_complete close-outs). The Paid headline
+        // = completedUsd MINUS completedNoProofUsd, mirroring how paid rows are
+        // split into paidUsd / paidNoProofUsd. New fields are additive so old
+        // consumers reading completedUsd/completedCount don't change meaning.
+        completedNoProofCount: number;
+        completedNoProofUsd: number;
         flaggedReadyCount: number;
         lastActivityAt: Date;
         payouts: any[]; // raw Prisma rows; serialized below
@@ -1952,6 +1961,7 @@ router.get(
             failedCount: 0, failedUsd: 0,
             withdrawnCount: 0, withdrawnUsd: 0,
             completedCount: 0, completedUsd: 0,
+            completedNoProofCount: 0, completedNoProofUsd: 0,
             flaggedReadyCount: 0,
             lastActivityAt: row.updatedAt,
             payouts: [],
@@ -1982,7 +1992,15 @@ router.get(
             b.withdrawnCount += 1; b.withdrawnUsd += usd; break;
           case 'completed':
             // provolone-92103: terminal close-out — counted in its own bucket.
-            b.completedCount += 1; b.completedUsd += usd; break;
+            // bresaola-49340: split proof-gated vs proofless, mirroring the
+            // 'paid' / paidNoProof split above. completedCount/completedUsd
+            // still count ALL completed rows (backward compat); the proofless
+            // subset is ALSO tracked so the Paid headline can subtract it.
+            b.completedCount += 1; b.completedUsd += usd;
+            if (!paidRowHasProof(row as any)) {
+              b.completedNoProofCount += 1; b.completedNoProofUsd += usd;
+            }
+            break;
         }
         if (pageFlagged.has(row.id)) b.flaggedReadyCount += 1;
         b.payouts.push(row);
@@ -2074,6 +2092,11 @@ router.get(
             withdrawnUsd: b.withdrawnUsd,
             completedCount: b.completedCount,
             completedUsd: b.completedUsd,
+            // bresaola-49340: proofless completed subset. Paid headline =
+            // completedUsd - completedNoProofUsd. Additive fields; existing
+            // consumers of completedUsd/completedCount keep their meaning.
+            completedNoProofCount: b.completedNoProofCount,
+            completedNoProofUsd: b.completedNoProofUsd,
             totalReceiptCount: receiptCounts.get(partyId) ?? 0,
             lastActivityAt: b.lastActivityAt.toISOString(),
             flaggedReadyCount: b.flaggedReadyCount,

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -256,9 +256,12 @@ function isPaidStatus(s: PayoutStatus): boolean {
  * prosciutto-92106: a paid payout is "proven" iff the per-method proof field
  * is set. Keep in sync with backend `paidRowHasProof` / `PAID_HAS_PROOF_WHERE`.
  *
- * 'completed' rows are always treated as proven for display purposes — they
- * are the intentional `mark_pending_complete` bookkeeping close-out
- * (provolone-92103) which by design has no per-row proof.
+ * bresaola-49340: 'completed' rows are NO LONGER auto-treated as proven. They
+ * go through the same per-method proof check as 'paid'. Never-sent rows swept
+ * to 'completed' by "Mark city paid" (provolone-92103 / mark_pending_complete)
+ * were inflating the Paid total because they short-circuited here. Proofless
+ * completed close-outs now fall out of the Paid $ figure (they still appear in
+ * their own completed count via the API aggregates).
  */
 function payoutHasProof(p: {
   status?: PayoutStatus | string | null;
@@ -269,7 +272,6 @@ function payoutHasProof(p: {
   mercuryCardId?: string | null;
   externalProofUrl?: string | null;
 }): boolean {
-  if (p.status === 'completed') return true;
   if (p.externalProofUrl && String(p.externalProofUrl).trim()) return true;
   if (p.payoutMethod === 'usdc_base') {
     return !!(p.transactionHash && String(p.transactionHash).trim());
@@ -2709,12 +2711,20 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                   receiptUsdTotal += Number(amt) || 0;
                 }
               }
+              // bresaola-49340: proof-gate the completed contribution. Proofless
+              // completed rows (never-sent close-outs) are excluded from BOTH
+              // the committed and paid sums — mirroring how the per-row rollup
+              // drops proofless rows from approved AND paid, leaving outstanding
+              // unchanged. completedUsd still counts ALL completed; we subtract
+              // the proofless subset here for the money math.
+              const completedProvenUsd =
+                (row.aggregates.completedUsd ?? 0)
+                - (row.aggregates.completedNoProofUsd ?? 0);
               const approvedSumUsd =
                 row.aggregates.approvedUsd
                 + row.aggregates.paidUsd
-                + (row.aggregates.completedUsd ?? 0);
-              const paidSumUsd =
-                row.aggregates.paidUsd + (row.aggregates.completedUsd ?? 0);
+                + completedProvenUsd;
+              const paidSumUsd = row.aggregates.paidUsd + completedProvenUsd;
               const outstandingUsd = Math.max(0, approvedSumUsd - paidSumUsd);
 
               return (

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1149,12 +1149,19 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             // primary host id pre-loaded so the admin can confirm-and-send.
             // Admin-only via the viewerRole gate on the menu.
             onSendPayment={(row) => {
+              // bresaola-49340: proof-gate the completed contribution so the
+              // Send-payment modal's paid/outstanding defaults match the
+              // by-city Paid column. Proofless completed close-outs (never
+              // actually sent) drop out of both sums; completedUsd still counts
+              // all completed, so we subtract the proofless subset here.
+              const completedProvenUsd =
+                (row.aggregates.completedUsd ?? 0)
+                - (row.aggregates.completedNoProofUsd ?? 0);
               const approvedSumUsd =
                 row.aggregates.approvedUsd
                 + row.aggregates.paidUsd
-                + (row.aggregates.completedUsd ?? 0);
-              const paidSumUsd =
-                row.aggregates.paidUsd + (row.aggregates.completedUsd ?? 0);
+                + completedProvenUsd;
+              const paidSumUsd = row.aggregates.paidUsd + completedProvenUsd;
               const outstandingUsd = Math.max(0, approvedSumUsd - paidSumUsd);
               // gnocchi-92105: tally non-duplicate, eligible receipt OCR USD
               // across every payout on the party. Matches the coppa-92105 +

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2287,6 +2287,15 @@ export interface PartyPayoutsRow {
      */
     completedCount?: number;
     completedUsd?: number;
+    /**
+     * bresaola-49340: subset of `completed` rows lacking per-row proof
+     * (tx hash / wire ref / mercury card / external proof). The proof-gated
+     * Paid headline = completedUsd - completedNoProofUsd. completedUsd/
+     * completedCount still count ALL completed rows for backward compat.
+     * Optional for cached payloads pre-bresaola.
+     */
+    completedNoProofCount?: number;
+    completedNoProofUsd?: number;
     /** payout_documents rows where kind='receipt' for this party. */
     totalReceiptCount: number;
     /** ISO timestamp — max(updated_at) across this party's payouts. */


### PR DESCRIPTION
## Problem

The admin `/payments` "Paid" totals counted `status='completed'` payout rows **without** requiring proof-of-payment, while `status='paid'` rows ARE proof-gated (prosciutto-92106 / `paidRowHasProof`). Never-sent rows swept into `completed` by "Mark city paid" (provolone-92103 / `mark_pending_complete`) inflated a city's Paid total — Prayagraj showed ~3× its real Paid figure.

"Proof" = any of `transaction_hash` / `wire_reference` / `mercury_card_last4` (or `mercury_card_id`) / `external_proof_url`, per `paidRowHasProof` (backend) and `payoutHasProof` (frontend), which are documented as needing to stay in sync.

## Changes

**1. Frontend `payoutHasProof`** (`PayoutsByPartyTable.tsx`) — removed the `if (p.status === 'completed') return true;` short-circuit so `completed` rows run the same per-method proof check as `paid`. This fixes the visible by-city "Paid" column (computed client-side via `isPaidStatus` + `payoutHasProof`) and the per-row rollup tiles. `isPaidStatus` left as-is.

**2. Backend by-party rollup** (`admin-payout.routes.ts`, `case 'completed'`) — split the completed bucket using `paidRowHasProof(row)`, mirroring the existing `paid` / `paidNoProof` split. Added NEW backward-compatible fields `completedNoProofCount` / `completedNoProofUsd` for the proofless subset. The existing `completedUsd` / `completedCount` still count **all** completed rows (no consumer breakage). The Paid-headline math now uses the proof-gated amount = `completedUsd - completedNoProofUsd`.

- `completedNoProof*` added to the `aggregates` response, the `Bucket` type + init, and the frontend `types.ts` interface (optional, for cached payloads).
- `fetchPaidTotalsByParty` (the `paidTotalUsd` "already paid" warning) was already scoped to `status='paid' AND has-proof` and does NOT include completed — left untouched.
- `assertWithinPartyCap` intentionally counts completed as committed (cap enforcement, not a Paid headline) — left untouched, out of scope.

## Consumers of `completedUsd` / `completedCount` checked

Grepped frontend + backend for the by-party response fields:
- `PaymentsAdminPage.tsx` `onSendPayment` (Send-payment modal defaults) — **updated** to subtract `completedNoProofUsd` from both the committed and paid sums (outstanding unchanged, mirroring the per-row rollup which drops proofless rows from approved AND paid).
- `PayoutsByPartyTable.tsx` `onSendPayment` (by-city row Send-payment) — **updated** the same way.
- `scorecard.routes.ts` `completedCount` — unrelated (checklist-item count), not the payout aggregate.
- No test snapshots or other readers reference `aggregates.completedUsd`.

## ⚠️ Intentional behavior change — needs Snax's eyes

After this change, legitimately **proofless** `mark_pending_complete` close-outs (cities "paid externally" with no per-row tx/wire/card/external proof) will **STOP counting toward the Paid $ figure**. They still appear in their own `completedCount` (and total `completedUsd`), but drop out of the Paid headline and outstanding math. If those external close-outs should count as Paid, we need a different approach (e.g. require an `external_proof_url` on the close-out, or keep a "trusted completed" carve-out). **Flagging for veto.**

## Verification

- `cd frontend && npm install && npm run build` — **passes** (exit 0; only pre-existing chunk-size warnings).
- `cd backend && npx tsc --noEmit` — **passes**; only the pre-existing `auth.test.ts` jwt-overload error remains (unrelated, per task instructions).
- Note: the backend rollup change is NOT verifiable on the Vercel preview (previews hit the prod backend, which deploys only from master). The frontend `payoutHasProof` change IS verifiable on preview — prod backend already returns the per-method proof fields on completed rows.

Preview: https://rsvpizza-git-bresaola-49340-completed-proof-gate-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
