### PR TITLE
feta-64218: surface real Supabase upload errors to hosts

### DIFF
--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -261,10 +261,6 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
       // still matches `payouts/{partyId}/{group}/{kind}/...`.
       const groupId = `external-${Date.now()}`;
       const result = await uploadPayoutPhoto(file, partyId.trim(), groupId, 'receipt');
-      if (!result) {
-        setUploadError('Upload failed — check the file type (jpg/png/webp/heic) and size (<10MB).');
-        return;
-      }
       setUploadedProofUrl(result.url);
     } catch (err: any) {
       setUploadError(err?.message || 'Upload failed');

--- a/frontend/src/components/payouts/PizzaPhotoUpload.tsx
+++ b/frontend/src/components/payouts/PizzaPhotoUpload.tsx
@@ -67,15 +67,15 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
 
     await Promise.all(fileArr.map(async (file, i) => {
       const itemId = newItems[i].id;
-      const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, kind);
-      if (!uploaded) {
-        nextItems = nextItems.map(it => it.id === itemId
-          ? { ...it, status: 'error' as const, error: 'Upload failed' } : it);
-      } else {
+      try {
+        const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, kind);
         nextItems = nextItems.map(it => it.id === itemId
           ? { ...it, status: 'done' as const, url: uploaded.url,
               fileName: uploaded.fileName, fileSize: uploaded.fileSize, mimeType: uploaded.mimeType }
           : it);
+      } catch (err) {
+        nextItems = nextItems.map(it => it.id === itemId
+          ? { ...it, status: 'error' as const, error: err instanceof Error ? err.message : 'Upload failed' } : it);
       }
       onChange(nextItems);
     }));

--- a/frontend/src/components/payouts/ReceiptUpload.tsx
+++ b/frontend/src/components/payouts/ReceiptUpload.tsx
@@ -61,9 +61,14 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
     // Upload each file in parallel, then run OCR.
     await Promise.all(fileArr.map(async (file, i) => {
       const itemId = newItems[i].id;
-      const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, 'receipt');
-      if (!uploaded) {
-        nextItems = updateItem(nextItems, itemId, { status: 'error', error: 'Upload failed' });
+      let uploaded: Awaited<ReturnType<typeof uploadPayoutPhoto>>;
+      try {
+        uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, 'receipt');
+      } catch (err) {
+        nextItems = updateItem(nextItems, itemId, {
+          status: 'error',
+          error: err instanceof Error ? err.message : 'Upload failed',
+        });
         onChange(nextItems);
         return;
       }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -349,7 +349,7 @@ export async function uploadPayoutPhoto(
   fileName: string;
   fileSize: number;
   mimeType: string;
-} | null> {
+}> {
   // bocconcino-92104: receipts accept PDF in addition to image MIMEs. Pizza
   // photos remain image-only (PDFs make no sense as a pizza shot).
   const allowedImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif'];
@@ -358,12 +358,12 @@ export async function uploadPayoutPhoto(
     : allowedImageTypes;
   if (!allowedTypes.includes(file.type)) {
     console.error('Invalid file type for payout photo:', file.type);
-    return null;
+    throw new Error(`Unsupported file type: ${file.type || 'unknown'}. Accepted: JPEG, PNG, WebP, HEIC, PDF.`);
   }
   const maxSize = 10 * 1024 * 1024; // 10MB
   if (file.size > maxSize) {
     console.error('Payout photo too large:', file.size);
-    return null;
+    throw new Error(`File is too large (${(file.size / 1048576).toFixed(1)}MB). Max 10MB.`);
   }
 
   try {
@@ -378,7 +378,7 @@ export async function uploadPayoutPhoto(
 
     if (error) {
       console.error('Error uploading payout photo:', error);
-      return null;
+      throw new Error(error.message);
     }
 
     const { data: urlData } = supabase.storage
@@ -423,7 +423,7 @@ export async function uploadPayoutPhoto(
     };
   } catch (err) {
     console.error('Error uploading payout photo:', err);
-    return null;
+    throw err instanceof Error ? err : new Error(String(err));
   }
 }
 


### PR DESCRIPTION
## What

Upload helpers in `frontend/src/lib/supabase.ts` were swallowing the structured Supabase error and returning `null`, so every failure surfaced to hosts as a flat "Upload failed". This made the Craiova (2026-05-18) and San Salvador PDF-receipt (2026-06-03, real cause `mime_type_not_allowed`) incidents opaque to debug.

`uploadEventImage` and `uploadSponsorLogo` (plus their call sites: `useImageUpload`, `EventDetailsTab`, `PartnerForm`, `FlyerGenerator`) were already converted in a prior PR on master. This PR finishes the job for the **receipt path** — `uploadPayoutPhoto` — which was still returning `null` in all four failure modes and was the actual 2026-06-03 trigger.

### Changes
- **`uploadPayoutPhoto`** now throws with the real message instead of `return null`:
  - Invalid MIME pre-check → `throw new Error("Unsupported file type: ...")`
  - Too-large pre-check → `throw new Error("File is too large (X.XMB). Max 10MB.")`
  - Supabase `if (error)` branch → `throw new Error(error.message)` (kept the `console.error`)
  - Outer `catch` → re-throws
  - Return type tightened `... | null` → non-nullable
  - **PDF-thumbnail sub-upload left non-fatal** (inner try/catch + `console.warn` untouched) — a thumbnail failure must not block the receipt.
- Call sites converted from null-check to try/catch, surfacing `err.message`:
  - `payouts/ReceiptUpload.tsx` — per-item error UI now shows the real message
  - `payouts/PizzaPhotoUpload.tsx` — same (also a `uploadPayoutPhoto` caller; converted to avoid an unhandled rejection inside `Promise.all` now that the helper throws)
  - `payments-admin/ExternalPaymentModal.tsx` — already had a `catch (err)` surfacing `err.message`; removed the now-dead `if (!result)` branch.

## Files changed
- `frontend/src/lib/supabase.ts`
- `frontend/src/components/payouts/ReceiptUpload.tsx`
- `frontend/src/components/payouts/PizzaPhotoUpload.tsx`
- `frontend/src/components/payments-admin/ExternalPaymentModal.tsx`

## Out of scope (left untouched)
- `uploadProfilePicture`, legacy `uploadReceipt`, `uploadEventPhoto`, venue-photo helpers, and `uploadCoHostAvatar` — same null-swallowing pattern applies but outside this incident's blast radius.
- No new client-side validation (existing pre-checks stay; we only make their messages visible).
- No i18n of Supabase messages (English is acceptable for a host debugging their own upload).

## Verify
- `cd frontend && npx tsc --noEmit` — clean.
- Preview: https://rsvpizza-git-feta-64218-upload-errors-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)