### PR TITLE
pancetta-49350: mark-complete withdraws no-proof payouts (keep receipts)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -6266,6 +6266,15 @@ partyMarkPaidRouter.post(
           adminNotes: true,
           payoutMethod: true,
           finalAmountUsd: true,
+          // pancetta-49350: proof fields surface so paidRowHasProof(p) can be
+          // evaluated per in-flight row. Rows WITHOUT payment proof are closed
+          // out as 'withdrawn' (not 'completed') so never-sent claims don't
+          // inflate a city's Paid total.
+          transactionHash: true,
+          wireReference: true,
+          mercuryCardLast4: true,
+          mercuryCardId: true,
+          externalProofUrl: true,
         },
       });
 
@@ -6376,9 +6385,20 @@ partyMarkPaidRouter.post(
           // so the audit trail makes clear *why* a pending row was closed
           // out (vs a host self-withdraw via ravioli-82931's DELETE
           // endpoint).
+          // pancetta-49350: "without an associated transaction" is interpreted
+          // as "without any payment proof" — using the SAME definition as the
+          // paidRowHasProof() helper (transaction_hash OR wire_reference OR
+          // mercury_card_last4/id OR external_proof_url, keyed on payoutMethod).
+          // So a genuinely wire/mercury/usdc/externally-paid in-flight row is
+          // closed out as 'completed' (counts as Paid), while a never-sent row
+          // is set to 'withdrawn' (does NOT count as Paid). Receipts
+          // (payout_documents) are NEVER touched in either branch.
+          const hasProof = paidRowHasProof(p);
+
           let nextAdminNotes: string | null | undefined = undefined;
-          const noteBody =
-            resolvedMode === 'mark_pending_complete'
+          const noteBody = !hasProof
+            ? `Marked-complete sweep: no payment proof — withdrawn (not counted as paid). Receipts retained.${note ? `; ${note}` : ''}`
+            : resolvedMode === 'mark_pending_complete'
               ? `Marked complete via Mark Party Paid; city fully paid${note ? `; ${note}` : ''}`
               : note;
           if (noteBody) {
@@ -6389,7 +6409,46 @@ partyMarkPaidRouter.post(
               : appended;
           }
 
-          if (resolvedMode === 'mark_paid') {
+          if (!hasProof) {
+            // pancetta-49350: no payment proof on this in-flight row. The city
+            // is being marked complete, but money was never actually sent for
+            // this claim — so close it out as 'withdrawn' instead of
+            // 'completed'. 'withdrawn' is excluded from Paid totals (see the
+            // status bucketing earlier in this file), preventing never-sent
+            // rows from inflating a city's Paid figure.
+            //
+            // Do NOT touch paid_at, payout_method, or any payout_documents —
+            // the host's uploaded receipts stay attached and visible in the
+            // receipts library.
+            const data: any = {
+              status: 'withdrawn',
+            };
+            if (nextAdminNotes !== undefined) {
+              data.adminNotes = nextAdminNotes;
+            }
+
+            await tx.payout.update({
+              where: { id: p.id },
+              data,
+            });
+
+            // 'cancel' is the valid payout_audit action for a -> 'withdrawn'
+            // transition: the host self-withdraw flow (ravioli-82931, in
+            // payout.routes.ts) documents that 'withdraw' is NOT in the action
+            // CHECK constraint and uses 'cancel' for exactly this transition.
+            // newStatus carries the real target ('withdrawn').
+            await tx.payoutAudit.create({
+              data: {
+                payoutId: p.id,
+                action: 'cancel',
+                oldStatus: p.status,
+                newStatus: 'withdrawn',
+                actorEmail: actor.email,
+                actorKind: actor.actorKind,
+                note: noteBody,
+              },
+            });
+          } else if (resolvedMode === 'mark_paid') {
             // Only stamp payoutMethod when (a) admin supplied one AND (b) the
             // row currently has none. Preserves the truth of how routed rows
             // were originally configured.


### PR DESCRIPTION
## Rule (Snax)

When an admin marks a **city** complete, payouts that have **no associated payment proof** must be set to status `withdrawn` (NOT `completed`), so they don't count as Paid. Payouts that **do** have proof are closed out as before. **Receipts are preserved in all cases** — `payout_documents` are never modified or deleted.

### Today's bug

The mark-city-complete handler (`POST /api/admin/parties/:partyId/mark-paid`) flipped **all** in-flight rows (`pending`/`approved`/`queued`) to `completed` regardless of whether money was actually sent. Since `completed` counts toward Paid, never-sent rows inflated a city's Paid total (e.g. one city showed $1453 Paid when only $675 was sent).

### "Associated transaction" = payment proof

Snax phrased the condition as "without an associated transaction." This is interpreted as **"without any payment proof"**, using the **same definition as the existing `paidRowHasProof` helper** in this file:

- `external_proof_url`, OR
- `transaction_hash` (when `payoutMethod === 'usdc_base'`), OR
- `wire_reference` (when `payoutMethod === 'wire'`), OR
- `mercury_card_last4` / `mercury_card_id` (when `payoutMethod === 'mercury_card'`)

This means a genuinely wire/mercury/usdc/externally-paid in-flight row is **not** wrongly withdrawn. A code comment notes this interpretation.

## Changes

1. The in-flight query now also selects `transactionHash`, `wireReference`, `mercuryCardLast4`, `mercuryCardId`, `externalProofUrl` so `paidRowHasProof(p)` can be evaluated per row.
2. Per-row branch on `paidRowHasProof(p)`:
   - **Has proof** → existing behavior unchanged (`status: 'completed'`, audit `action: 'mark_paid'`, `newStatus: 'completed'`, mode-specific note prefix).
   - **No proof** → `status: 'withdrawn'`; audit `action: 'cancel'`, `oldStatus: p.status`, `newStatus: 'withdrawn'`, note `Marked-complete sweep: no payment proof — withdrawn (not counted as paid). Receipts retained.`
3. Mode resolution, `paymentsClosedAt` close logic, "already covered" counting, and response shape are unchanged. `count` still reflects all rows acted on (withdrawn + completed).

### Audit `action` value

Used `action: 'cancel'`. The `payout_audit` action CHECK constraint does **NOT** include a `withdraw` value — the existing host self-withdraw flow (ravioli-82931, in `payout.routes.ts`) explicitly documents this and uses `'cancel'` for the `-> 'withdrawn'` transition. So `'cancel'` is the in-repo-validated, semantically-correct action; `newStatus` carries the real target (`'withdrawn'`). No migration needed.

## Receipts

`payout_documents` are never touched in either branch. The no-proof branch only sets `status` (and appends an admin note). The host's uploaded receipts stay attached and visible in the receipts library.

## Walk-throughs

**(a)** City with one paid+proof row + three no-proof in-flight rows → the three in-flight rows become `withdrawn` (excluded from Paid), the paid row is unchanged, and the city's Paid total reflects only the proof row.

**(b)** An in-flight row that has a `wire_reference` (method `wire`) → `paidRowHasProof` returns true → kept and closed out as `completed`, **not** withdrawn.

## Notes

- Backend-only change. **Not preview-testable** — preview frontends hit the production backend, which only deploys from `master`.
- `npx tsc --noEmit` passes (only the pre-existing `auth.test.ts` error remains).
- Relationship to #773: this PR prevents **new** no-proof rows from being created as `completed`; #773 stops **legacy** no-proof rows from counting.

🤖 Generated with Claude Code
