### PR TITLE
feat(stracchino-92108): /payments "Hide possible scams" toggle

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2116,9 +2116,12 @@ router.get(
       // (vs. in the table component) keeps row counts honest and is cheap —
       // grouping has already happened and the bucket meta has the flag.
       const hideClosed = req.query.hideClosed === 'true' || req.query.hideClosed === '1';
-      const filteredRows = hideClosed
-        ? rows.filter((r) => !r.party.paymentsClosedAt)
-        : rows;
+      // stracchino-92108: also hide cities flagged with the `possible-scam` tag.
+      const hideScams = req.query.hideScams === 'true' || req.query.hideScams === '1';
+      const filteredRows = rows.filter((r) =>
+        (!hideClosed || !r.party.paymentsClosedAt) &&
+        (!hideScams || !(r.party.eventTags ?? []).includes('possible-scam'))
+      );
 
       // 6. Sort outer rows. Default: most recent activity desc. The same
       //    `sort` query param shape is supported as the LIST endpoint for

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -30,6 +30,11 @@ interface PayoutsFilterBarProps {
    */
   showHideClosedToggle?: boolean;
   /**
+   * stracchino-92108: when true, render the "Hide possible scams" checkbox.
+   * By-city view only, mirroring showHideClosedToggle. Defaults to false.
+   */
+  showHideScamsToggle?: boolean;
+  /**
    * pancetta-92103: when true, render the Regions multi-select dropdown
    * (admin /payments). Hidden on regional sub-portals (which are already
    * hard-scoped by their `regionFilter` prop). Defaults to false.
@@ -114,6 +119,8 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.sort && filters.sort !== 'created_desc') n += 1;
   // pinsa-92103: count Hide closed cities so admins see they've hidden rows.
   if (filters.hideClosed) n += 1;
+  // stracchino-92108: count Hide possible scams alongside Hide closed cities.
+  if (filters.hideScams) n += 1;
   return n;
 }
 
@@ -136,6 +143,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   availableCurrencies,
   availableTags,
   showHideClosedToggle,
+  showHideScamsToggle,
   showRegionsFilter,
 }) => {
   const [expanded, setExpanded] = useState(false);
@@ -424,6 +432,17 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
                 checked={!!filters.hideClosed}
                 onChange={() => update({ hideClosed: !filters.hideClosed })}
                 label="Hide closed cities"
+                labelClassName="text-xs text-theme-text-secondary"
+                size={14}
+              />
+            )}
+            {/* stracchino-92108: Hide possible-scam-flagged cities. By-city view only,
+                same as Hide closed cities. */}
+            {showHideScamsToggle && (
+              <Checkbox
+                checked={!!filters.hideScams}
+                onChange={() => update({ hideScams: !filters.hideScams })}
+                label="Hide possible scams"
                 labelClassName="text-xs text-theme-text-secondary"
                 size={14}
               />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4319,6 +4319,10 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.hideClosed) {
     params.set('hideClosed', 'true');
   }
+  // stracchino-92108: hide possible-scam-flagged cities on the by-city view.
+  if (filters.hideScams) {
+    params.set('hideScams', 'true');
+  }
   const qs = params.toString();
   return qs ? `?${qs}` : '';
 }

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -99,6 +99,8 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   purpose: 'all',
   // caciotta-92105: hide payments-closed cities (pinsa-92103) by default.
   hideClosed: true,
+  // stracchino-92108: hide possible-scam-flagged cities (bottarga-92104) by default.
+  hideScams: true,
   // arancino-92103: sort order default — newest submitted first. Matches the
   // prior implicit backend ordering, so non-sorting callers see no change.
   sort: 'created_desc',
@@ -1015,6 +1017,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           // view (paymentsClosedAt is a party-level signal). The per-payment
           // view has no party-row, so the toggle would be confusing there.
           showHideClosedToggle={viewMode === 'by-city'}
+          // stracchino-92108: Hide possible scams, by-city view only (same as above).
+          showHideScamsToggle={viewMode === 'by-city'}
           // pancetta-92103: Regions multi-select is the admin /payments tool;
           // regional sub-portals (`/payments/latam` etc.) are hard-scoped by
           // their `regionFilter` prop and shouldn't show a second region

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2109,6 +2109,11 @@ export interface AdminPayoutFilters {
    * closed cities (with the ✓ Closed pill).
    */
   hideClosed?: boolean;
+  /**
+   * stracchino-92108: hide cities flagged with the `possible-scam` event tag
+   * (bottarga-92104). By-city endpoint only, like hideClosed. Default true.
+   */
+  hideScams?: boolean;
 }
 
 export interface AdminPayoutTotals {


### PR DESCRIPTION
Adds a "Hide possible scams" toggle to the `/payments` admin dashboard, mirroring the existing "Hide closed cities" (`hideClosed`) filter exactly.

## What
- New `hideScams?: boolean` filter on `AdminPayoutFilters` (default ON).
- By-city view only — rendered via `showHideScamsToggle={viewMode === 'by-city'}`, same gating as `hideClosed`.
- Drops by-city rows whose party carries the `possible-scam` event tag (bottarga-92104).
- Counts toward the active-filter badge, resets with `onReset`, and serializes as `?hideScams=true` on the by-city fetch.

## How it mirrors hideClosed
Every place `hideClosed` appears now has a sibling `hideScams`: the `AdminPayoutFilters` type, `buildPayoutQuery`, the `PayoutsFilterBar` prop + counter + checkbox, `DEFAULT_FILTERS` + the `<PayoutsFilterBar>` toggle prop in `PaymentsAdminPage`, and the `/by-party` backend filter.

## Files
- `frontend/src/types.ts`
- `frontend/src/lib/api.ts`
- `frontend/src/components/payments-admin/PayoutsFilterBar.tsx`
- `frontend/src/pages/PaymentsAdminPage.tsx`
- `backend/src/routes/admin-payout.routes.ts`

## Deploy note
Backend `/by-party` gains an optional `hideScams` query param (additive). A preview frontend hitting the prod backend won't filter scams until the backend change is on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)