### PR TITLE
ciabatta-92110: closed-cities KPI + Closed status tab

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -641,6 +641,11 @@ function buildPayoutWhere(query: Request['query']): any {
     ? { region: { in: regionsFromQuery } }
     : {};
 
+  // ciabatta-92110: the "Closed" status tab is a party-level pseudo-status —
+  // filters on cities the admin has closed out (payments_closed_at set), not payout.status.
+  const closedClause =
+    query.status === 'closed' ? { paymentsClosedAt: { not: null } } : {};
+
   // tartufo-58291: hide payouts from unapproved parties from the admin queue
   // + CSV export. Existing rows from before the bresaola-49185 backend gate
   // shouldn't surface in routine review. Stats/totals reuse this same `where`
@@ -653,6 +658,7 @@ function buildPayoutWhere(query: Request['query']): any {
     ...countryClause,
     ...tagClause,
     ...regionClause,
+    ...closedClause,
   };
 
   return where;
@@ -2381,6 +2387,8 @@ router.get(
               id: true,
               name: true,
               country: true,
+              // ciabatta-92110: needed to compute closedCitiesCount KPI.
+              paymentsClosedAt: true,
             },
           },
         },
@@ -2418,6 +2426,9 @@ router.get(
         string,
         { paidOrCompletedCount: number; pendingOrApprovedCount: number }
       >();
+
+      // ciabatta-92110: distinct closed-out cities within the current filter window.
+      const closedPartyIds = new Set<string>();
 
       const now = new Date();
       const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -2500,6 +2511,9 @@ router.get(
           }
           byPartyStatusCounts.set(r.party.id, existing);
         }
+
+        // ciabatta-92110: collect distinct closed-out cities for the KPI.
+        if (r.party?.paymentsClosedAt) closedPartyIds.add(r.party.id);
       }
 
       // cotechino-92103: count cities whose payouts are all "settled" —
@@ -2510,6 +2524,10 @@ router.get(
           paidCitiesCount++;
         }
       }
+
+      // ciabatta-92110: count of cities the admin has explicitly closed out
+      // (payments_closed_at set) within the current filter window.
+      const closedCitiesCount = closedPartyIds.size;
 
       // taleggio-92104: AVG PAYMENT averages per-city committed totals
       // (sum of each party's paid+approved finalAmountUsd, then average
@@ -2580,6 +2598,7 @@ router.get(
           avgUsd,
           awaitingReview,
           paidCitiesCount,
+          closedCitiesCount,
         },
       });
     } catch (error) {

--- a/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
+++ b/frontend/src/components/payments-admin/PaymentsStatsCards.tsx
@@ -61,12 +61,13 @@ export const PaymentsStatsCards: React.FC<PaymentsStatsCardsProps> = ({ totals, 
         label="Avg payment"
         value={formatUsd(totals.avgUsd)}
       />
-      {/* cotechino-92103: cities (parties) with at least one paid/completed
-          payout and no in-flight pending/approved payouts. */}
+      {/* ciabatta-92110: cities the admin has explicitly closed out
+          (parties.payments_closed_at set), within the current filter window.
+          Distinct from the cotechino-92103 paidCitiesCount heuristic. */}
       <StatCard
         icon={<CheckCircle2 size={14} />}
-        label="Paid cities"
-        value={String(totals.paidCitiesCount)}
+        label="Closed cities"
+        value={String(totals.closedCitiesCount ?? 0)}
         tone="emerald"
       />
       <StatCard

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -49,7 +49,9 @@ interface PayoutsFilterBarProps {
   showStatusTabs?: boolean;
 }
 
-const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
+// ciabatta-92110: `'closed'` is a party-level pseudo-status (filters on
+// parties.payments_closed_at), so the tab value type widens beyond PayoutStatus.
+const STATUS_TABS: Array<{ value: PayoutStatus | 'all' | 'closed'; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'pending', label: 'Pending' },
   { value: 'approved', label: 'Approved' },
@@ -66,6 +68,10 @@ const STATUS_TABS: Array<{ value: PayoutStatus | 'all'; label: string }> = [
   // by Mark-Party-Paid's "mark pending complete" mode. Distinct from 'paid'
   // (a direct payment record) but treated like paid for cap math.
   { value: 'completed', label: 'Completed' },
+  // ciabatta-92110: party-level pseudo-status — filters the queue (list AND
+  // by-city) to cities the admin has explicitly closed out
+  // (parties.payments_closed_at set), not on payout.status.
+  { value: 'closed', label: 'Closed' },
 ];
 
 const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2116,7 +2116,9 @@ export interface AdminPayoutFilters {
    * accepts either shape on `?status=`; the by-city status-tab strip only
    * sets single values so the existing membership check keeps working.
    */
-  status?: PayoutStatus | 'all' | string;
+  // ciabatta-92110: `'closed'` is a pseudo-status accepted by the status tab
+  // strip — the backend filters on `party.paymentsClosedAt` (not payout.status).
+  status?: PayoutStatus | 'all' | 'closed' | string;
   payoutMethod?: PayoutMethod | 'all';
   partyId?: string;
   /** salame-83472: unified search — host email|name OR party name (case-insensitive contains). */
@@ -2208,6 +2210,14 @@ export interface AdminPayoutTotals {
    * scope as the other KPI fields.
    */
   paidCitiesCount: number;
+  /**
+   * ciabatta-92110: count of distinct cities (parties) the admin has
+   * explicitly closed out (`parties.payments_closed_at` set), within the
+   * current filter window. Distinct from the paidCitiesCount heuristic.
+   * Optional for graceful degradation: an old backend (deploys only from
+   * master) won't return this field on preview branches.
+   */
+  closedCitiesCount?: number;
 }
 
 export interface AdminPayoutsResponse {


### PR DESCRIPTION
## Summary
On the /payments admin dashboard:

1. **Renamed the "Paid cities" KPI card to "Closed cities"** — now shows the count of distinct cities the admin has explicitly closed out (`parties.payments_closed_at` / Prisma `paymentsClosedAt` set), scoped to the current filter window. This replaces the derived `paidCitiesCount` heuristic in the card. `paidCitiesCount` is left untouched in the API.
2. **Added a "Closed" tab** to the status tab strip. `'closed'` is a party-level pseudo-status: it filters the queue (per-payment list AND by-city view) to only cities that have been closed out, via `party.paymentsClosedAt`, not `payout.status`.

## Changes
- `backend/src/routes/admin-payout.routes.ts`
  - `buildPayoutWhere`: added `closedClause` (`{ paymentsClosedAt: { not: null } }` when `status === 'closed'`) merged into `where.party`. Used by both the list and `/by-party` endpoints (both build their where via `buildPayoutWhere`).
  - Totals: added `paymentsClosedAt` to the `allFiltered` party select, collected distinct closed-out party ids in the loop, and returned `closedCitiesCount` in `totals`.
- `frontend/src/types.ts`: added `closedCitiesCount?: number` to `AdminPayoutTotals` (optional for graceful degradation); widened `AdminPayoutFilters.status` to include `'closed'`.
- `frontend/src/components/payments-admin/PaymentsStatsCards.tsx`: card label → "Closed cities", value → `totals.closedCitiesCount ?? 0`.
- `frontend/src/components/payments-admin/PayoutsFilterBar.tsx`: appended `{ value: 'closed', label: 'Closed' }` to `STATUS_TABS` and widened the tab value type. `buildPayoutQuery` already forwards `status` when `!== 'all'`, so no api.ts change was needed.

## Verification
- `frontend`: `tsc --noEmit` clean, `npm run build` succeeds.
- `backend`: `tsc --noEmit` clean for all touched files (only pre-existing unrelated `auth.test.ts` jsonwebtoken type-overload errors remain, untouched by this PR).

> ⚠️ Backend deploys from master only; previews use the prod backend. The Closed tab + closedCitiesCount won't fully work on this preview until merged + backend redeploys. Frontend degrades gracefully (`?? 0`, status=closed ignored by old backend = shows all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)