### PR TITLE
feat(marinara-60931): check-in attendance-fraud heuristics

### DIFF
--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -31,6 +31,10 @@ import {
   checkCoHostTwitterHandlesMissing,
   checkRepeatSessionRsvpCount,
   checkHighBounceRate,
+  checkCheckinVelocitySuperhuman,
+  checkCheckinTimestampCollapse,
+  checkSingleCheckerDominance,
+  checkCheckinRatioExtreme,
   scoreEvent,
   buildSybilWalletSet,
   tierFromScore,
@@ -1230,5 +1234,161 @@ describe('scoreEvent — integration fixtures', () => {
     expect(firedIds).not.toContain('name_token_zscore');
     expect(firedIds).not.toContain('lsh_field_sig_cluster');
     expect(firedIds).not.toContain('email_digit_benford');
+  });
+});
+
+// ============================================
+// Check-in attendance-fraud heuristics (marinara-60931)
+// ============================================
+
+/** Build a roster of `n` guests all checked in within `windowSec` by one checker. */
+function fraudCheckinRoster(
+  n: number,
+  windowSec: number,
+  checkedInBy: string | null = 'host-1',
+): FakeDetectionGuest[] {
+  const base = new Date('2026-04-01T19:00:00Z').getTime();
+  return Array.from({ length: n }, (_, i) =>
+    makeGuest({
+      name: `Guest ${i}`,
+      email: `guest${i}@example.com`,
+      submittedVia: i % 2 === 0 ? 'link' : 'invite',
+      // Spread evenly across the (tiny) window → many collisions per second.
+      checkedInAt: new Date(base + Math.floor((i / n) * windowSec * 1000)),
+      checkedInBy,
+    }),
+  );
+}
+
+/** Build a healthy roster: check-ins spread over hours, multiple checkers. */
+function healthyCheckinRoster(n: number, checkedInCount: number): FakeDetectionGuest[] {
+  const base = new Date('2026-04-01T18:00:00Z').getTime();
+  const checkers = ['door-1', 'door-2', 'door-3', 'door-4'];
+  return Array.from({ length: n }, (_, i) =>
+    makeGuest({
+      name: `Guest ${i}`,
+      email: `guest${i}@example.com`,
+      // First `checkedInCount` guests checked in, spread over ~4 hours.
+      checkedInAt:
+        i < checkedInCount
+          ? new Date(base + Math.floor((i / checkedInCount) * 4 * 3600 * 1000))
+          : null,
+      checkedInBy: i < checkedInCount ? checkers[i % checkers.length] : null,
+    }),
+  );
+}
+
+describe('checkCheckinVelocitySuperhuman', () => {
+  it('fires when an entire roster is checked in within ~1 minute', () => {
+    const guests = fraudCheckinRoster(60, 60); // 60 check-ins over 60s
+    const r = checkCheckinVelocitySuperhuman(guests);
+    expect(r.fired).toBe(true);
+    expect(r.weight).toBe(WEIGHTS.checkin_velocity_superhuman);
+  });
+
+  it('collapses (not fired) below n=20', () => {
+    const guests = fraudCheckinRoster(19, 60);
+    expect(checkCheckinVelocitySuperhuman(guests).fired).toBe(false);
+  });
+
+  it('does not fire when check-ins are spread over hours', () => {
+    const guests = healthyCheckinRoster(50, 30); // 30 check-ins over 4h → <0.2/min
+    expect(checkCheckinVelocitySuperhuman(guests).fired).toBe(false);
+  });
+});
+
+describe('checkCheckinTimestampCollapse', () => {
+  it('fires when many guests share the same check-in second', () => {
+    // 78 guests, all within 30 seconds → far fewer distinct seconds than guests.
+    const guests = fraudCheckinRoster(78, 30);
+    const r = checkCheckinTimestampCollapse(guests);
+    expect(r.fired).toBe(true);
+  });
+
+  it('collapses (not fired) below n=20', () => {
+    const guests = fraudCheckinRoster(19, 5);
+    expect(checkCheckinTimestampCollapse(guests).fired).toBe(false);
+  });
+
+  it('does not fire when each check-in lands on a distinct second', () => {
+    const guests = healthyCheckinRoster(40, 40); // spread over 4h → all distinct seconds
+    expect(checkCheckinTimestampCollapse(guests).fired).toBe(false);
+  });
+});
+
+describe('checkSingleCheckerDominance', () => {
+  it('fires when one checker performed ≥95% of check-ins', () => {
+    const guests = fraudCheckinRoster(40, 3600, 'host-1');
+    const r = checkSingleCheckerDominance(guests);
+    expect(r.fired).toBe(true);
+    expect((r.evidence as { distinctCheckers: number }).distinctCheckers).toBe(1);
+  });
+
+  it('treats null checker as a single dominant bucket', () => {
+    const guests = fraudCheckinRoster(40, 3600, null);
+    const r = checkSingleCheckerDominance(guests);
+    expect(r.fired).toBe(true);
+    expect((r.evidence as { dominantIsNull: boolean }).dominantIsNull).toBe(true);
+  });
+
+  it('collapses (not fired) below n=20', () => {
+    const guests = fraudCheckinRoster(19, 3600, 'host-1');
+    expect(checkSingleCheckerDominance(guests).fired).toBe(false);
+  });
+
+  it('does not fire with multiple distinct checkers', () => {
+    const guests = healthyCheckinRoster(40, 40); // 4 rotating checkers → topShare 25%
+    expect(checkSingleCheckerDominance(guests).fired).toBe(false);
+  });
+});
+
+describe('checkCheckinRatioExtreme', () => {
+  it('fires when ≥95% of the roster is checked in', () => {
+    // 78 checked in + 3 not = 81 total → 96%.
+    const checkedIn = fraudCheckinRoster(78, 3600);
+    const notCheckedIn = Array.from({ length: 3 }, (_, i) =>
+      makeGuest({ name: `NoShow ${i}`, checkedInAt: null }),
+    );
+    const guests = [...checkedIn, ...notCheckedIn];
+    const r = checkCheckinRatioExtreme(guests);
+    expect(r.fired).toBe(true);
+  });
+
+  it('collapses (not fired) below n=20 total guests', () => {
+    const guests = fraudCheckinRoster(19, 3600);
+    expect(checkCheckinRatioExtreme(guests).fired).toBe(false);
+  });
+
+  it('does not fire on a healthy ~60% attendance rate', () => {
+    const guests = healthyCheckinRoster(50, 30); // 30/50 = 60%
+    expect(checkCheckinRatioExtreme(guests).fired).toBe(false);
+  });
+});
+
+describe('scoreEvent — check-in heuristics integration', () => {
+  it('attendance-fraud roster fires all four check-in flags and scores high', () => {
+    const party = makeParty();
+    // 60 guests all checked in within ~30s by one host → ratio 100%.
+    const guests = fraudCheckinRoster(60, 30, 'host-1');
+    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests);
+    const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
+    expect(firedIds).toContain('checkin_velocity_superhuman');
+    expect(firedIds).toContain('checkin_timestamp_collapse');
+    expect(firedIds).toContain('single_checker_dominance');
+    expect(firedIds).toContain('checkin_ratio_extreme');
+    expect(row.score).toBeGreaterThanOrEqual(
+      WEIGHTS.checkin_velocity_superhuman + WEIGHTS.checkin_ratio_extreme,
+    );
+  });
+
+  it('healthy roster fires none of the check-in flags', () => {
+    const party = makeParty();
+    const guests = healthyCheckinRoster(50, 30);
+    const row = scoreEvent(party, guests, [], new Set(), party.maxGuests);
+    const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
+    expect(firedIds).not.toContain('checkin_velocity_superhuman');
+    expect(firedIds).not.toContain('checkin_timestamp_collapse');
+    expect(firedIds).not.toContain('single_checker_dominance');
+    expect(firedIds).not.toContain('checkin_ratio_extreme');
   });
 });

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -36,6 +36,13 @@ export interface FakeDetectionGuest {
   // | 'complained' | 'delivery_delayed' | 'failed' | 'suppressed'. Nullable
   // for legacy/non-email RSVPs; only populated rows are scored.
   emailStatus?: string | null;
+  // checkin-heuristics (marinara-60931): door check-in timestamp and the
+  // user/host who performed the check-in. Null for guests who never checked
+  // in. Used to detect attendance-fraud (one account marking the whole
+  // roster checked-in within minutes). Optional so existing construction
+  // sites keep compiling.
+  checkedInAt?: Date | null;
+  checkedInBy?: string | null;
 }
 
 export interface FakeDetectionCoHost {
@@ -124,6 +131,12 @@ export const WEIGHTS = {
   co_host_twitter_handles_missing: 12,
   repeat_session_rsvp_count: 20,
   high_bounce_rate: 25,
+  // checkin-heuristics (marinara-60931): attendance-fraud signals derived from
+  // guests.checked_in_at / checked_in_by.
+  checkin_velocity_superhuman: 20,
+  checkin_timestamp_collapse: 15,
+  single_checker_dominance: 10,
+  checkin_ratio_extreme: 12,
 } as const;
 
 // ============================================
@@ -1013,6 +1026,117 @@ export function checkHighBounceRate(guests: FakeDetectionGuest[]): FlagResult {
 }
 
 // ============================================
+// Check-in attendance-fraud heuristics (marinara-60931)
+//
+// Fraudulent events inflate attendance by having a single account mark the
+// entire RSVP roster `checked_in_at` within minutes (physically impossible).
+// These run over ALL guests (not just direct RSVPs) because fraud check-ins
+// can land on invite/host rows too.
+// ============================================
+
+/** Guests that have a non-null check-in timestamp. */
+function checkedInGuests(guests: FakeDetectionGuest[]): FakeDetectionGuest[] {
+  return guests.filter(g => g.checkedInAt != null);
+}
+
+/**
+ * checkin_velocity_superhuman — check-ins arrive faster than a human door can
+ * scan them. >10 check-ins/min sustained over the check-in window.
+ */
+export function checkCheckinVelocitySuperhuman(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'checkin_velocity_superhuman';
+  const checkedIn = checkedInGuests(guests);
+  const n = checkedIn.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const times = checkedIn.map(g => g.checkedInAt!.getTime());
+  const wMin = (Math.max(...times) - Math.min(...times)) / 60000;
+  // Floor the window at 1 second so an all-same-timestamp roster → very high rate.
+  const rate = n / Math.max(wMin, 1 / 60);
+  const fired = rate > 10;
+  return flag(
+    id,
+    fired,
+    `rate=${rate.toFixed(1)}/min over ${wMin.toFixed(1)}min, n=${n}`,
+    { n, windowMin: wMin, ratePerMin: rate },
+  );
+}
+
+/**
+ * checkin_timestamp_collapse — distinct check-in seconds collapse relative to
+ * the number of check-ins, i.e. many guests share the exact same second.
+ */
+export function checkCheckinTimestampCollapse(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'checkin_timestamp_collapse';
+  const checkedIn = checkedInGuests(guests);
+  const n = checkedIn.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const distinctSeconds = new Set(
+    checkedIn.map(g => Math.floor(g.checkedInAt!.getTime() / 1000)),
+  ).size;
+  const ratio = distinctSeconds / n;
+  const fired = ratio <= 0.6;
+  return flag(
+    id,
+    fired,
+    `distinctSeconds=${distinctSeconds}/${n} (ratio=${ratio.toFixed(2)})`,
+    { n, distinctSeconds, ratio },
+  );
+}
+
+/**
+ * single_checker_dominance — one account (`checked_in_by`) performed ≥95% of
+ * all check-ins. Null/undefined checkers bucket under the literal "__null__".
+ */
+export function checkSingleCheckerDominance(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'single_checker_dominance';
+  const checkedIn = checkedInGuests(guests);
+  const n = checkedIn.length;
+  if (n < 20) return flag(id, false, `n=${n} below 20`);
+  const counts = new Map<string, number>();
+  for (const g of checkedIn) {
+    const key = g.checkedInBy ?? '__null__';
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  let maxCount = 0;
+  let topKey = '';
+  for (const [key, c] of counts) {
+    if (c > maxCount) {
+      maxCount = c;
+      topKey = key;
+    }
+  }
+  const topShare = maxCount / n;
+  const distinctCheckers = counts.size;
+  const dominantIsNull = topKey === '__null__';
+  const fired = topShare >= 0.95;
+  return flag(
+    id,
+    fired,
+    `topShare=${(topShare * 100).toFixed(1)}%, distinctCheckers=${distinctCheckers}, dominantIsNull=${dominantIsNull}`,
+    { n, topShare, distinctCheckers, dominantIsNull },
+  );
+}
+
+/**
+ * checkin_ratio_extreme — ≥95% of the entire RSVP roster is marked checked-in.
+ * Real events have no-shows; a near-100% attendance rate is a fraud tell.
+ */
+export function checkCheckinRatioExtreme(guests: FakeDetectionGuest[]): FlagResult {
+  const id = 'checkin_ratio_extreme';
+  const rsvps = guests.length;
+  if (rsvps < 20) return flag(id, false, `n=${rsvps} below 20`);
+  const checkedIn = checkedInGuests(guests).length;
+  const ratio = checkedIn / rsvps;
+  const fired = ratio >= 0.95;
+  return flag(
+    id,
+    fired,
+    `${checkedIn}/${rsvps} = ${(ratio * 100).toFixed(0)}%`,
+    { rsvps, checkedIn, ratio },
+  );
+}
+
+// ============================================
 // Aggregator
 // ============================================
 
@@ -1057,6 +1181,12 @@ export function scoreEvent(
     checkCoHostTwitterHandlesMissing(party),
     checkRepeatSessionRsvpCount(guests),
     checkHighBounceRate(guests),
+    // checkin-heuristics (marinara-60931): run over ALL guests, since fraud
+    // check-ins can land on invite/host rows, not just direct RSVPs.
+    checkCheckinVelocitySuperhuman(allGuests),
+    checkCheckinTimestampCollapse(allGuests),
+    checkSingleCheckerDominance(allGuests),
+    checkCheckinRatioExtreme(allGuests),
   ];
 
   const score = Math.min(

--- a/backend/src/lib/fakeDetectionScan.ts
+++ b/backend/src/lib/fakeDetectionScan.ts
@@ -98,6 +98,8 @@ export async function scorePartiesByIds(
           mailingListOptIn: true,
           visitorSessionId: true,
           emailStatus: true,
+          checkedInAt: true,
+          checkedInBy: true,
         },
       },
       linkClicks: {
@@ -146,6 +148,8 @@ export async function scorePartiesByIds(
         mailingListOptIn: g.mailingListOptIn,
         visitorSessionId: g.visitorSessionId,
         emailStatus: g.emailStatus,
+        checkedInAt: g.checkedInAt,
+        checkedInBy: g.checkedInBy,
       })),
       p.linkClicks.map(c => ({ clickedAt: c.clickedAt })),
       sybilWallets,


### PR DESCRIPTION
## Summary

Adds 4 guest-only **check-in attendance-fraud** heuristics to the fake-detection scorer (`backend/src/lib/fakeDetection.ts`). Motivation: fraudulent events inflate attendance by having a single account mark the entire RSVP roster `checked_in_at` within minutes — physically impossible for a real door. These scores feed the `/underboss` review queue and the `/payments` risk badge (both route through the centralized `scorePartiesByIds` in `fakeDetectionScan.ts`).

Each heuristic runs over **all** guests (not just direct RSVPs), since fraud check-ins can land on invite/host rows too. All follow the established `flag()` + n<20 collapse conventions.

| id | weight | fires when |
|----|--------|------------|
| `checkin_velocity_superhuman` | 20 | >10 check-ins/min sustained over the check-in window (1s window floor → all-same-timestamp = very high rate) |
| `checkin_timestamp_collapse` | 15 | distinct check-in seconds ≤ 0.6 × n (many guests share the exact same second) |
| `single_checker_dominance` | 10 | one `checked_in_by` account (null buckets as `__null__`) performed ≥95% of check-ins |
| `checkin_ratio_extreme` | 12 | ≥95% of the entire RSVP roster is marked checked-in (real events have no-shows) |

## Changes
- `fakeDetection.ts`: added optional `checkedInAt?`/`checkedInBy?` to `FakeDetectionGuest`, 4 `WEIGHTS` entries, 4 `checkX` functions + a small `checkedInGuests` helper, wired all 4 into `scoreEvent`'s `flags` array (passing `allGuests`).
- `fakeDetectionScan.ts`: added `checkedInAt`/`checkedInBy` to the Prisma guest `select` and the `FakeDetectionGuest` mapping.
- `fakeDetection.test.ts`: 15 new tests (fires / collapses-below-n / healthy-roster for each heuristic + 2 `scoreEvent` integration cases).

## No DB change
`guests.checked_in_at` and `guests.checked_in_by` columns already exist — no migration. Scores recompute live, so flagged attendance-fraud events (e.g. the Nigerian GPP cluster + kitwe) will rise in the `/underboss` queue and start showing the `/payments` risk badge as soon as backend deploys.

Receipt/payout fraud signals are intentionally **not** included here (separate future task).

## Verification
- `npx tsc --noEmit` — no errors in the three changed files (pre-existing unrelated errors remain from a stale local Prisma client: `taxForm`/`superlativeSubmission`/`taxFormRequired` models + missing `pdf-lib`/`sharp` — not introduced by this PR).
- `npx vitest run src/lib/fakeDetection.test.ts` — **123 passed** (108 prior + 15 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
