### PR TITLE
montanara-58301: payments UX — caret nav in receipt fields + drop currency filter

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -15,12 +15,10 @@ interface PayoutsFilterBarProps {
   filters: AdminPayoutFilters;
   onChange: (next: AdminPayoutFilters) => void;
   onReset: () => void;
-  availableCurrencies: string[];
   /**
    * mascarpone-49102: distinct event-tag values across the currently-loaded
-   * payouts (flattened from each `party.eventTags` array). Mirrors the
-   * `availableCurrencies` pattern — derived in `PaymentsAdminPage`. Sorted
-   * ascending.
+   * payouts (flattened from each `party.eventTags` array). Derived in
+   * `PaymentsAdminPage`. Sorted ascending.
    */
   availableTags: string[];
   /**
@@ -122,7 +120,6 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.search && filters.search.trim()) n += 1;
   if (filters.partyId && filters.partyId.trim()) n += 1;
   if (filters.payoutMethod && filters.payoutMethod !== 'all') n += 1;
-  if (filters.currency && filters.currency !== 'all') n += 1;
   if (filters.country && filters.country !== 'all') n += 1;
   // pancetta-92103: regions multi-select counts as a single active filter
   // when at least one portal is selected (regardless of how many).
@@ -157,7 +154,6 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   filters,
   onChange,
   onReset,
-  availableCurrencies,
   availableTags,
   showHideClosedToggle,
   showHideScamsToggle,
@@ -297,21 +293,6 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
             </select>
           </div>
 
-          {/* Currency dropdown */}
-          <div>
-            <select
-              value={filters.currency ?? 'all'}
-              onChange={(e) => update({ currency: e.target.value })}
-              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Filter by currency"
-            >
-              <option value="all">All currencies</option>
-              {availableCurrencies.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </select>
-          </div>
-
           {/* pancetta-92103: Regions multi-select — replaces the prior
               bruschetta-58291 single-country dropdown. Each region maps to a
               fixed list of `parties.region` slugs (PAYMENTS_REGION_SCOPES);
@@ -369,8 +350,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
           )}
 
           {/* mascarpone-49102: Tag dropdown — populated from event_tags
-              flattened across the loaded payout set (parallels
-              availableCurrencies/availableCountries). Backend filters
+              flattened across the loaded payout set. Backend filters
               `party.eventTags` via Prisma `{ has: tag }`. */}
           <div>
             <select

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -160,28 +160,33 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
 
   // Keyboard nav — Esc closes, arrows cycle (when more than one image).
   // pesto-92104: `D` fires onDuplicateShortcut (admin only — guarded by the
-  // prop being supplied). Ignore D when focus is inside an editable input
-  // so typing the letter in a text field doesn't accidentally toggle.
+  // prop being supplied). Ignore arrows + D when focus is inside an editable
+  // input so the caret moves / the letter types in a text field (e.g. a
+  // receipt note) instead of changing receipts or toggling duplicate.
   useEffect(() => {
     if (!isOpen) return;
     const onKey = (e: KeyboardEvent) => {
+      // When focus is inside an editable field, let arrow keys move the caret
+      // and `D` type normally instead of hijacking them for nav/shortcuts.
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      const editable =
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        (target?.isContentEditable ?? false);
       if (e.key === 'Escape') {
         e.stopPropagation();
         onClose();
       } else if (e.key === 'ArrowLeft' && hasMultiple) {
+        if (editable) return;
         e.preventDefault();
         void goPrev();
       } else if (e.key === 'ArrowRight' && hasMultiple) {
+        if (editable) return;
         e.preventDefault();
         void goNext();
       } else if ((e.key === 'd' || e.key === 'D') && onDuplicateShortcut) {
-        const target = e.target as HTMLElement | null;
-        const tag = target?.tagName?.toLowerCase();
-        const editable =
-          tag === 'input' ||
-          tag === 'textarea' ||
-          tag === 'select' ||
-          (target?.isContentEditable ?? false);
         if (editable) return;
         e.preventDefault();
         onDuplicateShortcut();

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -546,14 +546,6 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     [prepayQueue, prepaySearch],
   );
 
-  const availableCurrencies = useMemo(() => {
-    const set = new Set<string>();
-    for (const p of payouts) {
-      if (p.originalCurrency) set.add(p.originalCurrency.toUpperCase());
-    }
-    return Array.from(set).sort();
-  }, [payouts]);
-
   // pancetta-92103: the prior `availableCountries` derivation was removed
   // alongside the single-country dropdown. The new Regions multi-select is
   // sourced from PAYMENTS_REGION_SCOPES (a static map) — no per-load derivation
@@ -1110,7 +1102,6 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           filters={filters}
           onChange={setFilters}
           onReset={() => setFilters(DEFAULT_FILTERS)}
-          availableCurrencies={availableCurrencies}
           availableTags={availableTags}
           // pinsa-92103: Hide closed cities only makes sense on the by-city
           // view (paymentsClosedAt is a party-level signal). The per-payment


### PR DESCRIPTION
@
## What

Two small admin **/payments** UX fixes:

1. **Arrow keys move the caret in receipt text fields** — previously, with a text field selected on a receipt in the lightbox, ArrowLeft/ArrowRight cycled to the previous/next receipt instead of moving the cursor. Hoisted the existing `D`-shortcut "is focus editable?" guard (`input`/`textarea`/`select`/`contentEditable`) to also cover the arrow branches.
2. **Removed the "All currencies" filter dropdown** from the payouts filter bar. Also drops the now-unused `availableCurrencies` prop + its `useMemo` derivation in `PaymentsAdminPage`, and the dead currency entry in `countActiveFilters`. The `currency` filter field/default and the `api.ts` query param are left inert (always `"all"`) to avoid a wider type refactor.

## Notes

- Frontend-only; no backend or DB changes.
- Branched off `origin/master` (includes #815 HEIC preview) — the ReceiptLightbox keydown region was unchanged by that PR so the edit applies cleanly.
- None of the 3 changed files produce tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@