### PR TITLE
montanara-58940: /underboss filter for submitted estimated guest counts

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -63,6 +63,7 @@ function computeProgress(party: any, underbossEmails: string[] = []) {
     hasPrepared: false, // manual step — always false for now
     hasSocialPosts: !!(party.xPostUrl || party.farcasterPostUrl),
     hasThrown: eventPassed && checkedInCount > 0,
+    hasEstimatedAttendance: party.estimatedAttendance != null,
   };
 }
 

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -35,6 +35,7 @@ const PROGRESS_FILTER_KEYS: { key: keyof UnderbossEventProgress; labelKey: strin
   { key: 'hasSponsors', labelKey: 'progress.partners' },
   { key: 'hasSocialPosts', labelKey: 'progress.social' },
   { key: 'hasThrown', labelKey: 'progress.thrown' },
+  { key: 'hasEstimatedAttendance', labelKey: 'progress.estimate' },
 ];
 
 function countProgress(event: UnderbossEvent): number {

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -35,7 +35,8 @@
     "budget": "Budget",
     "partners": "Partner",
     "social": "Social",
-    "thrown": "Durchgeführt"
+    "thrown": "Durchgeführt",
+    "estimate": "Schätzung"
   },
   "eventCard": {
     "hostedBy": "Veranstaltet von {{name}}",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -35,7 +35,8 @@
     "budget": "Budget",
     "partners": "Partners",
     "social": "Social",
-    "thrown": "Thrown"
+    "thrown": "Thrown",
+    "estimate": "Estimate"
   },
   "eventCard": {
     "hostedBy": "Hosted by {{name}}",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -35,7 +35,8 @@
     "budget": "Presupuesto",
     "partners": "Socios",
     "social": "Social",
-    "thrown": "Realizado"
+    "thrown": "Realizado",
+    "estimate": "Estimación"
   },
   "eventCard": {
     "hostedBy": "Organizado por {{name}}",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -35,7 +35,8 @@
     "budget": "Budget",
     "partners": "Partenaires",
     "social": "Réseaux",
-    "thrown": "Réalisé"
+    "thrown": "Réalisé",
+    "estimate": "Estimation"
   },
   "eventCard": {
     "hostedBy": "Organisé par {{name}}",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -35,7 +35,8 @@
     "budget": "予算",
     "partners": "パートナー",
     "social": "ソーシャル",
-    "thrown": "開催済み"
+    "thrown": "開催済み",
+    "estimate": "予想人数"
   },
   "eventCard": {
     "hostedBy": "主催：{{name}}",

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -35,7 +35,8 @@
     "budget": "예산",
     "partners": "파트너",
     "social": "소셜",
-    "thrown": "개최됨"
+    "thrown": "개최됨",
+    "estimate": "예상 인원"
   },
   "eventCard": {
     "hostedBy": "{{name}} 주최",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -35,7 +35,8 @@
     "budget": "Orçamento",
     "partners": "Parceiros",
     "social": "Social",
-    "thrown": "Realizado"
+    "thrown": "Realizado",
+    "estimate": "Estimativa"
   },
   "eventCard": {
     "hostedBy": "Organizado por {{name}}",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -35,7 +35,8 @@
     "budget": "预算",
     "partners": "合作伙伴",
     "social": "社交",
-    "thrown": "已举办"
+    "thrown": "已举办",
+    "estimate": "预估人数"
   },
   "eventCard": {
     "hostedBy": "由 {{name}} 主办",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1102,6 +1102,7 @@ export interface UnderbossEventProgress {
   hasPrepared: boolean;
   hasSocialPosts: boolean;
   hasThrown: boolean;
+  hasEstimatedAttendance: boolean;
 }
 
 export interface UnderbossEvent {


### PR DESCRIPTION
## Summary
Adds an "Estimate" three-state progress pill to the /underboss Events tab so underbosses can filter events/cities by whether the host submitted their estimated guest count.

"Submitted estimate" = `parties.estimated_attendance` (Prisma `estimatedAttendance`) is non-null. This is the host's dedicated checklist estimate — **not** `expected_guests`.

The change reuses the existing `PROGRESS_FILTER_KEYS` machinery (the Kit / Team / Venue / Budget / Partners / Social / Thrown pills). `EventTable` already renders a `FilterPill` for every key and filters generically on `e.progress[key]`, so this adds one boolean flag, one filter-key entry, and i18n labels — no new filter state or logic.

## Files changed
- `backend/src/routes/underboss.routes.ts` — `computeProgress` returns `hasEstimatedAttendance: party.estimatedAttendance != null`
- `frontend/src/types.ts` — `hasEstimatedAttendance: boolean` on `UnderbossEventProgress`
- `frontend/src/components/underboss/EventTable.tsx` — new `PROGRESS_FILTER_KEYS` entry `{ key: 'hasEstimatedAttendance', labelKey: 'progress.estimate' }`
- `frontend/src/i18n/locales/{de,en,es,fr,ja,ko,pt,zh}/partner.json` — `progress.estimate` label in all 8 locales

## Verification
- Frontend `npx tsc --noEmit`: clean (exit 0)
- Backend `npx tsc --noEmit`: no new errors; pre-existing failures are missing optional deps (sharp/openai/archiver) + a jwt test-file type mismatch, none in the edited file
- All 8 partner.json files validated as parseable JSON

⚠️ Backend deploy note: `computeProgress` is a backend change. Previews talk to the production backend, so the pill only works on the preview AFTER the backend is on master/deployed. Until then the field is undefined on preview (include→empty, exclude→all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)