### PR TITLE
pomodoro-92110: split payout photos into Pizza (10) + Event (30) zones

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1797,7 +1797,7 @@ model PayoutDocument {
   party            Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
   payoutId         String?   @map("payout_id") @db.Uuid
   payout           Payout?   @relation(fields: [payoutId], references: [id], onDelete: SetNull)
-  kind             String // 'pizza' | 'receipt'
+  kind             String // 'pizza' | 'receipt' | 'event'
   url              String
   fileName         String    @map("file_name")
   fileSize         Int       @map("file_size")

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -704,6 +704,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     const { partyId } = req.params;
     const {
       pizzaPhotos = [],
+      // pomodoro-92110: event photos (cap 30) persist as kind:'event' docs and
+      // mirror to the gallery exactly like pizza photos.
+      eventPhotos = [],
       receiptPhotos = [],
       hostNotes,
       payoutMethod,
@@ -878,6 +881,13 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     if (pizzaPhotos.length > 10) {
       throw new AppError('Max 10 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
     }
+    // pomodoro-92110: event photos validated with a higher cap (30).
+    if (!Array.isArray(eventPhotos)) {
+      throw new AppError('eventPhotos must be an array', 400, 'INVALID_EVENT_PHOTOS');
+    }
+    if (eventPhotos.length > 30) {
+      throw new AppError('Max 30 event photos', 400, 'TOO_MANY_EVENT_PHOTOS');
+    }
     // When zero receipts are supplied, finalAmountUsd MUST be a positive number.
     if (
       receiptPhotos.length === 0
@@ -911,6 +921,13 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     for (const p of pizzaPhotos as IncomingDocument[]) {
       if (!p || typeof p.url !== 'string') {
         throw new AppError('Each pizzaPhoto must have a url', 400, 'INVALID_PIZZA_PHOTO');
+      }
+      assertSupabasePayoutUrl(p.url, partyId);
+    }
+    // pomodoro-92110: same bucket-scope validation for event photos.
+    for (const p of eventPhotos as IncomingDocument[]) {
+      if (!p || typeof p.url !== 'string') {
+        throw new AppError('Each eventPhoto must have a url', 400, 'INVALID_EVENT_PHOTO');
       }
       assertSupabasePayoutUrl(p.url, partyId);
     }
@@ -1099,6 +1116,29 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       });
     });
 
+    // pomodoro-92110: event photos persist as kind:'event' docs. Same shape as
+    // pizza (no FX detail); they mirror to the gallery in the transaction below.
+    (eventPhotos as IncomingDocument[]).forEach((p, i) => {
+      docsToCreate.push({
+        kind: 'event',
+        url: p.url,
+        fileName: p.fileName || extractFileName(p.url),
+        fileSize: typeof p.fileSize === 'number' ? p.fileSize : 0,
+        mimeType: p.mimeType || 'image/jpeg',
+        ocrAmount: null,
+        ocrCurrency: null,
+        ocrConfidence: null,
+        originalAmount: null,
+        originalCurrency: null,
+        exchangeRate: null,
+        ocrRaw: null,
+        ocrLineItems: null,
+        ocrError: null,
+        sortOrder: i,
+        photoId: null,
+      });
+    });
+
     // Final amount: host override (if provided) or OCR sum
     const hasExplicitAmount = typeof finalAmountUsd === 'number' && finalAmountUsd > 0;
     let finalUsd = hasExplicitAmount
@@ -1229,7 +1269,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       > = [];
       for (const d of docsToCreate) {
         let photoId: string | null = d.photoId;
-        if (d.kind === 'pizza') {
+        // pomodoro-92110: event docs mirror to the gallery identically to pizza.
+        if (d.kind === 'pizza' || d.kind === 'event') {
           // sicilian-58196: dedup pre-check. If a photo with the same
           // (partyId, fileSize, mimeType) already exists, reuse its id
           // instead of inserting a new row. Same bytes uploaded a second
@@ -1520,6 +1561,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       // are applied transactionally below.
       receiptPhotos,
       pizzaPhotos,
+      // pomodoro-92110: event photos (cap 30) on edit.
+      eventPhotos,
       removeDocumentIds,
     } = req.body || {};
 
@@ -1661,12 +1704,16 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     if (pizzaPhotos !== undefined && !Array.isArray(pizzaPhotos)) {
       throw new AppError('pizzaPhotos must be an array', 400, 'INVALID_PIZZA_PHOTOS');
     }
+    if (eventPhotos !== undefined && !Array.isArray(eventPhotos)) {
+      throw new AppError('eventPhotos must be an array', 400, 'INVALID_EVENT_PHOTOS');
+    }
     if (removeDocumentIds !== undefined && !Array.isArray(removeDocumentIds)) {
       throw new AppError('removeDocumentIds must be an array', 400, 'INVALID_REMOVE_IDS');
     }
 
     const newReceipts: IncomingDocument[] = Array.isArray(receiptPhotos) ? receiptPhotos : [];
     const newPizza: IncomingDocument[] = Array.isArray(pizzaPhotos) ? pizzaPhotos : [];
+    const newEvent: IncomingDocument[] = Array.isArray(eventPhotos) ? eventPhotos : [];
     const removeIds: string[] = Array.isArray(removeDocumentIds)
       ? removeDocumentIds.filter((s: unknown): s is string => typeof s === 'string')
       : [];
@@ -1674,8 +1721,21 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     if (newReceipts.length > 10) {
       throw new AppError('Max 10 receipt photos', 400, 'TOO_MANY_RECEIPTS');
     }
-    if (newPizza.length > 10) {
+    // pomodoro-92110: caps enforced as a TOTAL (surviving existing + new), not
+    // per-batch. `removeIds` is already filtered above; survivors = existing
+    // docs of that kind that aren't being removed in this same PATCH.
+    const removedSet = new Set(removeIds);
+    const survivingPizza = existing.documents.filter(
+      d => d.kind === 'pizza' && !removedSet.has(d.id)
+    ).length;
+    const survivingEvent = existing.documents.filter(
+      d => d.kind === 'event' && !removedSet.has(d.id)
+    ).length;
+    if (survivingPizza + newPizza.length > 10) {
       throw new AppError('Max 10 pizza photos', 400, 'TOO_MANY_PIZZA_PHOTOS');
+    }
+    if (survivingEvent + newEvent.length > 30) {
+      throw new AppError('Max 30 event photos', 400, 'TOO_MANY_EVENT_PHOTOS');
     }
 
     // Verify each new URL points into the bucket scoped to this party.
@@ -1688,6 +1748,13 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     for (const p of newPizza) {
       if (!p || typeof p.url !== 'string') {
         throw new AppError('Each pizzaPhoto must have a url', 400, 'INVALID_PIZZA_PHOTO');
+      }
+      assertSupabasePayoutUrl(p.url, partyId);
+    }
+    // pomodoro-92110: same bucket-scope validation for event photos.
+    for (const p of newEvent) {
+      if (!p || typeof p.url !== 'string') {
+        throw new AppError('Each eventPhoto must have a url', 400, 'INVALID_EVENT_PHOTO');
       }
       assertSupabasePayoutUrl(p.url, partyId);
     }
@@ -1862,7 +1929,28 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       photoId: null as string | null,
     }));
 
-    const documentsChanged = newReceiptDocs.length > 0 || newPizzaDocs.length > 0 || removeIds.length > 0;
+    // pomodoro-92110: event photos — same shape as newPizzaDocs (kind:'event'),
+    // mirrored to the gallery in the transaction below.
+    const newEventDocs = newEvent.map((p, i) => ({
+      kind: 'event',
+      url: p.url,
+      fileName: p.fileName || extractFileName(p.url),
+      fileSize: typeof p.fileSize === 'number' ? p.fileSize : 0,
+      mimeType: p.mimeType || 'image/jpeg',
+      ocrAmount: null,
+      ocrCurrency: null,
+      ocrConfidence: null,
+      originalAmount: null as Decimal | null,
+      originalCurrency: null as string | null,
+      exchangeRate: null as Decimal | null,
+      ocrRaw: null,
+      ocrLineItems: null,
+      ocrError: null,
+      sortOrder: i,
+      photoId: null as string | null,
+    }));
+
+    const documentsChanged = newReceiptDocs.length > 0 || newPizzaDocs.length > 0 || newEventDocs.length > 0 || removeIds.length > 0;
     const explicitAmount = data.finalAmountUsd !== undefined;
 
     // If receipts changed AND host didn't pass finalAmountUsd, recompute from
@@ -1885,7 +1973,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     const allowRecompute = existing.status === 'pending';
 
     if (receiptsChanged && allowRecompute) {
-      const removedSet = new Set(removeIds);
+      // pomodoro-92110: reuse the hoisted `removedSet` declared above (total-cap
+      // check) instead of re-declaring it here.
       const survivingReceipts = existing.documents.filter(
         d => d.kind === 'receipt' && !removedSet.has(d.id)
       );
@@ -1963,7 +2052,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           where: { id: { in: removeIds }, payoutId: existing.id },
         });
       }
-      if (newReceiptDocs.length > 0 || newPizzaDocs.length > 0) {
+      if (newReceiptDocs.length > 0 || newPizzaDocs.length > 0 || newEventDocs.length > 0) {
         // pancetta-37195: stamp the editing user on every new document so
         // the per-receipt "Uploaded by X" line shows the cohost who added it,
         // not the original payout submitter.
@@ -1975,12 +2064,14 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         // payout_documents row links to the canonical photos record. If any
         // photos.create fails, the surrounding transaction aborts and the
         // patch is rolled back. Receipts skip this step (photoId stays null).
+        // pomodoro-92110: event docs mirror to the gallery exactly like pizza,
+        // so iterate both arrays here.
         //
         // sicilian-58196: dedup pre-check before insert — if a photo already
         // exists with the same (partyId, fileSize, mimeType), reuse it
         // instead of creating a duplicate row.
         const now = new Date();
-        for (const d of newPizzaDocs) {
+        for (const d of [...newPizzaDocs, ...newEventDocs]) {
           const dup = await tx.photo.findFirst({
             where: {
               partyId,
@@ -2015,7 +2106,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         }
 
         await tx.payoutDocument.createMany({
-          data: [...newReceiptDocs, ...newPizzaDocs].map(d => ({
+          data: [...newReceiptDocs, ...newPizzaDocs, ...newEventDocs].map(d => ({
             ...d,
             // agnolotti-58291: stamp partyId on every new doc — the FK is now
             // NOT NULL party-side, optional payout-side.
@@ -2083,7 +2174,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
             actorEmail: auditActorEmail,
             actorKind: 'host',
             note: documentsChanged
-              ? `Host edit (${newReceiptDocs.length} new receipt(s), ${newPizzaDocs.length} new photo(s), ${removeIds.length} removed)`
+              ? `Host edit (${newReceiptDocs.length} new receipt(s), ${newPizzaDocs.length} new pizza photo(s), ${newEventDocs.length} new event photo(s), ${removeIds.length} removed)`
               : 'Host edit',
           },
         });
@@ -2094,7 +2185,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
             action: 'edit_documents',
             actorEmail: auditActorEmail,
             actorKind: 'host',
-            note: `Host edit (${newReceiptDocs.length} new receipt(s), ${newPizzaDocs.length} new photo(s), ${removeIds.length} removed)`,
+            note: `Host edit (${newReceiptDocs.length} new receipt(s), ${newPizzaDocs.length} new pizza photo(s), ${newEventDocs.length} new event photo(s), ${removeIds.length} removed)`,
           },
         });
       }

--- a/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
+++ b/frontend/src/components/payments-admin/CreatePrepaymentModal.tsx
@@ -130,6 +130,7 @@ export const CreatePrepaymentModal: React.FC<CreatePrepaymentModalProps> = ({
     try {
       await createPayout(party.id, {
         pizzaPhotos: [],
+        eventPhotos: [],
         receiptPhotos: [],
         payoutMethod: selectedCandidate.method,
         payoutWalletAddress:

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -562,6 +562,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     () => payout.documents.filter((d) => d.kind === 'pizza'),
     [payout.documents],
   );
+  // pomodoro-92110: host-uploaded event photos persist as kind:'event' payout
+  // documents — surfaced here as an "Event proof" section. Distinct from the
+  // gallery `eventPhotos` below (which comes from party.photos / the wire's
+  // AdminPayoutDetail.eventPhotos). NEVER conflate the two.
+  const eventDocs = useMemo(
+    () => payout.documents.filter((d) => d.kind === 'event'),
+    [payout.documents],
+  );
   // bottarga-92103: event-level photos from the party's Photos tab. Separate
   // from payment-app photos (`payout.documents`). Optional on the wire — older
   // cached responses simply render an empty section.
@@ -593,13 +601,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     ),
     [allEventPhotos],
   );
-  // Unified lightbox carousel order (focaccia-92104):
-  //   pizzas (payment-app) → receipts → pizzaPhotos → eventPhotos
+  // Unified lightbox carousel order (focaccia-92104; pomodoro-92110 inserts
+  // eventDocs right after pizzas):
+  //   pizzas (payment-app) → eventDocs (Event proof) → receipts → pizzaPhotos
+  //   → eventPhotos
   // Order matters so each thumbnail grid's offset into `allPhotos` resolves
   // to the right starting image.
   const allPhotos = useMemo(
     () => [
       ...pizzas.map((d) => ({
+        url: d.url,
+        fileName: d.fileName,
+        mimeType: d.mimeType,
+      })),
+      ...eventDocs.map((d) => ({
         url: d.url,
         fileName: d.fileName,
         mimeType: d.mimeType,
@@ -620,7 +635,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         mimeType: p.mimeType,
       })),
     ],
-    [pizzas, receipts, pizzaPhotos, eventPhotos],
+    [pizzas, eventDocs, receipts, pizzaPhotos, eventPhotos],
   );
 
   async function saveReceiptEdit(docId: string) {
@@ -1125,16 +1140,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   }, [onClose, lightboxIndex]);
 
   // pesto-92104: derive the receipt that's currently in the lightbox (if
-  // any). The unified carousel order is pizzas → receipts → pizzaPhotos →
-  // eventPhotos (see `allPhotos` above), so the receipt slice starts at
-  // `pizzas.length` and runs through `pizzas.length + receipts.length`.
+  // any). The unified carousel order is pizzas → eventDocs → receipts →
+  // pizzaPhotos → eventPhotos (see `allPhotos` above; pomodoro-92110 inserted
+  // eventDocs), so the receipt slice starts at `pizzas.length +
+  // eventDocs.length` and runs through `... + receipts.length`.
   const lightboxReceipt = useMemo(() => {
     if (lightboxCurrentIndex == null) return null;
-    const offset = pizzas.length;
+    const offset = pizzas.length + eventDocs.length;
     const idx = lightboxCurrentIndex - offset;
     if (idx < 0 || idx >= receipts.length) return null;
     return receipts[idx];
-  }, [lightboxCurrentIndex, pizzas.length, receipts]);
+  }, [lightboxCurrentIndex, pizzas.length, eventDocs.length, receipts]);
 
   // pesto-92104: "is the editor dirty?" — used by the navigation prompt
   // (Save / Discard / Cancel) so admins don't accidentally lose in-flight
@@ -1636,9 +1652,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 <div className="grid grid-cols-3 gap-2">
                   {eventPhotos.map((p, idx) => {
                     // focaccia-92104: event photos sit at the END of the
-                    // merged carousel.
+                    // merged carousel. pomodoro-92110: + eventDocs.length for
+                    // the Event-proof payout docs inserted after pizzas.
                     const carouselIdx =
-                      pizzas.length + receipts.length + pizzaPhotos.length + idx;
+                      pizzas.length + eventDocs.length + receipts.length + pizzaPhotos.length + idx;
                     const isHidden = p.status !== 'approved';
                     return (
                       <button
@@ -1707,8 +1724,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 <div className="grid grid-cols-3 gap-2">
                   {pizzaPhotos.map((p, idx) => {
                     // focaccia-92104: pizza photos sit between receipts and
-                    // event photos in the merged carousel.
-                    const carouselIdx = pizzas.length + receipts.length + idx;
+                    // event photos in the merged carousel. pomodoro-92110:
+                    // + eventDocs.length for the Event-proof payout docs.
+                    const carouselIdx = pizzas.length + eventDocs.length + receipts.length + idx;
                     const isHidden = p.status !== 'approved';
                     return (
                       <button
@@ -1774,8 +1792,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 <div className="grid grid-cols-3 gap-2">
                   {receipts.map((doc, idx) => {
                     // focaccia-92104: receipt thumbnails sit after the
-                    // payment-app pizzas in the merged carousel.
-                    const carouselIdx = pizzas.length + idx;
+                    // payment-app pizzas in the merged carousel. pomodoro-92110:
+                    // + eventDocs.length for the Event-proof payout docs.
+                    const carouselIdx = pizzas.length + eventDocs.length + idx;
                     const isDup = doc.isDuplicate === true;
                     // provola-92106: ineligible-but-not-duplicate gets its
                     // own amber treatment. When BOTH flags are true, the
@@ -2770,6 +2789,51 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       )}
                       <span className="absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-emerald-500 text-white">
                         pizza
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* pomodoro-92110: Event proof — host-uploaded kind=event payout
+                documents. Sits right after Payment proof; the carousel order is
+                pizzas → eventDocs → receipts → ... so the lightbox index is
+                `pizzas.length + idx`. */}
+            {eventDocs.length > 0 && (
+              <div className="rounded-xl border border-theme-stroke p-3 bg-theme-surface">
+                <h3 className="text-sm font-semibold text-theme-text mb-2">
+                  Event proof ({eventDocs.length})
+                </h3>
+                <div className="grid grid-cols-3 gap-2">
+                  {eventDocs.map((doc, idx) => (
+                    <button
+                      key={doc.id}
+                      type="button"
+                      onClick={() => setLightboxIndex(pizzas.length + idx)}
+                      className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
+                      title={doc.fileName}
+                    >
+                      {isVideoFile(doc) ? (
+                        <>
+                          <video
+                            src={doc.url}
+                            preload="metadata"
+                            muted
+                            playsInline
+                            className="w-full h-full object-cover"
+                          />
+                          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                            <div className="bg-black/50 rounded-full p-3">
+                              <Play className="text-white" size={20} fill="white" />
+                            </div>
+                          </div>
+                        </>
+                      ) : (
+                        <img src={doc.url} alt={doc.fileName} className="w-full h-full object-cover" loading="lazy" />
+                      )}
+                      <span className="absolute top-1 left-1 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-indigo-500 text-white">
+                        event
                       </span>
                     </button>
                   ))}

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -321,6 +321,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
       if (!createdPayoutIdRef.current) {
         const created = await createPayout(partyId, {
           pizzaPhotos: [],
+          eventPhotos: [],
           receiptPhotos: [],
           payoutMethod: method,
           payoutWalletAddress:

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -66,8 +66,12 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
   onCapUpdated,
 }) => {
   const admin = payout as AdminPayout;
-  const firstPizza = (payout.documents || []).find((d) => d.kind === 'pizza');
-  const thumbUrl = firstPizza?.url || null;
+  // pomodoro-92110: thumbnail fallback order pizza → event → receipt.
+  const firstThumbDoc =
+    (payout.documents || []).find((d) => d.kind === 'pizza')
+    ?? (payout.documents || []).find((d) => d.kind === 'event')
+    ?? (payout.documents || []).find((d) => d.kind === 'receipt');
+  const thumbUrl = firstThumbDoc?.url || null;
 
   const submittedAbs = new Date(payout.createdAt).toLocaleString();
   const submittedRel = relativeTime(new Date(payout.createdAt));

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -87,6 +87,9 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
 
   const [receipts, setReceipts] = useState<ReceiptItem[]>([]);
   const [pizzaPhotos, setPizzaPhotos] = useState<PizzaPhotoItem[]>([]);
+  // pomodoro-92110: event photos are a separate dropzone (cap 30) persisted as
+  // kind:'event' payout documents.
+  const [eventPhotos, setEventPhotos] = useState<PizzaPhotoItem[]>([]);
   const [notes, setNotes] = useState('');
   const [overrideAmount, setOverrideAmount] = useState<number | null>(null);
 
@@ -155,7 +158,8 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   const finalAmount = overrideAmount != null ? overrideAmount : ocrSum;
 
   const isProcessing = receipts.some(r => r.status === 'uploading' || r.status === 'ocring')
-    || pizzaPhotos.some(p => p.status === 'uploading');
+    || pizzaPhotos.some(p => p.status === 'uploading')
+    || eventPhotos.some(p => p.status === 'uploading');
 
   // When the attendance section is shown, require a positive integer before submit.
   const attendanceValid = !askForAttendance
@@ -246,6 +250,15 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
             ocrError: r.ocr?.ocrError,
           })),
         pizzaPhotos: pizzaPhotos
+          .filter(p => p.status === 'done' && p.url)
+          .map(p => ({
+            url: p.url!,
+            fileName: p.fileName,
+            fileSize: p.fileSize,
+            mimeType: p.mimeType,
+          })),
+        // pomodoro-92110: event photos persist as kind:'event' payout docs.
+        eventPhotos: eventPhotos
           .filter(p => p.status === 'done' && p.url)
           .map(p => ({
             url: p.url!,
@@ -379,19 +392,39 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         />
       </div>
 
-      {/* 2. Pizza photos */}
+      {/* 2. Pizza photos (pomodoro-92110: cap 10) */}
       <div className="card p-6">
         <div className="mb-3">
-          <h3 className="text-base font-semibold text-theme-text">Pizza or event photos</h3>
+          <h3 className="text-base font-semibold text-theme-text">Pizza photos</h3>
           <p className="text-xs text-theme-text-muted mt-0.5">
-            Proof-of-event photos help your reviewer.
+            Photos of the pizza help your reviewer.
           </p>
         </div>
         <PizzaPhotoUpload
           partyId={partyId}
           payoutTempId={payoutTempId}
+          kind="pizza"
+          maxItems={10}
           items={pizzaPhotos}
           onChange={setPizzaPhotos}
+        />
+      </div>
+
+      {/* 2b. Event photos (pomodoro-92110: cap 30) */}
+      <div className="card p-6">
+        <div className="mb-3">
+          <h3 className="text-base font-semibold text-theme-text">Event photos</h3>
+          <p className="text-xs text-theme-text-muted mt-0.5">
+            Photos from the event help your reviewer.
+          </p>
+        </div>
+        <PizzaPhotoUpload
+          partyId={partyId}
+          payoutTempId={payoutTempId}
+          kind="event"
+          maxItems={30}
+          items={eventPhotos}
+          onChange={setEventPhotos}
         />
       </div>
 

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -96,6 +96,8 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   // New uploads since edit-mode was opened (existing docs aren't re-uploaded).
   const [newReceipts, setNewReceipts] = useState<ReceiptItem[]>([]);
   const [newPizzaPhotos, setNewPizzaPhotos] = useState<PizzaPhotoItem[]>([]);
+  // pomodoro-92110: separate dropzone for event photos (cap 30).
+  const [newEventPhotos, setNewEventPhotos] = useState<PizzaPhotoItem[]>([]);
   // IDs of existing documents the host has clicked X on (deferred until save).
   const [removedDocIds, setRemovedDocIds] = useState<Set<string>>(new Set());
   const [editNotes, setEditNotes] = useState('');
@@ -130,6 +132,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     setSaveError(null);
     setNewReceipts([]);
     setNewPizzaPhotos([]);
+    setNewEventPhotos([]);
     setRemovedDocIds(new Set());
     setDocFxOverrides({});
     setEditNotes(payout.hostNotes ?? '');
@@ -143,6 +146,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     setSaveError(null);
     setNewReceipts([]);
     setNewPizzaPhotos([]);
+    setNewEventPhotos([]);
     setRemovedDocIds(new Set());
     setDocFxOverrides({});
   };
@@ -157,6 +161,12 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     () => (payout?.documents ?? []).filter(d => d.kind === 'pizza' && !removedDocIds.has(d.id)),
     [payout, removedDocIds]
   );
+  // pomodoro-92110: surviving event photos drive both the edit-mode existing
+  // grid and the total-cap `existingCount` for the event dropzone.
+  const survivingEventPhotos = useMemo(
+    () => (payout?.documents ?? []).filter(d => d.kind === 'event' && !removedDocIds.has(d.id)),
+    [payout, removedDocIds]
+  );
 
   // bresaola-89172: unified lightbox list across receipts + pizza photos so
   // arrow-key nav walks the whole set. Receipts listed first (matches the
@@ -169,21 +179,28 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     () => (payout?.documents ?? []).filter(d => d.kind === 'pizza'),
     [payout]
   );
+  // pomodoro-92110: event photos listed after pizza in the carousel.
+  const viewEventPhotos = useMemo(
+    () => (payout?.documents ?? []).filter(d => d.kind === 'event'),
+    [payout]
+  );
   const lightboxImages = useMemo(
     () =>
-      [...viewReceipts, ...viewPizzaPhotos].map(d => ({
+      [...viewReceipts, ...viewPizzaPhotos, ...viewEventPhotos].map(d => ({
         url: d.url,
         fileName: d.fileName,
         mimeType: d.mimeType,
       })),
-    [viewReceipts, viewPizzaPhotos]
+    [viewReceipts, viewPizzaPhotos, viewEventPhotos]
   );
   const receiptsLightboxOffset = 0;
   const pizzasLightboxOffset = viewReceipts.length;
+  const eventsLightboxOffset = viewReceipts.length + viewPizzaPhotos.length;
 
   const isProcessingUploads =
     newReceipts.some(r => r.status === 'uploading' || r.status === 'ocring') ||
-    newPizzaPhotos.some(p => p.status === 'uploading');
+    newPizzaPhotos.some(p => p.status === 'uploading') ||
+    newEventPhotos.some(p => p.status === 'uploading');
 
   // gouda-83912: only the submitter (or any admin) may edit / cancel a payout.
   // Other cohosts on the same party can still see the row but the affordances
@@ -259,6 +276,18 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
       if (newPizzaPayload.length > 0) {
         patch.pizzaPhotos = newPizzaPayload;
       }
+      // pomodoro-92110: event photos (kind:'event') — append-only on edit.
+      const newEventPayload = newEventPhotos
+        .filter(p => p.status === 'done' && p.url)
+        .map(p => ({
+          url: p.url!,
+          fileName: p.fileName,
+          fileSize: p.fileSize,
+          mimeType: p.mimeType,
+        }));
+      if (newEventPayload.length > 0) {
+        patch.eventPhotos = newEventPayload;
+      }
 
       if (removedDocIds.size > 0) {
         patch.removeDocumentIds = Array.from(removedDocIds);
@@ -276,6 +305,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
       setEditing(false);
       setNewReceipts([]);
       setNewPizzaPhotos([]);
+      setNewEventPhotos([]);
       setRemovedDocIds(new Set());
       onUpdated?.();
     } catch (err: any) {
@@ -534,7 +564,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
               {/* Pizza photos */}
               {viewPizzaPhotos.length > 0 && (
                 <div>
-                  <p className="text-xs text-theme-text-muted mb-2">Pizza / event photos</p>
+                  <p className="text-xs text-theme-text-muted mb-2">Pizza photos</p>
                   <div className="grid grid-cols-4 sm:grid-cols-5 gap-2">
                     {viewPizzaPhotos.map((d, idx) => (
                       <div key={d.id} className="space-y-1">
@@ -572,6 +602,50 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                         </button>
                         {/* pancetta-37195: per-photo uploader attribution.
                             Hidden for historical rows (null uploadedByUserId). */}
+                        {d.uploadedByUserId && (
+                          <p className="text-[10px] text-theme-text-muted truncate">
+                            Uploaded by {d.uploadedByName ?? d.uploadedByEmail ?? 'Unknown'}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Event photos (pomodoro-92110) */}
+              {viewEventPhotos.length > 0 && (
+                <div>
+                  <p className="text-xs text-theme-text-muted mb-2">Event photos</p>
+                  <div className="grid grid-cols-4 sm:grid-cols-5 gap-2">
+                    {viewEventPhotos.map((d, idx) => (
+                      <div key={d.id} className="space-y-1">
+                        <button
+                          type="button"
+                          onClick={() => setLightboxState({ open: true, initialIndex: eventsLightboxOffset + idx })}
+                          className="relative block w-full aspect-square rounded-lg overflow-hidden bg-theme-surface hover:opacity-90 transition-opacity"
+                          aria-label={`Open ${d.fileName}`}
+                          title={d.fileName}
+                        >
+                          {isVideoFile(d) ? (
+                            <>
+                              <video
+                                src={d.url}
+                                preload="metadata"
+                                muted
+                                playsInline
+                                className="w-full h-full object-cover"
+                              />
+                              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                                <div className="bg-black/50 rounded-full p-3">
+                                  <Play className="text-white" size={20} fill="white" />
+                                </div>
+                              </div>
+                            </>
+                          ) : (
+                            <img src={d.url} alt={d.fileName} className="w-full h-full object-cover" />
+                          )}
+                        </button>
                         {d.uploadedByUserId && (
                           <p className="text-[10px] text-theme-text-muted truncate">
                             Uploaded by {d.uploadedByName ?? d.uploadedByEmail ?? 'Unknown'}
@@ -727,7 +801,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
               {/* Existing pizza photos — host can click X to mark for removal */}
               {survivingPizzaPhotos.length > 0 && (
                 <div>
-                  <p className="text-xs text-theme-text-muted mb-2">Existing pizza / event photos</p>
+                  <p className="text-xs text-theme-text-muted mb-2">Existing pizza photos</p>
                   <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
                     {survivingPizzaPhotos.map(d => (
                       <div key={d.id} className="relative aspect-square rounded-lg overflow-hidden bg-theme-surface group">
@@ -766,15 +840,70 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 </div>
               )}
 
-              {/* Add pizza photos */}
+              {/* Add pizza photos (pomodoro-92110: cap 10, total enforced) */}
               <div>
-                <p className="text-xs text-theme-text-muted mb-2">Add pizza / event photos</p>
+                <p className="text-xs text-theme-text-muted mb-2">Add pizza photos</p>
                 <PizzaPhotoUpload
                   partyId={partyId}
                   payoutTempId={payout.id}
+                  kind="pizza"
                   items={newPizzaPhotos}
                   onChange={setNewPizzaPhotos}
                   maxItems={10}
+                  existingCount={survivingPizzaPhotos.length}
+                />
+              </div>
+
+              {/* Existing event photos — host can click X to mark for removal */}
+              {survivingEventPhotos.length > 0 && (
+                <div>
+                  <p className="text-xs text-theme-text-muted mb-2">Existing event photos</p>
+                  <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+                    {survivingEventPhotos.map(d => (
+                      <div key={d.id} className="relative aspect-square rounded-lg overflow-hidden bg-theme-surface group">
+                        {isVideoFile(d) ? (
+                          <>
+                            <video
+                              src={d.url}
+                              preload="metadata"
+                              muted
+                              playsInline
+                              className="w-full h-full object-cover"
+                            />
+                            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                              <div className="bg-black/50 rounded-full p-3">
+                                <Play className="text-white" size={20} fill="white" />
+                              </div>
+                            </div>
+                          </>
+                        ) : (
+                          <img src={d.url} alt="" className="w-full h-full object-cover" />
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => setRemovedDocIds(prev => new Set(prev).add(d.id))}
+                          className="absolute top-1 right-1 p-1 rounded-full bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity"
+                          aria-label="Remove"
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Add event photos (pomodoro-92110: cap 30, total enforced) */}
+              <div>
+                <p className="text-xs text-theme-text-muted mb-2">Add event photos</p>
+                <PizzaPhotoUpload
+                  partyId={partyId}
+                  payoutTempId={payout.id}
+                  kind="event"
+                  items={newEventPhotos}
+                  onChange={setNewEventPhotos}
+                  maxItems={30}
+                  existingCount={survivingEventPhotos.length}
                 />
               </div>
 

--- a/frontend/src/components/payouts/PayoutListRow.tsx
+++ b/frontend/src/components/payouts/PayoutListRow.tsx
@@ -97,8 +97,10 @@ export const PayoutListRow: React.FC<PayoutListRowProps> = ({
   // record). `paid`, `rejected`, `failed` remain terminal.
   const canWithdraw = payout.status === 'pending' || payout.status === 'approved';
 
-  // First pizza photo, or first receipt as a fallback thumbnail
+  // First pizza photo, then event photo, then receipt as a fallback thumbnail
+  // (pomodoro-92110).
   const thumb = payout.documents.find(d => d.kind === 'pizza')
+    ?? payout.documents.find(d => d.kind === 'event')
     ?? payout.documents.find(d => d.kind === 'receipt');
 
   const handleWithdraw = async (e: React.MouseEvent) => {

--- a/frontend/src/components/payouts/PizzaPhotoUpload.tsx
+++ b/frontend/src/components/payouts/PizzaPhotoUpload.tsx
@@ -18,10 +18,23 @@ interface PizzaPhotoUploadProps {
   items: PizzaPhotoItem[];
   onChange: (items: PizzaPhotoItem[]) => void;
   maxItems?: number;
+  /**
+   * pomodoro-92110: which kind of payout document these uploads become.
+   * 'pizza' and 'event' are both image-only and mirror to the gallery; the
+   * value flows into both the storage path and `uploadPayoutPhoto`.
+   */
+  kind: 'pizza' | 'event';
+  /**
+   * pomodoro-92110: count of already-persisted documents of this kind on the
+   * payout (edit mode). The cap is enforced as a TOTAL (existing + new), so
+   * `remaining` subtracts both this and the in-flight items.
+   */
+  existingCount?: number;
 }
 
 /**
- * Multi-image dropzone for pizza/event photos (no OCR). Max 10 by default.
+ * Multi-image dropzone for pizza OR event photos (no OCR). Max 10 by default;
+ * callers pass `maxItems={30}` for event photos.
  */
 export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
   partyId,
@@ -29,11 +42,14 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
   items,
   onChange,
   maxItems = 10,
+  kind,
+  existingCount = 0,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
 
-  const remaining = maxItems - items.length;
+  const noun = kind === 'event' ? 'event' : 'pizza';
+  const remaining = Math.max(0, maxItems - existingCount - items.length);
 
   const handleFiles = async (files: FileList | File[]) => {
     const fileArr = Array.from(files).slice(0, remaining);
@@ -51,7 +67,7 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
 
     await Promise.all(fileArr.map(async (file, i) => {
       const itemId = newItems[i].id;
-      const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, 'pizza');
+      const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, kind);
       if (!uploaded) {
         nextItems = nextItems.map(it => it.id === itemId
           ? { ...it, status: 'error' as const, error: 'Upload failed' } : it);
@@ -107,8 +123,8 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
         <Upload className="mx-auto mb-2 text-theme-text-muted" size={28} />
         <p className="text-sm text-theme-text">
           {remaining === 0
-            ? `Maximum ${maxItems} photos uploaded`
-            : 'Drop pizza / event photos here, or click to choose files'}
+            ? `Maximum ${maxItems} ${noun} photos reached — remove a photo to add another.`
+            : `Drop ${noun} photos here, or click to choose files`}
         </p>
         <p className="text-xs text-theme-text-muted mt-1">
           {remaining > 0 && `Up to ${remaining} more.`}

--- a/frontend/src/components/shipping/NewShippingReceiptModal.tsx
+++ b/frontend/src/components/shipping/NewShippingReceiptModal.tsx
@@ -122,6 +122,7 @@ export const NewShippingReceiptModal: React.FC<NewShippingReceiptModalProps> = (
           })),
         // Shipping receipts don't carry pizza/event proof photos.
         pizzaPhotos: [],
+        eventPhotos: [],
         hostNotes: notes.trim() || undefined,
         purpose: 'shipping',
         partyKitId: selectedKit.id,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5248,6 +5248,9 @@ export interface CreatePayoutPhotoInput {
 
 export interface CreatePayoutData {
   pizzaPhotos: CreatePayoutPhotoInput[];
+  // pomodoro-92110: event photos (cap 30) persist as kind:'event' payout docs
+  // and mirror to the public gallery just like pizza photos.
+  eventPhotos: CreatePayoutPhotoInput[];
   receiptPhotos: CreatePayoutPhotoInput[];
   hostNotes?: string;
   /**
@@ -5356,6 +5359,14 @@ export interface UpdatePayoutData {
     ocrError?: string | null;
   }>;
   pizzaPhotos?: Array<{
+    url: string;
+    fileName: string;
+    fileSize: number;
+    mimeType: string;
+  }>;
+  // pomodoro-92110: event photos (cap 30) on edit. Append-only, mirror to the
+  // gallery; total cap is enforced server-side against surviving docs.
+  eventPhotos?: Array<{
     url: string;
     fileName: string;
     fileSize: number;

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -335,13 +335,15 @@ export async function uploadReceipt(file: File, partyId: string): Promise<string
  * @param file       The image file (JPEG / PNG / WebP / HEIC) or PDF (receipt only)
  * @param partyId    The party we're submitting a payout against
  * @param payoutTempId  A client-generated id to group files for one in-progress submission
- * @param kind       'pizza' or 'receipt' — drives OCR behavior server-side
+ * @param kind       'pizza', 'event', or 'receipt' — drives OCR behavior
+ *                   server-side. 'pizza' and 'event' are image-only; only
+ *                   'receipt' accepts application/pdf.
  */
 export async function uploadPayoutPhoto(
   file: File,
   partyId: string,
   payoutTempId: string,
-  kind: 'pizza' | 'receipt'
+  kind: 'pizza' | 'receipt' | 'event'
 ): Promise<{
   url: string;
   fileName: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1668,7 +1668,9 @@ export type PayoutMethod = 'mercury_card' | 'wire' | 'usdc_base';
 
 export interface PayoutDocument {
   id: string;
-  kind: 'pizza' | 'receipt';
+  // pomodoro-92110: 'event' added — host-uploaded event photos persist as
+  // payout documents and mirror to the gallery like 'pizza'.
+  kind: 'pizza' | 'receipt' | 'event';
   url: string;
   fileName: string;
   fileSize: number;


### PR DESCRIPTION
## Summary

Splits the host payments/reimbursement form's single combined **"Pizza or event photos"** dropzone into **two separate dropzones**:

- **Pizza photos** — cap **10**
- **Event photos** — cap **30** (new)

Both zones show "Up to N more." when there's room; when full they show "Maximum N {pizza|event} photos reached — remove a photo to add another." The cap is enforced as a **TOTAL** (existing + newly added), not per-batch.

## Host form split
- `NewPayoutForm` now renders two cards ("Pizza photos" maxItems=10, "Event photos" maxItems=30) backed by separate state.
- `PizzaPhotoUpload` gained a required `kind: 'pizza' | 'event'` prop + optional `existingCount` so `remaining = max(0, maxItems - existingCount - items.length)`. Copy is kind-specific.
- `PayoutDetailModal` edit mode mirrors the split with separate existing/add grids for pizza and event, passing `existingCount` so the total cap counts surviving docs.

## Total-cap enforcement
- **POST**: validates `eventPhotos` array + cap 30.
- **PATCH**: replaced the per-batch `newPizza.length > 10` check with TOTAL enforcement using survivors (existing minus removeIds) for **both** pizza (10) and event (30). Receipts left unchanged.

## Gallery mirror
Event docs persist as `kind:'event'` `PayoutDocument` rows and are mirrored into the public photo gallery **exactly like pizza** — approved + starred + untagged `photos` row, reusing the sicilian-58196 dedup pre-check — in both the POST and PATCH transactions.

## Admin "Event proof" section
`PayoutReviewModal` gained an `eventDocs` memo + a new **"Event proof (N)"** grid right after "Payment proof". `eventDocs` is inserted into the lightbox carousel right after `pizzas` (order: pizzas → eventDocs → receipts → gallery pizzaPhotos → gallery eventPhotos); all offsets based on `pizzas.length` were updated by `+ eventDocs.length`. The gallery `eventPhotos`/`pizzaPhotos` (AdminPayoutDetail) are left untouched.

## No migration
`PayoutDocument.kind` is a free-text `String` — `'event'` is a new value, no schema migration. Only the cosmetic schema comment was updated.

## Deploy ordering note
Preview frontends talk to the **production backend**. The new `eventPhotos` wire field + `kind:'event'` handling must reach **master's backend** before the feature works on the preview branch.

## Verification
- `assertSupabasePayoutUrl` validates path **shape** (`/event-images/payouts/<partyId>/`) and does NOT hardcode the kind token, so `payouts/{partyId}/{tempId}/event/...` passes without changes — confirmed.
- Frontend typecheck: 0 new errors (436 total, identical to master baseline).
- Backend typecheck: 0 new errors in `payout.routes.ts` (the 5 backend errors are pre-existing missing-dep/test issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)