### PR TITLE
crostino-58241: clean up payments-admin tsc errors (misplaced Mark-paid block + unused imports)

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -9,7 +9,6 @@ import {
   Flag,
   CheckCircle2,
   MoreVertical,
-  Coins,
   DollarSign,
   XCircle,
   Plus,
@@ -436,7 +435,6 @@ function CityActionsMenu({
   tagBusy,
   receiptsReminderSentAt,
   paymentsApprovedUsd,
-  paymentsApprovedAt,
   receiptsTotalUsd,
 }: {
   onMarkPartyPaid?: () => void;
@@ -2561,21 +2559,6 @@ function RollupTile({
       <div className={`text-lg font-semibold ${accent}`}>{value}</div>
       {sub && (
         <div className="text-xs text-theme-text-muted mt-0.5">{sub}</div>
-      )}
-
-      {/* gnocchi-92104: queued row gets a single Mark paid (settled) button.
-          Approved -> queued / queued -> approved transitions live in the
-          modal so the admin can leave a confirmation note. */}
-      {status === 'queued' && (
-        <button
-          type="button"
-          onClick={() => onMarkPaid(payout)}
-          disabled={busy}
-          className="p-1.5 rounded-md hover:bg-blue-50 text-blue-600 disabled:opacity-50"
-          title="Mark paid (wire settled)"
-        >
-          <DollarSign size={15} />
-        </button>
       )}
     </div>
   );

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { ShieldX, Loader2, DollarSign, Download, Plus, Search } from 'lucide-react';
 import { Layout } from '../components/Layout';


### PR DESCRIPTION
## Summary
Cleans up the payments-admin TypeScript error subset only (frontend, no DB/backend change).

### The real fix
- **`PayoutsByPartyTable.tsx`** — deleted the misplaced dead `{status === 'queued' && (…)}` Mark-paid button block (and its `gnocchi-92104` comment) that lived inside the `RollupTile` component. `status`/`onMarkPaid`/`payout`/`busy` were never in scope there (TS2304 ×3); the block never rendered because `status` resolved to the empty global `window.status`. Legitimate row-level Mark-paid buttons are untouched.

### Unused-symbol removals (payments files only)
- `PayoutsByPartyTable.tsx` — removed unused `Coins` lucide import.
- `PayoutsByPartyTable.tsx` — removed unused `paymentsApprovedAt` destructure binding in `CityActionsMenu` (kept in the props type interface).
- `PaymentsAdminPage.tsx` — removed unused `React` default import (automatic JSX runtime; named hook imports retained).

### Out of scope (untouched)
- TS2322 textarea `onChange` mismatches in `PayoutReviewModal.tsx` / `RejectReasonModal.tsx`.
- All non-payments project-wide tsc errors.

### Verification
- `npx tsc -b` now reports **zero** errors in both payments files; the targeted 2304 (onMarkPaid/payout/busy) and 6133 (Coins/paymentsApprovedAt/React) lines are gone.
- No behavior change — deleted block never rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)