### PR TITLE
fix(marinara-62104): honest payout amount headline

### DIFF
--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -5,7 +5,7 @@ import type { AdminPayout, Payout } from '../../types';
 import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
 import { PayoutMethodIcon } from './PayoutMethodIcon';
-import { formatPayoutAmount } from './formatPayoutAmount';
+import { formatPayoutAmount, formatOriginalCurrency } from './formatPayoutAmount';
 import { CapInlineEditor } from './CapInlineEditor';
 
 /**
@@ -226,6 +226,7 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
             Number(payout.finalAmountUsd),
             Number(payout.originalAmount),
             payout.originalCurrency,
+            Number(payout.exchangeRate),
           )}
           {/* speck-89172: amber AlertTriangle when the payout's final amount
               exceeds the party's effective reimbursement cap. Additive to
@@ -243,6 +244,35 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
               </span>
             )}
         </div>
+        {/* marinara-62104: when the OCR receipt total (uncapped) exceeds the
+            displayed final amount, the headline USD is a cap-clamped sum — and
+            the FX parenthetical was suppressed above. Surface the hidden truth
+            so admins see how much was claimed before the reimbursement cap.
+            Inline IIFE (no hooks) so it doesn't affect rules-of-hooks. */}
+        {(() => {
+          const final = Number(payout.finalAmountUsd);
+          const claimed = Number(payout.extractedAmountUsd);
+          const isCapped = Number.isFinite(claimed) && claimed > final + 0.005;
+          if (!isCapped) return null;
+          let claimedNote = `$${claimed.toFixed(2)} claimed`;
+          const docs = payout.documents ?? [];
+          const fxDocs = docs.filter(
+            (d) => d.kind === 'receipt' && d.originalCurrency && d.originalAmount != null,
+          );
+          const currencies = [...new Set(fxDocs.map((d) => d.originalCurrency!.toUpperCase()))];
+          if (currencies.length === 1 && currencies[0] !== 'USD') {
+            const sum = fxDocs.reduce((a, d) => a + Number(d.originalAmount), 0);
+            claimedNote = `$${claimed.toFixed(2)} (${formatOriginalCurrency(sum, currencies[0])}) claimed`;
+          }
+          return (
+            <div
+              className="text-xs text-theme-text-muted mt-0.5"
+              title="OCR receipt total before the party reimbursement cap was applied"
+            >
+              Capped from {claimedNote}
+            </div>
+          );
+        })()}
       </td>
 
       <td className="px-3 py-3">

--- a/frontend/src/components/payments-shared/formatPayoutAmount.ts
+++ b/frontend/src/components/payments-shared/formatPayoutAmount.ts
@@ -39,15 +39,39 @@ export function formatOriginalCurrency(amount: number, currency: string): string
  * Combined formatter: "$15.75 USD (€14.00 EUR)" style. If the original
  * currency is USD (or matches the USD amount) we just return the USD form
  * with no parenthetical footnote.
+ *
+ * marinara-62104: the parenthetical is now gated on a rate-faithfulness check.
+ * The backend's parent-payout `originalAmount`/`originalCurrency` headline is
+ * only the FIRST receipt's FX, and `finalAmountUsd` can be a cap-clamped total
+ * of many receipts. Pairing those two numbers implies a bogus exchange rate
+ * (e.g. "$625.00 USD (880 MYR)" for a 4-receipt, cap-clamped KL payout). We
+ * only append "(orig CUR)" when `originalAmount * exchangeRate` actually
+ * reconstructs the displayed USD — i.e. it's a faithful single conversion.
  */
 export function formatPayoutAmount(
   usdAmount: number,
   originalAmount?: number | null,
   originalCurrency?: string | null,
+  exchangeRate?: number | null,
 ): string {
   const usd = formatUsd(usdAmount);
-  if (originalAmount == null || !originalCurrency || originalCurrency.toUpperCase() === 'USD') {
+  if (
+    originalAmount == null ||
+    !originalCurrency ||
+    originalCurrency.toUpperCase() === 'USD' ||
+    !(originalAmount > 0)
+  ) {
     return usd;
   }
+  // marinara-62104: only show the parenthetical when originalAmount * rate ≈
+  // the displayed USD. Suppresses the misleading line for multi-receipt payouts
+  // (parenthetical is only the first receipt) and cap-clamped payouts (the USD
+  // is the capped total, not a conversion of originalAmount).
+  const rate = exchangeRate ?? null;
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+  const faithful =
+    rate != null && rate > 0 &&
+    Math.abs(round2(originalAmount * rate) - round2(usdAmount)) < 0.01;
+  if (!faithful) return usd;
   return `${usd} (${formatOriginalCurrency(originalAmount, originalCurrency)})`;
 }


### PR DESCRIPTION
## Problem

On `/payments`, `PayoutRow` rendered a misleading amount headline. The KL (kualalumpur) payout showed **"$625.00 USD (880 MYR)"**, which implies a ~0.71 USD/MYR rate — false.

## Root cause

The headline was assembled from two unrelated numbers on the parent payout row:
- `finalAmountUsd` (625) = sum of all 4 MYR receipts' USD ($916.23) **clamped** to the party's $625 reimbursement cap.
- `originalAmount` / `originalCurrency` (880 MYR) = **only the first receipt** (backend stores first-receipt FX as the parent headline). The real receipt total is 3,632.82 MYR.

So "880 MYR" next to "$625" implies a bogus exchange rate. Worse, because `final === cap` exactly, the existing amber over-cap flag never fired, hiding the ~$291 of dropped claims.

## Fix (frontend-only, no backend/DB changes)

1. **`formatPayoutAmount.ts`** — new optional 4th param `exchangeRate`. The `(orig CUR)` parenthetical is now only appended when `originalAmount * exchangeRate ≈ displayed USD` (a faithful single conversion). This suppresses the misleading line for multi-receipt and cap-clamped payouts.
2. **`PayoutRow.tsx`** — passes `exchangeRate` to the formatter, and adds a muted **"Capped from \$X claimed"** caption (with the receipt-currency total when all receipts share one non-USD currency) whenever the uncapped OCR total (`extractedAmountUsd`) exceeds the displayed `finalAmountUsd`. This surfaces the hidden over-cap truth that the silent clamp was masking.

The caption is an inline IIFE returning JSX — introduces no hooks, so it does not affect rules-of-hooks.

## Verify

- `npm run build` passes with no type errors.
- `PayoutRow` is the only render caller of `formatPayoutAmount` (confirmed via `git grep`).
- Preview: https://rsvpizza-git-marinara-62104-fx-headline-pizza-dao.vercel.app/payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)