### PR TITLE
stracciatella-71042: preview HEIC receipts in lightbox

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@wagmi/connectors": "^5.11.2",
     "connectkit": "^1.9.1",
     "date-fns": "^4.1.0",
+    "heic2any": "^0.0.4",
     "html5-qrcode": "^2.3.8",
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -191,11 +191,47 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
     return () => window.removeEventListener('keydown', onKey);
   }, [isOpen, onClose, goPrev, goNext, hasMultiple, onDuplicateShortcut]);
 
-  if (!isOpen || count === 0) return null;
-
   const current = images[index];
-  if (!current) return null;
   const heic = isHeic(current);
+
+  // stracciatella-71042: HEIC receipts can't render in an <img> natively, so
+  // decode them to a JPEG blob in-browser via heic2any (lazy-loaded so the WASM
+  // codec stays off the main bundle). Hook MUST live above the early return so
+  // the hook order stays stable (adding a hook below a conditional return has
+  // black-screened this app before).
+  const [heicState, setHeicState] = React.useState<
+    { status: 'idle' | 'loading' | 'ready' | 'error'; url?: string }
+  >({ status: 'idle' });
+
+  useEffect(() => {
+    if (!isOpen || !heic || !current) { setHeicState({ status: 'idle' }); return; }
+    let cancelled = false;
+    let objectUrl: string | undefined;
+    setHeicState({ status: 'loading' });
+    (async () => {
+      try {
+        const res = await fetch(current.url);
+        if (!res.ok) throw new Error(`fetch ${res.status}`);
+        const blob = await res.blob();
+        const heic2any = (await import('heic2any')).default;
+        const out = await heic2any({ blob, toType: 'image/jpeg', quality: 0.92 });
+        const outBlob = Array.isArray(out) ? out[0] : out;
+        objectUrl = URL.createObjectURL(outBlob);
+        if (cancelled) { URL.revokeObjectURL(objectUrl); return; }
+        setHeicState({ status: 'ready', url: objectUrl });
+      } catch {
+        if (!cancelled) setHeicState({ status: 'error' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, heic, current?.url]);
+
+  if (!isOpen || count === 0 || !current) return null;
+
   // melanzane-92103: when the focused item is a video, render a <video> with
   // controls + autoplay so admins can scrub. `muted` is required for autoplay
   // under browser policy; `playsInline` keeps mobile from kicking into the
@@ -328,22 +364,38 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
             </>
           )}
           {heic ? (
-            <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
-              <p className="text-sm font-semibold">Can't preview HEIC files</p>
-              <p className="text-xs text-theme-text-muted">
-                Your browser doesn't render <span className="font-mono">.heic</span>{' '}
-                images natively. Open the file in a new tab to download or view it.
-              </p>
-              <a
-                href={current.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
-              >
-                Open in new tab <ExternalLink size={14} />
-              </a>
-              <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
-            </div>
+            heicState.status === 'ready' && heicState.url ? (
+              /* stracciatella-71042: decoded HEIC -> JPEG blob URL, shown inline. */
+              <img
+                src={heicState.url}
+                alt={current.fileName}
+                className={`${mediaSizing} object-contain`}
+              />
+            ) : heicState.status === 'loading' ? (
+              <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
+                <div className="mx-auto h-8 w-8 rounded-full border-2 border-theme-stroke border-t-[#ff393a] animate-spin" />
+                <p className="text-sm font-semibold">Converting HEIC…</p>
+                <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
+              </div>
+            ) : (
+              /* error / idle — fall back to the original open-in-new-tab card. */
+              <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
+                <p className="text-sm font-semibold">Can't preview HEIC files</p>
+                <p className="text-xs text-theme-text-muted">
+                  Your browser doesn't render <span className="font-mono">.heic</span>{' '}
+                  images natively. Open the file in a new tab to download or view it.
+                </p>
+                <a
+                  href={current.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
+                >
+                  Open in new tab <ExternalLink size={14} />
+                </a>
+                <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
+              </div>
+            )
           ) : video ? (
             /* melanzane-92103: keying on src so swapping between videos via
                arrow nav cleanly remounts the <video> with the new source. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,7 @@
         "@wagmi/connectors": "^5.11.2",
         "connectkit": "^1.9.1",
         "date-fns": "^4.1.0",
+        "heic2any": "^0.0.4",
         "html5-qrcode": "^2.3.8",
         "i18next": "^26.0.8",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -14435,6 +14436,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hey-listen": {
       "version": "1.0.8",


### PR DESCRIPTION
## What

HEIC receipt images now render **inline** in the receipt lightbox instead of showing the "Can't preview HEIC files" fallback card.

## How

- When the current lightbox item is HEIC, it is fetched and decoded to a JPEG blob **client-side** via [`heic2any`](https://www.npmjs.com/package/heic2any) and shown in an `<img>`.
- `heic2any` is **lazy-loaded** (`await import('heic2any')`) so its WASM codec stays off the main bundle and only loads when a HEIC receipt is actually opened.
- A "Converting HEIC…" spinner card shows during decode.
- The original "Open in new tab" card is **kept as the error fallback** (decode failure / fetch error).
- The conversion `useEffect` is declared with the other hooks, **above** the early return, to keep hook order stable.

## Scope

Frontend-only — no backend, DB, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
