### PR TITLE
fix(marzano-31057): add ZMW to receipt currency pickers

### DIFF
--- a/frontend/src/lib/currencies.ts
+++ b/frontend/src/lib/currencies.ts
@@ -76,6 +76,7 @@ export const COMMON_CURRENCIES: CurrencyOption[] = [
   { code: 'USD', label: 'USD — US Dollar', symbol: '$' },
   { code: 'VND', label: 'VND — Vietnamese Dong', symbol: '₫' },
   { code: 'ZAR', label: 'ZAR — South African Rand', symbol: 'R' },
+  { code: 'ZMW', label: 'ZMW — Zambian Kwacha', symbol: 'K' },
 ];
 
 /**

--- a/frontend/src/utils/currencies.ts
+++ b/frontend/src/utils/currencies.ts
@@ -73,6 +73,7 @@ export const SUPPORTED_CURRENCIES: CurrencyOption[] = [
   { code: 'MAD', name: 'Moroccan Dirham', country: 'Morocco', flag: '🇲🇦' },
   { code: 'ETB', name: 'Ethiopian Birr', country: 'Ethiopia', flag: '🇪🇹' },
   { code: 'MWK', name: 'Malawian Kwacha', country: 'Malawi', flag: '🇲🇼' },
+  { code: 'ZMW', name: 'Zambian Kwacha', country: 'Zambia', flag: '🇿🇲' },
   {
     code: 'XOF',
     name: 'West African CFA franc',


### PR DESCRIPTION
## Problem
`ZMW` (Zambian Kwacha) was missing from the receipt currency pickers, so searching "zmw" returned "No currencies match" — even though the OCR service (gpt-4o) and the FX service already detect and convert it.

## Fix (two-catalog, data-only)
- `frontend/src/utils/currencies.ts` — added ZMW to `SUPPORTED_CURRENCIES` (the searchable admin CurrencyPicker), in the Africa group after MWK.
- `frontend/src/lib/currencies.ts` — added ZMW to `COMMON_CURRENCIES` (the CurrencyOverrideSelect native select), after ZAR (alphabetical).

No backend, migration, or other entries touched. `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)