### PR TITLE
fix(crescenza-92110): retry-ocr currency resolution (party country hint)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -5754,7 +5754,7 @@ router.post(
 
       const existing = await prisma.payoutDocument.findUnique({
         where: { id: docId },
-        select: { id: true, url: true, kind: true },
+        select: { id: true, url: true, kind: true, party: { select: { country: true } } },
       });
       if (!existing) {
         throw new AppError('Document not found', 404, 'NOT_FOUND');
@@ -5782,7 +5782,13 @@ router.post(
           // items — not just line items. Mirror the ocr-preview FX pattern in
           // payout.routes.ts so the unresolved-currency case is handled
           // identically (CURRENCY_UNRESOLVED, no synthetic USD value).
-          const result = await analyzeReceipt(existing.url);
+          // crescenza-92110: pass the party country prior (same as ocr-preview)
+          // so ambiguous-currency receipts (e.g. EGP) resolve instead of
+          // nulling the amount with CURRENCY_UNRESOLVED.
+          const result = await analyzeReceipt({
+            imageUrl: existing.url,
+            partyCountry: existing.party?.country ?? null,
+          });
           const fx = await convertToUSD(result.amount, result.currency);
           const unresolved = fx.source === 'unresolved';
           await prisma.payoutDocument.update({


### PR DESCRIPTION
Follow-up to #803. The admin **Re-run OCR** endpoint wasn't passing the party-country hint to `analyzeReceipt`, so ambiguous-currency receipts (e.g. an Egyptian EGP receipt) resolved to `CURRENCY_UNRESOLVED` and lost their amount on re-run.

Now selects the doc's `party.country` (PayoutDocument has a direct party relation) and forwards it to `analyzeReceipt`, matching the `ocr-preview` upload path.

- `backend/src/routes/admin-payout.routes.ts` — retry-ocr handler only: add `party.country` to the `existing` select, pass `{ imageUrl, partyCountry }` to `analyzeReceipt`.
- Backend `tsc` clean (except the pre-existing, unrelated `auth.test.ts` jsonwebtoken typing error).
- Backend deploys from master only — will be redeployed from master tip after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)