### PR TITLE
feat(crescenza-92112): line-item subtotal is a calculated field

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -17,7 +17,7 @@ import {
   formatOriginalCurrency,
   ReceiptLightbox,
 } from '../payments-shared';
-import { ReceiptEditor } from './ReceiptEditor';
+import { ReceiptEditor, computeLineSubtotal } from './ReceiptEditor';
 import { TaxFormReviewPanel } from './TaxFormReviewPanel';
 
 /**
@@ -973,8 +973,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       // shared ReceiptEditor's `draftSubtotalSum` helper so the live total
       // shown in the right-pane editor matches the lightbox editor.
       if (d.ineligible === true) continue;
-      const n = Number(d.subtotal);
-      if (Number.isFinite(n) && n >= 0) sum += n;
+      sum += computeLineSubtotal(d);
     }
     return sum;
   }
@@ -1014,16 +1013,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       const items: ReceiptLineItem[] = drafts.map((d, idx) => {
         const qty = Number(d.qty);
         const unitPrice = Number(d.unitPrice);
-        const subtotal = Number(d.subtotal);
         if (!Number.isFinite(qty) || qty < 0) {
           throw new Error(`Line ${idx + 1}: qty must be a non-negative number`);
         }
         if (!Number.isFinite(unitPrice) || unitPrice < 0) {
           throw new Error(`Line ${idx + 1}: unit price must be a non-negative number`);
         }
-        if (!Number.isFinite(subtotal) || subtotal < 0) {
-          throw new Error(`Line ${idx + 1}: subtotal must be a non-negative number`);
-        }
+        // crescenza-92112: subtotal is calculated, not entered.
+        const subtotal = computeLineSubtotal(d);
         // provola-92106: persist the per-line ineligible flag only when
         // true so existing items + items the admin never touched don't
         // sprout a `false` field. Backend sanitizer matches this stance.
@@ -2688,17 +2685,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                         }
                                         className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
                                       />
+                                      {/* crescenza-92112: subtotal is
+                                          calculated (qty × unit), read-only. */}
                                       <input
                                         type="number"
-                                        step="0.01"
-                                        min="0"
                                         inputMode="decimal"
-                                        value={d.subtotal}
+                                        value={computeLineSubtotal(d).toFixed(2)}
+                                        readOnly
+                                        tabIndex={-1}
                                         placeholder="subtotal"
-                                        onChange={(e) =>
-                                          updateLineItemDraft(r.id, idx, { subtotal: e.target.value })
-                                        }
-                                        className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                                        title="Auto-calculated (qty × unit price)"
+                                        className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-bg text-theme-text-muted text-xs text-right cursor-not-allowed"
                                       />
                                       <select
                                         value={d.category}

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -64,6 +64,7 @@ import {
 } from '../../lib/api';
 import {
   ReceiptEditor,
+  computeLineSubtotal,
   lineItemToDraft,
   emptyLineItemDraft,
   type ReceiptDraft,
@@ -1443,8 +1444,7 @@ function CityExpansion({
     for (const d of drafts) {
       // provola-92106: ineligible lines stay out of the rolled-up amount.
       if (d.ineligible === true) continue;
-      const n = Number(d.subtotal);
-      if (Number.isFinite(n) && n >= 0) sum += n;
+      sum += computeLineSubtotal(d);
     }
     // caprino-92104: line items are in the receipt's ORIGINAL currency, so
     // the line sum maps to the originalAmount draft, not USD.
@@ -1473,16 +1473,14 @@ function CityExpansion({
       const items: ReceiptLineItem[] = drafts.map((d, idx) => {
         const qty = Number(d.qty);
         const unitPrice = Number(d.unitPrice);
-        const subtotal = Number(d.subtotal);
         if (!Number.isFinite(qty) || qty < 0) {
           throw new Error(`Line ${idx + 1}: qty must be a non-negative number`);
         }
         if (!Number.isFinite(unitPrice) || unitPrice < 0) {
           throw new Error(`Line ${idx + 1}: unit price must be a non-negative number`);
         }
-        if (!Number.isFinite(subtotal) || subtotal < 0) {
-          throw new Error(`Line ${idx + 1}: subtotal must be a non-negative number`);
-        }
+        // crescenza-92112: subtotal is calculated, not entered.
+        const subtotal = computeLineSubtotal(d);
         // provola-92106: persist per-line ineligible only when true.
         const out: ReceiptLineItem = {
           name: d.name,

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -111,6 +111,21 @@ interface ReceiptEditorProps {
   isDirty: boolean;
 }
 
+/**
+ * crescenza-92112: the line-item subtotal is a CALCULATED field — always
+ * qty × unitPrice. The subtotal input is read-only; this helper is the single
+ * source of truth used by the live sum, the "Use line sum" amount, and the
+ * value persisted on save. Returns 0 for blank/invalid qty or unitPrice.
+ */
+export function computeLineSubtotal(d: Pick<LineItemDraft, 'qty' | 'unitPrice'>): number {
+  const qty = Number(d.qty);
+  const unitPrice = Number(d.unitPrice);
+  if (!Number.isFinite(qty) || qty < 0 || !Number.isFinite(unitPrice) || unitPrice < 0) {
+    return 0;
+  }
+  return qty * unitPrice;
+}
+
 function draftSubtotalSum(drafts: LineItemDraft[] | undefined): number {
   if (!drafts) return 0;
   let sum = 0;
@@ -119,8 +134,7 @@ function draftSubtotalSum(drafts: LineItemDraft[] | undefined): number {
     // personal items). The live sum + "Use line sum" button both rely on
     // this helper so the receipt total reflects only reimbursable items.
     if (d.ineligible === true) continue;
-    const n = Number(d.subtotal);
-    if (Number.isFinite(n) && n >= 0) sum += n;
+    sum += computeLineSubtotal(d);
   }
   return sum;
 }
@@ -572,17 +586,17 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
                   }
                   className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
                 />
+                {/* crescenza-92112: subtotal is calculated (qty × unit), not
+                    entered. Read-only, derived live from the row. */}
                 <input
                   type="number"
-                  step="0.01"
-                  min="0"
                   inputMode="decimal"
-                  value={d.subtotal}
+                  value={computeLineSubtotal(d).toFixed(2)}
+                  readOnly
+                  tabIndex={-1}
                   placeholder="subtotal"
-                  onChange={(e) =>
-                    onLineItemDraftChange(idx, { subtotal: e.target.value })
-                  }
-                  className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
+                  title="Auto-calculated (qty × unit price)"
+                  className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-bg text-theme-text-muted text-xs text-right cursor-not-allowed"
                 />
                 <select
                   value={d.category}


### PR DESCRIPTION
Per request: the line-item **subtotal** is a calculated field, not a free-entry input.

- Added shared `computeLineSubtotal(d)` = `qty × unitPrice` in `ReceiptEditor.tsx`, exported as the single source of truth.
- Subtotal `<input>` is now **read-only** (derives live from qty/unit) in both editors: the shared `ReceiptEditor` grid and `PayoutReviewModal`'s inline right-pane grid.
- The live line-sum, the **Use line sum** amount, and the value **persisted on save** all use `computeLineSubtotal` — in `ReceiptEditor`, `PayoutReviewModal`, and `PayoutsByPartyTable`. (Saving normalizes any OCR-extracted subtotal to qty × unit.)

Frontend-only — `npm run build` passes. Preview: https://rsvpizza-git-crescenza-92112-subtotal-calc-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)