### PR TITLE
feat(tonda-58293): move Telegram city group chat IDs into the DB (Phase 1)

### DIFF
--- a/backend/prisma/migrations/tonda-58293-city-telegram-groups.sql
+++ b/backend/prisma/migrations/tonda-58293-city-telegram-groups.sql
@@ -1,0 +1,30 @@
+-- tonda-58293: durable per-city Telegram group chat store.
+-- Previously the city -> group chat_id mapping lived ONLY in a Google Sheet
+-- and was fetched client-side; supergroup migrations (Telegram's
+-- migrate_to_chat_id) were never persisted, so broadcasts silently drifted.
+-- Keyed by city_key (lower(trim(city)), same convention as city_statuses).
+-- Idempotent so it is safe to re-run.
+
+CREATE TABLE IF NOT EXISTS city_telegram_groups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  city_key text NOT NULL,
+  chat_id bigint,
+  chat_url varchar,
+  title text,
+  is_supergroup boolean NOT NULL DEFAULT false,
+  source text NOT NULL DEFAULT 'manual',
+  last_verified_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS city_telegram_groups_city_key_key
+  ON city_telegram_groups (city_key);
+
+-- tonda-58293 follow-up: restore the country / underboss / region metadata
+-- that the legacy Google Sheet supplied so the broadcast modal can render
+-- those columns and the region filter again.
+
+ALTER TABLE city_telegram_groups ADD COLUMN IF NOT EXISTS country text;
+ALTER TABLE city_telegram_groups ADD COLUMN IF NOT EXISTS region text;
+ALTER TABLE city_telegram_groups ADD COLUMN IF NOT EXISTS underboss text;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1419,6 +1419,26 @@ model CityStatus {
   @@map("city_statuses")
 }
 
+// tonda-58293: durable per-city Telegram group chat store. Previously the
+// city → group chat_id mapping lived ONLY in a Google Sheet and was fetched
+// client-side; supergroup migrations (Telegram's `migrate_to_chat_id`) were
+// never persisted, so broadcasts silently drifted. Keyed by `cityKey`
+// (`lower(trim(city))`, same convention as `CityStatus.city_key`).
+model CityTelegramGroup {
+  id             String    @id @default(uuid()) @db.Uuid
+  cityKey        String    @unique @map("city_key")
+  chatId         BigInt?   @map("chat_id")
+  chatUrl        String?   @map("chat_url") @db.VarChar
+  title          String?
+  isSupergroup   Boolean   @default(false) @map("is_supergroup")
+  source         String    @default("manual") // sheet | webhook | migration | manual
+  lastVerifiedAt DateTime? @map("last_verified_at") @db.Timestamptz
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@map("city_telegram_groups")
+}
+
 // ============================================
 // Shipping Coordinator Models
 // ============================================

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1430,6 +1430,9 @@ model CityTelegramGroup {
   chatId         BigInt?   @map("chat_id")
   chatUrl        String?   @map("chat_url") @db.VarChar
   title          String?
+  country        String?
+  region         String?
+  underboss      String?
   isSupergroup   Boolean   @default(false) @map("is_supergroup")
   source         String    @default("manual") // sheet | webhook | migration | manual
   lastVerifiedAt DateTime? @map("last_verified_at") @db.Timestamptz

--- a/backend/scripts/import-telegram-groups.ts
+++ b/backend/scripts/import-telegram-groups.ts
@@ -14,7 +14,10 @@
  * `source` is set to 'sheet' for every imported row.
  *
  * Sheet source: same gviz JSON URL the frontend `fetchTelegramGroups()` uses.
+ *   col 4  = country
  *   col 5  = city
+ *   col 6  = underboss
+ *   col 7  = region
  *   col 8  = chatUrl
  *   col 10 = groupId (chat_id)
  */
@@ -26,7 +29,10 @@ const SHEET_ID = '16T3_iXywToXQqxTyDIniWIA4SUI8Wj0a5LKHSAJL_9Q';
 const GID = '811297100';
 
 interface SheetRow {
+  country: string;
   city: string;
+  underboss: string;
+  region: string;
   chatUrl: string;
   groupId: string;
 }
@@ -40,7 +46,10 @@ async function fetchSheetRows(): Promise<SheetRow[]> {
 
   return (json.table.rows as any[])
     .map((row: any): SheetRow => ({
+      country: String(row.c?.[4]?.v ?? '').trim(),
       city: String(row.c?.[5]?.v ?? '').trim(),
+      underboss: String(row.c?.[6]?.v ?? '').trim(),
+      region: String(row.c?.[7]?.v ?? '').trim(),
       chatUrl: String(row.c?.[8]?.v ?? '').trim(),
       groupId: String(row.c?.[10]?.v ?? '').replace('#', '').trim(),
     }))
@@ -74,12 +83,19 @@ async function main() {
       continue;
     }
 
+    const country = r.country || null;
+    const underboss = r.underboss || null;
+    const region = r.region || null;
+
     await prisma.cityTelegramGroup.upsert({
       where: { cityKey },
       create: {
         cityKey,
         chatId,
         chatUrl: r.chatUrl || null,
+        country,
+        underboss,
+        region,
         isSupergroup,
         source: 'sheet',
         lastVerifiedAt: new Date(),
@@ -87,6 +103,9 @@ async function main() {
       update: {
         chatId,
         chatUrl: r.chatUrl || null,
+        country,
+        underboss,
+        region,
         isSupergroup,
         source: 'sheet',
         lastVerifiedAt: new Date(),

--- a/backend/scripts/import-telegram-groups.ts
+++ b/backend/scripts/import-telegram-groups.ts
@@ -1,0 +1,110 @@
+/**
+ * tonda-58293: one-time import of the city → Telegram group chat_id mapping
+ * from the legacy Google Sheet into the new `city_telegram_groups` table.
+ *
+ * Run manually with DATABASE_URL set (the main session runs this AFTER the
+ * `tonda-58293-city-telegram-groups.sql` migration is applied to prod):
+ *
+ *   cd backend
+ *   DATABASE_URL=... npx tsx scripts/import-telegram-groups.ts
+ *   # add --dry-run to print what would change without writing
+ *
+ * Idempotent: upserts keyed by city_key, so re-running is safe. Only rows
+ * whose groupId matches /^-?\d+$/ are imported (skips blanks / "tbd" / "x").
+ * `source` is set to 'sheet' for every imported row.
+ *
+ * Sheet source: same gviz JSON URL the frontend `fetchTelegramGroups()` uses.
+ *   col 5  = city
+ *   col 8  = chatUrl
+ *   col 10 = groupId (chat_id)
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const SHEET_ID = '16T3_iXywToXQqxTyDIniWIA4SUI8Wj0a5LKHSAJL_9Q';
+const GID = '811297100';
+
+interface SheetRow {
+  city: string;
+  chatUrl: string;
+  groupId: string;
+}
+
+async function fetchSheetRows(): Promise<SheetRow[]> {
+  const url = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/gviz/tq?tqx=out:json&gid=${GID}&headers=11`;
+  const response = await fetch(url);
+  const text = await response.text();
+  // Strip the JSONP wrapper: google.visualization.Query.setResponse({...})
+  const json = JSON.parse(text.replace(/^[^(]*\(/, '').replace(/\);?$/, ''));
+
+  return (json.table.rows as any[])
+    .map((row: any): SheetRow => ({
+      city: String(row.c?.[5]?.v ?? '').trim(),
+      chatUrl: String(row.c?.[8]?.v ?? '').trim(),
+      groupId: String(row.c?.[10]?.v ?? '').replace('#', '').trim(),
+    }))
+    .filter((r) => r.city && r.groupId && /^-?\d+$/.test(r.groupId));
+}
+
+async function main() {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+
+  console.log(`[import-telegram-groups] fetching sheet (dryRun=${dryRun})...`);
+  const rows = await fetchSheetRows();
+  console.log(`[import-telegram-groups] ${rows.length} valid sheet rows`);
+
+  // De-dup by cityKey: last writer wins (sheet may carry duplicate cities).
+  const byCityKey = new Map<string, SheetRow>();
+  for (const r of rows) {
+    byCityKey.set(r.city.toLowerCase().trim(), r);
+  }
+
+  let upserted = 0;
+  let skipped = 0;
+  for (const [cityKey, r] of byCityKey) {
+    const chatId = BigInt(r.groupId);
+    const isSupergroup = r.groupId.startsWith('-100');
+
+    if (dryRun) {
+      console.log(
+        `[dry-run] ${cityKey} -> chat_id=${chatId.toString()} supergroup=${isSupergroup} url=${r.chatUrl || '(none)'}`,
+      );
+      skipped++;
+      continue;
+    }
+
+    await prisma.cityTelegramGroup.upsert({
+      where: { cityKey },
+      create: {
+        cityKey,
+        chatId,
+        chatUrl: r.chatUrl || null,
+        isSupergroup,
+        source: 'sheet',
+        lastVerifiedAt: new Date(),
+      },
+      update: {
+        chatId,
+        chatUrl: r.chatUrl || null,
+        isSupergroup,
+        source: 'sheet',
+        lastVerifiedAt: new Date(),
+      },
+    });
+    upserted++;
+  }
+
+  console.log(
+    `[import-telegram-groups] done — ${upserted} upserted, ${skipped} skipped${dryRun ? ' (dry-run)' : ''} from ${byCityKey.size} unique cities`,
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error('[import-telegram-groups] FAILED:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -47,6 +47,8 @@ import {
   type RegionalAuthRequest,
 } from '../middleware/regionalUnderboss.js';
 import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
+import { sendToCityGroup } from '../services/cityTelegramGroup.js';
+import { cityKeyFromPartyName } from '../helpers/underbossScope.js';
 
 const router = Router();
 
@@ -6059,17 +6061,15 @@ router.post(
         hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
       }
 
-      // Group chat — per-city chat_id supplied by the caller. The frontend
-      // resolves it from the GPP sheet (`SheetCity.groupId`) using the same
-      // city→chat_id map that /underboss uses for its broadcast tooling. We
-      // intentionally don't fetch the sheet from the backend; mirrors the
-      // `/api/telegram/broadcast` contract where the client supplies chatIds.
-      const rawGroupChatId =
-        typeof req.body?.groupChatId === 'string' ? req.body.groupChatId.trim() : '';
+      // Group chat — tonda-58293: the backend now resolves the per-city group
+      // chat_id from `city_telegram_groups` (keyed by cityKey from the party
+      // name) via `sendToCityGroup`, which also persists supergroup migrations.
+      // The client no longer supplies `groupChatId`.
+      const cityKey = cityKeyFromPartyName(party.name);
       let groupSent = false;
       let groupReason: string | undefined;
-      if (rawGroupChatId) {
-        const result = await sendTelegramMessage(rawGroupChatId, text);
+      if (cityKey) {
+        const result = await sendToCityGroup(cityKey, text);
         if (result.ok) {
           groupSent = true;
         } else {
@@ -6156,12 +6156,14 @@ router.post(
         hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
       }
 
-      const rawGroupChatId =
-        typeof req.body?.groupChatId === 'string' ? req.body.groupChatId.trim() : '';
+      // Group chat — tonda-58293: resolved server-side from
+      // `city_telegram_groups` via `sendToCityGroup` (adds the migration
+      // retry+persist this endpoint previously lacked). No client groupChatId.
+      const cityKey = cityKeyFromPartyName(party.name);
       let groupSent = false;
       let groupReason: string | undefined;
-      if (rawGroupChatId) {
-        const result = await sendTelegramMessage(rawGroupChatId, text);
+      if (cityKey) {
+        const result = await sendToCityGroup(cityKey, text);
         if (result.ok) {
           groupSent = true;
         } else {

--- a/backend/src/routes/telegram.routes.ts
+++ b/backend/src/routes/telegram.routes.ts
@@ -130,7 +130,32 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
           );
           telegramResult = await retryResponse.json();
           if (telegramResult.ok) {
-            results.push({ chatId, city: city || '', success: true, error: `Migrated: update sheet to ${newChatId}` });
+            // tonda-58293: persist the new supergroup id to city_telegram_groups
+            // so the mapping no longer drifts. cityKey = lower(trim(city)).
+            const cityKey = (city || '').toLowerCase().trim();
+            if (cityKey) {
+              try {
+                await prisma.cityTelegramGroup.upsert({
+                  where: { cityKey },
+                  create: {
+                    cityKey,
+                    chatId: BigInt(newChatId),
+                    isSupergroup: true,
+                    source: 'migration',
+                    lastVerifiedAt: new Date(),
+                  },
+                  update: {
+                    chatId: BigInt(newChatId),
+                    isSupergroup: true,
+                    source: 'migration',
+                    lastVerifiedAt: new Date(),
+                  },
+                });
+              } catch (persistErr: any) {
+                console.error(`[tonda-58293][broadcast] failed to persist migration for ${cityKey}:`, persistErr?.message || persistErr);
+              }
+            }
+            results.push({ chatId, city: city || '', success: true, error: `Migrated to ${newChatId} (saved automatically)` });
           } else {
             results.push({ chatId, city: city || '', success: false, error: telegramResult.description || 'Failed after migration retry' });
           }
@@ -491,6 +516,58 @@ router.post('/test', requireAuth, requireUnderbossAuth, async (req: UnderbossAut
         error: err.message || 'Network error',
       });
     }
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /groups — DB-first read of the city → Telegram group mapping.
+//
+// tonda-58293: replaces the client-side Google Sheet fetch. Returns the
+// `city_telegram_groups` rows the caller is allowed to see:
+//   - Admin / graphics-admin (regions includes '__admin__') → all rows.
+//   - Region-scoped UB with no explicit cities → all rows (the city→region
+//     map lives in the sheet, not the backend; mirrors groupInBroadcastScope).
+//   - City-scoped UB → only rows whose city_key is in their assigned cities.
+// Scoping is pushed into the Prisma `where` (never JS-filtered after a query).
+// chatId is serialized to string because BigInt is not JSON-safe.
+router.get('/groups', requireAuth, requireUnderbossAuth, async (req: UnderbossAuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const ub = req.underboss!;
+    const isAdminScope = ub.regions.includes('__admin__');
+    const hasCities = (ub.cities?.length ?? 0) > 0;
+    const regionOnly = !isAdminScope && ub.regions.length > 0 && !hasCities;
+
+    let where: { cityKey?: { in: string[] } } | undefined;
+    if (isAdminScope || regionOnly) {
+      // Full visibility for admins and region-only UBs.
+      where = undefined;
+    } else if (hasCities) {
+      const cityKeys = (ub.cities || []).map((c) => c.toLowerCase().trim()).filter(Boolean);
+      // Empty after normalization → return nothing.
+      where = { cityKey: { in: cityKeys.length > 0 ? cityKeys : ['__no_match__'] } };
+    } else {
+      // Neither admin, nor region, nor cities → no access.
+      where = { cityKey: { in: ['__no_match__'] } };
+    }
+
+    const rows = await prisma.cityTelegramGroup.findMany({
+      where,
+      orderBy: { cityKey: 'asc' },
+    });
+
+    res.json({
+      groups: rows.map((r) => ({
+        id: r.id,
+        cityKey: r.cityKey,
+        chatId: r.chatId !== null ? r.chatId.toString() : null,
+        chatUrl: r.chatUrl,
+        title: r.title,
+        isSupergroup: r.isSupergroup,
+        source: r.source,
+        lastVerifiedAt: r.lastVerifiedAt,
+      })),
+    });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/telegram.routes.ts
+++ b/backend/src/routes/telegram.routes.ts
@@ -526,8 +526,10 @@ router.post('/test', requireAuth, requireUnderbossAuth, async (req: UnderbossAut
 // tonda-58293: replaces the client-side Google Sheet fetch. Returns the
 // `city_telegram_groups` rows the caller is allowed to see:
 //   - Admin / graphics-admin (regions includes '__admin__') → all rows.
-//   - Region-scoped UB with no explicit cities → all rows (the city→region
-//     map lives in the sheet, not the backend; mirrors groupInBroadcastScope).
+//   - Region-scoped UB with no explicit cities → rows whose `region` matches
+//     one of the caller's assigned regions (case-insensitive). Now that the
+//     region metadata lives in the DB we can push this predicate into the
+//     query instead of returning everything.
 //   - City-scoped UB → only rows whose city_key is in their assigned cities.
 // Scoping is pushed into the Prisma `where` (never JS-filtered after a query).
 // chatId is serialized to string because BigInt is not JSON-safe.
@@ -538,10 +540,18 @@ router.get('/groups', requireAuth, requireUnderbossAuth, async (req: UnderbossAu
     const hasCities = (ub.cities?.length ?? 0) > 0;
     const regionOnly = !isAdminScope && ub.regions.length > 0 && !hasCities;
 
-    let where: { cityKey?: { in: string[] } } | undefined;
-    if (isAdminScope || regionOnly) {
-      // Full visibility for admins and region-only UBs.
+    type GroupWhere = {
+      cityKey?: { in: string[] };
+      region?: { in: string[]; mode: 'insensitive' };
+    };
+    let where: GroupWhere | undefined;
+    if (isAdminScope) {
+      // Full visibility for admins.
       where = undefined;
+    } else if (regionOnly) {
+      // Region-scoped UB: restrict to rows tagged with one of their regions.
+      const regions = (ub.regions || []).map((r) => r.trim()).filter(Boolean);
+      where = { region: { in: regions.length > 0 ? regions : ['__no_match__'], mode: 'insensitive' } };
     } else if (hasCities) {
       const cityKeys = (ub.cities || []).map((c) => c.toLowerCase().trim()).filter(Boolean);
       // Empty after normalization → return nothing.
@@ -563,6 +573,9 @@ router.get('/groups', requireAuth, requireUnderbossAuth, async (req: UnderbossAu
         chatId: r.chatId !== null ? r.chatId.toString() : null,
         chatUrl: r.chatUrl,
         title: r.title,
+        country: r.country,
+        region: r.region,
+        underboss: r.underboss,
         isSupergroup: r.isSupergroup,
         source: r.source,
         lastVerifiedAt: r.lastVerifiedAt,

--- a/backend/src/services/cityTelegramGroup.ts
+++ b/backend/src/services/cityTelegramGroup.ts
@@ -1,0 +1,149 @@
+/**
+ * tonda-58293: shared sender for a city's Telegram GROUP chat.
+ *
+ * Looks up the per-city group chat_id in `city_telegram_groups` (keyed by
+ * `cityKey = lower(trim(city))`) and sends a message via the Molto Benny bot
+ * (TELEGRAM_BOT_TOKEN). The key behavior — missing from the old client-supplied
+ * `groupChatId` paths — is that when Telegram reports the group was upgraded to
+ * a supergroup (`parameters.migrate_to_chat_id`), we retry with the new id AND
+ * persist it back to the table so the mapping never silently drifts again.
+ *
+ * Mirrors the fetch/retry shape in `telegram.routes.ts` `/broadcast` so all
+ * group sends behave consistently.
+ *
+ * Returns a structured result instead of throwing; callers decide how to
+ * surface skips/failures.
+ */
+import { prisma } from '../config/database.js';
+
+const BOT_API = 'https://api.telegram.org';
+
+export interface SendToCityGroupResult {
+  ok: boolean;
+  /** True when there is no group on file for the city (no row or null chat_id). */
+  skipped?: boolean;
+  /** Human-readable reason for a skip or failure. */
+  reason?: string;
+  /** The chat_id we ultimately sent to (string form), when known. */
+  chatId?: string;
+  /** Set when the group had migrated to a supergroup and we persisted the new id. */
+  migratedTo?: string;
+}
+
+/**
+ * Send `text` to the Telegram group chat registered for `cityKey`.
+ *
+ * @param cityKey  Already-normalized city key (caller should pass `lower(trim(city))`).
+ * @param text     Message body.
+ * @param parseMode Optional Telegram parse_mode ('HTML' | 'Markdown'); omit/None for plain.
+ */
+export async function sendToCityGroup(
+  cityKey: string,
+  text: string,
+  parseMode?: string,
+): Promise<SendToCityGroupResult> {
+  const key = (cityKey || '').toLowerCase().trim();
+  if (!key) {
+    return { ok: false, skipped: true, reason: 'no city TG group set' };
+  }
+
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    return { ok: false, reason: 'TELEGRAM_BOT_TOKEN not configured' };
+  }
+
+  const row = await prisma.cityTelegramGroup.findUnique({
+    where: { cityKey: key },
+    select: { chatId: true },
+  });
+
+  if (!row || row.chatId === null) {
+    return { ok: false, skipped: true, reason: 'no city TG group set' };
+  }
+
+  const effectiveParseMode = parseMode && parseMode !== 'None' ? parseMode : undefined;
+
+  const send = async (chatId: string) => {
+    const resp = await fetch(`${BOT_API}/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        disable_web_page_preview: true,
+        ...(effectiveParseMode && { parse_mode: effectiveParseMode }),
+      }),
+    });
+    return resp.json() as Promise<any>;
+  };
+
+  const originalChatId = row.chatId.toString();
+
+  try {
+    let result = await send(originalChatId);
+
+    // Auto-retry + PERSIST if the group was upgraded to a supergroup.
+    if (!result.ok && result.parameters?.migrate_to_chat_id) {
+      const newChatId = String(result.parameters.migrate_to_chat_id);
+      console.log(
+        `[tonda-58293][city-group] ${key} migrated ${originalChatId} -> ${newChatId}, retrying...`,
+      );
+      result = await send(newChatId);
+
+      if (result.ok) {
+        try {
+          await prisma.cityTelegramGroup.update({
+            where: { cityKey: key },
+            data: {
+              chatId: BigInt(newChatId),
+              isSupergroup: true,
+              source: 'migration',
+              lastVerifiedAt: new Date(),
+            },
+          });
+        } catch (persistErr: any) {
+          // Send succeeded; failing to persist must not flip the result to error.
+          console.error(
+            `[tonda-58293][city-group] failed to persist migration for ${key}:`,
+            persistErr?.message || persistErr,
+          );
+        }
+        return { ok: true, chatId: newChatId, migratedTo: newChatId };
+      }
+
+      return {
+        ok: false,
+        reason: result.description || 'Failed after migration retry',
+        chatId: newChatId,
+      };
+    }
+
+    if (result.ok) {
+      // Touch last_verified_at so we know the mapping is still live.
+      try {
+        await prisma.cityTelegramGroup.update({
+          where: { cityKey: key },
+          data: { lastVerifiedAt: new Date() },
+        });
+      } catch (touchErr: any) {
+        console.error(
+          `[tonda-58293][city-group] failed to touch last_verified_at for ${key}:`,
+          touchErr?.message || touchErr,
+        );
+      }
+      return { ok: true, chatId: originalChatId };
+    }
+
+    return {
+      ok: false,
+      reason: result.description || 'Unknown Telegram error',
+      chatId: originalChatId,
+    };
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: err?.message || 'Network error',
+      chatId: originalChatId,
+    };
+  }
+}

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -207,15 +207,6 @@ interface PayoutsByPartyTableProps {
     } | { error: string },
   ) => void;
   /**
-   * crocchetta-92107: per-city Telegram group chat_id map keyed by the
-   * lower-cased, trimmed city name (with the "Global Pizza Party " prefix
-   * stripped). Populated by the parent from `fetchSheetCities()` —
-   * `SheetCity.groupId` — the same source /underboss uses for its broadcast
-   * tooling. When a row's city is missing from the map, the group post is
-   * skipped server-side with `groupReason: 'no city TG group set'`.
-   */
-  cityGroupChatIds?: Map<string, string>;
-  /**
    * bufalina-60733: fake-detection risk scores keyed by party id. Only
    * medium/high (≥30) parties are present; an absent key means "no badge".
    * Rendered as a caution pill in the city header strip.
@@ -2580,7 +2571,6 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onTagsChanged,
   onTgReminderResult,
   onTgWalletReminderResult,
-  cityGroupChatIds,
   fakeScores,
   viewerRole = 'admin',
   busyRowId,
@@ -2853,20 +2843,17 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
    * crocchetta-92106 + crocchetta-92107: dispatch the Send-receipts-reminder
    * POST and surface the per-channel outcome to the parent via
    * `onTgReminderResult` so the page-level toast stack renders the right
-   * message. The per-city Telegram group chat_id is resolved from
-   * `cityGroupChatIds` (a sheet-derived map keyed by the stripped,
-   * lower-cased city name); when the map has no entry the request omits the
-   * field and the backend marks the group post skipped. Errors are caught
-   * and forwarded with an `error` shape so the parent can flash a failure
-   * toast without the table needing its own alert path.
+   * message. tonda-58293: the per-city Telegram group chat_id is now resolved
+   * server-side from `city_telegram_groups` (the backend derives the city from
+   * the party name); the client no longer passes a groupChatId. Errors are
+   * caught and forwarded with an `error` shape so the parent can flash a
+   * failure toast without the table needing its own alert path.
    */
   async function handleSendTgReminder(row: PartyPayoutsRow) {
     const partyId = row.party.id;
-    const cityKey = stripGppPrefix(row.party.name).toLowerCase().trim();
-    const groupChatId = cityGroupChatIds?.get(cityKey);
     setTgReminderBusyPartyId(partyId);
     try {
-      const result = await sendTgReceiptsReminder(partyId, groupChatId);
+      const result = await sendTgReceiptsReminder(partyId);
       onTgReminderResult?.(partyId, result);
     } catch (err) {
       onTgReminderResult?.(partyId, {
@@ -2879,16 +2866,14 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
 
   /**
    * Sibling of {@link handleSendTgReminder}: dispatch the wallet reminder POST
-   * and forward the per-channel outcome via `onTgWalletReminderResult`. Same
-   * city→group chat_id resolution.
+   * and forward the per-channel outcome via `onTgWalletReminderResult`. Group
+   * chat_id resolved server-side (tonda-58293) — no client groupChatId.
    */
   async function handleSendWalletReminder(row: PartyPayoutsRow) {
     const partyId = row.party.id;
-    const cityKey = stripGppPrefix(row.party.name).toLowerCase().trim();
-    const groupChatId = cityGroupChatIds?.get(cityKey);
     setWalletReminderBusyPartyId(partyId);
     try {
-      const result = await sendTgWalletReminder(partyId, groupChatId);
+      const result = await sendTgWalletReminder(partyId);
       onTgWalletReminderResult?.(partyId, result);
     } catch (err) {
       onTgWalletReminderResult?.(partyId, {

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -170,17 +170,17 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
       try {
         // tonda-58293: source the city → group chat_id map from the DB
         // (`/api/underboss/telegram/groups`) instead of the Google Sheet. The
-        // endpoint is already scoped to the caller's cities. The legacy
-        // country/underboss/region columns aren't stored in the DB, so they
-        // render blank here — only city + chat_id are needed for sends.
+        // endpoint is already scoped to the caller's cities/regions, and the
+        // follow-up persists the legacy country/underboss/region metadata so
+        // those columns + the region filter render again.
         const rows = await fetchCityTelegramGroups();
         const data: TelegramGroup[] = rows
           .filter((r) => r.chatId && r.cityKey)
           .map((r) => ({
-            country: '',
+            country: r.country || '',
             city: r.cityKey,
-            underboss: '',
-            region: '',
+            underboss: r.underboss || '',
+            region: r.region || '',
             chatUrl: r.chatUrl || '',
             groupId: r.chatId as string,
           }));

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -3,12 +3,13 @@ import { createPortal } from 'react-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { X, Search, Check, AlertCircle, Loader2, Send, ChevronDown, MessageSquare } from 'lucide-react';
 import { IconInput } from '../IconInput';
-import { fetchTelegramGroups, TelegramGroup } from '../../lib/telegram';
+import { TelegramGroup } from '../../lib/telegram';
 import {
   sendTelegramBroadcast,
   sendTelegramTest,
   sendHostTelegramBroadcast,
   sendHostTelegramTest,
+  fetchCityTelegramGroups,
   BroadcastResult,
 } from '../../lib/api';
 import type { UnderbossEvent } from '../../types';
@@ -167,7 +168,22 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
   useEffect(() => {
     async function load() {
       try {
-        const data = await fetchTelegramGroups();
+        // tonda-58293: source the city → group chat_id map from the DB
+        // (`/api/underboss/telegram/groups`) instead of the Google Sheet. The
+        // endpoint is already scoped to the caller's cities. The legacy
+        // country/underboss/region columns aren't stored in the DB, so they
+        // render blank here — only city + chat_id are needed for sends.
+        const rows = await fetchCityTelegramGroups();
+        const data: TelegramGroup[] = rows
+          .filter((r) => r.chatId && r.cityKey)
+          .map((r) => ({
+            country: '',
+            city: r.cityKey,
+            underboss: '',
+            region: '',
+            chatUrl: r.chatUrl || '',
+            groupId: r.chatId as string,
+          }));
         setGroups(data);
         // Auto-select groups matching pre-selected cities (fuzzy match)
         if (preSelectedCities && preSelectedCities.length > 0) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -546,6 +546,9 @@ export interface CityTelegramGroupRow {
   chatId: string | null;
   chatUrl: string | null;
   title: string | null;
+  country: string | null;
+  region: string | null;
+  underboss: string | null;
   isSupergroup: boolean;
   source: string;
   lastVerifiedAt: string | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -484,11 +484,11 @@ export async function removeCustomTag(
  * Two messages, same body:
  *   1. DM to the primary host (uses `parties.host_telegram_chat_id`; skipped
  *      with a reason when the host hasn't linked Telegram).
- *   2. Post to the **city's** Telegram group chat. The caller resolves the
- *      chat_id from the GPP sheet (same `SheetCity.groupId` field that
- *      powers /underboss broadcasts) and passes it in `groupChatId`. When
- *      omitted/empty, the backend skips with `groupReason: 'no city TG
- *      group set'` (per-party, not a global env var).
+ *   2. Post to the **city's** Telegram group chat. tonda-58293: the backend
+ *      now resolves the group chat_id from `city_telegram_groups` (keyed by
+ *      the city derived from the party name) — the client no longer passes a
+ *      `groupChatId`. When no group is on file the backend skips with
+ *      `groupReason: 'no city TG group set'`.
  *
  * Backend returns per-channel success + skip reason so the UI can render an
  * accurate partial-success toast. Triggered from the /payments by-city ⋮
@@ -503,14 +503,12 @@ export interface SendTgReceiptsReminderResponse {
 
 export async function sendTgReceiptsReminder(
   partyId: string,
-  groupChatId?: string | null,
 ): Promise<SendTgReceiptsReminderResponse> {
   return apiRequest<SendTgReceiptsReminderResponse>(
     `/api/admin/payouts/${partyId}/tg-receipts-reminder`,
     {
       method: 'POST',
       requireAuth: true,
-      body: groupChatId ? { groupChatId } : undefined,
     },
   );
 }
@@ -520,20 +518,45 @@ export async function sendTgReceiptsReminder(
  * address at rsv.pizza/host/<slug>/payments" reminder via the Molto Benny
  * Telegram bot — DM to the primary host + post to the city's group chat. Same
  * per-channel success + skip-reason contract. Unlike the receipts reminder this
- * does NOT persist a sent-at timestamp.
+ * does NOT persist a sent-at timestamp. tonda-58293: group chat_id resolved
+ * server-side; no `groupChatId` arg.
  */
 export async function sendTgWalletReminder(
   partyId: string,
-  groupChatId?: string | null,
 ): Promise<SendTgReceiptsReminderResponse> {
   return apiRequest<SendTgReceiptsReminderResponse>(
     `/api/admin/payouts/${partyId}/tg-wallet-reminder`,
     {
       method: 'POST',
       requireAuth: true,
-      body: groupChatId ? { groupChatId } : undefined,
     },
   );
+}
+
+/**
+ * tonda-58293: DB-first read of the city → Telegram group mapping. Replaces
+ * the client-side Google Sheet fetch (`fetchTelegramGroups()`) for sends.
+ * Returns rows from `city_telegram_groups` scoped to the caller's cities
+ * (admins/region-only UBs get all). `chatId` is a string (BigInt-safe).
+ * Mounted at `/api/underboss/telegram/groups` (underboss-scoped auth).
+ */
+export interface CityTelegramGroupRow {
+  id: string;
+  cityKey: string;
+  chatId: string | null;
+  chatUrl: string | null;
+  title: string | null;
+  isSupergroup: boolean;
+  source: string;
+  lastVerifiedAt: string | null;
+}
+
+export async function fetchCityTelegramGroups(): Promise<CityTelegramGroupRow[]> {
+  const res = await apiRequest<{ groups: CityTelegramGroupRow[] }>(
+    `/api/underboss/telegram/groups`,
+    { method: 'GET', requireAuth: true },
+  );
+  return res.groups;
 }
 
 /**

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -39,7 +39,6 @@ import type {
 import { formatUsd } from '../components/payments-shared';
 import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
 import { isSwcHubParty } from '../utils/swcHub';
-import { fetchSheetCities } from '../lib/cities';
 import {
   PayoutsFilterBar,
   PayoutsTable,
@@ -335,36 +334,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     [],
   );
 
-  // crocchetta-92107: city-name → Telegram group chat_id map, sourced from
-  // the same GPP sheet (`fetchSheetCities` → `SheetCity.groupId`) that
-  // /underboss uses for its broadcast tooling. Drives the per-city group
-  // post on the Send-receipts-reminder action; rows without a matching city
-  // entry skip the group post server-side. Fetched once on mount; failures
-  // collapse to an empty map (the host DM still goes out).
-  const [cityGroupChatIds, setCityGroupChatIds] = useState<Map<string, string>>(
-    new Map(),
-  );
-  useEffect(() => {
-    let cancelled = false;
-    fetchSheetCities()
-      .then((cities) => {
-        if (cancelled) return;
-        const map = new Map<string, string>();
-        for (const c of cities) {
-          if (c.groupId) {
-            map.set(c.city.toLowerCase().trim(), c.groupId);
-          }
-        }
-        setCityGroupChatIds(map);
-      })
-      .catch(() => {
-        // Sheet fetch is best-effort — silently collapse on failure. The DM
-        // path still runs and the toast surfaces "no city TG group set".
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // tonda-58293: the per-city Telegram group chat_id is now resolved
+  // server-side from `city_telegram_groups` (the reminder endpoints derive the
+  // city from the party name). The page no longer fetches the GPP sheet to
+  // build a city→chat_id map.
 
   const loadPrepayQueue = useCallback(async () => {
     try {
@@ -1420,11 +1393,6 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 result.hostDmSent || result.groupSent ? 'success' : 'error';
               pushToast(`Wallet reminder: ${hostLabel} | ${groupLabel}`, tone);
             }}
-            // crocchetta-92107: sheet-derived city → TG group chat_id map so
-            // the Send-receipts-reminder action can post into the city's
-            // group chat (same source /underboss uses). Reused by the wallet
-            // reminder too.
-            cityGroupChatIds={cityGroupChatIds}
             viewerRole={viewerKind}
             busyRowId={rowBusyId}
             loading={loading}

--- a/plans/tonda-58293-telegram-group-id-store-collect.md
+++ b/plans/tonda-58293-telegram-group-id-store-collect.md
@@ -1,0 +1,67 @@
+# tonda-58293 — Telegram city group chat IDs in the DB (Phase 1)
+
+## Problem
+City Telegram group chat IDs live ONLY in a Google Sheet
+(`16T3_iXywToXQqxTyDIniWIA4SUI8Wj0a5LKHSAJL_9Q`, gid `811297100`, col 10 =
+groupId), fetched client-side via `frontend/src/lib/telegram.ts`. The backend
+has no copy. When a group is upgraded to a supergroup, Telegram returns a 400
+with `parameters.migrate_to_chat_id`:
+
+- The `/underboss` broadcast retries with the new id and succeeds, but only
+  returns `"Migrated: update sheet to {newChatId}"` — it never persists.
+- The receipts/wallet reminder endpoints have NO retry at all and read the
+  chat id from a client-supplied `groupChatId`.
+
+So the mapping silently drifts and reminders/broadcasts stop reaching migrated
+groups.
+
+## Phase 1 scope (this PR — code only)
+
+1. **Schema** — new table `city_telegram_groups` (`CityTelegramGroup` model)
+   keyed by `cityKey = lower(trim(city))`, with `chatId BigInt?`, `chatUrl`,
+   `title`, `isSupergroup`, `source` (sheet|webhook|migration|manual),
+   `lastVerifiedAt`. Migration SQL at
+   `backend/prisma/migrations/tonda-58293-city-telegram-groups.sql`
+   (CREATE TABLE IF NOT EXISTS + unique index on `city_key`).
+
+2. **Import script** — `backend/scripts/import-telegram-groups.ts`. Fetches the
+   sheet gviz JSON (col 5 city, col 8 chatUrl, col 10 groupId), keeps only
+   groupIds matching `/^-?\d+$/`, upserts keyed by cityKey with `source='sheet'`,
+   `isSupergroup = startsWith('-100')`. Idempotent, `--dry-run` supported.
+
+3. **Shared helper** — `backend/src/services/cityTelegramGroup.ts` exports
+   `sendToCityGroup(cityKey, text, parseMode?)`. Looks up the row; skips when no
+   row / null chatId; sends via the bot; on `migrate_to_chat_id` retries once and
+   persists the new id (`source='migration'`, `isSupergroup=true`); touches
+   `lastVerifiedAt` on success. Returns `{ ok, skipped?, reason?, chatId, migratedTo? }`.
+
+4. **Persist migrations in both paths**
+   - `telegram.routes.ts` `/broadcast`: after a successful migration retry, upsert
+     the new id into `city_telegram_groups` for that city; message now notes it's
+     saved automatically.
+   - `admin-payout.routes.ts` `tg-receipts-reminder` + `tg-wallet-reminder`: the
+     GROUP channel now goes through `sendToCityGroup(cityKeyFromPartyName(name))`,
+     adding the migration retry+persist these endpoints lacked. Host-DM channel
+     unchanged.
+
+5. **DB-first read endpoint** — `GET /api/underboss/telegram/groups`
+   (requireAuth + requireUnderbossAuth). Returns `city_telegram_groups` rows
+   scoped to the caller's cities (admin/region-only UB = all), chatId serialized
+   to string. Scoping pushed into the Prisma `where`.
+
+6. **Frontend → DB** — `TelegramBroadcast.tsx` and the payouts reminder UI read
+   from the new endpoint (`fetchCityTelegramGroups()` in `api.ts`) instead of the
+   sheet. Reminder calls no longer pass `groupChatId` (backend resolves it);
+   removed the `cityGroupChatIds` map/state/prop from `PaymentsAdminPage` +
+   `PayoutsByPartyTable`. `frontend/src/lib/telegram.ts` is left in place as
+   legacy/import-only.
+
+## Out of scope (later phases)
+- Webhook-driven capture of migrations / new groups (`source='webhook'`).
+- Admin UI to edit/add city groups directly.
+
+## Post-merge ops (main session)
+1. Apply `backend/prisma/migrations/tonda-58293-city-telegram-groups.sql` to prod
+   (Supabase MCP or pg + DATABASE_URL — this repo has no migration auto-apply).
+2. Run `backend/scripts/import-telegram-groups.ts` with DATABASE_URL to seed the
+   table from the sheet. Until both run, the preview shows an empty group list.


### PR DESCRIPTION
## tonda-58293 — Phase 1: durable Telegram city group chat IDs

City group chat IDs previously lived **only** in a Google Sheet, fetched
client-side. Supergroup migrations (Telegram `migrate_to_chat_id`) were never
persisted, so broadcasts/reminders silently drifted to dead chat IDs. This PR
moves the mapping into a new DB table and persists migrations everywhere.

### Changes
- **Schema:** new `city_telegram_groups` table (`CityTelegramGroup` model),
  keyed by `city_key = lower(trim(city))`. Migration SQL at
  `backend/prisma/migrations/tonda-58293-city-telegram-groups.sql`.
- **Import script:** `backend/scripts/import-telegram-groups.ts` — one-time,
  idempotent upsert from the sheet (col 5 city / col 8 chatUrl / col 10 groupId),
  `source='sheet'`. `--dry-run` supported. Not run here.
- **Shared helper:** `backend/src/services/cityTelegramGroup.ts` →
  `sendToCityGroup(cityKey, text, parseMode?)`. Skips when no row/null chatId;
  on `migrate_to_chat_id` retries once and persists the new id
  (`source='migration'`, `isSupergroup=true`); touches `lastVerifiedAt`.
- **Persist migrations in both existing paths:**
  - `/api/underboss/telegram/broadcast`: upserts the new supergroup id after a
    successful migration retry (message now says it's saved automatically).
  - `tg-receipts-reminder` + `tg-wallet-reminder`: GROUP channel now goes through
    `sendToCityGroup` (adds the migration retry+persist these endpoints lacked).
    Host-DM channel unchanged.
- **DB-first read endpoint:** `GET /api/underboss/telegram/groups`, city-scoped
  (admin/region-only UB = all), chatId serialized to string, scoping in the
  Prisma `where`.
- **Frontend:** `TelegramBroadcast.tsx` + payouts reminders now read the DB
  endpoint (`fetchCityTelegramGroups()`); dropped the client `groupChatId` arg
  and the `cityGroupChatIds` sheet-fetch plumbing in `PaymentsAdminPage` /
  `PayoutsByPartyTable`. `frontend/src/lib/telegram.ts` left in place as
  legacy/import-only.

### Verification
- `backend: npx tsc --noEmit` — clean (3 pre-existing unrelated errors on master:
  missing optional `openai`/`pdf-lib` deps + `auth.test.ts` jwt typing).
- `frontend: npx tsc --noEmit` — clean.

### ⚠️ Main session must do BEFORE the preview works
This repo has **no Prisma migration auto-apply** and the backend deploys only
from master. Before the preview/prod behaves:
1. **Apply** `backend/prisma/migrations/tonda-58293-city-telegram-groups.sql` to
   prod (Supabase MCP or pg + DATABASE_URL).
2. **Run** `backend/scripts/import-telegram-groups.ts` with DATABASE_URL to seed
   the table from the sheet.

Until both run, the group list is empty and group sends skip with
`"no city TG group set"` (host DMs still go out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)