### PR TITLE
feat(stracchino-58931): add "Did you attend the event?" survey question

### DIFF
--- a/backend/src/lib/surveyQuestions.ts
+++ b/backend/src/lib/surveyQuestions.ts
@@ -17,9 +17,14 @@ export interface SurveyQuestion {
   allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
-export const SURVEY_QUESTION_SET_VERSION = 1;
+export const SURVEY_QUESTION_SET_VERSION = 2;
 
 export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
+  {
+    id: 'attended',
+    type: 'yesno',
+    text: 'Did you attend the event?',
+  },
   {
     id: 'overall_rating',
     type: 'rating',

--- a/frontend/src/lib/surveyQuestions.ts
+++ b/frontend/src/lib/surveyQuestions.ts
@@ -17,9 +17,14 @@ export interface SurveyQuestion {
   allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
-export const SURVEY_QUESTION_SET_VERSION = 1;
+export const SURVEY_QUESTION_SET_VERSION = 2;
 
 export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
+  {
+    id: 'attended',
+    type: 'yesno',
+    text: 'Did you attend the event?',
+  },
   {
     id: 'overall_rating',
     type: 'rating',


### PR DESCRIPTION
Adds `attended` (yes/no) as the **first** question in the post-event guest survey: "Did you attend the event?".

- Inserted as the first element of `SURVEY_QUESTION_SET` in both `backend/src/lib/surveyQuestions.ts` (source of truth) and `frontend/src/lib/surveyQuestions.ts` (mirror), kept in sync.
- Bumps `SURVEY_QUESTION_SET_VERSION` 1 → 2 so stored responses are interpreted against the version they were collected under.
- **No DB migration needed** — answers are stored as jsonb and `question_set_version` is just an int per response.
- Results aggregation (backend `survey.routes.ts`) and the host results UI (frontend `SurveyTab.tsx`) iterate generically over `SURVEY_QUESTION_SET` by type, so the new yes/no question is collected, validated, and rendered automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
