### PR TITLE
panzerotti-58931: party check-in game — Play/Leaderboard + Photo Game (Phase 1)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -281,6 +281,7 @@ model Party {
   quizQuestions           QuizQuestion[]
   slugAliases             SlugAlias[]
   scorecardItems          GuestScorecardItem[]
+  superlativeSubmissions  SuperlativeSubmission[]
   payouts                 Payout[]
   // agnolotti-58291: receipts are now party-level (PayoutDocument.partyId);
   // payout association is optional. Inverse relation lives here so cascading
@@ -474,6 +475,7 @@ model Guest {
   notableAttendees NotableAttendee[]
   quizAnswers      QuizAnswer[]
   scorecardItems   GuestScorecardItem[]
+  superlativeSubmissions SuperlativeSubmission[]
 
   // provolone-39042: peer/host/self attestations for check-in attribution
   attestationsReceived GuestAttestation[] @relation("AttestationsOfGuest")
@@ -1686,6 +1688,30 @@ model GuestScorecardItem {
   @@index([guestId, partyId])
   @@index([partyId])
   @@map("guest_scorecard_items")
+}
+
+// panzerotti-58931: superlative submissions (judged after the event in Phase 2).
+// Separate from scorecard items; worth 0 points until judged.
+model SuperlativeSubmission {
+  id      String @id @default(uuid()) @db.Uuid
+  guestId String @map("guest_id") @db.Uuid
+  guest   Guest  @relation(fields: [guestId], references: [id], onDelete: Cascade)
+  partyId String @map("party_id") @db.Uuid
+  party   Party  @relation(fields: [partyId], references: [id], onDelete: Cascade)
+
+  superlativeKey String  @map("superlative_key") @db.VarChar
+  photoUrl       String  @map("photo_url")
+  numericValue   Int?    @map("numeric_value")
+  status         String  @default("pending") @db.VarChar
+  judgedBy       String? @map("judged_by")
+  judgedAt       DateTime? @map("judged_at") @db.Timestamptz
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@unique([guestId, partyId, superlativeKey])
+  @@index([partyId])
+  @@index([superlativeKey, status])
+  @@map("superlative_submissions")
 }
 
 // ============================================

--- a/backend/src/routes/scorecard.routes.ts
+++ b/backend/src/routes/scorecard.routes.ts
@@ -15,9 +15,38 @@ const SCORECARD_ITEMS = [
   'join_telegram',
   'follow_pizzadao',
   'signup_pizzadao',
+  // panzerotti-58931: Photo Game challenges
+  'photo_box_stack',
+  'photo_host',
+  'photo_partner',
 ] as const;
 
 type ScorecardItemKey = typeof SCORECARD_ITEMS[number];
+
+// panzerotti-58931: map each item key to a game category. Used by the frontend
+// hub to split items between the "Missions" and "Photo Game" surfaces. No
+// schema change — category is derived server-side and attached to responses.
+const CATEGORY: Record<ScorecardItemKey, 'mission' | 'photo'> = {
+  post: 'mission',
+  vouch: 'mission',
+  join_telegram: 'mission',
+  follow_pizzadao: 'mission',
+  signup_pizzadao: 'mission',
+  photo: 'photo',
+  pizza_selfie: 'photo',
+  sign_pizza_box: 'photo',
+  photo_box_stack: 'photo',
+  photo_host: 'photo',
+  photo_partner: 'photo',
+};
+
+function categoryFor(itemKey: string): 'mission' | 'photo' | undefined {
+  return CATEGORY[itemKey as ScorecardItemKey];
+}
+
+// panzerotti-58931: superlative submission keys (separate table, not scorecard items)
+const SUPERLATIVE_KEYS = ['super_slices', 'super_cheese_pull', 'super_box_stack'] as const;
+type SuperlativeKey = typeof SUPERLATIVE_KEYS[number];
 
 // Helper: find party by inviteCode or customUrl
 async function findPartyByCode(inviteCode: string) {
@@ -126,7 +155,7 @@ router.get('/:inviteCode', requireAuth, async (req: AuthRequest, res: Response, 
     const completedCount = items.filter((item) => item.completed).length;
 
     res.json({
-      items,
+      items: items.map((item) => ({ ...item, category: categoryFor(item.itemKey) })),
       pizzaChefScore: completedCount,
       totalItems: SCORECARD_ITEMS.length,
     });
@@ -190,10 +219,141 @@ router.post('/:inviteCode/complete', requireAuth, async (req: AuthRequest, res: 
     const completedCount = allItems.filter((i) => i.completed).length;
 
     res.json({
-      item,
+      item: { ...item, category: categoryFor(item.itemKey) },
       pizzaChefScore: completedCount,
       totalItems: SCORECARD_ITEMS.length,
     });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/scorecard/:inviteCode/leaderboard — checked-in guests ranked by
+// completed-item count. panzerotti-58931.
+router.get('/:inviteCode/leaderboard', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { inviteCode } = req.params;
+
+    const party = await findPartyByCode(inviteCode);
+    if (!party) {
+      throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+    }
+
+    // Checked-in guests with their completed-item count. Rejected guests
+    // (approved=false) are excluded to mirror findGuestForUser.
+    const guests = await prisma.guest.findMany({
+      where: {
+        partyId: party.id,
+        checkedInAt: { not: null },
+        OR: [{ approved: true }, { approved: null }],
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        scorecardItems: {
+          where: { completed: true },
+          select: { id: true },
+        },
+      },
+    });
+
+    const callerEmail = req.userEmail?.toLowerCase();
+
+    const privacyName = (raw: string | null | undefined): string => {
+      const trimmed = (raw || '').trim();
+      if (!trimmed) return 'Guest';
+      const parts = trimmed.split(/\s+/);
+      const first = parts[0];
+      const lastInitial = parts.length > 1 ? parts[parts.length - 1][0] : '';
+      return lastInitial ? `${first} ${lastInitial.toUpperCase()}.` : first;
+    };
+
+    const leaderboard = guests
+      .map((g) => ({
+        guestId: g.id,
+        name: privacyName(g.name),
+        score: g.scorecardItems.length,
+        isCurrentUser: !!callerEmail && g.email?.toLowerCase() === callerEmail,
+      }))
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.name.localeCompare(b.name);
+      });
+
+    res.json({ leaderboard });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/scorecard/:inviteCode/superlative — submit a superlative entry for
+// later judging. Worth 0 points until judged (Phase 2). panzerotti-58931.
+router.post('/:inviteCode/superlative', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { inviteCode } = req.params;
+    const { superlativeKey, photoUrl, numericValue } = req.body;
+
+    if (!superlativeKey || !SUPERLATIVE_KEYS.includes(superlativeKey as SuperlativeKey)) {
+      throw new AppError(
+        `Invalid superlativeKey. Must be one of: ${SUPERLATIVE_KEYS.join(', ')}`,
+        400,
+        'VALIDATION_ERROR'
+      );
+    }
+
+    if (!photoUrl || typeof photoUrl !== 'string') {
+      throw new AppError('photoUrl is required', 400, 'VALIDATION_ERROR');
+    }
+
+    const party = await findPartyByCode(inviteCode);
+    if (!party) {
+      throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+    }
+
+    const guest = await findGuestForUser(party.id, req.userEmail);
+    if (!guest) {
+      throw new AppError('You must be an RSVPd guest to submit a superlative', 403, 'NOT_A_GUEST');
+    }
+
+    if (!guest.checkedInAt) {
+      throw new AppError('You must be checked in to submit a superlative', 403, 'NOT_CHECKED_IN');
+    }
+
+    let numeric: number | null = null;
+    if (numericValue !== undefined && numericValue !== null && numericValue !== '') {
+      const parsed = Number(numericValue);
+      numeric = Number.isFinite(parsed) ? Math.trunc(parsed) : null;
+    }
+
+    // UPSERT one row per (guestId, partyId, superlativeKey). Re-submit replaces
+    // the prior entry and resets status to 'pending'.
+    const row = await prisma.superlativeSubmission.upsert({
+      where: {
+        guestId_partyId_superlativeKey: {
+          guestId: guest.id,
+          partyId: party.id,
+          superlativeKey,
+        },
+      },
+      create: {
+        guestId: guest.id,
+        partyId: party.id,
+        superlativeKey,
+        photoUrl,
+        numericValue: numeric,
+        status: 'pending',
+      },
+      update: {
+        photoUrl,
+        numericValue: numeric,
+        status: 'pending',
+        judgedBy: null,
+        judgedAt: null,
+      },
+    });
+
+    res.json({ submission: row });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -1,7 +1,14 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Trophy, Loader2 } from 'lucide-react';
-import { getScorecard, completeScorecardItem, ScorecardItem as ScorecardItemType } from '../../lib/api';
+import { useState, useEffect, useCallback } from 'react';
+import { Trophy, Loader2, Camera, Gamepad2, ListChecks, ChevronLeft } from 'lucide-react';
+import {
+  getScorecard,
+  completeScorecardItem,
+  ScorecardItem as ScorecardItemType,
+  PublicEventSponsor,
+} from '../../lib/api';
 import { ScorecardItem, ScorecardItemKey } from './ScorecardItem';
+import { PhotoGameModal } from './PhotoGameModal';
+import { LeaderboardModal } from './LeaderboardModal';
 
 interface GuestScorecardProps {
   inviteCode: string;
@@ -16,18 +23,22 @@ interface GuestScorecardProps {
   partnerHandles?: string[];
   /** Per-event Telegram URL (normalized). Falls back to https://t.me/pizzadao when absent. */
   telegramUrl?: string | null;
+  /** panzerotti-58931: host display name, used in Photo Game prompts. */
+  hostName?: string | null;
+  /** panzerotti-58931: event sponsors, surfaced as Photo Game partner prompts. */
+  sponsors?: PublicEventSponsor[];
 }
 
-const ITEM_ORDER: ScorecardItemKey[] = [
+// Mission-category items, rendered via ScorecardItem in the Missions tile.
+const MISSION_ORDER: ScorecardItemKey[] = [
   'post',
-  'photo',
   'vouch',
-  'pizza_selfie',
-  'sign_pizza_box',
   'join_telegram',
   'follow_pizzadao',
   'signup_pizzadao',
 ];
+
+type View = 'hub' | 'play' | 'missions';
 
 export function GuestScorecard({
   inviteCode,
@@ -38,13 +49,19 @@ export function GuestScorecard({
   eventUrl,
   partnerHandles,
   telegramUrl,
+  hostName,
+  sponsors,
 }: GuestScorecardProps) {
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
-  const [totalItems, setTotalItems] = useState(8);
+  const [totalItems, setTotalItems] = useState(11);
   const [loading, setLoading] = useState(true);
   const [completingItem, setCompletingItem] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [view, setView] = useState<View>('hub');
+  const [showPhotoGame, setShowPhotoGame] = useState(false);
+  const [showLeaderboard, setShowLeaderboard] = useState(false);
 
   const fetchScorecard = useCallback(async () => {
     try {
@@ -77,23 +94,28 @@ export function GuestScorecard({
     fetchScorecard();
   }, [refreshSignal, fetchScorecard]);
 
-  const handleComplete = async (itemKey: ScorecardItemKey, proofUrl?: string, proofType?: string) => {
-    setCompletingItem(itemKey);
-    try {
-      const data = await completeScorecardItem(inviteCode, itemKey, proofUrl, proofType);
-      // Update local state
-      setItems((prev) =>
-        prev.map((item) =>
-          item.itemKey === itemKey ? data.item : item
-        )
-      );
-      setPizzaChefScore(data.pizzaChefScore);
-    } catch (err: any) {
-      console.error('Failed to complete scorecard item:', err);
-    } finally {
-      setCompletingItem(null);
-    }
-  };
+  const handleComplete = useCallback(
+    async (itemKey: ScorecardItemKey, proofUrl?: string, proofType?: string) => {
+      setCompletingItem(itemKey);
+      try {
+        const data = await completeScorecardItem(inviteCode, itemKey, proofUrl, proofType);
+        // Update local state (insert if not present, e.g. Photo Game keys)
+        setItems((prev) => {
+          const exists = prev.some((item) => item.itemKey === itemKey);
+          return exists
+            ? prev.map((item) => (item.itemKey === itemKey ? data.item : item))
+            : [...prev, data.item];
+        });
+        setPizzaChefScore(data.pizzaChefScore);
+      } catch (err: any) {
+        console.error('Failed to complete scorecard item:', err);
+        throw err;
+      } finally {
+        setCompletingItem(null);
+      }
+    },
+    [inviteCode]
+  );
 
   if (loading) {
     return (
@@ -108,7 +130,7 @@ export function GuestScorecard({
   if (error) return null;
 
   const isComplete = pizzaChefScore === totalItems;
-  const progressPercent = Math.round((pizzaChefScore / totalItems) * 100);
+  const progressPercent = totalItems > 0 ? Math.round((pizzaChefScore / totalItems) * 100) : 0;
 
   return (
     <div className="mt-6 border border-theme-stroke rounded-xl bg-theme-surface/50 overflow-hidden">
@@ -140,29 +162,116 @@ export function GuestScorecard({
         </p>
       </div>
 
-      {/* Items list */}
-      <div className="px-3 pb-3 space-y-1">
-        {ITEM_ORDER.map((key) => {
-          const item = items.find((i) => i.itemKey === key);
-          if (!item) return null;
-          return (
-            <div key={item.id} className="relative">
-              <ScorecardItem
-                itemKey={key}
-                completed={item.completed}
-                loading={completingItem === key}
-                onComplete={handleComplete}
-                onUploadPhoto={onUploadPhoto}
-                onScanGuest={onScanGuest}
-                onTakeSelfie={onTakeSelfie}
-                eventUrl={eventUrl}
-                partnerHandles={partnerHandles}
-                telegramUrl={telegramUrl}
-              />
+      <div className="px-3 pb-3">
+        {/* Hub: Play + Leaderboard */}
+        {view === 'hub' && (
+          <div className="grid grid-cols-2 gap-2 pt-1">
+            <button
+              onClick={() => setView('play')}
+              className="flex flex-col items-center gap-1.5 rounded-xl bg-[#ff393a] hover:bg-[#ff5a5b] py-4 text-[#ffffff] transition-colors"
+            >
+              <Gamepad2 className="w-6 h-6" />
+              <span className="text-sm font-semibold">Play</span>
+            </button>
+            <button
+              onClick={() => setShowLeaderboard(true)}
+              className="flex flex-col items-center gap-1.5 rounded-xl bg-white/10 hover:bg-white/15 py-4 text-white transition-colors"
+            >
+              <Trophy className="w-6 h-6 text-yellow-400" />
+              <span className="text-sm font-semibold">Leaderboard</span>
+            </button>
+          </div>
+        )}
+
+        {/* Play: three tiles */}
+        {view === 'play' && (
+          <div className="pt-1">
+            <button
+              onClick={() => setView('hub')}
+              className="mb-2 flex items-center gap-1 text-xs text-white/60 hover:text-white"
+            >
+              <ChevronLeft className="w-4 h-4" /> Back
+            </button>
+            <div className="space-y-2">
+              <button
+                onClick={() => setShowPhotoGame(true)}
+                className="flex w-full items-center gap-3 rounded-xl bg-white/5 hover:bg-white/10 px-3 py-3 text-left transition-colors"
+              >
+                <Camera className="w-5 h-5 text-[#ff393a]" />
+                <span className="flex-1 text-sm font-medium text-white">Photo Game</span>
+                <span className="text-xs text-white/40">Tap to play</span>
+              </button>
+
+              <div className="flex w-full items-center gap-3 rounded-xl bg-white/5 px-3 py-3 opacity-50">
+                <Gamepad2 className="w-5 h-5 text-white/50" />
+                <span className="flex-1 text-sm font-medium text-white">Mini Game</span>
+                <span className="text-xs text-white/40">Coming soon</span>
+              </div>
+
+              <button
+                onClick={() => setView('missions')}
+                className="flex w-full items-center gap-3 rounded-xl bg-white/5 hover:bg-white/10 px-3 py-3 text-left transition-colors"
+              >
+                <ListChecks className="w-5 h-5 text-[#ff393a]" />
+                <span className="flex-1 text-sm font-medium text-white">Missions</span>
+                <span className="text-xs text-white/40">Tap to play</span>
+              </button>
             </div>
-          );
-        })}
+          </div>
+        )}
+
+        {/* Missions: existing scorecard items (mission category) */}
+        {view === 'missions' && (
+          <div className="pt-1">
+            <button
+              onClick={() => setView('play')}
+              className="mb-2 flex items-center gap-1 text-xs text-white/60 hover:text-white"
+            >
+              <ChevronLeft className="w-4 h-4" /> Back
+            </button>
+            <div className="space-y-1">
+              {MISSION_ORDER.map((key) => {
+                const item = items.find((i) => i.itemKey === key);
+                if (!item) return null;
+                return (
+                  <div key={item.id} className="relative">
+                    <ScorecardItem
+                      itemKey={key}
+                      completed={item.completed}
+                      loading={completingItem === key}
+                      onComplete={handleComplete}
+                      onUploadPhoto={onUploadPhoto}
+                      onScanGuest={onScanGuest}
+                      onTakeSelfie={onTakeSelfie}
+                      eventUrl={eventUrl}
+                      partnerHandles={partnerHandles}
+                      telegramUrl={telegramUrl}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
+
+      {showPhotoGame && (
+        <PhotoGameModal
+          inviteCode={inviteCode}
+          hostName={hostName}
+          sponsors={sponsors}
+          items={items}
+          onComplete={handleComplete}
+          onClose={() => setShowPhotoGame(false)}
+        />
+      )}
+
+      {showLeaderboard && (
+        <LeaderboardModal
+          inviteCode={inviteCode}
+          onClose={() => setShowLeaderboard(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/scorecard/LeaderboardModal.tsx
+++ b/frontend/src/components/scorecard/LeaderboardModal.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Loader2, Trophy } from 'lucide-react';
+import { getPartyLeaderboard, LeaderboardEntry } from '../../lib/api';
+
+interface LeaderboardModalProps {
+  inviteCode: string;
+  onClose: () => void;
+}
+
+type Tab = 'party' | 'worldwide';
+
+export function LeaderboardModal({ inviteCode, onClose }: LeaderboardModalProps) {
+  const [tab, setTab] = useState<Tab>('party');
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await getPartyLeaderboard(inviteCode);
+        if (!cancelled) {
+          setEntries(data.leaderboard);
+          setError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message || 'Failed to load leaderboard');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [inviteCode]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md max-h-[85vh] overflow-y-auto rounded-2xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="sticky top-0 flex items-center justify-between border-b border-gray-200 bg-white px-5 py-4">
+          <h2 className="flex items-center gap-2 text-lg font-bold text-gray-900">
+            <Trophy className="h-5 w-5 text-yellow-500" /> Leaderboard
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-900"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-gray-200 px-3 pt-3">
+          <button
+            onClick={() => setTab('party')}
+            className={`rounded-t-lg px-4 py-2 text-sm font-medium ${
+              tab === 'party'
+                ? 'bg-gray-100 text-gray-900'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            This Party
+          </button>
+          <button
+            disabled
+            title="Coming soon"
+            className="cursor-not-allowed rounded-t-lg px-4 py-2 text-sm font-medium text-gray-300"
+          >
+            Worldwide
+          </button>
+        </div>
+
+        <div className="px-5 py-4">
+          {tab === 'party' && (
+            <>
+              {loading ? (
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+                </div>
+              ) : error ? (
+                <p className="py-6 text-center text-sm text-red-600">{error}</p>
+              ) : entries.length === 0 ? (
+                <p className="py-6 text-center text-sm text-gray-400">
+                  No checked-in guests yet.
+                </p>
+              ) : (
+                <ol className="space-y-1.5">
+                  {entries.map((entry, idx) => (
+                    <li
+                      key={entry.guestId}
+                      className={`flex items-center gap-3 rounded-xl px-3 py-2.5 ${
+                        entry.isCurrentUser
+                          ? 'border border-[#ff393a]/40 bg-[#ff393a]/10'
+                          : 'bg-gray-50'
+                      }`}
+                    >
+                      <span className="w-6 text-center text-sm font-bold text-gray-400">
+                        {idx + 1}
+                      </span>
+                      <span
+                        className={`flex-1 text-sm ${
+                          entry.isCurrentUser
+                            ? 'font-semibold text-gray-900'
+                            : 'text-gray-700'
+                        }`}
+                      >
+                        {entry.name}
+                        {entry.isCurrentUser && (
+                          <span className="ml-1.5 text-xs text-[#ff393a]">(you)</span>
+                        )}
+                      </span>
+                      <span className="text-sm font-bold text-gray-900">{entry.score}</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/scorecard/PhotoGameModal.tsx
+++ b/frontend/src/components/scorecard/PhotoGameModal.tsx
@@ -23,7 +23,7 @@ type PhotoChallengeKey = 'sign_pizza_box' | 'photo_box_stack' | 'photo_host' | '
 type SuperlativeKey = 'super_slices' | 'super_cheese_pull' | 'super_box_stack';
 
 const SUPERLATIVE_CONFIG: Record<SuperlativeKey, { label: string; emoji: string; numeric?: boolean }> = {
-  super_slices: { label: 'Most slices eaten', emoji: '🍕', numeric: true },
+  super_slices: { label: 'Most people with a slice', emoji: '🍕', numeric: true },
   super_cheese_pull: { label: 'Best cheese pull', emoji: '🧀' },
   super_box_stack: { label: 'Tallest box stack', emoji: '📦' },
 };
@@ -220,7 +220,7 @@ export function PhotoGameModal({
           {/* Superlatives */}
           <section>
             <h3 className="mb-1 text-sm font-semibold uppercase tracking-wide text-gray-500">
-              Superlatives
+              Best Of
             </h3>
             <p className="mb-2 text-xs text-gray-400">
               Submit your best shot — judged after the event.
@@ -269,7 +269,7 @@ export function PhotoGameModal({
                           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             setNumericValues((prev) => ({ ...prev, [key]: e.target.value }))
                           }
-                          placeholder="How many slices?"
+                          placeholder="How many people?"
                           className="text-sm"
                         />
                       </div>

--- a/frontend/src/components/scorecard/PhotoGameModal.tsx
+++ b/frontend/src/components/scorecard/PhotoGameModal.tsx
@@ -1,0 +1,296 @@
+import React, { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Loader2, Camera, Check, Hash } from 'lucide-react';
+import { uploadEventImage } from '../../lib/supabase';
+import {
+  submitSuperlative,
+  ScorecardItem as ScorecardItemType,
+  PublicEventSponsor,
+} from '../../lib/api';
+import { ScorecardItemKey } from './ScorecardItem';
+import { IconInput } from '../IconInput';
+
+interface PhotoGameModalProps {
+  inviteCode: string;
+  hostName?: string | null;
+  sponsors?: PublicEventSponsor[];
+  items: ScorecardItemType[];
+  onComplete: (itemKey: ScorecardItemKey, proofUrl?: string, proofType?: string) => Promise<void> | void;
+  onClose: () => void;
+}
+
+type PhotoChallengeKey = 'sign_pizza_box' | 'photo_box_stack' | 'photo_host' | 'photo_partner';
+type SuperlativeKey = 'super_slices' | 'super_cheese_pull' | 'super_box_stack';
+
+const SUPERLATIVE_CONFIG: Record<SuperlativeKey, { label: string; emoji: string; numeric?: boolean }> = {
+  super_slices: { label: 'Most slices eaten', emoji: '🍕', numeric: true },
+  super_cheese_pull: { label: 'Best cheese pull', emoji: '🧀' },
+  super_box_stack: { label: 'Tallest box stack', emoji: '📦' },
+};
+
+export function PhotoGameModal({
+  inviteCode,
+  hostName,
+  sponsors,
+  items,
+  onComplete,
+  onClose,
+}: PhotoGameModalProps) {
+  const [uploadingKey, setUploadingKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Superlatives submitted this session (keyed by superlative key)
+  const [submitted, setSubmitted] = useState<Record<string, boolean>>({});
+  // Numeric inputs for superlatives that need one
+  const [numericValues, setNumericValues] = useState<Record<string, string>>({});
+
+  const fileInputs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const isComplete = (key: string) => items.find((i) => i.itemKey === key)?.completed ?? false;
+
+  const PHOTO_CHALLENGES: { key: PhotoChallengeKey; label: string; emoji: string }[] = [
+    { key: 'sign_pizza_box', label: 'Photo of your signature on the box', emoji: '✍️' },
+    { key: 'photo_box_stack', label: 'Photo with the box stack', emoji: '📦' },
+    { key: 'photo_host', label: `Photo with ${hostName ?? 'the host'}`, emoji: '🧑‍🍳' },
+    { key: 'photo_partner', label: 'Photo with a partner', emoji: '🤝' },
+  ];
+
+  const triggerPicker = (key: string) => {
+    setError(null);
+    fileInputs.current[key]?.click();
+  };
+
+  const handleChallengeFile = async (
+    key: PhotoChallengeKey,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setUploadingKey(key);
+    setError(null);
+    try {
+      const url = await uploadEventImage(file);
+      if (!url) {
+        setError('Photo upload failed. Please try again.');
+        return;
+      }
+      await onComplete(key, url, 'photo_id');
+    } catch (err: any) {
+      setError(err?.message || 'Photo upload failed. Please try again.');
+    } finally {
+      setUploadingKey(null);
+    }
+  };
+
+  const handleSuperlativeFile = async (
+    key: SuperlativeKey,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setUploadingKey(key);
+    setError(null);
+    try {
+      const url = await uploadEventImage(file);
+      if (!url) {
+        setError('Photo upload failed. Please try again.');
+        return;
+      }
+      const rawNumeric = numericValues[key];
+      const numericValue =
+        SUPERLATIVE_CONFIG[key].numeric && rawNumeric ? Number(rawNumeric) : undefined;
+      await submitSuperlative(inviteCode, {
+        superlativeKey: key,
+        photoUrl: url,
+        numericValue: Number.isFinite(numericValue as number) ? numericValue : undefined,
+      });
+      setSubmitted((prev) => ({ ...prev, [key]: true }));
+    } catch (err: any) {
+      setError(err?.message || 'Submission failed. Please try again.');
+    } finally {
+      setUploadingKey(null);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md max-h-[85vh] overflow-y-auto rounded-2xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="sticky top-0 flex items-center justify-between border-b border-gray-200 bg-white px-5 py-4">
+          <h2 className="text-lg font-bold text-gray-900">Photo Game</h2>
+          <button
+            onClick={onClose}
+            className="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-900"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-6 px-5 py-4">
+          {error && (
+            <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
+          )}
+
+          {/* Challenges */}
+          <section>
+            <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+              Challenges
+            </h3>
+            <div className="space-y-2">
+              {PHOTO_CHALLENGES.map(({ key, label, emoji }) => {
+                const done = isComplete(key);
+                const busy = uploadingKey === key;
+                return (
+                  <div key={key}>
+                    <div
+                      className={`flex items-center gap-3 rounded-xl border px-3 py-3 ${
+                        done ? 'border-green-200 bg-green-50' : 'border-gray-200 bg-gray-50'
+                      }`}
+                    >
+                      <span className="text-2xl leading-none">{done ? '✅' : emoji}</span>
+                      <span
+                        className={`flex-1 text-sm ${
+                          done ? 'text-green-700' : 'text-gray-700'
+                        }`}
+                      >
+                        {label}
+                      </span>
+                      {done ? (
+                        <span className="flex items-center gap-1 text-xs font-medium text-green-600">
+                          <Check className="h-3.5 w-3.5" /> Done
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => triggerPicker(key)}
+                          disabled={busy}
+                          className="flex items-center gap-1.5 rounded-full bg-[#ff393a] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#ff5a5b] disabled:opacity-50"
+                        >
+                          {busy ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Camera className="h-3.5 w-3.5" />
+                          )}
+                          Upload
+                        </button>
+                      )}
+                    </div>
+                    {/* Partner prompts: show sponsor names/logos as hints */}
+                    {key === 'photo_partner' && !done && sponsors && sponsors.length > 0 && (
+                      <div className="ml-9 mt-1.5 flex flex-wrap items-center gap-2">
+                        {sponsors.map((s) => (
+                          <span
+                            key={s.id}
+                            className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                          >
+                            {s.logoUrl && (
+                              <img
+                                src={s.logoUrl}
+                                alt=""
+                                className="h-4 w-4 rounded-full object-contain"
+                              />
+                            )}
+                            {s.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <input
+                      ref={(el) => {
+                        fileInputs.current[key] = el;
+                      }}
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) => handleChallengeFile(key, e)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Superlatives */}
+          <section>
+            <h3 className="mb-1 text-sm font-semibold uppercase tracking-wide text-gray-500">
+              Superlatives
+            </h3>
+            <p className="mb-2 text-xs text-gray-400">
+              Submit your best shot — judged after the event.
+            </p>
+            <div className="space-y-2">
+              {(Object.keys(SUPERLATIVE_CONFIG) as SuperlativeKey[]).map((key) => {
+                const config = SUPERLATIVE_CONFIG[key];
+                const done = submitted[key];
+                const busy = uploadingKey === key;
+                return (
+                  <div
+                    key={key}
+                    className={`rounded-xl border px-3 py-3 ${
+                      done ? 'border-blue-200 bg-blue-50' : 'border-gray-200 bg-gray-50'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-2xl leading-none">{config.emoji}</span>
+                      <span className="flex-1 text-sm text-gray-700">{config.label}</span>
+                      {done ? (
+                        <span className="text-xs font-medium text-blue-600">
+                          Submitted — judged after the event
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => triggerPicker(key)}
+                          disabled={busy}
+                          className="flex items-center gap-1.5 rounded-full bg-gray-800 px-3 py-1.5 text-xs font-medium text-white hover:bg-gray-700 disabled:opacity-50"
+                        >
+                          {busy ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Camera className="h-3.5 w-3.5" />
+                          )}
+                          Submit
+                        </button>
+                      )}
+                    </div>
+                    {config.numeric && !done && (
+                      <div className="ml-9 mt-2">
+                        <IconInput
+                          icon={Hash}
+                          type="number"
+                          min={0}
+                          value={numericValues[key] ?? ''}
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                            setNumericValues((prev) => ({ ...prev, [key]: e.target.value }))
+                          }
+                          placeholder="How many slices?"
+                          className="text-sm"
+                        />
+                      </div>
+                    )}
+                    <input
+                      ref={(el) => {
+                        fileInputs.current[key] = el;
+                      }}
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) => handleSuperlativeFile(key, e)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/scorecard/ScorecardItem.tsx
+++ b/frontend/src/components/scorecard/ScorecardItem.tsx
@@ -13,7 +13,12 @@ export type ScorecardItemKey =
   | 'sign_pizza_box'
   | 'join_telegram'
   | 'follow_pizzadao'
-  | 'signup_pizzadao';
+  | 'signup_pizzadao'
+  // panzerotti-58931: Photo Game challenge keys (rendered by PhotoGameModal,
+  // not by ScorecardItem — included here so onComplete callers type-check).
+  | 'photo_box_stack'
+  | 'photo_host'
+  | 'photo_partner';
 
 interface ScorecardItemProps {
   itemKey: ScorecardItemKey;
@@ -40,6 +45,11 @@ const ITEM_CONFIG: Record<ScorecardItemKey, { label: string; emoji: string }> = 
   join_telegram: { label: "Join your city's PizzaDAO Telegram", emoji: 'tg' },
   follow_pizzadao: { label: 'Follow @pizza_dao', emoji: '🐦' },
   signup_pizzadao: { label: 'Sign up on pizzadao.org', emoji: '🌐' },
+  // panzerotti-58931: Photo Game challenges are rendered by PhotoGameModal, but
+  // configs are kept here so the Record type stays exhaustive.
+  photo_box_stack: { label: 'Photo with the box stack', emoji: '📦' },
+  photo_host: { label: 'Photo with the host', emoji: '🧑‍🍳' },
+  photo_partner: { label: 'Photo with a partner', emoji: '🤝' },
 };
 
 export function ScorecardItem({

--- a/frontend/src/components/scorecard/index.ts
+++ b/frontend/src/components/scorecard/index.ts
@@ -1,2 +1,4 @@
 export { GuestScorecard } from './GuestScorecard';
 export { ScorecardItem } from './ScorecardItem';
+export { PhotoGameModal } from './PhotoGameModal';
+export { LeaderboardModal } from './LeaderboardModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4185,6 +4185,8 @@ export interface ScorecardItem {
   metadata: Record<string, any>;
   createdAt: string;
   updatedAt: string;
+  /** panzerotti-58931: game category, derived server-side. */
+  category?: 'mission' | 'photo';
 }
 
 export interface ScorecardResponse {
@@ -4212,6 +4214,46 @@ export async function completeScorecardItem(
   return apiRequest<CompleteScorecardResponse>(`/api/scorecard/${inviteCode}/complete`, {
     method: 'POST',
     body: { itemKey, proofUrl, proofType },
+  });
+}
+
+// panzerotti-58931: party check-in game — leaderboard + superlatives
+
+export interface LeaderboardEntry {
+  guestId: string;
+  name: string;
+  score: number;
+  isCurrentUser: boolean;
+}
+
+export interface LeaderboardResponse {
+  leaderboard: LeaderboardEntry[];
+}
+
+export async function getPartyLeaderboard(inviteCode: string): Promise<LeaderboardResponse> {
+  return apiRequest<LeaderboardResponse>(`/api/scorecard/${inviteCode}/leaderboard`);
+}
+
+export interface SuperlativeSubmission {
+  id: string;
+  guestId: string;
+  partyId: string;
+  superlativeKey: string;
+  photoUrl: string;
+  numericValue: number | null;
+  status: string;
+  judgedBy: string | null;
+  judgedAt: string | null;
+  createdAt: string;
+}
+
+export async function submitSuperlative(
+  inviteCode: string,
+  body: { superlativeKey: string; photoUrl: string; numericValue?: number | null }
+): Promise<{ submission: SuperlativeSubmission }> {
+  return apiRequest<{ submission: SuperlativeSubmission }>(`/api/scorecard/${inviteCode}/superlative`, {
+    method: 'POST',
+    body,
   });
 }
 

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -1305,6 +1305,8 @@ export function EventPage() {
                     eventUrl={eventUrl}
                     partnerHandles={partnerHandles}
                     telegramUrl={telegramLink}
+                    hostName={event.hostName}
+                    sponsors={event.sponsors}
                   />
                 )}
 

--- a/supabase/migrations/20260603000000_create_superlative_submissions.sql
+++ b/supabase/migrations/20260603000000_create_superlative_submissions.sql
@@ -5,10 +5,12 @@ CREATE TABLE superlative_submissions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   guest_id uuid NOT NULL REFERENCES guests(id) ON DELETE CASCADE,
   party_id uuid NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
-  superlative_key varchar NOT NULL, -- 'super_slices', 'super_cheese_pull', 'super_box_stack'
+  -- superlative_key: 'super_slices' | 'super_cheese_pull' | 'super_box_stack'
+  superlative_key varchar NOT NULL,
   photo_url text NOT NULL,
   numeric_value int,
-  status varchar NOT NULL DEFAULT 'pending', -- 'pending', 'winner', 'rejected'
+  -- status: 'pending' | 'winner' | 'rejected'
+  status varchar NOT NULL DEFAULT 'pending',
   judged_by text,
   judged_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now(),

--- a/supabase/migrations/20260603000000_create_superlative_submissions.sql
+++ b/supabase/migrations/20260603000000_create_superlative_submissions.sql
@@ -1,0 +1,49 @@
+-- panzerotti-58931: superlative submissions for the party check-in game.
+-- Separate from guest_scorecard_items; entries are judged after the event
+-- (Phase 2) and are worth 0 points until then.
+CREATE TABLE superlative_submissions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  guest_id uuid NOT NULL REFERENCES guests(id) ON DELETE CASCADE,
+  party_id uuid NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  superlative_key varchar NOT NULL, -- 'super_slices', 'super_cheese_pull', 'super_box_stack'
+  photo_url text NOT NULL,
+  numeric_value int,
+  status varchar NOT NULL DEFAULT 'pending', -- 'pending', 'winner', 'rejected'
+  judged_by text,
+  judged_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (guest_id, party_id, superlative_key)
+);
+
+CREATE INDEX idx_superlative_party ON superlative_submissions(party_id);
+CREATE INDEX idx_superlative_key_status ON superlative_submissions(superlative_key, status);
+
+-- RLS policies (mirror guest_scorecard_items)
+ALTER TABLE superlative_submissions ENABLE ROW LEVEL SECURITY;
+
+-- Guests can read their own superlative submissions
+CREATE POLICY "Guests can read own superlative submissions"
+  ON superlative_submissions FOR SELECT
+  USING (auth.uid()::text IN (
+    SELECT g.id::text FROM guests g WHERE g.id = superlative_submissions.guest_id
+  ));
+
+-- Guests can insert their own superlative submissions
+CREATE POLICY "Guests can insert own superlative submissions"
+  ON superlative_submissions FOR INSERT
+  WITH CHECK (auth.uid()::text IN (
+    SELECT g.id::text FROM guests g WHERE g.id = superlative_submissions.guest_id
+  ));
+
+-- Guests can update their own superlative submissions
+CREATE POLICY "Guests can update own superlative submissions"
+  ON superlative_submissions FOR UPDATE
+  USING (auth.uid()::text IN (
+    SELECT g.id::text FROM guests g WHERE g.id = superlative_submissions.guest_id
+  ));
+
+-- Service role has full access (backend upsert + Phase 2 judging)
+CREATE POLICY "Service role full access superlatives"
+  ON superlative_submissions FOR ALL
+  USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Phase 1: Party check-in game

Reworks the post-check-in `GuestScorecard` into a game **hub** and adds the Photo Game + Leaderboard.

### Scoring model
Guest score = count of completed scorecard items (Missions + Photo Game categories). Superlatives are submitted now and judged in **Phase 2** — a submission is worth **0 points** until judged. Item→category mapping is derived server-side (no schema change):
- **mission**: `post`, `vouch`, `join_telegram`, `follow_pizzadao`, `signup_pizzadao`
- **photo**: `photo`, `pizza_selfie`, `sign_pizza_box`, `photo_box_stack`, `photo_host`, `photo_partner` (`sign_pizza_box` moved into the photo category and is now a photo-upload challenge)
- **superlative keys** (separate table): `super_slices`, `super_cheese_pull`, `super_box_stack`

### Backend
- `scorecard.routes.ts`: added `photo_box_stack`/`photo_host`/`photo_partner` to `SCORECARD_ITEMS`; added a `CATEGORY` map and attach `category` to each item in the GET and complete responses.
- **NEW** `GET /:inviteCode/leaderboard` — checked-in guests ranked by completed-item count; name privacy = first name + last initial; flags `isCurrentUser`.
- **NEW** `POST /:inviteCode/superlative` — validates key + photoUrl, guards on guest + checked-in (mirrors `/complete`), UPSERTs one row per (guest, party, key), resets status to `pending` on re-submit.
- New Prisma model `SuperlativeSubmission` (`@@map("superlative_submissions")`, unique on guest+party+key) + back-relations on `Guest`/`Party`.

### Frontend
- `GuestScorecard` is now a hub: Pizza Chef header + **Play** / **Leaderboard** buttons. Play reveals **Photo Game**, **Mini Game** (disabled, "Coming soon"), and **Missions** (mission-category items via existing `ScorecardItem`).
- New `PhotoGameModal` — photo-upload challenge tiles (partner tile renders sponsor names/logos as prompts) + superlative tiles (number input for `super_slices`; "Submitted — judged after the event" state). Uses `uploadEventImage`, surfaces upload errors.
- New `LeaderboardModal` — "This Party" tab (ranked list, highlights you) + disabled "Worldwide" stub.
- `api.ts`: `getPartyLeaderboard`, `submitSuperlative`, `category?` on `ScorecardItem`.
- `EventPage.tsx` passes `hostName` + `sponsors` into `GuestScorecard`.

### Migration
`supabase/migrations/20260603000000_create_superlative_submissions.sql` — **migration NOT yet applied to prod.** Apply before merge (preview frontends talk to the prod backend + DB; the leaderboard/superlative endpoints and the new photo item keys need the table + backend deploy live first).

### TODOs (for Phase 2 / for maintainer)
- [ ] Apply the migration SQL to prod (manual — no `_prisma_migrations` auto-apply in this repo).
- [ ] Deploy backend from master tip after merge (new endpoints + photo item keys).
- [ ] Phase 2: judging UI for superlatives (status → winner/rejected, scoring), and the "Worldwide" leaderboard.

### Preview
https://rsvpizza-git-panzerotti-58931-checkin-game-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)