### PR TITLE
pizzelle-58293: raise pizza/event photo upload cap 10 -> 30

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -875,8 +875,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     if (receiptPhotos.length > 10) {
       throw new AppError('Max 10 receipt photos', 400, 'TOO_MANY_RECEIPTS');
     }
-    if (pizzaPhotos.length > 10) {
-      throw new AppError('Max 10 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
+    if (pizzaPhotos.length > 30) {
+      throw new AppError('Max 30 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
     }
     // When zero receipts are supplied, finalAmountUsd MUST be a positive number.
     if (
@@ -1674,8 +1674,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     if (newReceipts.length > 10) {
       throw new AppError('Max 10 receipt photos', 400, 'TOO_MANY_RECEIPTS');
     }
-    if (newPizza.length > 10) {
-      throw new AppError('Max 10 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
+    if (newPizza.length > 30) {
+      throw new AppError('Max 30 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
     }
 
     // Verify each new URL points into the bucket scoped to this party.

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -774,7 +774,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                   payoutTempId={payout.id}
                   items={newPizzaPhotos}
                   onChange={setNewPizzaPhotos}
-                  maxItems={10}
+                  maxItems={30}
                 />
               </div>
 

--- a/frontend/src/components/payouts/PizzaPhotoUpload.tsx
+++ b/frontend/src/components/payouts/PizzaPhotoUpload.tsx
@@ -28,7 +28,7 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
   payoutTempId,
   items,
   onChange,
-  maxItems = 10,
+  maxItems = 30,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);


### PR DESCRIPTION
Raises the pizza / event proof photo upload cap from 10 to 30 in the host payments/reimbursement flow. Receipts remain capped at 10.

## Edit sites (4)
1. `frontend/src/components/payouts/PizzaPhotoUpload.tsx` — default prop `maxItems = 10` → `maxItems = 30`.
2. `frontend/src/components/payouts/PayoutDetailModal.tsx` — the `<PizzaPhotoUpload ... maxItems={10} />` (Add pizza / event photos block) → `maxItems={30}`. The `<ReceiptUpload ... maxItems={10} />` is left unchanged.
3. `backend/src/routes/payout.routes.ts` POST handler — `pizzaPhotos.length > 10` / "Max 10 pizza photos" → `> 30` / "Max 30 pizza photos".
4. `backend/src/routes/payout.routes.ts` PATCH handler — `newPizza.length > 10` / "Max 10 pizza photos" → `> 30` / "Max 30 pizza photos".

Receipt caps (`receiptPhotos`/`newReceipts` > 10, "Max 10 receipt photos") are untouched.

Note: backend must deploy from master before the new cap takes effect on preview branches (preview frontends talk to the production backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)