### PR TITLE
feat(bufalina-60733): fake-detection risk badge on payments + send gate

### DIFF
--- a/backend/src/lib/fakeDetectionScan.ts
+++ b/backend/src/lib/fakeDetectionScan.ts
@@ -1,0 +1,160 @@
+/**
+ * Shared fake-detection scan helper (bufalina-60733).
+ *
+ * Extracted from `GET /api/underboss/fake-detection` so both the underboss
+ * review queue and the payments-admin badge feed score parties through one
+ * code path.
+ *
+ * `scorePartiesByIds(partyIds?)`:
+ *  - runs the cross-event sybil-wallet pre-pass,
+ *  - fetches the full party + guest + linkClick + funnel select used by the
+ *    underboss queue,
+ *  - scores each party via `scoreEvent`,
+ *  - returns the same `FakeDetectionRow[]` shape `scoreEvent` produces.
+ *
+ * When `partyIds` is provided, the `findMany` is scoped to those ids (still
+ * gpp-only); otherwise it behaves exactly as the all-gpp underboss feed.
+ */
+import { prisma } from '../config/database.js';
+import {
+  scoreEvent,
+  buildSybilWalletSet,
+  type FakeDetectionRow,
+} from './fakeDetection.js';
+
+/**
+ * Cross-event sybil-wallet pre-pass. A wallet is "sybil" when it appears on ≥4
+ * distinct events under ≥2 distinct trimmed-lower names. Exported so the
+ * underboss feed can still report `meta.sybilWalletCount` without duplicating
+ * the query.
+ */
+export async function buildSybilWalletSetFromDb(): Promise<Set<string>> {
+  const sybilRows = await prisma.$queryRaw<
+    Array<{ ethereum_address: string; party_ids: string[]; names: string[] }>
+  >`
+    SELECT
+      lower(ethereum_address) AS ethereum_address,
+      array_agg(DISTINCT party_id::text) AS party_ids,
+      array_agg(DISTINCT lower(trim(name))) AS names
+    FROM guests
+    WHERE ethereum_address IS NOT NULL
+      AND submitted_via IN ('link','rsvp','api')
+    GROUP BY lower(ethereum_address)
+    HAVING COUNT(DISTINCT party_id) >= 4
+  `;
+  return buildSybilWalletSet(
+    sybilRows.map(r => ({
+      ethereumAddress: r.ethereum_address,
+      partyIds: r.party_ids,
+      names: r.names,
+    })),
+  );
+}
+
+export async function scorePartiesByIds(
+  partyIds?: string[],
+  precomputedSybilWallets?: Set<string>,
+): Promise<FakeDetectionRow[]> {
+  const sybilWallets =
+    precomputedSybilWallets ?? (await buildSybilWalletSetFromDb());
+
+  const whereClause =
+    partyIds && partyIds.length > 0
+      ? { eventType: 'gpp' as const, id: { in: partyIds } }
+      : { eventType: 'gpp' as const };
+
+  const parties = await prisma.party.findMany({
+    where: whereClause,
+    select: {
+      id: true,
+      name: true,
+      customUrl: true,
+      country: true,
+      region: true,
+      timezone: true,
+      maxGuests: true,
+      createdAt: true,
+      underbossStatus: true,
+      coHosts: true,
+      user: { select: { id: true, name: true, email: true } },
+      guests: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          ethereumAddress: true,
+          submittedAt: true,
+          submittedVia: true,
+          waitlistPosition: true,
+          walletSource: true,
+          likedToppings: true,
+          dislikedToppings: true,
+          likedBeverages: true,
+          dislikedBeverages: true,
+          dietaryRestrictions: true,
+          roles: true,
+          pizzeriaRankings: true,
+          suggestedPizzerias: true,
+          mailingListOptIn: true,
+          visitorSessionId: true,
+          emailStatus: true,
+        },
+      },
+      linkClicks: {
+        select: { clickedAt: true },
+      },
+      rsvpFunnelEvents: {
+        select: { visitorHash: true, step: true, createdAt: true },
+      },
+    },
+  });
+
+  return parties.map(p =>
+    scoreEvent(
+      {
+        id: p.id,
+        name: p.name,
+        customUrl: p.customUrl,
+        country: p.country,
+        region: p.region,
+        timezone: p.timezone,
+        maxGuests: p.maxGuests,
+        createdAt: p.createdAt ?? new Date(0),
+        underbossStatus: p.underbossStatus ?? null,
+        user: p.user
+          ? { id: p.user.id, name: p.user.name, email: p.user.email }
+          : null,
+        coHosts: p.coHosts,
+      },
+      p.guests.map(g => ({
+        id: g.id,
+        name: g.name,
+        email: g.email,
+        ethereumAddress: g.ethereumAddress,
+        submittedAt: g.submittedAt,
+        submittedVia: g.submittedVia,
+        waitlistPosition: g.waitlistPosition,
+        walletSource: g.walletSource,
+        likedToppings: g.likedToppings,
+        dislikedToppings: g.dislikedToppings,
+        likedBeverages: g.likedBeverages,
+        dislikedBeverages: g.dislikedBeverages,
+        dietaryRestrictions: g.dietaryRestrictions,
+        roles: g.roles,
+        pizzeriaRankings: g.pizzeriaRankings,
+        suggestedPizzerias: g.suggestedPizzerias,
+        mailingListOptIn: g.mailingListOptIn,
+        visitorSessionId: g.visitorSessionId,
+        emailStatus: g.emailStatus,
+      })),
+      p.linkClicks.map(c => ({ clickedAt: c.clickedAt })),
+      sybilWallets,
+      p.maxGuests,
+      p.rsvpFunnelEvents.map(e => ({
+        visitorHash: e.visitorHash,
+        step: e.step,
+        createdAt: e.createdAt,
+      })),
+    ),
+  );
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -46,6 +46,7 @@ import {
   parseRegionsQuery,
   type RegionalAuthRequest,
 } from '../middleware/regionalUnderboss.js';
+import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
 
 const router = Router();
 
@@ -2191,6 +2192,77 @@ router.get(
       });
 
       res.json({ rows: filteredRows, total: filteredRows.length });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ============================================
+// bufalina-60733: POST /api/admin/payouts/fake-detection-scores
+//
+// Surfaces each GPP party's existing fake-detection risk score (the same
+// scorer that backs /underboss's review queue) as a compact map for the
+// payments-admin by-city table badges + the send-payment confirmation gate.
+//
+// Body: { partyIds: string[] }  (string array, capped at 500).
+// Response: { scores: Record<partyId, { score, tier, topFlags }> }
+//   - `topFlags` = up to 3 fired-flag `detail` strings, highest weight first.
+//   - tier `clean` entries (score < 10) are OMITTED to keep the payload small;
+//     the frontend badge self-hides for anything below `medium` anyway.
+//
+// Auth: `requireAdminOrRegionalUnderboss()` — the SAME guard the by-party feed
+// uses — NOT the underboss `__admin__`-only gate, so regional underbosses who
+// drive the regional payment portals don't 403. This is a pure-read endpoint.
+//
+// Literal `/fake-detection-scores` MUST be declared before `/:id`.
+// ============================================
+router.post(
+  '/fake-detection-scores',
+  requireAuth,
+  requireAdminOrRegionalUnderboss(),
+  async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as { partyIds?: unknown };
+      const partyIds = body?.partyIds;
+      if (
+        !Array.isArray(partyIds) ||
+        !partyIds.every(id => typeof id === 'string')
+      ) {
+        throw new AppError(
+          'partyIds must be an array of strings',
+          400,
+          'INVALID_PARTY_IDS',
+        );
+      }
+      if (partyIds.length > 500) {
+        throw new AppError(
+          'partyIds may contain at most 500 ids',
+          400,
+          'TOO_MANY_PARTY_IDS',
+        );
+      }
+
+      const scores: Record<
+        string,
+        { score: number; tier: string; topFlags: string[] }
+      > = {};
+
+      if (partyIds.length > 0) {
+        const rows = await scorePartiesByIds(partyIds);
+        for (const r of rows) {
+          // Omit clean events to keep the payload small.
+          if (r.tier === 'clean') continue;
+          const topFlags = r.flags
+            .filter(f => f.fired)
+            .sort((a, b) => b.weight - a.weight)
+            .slice(0, 3)
+            .map(f => f.detail);
+          scores[r.id] = { score: r.score, tier: r.tier, topFlags };
+        }
+      }
+
+      res.json({ scores });
     } catch (error) {
       next(error);
     }

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -8,7 +8,7 @@ import { addPartnerToParty, removePartnerFromParty, getAutoCoHostPartners } from
 import { setDeleteContext } from '../helpers/auditContext.js';
 import { buildScopedWhereClause, partyMatchesScope, UnderbossScope } from '../helpers/underbossScope.js';
 import { writeStatusAudit, ActorKind } from '../helpers/statusAudit.js';
-import { scoreEvent, buildSybilWalletSet } from '../lib/fakeDetection.js';
+import { scorePartiesByIds, buildSybilWalletSetFromDb } from '../lib/fakeDetectionScan.js';
 
 // Re-export the request type under the local name used throughout this file
 type UnderbossRequest = UnderbossAuthRequest;
@@ -399,126 +399,10 @@ router.get('/fake-detection', requireAuth, requireUnderbossAuth, async (req: Und
       throw new AppError('Admin access required', 403, 'FORBIDDEN');
     }
 
-    // Admin-only: see all GPP events.
-    const whereClause: { eventType: 'gpp' } = { eventType: 'gpp' };
-
-    // Cross-event wallet pre-pass — one raw query, then Set lookup per event.
-    // A wallet is "sybil" when it appears on ≥4 distinct events under ≥2 distinct trimmed-lower names.
-    const sybilRows = await prisma.$queryRaw<
-      Array<{ ethereum_address: string; party_ids: string[]; names: string[] }>
-    >`
-      SELECT
-        lower(ethereum_address) AS ethereum_address,
-        array_agg(DISTINCT party_id::text) AS party_ids,
-        array_agg(DISTINCT lower(trim(name))) AS names
-      FROM guests
-      WHERE ethereum_address IS NOT NULL
-        AND submitted_via IN ('link','rsvp','api')
-      GROUP BY lower(ethereum_address)
-      HAVING COUNT(DISTINCT party_id) >= 4
-    `;
-    const sybilWallets = buildSybilWalletSet(
-      sybilRows.map(r => ({
-        ethereumAddress: r.ethereum_address,
-        partyIds: r.party_ids,
-        names: r.names,
-      })),
-    );
-
-    const parties = await prisma.party.findMany({
-      where: whereClause,
-      select: {
-        id: true,
-        name: true,
-        customUrl: true,
-        country: true,
-        region: true,
-        timezone: true,
-        maxGuests: true,
-        createdAt: true,
-        underbossStatus: true,
-        coHosts: true,
-        user: { select: { id: true, name: true, email: true } },
-        guests: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            ethereumAddress: true,
-            submittedAt: true,
-            submittedVia: true,
-            waitlistPosition: true,
-            walletSource: true,
-            likedToppings: true,
-            dislikedToppings: true,
-            likedBeverages: true,
-            dislikedBeverages: true,
-            dietaryRestrictions: true,
-            roles: true,
-            pizzeriaRankings: true,
-            suggestedPizzerias: true,
-            mailingListOptIn: true,
-            visitorSessionId: true,
-            emailStatus: true,
-          },
-        },
-        linkClicks: {
-          select: { clickedAt: true },
-        },
-        rsvpFunnelEvents: {
-          select: { visitorHash: true, step: true, createdAt: true },
-        },
-      },
-    });
-
-    const rows: ReturnType<typeof scoreEvent>[] = parties.map(p =>
-      scoreEvent(
-        {
-          id: p.id,
-          name: p.name,
-          customUrl: p.customUrl,
-          country: p.country,
-          region: p.region,
-          timezone: p.timezone,
-          maxGuests: p.maxGuests,
-          createdAt: p.createdAt ?? new Date(0),
-          underbossStatus: p.underbossStatus ?? null,
-          user: p.user
-            ? { id: p.user.id, name: p.user.name, email: p.user.email }
-            : null,
-          coHosts: p.coHosts,
-        },
-        p.guests.map(g => ({
-          id: g.id,
-          name: g.name,
-          email: g.email,
-          ethereumAddress: g.ethereumAddress,
-          submittedAt: g.submittedAt,
-          submittedVia: g.submittedVia,
-          waitlistPosition: g.waitlistPosition,
-          walletSource: g.walletSource,
-          likedToppings: g.likedToppings,
-          dislikedToppings: g.dislikedToppings,
-          likedBeverages: g.likedBeverages,
-          dislikedBeverages: g.dislikedBeverages,
-          dietaryRestrictions: g.dietaryRestrictions,
-          roles: g.roles,
-          pizzeriaRankings: g.pizzeriaRankings,
-          suggestedPizzerias: g.suggestedPizzerias,
-          mailingListOptIn: g.mailingListOptIn,
-          visitorSessionId: g.visitorSessionId,
-          emailStatus: g.emailStatus,
-        })),
-        p.linkClicks.map(c => ({ clickedAt: c.clickedAt })),
-        sybilWallets,
-        p.maxGuests,
-        p.rsvpFunnelEvents.map(e => ({
-          visitorHash: e.visitorHash,
-          step: e.step,
-          createdAt: e.createdAt,
-        })),
-      ),
-    );
+    // Admin-only: score all GPP events via the shared scan helper.
+    // Compute the sybil set once so we can still report its count in meta.
+    const sybilWallets = await buildSybilWalletSetFromDb();
+    const rows = await scorePartiesByIds(undefined, sybilWallets);
 
     rows.sort((a, b) => b.score - a.score);
 

--- a/frontend/src/components/payments-admin/FakeDetectionBadge.tsx
+++ b/frontend/src/components/payments-admin/FakeDetectionBadge.tsx
@@ -1,0 +1,48 @@
+/**
+ * FakeDetectionBadge (bufalina-60733)
+ *
+ * Two-level caution badge for a GPP party's fake-detection risk score, shown
+ * in the payments-admin by-city header pill strip next to the SWC Hub /
+ * "Possible scam" pills.
+ *
+ * Renders NOTHING unless tier is `medium` (amber) or `high` (red) — clean/low
+ * parties get no badge. Tooltip (native `title`) shows the score line plus the
+ * top fired-flag details, one per line.
+ *
+ * v1 is a non-link span (no deep link into the underboss queue).
+ */
+import { AlertTriangle } from 'lucide-react';
+
+export interface FakeDetectionBadgeProps {
+  score: number;
+  /** 'high' | 'medium' | 'low' | 'clean' — widened to string to match the
+   *  compact server payload (`tier: string`). Anything but medium/high renders
+   *  nothing. */
+  tier: string;
+  topFlags: string[];
+  customUrl?: string | null;
+}
+
+export function FakeDetectionBadge({
+  score,
+  tier,
+  topFlags,
+}: FakeDetectionBadgeProps) {
+  if (tier !== 'medium' && tier !== 'high') return null;
+
+  const className =
+    tier === 'high'
+      ? 'inline-flex items-center gap-1 text-[11px] text-red-500 px-1.5 py-0.5 rounded-full bg-red-500/10 border border-red-500/40'
+      : 'inline-flex items-center gap-1 text-[11px] text-amber-300 px-1.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/30';
+
+  const tooltip =
+    `Fake-detection risk ${score}/100 (${tier})` +
+    (topFlags.length > 0 ? '\n' + topFlags.map(f => `• ${f}`).join('\n') : '');
+
+  return (
+    <span className={className} title={tooltip}>
+      <AlertTriangle size={11} />
+      Risk {score} ({tier})
+    </span>
+  );
+}

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -69,6 +69,7 @@ import {
   type ReceiptDraft,
   type LineItemDraft,
 } from './ReceiptEditor';
+import { FakeDetectionBadge } from './FakeDetectionBadge';
 
 /**
  * ricotta-92104: split party.photos into "Pizza photos" (tag === 'Pizza' —
@@ -202,6 +203,12 @@ interface PayoutsByPartyTableProps {
    * skipped server-side with `groupReason: 'no city TG group set'`.
    */
   cityGroupChatIds?: Map<string, string>;
+  /**
+   * bufalina-60733: fake-detection risk scores keyed by party id. Only
+   * medium/high (≥30) parties are present; an absent key means "no badge".
+   * Rendered as a caution pill in the city header strip.
+   */
+  fakeScores?: Record<string, { score: number; tier: string; topFlags: string[] }>;
   viewerRole?: 'admin' | 'underboss';
   busyRowId?: string | null;
   loading?: boolean;
@@ -2489,6 +2496,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onTgReminderResult,
   onTgWalletReminderResult,
   cityGroupChatIds,
+  fakeScores,
   viewerRole = 'admin',
   busyRowId,
   loading,
@@ -2922,6 +2930,17 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                             SWC Hub
                           </span>
                         )}
+                        {/* bufalina-60733: fake-detection risk badge. Self-hides
+                            unless the party scored medium (amber ≥30) or high
+                            (red ≥60). Tooltip lists the top fired flags. */}
+                        <FakeDetectionBadge
+                          {...(fakeScores?.[row.party.id] ?? {
+                            score: 0,
+                            tier: 'clean' as const,
+                            topFlags: [],
+                          })}
+                          customUrl={row.party.customUrl}
+                        />
                         {row.aggregates.flaggedReadyCount > 0 && (
                           <span
                             className="inline-flex items-center gap-1 text-[11px] text-emerald-500"

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -82,6 +82,15 @@ interface SendPaymentModalProps {
    * admin doesn't have to re-type the address the host already gave us.
    */
   hostWalletByUserId?: Record<string, string>;
+  /**
+   * bufalina-60733: fake-detection risk for this party (looked up by the
+   * parent from the by-city score map at open time). When `fakeTier` is
+   * `medium`/`high`, the modal shows a caution card and gates "Send" behind
+   * an extra ack. Undefined / clean / low = no gate.
+   */
+  fakeScore?: number;
+  fakeTier?: string;
+  fakeTopFlags?: string[];
   onClose: () => void;
   /**
    * Called on a successful send. Receives the city name + method + amount so
@@ -107,6 +116,9 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   paidTotalUsd,
   primaryHostUserId,
   hostWalletByUserId,
+  fakeScore,
+  fakeTier,
+  fakeTopFlags,
   onClose,
   onSent,
 }) => {
@@ -226,6 +238,11 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   // SWC Hub ack — controlled, surfaced via the shared SwcHubWarning component.
   const [swcAck, setSwcAck] = useState(false);
 
+  // bufalina-60733: fake-detection ack. Required before sending when this party
+  // scored medium/high. Reset on recipient/amount change like the other acks.
+  const [fakeAck, setFakeAck] = useState(false);
+  const isFlagged = fakeTier === 'medium' || fakeTier === 'high';
+
   // Close on Escape.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -245,6 +262,13 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   useEffect(() => {
     createdPayoutIdRef.current = null;
   }, [recipientUserId, method, amountNum, walletAddress, bankEmail, mercuryCardLast4]);
+
+  // bufalina-60733: reset the fake-detection ack whenever the recipient or
+  // amount changes, so an ack made for one recipient/amount can't carry over
+  // to a different one (mirrors the cap/SWC ack-reset intent).
+  useEffect(() => {
+    setFakeAck(false);
+  }, [recipientUserId, amountNum]);
 
   // Cap math (salame-92103 mirror). Cap remaining = cap - already-paid. We
   // also include this in-flight amount in `wouldExceed` so the warning fires
@@ -298,6 +322,8 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
     (!partyWouldExceedCap || overridePartyCap) &&
     // parmigiana-92104: SWC Hub requires explicit ack.
     (!swcHub || swcAck) &&
+    // bufalina-60733: flagged (medium/high fake-detection) requires explicit ack.
+    (!isFlagged || fakeAck) &&
     !submitting &&
     !candidatesLoading;
 
@@ -649,6 +675,47 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
                       checked={overridePartyCap}
                       onChange={() => setOverridePartyCap((v) => !v)}
                       label="I acknowledge — proceed anyway"
+                      labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* bufalina-60733: fake-detection risk warning + ack. Shows when
+              this party scored medium/high; gates Send behind an explicit
+              acknowledgement (mirrors the cap-override ack card above). */}
+          {isFlagged && (
+            <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+              <div className="flex items-start gap-2.5">
+                <AlertTriangle
+                  className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0"
+                  size={16}
+                />
+                <div className="flex-1 text-sm">
+                  <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
+                    Fake-detection risk on {cleanName}
+                  </div>
+                  <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
+                    This event scored{' '}
+                    <b>
+                      Risk {fakeScore ?? 0} ({fakeTier})
+                    </b>{' '}
+                    in fake-event detection. Review its flags before sending.
+                  </div>
+                  {fakeTopFlags && fakeTopFlags.length > 0 && (
+                    <ul className="mt-2 space-y-0.5 text-xs text-theme-text-secondary [.gpp-theme_&]:text-amber-900 list-disc list-inside">
+                      {fakeTopFlags.map((f, i) => (
+                        <li key={i}>{f}</li>
+                      ))}
+                    </ul>
+                  )}
+                  <div className="mt-3">
+                    <Checkbox
+                      checked={fakeAck}
+                      onChange={() => setFakeAck((v) => !v)}
+                      label="I've reviewed this event's fake-detection flags"
                       labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                     />
                   </div>

--- a/frontend/src/components/payments-admin/index.ts
+++ b/frontend/src/components/payments-admin/index.ts
@@ -15,3 +15,4 @@ export { BulkSendModal } from './BulkSendModal';
 export { RejectReasonModal } from './RejectReasonModal';
 export { HotWalletCard } from './HotWalletCard';
 export { SwcHubWarning } from './SwcHubWarning';
+export { FakeDetectionBadge } from './FakeDetectionBadge';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -540,6 +540,34 @@ export async function approveCity(
 }
 
 /**
+ * bufalina-60733: Fake-detection risk scores for a set of GPP parties, used to
+ * badge the payments-admin by-city table + gate the send-payment confirm.
+ *
+ * Compact map keyed by party id; `clean`/sub-10 parties are omitted server-side
+ * so the badge self-hides for them. Best-effort — callers should `.catch(()=>{})`.
+ */
+export interface FakeDetectionScoreEntry {
+  score: number;
+  tier: string;
+  topFlags: string[];
+}
+
+export type FakeDetectionScoreMap = Record<string, FakeDetectionScoreEntry>;
+
+export async function fetchFakeDetectionScores(
+  partyIds: string[],
+): Promise<{ scores: FakeDetectionScoreMap }> {
+  return apiRequest<{ scores: FakeDetectionScoreMap }>(
+    '/api/admin/payouts/fake-detection-scores',
+    {
+      method: 'POST',
+      requireAuth: true,
+      body: { partyIds },
+    },
+  );
+}
+
+/**
  * quattro-71244: Fetches this party's rank against peer GPP events.
  * Returns null on 401/403/404/network failure so callers (the LeaderboardPill)
  * can gracefully hide instead of crashing the dashboard.

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -24,7 +24,9 @@ import {
   exportAdminPayoutsCsv,
   fetchPrepayQueue,
   flagReadyForPayment,
+  fetchFakeDetectionScores,
 } from '../lib/api';
+import type { FakeDetectionScoreMap } from '../lib/api';
 import type {
   AdminPayout,
   AdminPayoutDetail,
@@ -207,6 +209,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   // same loader (`loadPage`) so the rest of the page can read from whichever
   // is active.
   const [byPartyRows, setByPartyRows] = useState<PartyPayoutsRow[]>([]);
+  // bufalina-60733: fake-detection risk scores for the loaded by-city parties.
+  // Keyed by party id; only medium/high (≥30) parties are returned, so an
+  // absent key means "no badge". Fetched best-effort after byPartyRows loads.
+  const [fakeScores, setFakeScores] = useState<FakeDetectionScoreMap>({});
   const [totals, setTotals] = useState<AdminPayoutTotals | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -273,6 +279,12 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         // over the resolved 0x). Lets SendPaymentModal pre-fill the wallet
         // field per selected recipient instead of making the admin re-type it.
         hostWalletByUserId: Record<string, string>;
+        // bufalina-60733: fake-detection risk for this party, looked up from
+        // `fakeScores` at open time so the modal can gate "Send" behind an ack
+        // when the event is flagged (medium/high). Undefined = no flag.
+        fakeScore?: number;
+        fakeTier?: string;
+        fakeTopFlags?: string[];
       }
     | null
   >(null);
@@ -419,6 +431,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   // allowed to write state.
   const loadSeqRef = useRef(0);
 
+  // bufalina-60733: separate monotonic id for the best-effort fake-detection
+  // score fetch so a slow score response can't clobber a newer filter's scores.
+  const fakeScoresSeqRef = useRef(0);
+
   const loadPage = useCallback(
     async (f: AdminPayoutFilters, append = false) => {
       // risotto-58931: monotonic request id — only the latest loadPage call is
@@ -500,6 +516,28 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     if (role.kind !== 'allowed') return;
     loadPrepayQueue();
   }, [role.kind, loadPrepayQueue]);
+
+  // bufalina-60733: best-effort fake-detection score fetch for the loaded
+  // by-city parties. Non-blocking — failures are swallowed and just leave the
+  // badges hidden. Guarded by `fakeScoresSeqRef` so a slow response from an
+  // older filter can't overwrite a newer one's scores.
+  useEffect(() => {
+    if (role.kind !== 'allowed') return;
+    const ids = byPartyRows.map((r) => r.party.id);
+    if (ids.length === 0) {
+      setFakeScores({});
+      return;
+    }
+    const myReq = ++fakeScoresSeqRef.current;
+    fetchFakeDetectionScores(ids)
+      .then((res) => {
+        if (myReq !== fakeScoresSeqRef.current) return;
+        setFakeScores(res.scores);
+      })
+      .catch(() => {
+        /* best-effort: leave badges hidden on failure */
+      });
+  }, [byPartyRows, role.kind]);
 
   // lardo-58294: apply the substring filter. When the search is empty this
   // is identity-equal to prepayQueue.
@@ -1185,6 +1223,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         {viewMode === 'by-city' ? (
           <PayoutsByPartyTable
             rows={displayedByPartyRows}
+            fakeScores={fakeScores}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
             onRowClick={openDetail}
@@ -1277,6 +1316,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 const wallet = (p.payoutWalletInput || p.payoutWalletAddress || '').trim();
                 if (wallet) hostWalletByUserId[p.hostUserId] = wallet;
               }
+              // bufalina-60733: attach the looked-up fake-detection risk for
+              // this party so the modal can gate the send behind an ack.
+              const fake = fakeScores[row.party.id];
               setSendPaymentTarget({
                 partyId: row.party.id,
                 partyName: row.party.name,
@@ -1288,6 +1330,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 paidTotalUsd: paidSumUsd,
                 primaryHostUserId: row.party.userId ?? null,
                 hostWalletByUserId,
+                fakeScore: fake?.score,
+                fakeTier: fake?.tier,
+                fakeTopFlags: fake?.topFlags,
               });
             }}
             // bottarga-92104: after the table toggles the `possible-scam` tag,
@@ -1741,6 +1786,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             paidTotalUsd={sendPaymentTarget.paidTotalUsd}
             primaryHostUserId={sendPaymentTarget.primaryHostUserId}
             hostWalletByUserId={sendPaymentTarget.hostWalletByUserId}
+            fakeScore={sendPaymentTarget.fakeScore}
+            fakeTier={sendPaymentTarget.fakeTier}
+            fakeTopFlags={sendPaymentTarget.fakeTopFlags}
             onClose={() => setSendPaymentTarget(null)}
             onSent={async ({ partyName: sentTo, method, amountUsd }) => {
               const methodLabel =


### PR DESCRIPTION
## Summary
Surfaces each GPP party's existing fake-detection risk score (the same scorer that backs /underboss's review queue) as a two-level caution badge on the by-city payments table, and gates the **Send payment** action behind an extra confirmation when the party scores ≥30.

- **Two-level badge:** amber pill for `medium` (≥30), red pill for `high` (≥60), nothing below 30. Tooltip lists the top fired flags.
- **Applies to all payments pages** — they all render through `PaymentsAdminPage → PayoutsByPartyTable`, so the 7 regional wrapper pages are untouched.
- **Warn + confirm:** badge + tooltip on the table, AND an amber ack card in `SendPaymentModal` ("I've reviewed this event's fake-detection flags") that gates the Send button when the party is flagged.

## Backend
- New shared helper `backend/src/lib/fakeDetectionScan.ts` — `scorePartiesByIds(partyIds?)` + `buildSybilWalletSetFromDb()` extract the sybil pre-pass + party `findMany` + per-party `scoreEvent` block out of `underboss.routes.ts`. Scopes the query to a party-id set when provided, else all gpp (today's behavior).
- `GET /api/underboss/fake-detection` refactored to call the shared helper. **Response shape is unchanged** (still returns `meta.sybilWalletCount`).
- New `POST /api/admin/payouts/fake-detection-scores` in `admin-payout.routes.ts`. Body `{ partyIds: string[] }` (capped at 500). Returns a compact map keyed by party id: `{ score, tier, topFlags }`, with `clean` (score <10) entries omitted to keep the payload small.

## Auth choice
The new endpoint is guarded by **`requireAdminOrRegionalUnderboss()`** — the same guard the by-party payments feed uses — **not** the underboss `__admin__`-only gate. The regional payment portals (`/payments/latam`, etc.) are driven by regional underbosses, who would otherwise 403 on the score fetch and never see badges.

## Frontend
- New `FakeDetectionBadge` component (+ index export).
- `api.ts`: `fetchFakeDetectionScores()` + `FakeDetectionScoreMap` type.
- `PaymentsAdminPage`: best-effort, non-blocking score fetch keyed on the loaded by-city rows, guarded by its own sequence ref so a slow response can't clobber a newer filter. Passes `fakeScores` to the table and attaches the looked-up score to the send-payment target.
- `PayoutsByPartyTable`: renders the badge in the city-header pill strip.
- `SendPaymentModal`: amber warning card + `Checkbox` ack gating `canSubmit` when flagged; ack resets on recipient/amount change.

## Notes
- **Pure read — no DB/schema change.**
- The new `POST /fake-detection-scores` endpoint **must be deployed to master before the preview renders badges** — previews share the production backend, so until the route is live the best-effort fetch 404s and badges stay hidden (no breakage, just no badges).

## Typechecks
- `backend`: `npx tsc --noEmit` clean for all changed files (only pre-existing unrelated errors remain — missing `sharp`/`openai`/`pdf-lib` modules and the salame-92110 `taxForm` Prisma-client-regen errors).
- `frontend`: `npx tsc --noEmit` fully clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)