### PR TITLE
fix(asiago-58472): merge party state in place instead of loadParty refetch (no reload on save)

### DIFF
--- a/frontend/src/components/checklist/ChecklistTab.tsx
+++ b/frontend/src/components/checklist/ChecklistTab.tsx
@@ -233,7 +233,6 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
         open={attendanceModalOpen}
         onClose={() => setAttendanceModalOpen(false)}
         partyId={partyId}
-        inviteCode={inviteCode ?? ''}
         currentEstimate={party?.estimatedAttendance ?? null}
         onSaved={loadChecklist}
       />

--- a/frontend/src/components/checklist/EstimatedAttendanceModal.tsx
+++ b/frontend/src/components/checklist/EstimatedAttendanceModal.tsx
@@ -9,7 +9,6 @@ interface EstimatedAttendanceModalProps {
   open: boolean;
   onClose: () => void;
   partyId: string;
-  inviteCode: string;
   currentEstimate: number | null;
   onSaved?: () => void;
 }
@@ -18,12 +17,11 @@ export const EstimatedAttendanceModal: React.FC<EstimatedAttendanceModalProps> =
   open,
   onClose,
   partyId,
-  inviteCode,
   currentEstimate,
   onSaved,
 }) => {
   const { t } = useTranslation('host');
-  const { loadParty } = usePizza();
+  const { mergeParty } = usePizza();
   const [value, setValue] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,7 +49,7 @@ export const EstimatedAttendanceModal: React.FC<EstimatedAttendanceModalProps> =
     const success = await updateParty(partyId, { estimated_attendance: num });
     setSaving(false);
     if (success) {
-      await loadParty(inviteCode);
+      mergeParty({ estimatedAttendance: num });
       onSaved?.();
       onClose();
     } else {

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -505,7 +505,6 @@ export const GPPDashboardTab: React.FC = () => {
         open={attendanceModalOpen}
         onClose={() => setAttendanceModalOpen(false)}
         partyId={party.id}
-        inviteCode={inviteCode!}
         currentEstimate={party.estimatedAttendance ?? null}
         onSaved={loadChecklist}
       />


### PR DESCRIPTION
Restores the no-reload UX fix for the Estimated Attendance modal that missed the merge window for PR #736. The fix was pushed to `asiago-58472-estimated-attendance` (commit `e687c82d`) *after* #736 had already merged, so it never reached master.

## What changed
The `EstimatedAttendanceModal` previously called `loadParty(inviteCode)` after saving, which refetched the whole party and caused a perceptible page reload. This swaps it for `mergeParty({ estimatedAttendance: num })`, updating the party state in place — no reload.

- `EstimatedAttendanceModal.tsx`: use `mergeParty` instead of `loadParty`; drop the now-unused `inviteCode` prop (interface + destructure).
- `GPPDashboardTab.tsx` and `ChecklistTab.tsx`: remove the `inviteCode` prop from the modal call sites.

## Scope
Frontend-only. No DB, backend, or deploy impact. `mergeParty` already exists in `PizzaContext`. `npx tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>