### PR TITLE
feat(brie-92108): add Unreject button to revert rejected payouts to pending

### DIFF
--- a/backend/prisma/migrations/brie-92108-payout-audit-unreject.sql
+++ b/backend/prisma/migrations/brie-92108-payout-audit-unreject.sql
@@ -1,0 +1,7 @@
+-- brie-92108: allow action='unreject' on payout_audit
+ALTER TABLE payout_audit DROP CONSTRAINT payout_audit_action_check;
+ALTER TABLE payout_audit ADD CONSTRAINT payout_audit_action_check
+  CHECK (action = ANY (ARRAY['create','approve','unapprove','reject','unreject',
+    'edit_amount','edit_documents','edit_recipient','mark_paid','unmark_paid',
+    'mark_queued','unmark_queued','mark_failed','flag_ready','bulk_execute',
+    'retry','cancel']));

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -3373,6 +3373,102 @@ router.post(
 );
 
 // ============================================
+// POST /api/admin/payouts/:id/unreject
+//
+// brie-92108: revert a `rejected` payout back to `pending` so the admin can
+// re-review. Mirrors `unapprove` (approved -> pending) one step over for the
+// rejected terminal state — rejection was previously a one-way door.
+//
+// Atomic via prisma.$transaction:
+//   1. Lookup payout (404 if missing).
+//   2. Validate status === 'rejected' (400 NOT_REJECTED otherwise).
+//   3. status -> 'pending'; clear rejectionReason + reviewedAt + reviewedBy.
+//   4. Write payout_audit row with action='unreject'.
+// ============================================
+router.post(
+  '/:id/unreject',
+  requireAuth,
+  // argentina-92103: regional underbosses can REVERT rejected payouts on
+  // parties in their region (via `?regions=`). Per-row scope check below.
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const actor = await loadActor(req);
+      const existing = await prisma.payout.findUnique({
+        where: { id: req.params.id },
+        select: { id: true, status: true, hostUserId: true, partyId: true },
+      });
+
+      if (!existing) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+      if (existing.status !== 'rejected') {
+        throw new AppError(
+          `Cannot unreject a payout in status '${existing.status}'`,
+          400,
+          'NOT_REJECTED',
+        );
+      }
+
+      assertNotSelfPayout(actor, existing.hostUserId);
+
+      // argentina-92103: underboss-scope gate.
+      if (req.viewerRole === 'underboss') {
+        const regionsFromQuery = parseRegionsQuery(req.query.regions) ?? [];
+        const party = await prisma.party.findUnique({
+          where: { id: existing.partyId },
+          select: { region: true },
+        });
+        if (!party?.region || !regionsFromQuery.includes(party.region)) {
+          throw new AppError('This event is outside your region scope.', 403, 'OUT_OF_SCOPE');
+        }
+      }
+
+      const { note } = req.body || {};
+
+      const updated = await prisma.$transaction(async (tx) => {
+        const row = await tx.payout.update({
+          where: { id: existing.id },
+          data: {
+            status: 'pending',
+            rejectionReason: null,
+            reviewedAt: null,
+            reviewedBy: null,
+          },
+          include: {
+            party: { select: PAYOUT_PARTY_SELECT },
+            host: { select: { id: true, name: true, email: true } },
+            documents: {
+              orderBy: { sortOrder: 'asc' },
+              include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+            },
+            audits: { orderBy: { createdAt: 'desc' } },
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: existing.id,
+            action: 'unreject',
+            oldStatus: 'rejected',
+            newStatus: 'pending',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: typeof note === 'string' ? note : null,
+          },
+        });
+
+        return row;
+      });
+
+      res.json({ payout: serializePayout(updated) });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
 // POST /api/admin/payouts/:id/reject
 // ============================================
 router.post(

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -162,7 +162,7 @@ interface PayoutReviewModalProps {
    * warning panel before the admin clicks Send. Returns null if unavailable.
    */
   fetchWalletPaidTotal?: (address: string, amount: number) => Promise<WalletPaidTotal | null>;
-  /** Re-open (clear rejected/failed) — uses mark-paid plumbing or a future endpoint. */
+  /** brie-92108: un-reject a `rejected` payout back to `pending` (clears rejection) so the admin can re-review. */
   onReopen?: () => Promise<void> | void;
   /**
    * tiramisu-49102: "Pay again to this wallet" — only surfaced when this
@@ -3489,7 +3489,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-theme-surface-hover hover:bg-theme-stroke text-theme-text text-sm font-medium disabled:opacity-50"
             >
               <RefreshCw size={14} />
-              Re-open
+              Unreject
             </button>
           )}
           {/* culatello-92103: revert paid -> approved. Surfaced for ANY

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4635,6 +4635,31 @@ export async function unapproveAdminPayout(
 }
 
 /**
+ * brie-92108: revert a `rejected` payout back to `pending`. Rejection was a
+ * one-way terminal state with no undo. This lets admins flip rejected ->
+ * pending so they can re-review.
+ *
+ * Backend validates the current status is 'rejected' (400 NOT_REJECTED
+ * otherwise) and writes a payout_audit row with action='unreject'.
+ */
+export async function unrejectAdminPayout(
+  id: string,
+  noteOrOpts?: string | { note?: string; regions?: string[] },
+): Promise<AdminPayout> {
+  // Backward-compat: callers passing a bare `note` string still work.
+  const note = typeof noteOrOpts === 'string' ? noteOrOpts : noteOrOpts?.note;
+  const regions = typeof noteOrOpts === 'string' ? undefined : noteOrOpts?.regions;
+  const res = await apiRequest<{ payout: AdminPayout }>(
+    `/api/admin/payouts/${id}/unreject${regionsQuery(regions)}`,
+    {
+      method: 'POST',
+      body: { note },
+    },
+  );
+  return res.payout;
+}
+
+/**
  * culatello-92103: revert a `paid` payout back to `approved`. The previous
  * "Revert to Pending" affordance only worked for `approved` rows — there
  * was no way to undo an out-of-band `mark-paid` (wire, mercury_card,

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -12,6 +12,7 @@ import {
   approveAdminPayout,
   rejectAdminPayout,
   unapproveAdminPayout,
+  unrejectAdminPayout,
   revertPaidAdminPayout,
   markPayoutQueued,
   unmarkPayoutQueued,
@@ -1401,6 +1402,21 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 return;
               } catch (err: any) {
                 return err?.message || 'Revert failed';
+              } finally {
+                setModalBusy(false);
+              }
+            }}
+            // brie-92108: un-reject -> pending. Stays open + refreshes both
+            // lists like unapprove so the admin sees the new pending state.
+            onReopen={async () => {
+              setModalBusy(true);
+              try {
+                await unrejectAdminPayout(detail.id, regions ? { regions } : undefined);
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
+                setDetail(fresh);
+                await Promise.all([refresh(), loadPrepayQueue()]);
+              } catch (err: any) {
+                setErrorMsg(err.message || 'Unreject failed');
               } finally {
                 setModalBusy(false);
               }


### PR DESCRIPTION
## Summary

Adds an **Unreject** button to the admin payouts review UI that reverts a `rejected` payout back to `pending` so an admin can re-review it. Rejection was previously a one-way terminal state with no undo.

## Changes

- **Backend** — new `POST /api/admin/payouts/:id/unreject` in `admin-payout.routes.ts`, mirroring the existing `unapprove` handler: same auth (`requireAuth` + `requireAdminOrRegionalUnderboss`), self-payout guard, and underboss region-scope check. Validates `status === 'rejected'` (400 `NOT_REJECTED`), flips to `pending` clearing `rejectionReason` / `reviewedAt` / `reviewedBy`, and writes a `payout_audit` row with `action='unreject'`.
- **DB migration (record only)** — `backend/prisma/migrations/brie-92108-payout-audit-unreject.sql` extends `payout_audit_action_check` to allow `action='unreject'`.
- **Frontend** — `unrejectAdminPayout()` added to `lib/api.ts` (mirrors `unapproveAdminPayout`); `PaymentsAdminPage.tsx` now passes `onReopen` to the single-review `PayoutReviewModal`, lighting up the previously-dead scaffolded button. The button label is relabeled from `Re-open` to `Unreject`.

## Deploy note

The `payout_audit_action_check` constraint migration **must be applied to prod before the endpoint is exercised** — otherwise the audit insert violates the existing CHECK constraint and the transaction rolls back. The prod apply is handled separately.

## Verification

- `frontend` `tsc --noEmit`: clean.
- `backend` `tsc --noEmit`: no new errors in touched files (only pre-existing errors from uninstalled optional deps `sharp`/`openai`/`archiver` and an unrelated test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)