### PR TITLE
fix(crescenza-92113): subtotal shows as calculated value, not editable field

### DIFF
--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -2685,18 +2685,16 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                         }
                                         className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
                                       />
-                                      {/* crescenza-92112: subtotal is
-                                          calculated (qty × unit), read-only. */}
-                                      <input
-                                        type="number"
-                                        inputMode="decimal"
-                                        value={computeLineSubtotal(d).toFixed(2)}
-                                        readOnly
-                                        tabIndex={-1}
-                                        placeholder="subtotal"
+                                      {/* crescenza-92112/92113: subtotal is
+                                          calculated (qty × unit) — plain
+                                          computed value, not an editable field. */}
+                                      <div
+                                        className="w-20 px-2 py-1 text-xs text-right tabular-nums text-theme-text-muted select-none"
                                         title="Auto-calculated (qty × unit price)"
-                                        className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-bg text-theme-text-muted text-xs text-right cursor-not-allowed"
-                                      />
+                                        aria-label="Subtotal (auto-calculated)"
+                                      >
+                                        {computeLineSubtotal(d).toFixed(2)}
+                                      </div>
                                       <select
                                         value={d.category}
                                         onChange={(e) =>

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -586,18 +586,16 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
                   }
                   className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-surface text-theme-text text-xs text-right"
                 />
-                {/* crescenza-92112: subtotal is calculated (qty × unit), not
-                    entered. Read-only, derived live from the row. */}
-                <input
-                  type="number"
-                  inputMode="decimal"
-                  value={computeLineSubtotal(d).toFixed(2)}
-                  readOnly
-                  tabIndex={-1}
-                  placeholder="subtotal"
+                {/* crescenza-92112/92113: subtotal is calculated (qty × unit),
+                    not entered — render as a plain computed value, not a field,
+                    so it's visually distinct from the editable inputs. */}
+                <div
+                  className="w-20 px-2 py-1 text-xs text-right tabular-nums text-theme-text-muted select-none"
                   title="Auto-calculated (qty × unit price)"
-                  className="w-20 px-2 py-1 rounded border border-theme-stroke bg-theme-bg text-theme-text-muted text-xs text-right cursor-not-allowed"
-                />
+                  aria-label="Subtotal (auto-calculated)"
+                >
+                  {computeLineSubtotal(d).toFixed(2)}
+                </div>
                 <select
                   value={d.category}
                   onChange={(e) =>


### PR DESCRIPTION
Follow-up to #806. The line-item subtotal was already read-only/calculated, but it kept the bordered input styling so it still looked like an editable field next to qty/unit.

Now renders as a plain right-aligned computed value (no border, no input background, muted text) in both the shared `ReceiptEditor` grid and `PayoutReviewModal`'s inline grid. Frontend-only; build passes.

Preview: https://rsvpizza-git-crescenza-92113-subtotal-display-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)