### PR TITLE
guanciale-49342: don't mark USDC payout failed after a successful send

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -3906,10 +3906,16 @@ async function executePayout(params: {
       );
     }
 
+    // guanciale-49342: hoist the send result so the catch can distinguish a
+    // genuine send failure (no txHash) from a post-send DB write failure
+    // (txHash present — money already left the wallet). Never mark a payout
+    // `failed` once the on-chain send has succeeded.
+    let sendResult: Awaited<ReturnType<typeof sendUsdcPayment>> | null = null;
     try {
-      const result = await sendUsdcPayment(existing.payoutWalletAddress, finalAmountUsd, {
+      sendResult = await sendUsdcPayment(existing.payoutWalletAddress, finalAmountUsd, {
         allowOverPerAddressCap: !!allowOverPerAddressCap,
       });
+      const result = sendResult;
 
       const updated = await prisma.$transaction(async (tx) => {
         const row = await tx.payout.update({
@@ -3978,8 +3984,96 @@ async function executePayout(params: {
       });
       return updated;
     } catch (err: any) {
-      // Flip to failed + record the error so the admin UI shows what happened.
       const errMsg = err?.message || String(err);
+
+      // guanciale-49342: if the on-chain send already SUCCEEDED (we have a
+      // txHash) but the subsequent DB write threw, the money has already left
+      // the wallet. Marking the row `failed` here would record an on-chain
+      // payment as failed — a money-loss-of-record. Instead, recover by
+      // recording `paid` (best-effort), and NEVER mark it failed.
+      if (sendResult?.txHash) {
+        console.error(
+          `[admin-payout] CRITICAL: USDC sent (tx ${sendResult.txHash}) for payout ${existing.id} ` +
+            `but DB write failed — attempting recovery: ${errMsg}`,
+        );
+        try {
+          await prisma.payout.update({
+            where: { id: existing.id },
+            data: {
+              status: 'paid',
+              paidAt: new Date(),
+              transactionHash: sendResult.txHash,
+              ...(sendResult.resolvedFromEns
+                ? {
+                    payoutWalletAddress: sendResult.resolvedFromEns.address,
+                    payoutWalletInput: sendResult.resolvedFromEns.input,
+                  }
+                : {}),
+            },
+          });
+          await prisma.payoutAudit.create({
+            data: {
+              payoutId: existing.id,
+              action: 'mark_paid',
+              oldStatus: existing.status,
+              newStatus: 'paid',
+              actorEmail: actor.email,
+              actorKind: actor.actorKind,
+              note: `USDC sent tx ${sendResult.txHash} — recorded on retry after DB write failure`,
+            },
+          });
+        } catch (recoveryErr: any) {
+          // Recovery write ALSO failed. The money is gone but we cannot record
+          // it. Log everything needed to reconcile by hand and surface a 500
+          // that names the txHash. Do NOT mark the row failed.
+          const recoveryMsg = recoveryErr?.message || String(recoveryErr);
+          console.error(
+            `[admin-payout] CRITICAL UNRECOVERABLE: USDC SENT (tx ${sendResult.txHash}) for payout ` +
+              `${existing.id} to wallet ${existing.payoutWalletAddress} for $${finalAmountUsd.toFixed(2)} ` +
+              `but BOTH the original DB write AND the recovery write failed — MANUAL RECONCILE REQUIRED. ` +
+              `original error: ${errMsg} | recovery error: ${recoveryMsg}`,
+          );
+          // Host should still hear 'paid' — the money went out.
+          void notifyHostOfPaymentExecution(existing.id, 'paid', {
+            txHash: sendResult.txHash,
+          });
+          void emailHostOfPaymentExecution(existing.id, 'paid', {
+            txHash: sendResult.txHash,
+          });
+          throw new AppError(
+            `USDC payment SENT (tx ${sendResult.txHash}) but could not be recorded — ` +
+              `MANUAL RECONCILE REQUIRED for payout ${existing.id}`,
+            500,
+            'USDC_SENT_RECORD_FAILED',
+          );
+        }
+
+        // Recovery succeeded — money went out and is now recorded as paid.
+        // Host should hear 'paid', not 'failed'.
+        void notifyHostOfPaymentExecution(existing.id, 'paid', {
+          txHash: sendResult.txHash,
+        });
+        void emailHostOfPaymentExecution(existing.id, 'paid', {
+          txHash: sendResult.txHash,
+        });
+        // Re-fetch with the same include shape the success path returns so the
+        // API responds 200 with the paid row.
+        return prisma.payout.findUniqueOrThrow({
+          where: { id: existing.id },
+          include: {
+            party: { select: PAYOUT_PARTY_SELECT },
+            host: { select: { id: true, name: true, email: true } },
+            documents: {
+              orderBy: { sortOrder: 'asc' },
+              include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+            },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+      }
+
+      // Genuine send failure (no txHash) — keep the existing behavior exactly.
+      // Flip to failed + record the error so the admin UI shows what happened.
       console.error(`[admin-payout] USDC execute failed for ${existing.id}: ${errMsg}`);
       await prisma.$transaction(async (tx) => {
         await tx.payout.update({


### PR DESCRIPTION
## The bug

In the USDC branch of the execute-payout helper (`backend/src/routes/admin-payout.routes.ts`), `sendUsdcPayment` (money leaves the wallet) and the subsequent `prisma.$transaction` that records `status: 'paid'` + `transactionHash` shared a single `try`. If the on-chain send **succeeded** (we have `result.txHash`) but the DB write then **threw** (a transient DB blip), the `catch` flipped the row to `status: 'failed'` with **no** `transactionHash`. Result: an on-chain payment recorded as failed — money has left the wallet but it is invisible to reconciliation (a money-loss-of-record).

## The invariant

**Never mark a payout `failed` once the on-chain send has already succeeded.**

## The fix

- Hoist the send result into `let sendResult` declared before the `try`, so the `catch` can distinguish the two failure modes.
- In the `catch`, branch on `sendResult?.txHash`:
  - **txHash present** → the send succeeded; only the DB write failed. Log loudly, then best-effort recover by writing `status: 'paid'` + `transactionHash` (+ ENS resolution fields when present) and a `mark_paid` audit noting it was recorded on retry. Fire the existing `paid` host notifications (the money went out — host hears 'paid', not 'failed'), and return the re-fetched paid row (200).
    - If the recovery write ALSO throws → log an even louder line with everything needed for manual reconciliation (txHash, payout id, wallet, amount), still send `paid` notifications, and throw `AppError(..., 500, 'USDC_SENT_RECORD_FAILED')` naming the txHash + "MANUAL RECONCILE REQUIRED". The row is **not** marked failed.
  - **no txHash** → genuine send failure; the existing behavior is preserved byte-for-byte (mark `failed`, `mark_failed` audit, `failed` notifications, throw `USDC_SEND_FAILED`).

The success path (`$transaction` + audit + notifications) is unchanged — it still references `result`, now an alias of `sendResult`.

## The three cases

1. **Send + DB both succeed** → unchanged: row ends `paid` with `transactionHash`, success notifications fire, paid row returned.
2. **Send succeeds, DB write throws** → row recovered to `paid` with the txHash and a retry audit note; `paid` notifications fire; 200 with the paid row. If recovery *also* fails, the row is left non-failed, a loud reconcile log is emitted, `paid` notifications fire, and the API returns a 500 (`USDC_SENT_RECORD_FAILED`) naming the txHash. Never marked `failed`.
3. **Send throws (no txHash)** → unchanged failed path: `failed` + `mark_failed` audit + `failed` notifications + `USDC_SEND_FAILED` 502.

## Review notes

- This is a **money-path** change — please review carefully before merge.
- **Not preview-testable**: backend deploys only from `master`, and exercising this requires a real (or mocked) on-chain send followed by a DB failure. Recommend human review of the logic + (optionally) a unit test that stubs `sendUsdcPayment` to succeed and `prisma.$transaction` to throw.
- Untouched: `sendUsdcPayment` itself, the cap checks, the wire/mercury branches, the approve route, and everything outside this USDC `try/catch`.

🤖 Generated with Claude Code
