### PR TITLE
feat(soppressata-92110): show duplicate/ineligible receipt flags to hosts (read-only)

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -131,6 +131,11 @@ function serializeDocument(d: any) {
     exchangeRate: d.exchangeRate != null ? numberFromDecimal(d.exchangeRate) : null,
     ocrError: d.ocrError ?? null,
     sortOrder: d.sortOrder,
+    // soppressata-92110: surface admin exclusion flags read-only so hosts can
+    // see which receipts / OCR line items were excluded from their total.
+    isDuplicate: d.isDuplicate ?? false,
+    ineligible: d.ineligible ?? false,
+    ocrLineItems: d.ocrLineItems ?? null,
     // pancetta-37195: surface the per-doc uploader so cohosts can tell who
     // attached each receipt/photo. Live name from the join; cached email is
     // the fallback if the User row is later deleted.
@@ -1457,6 +1462,10 @@ router.get('/:partyId/payouts/receipts-library', async (req: AuthRequest, res: R
         ocrAmount: d.ocrAmount != null ? numberFromDecimal(d.ocrAmount) : null,
         ocrCurrency: d.ocrCurrency ?? null,
         ocrConfidence: d.ocrConfidence != null ? numberFromDecimal(d.ocrConfidence) : null,
+        // soppressata-92110: admin exclusion flags (read-only) so the library
+        // can dim + pill receipts excluded from the host's reimbursement total.
+        isDuplicate: d.isDuplicate ?? false,
+        ineligible: d.ineligible ?? false,
         // agnolotti-58291: uploader attribution. Falls back to cached email
         // if the User row is later deleted.
         uploadedByUserId: d.uploadedByUserId ?? null,

--- a/frontend/src/components/payouts/PayoutDetailModal.tsx
+++ b/frontend/src/components/payouts/PayoutDetailModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, Loader2, AlertCircle, ExternalLink, Pencil, StickyNote, DollarSign, Trash2, Play } from 'lucide-react';
 import { Payout, PayoutStatus } from '../../types';
 import { cancelPayout, getPayout, updatePayout, fetchAdminMe } from '../../lib/api';
@@ -61,6 +62,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
   onWithdrawn,
 }) => {
   const { user } = useAuth();
+  const { t } = useTranslation('host');
   const [payout, setPayout] = useState<Payout | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -92,6 +94,11 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     open: false,
     initialIndex: 0,
   });
+  // soppressata-92110: the lightbox owns its own index internally; mirror the
+  // currently-displayed index here so we can paint the read-only DUPLICATE /
+  // INELIGIBLE banners on the matching doc (admin viewers get the editor, but
+  // hosts only see these flags — no toggle).
+  const [lightboxCurrentIndex, setLightboxCurrentIndex] = useState(0);
 
   // New uploads since edit-mode was opened (existing docs aren't re-uploaded).
   const [newReceipts, setNewReceipts] = useState<ReceiptItem[]>([]);
@@ -169,17 +176,26 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
     () => (payout?.documents ?? []).filter(d => d.kind === 'pizza'),
     [payout]
   );
+  // soppressata-92110: keep the doc list parallel to `lightboxImages` so we can
+  // look up the flags for whatever index the lightbox is currently showing.
+  const lightboxDocs = useMemo(
+    () => [...viewReceipts, ...viewPizzaPhotos],
+    [viewReceipts, viewPizzaPhotos]
+  );
   const lightboxImages = useMemo(
     () =>
-      [...viewReceipts, ...viewPizzaPhotos].map(d => ({
+      lightboxDocs.map(d => ({
         url: d.url,
         fileName: d.fileName,
         mimeType: d.mimeType,
       })),
-    [viewReceipts, viewPizzaPhotos]
+    [lightboxDocs]
   );
   const receiptsLightboxOffset = 0;
   const pizzasLightboxOffset = viewReceipts.length;
+  // soppressata-92110: the doc currently shown in the lightbox (receipts only
+  // carry the flags; pizza photos never do).
+  const lightboxCurrentDoc = lightboxDocs[lightboxCurrentIndex] ?? null;
 
   const isProcessingUploads =
     newReceipts.some(r => r.status === 'uploading' || r.status === 'ocring') ||
@@ -482,8 +498,20 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                 <div>
                   <p className="text-xs text-theme-text-muted mb-2">Receipts</p>
                   <ul className="space-y-2">
-                    {viewReceipts.map((d, idx) => (
-                      <li key={d.id} className="flex items-center gap-3 p-2 rounded-lg bg-theme-surface-hover">
+                    {viewReceipts.map((d, idx) => {
+                      // soppressata-92110: surface (read-only) the admin
+                      // exclusion flags. Duplicate wins when both are set —
+                      // mirrors the admin grid convention. Hosts can't toggle.
+                      const isDup = d.isDuplicate === true;
+                      const isIne = d.ineligible === true && !isDup;
+                      const flagged = isDup || isIne;
+                      return (
+                      <li
+                        key={d.id}
+                        className={`flex items-center gap-3 p-2 rounded-lg bg-theme-surface-hover ${
+                          flagged ? 'opacity-60' : ''
+                        }`}
+                      >
                         {/* bresaola-89172: thumbnail opens the shared lightbox
                             instead of popping the raw URL in a new tab.
                             bocconcino-92104: PDFs render via their sibling
@@ -492,7 +520,7 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                         <button
                           type="button"
                           onClick={() => setLightboxState({ open: true, initialIndex: receiptsLightboxOffset + idx })}
-                          className="flex-shrink-0 rounded overflow-hidden hover:opacity-80 transition-opacity"
+                          className="relative flex-shrink-0 rounded overflow-hidden hover:opacity-80 transition-opacity"
                           aria-label={`Open ${d.fileName}`}
                           title={d.fileName}
                         >
@@ -501,6 +529,19 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                             alt={d.fileName}
                             className="w-14 h-14 object-cover block"
                           />
+                          {/* soppressata-92110: diagonal-stripe overlay echoes
+                              the lightbox banner so flagged receipts read as
+                              "excluded" even at thumbnail size. */}
+                          {flagged && (
+                            <span
+                              className="absolute inset-0 pointer-events-none"
+                              style={{
+                                backgroundImage: isDup
+                                  ? 'repeating-linear-gradient(45deg, rgba(239,68,68,0.30) 0 4px, transparent 4px 8px)'
+                                  : 'repeating-linear-gradient(135deg, rgba(245,158,11,0.30) 0 4px, transparent 4px 8px)',
+                              }}
+                            />
+                          )}
                         </button>
                         <div className="flex-1 min-w-0">
                           <p className="text-sm text-theme-text truncate">{d.fileName}</p>
@@ -522,12 +563,34 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
                             </p>
                           )}
                         </div>
+                        {/* soppressata-92110: read-only exclusion pill. Explicit
+                            text colors (not theme vars) — this modal portals
+                            outside `.gpp-theme` so theme vars don't resolve. */}
+                        {isDup && (
+                          <span className="flex-shrink-0 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-red-500 text-[#ffffff]">
+                            {t('payouts.duplicatePill')}
+                          </span>
+                        )}
+                        {isIne && (
+                          <span className="flex-shrink-0 text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-amber-500 text-[#ffffff]">
+                            {t('payouts.ineligiblePill')}
+                          </span>
+                        )}
                         <a href={d.url} target="_blank" rel="noreferrer" className="p-1 text-theme-text-muted hover:text-theme-text" title="Open raw file">
                           <ExternalLink size={14} />
                         </a>
                       </li>
-                    ))}
+                      );
+                    })}
                   </ul>
+                  {/* soppressata-92110: explain why a flagged receipt's amount
+                      doesn't count toward the host's reimbursement total. Only
+                      shown when at least one receipt is flagged. */}
+                  {viewReceipts.some(d => d.isDuplicate === true || d.ineligible === true) && (
+                    <p className="text-xs text-theme-text-muted mt-2 italic">
+                      {t('payouts.excludedNote')}
+                    </p>
+                  )}
                 </div>
               )}
 
@@ -853,6 +916,17 @@ export const PayoutDetailModal: React.FC<PayoutDetailModalProps> = ({
         images={lightboxImages}
         initialIndex={lightboxState.initialIndex}
         onClose={() => setLightboxState({ open: false, initialIndex: 0 })}
+        onIndexChange={setLightboxCurrentIndex}
+        /* soppressata-92110: READ-ONLY duplicate / ineligible banners so hosts
+           can see which receipts an admin excluded from their total. No
+           onDuplicateShortcut / editorPane — hosts can't toggle these flags.
+           Duplicate wins when both are set (pass ineligible only when NOT a
+           duplicate), matching the admin convention. */
+        isDuplicate={lightboxCurrentDoc?.isDuplicate === true}
+        isIneligible={
+          lightboxCurrentDoc?.ineligible === true
+          && lightboxCurrentDoc?.isDuplicate !== true
+        }
       />
     </div>
   );

--- a/frontend/src/components/payouts/ReceiptsLibrary.tsx
+++ b/frontend/src/components/payouts/ReceiptsLibrary.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Loader2, AlertCircle, RefreshCw, FileText, ExternalLink, Play } from 'lucide-react';
 import { fetchReceiptsLibrary } from '../../lib/api';
 import type { ReceiptLibraryEntry } from '../../types';
@@ -25,6 +26,7 @@ interface ReceiptsLibraryProps {
  * pending-only edit flow.
  */
 export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => {
+  const { t } = useTranslation('host');
   const [receipts, setReceipts] = useState<ReceiptLibraryEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -35,6 +37,10 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
     open: false,
     initialIndex: 0,
   });
+  // soppressata-92110: mirror the lightbox's current index so the read-only
+  // DUPLICATE / INELIGIBLE banners paint the matching receipt.
+  const [lightboxCurrentIndex, setLightboxCurrentIndex] = useState(0);
+  const lightboxCurrentReceipt = receipts[lightboxCurrentIndex] ?? null;
 
   // Build the carousel list once per receipts array. Includes every entry —
   // non-image rows still get a fallback render inside the lightbox via the
@@ -129,8 +135,13 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
             // to the cached email when the User row has been deleted. Empty
             // when both are missing (historical pre-pancetta receipts).
             const uploader = r.uploadedByName || r.uploadedByEmail || null;
+            // soppressata-92110: read-only admin exclusion flags. Duplicate
+            // wins when both are set (same convention as the admin grid).
+            const isDup = r.isDuplicate === true;
+            const isIne = r.ineligible === true && !isDup;
+            const flagged = isDup || isIne;
             return (
-              <li key={r.id} className="flex items-center gap-3 py-3">
+              <li key={r.id} className={`flex items-center gap-3 py-3 ${flagged ? 'opacity-60' : ''}`}>
                 {/* bresaola-89172: thumbnail wrapped in a button so clicking
                     opens the shared lightbox carousel scrolled to this row.
                     Non-image rows (PDFs etc.) still open in a new tab via
@@ -138,7 +149,7 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
                 <button
                   type="button"
                   onClick={() => setLightboxState({ open: true, initialIndex: idx })}
-                  className="flex-shrink-0 rounded border border-theme-stroke overflow-hidden hover:opacity-80 transition-opacity"
+                  className="relative flex-shrink-0 rounded border border-theme-stroke overflow-hidden hover:opacity-80 transition-opacity"
                   aria-label={`Open ${r.fileName}`}
                   title={r.fileName}
                 >
@@ -179,6 +190,19 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
                       <FileText size={20} className="text-theme-text-secondary" />
                     </div>
                   )}
+                  {/* soppressata-92110: diagonal-stripe overlay marks flagged
+                      receipts as excluded at thumbnail size (red 45° for
+                      duplicate, amber 135° for ineligible). */}
+                  {flagged && (
+                    <span
+                      className="absolute inset-0 pointer-events-none"
+                      style={{
+                        backgroundImage: isDup
+                          ? 'repeating-linear-gradient(45deg, rgba(239,68,68,0.30) 0 4px, transparent 4px 8px)'
+                          : 'repeating-linear-gradient(135deg, rgba(245,158,11,0.30) 0 4px, transparent 4px 8px)',
+                      }}
+                    />
+                  )}
                 </button>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
@@ -186,6 +210,19 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
                       {r.fileName}
                     </span>
                     {r.payoutStatus && <PayoutStatusPill status={r.payoutStatus} />}
+                    {/* soppressata-92110: read-only exclusion pill. Explicit
+                        white text (text-[#ffffff]) dodges the `.gpp-theme
+                        .text-white` override on GPP host pages. */}
+                    {isDup && (
+                      <span className="text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-red-500 text-[#ffffff]">
+                        {t('payouts.duplicatePill')}
+                      </span>
+                    )}
+                    {isIne && (
+                      <span className="text-[10px] uppercase font-bold px-1.5 py-0.5 rounded bg-amber-500 text-[#ffffff]">
+                        {t('payouts.ineligiblePill')}
+                      </span>
+                    )}
                   </div>
                   <div className="text-xs text-white/40 mt-0.5">
                     Uploaded {formattedDate}
@@ -210,11 +247,26 @@ export const ReceiptsLibrary: React.FC<ReceiptsLibraryProps> = ({ partyId }) => 
         </ul>
       )}
 
+      {/* soppressata-92110: explain the exclusion when any receipt is flagged. */}
+      {!loading && !error && receipts.some(r => r.isDuplicate === true || r.ineligible === true) && (
+        <p className="text-xs text-theme-text-muted mt-3 italic">
+          {t('payouts.excludedNote')}
+        </p>
+      )}
+
       <ReceiptLightbox
         isOpen={lightboxState.open}
         images={lightboxImages}
         initialIndex={lightboxState.initialIndex}
         onClose={() => setLightboxState({ open: false, initialIndex: 0 })}
+        onIndexChange={setLightboxCurrentIndex}
+        /* soppressata-92110: READ-ONLY duplicate / ineligible banners. No
+           onDuplicateShortcut / editorPane — hosts can't toggle these. */
+        isDuplicate={lightboxCurrentReceipt?.isDuplicate === true}
+        isIneligible={
+          lightboxCurrentReceipt?.ineligible === true
+          && lightboxCurrentReceipt?.isDuplicate !== true
+        }
       />
     </div>
   );

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -814,5 +814,11 @@
       "daysAgo": "vor {{count}} T.",
       "recentRsvps": "Aktuelle Zusagen"
     }
+  },
+  "payouts": {
+    "excludedNote": "Belege oder Positionen, die als Duplikat oder Nicht erstattungsfähig markiert sind, werden von deiner Erstattungssumme ausgeschlossen.",
+    "duplicatePill": "Duplikat",
+    "ineligiblePill": "Nicht erstattungsfähig",
+    "ineligibleLineTag": "nicht erstattungsfähig"
   }
 }

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -865,5 +865,11 @@
       "daysAgo": "{{count}}d ago",
       "recentRsvps": "Recent RSVPs"
     }
+  },
+  "payouts": {
+    "excludedNote": "Receipts or items marked Duplicate or Ineligible are excluded from your reimbursement total.",
+    "duplicatePill": "Duplicate",
+    "ineligiblePill": "Ineligible",
+    "ineligibleLineTag": "ineligible"
   }
 }

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -814,5 +814,11 @@
       "daysAgo": "hace {{count}} d",
       "recentRsvps": "Confirmaciones recientes"
     }
+  },
+  "payouts": {
+    "excludedNote": "Los recibos o artículos marcados como Duplicado o No elegible se excluyen del total de tu reembolso.",
+    "duplicatePill": "Duplicado",
+    "ineligiblePill": "No elegible",
+    "ineligibleLineTag": "no elegible"
   }
 }

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -814,5 +814,11 @@
       "daysAgo": "il y a {{count}} j",
       "recentRsvps": "Confirmations récentes"
     }
+  },
+  "payouts": {
+    "excludedNote": "Les reçus ou articles marqués comme Doublon ou Non éligible sont exclus du total de votre remboursement.",
+    "duplicatePill": "Doublon",
+    "ineligiblePill": "Non éligible",
+    "ineligibleLineTag": "non éligible"
   }
 }

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -814,5 +814,11 @@
       "daysAgo": "{{count}}日前",
       "recentRsvps": "最近のRSVP"
     }
+  },
+  "payouts": {
+    "excludedNote": "「重複」または「対象外」とマークされたレシートや項目は、払い戻し合計から除外されます。",
+    "duplicatePill": "重複",
+    "ineligiblePill": "対象外",
+    "ineligibleLineTag": "対象外"
   }
 }

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -770,5 +770,11 @@
     "eligible": "{{count}}명 응모 가능",
     "pickAWinnerBtn": "당첨자 뽑기",
     "winnersThisSession": "이번 세션 당첨자 ({{count}})"
+  },
+  "payouts": {
+    "excludedNote": "중복 또는 부적격으로 표시된 영수증이나 항목은 환급 합계에서 제외됩니다.",
+    "duplicatePill": "중복",
+    "ineligiblePill": "부적격",
+    "ineligibleLineTag": "부적격"
   }
 }

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -814,5 +814,11 @@
       "daysAgo": "há {{count}} d",
       "recentRsvps": "Confirmações recentes"
     }
+  },
+  "payouts": {
+    "excludedNote": "Recibos ou itens marcados como Duplicado ou Inelegível são excluídos do total do seu reembolso.",
+    "duplicatePill": "Duplicado",
+    "ineligiblePill": "Inelegível",
+    "ineligibleLineTag": "inelegível"
   }
 }

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -814,5 +814,11 @@
       "daysAgo": "{{count}} 天前",
       "recentRsvps": "最近的 RSVP"
     }
+  },
+  "payouts": {
+    "excludedNote": "标记为重复或不符合条件的收据或项目将从您的报销总额中扣除。",
+    "duplicatePill": "重复",
+    "ineligiblePill": "不符合条件",
+    "ineligibleLineTag": "不符合条件"
   }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1662,6 +1662,11 @@ export interface ReceiptLibraryEntry {
   uploadedByUserId: string | null;
   uploadedByName: string | null;
   uploadedByEmail: string | null;
+  // soppressata-92110: admin exclusion flags (read-only) so the host receipts
+  // library can dim + pill receipts excluded from the reimbursement total.
+  // Optional on the wire so older cached payloads still type-check.
+  isDuplicate?: boolean;
+  ineligible?: boolean;
   createdAt: string;
 }
 export type PayoutMethod = 'mercury_card' | 'wire' | 'usdc_base';


### PR DESCRIPTION
## What

Event hosts can now **see (read-only)** which receipts and OCR line items an admin marked **duplicate** (`is_duplicate`) or **ineligible** (`ineligible`). These flags exclude receipts/lines from the host's reimbursement total, but hosts previously got no indication of which/why.

### Changes
- **Backend** (`payout.routes.ts`): the two host serializers now expose the flags (additive fields only):
  - `serializeDocument` (used by `GET /:partyId/payouts` list + `GET /:partyId/payouts/:payoutId`) → `isDuplicate`, `ineligible`, `ocrLineItems`.
  - `GET /:partyId/payouts/receipts-library` map → `isDuplicate`, `ineligible`.
  - The host PATCH recompute (already excludes `isDuplicate || ineligible`) is **untouched**.
- **Frontend types**: added `isDuplicate?`/`ineligible?` to `ReceiptLibraryEntry` (`PayoutDocument` already had them).
- **Host UI** reuses the existing shared `ReceiptLightbox` which already renders the DUPLICATE (red 45°) / INELIGIBLE (amber 135°) banners + stripe overlays:
  - `PayoutDetailModal` — read-only lightbox banners for the current image, dimmed + striped + pilled flagged receipt rows, and an explanatory note. (No per-receipt line-item list exists in the read-only view, so no line-item grid was added.)
  - `ReceiptsLibrary` — same read-only lightbox banners + dimmed/pilled/striped flagged rows + note.
  - `PayoutsList` / `PayoutListRow` / shared `PayoutRow` only render a single summary thumbnail (pizza-first), not a per-receipt list → no change.
- **i18n**: new `payouts.*` keys (`excludedNote`, `duplicatePill`, `ineligiblePill`, `ineligibleLineTag`) added to all 8 host.json locales (de, en, es, fr, ja, ko, pt, zh).

### Read-only constraint
This is **display only**. No host write/toggle, no `D`-key duplicate shortcut, no editor pane is wired for hosts. Duplicate wins when both flags are set (`isIneligible` passed only when not also a duplicate), matching the admin convention.

### Deploy ordering
The new serializer fields are **additive** — deploy the backend (from master) **before** relying on the frontend preview, since previews talk to the production backend. No DB migration (columns `is_duplicate` / `ineligible` / `ocr_line_items` already exist in prod). No DB writes.

### Validation
- Frontend `tsc` introduces **zero new errors** (the only errors in changed files — STATUS_STYLES missing completed/queued + types.ts duplicate brandInstagram — are pre-existing on master).
- Backend `tsc --noEmit` clean for `payout.routes.ts` (other errors are pre-existing missing-module deps not installed in the worktree).
- All 8 host.json locales parse as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)