### PR TITLE
panzerotti-58931: game Phase 2.1 — worldwide leaderboard + score rollups + Best Of judging

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -62,6 +62,7 @@ import quizTemplateRoutes from './routes/quiz-template.routes.js';
 import { quizHostRouter, quizPublicRouter } from './routes/quiz.routes.js';
 import onesheetRoutes from './routes/onesheet.routes.js';
 import scorecardRoutes from './routes/scorecard.routes.js';
+import scorecardLeaderboardRoutes from './routes/scorecardLeaderboard.routes.js';
 import citiesRoutes from './routes/cities.routes.js';
 import resendWebhookRouter from './routes/webhooks.resend.routes.js';
 import ensRoutes from './routes/ens.routes.js';
@@ -202,6 +203,7 @@ app.use('/api/checkin', checkinRoutes);
 app.use('/api/survey', surveyPublicRouter); // romana-61204: public token-based survey (no auth)
 app.use('/api/cron', cronRouter); // romana-61204: cron-only survey auto-send (CRON_SECRET gate)
 app.use('/api/scorecard', scorecardRoutes);
+app.use('/api/scorecard-leaderboard', scorecardLeaderboardRoutes); // panzerotti-58931: worldwide game leaderboard + rollups
 app.use('/api/display', displayRoutes); // Public display viewer routes
 app.use('/api/reports', reportRoutes); // Public report viewing via slug
 app.use('/api/reports', venueReportRoutes); // Public venue report viewing via slug

--- a/backend/src/routes/scorecard.routes.ts
+++ b/backend/src/routes/scorecard.routes.ts
@@ -2,6 +2,7 @@ import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
+import { BEST_OF_BONUS } from './scorecardLeaderboard.routes.js';
 
 const router = Router();
 
@@ -47,6 +48,19 @@ function categoryFor(itemKey: string): 'mission' | 'photo' | undefined {
 // panzerotti-58931: superlative submission keys (separate table, not scorecard items)
 const SUPERLATIVE_KEYS = ['super_slices', 'super_cheese_pull', 'super_box_stack'] as const;
 type SuperlativeKey = typeof SUPERLATIVE_KEYS[number];
+
+// panzerotti-58931 Phase 2.1: human labels for "Best Of" superlatives. Used on
+// the guest scorecard to show which wins a guest earned, and on the admin
+// judging queue. Keep in sync with SUPERLATIVE_KEYS.
+const SUPERLATIVE_LABELS: Record<string, string> = {
+  super_slices: 'Most people with a slice',
+  super_cheese_pull: 'Best cheese pull',
+  super_box_stack: 'Tallest box stack',
+};
+
+function superlativeLabel(key: string): string {
+  return SUPERLATIVE_LABELS[key] ?? key;
+}
 
 // Helper: find party by inviteCode or customUrl
 async function findPartyByCode(inviteCode: string) {
@@ -154,10 +168,21 @@ router.get('/:inviteCode', requireAuth, async (req: AuthRequest, res: Response, 
     // Compute Pizza Chef score (number of completed items)
     const completedCount = items.filter((item) => item.completed).length;
 
+    // panzerotti-58931 Phase 2.1: the calling guest's judged "Best Of" wins.
+    const winnerRows = await prisma.superlativeSubmission.findMany({
+      where: { guestId: guest.id, partyId: party.id, status: 'winner' },
+      select: { superlativeKey: true },
+    });
+    const bestOfWins = winnerRows.map((r) => ({
+      superlativeKey: r.superlativeKey,
+      label: superlativeLabel(r.superlativeKey),
+    }));
+
     res.json({
       items: items.map((item) => ({ ...item, category: categoryFor(item.itemKey) })),
       pizzaChefScore: completedCount,
       totalItems: SCORECARD_ITEMS.length,
+      bestOfWins,
     });
   } catch (error) {
     next(error);
@@ -255,6 +280,11 @@ router.get('/:inviteCode/leaderboard', requireAuth, async (req: AuthRequest, res
           where: { completed: true },
           select: { id: true },
         },
+        // panzerotti-58931 Phase 2.1: Best Of wins add BEST_OF_BONUS each.
+        superlativeSubmissions: {
+          where: { status: 'winner' },
+          select: { id: true },
+        },
       },
     });
 
@@ -273,7 +303,7 @@ router.get('/:inviteCode/leaderboard', requireAuth, async (req: AuthRequest, res
       .map((g) => ({
         guestId: g.id,
         name: privacyName(g.name),
-        score: g.scorecardItems.length,
+        score: g.scorecardItems.length + g.superlativeSubmissions.length * BEST_OF_BONUS,
         isCurrentUser: !!callerEmail && g.email?.toLowerCase() === callerEmail,
       }))
       .sort((a, b) => {

--- a/backend/src/routes/scorecardLeaderboard.routes.ts
+++ b/backend/src/routes/scorecardLeaderboard.routes.ts
@@ -1,0 +1,298 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { getCountryCode } from '../lib/countryCode.js';
+
+/**
+ * panzerotti-58931 (Phase 2.1): worldwide scorecard ("check-in game") leaderboard.
+ *
+ * Mounted at `/api/scorecard-leaderboard` so the full path is
+ *   GET /api/scorecard-leaderboard
+ *
+ * Distinct from `publicLeaderboard.routes.ts` (the GPP RSVP/check-in/photo
+ * composite board). This board ranks by the *game* score:
+ *
+ *   guestScore   = completed scorecard items + winsCount * BEST_OF_BONUS
+ *   partyScore   = Σ guestScore over the party's checked-in guests
+ *   countryScore = Σ partyScore grouped by trimmed/case-insensitive country
+ *
+ * A "win" is a `superlative_submissions` row with status='winner' for the guest.
+ *
+ * Scope: every checked-in, non-rejected guest of any party — no GPP/approved
+ * gate, since the game runs at all events. Mirrors `findGuestForUser` in
+ * scorecard.routes.ts: checkedInAt IS NOT NULL AND (approved IS TRUE OR
+ * approved IS NULL).
+ *
+ * Cache: in-memory, 5-minute TTL, plus `Cache-Control: public, max-age=300`.
+ */
+
+// Single tunable bonus per Best Of win. Imported by scorecard.routes.ts so the
+// per-party board and the global board agree.
+export const BEST_OF_BONUS = 5;
+
+// ---- types ----
+
+export interface ScorecardGuestRow {
+  rank: number;
+  name: string; // privacy "First L."
+  city: string | null;
+  country: string | null;
+  countryCode: string | null;
+  score: number;
+}
+
+export interface ScorecardPartyRow {
+  rank: number;
+  partyId: string;
+  name: string;
+  city: string | null;
+  country: string | null;
+  countryCode: string | null;
+  slug: string;
+  score: number;
+}
+
+export interface ScorecardCountryRow {
+  rank: number;
+  country: string;
+  countryCode: string | null;
+  partyCount: number;
+  score: number;
+}
+
+export interface ScorecardGlobalLeaderboardResponse {
+  guests: ScorecardGuestRow[];
+  parties: ScorecardPartyRow[];
+  countries: ScorecardCountryRow[];
+  computedAt: string;
+}
+
+// Raw row shape returned by the aggregate query (one row per checked-in guest).
+interface RawGuestRow {
+  guest_id: string;
+  name: string | null;
+  party_id: string;
+  party_name: string | null;
+  city: string | null;
+  country: string | null;
+  custom_url: string | null;
+  invite_code: string | null;
+  item_count: bigint | number;
+  win_count: bigint | number;
+}
+
+// ---- cache ----
+const TTL_MS = 5 * 60 * 1000;
+interface CacheEntry {
+  expiresAt: number;
+  data: ScorecardGlobalLeaderboardResponse;
+}
+let cache: CacheEntry | null = null;
+
+// ---- helpers ----
+
+function privacyName(raw: string | null | undefined): string {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return 'Guest';
+  const parts = trimmed.split(/\s+/);
+  const first = parts[0];
+  const lastInitial = parts.length > 1 ? parts[parts.length - 1][0] : '';
+  return lastInitial ? `${first} ${lastInitial.toUpperCase()}.` : first;
+}
+
+function toNum(v: bigint | number): number {
+  return typeof v === 'bigint' ? Number(v) : v;
+}
+
+export async function computeScorecardLeaderboard(): Promise<ScorecardGlobalLeaderboardResponse> {
+  // One pass over checked-in guests. COUNT(DISTINCT ...) FILTER avoids join
+  // fan-out between scorecard items and superlative submissions.
+  const rows = await prisma.$queryRaw<RawGuestRow[]>`
+    SELECT
+      g.id                                                              AS guest_id,
+      g.name                                                            AS name,
+      p.id                                                              AS party_id,
+      p.name                                                            AS party_name,
+      p.city                                                            AS city,
+      p.country                                                         AS country,
+      p.custom_url                                                      AS custom_url,
+      p.invite_code                                                     AS invite_code,
+      COUNT(DISTINCT i.id) FILTER (WHERE i.completed)                   AS item_count,
+      COUNT(DISTINCT s.id) FILTER (WHERE s.status = 'winner')           AS win_count
+    FROM guests g
+    JOIN parties p ON p.id = g.party_id
+    LEFT JOIN guest_scorecard_items i ON i.guest_id = g.id
+    LEFT JOIN superlative_submissions s ON s.guest_id = g.id
+    WHERE g.checked_in_at IS NOT NULL
+      AND (g.approved IS TRUE OR g.approved IS NULL)
+    GROUP BY g.id, g.name, p.id, p.name, p.city, p.country, p.custom_url, p.invite_code
+  `;
+
+  // ---- per-guest score ----
+  interface GuestAcc {
+    guestId: string;
+    name: string;
+    city: string | null;
+    country: string | null;
+    score: number;
+  }
+  const guestAccs: GuestAcc[] = rows.map((r) => ({
+    guestId: r.guest_id,
+    name: privacyName(r.name),
+    city: r.city,
+    country: r.country,
+    score: toNum(r.item_count) + toNum(r.win_count) * BEST_OF_BONUS,
+  }));
+
+  // ---- per-party aggregation ----
+  interface PartyAcc {
+    partyId: string;
+    name: string;
+    city: string | null;
+    country: string | null;
+    slug: string;
+    score: number;
+  }
+  const partyMap = new Map<string, PartyAcc>();
+  for (const r of rows) {
+    const guestScore = toNum(r.item_count) + toNum(r.win_count) * BEST_OF_BONUS;
+    let acc = partyMap.get(r.party_id);
+    if (!acc) {
+      acc = {
+        partyId: r.party_id,
+        name: r.party_name || 'Untitled',
+        city: r.city,
+        country: r.country,
+        slug: r.custom_url || r.invite_code || r.party_id,
+        score: 0,
+      };
+      partyMap.set(r.party_id, acc);
+    }
+    acc.score += guestScore;
+  }
+
+  // ---- per-country aggregation (case-insensitive trimmed) ----
+  interface CountryAcc {
+    spellingCounts: Map<string, number>;
+    firstSpelling: string;
+    score: number;
+    partyCount: number;
+  }
+  const countryMap = new Map<string, CountryAcc>();
+  for (const party of partyMap.values()) {
+    if (!party.country) continue;
+    const trimmed = party.country.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    let acc = countryMap.get(key);
+    if (!acc) {
+      acc = { spellingCounts: new Map(), firstSpelling: trimmed, score: 0, partyCount: 0 };
+      countryMap.set(key, acc);
+    }
+    acc.spellingCounts.set(trimmed, (acc.spellingCounts.get(trimmed) || 0) + 1);
+    acc.score += party.score;
+    acc.partyCount += 1;
+  }
+
+  // ---- guest rows: top 100, score desc, name asc tiebreak ----
+  const guests: ScorecardGuestRow[] = guestAccs
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, 100)
+    .map((g, i) => ({
+      rank: i + 1,
+      name: g.name,
+      city: g.city,
+      country: g.country,
+      countryCode: getCountryCode(g.country),
+      score: g.score,
+    }));
+
+  // ---- party rows: score desc, name asc tiebreak ----
+  const parties: ScorecardPartyRow[] = Array.from(partyMap.values())
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return (a.name || '').localeCompare(b.name || '');
+    })
+    .map((p, i) => ({
+      rank: i + 1,
+      partyId: p.partyId,
+      name: p.name,
+      city: p.city,
+      country: p.country,
+      countryCode: getCountryCode(p.country),
+      slug: p.slug,
+      score: p.score,
+    }));
+
+  // ---- country rows: pick canonical spelling, score desc ----
+  const countries: ScorecardCountryRow[] = [];
+  for (const acc of countryMap.values()) {
+    let best = acc.firstSpelling;
+    let bestCount = 0;
+    for (const [spelling, count] of acc.spellingCounts.entries()) {
+      if (count > bestCount) {
+        best = spelling;
+        bestCount = count;
+      }
+    }
+    countries.push({
+      rank: 0,
+      country: best,
+      countryCode: getCountryCode(best),
+      partyCount: acc.partyCount,
+      score: acc.score,
+    });
+  }
+  countries.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.partyCount !== a.partyCount) return b.partyCount - a.partyCount;
+    return a.country.localeCompare(b.country);
+  });
+  countries.forEach((c, i) => {
+    c.rank = i + 1;
+  });
+
+  return {
+    guests,
+    parties,
+    countries,
+    computedAt: new Date().toISOString(),
+  };
+}
+
+async function getCached(nocache: boolean): Promise<ScorecardGlobalLeaderboardResponse> {
+  const now = Date.now();
+  if (!nocache && cache && cache.expiresAt > now) {
+    return cache.data;
+  }
+  const data = await computeScorecardLeaderboard();
+  cache = { expiresAt: now + TTL_MS, data };
+  return data;
+}
+
+// ---- router ----
+
+const router = Router();
+
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const nocache = !!req.query.nocache;
+    const data = await getCached(nocache);
+    res.set('Cache-Control', 'public, max-age=300');
+    res.json(data);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Exported for tests.
+export const __testing = {
+  computeScorecardLeaderboard,
+  reset: () => {
+    cache = null;
+  },
+};
+
+export default router;

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -782,6 +782,109 @@ router.get('/outreach/parties-search', requireAuth, requireUnderbossAuth, async 
   }
 });
 
+// ============================================
+// Best Of / superlative judging queue (panzerotti-58931 Phase 2.1)
+// NOTE: literal routes — MUST be registered BEFORE the /:region catch-all
+// so 'superlatives' isn't captured as a region param.
+// ============================================
+
+// Human labels for the three superlative keys (mirror scorecard.routes.ts).
+const SUPERLATIVE_LABELS: Record<string, string> = {
+  super_slices: 'Most people with a slice',
+  super_cheese_pull: 'Best cheese pull',
+  super_box_stack: 'Tallest box stack',
+};
+const SUPERLATIVE_STATUSES = new Set(['winner', 'rejected', 'pending']);
+
+// GET /api/underboss/superlatives - all submissions grouped by key (admin only)
+router.get('/superlatives', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const isAdminUser = req.underboss!.regions.includes('__admin__');
+    if (!isAdminUser) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const submissions = await prisma.superlativeSubmission.findMany({
+      select: {
+        id: true,
+        superlativeKey: true,
+        photoUrl: true,
+        numericValue: true,
+        status: true,
+        guest: { select: { name: true } },
+        party: { select: { name: true, city: true, country: true } },
+      },
+      orderBy: [{ superlativeKey: 'asc' }, { createdAt: 'asc' }],
+    });
+
+    const rows = submissions.map((s) => ({
+      id: s.id,
+      superlativeKey: s.superlativeKey,
+      guestName: s.guest?.name || 'Guest',
+      partyName: s.party?.name || 'Untitled',
+      city: s.party?.city || null,
+      country: s.party?.country || null,
+      photoUrl: s.photoUrl,
+      numericValue: s.numericValue,
+      status: s.status,
+    }));
+
+    // Group by superlative_key, preserving label for the UI.
+    const groupMap = new Map<string, { superlativeKey: string; label: string; submissions: typeof rows }>();
+    for (const r of rows) {
+      let g = groupMap.get(r.superlativeKey);
+      if (!g) {
+        g = {
+          superlativeKey: r.superlativeKey,
+          label: SUPERLATIVE_LABELS[r.superlativeKey] ?? r.superlativeKey,
+          submissions: [],
+        };
+        groupMap.set(r.superlativeKey, g);
+      }
+      g.submissions.push(r);
+    }
+
+    res.json({ groups: Array.from(groupMap.values()) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/underboss/superlatives/:id - judge a submission (admin only)
+router.patch('/superlatives/:id', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const isAdminUser = req.underboss!.regions.includes('__admin__');
+    if (!isAdminUser) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const { id } = req.params;
+    const { status } = req.body as { status?: string };
+
+    if (!status || !SUPERLATIVE_STATUSES.has(status)) {
+      throw new AppError(
+        "status must be one of: winner, rejected, pending",
+        400,
+        'VALIDATION_ERROR'
+      );
+    }
+
+    const updated = await prisma.superlativeSubmission.update({
+      where: { id },
+      data: {
+        status,
+        judgedBy: req.userEmail || null,
+        judgedAt: new Date(),
+      },
+      select: { id: true, status: true, judgedBy: true, judgedAt: true },
+    });
+
+    res.json({ submission: updated });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // GET /api/underboss/:region - Main dashboard data
 router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {

--- a/frontend/src/components/scorecard/GuestScorecard.tsx
+++ b/frontend/src/components/scorecard/GuestScorecard.tsx
@@ -55,6 +55,8 @@ export function GuestScorecard({
   const [items, setItems] = useState<ScorecardItemType[]>([]);
   const [pizzaChefScore, setPizzaChefScore] = useState(0);
   const [totalItems, setTotalItems] = useState(11);
+  // panzerotti-58931 Phase 2.1: the guest's judged "Best Of" wins.
+  const [bestOfWins, setBestOfWins] = useState<{ superlativeKey: string; label: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [completingItem, setCompletingItem] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -69,6 +71,7 @@ export function GuestScorecard({
       setItems(data.items);
       setPizzaChefScore(data.pizzaChefScore);
       setTotalItems(data.totalItems);
+      setBestOfWins(data.bestOfWins ?? []);
       setError(null);
     } catch (err: any) {
       // If guest isn't checked in yet or not a guest, just hide quietly
@@ -146,6 +149,15 @@ export function GuestScorecard({
           </span>
         </div>
       </div>
+
+      {/* panzerotti-58931 Phase 2.1: Best Of wins */}
+      {bestOfWins.length > 0 && (
+        <div className="px-4 pt-2">
+          <p className="text-xs font-medium text-yellow-400">
+            🏆 Best Of winner: {bestOfWins.map((w) => w.label).join(', ')}
+          </p>
+        </div>
+      )}
 
       {/* Progress bar */}
       <div className="px-4 pt-3">

--- a/frontend/src/components/scorecard/LeaderboardModal.tsx
+++ b/frontend/src/components/scorecard/LeaderboardModal.tsx
@@ -1,41 +1,124 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Loader2, Trophy } from 'lucide-react';
-import { getPartyLeaderboard, LeaderboardEntry } from '../../lib/api';
+import {
+  getPartyLeaderboard,
+  getScorecardGlobalLeaderboard,
+  LeaderboardEntry,
+  ScorecardGuestRow,
+  ScorecardPartyRow,
+  ScorecardCountryRow,
+} from '../../lib/api';
 
 interface LeaderboardModalProps {
   inviteCode: string;
   onClose: () => void;
 }
 
-type Tab = 'party' | 'worldwide';
+type Tab = 'party' | 'worldwide' | 'parties' | 'countries';
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'party', label: 'This Party' },
+  { key: 'worldwide', label: 'Worldwide' },
+  { key: 'parties', label: 'Parties' },
+  { key: 'countries', label: 'Countries' },
+];
+
+interface GlobalData {
+  guests: ScorecardGuestRow[];
+  parties: ScorecardPartyRow[];
+  countries: ScorecardCountryRow[];
+}
 
 export function LeaderboardModal({ inviteCode, onClose }: LeaderboardModalProps) {
   const [tab, setTab] = useState<Tab>('party');
+
+  // "This Party" board
   const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [partyLoading, setPartyLoading] = useState(true);
+  const [partyError, setPartyError] = useState<string | null>(null);
+
+  // Global board (worldwide / parties / countries) — loaded once on first need.
+  const [global, setGlobal] = useState<GlobalData | null>(null);
+  const [globalLoading, setGlobalLoading] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      setLoading(true);
+      setPartyLoading(true);
       try {
         const data = await getPartyLeaderboard(inviteCode);
         if (!cancelled) {
           setEntries(data.leaderboard);
-          setError(null);
+          setPartyError(null);
         }
       } catch (err: any) {
-        if (!cancelled) setError(err?.message || 'Failed to load leaderboard');
+        if (!cancelled) setPartyError(err?.message || 'Failed to load leaderboard');
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setPartyLoading(false);
       }
     })();
     return () => {
       cancelled = true;
     };
   }, [inviteCode]);
+
+  // Lazy-load the global board the first time a worldwide tab is opened.
+  useEffect(() => {
+    if (tab === 'party') return;
+    if (global || globalLoading) return;
+    let cancelled = false;
+    (async () => {
+      setGlobalLoading(true);
+      try {
+        const data = await getScorecardGlobalLeaderboard();
+        if (!cancelled) {
+          setGlobal({ guests: data.guests, parties: data.parties, countries: data.countries });
+          setGlobalError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) setGlobalError(err?.message || 'Failed to load leaderboard');
+      } finally {
+        if (!cancelled) setGlobalLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, global, globalLoading]);
+
+  const renderRow = (
+    key: string,
+    rank: number,
+    primary: string,
+    secondary: string | null,
+    score: number,
+    highlight: boolean
+  ) => (
+    <li
+      key={key}
+      className={`flex items-center gap-3 rounded-xl px-3 py-2.5 ${
+        highlight ? 'border border-[#ff393a]/40 bg-[#ff393a]/10' : 'bg-gray-50'
+      }`}
+    >
+      <span className="w-6 text-center text-sm font-bold text-gray-400">{rank}</span>
+      <span className="flex-1 min-w-0">
+        <span className={`block truncate text-sm ${highlight ? 'font-semibold text-gray-900' : 'text-gray-700'}`}>
+          {primary}
+          {highlight && <span className="ml-1.5 text-xs text-[#ff393a]">(you)</span>}
+        </span>
+        {secondary && <span className="block truncate text-xs text-gray-400">{secondary}</span>}
+      </span>
+      <span className="text-sm font-bold text-gray-900">{score}</span>
+    </li>
+  );
+
+  const spinner = (
+    <div className="flex justify-center py-8">
+      <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+    </div>
+  );
 
   return createPortal(
     <div
@@ -47,7 +130,7 @@ export function LeaderboardModal({ inviteCode, onClose }: LeaderboardModalProps)
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="sticky top-0 flex items-center justify-between border-b border-gray-200 bg-white px-5 py-4">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-200 bg-white px-5 py-4">
           <h2 className="flex items-center gap-2 text-lg font-bold text-gray-900">
             <Trophy className="h-5 w-5 text-yellow-500" /> Leaderboard
           </h2>
@@ -61,69 +144,96 @@ export function LeaderboardModal({ inviteCode, onClose }: LeaderboardModalProps)
         </div>
 
         {/* Tabs */}
-        <div className="flex gap-1 border-b border-gray-200 px-3 pt-3">
-          <button
-            onClick={() => setTab('party')}
-            className={`rounded-t-lg px-4 py-2 text-sm font-medium ${
-              tab === 'party'
-                ? 'bg-gray-100 text-gray-900'
-                : 'text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            This Party
-          </button>
-          <button
-            disabled
-            title="Coming soon"
-            className="cursor-not-allowed rounded-t-lg px-4 py-2 text-sm font-medium text-gray-300"
-          >
-            Worldwide
-          </button>
+        <div className="flex gap-1 overflow-x-auto border-b border-gray-200 px-3 pt-3">
+          {TABS.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              className={`whitespace-nowrap rounded-t-lg px-3 py-2 text-sm font-medium ${
+                tab === t.key
+                  ? 'bg-gray-100 text-gray-900'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
         </div>
 
         <div className="px-5 py-4">
+          {/* This Party */}
           {tab === 'party' && (
             <>
-              {loading ? (
-                <div className="flex justify-center py-8">
-                  <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
-                </div>
-              ) : error ? (
-                <p className="py-6 text-center text-sm text-red-600">{error}</p>
+              {partyLoading ? (
+                spinner
+              ) : partyError ? (
+                <p className="py-6 text-center text-sm text-red-600">{partyError}</p>
               ) : entries.length === 0 ? (
-                <p className="py-6 text-center text-sm text-gray-400">
-                  No checked-in guests yet.
-                </p>
+                <p className="py-6 text-center text-sm text-gray-400">No checked-in guests yet.</p>
               ) : (
                 <ol className="space-y-1.5">
-                  {entries.map((entry, idx) => (
-                    <li
-                      key={entry.guestId}
-                      className={`flex items-center gap-3 rounded-xl px-3 py-2.5 ${
-                        entry.isCurrentUser
-                          ? 'border border-[#ff393a]/40 bg-[#ff393a]/10'
-                          : 'bg-gray-50'
-                      }`}
-                    >
-                      <span className="w-6 text-center text-sm font-bold text-gray-400">
-                        {idx + 1}
-                      </span>
-                      <span
-                        className={`flex-1 text-sm ${
-                          entry.isCurrentUser
-                            ? 'font-semibold text-gray-900'
-                            : 'text-gray-700'
-                        }`}
-                      >
-                        {entry.name}
-                        {entry.isCurrentUser && (
-                          <span className="ml-1.5 text-xs text-[#ff393a]">(you)</span>
-                        )}
-                      </span>
-                      <span className="text-sm font-bold text-gray-900">{entry.score}</span>
-                    </li>
-                  ))}
+                  {entries.map((entry, idx) =>
+                    renderRow(entry.guestId, idx + 1, entry.name, null, entry.score, entry.isCurrentUser)
+                  )}
                 </ol>
+              )}
+            </>
+          )}
+
+          {/* Worldwide / Parties / Countries (global board) */}
+          {tab !== 'party' && (
+            <>
+              {globalLoading ? (
+                spinner
+              ) : globalError ? (
+                <p className="py-6 text-center text-sm text-red-600">{globalError}</p>
+              ) : !global ? (
+                spinner
+              ) : tab === 'worldwide' ? (
+                global.guests.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-gray-400">No scores yet.</p>
+                ) : (
+                  <ol className="space-y-1.5">
+                    {global.guests.map((g) =>
+                      renderRow(`g-${g.rank}-${g.name}`, g.rank, g.name, g.country, g.score, false)
+                    )}
+                  </ol>
+                )
+              ) : tab === 'parties' ? (
+                global.parties.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-gray-400">No scores yet.</p>
+                ) : (
+                  <ol className="space-y-1.5">
+                    {global.parties.map((p) =>
+                      renderRow(
+                        p.partyId,
+                        p.rank,
+                        p.name,
+                        [p.city, p.country].filter(Boolean).join(', ') || null,
+                        p.score,
+                        false
+                      )
+                    )}
+                  </ol>
+                )
+              ) : (
+                // countries
+                global.countries.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-gray-400">No scores yet.</p>
+                ) : (
+                  <ol className="space-y-1.5">
+                    {global.countries.map((c) =>
+                      renderRow(
+                        `c-${c.rank}-${c.country}`,
+                        c.rank,
+                        c.country,
+                        `${c.partyCount} ${c.partyCount === 1 ? 'party' : 'parties'}`,
+                        c.score,
+                        false
+                      )
+                    )}
+                  </ol>
+                )
               )}
             </>
           )}

--- a/frontend/src/components/underboss/SuperlativesTab.tsx
+++ b/frontend/src/components/underboss/SuperlativesTab.tsx
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader2, Trophy, Check, X as XIcon, RotateCcw } from 'lucide-react';
+import {
+  getUnderbossSuperlatives,
+  markSuperlative,
+  UnderbossSuperlativeGroup,
+  UnderbossSuperlativeRow,
+} from '../../lib/api';
+import { ReceiptLightbox } from '../payments-shared/ReceiptLightbox';
+
+/**
+ * panzerotti-58931 Phase 2.1: admin "Best Of" judging queue. Mirrors the
+ * FakeDetectionTable admin tab pattern. Submissions are grouped by superlative
+ * key; each shows as a photo card. Clicking a card opens a ReceiptLightbox with
+ * an editorPane holding Mark winner / Reject / Reset buttons.
+ */
+
+const STATUS_BADGE: Record<string, string> = {
+  winner: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/40',
+  rejected: 'bg-red-500/15 text-red-400 border-red-500/30',
+  pending: 'bg-white/10 text-theme-text-muted border-theme-stroke',
+};
+
+export function SuperlativesTab() {
+  const [groups, setGroups] = useState<UnderbossSuperlativeGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Local status overrides + per-row pending state, keyed by submission id.
+  const [statusOverride, setStatusOverride] = useState<Record<string, string>>({});
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+
+  // Lightbox state: which group is open + which index within its submissions.
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [openIndex, setOpenIndex] = useState(0);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getUnderbossSuperlatives();
+      setGroups(data.groups);
+      setError(null);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load submissions');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const effectiveStatus = useCallback(
+    (row: UnderbossSuperlativeRow): string => statusOverride[row.id] ?? row.status,
+    [statusOverride]
+  );
+
+  const runAction = useCallback(
+    async (id: string, status: 'winner' | 'rejected' | 'pending') => {
+      const prev = statusOverride[id];
+      setPending((p) => ({ ...p, [id]: true }));
+      setStatusOverride((s) => ({ ...s, [id]: status }));
+      try {
+        await markSuperlative(id, status);
+      } catch (err) {
+        // Roll back the optimistic override on failure.
+        setStatusOverride((s) => {
+          const n = { ...s };
+          if (prev !== undefined) n[id] = prev;
+          else delete n[id];
+          return n;
+        });
+      } finally {
+        setPending((p) => ({ ...p, [id]: false }));
+      }
+    },
+    [statusOverride]
+  );
+
+  const openGroup = useMemo(
+    () => groups.find((g) => g.superlativeKey === openKey) || null,
+    [groups, openKey]
+  );
+
+  const lightboxImages = useMemo(
+    () =>
+      (openGroup?.submissions || []).map((s) => ({
+        url: s.photoUrl,
+        fileName: `${s.guestName} — ${s.partyName}`,
+      })),
+    [openGroup]
+  );
+
+  const currentRow: UnderbossSuperlativeRow | null =
+    openGroup && openGroup.submissions[openIndex] ? openGroup.submissions[openIndex] : null;
+
+  const editorPane = currentRow ? (
+    <div className="flex flex-col gap-4 p-5 text-gray-900">
+      <div>
+        <p className="text-lg font-bold">{currentRow.guestName}</p>
+        <p className="text-sm text-gray-600">{currentRow.partyName}</p>
+        <p className="text-sm text-gray-400">
+          {[currentRow.city, currentRow.country].filter(Boolean).join(', ')}
+        </p>
+        {currentRow.numericValue !== null && (
+          <p className="mt-1 text-sm text-gray-600">
+            Value: <span className="font-semibold">{currentRow.numericValue}</span>
+          </p>
+        )}
+      </div>
+
+      <div>
+        <span
+          className={`inline-block rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+            STATUS_BADGE[effectiveStatus(currentRow)] ?? STATUS_BADGE.pending
+          }`}
+        >
+          {effectiveStatus(currentRow)}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <button
+          disabled={!!pending[currentRow.id]}
+          onClick={() => runAction(currentRow.id, 'winner')}
+          className="flex items-center justify-center gap-2 rounded-lg bg-yellow-500 px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-yellow-400 disabled:opacity-50"
+        >
+          {pending[currentRow.id] ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Trophy className="h-4 w-4" />
+          )}
+          Mark winner
+        </button>
+        <button
+          disabled={!!pending[currentRow.id]}
+          onClick={() => runAction(currentRow.id, 'rejected')}
+          className="flex items-center justify-center gap-2 rounded-lg bg-red-100 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-200 disabled:opacity-50"
+        >
+          <XIcon className="h-4 w-4" />
+          Reject
+        </button>
+        <button
+          disabled={!!pending[currentRow.id]}
+          onClick={() => runAction(currentRow.id, 'pending')}
+          className="flex items-center justify-center gap-2 rounded-lg bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-200 disabled:opacity-50"
+        >
+          <RotateCcw className="h-4 w-4" />
+          Reset
+        </button>
+      </div>
+    </div>
+  ) : null;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="py-8 text-center text-sm text-red-400">{error}</p>;
+  }
+
+  if (groups.length === 0) {
+    return <p className="py-8 text-center text-sm text-theme-text-muted">No Best Of submissions yet.</p>;
+  }
+
+  return (
+    <div className="space-y-8">
+      {groups.map((group) => (
+        <div key={group.superlativeKey}>
+          <h3 className="mb-3 flex items-center gap-2 text-lg font-semibold text-theme-text">
+            <Trophy className="h-5 w-5 text-yellow-400" />
+            {group.label}
+            <span className="text-sm font-normal text-theme-text-muted">
+              ({group.submissions.length})
+            </span>
+          </h3>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+            {group.submissions.map((s, idx) => {
+              const status = effectiveStatus(s);
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => {
+                    setOpenKey(group.superlativeKey);
+                    setOpenIndex(idx);
+                  }}
+                  className="group relative overflow-hidden rounded-xl border border-theme-stroke bg-theme-surface text-left transition-colors hover:border-theme-text-muted"
+                >
+                  <div className="aspect-square w-full overflow-hidden bg-black/20">
+                    <img
+                      src={s.photoUrl}
+                      alt={`${s.guestName} — ${group.label}`}
+                      loading="lazy"
+                      className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                    />
+                  </div>
+                  {status === 'winner' && (
+                    <span className="absolute right-1.5 top-1.5 rounded-full bg-yellow-500 p-1 text-gray-900">
+                      <Check className="h-3.5 w-3.5" />
+                    </span>
+                  )}
+                  {status === 'rejected' && (
+                    <span className="absolute right-1.5 top-1.5 rounded-full bg-red-500 p-1 text-white">
+                      <XIcon className="h-3.5 w-3.5" />
+                    </span>
+                  )}
+                  <div className="px-2 py-1.5">
+                    <p className="truncate text-xs font-medium text-theme-text">{s.guestName}</p>
+                    <p className="truncate text-xs text-theme-text-muted">
+                      {[s.city, s.country].filter(Boolean).join(', ') || s.partyName}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      {openGroup && (
+        <ReceiptLightbox
+          isOpen
+          images={lightboxImages}
+          initialIndex={openIndex}
+          onIndexChange={setOpenIndex}
+          onClose={() => setOpenKey(null)}
+          editorPane={editorPane}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -9,6 +9,7 @@ export { PartnerManager } from './PartnerManager';
 export { FunnelTab } from './FunnelTab';
 export { CityScopePicker } from './CityScopePicker';
 export { FakeDetectionTable } from './FakeDetectionTable';
+export { SuperlativesTab } from './SuperlativesTab';
 export { OutreachTab } from './OutreachTab';
 export { ReimbursementCapCell } from './ReimbursementCapCell';
 export { AppealHistoryModal } from './AppealHistoryModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4197,6 +4197,8 @@ export interface ScorecardResponse {
   items: ScorecardItem[];
   pizzaChefScore: number;
   totalItems: number;
+  /** panzerotti-58931 Phase 2.1: the calling guest's judged "Best Of" wins. */
+  bestOfWins?: { superlativeKey: string; label: string }[];
 }
 
 export interface CompleteScorecardResponse {
@@ -4236,6 +4238,81 @@ export interface LeaderboardResponse {
 
 export async function getPartyLeaderboard(inviteCode: string): Promise<LeaderboardResponse> {
   return apiRequest<LeaderboardResponse>(`/api/scorecard/${inviteCode}/leaderboard`);
+}
+
+// panzerotti-58931 Phase 2.1: worldwide game leaderboard (guests / parties / countries)
+
+export interface ScorecardGuestRow {
+  rank: number;
+  name: string;
+  city: string | null;
+  country: string | null;
+  countryCode: string | null;
+  score: number;
+}
+
+export interface ScorecardPartyRow {
+  rank: number;
+  partyId: string;
+  name: string;
+  city: string | null;
+  country: string | null;
+  countryCode: string | null;
+  slug: string;
+  score: number;
+}
+
+export interface ScorecardCountryRow {
+  rank: number;
+  country: string;
+  countryCode: string | null;
+  partyCount: number;
+  score: number;
+}
+
+export interface ScorecardGlobalLeaderboardResponse {
+  guests: ScorecardGuestRow[];
+  parties: ScorecardPartyRow[];
+  countries: ScorecardCountryRow[];
+  computedAt: string;
+}
+
+export async function getScorecardGlobalLeaderboard(): Promise<ScorecardGlobalLeaderboardResponse> {
+  return apiRequest<ScorecardGlobalLeaderboardResponse>('/api/scorecard-leaderboard');
+}
+
+// panzerotti-58931 Phase 2.1: admin Best Of judging queue
+
+export interface UnderbossSuperlativeRow {
+  id: string;
+  superlativeKey: string;
+  guestName: string;
+  partyName: string;
+  city: string | null;
+  country: string | null;
+  photoUrl: string;
+  numericValue: number | null;
+  status: string;
+}
+
+export interface UnderbossSuperlativeGroup {
+  superlativeKey: string;
+  label: string;
+  submissions: UnderbossSuperlativeRow[];
+}
+
+export async function getUnderbossSuperlatives(): Promise<{ groups: UnderbossSuperlativeGroup[] }> {
+  return apiRequest<{ groups: UnderbossSuperlativeGroup[] }>('/api/underboss/superlatives');
+}
+
+export async function markSuperlative(
+  id: string,
+  status: 'winner' | 'rejected' | 'pending'
+): Promise<{ submission: { id: string; status: string } }> {
+  return apiRequest<{ submission: { id: string; status: string } }>(
+    `/api/underboss/superlatives/${id}`,
+    { method: 'PATCH', body: { status } }
+  );
 }
 
 export interface SuperlativeSubmission {

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -17,13 +17,23 @@ import {
   LeaderboardPartyRow,
   LeaderboardCountryRow,
   LeaderboardWindow,
+  getScorecardGlobalLeaderboard,
+  ScorecardGlobalLeaderboardResponse,
+  ScorecardPartyRow,
+  ScorecardCountryRow,
 } from '../lib/api';
 
 // stromboli-71593: public leaderboard page rendered at both `/leaderboard`
 // and `/gpp/leaderboard`. Single data fetch hydrates both tabs (parties +
 // countries) — no realtime subscriptions, fetched on mount + tab change.
+//
+// panzerotti-58931 Phase 2.2: metric toggle — Engagement (default, existing
+// composite) vs Pizza Chef (scorecard-based, global/unwindowed). Pizza Chef
+// reuses the same party/country board layout but drops the engagement-only
+// breakdown columns.
 
 type TabKey = 'parties' | 'countries';
+type MetricKey = 'engagement' | 'chef';
 
 const PAGE_SIZE = 50;
 const MAX_LIMIT = 200;
@@ -181,12 +191,87 @@ function LeaderboardCountryRowView({ row }: { row: LeaderboardCountryRow }) {
   );
 }
 
+// panzerotti-58931 Phase 2.2: Pizza Chef (scorecard) row views. Same layout as
+// the engagement rows above, minus the engagement-only breakdown chips (the
+// scorecard board has no linkRsvps / inviteRsvps / checkIns / photos split).
+function ScorecardPartyRowView({ row }: { row: ScorecardPartyRow }) {
+  return (
+    <Link
+      to={`/${row.slug}`}
+      className="flex items-center gap-3 px-4 py-3 border-b border-black/[0.06] hover:bg-black/[0.03] transition-colors last:border-b-0"
+    >
+      <div className="flex-shrink-0 w-8 text-center text-base font-bold tabular-nums" style={{ color: C.red }}>
+        {row.rank}
+      </div>
+      <div className="flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden bg-gray-100 flex items-center justify-center">
+        <Trophy size={18} className="text-gray-400" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-semibold text-[#1a1a1a] truncate">
+            {row.name}
+          </span>
+          <CountryFlag code={row.countryCode} />
+        </div>
+        <div className="flex items-center gap-2 text-[12px] text-[#555] mt-0.5 truncate">
+          {row.city && (
+            <span className="inline-flex items-center gap-1">
+              <MapPin size={11} />
+              {row.city}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex-shrink-0 text-right">
+        <div className="text-base font-bold tabular-nums" style={{ color: C.red }}>
+          {row.score.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+        </div>
+        <div className="text-[10px] uppercase tracking-wide text-gray-500">
+          score
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function ScorecardCountryRowView({ row }: { row: ScorecardCountryRow }) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 border-b border-black/[0.06] last:border-b-0">
+      <div className="flex-shrink-0 w-8 text-center text-base font-bold tabular-nums" style={{ color: C.red }}>
+        {row.rank}
+      </div>
+      <CountryFlag code={row.countryCode} />
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-semibold text-[#1a1a1a] truncate">
+          {row.country}
+        </div>
+        <div className="text-[12px] text-[#555]">
+          {row.partyCount.toLocaleString()}{' '}
+          {row.partyCount === 1 ? 'party' : 'parties'}
+        </div>
+      </div>
+      <div className="flex-shrink-0 text-right">
+        <div className="text-base font-bold tabular-nums" style={{ color: C.red }}>
+          {row.score.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+        </div>
+        <div className="text-[10px] uppercase tracking-wide text-gray-500">
+          score
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function LeaderboardPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = (searchParams.get('tab') === 'countries' ? 'countries' : 'parties') as TabKey;
   const windowParam = (searchParams.get('window') === 'year' ? 'year' : 'all') as LeaderboardWindow;
+  const metricParam = (searchParams.get('metric') === 'chef' ? 'chef' : 'engagement') as MetricKey;
 
+  // Engagement (existing) data path — byte-for-byte unchanged from before.
   const [data, setData] = useState<LeaderboardResponse | null>(null);
+  // Pizza Chef (scorecard) data path — global/unwindowed.
+  const [chefData, setChefData] = useState<ScorecardGlobalLeaderboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [limit, setLimit] = useState<number>(PAGE_SIZE);
@@ -209,9 +294,28 @@ export function LeaderboardPage() {
     [],
   );
 
+  const loadChef = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    getScorecardGlobalLeaderboard()
+      .then((res) => {
+        setChefData(res);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch Pizza Chef leaderboard:', err);
+        setError(err?.message || 'Failed to load leaderboard');
+        setLoading(false);
+      });
+  }, []);
+
   useEffect(() => {
-    load(windowParam, limit);
-  }, [load, windowParam, limit]);
+    if (metricParam === 'chef') {
+      loadChef();
+    } else {
+      load(windowParam, limit);
+    }
+  }, [metricParam, load, loadChef, windowParam, limit]);
 
   const setTab = useCallback(
     (next: TabKey) => {
@@ -235,24 +339,49 @@ export function LeaderboardPage() {
     [searchParams, setSearchParams],
   );
 
+  const setMetric = useCallback(
+    (next: MetricKey) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === 'engagement') params.delete('metric');
+      else params.set('metric', next);
+      // Reset page size on metric switch (Pizza Chef is unpaginated/global).
+      setLimit(PAGE_SIZE);
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
   const showMore = useCallback(() => {
     setLimit((cur) => Math.min(cur + PAGE_SIZE, MAX_LIMIT));
   }, []);
 
   // Derived values — all hooks declared BEFORE any early return, per
   // feedback_hooks_above_early_returns.md.
+  const isChef = metricParam === 'chef';
+
+  // Engagement (existing) derived values.
   const partyRows = data?.parties.rows ?? [];
   const countryRows = data?.countries.rows ?? [];
   const partyTotal = data?.parties.total ?? 0;
   const countryTotal = data?.countries.total ?? 0;
-  const hasMore = partyRows.length < partyTotal && limit < MAX_LIMIT;
+  // "Show more" pagination only applies to the windowed engagement board.
+  const hasMore = !isChef && partyRows.length < partyTotal && limit < MAX_LIMIT;
+
+  // Pizza Chef (scorecard) derived values — global, unpaginated.
+  const chefPartyRows = chefData?.parties ?? [];
+  const chefCountryRows = chefData?.countries ?? [];
+
+  // What's actually displayed, per metric.
+  const displayPartyCount = isChef ? chefPartyRows.length : partyTotal;
+  const displayCountryCount = isChef ? chefCountryRows.length : countryTotal;
+  const hasData = isChef ? !!chefData : !!data;
 
   const headline = useMemo(() => {
     if (tabParam === 'countries') {
-      return `${countryTotal.toLocaleString()} ${countryTotal === 1 ? 'country' : 'countries'}`;
+      return `${displayCountryCount.toLocaleString()} ${displayCountryCount === 1 ? 'country' : 'countries'}`;
     }
-    return `${partyTotal.toLocaleString()} ${partyTotal === 1 ? 'party' : 'parties'}`;
-  }, [tabParam, partyTotal, countryTotal]);
+    return `${displayPartyCount.toLocaleString()} ${displayPartyCount === 1 ? 'party' : 'parties'}`;
+  }, [tabParam, displayPartyCount, displayCountryCount]);
 
   // Segmented-control button helper for consistent styling.
   const segBtn = (active: boolean) =>
@@ -311,6 +440,26 @@ export function LeaderboardPage() {
               Approved Global Pizza Party events ranked by guest engagement.
             </p>
 
+            {/* Metric segmented control — Engagement (default) vs Pizza Chef */}
+            <div className="inline-flex items-center rounded-xl border border-black/[0.08] bg-white/90 backdrop-blur-sm p-1 self-start shadow-sm mb-3">
+              <button
+                type="button"
+                onClick={() => setMetric('engagement')}
+                className={segBtn(metricParam === 'engagement')}
+                style={segBtnStyle(metricParam === 'engagement')}
+              >
+                Engagement
+              </button>
+              <button
+                type="button"
+                onClick={() => setMetric('chef')}
+                className={segBtn(metricParam === 'chef')}
+                style={segBtnStyle(metricParam === 'chef')}
+              >
+                Pizza Chef
+              </button>
+            </div>
+
             {/* Tab + window segmented controls */}
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
               <div className="inline-flex items-center rounded-xl border border-black/[0.08] bg-white/90 backdrop-blur-sm p-1 self-start shadow-sm">
@@ -331,24 +480,28 @@ export function LeaderboardPage() {
                   Countries
                 </button>
               </div>
-              <div className="inline-flex items-center rounded-xl border border-black/[0.08] bg-white/90 backdrop-blur-sm p-1 self-start shadow-sm">
-                <button
-                  type="button"
-                  onClick={() => setWindow('all')}
-                  className={segBtn(windowParam === 'all')}
-                  style={segBtnStyle(windowParam === 'all')}
-                >
-                  All-time
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setWindow('year')}
-                  className={segBtn(windowParam === 'year')}
-                  style={segBtnStyle(windowParam === 'year')}
-                >
-                  2026
-                </button>
-              </div>
+              {/* Window selector is engagement-only — the Pizza Chef endpoint is
+                  global/unwindowed, so hide it when Pizza Chef is active. */}
+              {!isChef && (
+                <div className="inline-flex items-center rounded-xl border border-black/[0.08] bg-white/90 backdrop-blur-sm p-1 self-start shadow-sm">
+                  <button
+                    type="button"
+                    onClick={() => setWindow('all')}
+                    className={segBtn(windowParam === 'all')}
+                    style={segBtnStyle(windowParam === 'all')}
+                  >
+                    All-time
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setWindow('year')}
+                    className={segBtn(windowParam === 'year')}
+                    style={segBtnStyle(windowParam === 'year')}
+                  >
+                    2026
+                  </button>
+                </div>
+              )}
             </div>
 
             {loading && (
@@ -362,7 +515,7 @@ export function LeaderboardPage() {
                 <span>{error}</span>
                 <button
                   type="button"
-                  onClick={() => load(windowParam, limit)}
+                  onClick={() => (isChef ? loadChef() : load(windowParam, limit))}
                   className="px-4 py-2 rounded-xl text-sm font-medium text-white transition-all hover:-translate-y-0.5 self-start"
                   style={{ background: C.red }}
                   onMouseEnter={(e) => {
@@ -377,20 +530,40 @@ export function LeaderboardPage() {
               </div>
             )}
 
-            {!loading && !error && data && (
+            {!loading && !error && hasData && (
               <>
                 <div className="text-xs text-white/80 mb-2 tabular-nums">
                   {headline}
                 </div>
                 <div className="rounded-2xl border border-black/[0.08] bg-white/90 backdrop-blur-sm shadow-lg overflow-hidden">
                   {tabParam === 'parties' ? (
-                    partyRows.length === 0 ? (
+                    isChef ? (
+                      chefPartyRows.length === 0 ? (
+                        <div className="px-4 py-8 text-center text-sm text-[#555]">
+                          No parties yet.
+                        </div>
+                      ) : (
+                        chefPartyRows.map((row) => (
+                          <ScorecardPartyRowView key={row.partyId} row={row} />
+                        ))
+                      )
+                    ) : partyRows.length === 0 ? (
                       <div className="px-4 py-8 text-center text-sm text-[#555]">
                         No parties yet for this window.
                       </div>
                     ) : (
                       partyRows.map((row) => (
                         <LeaderboardPartyRowView key={row.id} row={row} />
+                      ))
+                    )
+                  ) : isChef ? (
+                    chefCountryRows.length === 0 ? (
+                      <div className="px-4 py-8 text-center text-sm text-[#555]">
+                        No countries yet.
+                      </div>
+                    ) : (
+                      chefCountryRows.map((row) => (
+                        <ScorecardCountryRowView key={row.country} row={row} />
                       ))
                     )
                   ) : countryRows.length === 0 ? (
@@ -424,8 +597,9 @@ export function LeaderboardPage() {
                 )}
 
                 <div className="text-[11px] text-white/70 mt-6 text-center">
-                  Score = link RSVPs + 0.3 invite RSVPs + 2 check-ins + 0.5 photos
-                  (max 100 photos).
+                  {isChef
+                    ? 'Score = sum of Pizza Chef scorecard points across guests at each party.'
+                    : 'Score = link RSVPs + 0.3 invite RSVPs + 2 check-ins + 0.5 photos (max 100 photos).'}
                 </div>
               </>
             )}

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -6,7 +6,7 @@ import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, C
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, OutreachTab } from '../components/underboss';
+import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, SuperlativesTab, OutreachTab } from '../components/underboss';
 import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
@@ -96,7 +96,7 @@ export function UnderbossDashboard() {
   const [availableRegions, setAvailableRegions] = useState<string[]>([]);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection' | 'outreach'>('events');
+  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection' | 'superlatives' | 'outreach'>('events');
 
   const [tableFilteredEvents, setTableFilteredEvents] = useState<UnderbossEvent[] | null>(null);
 
@@ -649,6 +649,21 @@ export function UnderbossDashboard() {
                 )}
               </button>
             )}
+            {isAdmin && (
+              <button
+                onClick={() => setActiveTab('superlatives')}
+                className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                  activeTab === 'superlatives'
+                    ? 'text-theme-text'
+                    : 'text-theme-text-muted hover:text-theme-text-secondary'
+                }`}
+              >
+                {t('underbossDashboard.tabs.bestOf', 'Best Of')}
+                {activeTab === 'superlatives' && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+                )}
+              </button>
+            )}
             <button
               onClick={() => setActiveTab('outreach')}
               className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
@@ -678,6 +693,10 @@ export function UnderbossDashboard() {
 
           {isAdmin && activeTab === 'fake-detection' && (
             <FakeDetectionTable />
+          )}
+
+          {isAdmin && activeTab === 'superlatives' && (
+            <SuperlativesTab />
           )}
 
           {activeTab === 'outreach' && (


### PR DESCRIPTION
## Summary

Phase 2.1 of the check-in game. Adds the worldwide game leaderboard with score rollups and an admin "Best Of" judging queue.

**Scoring model**
- Item score = count of completed `guest_scorecard_items` (drives the unchanged X/total Pizza Chef meter).
- Best Of bonus = `winsCount * BEST_OF_BONUS` (`BEST_OF_BONUS = 5`), a win = a `superlative_submissions` row with `status='winner'`.
- Leaderboard score = item score + Best Of bonus (every board ranks by this).
- Party score = Σ leaderboard score over checked-in guests; Country score = Σ party scores grouped by trimmed/case-insensitive `parties.country`.

**Backend**
- New `backend/src/routes/scorecardLeaderboard.routes.ts` mounted at `/api/scorecard-leaderboard`. One cached (`GET /` → `{ guests, parties, countries, computedAt }`) single-pass `$queryRaw` over checked-in, non-rejected guests with `COUNT(DISTINCT ...) FILTER` for item + winner counts (no join fan-out). 5-min in-memory cache + `Cache-Control: public, max-age=300`. `guests` top 100.
- `scorecard.routes.ts`: per-party `/leaderboard` score now includes the Best Of bonus; `GET /:inviteCode` returns `bestOfWins` for the calling guest. Added `SUPERLATIVE_LABELS`.
- `underboss.routes.ts`: admin `GET /superlatives` (grouped by key) + `PATCH /superlatives/:id` (`winner|rejected|pending`, sets `judgedBy=req.userEmail`, `judgedAt=now`). Declared above `/:region` so they aren't shadowed.

**Frontend**
- `LeaderboardModal`: **This Party | Worldwide | Parties | Countries** tabs (global tabs lazy-load `getScorecardGlobalLeaderboard()`; no "you" highlight worldwide).
- `GuestScorecard`: renders a "🏆 Best Of winner: …" line when the guest has wins; meter unchanged.
- New admin `SuperlativesTab` (photo grid grouped by category, click opens `ReceiptLightbox` with an `editorPane` holding Mark winner / Reject / Reset). Gated by existing `isAdmin`.
- `lib/api.ts`: `getScorecardGlobalLeaderboard()` + row types, `bestOfWins?` on the scorecard response, `getUnderbossSuperlatives()` + `markSuperlative()`.

## DB

**No migration; reuses existing `superlative_submissions` table.** No schema change.

## Verification

- Backend `tsc --noEmit`: clean for changed files (only pre-existing env-only module errors: sharp/openai/archiver, and an unrelated jwt test).
- Frontend: local `vite build` is blocked by a shared-node_modules walletconnect dependency-resolution issue (all source modules transform; failure is at a wallet-lib entry my code never imports). Vercel does a clean install from the unchanged lockfile, so the preview build is the source of truth.

## Exact `$queryRaw` SQL (please execute-verify against prod before merge)

```sql
SELECT
  g.id                                                              AS guest_id,
  g.name                                                            AS name,
  p.id                                                              AS party_id,
  p.name                                                            AS party_name,
  p.city                                                            AS city,
  p.country                                                         AS country,
  p.custom_url                                                      AS custom_url,
  p.invite_code                                                     AS invite_code,
  COUNT(DISTINCT i.id) FILTER (WHERE i.completed)                   AS item_count,
  COUNT(DISTINCT s.id) FILTER (WHERE s.status = 'winner')           AS win_count
FROM guests g
JOIN parties p ON p.id = g.party_id
LEFT JOIN guest_scorecard_items i ON i.guest_id = g.id
LEFT JOIN superlative_submissions s ON s.guest_id = g.id
WHERE g.checked_in_at IS NOT NULL
  AND (g.approved IS TRUE OR g.approved IS NULL)
GROUP BY g.id, g.name, p.id, p.name, p.city, p.country, p.custom_url, p.invite_code;
```

Note: `i.guest_id` is joined without scoping to `i.party_id = g.party_id`. A guest row belongs to exactly one party, and scorecard items / superlatives are keyed per (guest, party), so per-guest aggregation is correct; the join stays simple. Verify there are no orphaned `guest_scorecard_items` for a guest under a different party_id if guests are ever re-parented (not expected in this schema).

## Preview

https://rsvpizza-git-panzerotti-58931-game-phase2-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)