### PR TITLE
feat(crescenza-92110): Re-run OCR button in receipt review panel

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -16,6 +16,7 @@
  */
 import { Router, Request, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../config/database.js';
 import {
   requireAuth,
@@ -5764,15 +5765,32 @@ router.post(
 
       if (runNow && existing.kind === 'receipt' && existing.url) {
         const { analyzeReceipt } = await import('../services/ocr.service.js');
+        const { convertToUSD } = await import('../services/fx.service.js');
         try {
+          // crescenza-92110: a full fresh re-read — amount + currency + line
+          // items — not just line items. Mirror the ocr-preview FX pattern in
+          // payout.routes.ts so the unresolved-currency case is handled
+          // identically (CURRENCY_UNRESOLVED, no synthetic USD value).
           const result = await analyzeReceipt(existing.url);
+          const fx = await convertToUSD(result.amount, result.currency);
+          const unresolved = fx.source === 'unresolved';
           await prisma.payoutDocument.update({
             where: { id: docId },
             data: {
               ocrLineItems: (result.lineItems ?? []) as unknown as Prisma.InputJsonValue,
+              ocrConfidence: new Decimal(result.confidence),
+              ocrRaw: { ocr: result.raw, fx: { source: fx.source, rate: fx.exchangeRate } } as Prisma.InputJsonValue,
+              // Even unresolved rows keep originalAmount — the admin needs to
+              // see what the receipt said so they can pick the right currency.
+              originalAmount: new Decimal(fx.originalAmount),
+              ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
+              ocrCurrency: unresolved ? null : fx.originalCurrency,
+              exchangeRate: unresolved
+                ? null
+                : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
+              ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
               ocrAttemptedAt: new Date(),
               ocrAttemptCount: { increment: 1 },
-              ocrError: null,
             },
           });
           ranInline = true;
@@ -5805,6 +5823,7 @@ router.post(
           ocrError: true,
           ocrAttemptedAt: true,
           ocrAttemptCount: true,
+          ocrLineItems: true,
           sortOrder: true,
         },
       });
@@ -5829,6 +5848,9 @@ router.post(
             ? updated.ocrAttemptedAt.toISOString()
             : null,
           ocrAttemptCount: updated.ocrAttemptCount,
+          ocrLineItems: Array.isArray(updated.ocrLineItems)
+            ? updated.ocrLineItems
+            : null,
           sortOrder: updated.sortOrder,
         },
         ranInline,

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -794,8 +794,41 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       const res = await retryPayoutDocumentOcr(docId, { runNow: true });
       if (res.inlineError) {
         setRetryErrors((m) => ({ ...m, [docId]: res.inlineError ?? 'OCR failed' }));
+      } else if (res.ranInline && res.document) {
+        // crescenza-92110: the inline re-run is now a FULL re-read (amount +
+        // currency + line items). Mirror the saveLineItemsEdit success path so
+        // the panel reflects the fresh OCR result in place without a parent
+        // refetch.
+        const fresh = res.document;
+        setReceiptOverrides((m) => ({
+          ...m,
+          [docId]: {
+            ...m[docId],
+            ocrAmount: fresh.ocrAmount,
+            ocrCurrency: fresh.ocrCurrency,
+            ocrLineItems: fresh.ocrLineItems,
+            originalAmount: fresh.originalAmount,
+            originalCurrency: fresh.originalCurrency,
+            exchangeRate: fresh.exchangeRate,
+          },
+        }));
+        // Re-seed line item drafts from the fresh array.
+        setLineItemDrafts((m) => ({
+          ...m,
+          [docId]: (fresh.ocrLineItems ?? []).map(lineItemToDraft),
+        }));
+        // Drop the stale amount/currency draft so the inputs reseed from the
+        // new override on the next render.
+        setReceiptDrafts((m) => {
+          const next = { ...m };
+          delete next[docId];
+          return next;
+        });
+        // Locally suppress any stale ocrError from payout.documents.
+        setRetryClearedErrors((m) => ({ ...m, [docId]: true }));
       } else if (res.ranInline) {
-        // Success — locally suppress the stale ocrError from payout.documents.
+        // Ran inline but no document payload (shouldn't happen) — at least
+        // clear the stale error.
         setRetryClearedErrors((m) => ({ ...m, [docId]: true }));
       }
     } catch (err: any) {

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -434,55 +434,68 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
         )}
       </div>
 
-      {/* OCR retry — only visible when the doc errored. Keeps parity with
-          the right-pane row's per-row retry affordance (pancetta-92104). */}
+      {/* OCR error notice — only the amber message when the doc errored. The
+          re-run trigger itself lives next to the Line items header below
+          (crescenza-92110) so there's a single always-available button. */}
       {hasOcrError && onRetryOcr && (
-        <div className="rounded-lg border border-theme-stroke p-3 bg-theme-bg space-y-2">
+        <div className="rounded-lg border border-theme-stroke p-3 bg-theme-bg">
           <div className="text-xs text-amber-500 flex items-start gap-1.5">
             <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
             <span>{doc.ocrError || 'OCR failed for this receipt.'}</span>
           </div>
-          <button
-            type="button"
-            onClick={onRetryOcr}
-            disabled={retrying}
-            className="px-3 py-1.5 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center gap-1.5"
-          >
-            {retrying ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <RefreshCw size={12} />
-            )}
-            Retry OCR
-          </button>
-          {retryError && (
-            <div className="text-xs text-red-300">{retryError}</div>
-          )}
         </div>
       )}
 
       {/* Line items */}
       <div className="space-y-2">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <h4 className="text-sm font-semibold">
             Line items ({lineItemDrafts?.length ?? 0})
           </h4>
-          <span className="text-xs text-theme-text-muted">
-            Sum: {sumCurrency} {lineSum.toFixed(2)}
-            {/* provola-92106: when ineligible lines exist, note how many
-                were excluded from the live sum so admins see the math is
-                doing what they expect. */}
-            {(() => {
-              const ineligibleCount = (lineItemDrafts ?? []).filter(
-                (li) => li.ineligible === true,
-              ).length;
-              return ineligibleCount > 0 ? (
-                <span className="ml-1 text-amber-400">
-                  ({ineligibleCount} ineligible excluded)
-                </span>
-              ) : null;
-            })()}
-          </span>
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-2">
+              {/* crescenza-92110: always-available full re-read (amount +
+                  currency + line items). Triggers analyzeReceipt fresh even on
+                  a successfully-OCR'd receipt that came back with 0 line
+                  items. */}
+              {onRetryOcr && (
+                <button
+                  type="button"
+                  onClick={onRetryOcr}
+                  disabled={retrying}
+                  className="px-2.5 py-1 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center gap-1.5 flex-shrink-0"
+                >
+                  {retrying ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : (
+                    <RefreshCw size={12} />
+                  )}
+                  Re-run OCR
+                </button>
+              )}
+              <span className="text-xs text-theme-text-muted">
+                Sum: {sumCurrency} {lineSum.toFixed(2)}
+                {/* provola-92106: when ineligible lines exist, note how many
+                    were excluded from the live sum so admins see the math is
+                    doing what they expect. */}
+                {(() => {
+                  const ineligibleCount = (lineItemDrafts ?? []).filter(
+                    (li) => li.ineligible === true,
+                  ).length;
+                  return ineligibleCount > 0 ? (
+                    <span className="ml-1 text-amber-400">
+                      ({ineligibleCount} ineligible excluded)
+                    </span>
+                  ) : null;
+                })()}
+              </span>
+            </div>
+            {onRetryOcr && retryError && (
+              <div className="text-xs text-red-300 text-right max-w-[240px]">
+                {retryError}
+              </div>
+            )}
+          </div>
         </div>
         <div className="rounded-lg border border-theme-stroke bg-theme-bg p-2 space-y-1.5 max-h-80 overflow-y-auto">
           {/* Column headers. Widths mirror the input row below so each label

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4557,6 +4557,7 @@ export async function retryPayoutDocumentOcr(
     ocrError: string | null;
     ocrAttemptedAt: string | null;
     ocrAttemptCount: number;
+    ocrLineItems: ReceiptLineItem[] | null;
     sortOrder: number;
   } | null;
   ranInline: boolean;


### PR DESCRIPTION
## Summary

Adds an always-visible **Re-run OCR** button next to the "Line items (N)" header in the admin receipt-review panel. Previously OCR could only be re-triggered via the "Retry OCR" button that appeared *only* when OCR errored (`hasOcrError`). On a successfully-OCR'd receipt that came back with 0 line items (e.g. 98% confidence, no items parsed) there was no way to request a fresh read. The new button triggers a **full** fresh read — amount + currency + line items — and updates the panel in place.

## Changes (4 files)

1. **`backend/src/routes/admin-payout.routes.ts`** — the `POST /documents/:docId/retry-ocr` inline-success branch is now a full re-read. After `analyzeReceipt`, it runs `convertToUSD` and writes the full set (`ocrLineItems`, `ocrConfidence`, `ocrRaw`, `originalAmount`, and resolved/unresolved `ocrAmount`/`ocrCurrency`/`exchangeRate`/`ocrError`) using the verbatim unresolved-currency pattern from the `ocr-preview` handler in `payout.routes.ts`. `ocrLineItems` is added to the response `select` and emitted in the JSON. Only the `payout_documents` row is touched — the parent payout total is **not** recomputed (same contract as the per-receipt PATCH). Added the `Decimal` import.

2. **`frontend/src/lib/api.ts`** — `retryPayoutDocumentOcr` return type gains `ocrLineItems: ReceiptLineItem[] | null`.

3. **`frontend/src/components/payments-admin/ReceiptEditor.tsx`** — the amber error block now shows *only* the error message when `hasOcrError`; the trigger moved to a compact **Re-run OCR** button next to the Line items header, available whenever `onRetryOcr` is provided. Reuses the existing `RefreshCw`/`Loader2` spinner + `retrying`/`retryError` pattern. Single trigger — no stacked duplicate buttons.

4. **`frontend/src/components/payments-admin/PayoutReviewModal.tsx`** — `retryOcr` now mirrors `saveLineItemsEdit`'s success path on `ranInline && document`: writes `receiptOverrides` (amount/currency/lineItems/original/exchangeRate), re-seeds `lineItemDrafts`, drops the stale `receiptDrafts` entry so inputs reseed, and keeps the `retryClearedErrors` + error/catch branches.

## Build
- `cd frontend && npm run build` — passes (tsc + vite).
- `cd backend && npx tsc --noEmit` — clean (only the pre-existing `auth.test.ts` jsonwebtoken typing error, unrelated to this change).

## Preview
`https://rsvpizza-git-crescenza-92110-rerun-ocr-button-pizza-dao.vercel.app`

⚠️ **Backend deploys from master only.** The full-read behavior (amount + currency re-derivation) is **not live on preview** until this is merged and the backend is deployed. The always-visible button still ships safely against prod first: it refreshes line items via the existing endpoint, and the new `ocrLineItems` response field is handled as `null` when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)