### PR TITLE
marinara-61455: image-authenticity (AI/doctored) admin check

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "check:schema-drift": "node ../scripts/check-schema-drift.js"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.100.1",
     "@prisma/client": "^6.8.2",
     "@privy-io/server-auth": "^1.32.5",
     "@supabase/supabase-js": "^2.49.1",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2047,3 +2047,41 @@ model OutreachAttempt {
   @@index([sentAt(sort: Desc)])
   @@map("outreach_attempts")
 }
+
+// marinara-61455: cached verdict of a manual, admin-triggered image-authenticity
+// check (AI-generated / doctored detection) on a payment-receipt image or a
+// host event-cover image. SEPARATE table — does NOT widen payout_documents or
+// Party. Advisory only; never auto-rejects. Keyed by `imageUrl` for the cache
+// lookup ("return the cached row unless force").
+//
+// `partyId` / `payoutDocumentId` are intentionally PLAIN columns (no Prisma
+// `@relation`) so we don't have to add back-relations to Party / PayoutDocument.
+// The DB-level FKs (ON DELETE SET NULL) live in the SQL migration instead.
+//
+// ⚠️ No Prisma auto-migration in this repo — the live DDL is the matching file
+// supabase/migrations/20260604_marinara_61455_image_authenticity_checks.sql,
+// applied to prod manually before merge.
+model ImageAuthenticityCheck {
+  id               String   @id @default(uuid()) @db.Uuid
+  imageUrl         String   @map("image_url")
+  // 'receipt' | 'event_image'
+  sourceKind       String   @map("source_kind")
+  partyId          String?  @map("party_id") @db.Uuid
+  payoutDocumentId String?  @map("payout_document_id") @db.Uuid
+  // 'authentic' | 'suspicious' | 'likely_fake'
+  verdict          String
+  score            Int      @default(0)
+  // Per-signal flags + the vision model's structured observations.
+  reasons          Json     @default("[]")
+  // 'openai' | 'anthropic' | 'sightengine'
+  provider         String   @default("openai")
+  // Phase 2 ELA overlay artifact (downloadable PNG in event-images bucket).
+  elaArtifactUrl   String?  @map("ela_artifact_url")
+  checkedAt        DateTime @default(now()) @map("checked_at") @db.Timestamptz
+  // Admin email that triggered the check.
+  checkedBy        String?  @map("checked_by")
+
+  @@index([imageUrl])
+  @@index([partyId])
+  @@map("image_authenticity_checks")
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -54,6 +54,7 @@ import shippingRoutes from './routes/shipping.routes.js';
 import adminRoutes from './routes/admin.routes.js';
 import adminPayoutRoutes, { payoutWalletRouter, partyMarkPaidRouter } from './routes/admin-payout.routes.js';
 import adminPartyRoutes from './routes/admin-party.routes.js';
+import imageAuthenticityRoutes from './routes/imageAuthenticity.routes.js'; // marinara-61455: admin image-authenticity check
 import graphicsAdminRoutes from './routes/graphics-admin.routes.js';
 import logoAuditRoutes from './routes/logoAudit.routes.js';
 import { sponsorUserAdminRouter, sponsorDashboardRouter, partnerAiShareRouter } from './routes/sponsor-user.routes.js';
@@ -146,6 +147,7 @@ app.use('/api/admin/payouts', adminPayoutRoutes); // Host payouts admin dashboar
 app.use('/api/admin/payout-wallet', payoutWalletRouter); // coppa-91827: hot wallet address + balances (before /api/admin catch-all)
 app.use('/api/admin/parties', partyMarkPaidRouter); // panettone-92103: party-level "mark party paid" bulk action — before /api/admin catch-all
 app.use('/api/admin/parties', adminPartyRoutes); // fontina-91827: admin party-management routes (transfer ownership) — before /api/admin catch-all
+app.use('/api/admin/image-authenticity', imageAuthenticityRoutes); // marinara-61455: image-authenticity check — before /api/admin catch-all
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/telegram/webhook', telegramWebhookRoutes); // Telegram inbound webhook (no auth — secret-token header gate)

--- a/backend/src/lib/imageAuthenticity.ts
+++ b/backend/src/lib/imageAuthenticity.ts
@@ -1,0 +1,533 @@
+/**
+ * marinara-61455: image-authenticity (AI-generated / doctored) scorer.
+ *
+ * A manual, admin-triggered tool that judges whether a payment-receipt image or
+ * a host event-cover image is AI-generated or doctored. Advisory only — it
+ * surfaces a verdict + confidence + concrete reasons for a human reviewer; it
+ * NEVER auto-rejects.
+ *
+ * Mirrors the weighted-signal shape of `fakeDetection.ts`: each pass is a
+ * function returning `{ id, name, fired, weight, detail, evidence? }`; fired
+ * weights are summed, capped at 100, and mapped to a tiered verdict.
+ *
+ * Passes (cheapest-first):
+ *   1. Metadata / provenance  — generator/editor software tags + C2PA presence.
+ *      ⚠️ Presence is a STRONG positive signal; ABSENCE of EXIF is weak (our
+ *      Supabase re-encode + screenshots + chat compression all strip it), so
+ *      missing EXIF never dominates the score.
+ *   2. LLM vision verdict     — the PRIMARY judgment (OpenAI gpt-4o), behind a
+ *      provider interface so a Claude / 3rd-party second opinion can join later.
+ *   3. Receipt-math sanity    — (receipts only) line items not summing to the
+ *      total is a cheap, hard-to-fake tampering signal.
+ *   4. ELA overlay (Phase 2)  — a downloadable error-level-analysis artifact for
+ *      the admin. NOT scored (too noisy to auto-verdict reliably).
+ *   5. Second opinion (Phase 2) — env-gated Claude / Sightengine providers as a
+ *      tie-breaker on `suspicious` verdicts. Off unless their key is set.
+ */
+
+import sharp from 'sharp';
+import { createClient } from '@supabase/supabase-js';
+import {
+  primaryVisionProvider,
+  secondOpinionProviders,
+  VisionResult,
+  VisionVerdict,
+} from './providers/index.js';
+
+// ============================================
+// Types
+// ============================================
+
+export type SourceKind = 'receipt' | 'event_image';
+export type AuthenticityVerdict = VisionVerdict; // 'authentic' | 'suspicious' | 'likely_fake'
+
+export interface AuthenticitySignal {
+  id: string;
+  name: string;
+  fired: boolean;
+  weight: number;
+  detail: string;
+  evidence?: Record<string, unknown>;
+}
+
+export interface OcrLineItemLike {
+  subtotal?: number | null;
+  ineligible?: boolean | null;
+}
+
+export interface AuthenticityInput {
+  imageUrl: string;
+  sourceKind: SourceKind;
+  /** Receipts only — used by the receipt-math pass. */
+  ocrLineItems?: OcrLineItemLike[] | null;
+  ocrAmount?: number | null;
+}
+
+export interface AuthenticityResult {
+  verdict: AuthenticityVerdict;
+  score: number;
+  signals: AuthenticitySignal[];
+  /** Headline vision provider's structured output. */
+  vision: VisionResult | null;
+  /** Any env-gated second-opinion results that ran. */
+  secondOpinions: VisionResult[];
+  provider: string;
+  /** Phase 2 ELA overlay public URL, when generation + upload succeeded. */
+  elaArtifactUrl: string | null;
+  /** Flattened reasons array persisted to the check row's `reasons` jsonb. */
+  reasons: unknown;
+}
+
+// ============================================
+// Weights (tunable without code surgery)
+// ============================================
+
+export const WEIGHTS = {
+  // Metadata / provenance.
+  generator_software_tag: 55, // DALL-E / Midjourney / SD / Firefly etc.
+  editor_software_tag: 25, // Photoshop / GIMP — doctoring-capable editor.
+  c2pa_ai_manifest: 60, // Content Credentials declaring AI generation.
+  missing_exif: 4, // weak — re-encodes/screenshots strip EXIF.
+  // Vision verdict (primary).
+  vision_likely_fake: 60,
+  vision_suspicious: 30,
+  // Receipt math.
+  receipt_math_mismatch: 25,
+} as const;
+
+// ============================================
+// Verdict tiering
+// ============================================
+
+export function verdictFromScore(score: number): AuthenticityVerdict {
+  if (score >= 60) return 'likely_fake';
+  if (score >= 30) return 'suspicious';
+  return 'authentic';
+}
+
+// ============================================
+// Pass 1 — metadata / provenance
+// ============================================
+
+// Generator software / model markers (AI image generators). Lowercased.
+const GENERATOR_MARKERS = [
+  'dall-e',
+  'dall·e',
+  'dalle',
+  'midjourney',
+  'stable diffusion',
+  'stablediffusion',
+  'stable-diffusion',
+  'adobe firefly',
+  'firefly',
+  'sdxl',
+  'comfyui',
+  'automatic1111',
+  'invokeai',
+  'leonardo.ai',
+  'ideogram',
+];
+
+// Image-EDITOR markers (doctoring-capable). Lowercased.
+const EDITOR_MARKERS = [
+  'adobe photoshop',
+  'photoshop',
+  'gimp',
+  'pixlr',
+  'affinity photo',
+  'paint.net',
+];
+
+// C2PA / Content Credentials manifest markers.
+const C2PA_MARKERS = ['c2pa', 'contentcredentials', 'content credentials', 'jumbf', 'cai:'];
+
+export interface MetadataScan {
+  hasExif: boolean;
+  generatorHits: string[];
+  editorHits: string[];
+  c2paHit: boolean;
+  software: string | null;
+}
+
+/**
+ * Scan a raw image buffer for provenance markers. We look at the EXIF block
+ * (via sharp metadata) AND scan the head/tail of the raw bytes for ASCII
+ * software/C2PA markers — this catches XMP `xmp:CreatorTool`, PNG `tEXt`
+ * `Software`, JFIF comments, and C2PA/JUMBF boxes without pulling in a heavy
+ * EXIF/C2PA parsing dependency.
+ */
+export async function scanImageMetadata(buffer: Buffer): Promise<MetadataScan> {
+  let hasExif = false;
+  let software: string | null = null;
+  try {
+    const meta = await sharp(buffer).metadata();
+    hasExif = !!meta.exif && meta.exif.length > 0;
+    // sharp exposes the raw EXIF buffer; decode it as latin1 so we can substring
+    // it alongside any embedded XMP. (We are looking for ASCII software tags.)
+    if (meta.exif) {
+      const exifText = meta.exif.toString('latin1');
+      const swMatch = /Software\x00*([\x20-\x7e]{2,64})/.exec(exifText);
+      if (swMatch) software = swMatch[1].trim();
+    }
+  } catch {
+    // sharp can't parse — treat as no EXIF; the vision pass still runs.
+    hasExif = false;
+  }
+
+  // Scan a bounded window of the raw bytes for ASCII markers (XMP + PNG tEXt +
+  // C2PA boxes typically live near the head; cap the scan to stay cheap).
+  const head = buffer.subarray(0, Math.min(buffer.length, 256 * 1024)).toString('latin1').toLowerCase();
+  const tail = buffer.subarray(Math.max(0, buffer.length - 64 * 1024)).toString('latin1').toLowerCase();
+  const haystack = `${software ? software.toLowerCase() + ' ' : ''}${head}\n${tail}`;
+
+  const generatorHits = GENERATOR_MARKERS.filter((m) => haystack.includes(m));
+  const editorHits = EDITOR_MARKERS.filter((m) => haystack.includes(m));
+  const c2paHit = C2PA_MARKERS.some((m) => haystack.includes(m));
+
+  return { hasExif, generatorHits, editorHits, c2paHit, software };
+}
+
+export function metadataSignals(scan: MetadataScan): AuthenticitySignal[] {
+  const signals: AuthenticitySignal[] = [];
+
+  signals.push({
+    id: 'generator_software_tag',
+    name: 'AI-generator software tag',
+    fired: scan.generatorHits.length > 0,
+    weight: WEIGHTS.generator_software_tag,
+    detail: scan.generatorHits.length
+      ? `Image metadata references AI generator(s): ${scan.generatorHits.join(', ')}.`
+      : 'No AI-generator software tag found in metadata.',
+    evidence: { generatorHits: scan.generatorHits, software: scan.software },
+  });
+
+  signals.push({
+    id: 'editor_software_tag',
+    name: 'Image-editor software tag',
+    fired: scan.editorHits.length > 0,
+    weight: WEIGHTS.editor_software_tag,
+    detail: scan.editorHits.length
+      ? `Image was processed by editor(s): ${scan.editorHits.join(', ')} (doctoring-capable).`
+      : 'No image-editor software tag found in metadata.',
+    evidence: { editorHits: scan.editorHits },
+  });
+
+  signals.push({
+    id: 'c2pa_ai_manifest',
+    name: 'C2PA / Content Credentials manifest',
+    fired: scan.c2paHit,
+    weight: WEIGHTS.c2pa_ai_manifest,
+    detail: scan.c2paHit
+      ? 'A C2PA / Content-Credentials manifest is present — inspect it for an AI-generation assertion.'
+      : 'No C2PA / Content-Credentials manifest detected.',
+  });
+
+  // ⚠️ Absence of EXIF is a WEAK signal (Supabase re-encode, screenshots, and
+  // chat-app compression all strip it). Low weight by design — never condemn on
+  // missing EXIF alone.
+  signals.push({
+    id: 'missing_exif',
+    name: 'No camera EXIF metadata',
+    fired: !scan.hasExif,
+    weight: WEIGHTS.missing_exif,
+    detail: !scan.hasExif
+      ? 'No EXIF metadata (weak signal — re-encodes, screenshots, and chat compression strip it too).'
+      : 'EXIF metadata present.',
+  });
+
+  return signals;
+}
+
+// ============================================
+// Pass 3 — receipt-math sanity
+// ============================================
+
+/**
+ * Line items not summing to the receipt total (within tolerance) is a cheap,
+ * hard-to-fake tampering signal. Skips when we don't have both line items and a
+ * total. Only counts eligible (non-`ineligible`) lines, matching the reviewer's
+ * own sum semantics.
+ */
+export function receiptMathSignal(
+  lineItems: OcrLineItemLike[] | null | undefined,
+  ocrAmount: number | null | undefined,
+): AuthenticitySignal {
+  const id = 'receipt_math_mismatch';
+  const name = 'Receipt line items do not sum to total';
+
+  if (!lineItems || lineItems.length === 0 || ocrAmount == null || !Number.isFinite(ocrAmount)) {
+    return {
+      id,
+      name,
+      fired: false,
+      weight: WEIGHTS.receipt_math_mismatch,
+      detail: 'Not enough data to check receipt math (need line items + a total).',
+    };
+  }
+
+  const lineSum = lineItems.reduce((sum, li) => {
+    if (li?.ineligible === true) return sum;
+    const v = Number(li?.subtotal);
+    return sum + (Number.isFinite(v) && v >= 0 ? v : 0);
+  }, 0);
+
+  // Tolerance: the larger of $0.50 or 2% of the total (covers rounding + minor
+  // unparsed fees/tax without false-firing on legitimate receipts).
+  const tolerance = Math.max(0.5, Math.abs(ocrAmount) * 0.02);
+  const diff = Math.abs(lineSum - ocrAmount);
+  const fired = diff > tolerance;
+
+  return {
+    id,
+    name,
+    fired,
+    weight: WEIGHTS.receipt_math_mismatch,
+    detail: fired
+      ? `Line items sum to ${lineSum.toFixed(2)} but the stated total is ${ocrAmount.toFixed(2)} (off by ${diff.toFixed(2)}, tolerance ${tolerance.toFixed(2)}).`
+      : `Line items sum to ${lineSum.toFixed(2)}, consistent with the total ${ocrAmount.toFixed(2)}.`,
+    evidence: { lineSum, ocrAmount, diff, tolerance },
+  };
+}
+
+// ============================================
+// Pass 2 — vision verdict signals
+// ============================================
+
+export function visionSignals(vision: VisionResult | null): AuthenticitySignal[] {
+  if (!vision) {
+    return [
+      {
+        id: 'vision_verdict',
+        name: 'Vision model verdict',
+        fired: false,
+        weight: 0,
+        detail: 'Vision model did not return a verdict.',
+      },
+    ];
+  }
+  const fakeWeight =
+    vision.verdict === 'likely_fake'
+      ? WEIGHTS.vision_likely_fake
+      : vision.verdict === 'suspicious'
+        ? WEIGHTS.vision_suspicious
+        : 0;
+  return [
+    {
+      id: 'vision_verdict',
+      name: `Vision model verdict (${vision.provider})`,
+      fired: vision.verdict !== 'authentic',
+      weight: fakeWeight,
+      detail: `Vision model verdict: ${vision.verdict} (confidence ${vision.confidence}%).${
+        vision.observations.length ? ' Tells: ' + vision.observations.join('; ') : ''
+      }`,
+      evidence: { verdict: vision.verdict, confidence: vision.confidence, observations: vision.observations },
+    },
+  ];
+}
+
+// ============================================
+// Pass 4 — ELA overlay (Phase 2)
+// ============================================
+
+const ELA_BUCKET = 'event-images';
+
+/**
+ * Generate an error-level-analysis overlay and upload it to the event-images
+ * bucket. Recompress the image at a fixed JPEG quality, take the absolute
+ * per-pixel difference against the original, and normalise it so tampered /
+ * spliced regions (which compress differently) stand out. Returns the public
+ * URL of the uploaded PNG, or null on any failure (best-effort artifact —
+ * never blocks the verdict).
+ */
+export async function generateElaArtifact(
+  buffer: Buffer,
+  imageUrl: string,
+): Promise<string | null> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    return null;
+  }
+
+  try {
+    // Normalise both sides to a common pixel grid so the diff lines up even if
+    // the original is a PNG / odd dimensions.
+    const base = sharp(buffer).removeAlpha();
+    const meta = await base.metadata();
+    const width = Math.min(meta.width ?? 1024, 1600);
+
+    const original = await sharp(buffer)
+      .removeAlpha()
+      .resize({ width, withoutEnlargement: true })
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    // Recompress at a known quality, then decode back to raw to diff.
+    const recompressed = await sharp(buffer)
+      .removeAlpha()
+      .resize({ width, withoutEnlargement: true })
+      .jpeg({ quality: 75 })
+      .toBuffer();
+    const recompressedRaw = await sharp(recompressed)
+      .removeAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    const a = original.data;
+    const b = recompressedRaw.data;
+    const len = Math.min(a.length, b.length);
+    const diff = Buffer.alloc(len);
+    let maxDiff = 1;
+    for (let i = 0; i < len; i++) {
+      const d = Math.abs(a[i] - b[i]);
+      diff[i] = d;
+      if (d > maxDiff) maxDiff = d;
+    }
+    // Amplify so subtle differences are visible.
+    const scale = 255 / maxDiff;
+    for (let i = 0; i < len; i++) {
+      diff[i] = Math.min(255, Math.round(diff[i] * scale));
+    }
+
+    const overlayPng = await sharp(diff, {
+      raw: { width: original.info.width, height: original.info.height, channels: original.info.channels },
+    })
+      .png()
+      .toBuffer();
+
+    const supabase = createClient(supabaseUrl, serviceKey);
+    const safe = imageUrl.replace(/[^a-zA-Z0-9]/g, '').slice(-24) || 'img';
+    const fileName = `image-authenticity/ela-${Date.now()}-${safe}.png`;
+    const { error } = await supabase.storage
+      .from(ELA_BUCKET)
+      .upload(fileName, overlayPng, { cacheControl: '3600', upsert: false, contentType: 'image/png' });
+    if (error) {
+      return null;
+    }
+    const { data } = supabase.storage.from(ELA_BUCKET).getPublicUrl(fileName);
+    return data.publicUrl ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+/** Fetch an image from a public URL → base64 data URL (for vision providers). */
+export async function imageUrlToBase64DataUrl(imageUrl: string): Promise<{ dataUrl: string; buffer: Buffer }> {
+  const response = await fetch(imageUrl, { signal: AbortSignal.timeout(15_000) });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image (HTTP ${response.status}) from ${imageUrl}`);
+  }
+  const arrayBuf = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuf);
+  const base64 = buffer.toString('base64');
+  const contentType = response.headers.get('content-type') || 'image/jpeg';
+  return { dataUrl: `data:${contentType};base64,${base64}`, buffer };
+}
+
+// ============================================
+// Aggregator
+// ============================================
+
+/**
+ * Run all passes for one image and produce a cached-shape result. Network /
+ * model errors in any one pass are caught so a single failing pass never sinks
+ * the whole check — the verdict degrades gracefully (e.g. if vision throws, the
+ * metadata + receipt-math signals still produce a score).
+ */
+export async function scoreImageAuthenticity(input: AuthenticityInput): Promise<AuthenticityResult> {
+  const { dataUrl, buffer } = await imageUrlToBase64DataUrl(input.imageUrl);
+
+  // Pass 1 — metadata (deterministic, ~free).
+  let metaScan: MetadataScan;
+  try {
+    metaScan = await scanImageMetadata(buffer);
+  } catch {
+    metaScan = { hasExif: false, generatorHits: [], editorHits: [], c2paHit: false, software: null };
+  }
+  const metaSigs = metadataSignals(metaScan);
+
+  // Pass 2 — primary vision verdict.
+  let vision: VisionResult | null = null;
+  let visionError: string | null = null;
+  if (primaryVisionProvider.available()) {
+    try {
+      vision = await primaryVisionProvider.analyze(dataUrl, { sourceKind: input.sourceKind });
+    } catch (err: any) {
+      visionError = err?.message || 'vision provider failed';
+    }
+  } else {
+    visionError = 'primary vision provider unavailable (OPENAI_API_KEY not set)';
+  }
+  const visionSigs = visionSignals(vision);
+
+  // Pass 3 — receipt math (receipts only).
+  const mathSig =
+    input.sourceKind === 'receipt'
+      ? receiptMathSignal(input.ocrLineItems, input.ocrAmount)
+      : null;
+
+  // Pass 5 — second opinions (env-gated). Run only the available ones; a
+  // disagreement nudges the score up via the suspicious weight.
+  const secondOpinions: VisionResult[] = [];
+  for (const p of secondOpinionProviders) {
+    if (!p.available()) continue;
+    try {
+      // Sightengine needs a public URL; others take the data URL. Pass the URL
+      // for sightengine and the data URL otherwise.
+      const arg = p.id === 'sightengine' ? input.imageUrl : dataUrl;
+      const r = await p.analyze(arg, { sourceKind: input.sourceKind });
+      secondOpinions.push(r);
+    } catch {
+      // Dormant / failing second opinion never blocks the verdict.
+    }
+  }
+  const secondOpinionSigs: AuthenticitySignal[] = secondOpinions
+    .filter((r) => r.verdict !== 'authentic')
+    .map((r) => ({
+      id: `second_opinion_${r.provider}`,
+      name: `Second opinion (${r.provider})`,
+      fired: true,
+      weight: r.verdict === 'likely_fake' ? WEIGHTS.vision_suspicious : 12,
+      detail: `${r.provider} second opinion: ${r.verdict} (${r.confidence}%).${
+        r.observations.length ? ' ' + r.observations.join('; ') : ''
+      }`,
+      evidence: { verdict: r.verdict, confidence: r.confidence },
+    }));
+
+  // Pass 4 — ELA artifact (best-effort, unscored).
+  const elaArtifactUrl = await generateElaArtifact(buffer, input.imageUrl);
+
+  const signals: AuthenticitySignal[] = [
+    ...metaSigs,
+    ...visionSigs,
+    ...(mathSig ? [mathSig] : []),
+    ...secondOpinionSigs,
+  ];
+
+  const score = Math.min(
+    100,
+    signals.filter((s) => s.fired).reduce((sum, s) => sum + s.weight, 0),
+  );
+  const verdict = verdictFromScore(score);
+
+  return {
+    verdict,
+    score,
+    signals,
+    vision,
+    secondOpinions,
+    provider: vision?.provider ?? primaryVisionProvider.id,
+    elaArtifactUrl,
+    reasons: {
+      signals,
+      vision,
+      secondOpinions,
+      metadata: metaScan,
+      visionError,
+    },
+  };
+}

--- a/backend/src/lib/providers/anthropicVision.ts
+++ b/backend/src/lib/providers/anthropicVision.ts
@@ -1,0 +1,98 @@
+/**
+ * marinara-61455: Anthropic (Claude) vision provider — Phase 2, DORMANT.
+ *
+ * A second-opinion provider, off by default. `available()` returns false unless
+ * ANTHROPIC_API_KEY is set, and callers MUST skip it silently when unavailable
+ * so Phase 1 ships with only OPENAI_API_KEY. The `@anthropic-ai/sdk` dependency
+ * is declared in package.json but the provider stays inert until the key is set.
+ *
+ * The SDK client is lazily constructed inside `analyze()` (only when the key is
+ * present), so a missing key never throws at import / startup time.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  VisionProvider,
+  VisionResult,
+  VisionContext,
+  VISION_SYSTEM_PROMPT,
+  visionUserPrompt,
+  coerceVisionResult,
+} from './types.js';
+
+let client: Anthropic | null = null;
+
+function getAnthropic(): Anthropic {
+  if (!client) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error('ANTHROPIC_API_KEY is not set — anthropic vision provider is dormant.');
+    }
+    client = new Anthropic({ apiKey });
+  }
+  return client;
+}
+
+/** Split a `data:<mime>;base64,<data>` URL into its parts for the Anthropic API. */
+function parseDataUrl(dataUrl: string): { mediaType: string; data: string } {
+  const match = /^data:([^;]+);base64,(.*)$/s.exec(dataUrl);
+  if (!match) {
+    throw new Error('anthropic vision expects a base64 data URL');
+  }
+  return { mediaType: match[1], data: match[2] };
+}
+
+export const anthropicVisionProvider: VisionProvider = {
+  id: 'anthropic',
+
+  available(): boolean {
+    return !!process.env.ANTHROPIC_API_KEY;
+  },
+
+  async analyze(imageDataUrl: string, ctx: VisionContext): Promise<VisionResult> {
+    const { mediaType, data } = parseDataUrl(imageDataUrl);
+
+    const response = await getAnthropic().messages.create({
+      model: 'claude-3-5-sonnet-latest',
+      max_tokens: 800,
+      system: VISION_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                // The SDK types accept the common image media types.
+                media_type: mediaType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+                data,
+              },
+            },
+            {
+              type: 'text',
+              text: `${visionUserPrompt(ctx)}\n\nReturn ONLY the JSON object described in the system prompt.`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const text = textBlock && textBlock.type === 'text' ? textBlock.text : '';
+    if (!text) {
+      throw new Error('No text content from Anthropic vision');
+    }
+
+    // Claude may wrap JSON in prose / code fences — extract the first object.
+    const jsonMatch = /\{[\s\S]*\}/.exec(text);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonMatch ? jsonMatch[0] : text);
+    } catch {
+      throw new Error(`Anthropic vision returned non-JSON content: ${text.slice(0, 200)}`);
+    }
+
+    return { provider: 'anthropic', ...coerceVisionResult('anthropic', parsed) };
+  },
+};

--- a/backend/src/lib/providers/index.ts
+++ b/backend/src/lib/providers/index.ts
@@ -1,0 +1,25 @@
+/**
+ * marinara-61455: vision-provider registry.
+ *
+ * `openai` is the active primary. `anthropic` + `sightengine` are dormant
+ * second-opinion providers — present in the registry but skipped at runtime by
+ * `available()` unless their env vars are set. This lets Phase 1 run with only
+ * OPENAI_API_KEY while Phase 2 lights up automatically once a key is configured.
+ */
+
+export * from './types.js';
+import { openaiVisionProvider } from './openaiVision.js';
+import { anthropicVisionProvider } from './anthropicVision.js';
+import { sightengineProvider } from './sightengine.js';
+import type { VisionProvider } from './types.js';
+
+/** Primary provider — used for the headline verdict. */
+export const primaryVisionProvider: VisionProvider = openaiVisionProvider;
+
+/** Optional second-opinion providers, in priority order. Env-gated. */
+export const secondOpinionProviders: VisionProvider[] = [
+  anthropicVisionProvider,
+  sightengineProvider,
+];
+
+export { openaiVisionProvider, anthropicVisionProvider, sightengineProvider };

--- a/backend/src/lib/providers/openaiVision.ts
+++ b/backend/src/lib/providers/openaiVision.ts
@@ -1,0 +1,56 @@
+/**
+ * marinara-61455: OpenAI gpt-4o vision provider (Phase 1, active).
+ *
+ * Reuses `getOpenAI()` + the same gpt-4o vision call shape as the OCR service.
+ * Always available when OPENAI_API_KEY is set (the same key OCR already uses).
+ */
+
+import { getOpenAI } from '../openai.js';
+import {
+  VisionProvider,
+  VisionResult,
+  VisionContext,
+  VISION_SYSTEM_PROMPT,
+  visionUserPrompt,
+  coerceVisionResult,
+} from './types.js';
+
+export const openaiVisionProvider: VisionProvider = {
+  id: 'openai',
+
+  available(): boolean {
+    return !!process.env.OPENAI_API_KEY;
+  },
+
+  async analyze(imageDataUrl: string, ctx: VisionContext): Promise<VisionResult> {
+    const response = await getOpenAI().chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: VISION_SYSTEM_PROMPT },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: visionUserPrompt(ctx) },
+            { type: 'image_url', image_url: { url: imageDataUrl } },
+          ],
+        },
+      ],
+      max_tokens: 800,
+      response_format: { type: 'json_object' },
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      throw new Error('No response content from OpenAI vision');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      throw new Error(`OpenAI vision returned non-JSON content: ${content.slice(0, 200)}`);
+    }
+
+    return { provider: 'openai', ...coerceVisionResult('openai', parsed) };
+  },
+};

--- a/backend/src/lib/providers/sightengine.ts
+++ b/backend/src/lib/providers/sightengine.ts
@@ -1,0 +1,78 @@
+/**
+ * marinara-61455: Sightengine "AI-generated image" detector — Phase 2, DORMANT.
+ *
+ * A dedicated third-party detector usable as a tie-breaker on `suspicious`
+ * verdicts. Off by default: `available()` returns false unless BOTH
+ * SIGHTENGINE_API_USER and SIGHTENGINE_API_SECRET are set, and callers MUST
+ * skip it silently when unavailable. No SDK — plain fetch against the public
+ * REST endpoint. We pass the image as a public URL (Sightengine fetches it
+ * itself) rather than uploading bytes, so callers should pass the original
+ * Supabase object URL via the context, falling back to skipping if absent.
+ */
+
+import {
+  VisionProvider,
+  VisionResult,
+  VisionContext,
+  coerceVisionResult,
+} from './types.js';
+
+const ENDPOINT = 'https://api.sightengine.com/1.0/check.json';
+
+export const sightengineProvider: VisionProvider = {
+  id: 'sightengine',
+
+  available(): boolean {
+    return !!(process.env.SIGHTENGINE_API_USER && process.env.SIGHTENGINE_API_SECRET);
+  },
+
+  async analyze(imageDataUrl: string, _ctx: VisionContext): Promise<VisionResult> {
+    void _ctx;
+    const user = process.env.SIGHTENGINE_API_USER;
+    const secret = process.env.SIGHTENGINE_API_SECRET;
+    if (!user || !secret) {
+      throw new Error('SIGHTENGINE_API_USER / SIGHTENGINE_API_SECRET not set — dormant.');
+    }
+
+    // Sightengine's check.json with models=genai expects a hosted image URL.
+    // imageDataUrl is a base64 data URL; this provider only works when handed a
+    // real https URL, so guard against the data-URL form and skip cleanly.
+    if (imageDataUrl.startsWith('data:')) {
+      throw new Error('sightengine provider requires a public image URL, not a data URL');
+    }
+
+    const params = new URLSearchParams({
+      url: imageDataUrl,
+      models: 'genai',
+      api_user: user,
+      api_secret: secret,
+    });
+
+    const res = await fetch(`${ENDPOINT}?${params.toString()}`, {
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      throw new Error(`Sightengine HTTP ${res.status}`);
+    }
+    const json = (await res.json()) as Record<string, any>;
+
+    // Sightengine returns type.ai_generated in [0,1]. Map to our tiers.
+    const aiScore = Number(json?.type?.ai_generated);
+    const pct = Number.isFinite(aiScore) ? Math.round(aiScore * 100) : 50;
+    const verdict =
+      pct >= 70 ? 'likely_fake' : pct >= 35 ? 'suspicious' : 'authentic';
+
+    return {
+      provider: 'sightengine',
+      ...coerceVisionResult('sightengine', {
+        verdict,
+        confidence: pct,
+        observations:
+          pct >= 35
+            ? [`Sightengine genai detector scored ${pct}% AI-generated.`]
+            : [],
+      }),
+      raw: json,
+    };
+  },
+};

--- a/backend/src/lib/providers/types.ts
+++ b/backend/src/lib/providers/types.ts
@@ -1,0 +1,90 @@
+/**
+ * marinara-61455: vision-provider interface for the image-authenticity scorer.
+ *
+ * Each provider takes an image (as a base64 data URL) + a context hint and
+ * returns a structured authenticity judgment. Providers are env-gated: a
+ * provider whose API key is absent reports `available() === false` and is
+ * skipped silently, so Phase 1 ships with only OPENAI_API_KEY configured.
+ */
+
+export type VisionVerdict = 'authentic' | 'suspicious' | 'likely_fake';
+
+export interface VisionResult {
+  /** Provider id that produced this result ('openai' | 'anthropic' | ...). */
+  provider: string;
+  verdict: VisionVerdict;
+  /** Model self-reported confidence, 0-100. */
+  confidence: number;
+  /** Concrete tells the model observed (garbled text, melted edges, etc.). */
+  observations: string[];
+  /** Raw model response, retained for debugging. */
+  raw?: unknown;
+}
+
+export interface VisionContext {
+  /** 'receipt' | 'event_image' — steers the prompt's emphasis. */
+  sourceKind: 'receipt' | 'event_image';
+}
+
+export interface VisionProvider {
+  /** Stable id persisted on the check row's `provider` column. */
+  id: string;
+  /**
+   * True when the provider's required env vars are present. Callers MUST skip
+   * the provider silently when this is false so a missing optional key never
+   * breaks the Phase 1 path.
+   */
+  available(): boolean;
+  /**
+   * Run the vision judgment. `imageDataUrl` is a base64 `data:` URL (already
+   * fetched + encoded by the caller so providers don't each re-download).
+   */
+  analyze(imageDataUrl: string, ctx: VisionContext): Promise<VisionResult>;
+}
+
+/**
+ * Shared prompt copy so every provider asks for the same concrete tells and the
+ * same structured JSON shape. Keeps verdicts comparable across providers.
+ */
+export const VISION_SYSTEM_PROMPT = `You are an image-forensics assistant that judges whether an image is AI-GENERATED or DIGITALLY DOCTORED. You are given either a photo of a payment receipt or a host's event-cover image.
+
+Look for concrete tells:
+- AI generation: garbled / warped text and impossible glyphs (generators are bad at the dense text on receipts), inconsistent lighting and shadow directions, melted or smeared edges, nonsensical or duplicated patterns, anatomically impossible details.
+- Doctoring / tampering: mismatched fonts or kerning on amount/total fields, baseline misalignment of edited numbers, cloned or duplicated regions, abrupt compression or noise discontinuities, halos around pasted elements.
+
+Be calibrated: heavy compression, scanner artifacts, dark restaurant lighting, and screenshots are NOT by themselves evidence of fakery. Only flag concrete, image-grounded tells. When unsure, prefer "suspicious" over "likely_fake".
+
+Return ONLY a JSON object:
+{
+  "verdict": "authentic" | "suspicious" | "likely_fake",
+  "confidence": number (0-100, your confidence in the verdict),
+  "observations": string[] (each a short, specific, image-grounded tell; empty if none)
+}`;
+
+export function visionUserPrompt(ctx: VisionContext): string {
+  return ctx.sourceKind === 'receipt'
+    ? 'Judge whether this receipt image is AI-generated or doctored. Pay special attention to the legibility and consistency of the printed text and the total/amount fields.'
+    : 'Judge whether this event-cover image is AI-generated or doctored.';
+}
+
+/** Coerce an arbitrary parsed JSON blob into a safe VisionResult. */
+export function coerceVisionResult(
+  provider: string,
+  parsed: unknown,
+): Omit<VisionResult, 'provider'> {
+  const obj = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+  const rawVerdict = typeof obj.verdict === 'string' ? obj.verdict.toLowerCase().trim() : '';
+  const verdict: VisionVerdict =
+    rawVerdict === 'likely_fake' || rawVerdict === 'suspicious' || rawVerdict === 'authentic'
+      ? (rawVerdict as VisionVerdict)
+      : 'suspicious';
+  const confNum = Number(obj.confidence);
+  const confidence = Number.isFinite(confNum) ? Math.max(0, Math.min(100, confNum)) : 50;
+  const observations = Array.isArray(obj.observations)
+    ? obj.observations
+        .filter((o): o is string => typeof o === 'string' && o.trim().length > 0)
+        .map((o) => o.trim())
+        .slice(0, 20)
+    : [];
+  return { verdict, confidence, observations, raw: parsed };
+}

--- a/backend/src/routes/imageAuthenticity.routes.ts
+++ b/backend/src/routes/imageAuthenticity.routes.ts
@@ -1,0 +1,152 @@
+/**
+ * marinara-61455: admin image-authenticity (AI-generated / doctored) check.
+ *
+ * POST /api/admin/image-authenticity
+ *   Body: { imageUrl, sourceKind, partyId?, payoutDocumentId?, force? }
+ *   - Admin-gated (requireAuth → isAdmin), matching admin.routes.ts.
+ *   - Returns the cached row for `imageUrl` unless `force` is true; otherwise
+ *     runs the scorer, persists a row to `image_authenticity_checks`, returns it.
+ *
+ * Advisory only — the verdict flags for human review; nothing auto-rejects.
+ *
+ * Mounted path-scoped at `/api/admin/image-authenticity` in index.ts (NOT a
+ * path-less `router.use`, which would leak to sibling /api/admin routers).
+ */
+
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { scoreImageAuthenticity, SourceKind } from '../lib/imageAuthenticity.js';
+
+const router = Router();
+
+const VALID_SOURCE_KINDS: SourceKind[] = ['receipt', 'event_image'];
+
+/** Shape the persisted row into the response the frontend consumes. */
+function serializeCheck(row: {
+  id: string;
+  imageUrl: string;
+  sourceKind: string;
+  partyId: string | null;
+  payoutDocumentId: string | null;
+  verdict: string;
+  score: number;
+  reasons: unknown;
+  provider: string;
+  elaArtifactUrl: string | null;
+  checkedAt: Date;
+  checkedBy: string | null;
+}) {
+  return {
+    id: row.id,
+    imageUrl: row.imageUrl,
+    sourceKind: row.sourceKind,
+    partyId: row.partyId,
+    payoutDocumentId: row.payoutDocumentId,
+    verdict: row.verdict,
+    score: row.score,
+    reasons: row.reasons,
+    provider: row.provider,
+    elaArtifactUrl: row.elaArtifactUrl,
+    checkedAt: row.checkedAt.toISOString(),
+    checkedBy: row.checkedBy,
+  };
+}
+
+// GET /api/admin/image-authenticity?imageUrl=... — return the most recent
+// cached check for an image, or { check: null } when none exists.
+router.get('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const imageUrl = typeof req.query.imageUrl === 'string' ? req.query.imageUrl : '';
+    if (!imageUrl) {
+      throw new AppError('imageUrl is required', 400, 'VALIDATION_ERROR');
+    }
+    const cached = await prisma.imageAuthenticityCheck.findFirst({
+      where: { imageUrl },
+      orderBy: { checkedAt: 'desc' },
+    });
+    res.json({ check: cached ? serializeCheck(cached) : null });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/admin/image-authenticity — run (or return cached) authenticity check.
+router.post('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+
+    const { imageUrl, sourceKind, partyId, payoutDocumentId, force } = req.body ?? {};
+
+    if (typeof imageUrl !== 'string' || !imageUrl.trim()) {
+      throw new AppError('imageUrl is required', 400, 'VALIDATION_ERROR');
+    }
+    if (!VALID_SOURCE_KINDS.includes(sourceKind)) {
+      throw new AppError(
+        `sourceKind must be one of: ${VALID_SOURCE_KINDS.join(', ')}`,
+        400,
+        'VALIDATION_ERROR',
+      );
+    }
+
+    // Return the cached row unless force=true.
+    if (force !== true) {
+      const cached = await prisma.imageAuthenticityCheck.findFirst({
+        where: { imageUrl },
+        orderBy: { checkedAt: 'desc' },
+      });
+      if (cached) {
+        return res.json({ check: serializeCheck(cached), cached: true });
+      }
+    }
+
+    // For receipts, pull OCR line items + amount so the receipt-math pass runs.
+    let ocrLineItems: any = null;
+    let ocrAmount: number | null = null;
+    if (sourceKind === 'receipt' && typeof payoutDocumentId === 'string' && payoutDocumentId) {
+      const doc = await prisma.payoutDocument.findUnique({
+        where: { id: payoutDocumentId },
+        select: { ocrLineItems: true, ocrAmount: true },
+      });
+      if (doc) {
+        ocrLineItems = doc.ocrLineItems ?? null;
+        ocrAmount = doc.ocrAmount != null ? Number(doc.ocrAmount) : null;
+      }
+    }
+
+    const result = await scoreImageAuthenticity({
+      imageUrl,
+      sourceKind,
+      ocrLineItems,
+      ocrAmount,
+    });
+
+    const row = await prisma.imageAuthenticityCheck.create({
+      data: {
+        imageUrl,
+        sourceKind,
+        partyId: typeof partyId === 'string' && partyId ? partyId : null,
+        payoutDocumentId:
+          typeof payoutDocumentId === 'string' && payoutDocumentId ? payoutDocumentId : null,
+        verdict: result.verdict,
+        score: result.score,
+        reasons: result.reasons as any,
+        provider: result.provider,
+        elaArtifactUrl: result.elaArtifactUrl,
+        checkedBy: req.userEmail ?? null,
+      },
+    });
+
+    res.json({ check: serializeCheck(row), cached: false });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
 import { SwcHubWarning } from './SwcHubWarning';
 import { isSwcHubParty } from '../../utils/swcHub';
-import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, markReceiptDuplicate, markReceiptIneligible } from '../../lib/api';
+import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, markReceiptDuplicate, markReceiptIneligible, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
 import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal, ReceiptLineItem, ReceiptLineItemCategory } from '../../types';
@@ -16,6 +16,7 @@ import {
   formatUsd,
   formatOriginalCurrency,
   ReceiptLightbox,
+  AuthenticityPanel,
 } from '../payments-shared';
 import { ReceiptEditor, computeLineSubtotal } from './ReceiptEditor';
 import { TaxFormReviewPanel } from './TaxFormReviewPanel';
@@ -545,6 +546,16 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // doesn't clobber the other or the amount-edit error.
   const [ineligibleSavingId, setIneligibleSavingId] = useState<string | null>(null);
   const [ineligibleSaveErrors, setIneligibleSaveErrors] = useState<Record<string, string>>({});
+
+  // marinara-61455: per-image cached authenticity verdicts, keyed by image URL.
+  // Lazily loaded when a receipt is shown in the lightbox (so reopening doesn't
+  // re-pay for the API call), and updated in place when the admin runs / re-runs
+  // a check via the AuthenticityPanel. Advisory only — drives the purple banner
+  // + stripe overlay; never gates any action.
+  const [authChecks, setAuthChecks] = useState<Record<string, ImageAuthenticityCheck | null>>({});
+  // URLs we've already attempted to lazy-load, so we don't refetch a null result
+  // on every render of the lightbox.
+  const [authLoadedUrls, setAuthLoadedUrls] = useState<Record<string, boolean>>({});
 
   // Hooks must be declared above any early returns. There aren't any early
   // returns in this component today, but keeping all hooks grouped here makes
@@ -1234,6 +1245,29 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     return receipts[idx];
   }, [lightboxCurrentIndex, pizzas.length, eventDocs.length, receipts]);
 
+  // marinara-61455: lazily load the cached authenticity verdict for the receipt
+  // currently in the lightbox. Runs once per URL (tracked in authLoadedUrls) so
+  // navigating back and forth doesn't refetch. Best-effort — a failed fetch just
+  // leaves the panel in its "Verify authenticity" state.
+  useEffect(() => {
+    const url = lightboxReceipt?.url;
+    if (!url || !canEditReceipts) return;
+    if (authLoadedUrls[url]) return;
+    setAuthLoadedUrls((m) => ({ ...m, [url]: true }));
+    let cancelled = false;
+    (async () => {
+      try {
+        const cached = await getImageAuthenticityCheck(url);
+        if (!cancelled) setAuthChecks((m) => ({ ...m, [url]: cached }));
+      } catch {
+        // ignore — panel falls back to the un-checked state.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [lightboxReceipt?.url, canEditReceipts, authLoadedUrls]);
+
   // pesto-92104: "is the editor dirty?" — used by the navigation prompt
   // (Save / Discard / Cancel) so admins don't accidentally lose in-flight
   // amount / currency / line-item edits when arrow-keying through receipts.
@@ -1305,6 +1339,32 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     toggleDuplicate(lightboxReceipt.id, !(lightboxReceipt.isDuplicate === true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lightboxReceipt]);
+
+  // marinara-61455: V key = run the image-authenticity check on the current
+  // receipt (uses cache; force-recheck is the panel's "Re-check" button). Only
+  // wired when an editor is mounted, so non-receipt photos don't trigger it.
+  const lightboxOnVerifyShortcut = useCallback(() => {
+    const r = lightboxReceipt;
+    if (!r) return;
+    // Don't re-run if we already have a verdict cached for this image — the
+    // panel's "Re-check" button is the explicit force path.
+    if (authChecks[r.url]) return;
+    (async () => {
+      try {
+        const { verifyImageAuthenticity } = await import('../../lib/api');
+        const { check } = await verifyImageAuthenticity({
+          imageUrl: r.url,
+          sourceKind: 'receipt',
+          partyId: payout.partyId,
+          payoutDocumentId: r.id,
+        });
+        setAuthChecks((m) => ({ ...m, [r.url]: check }));
+      } catch {
+        // Swallow — the panel surfaces errors on explicit button clicks.
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lightboxReceipt, authChecks]);
 
   // pesto-92104: render the ReceiptEditor when the lightbox is showing a
   // receipt AND the viewer can edit (admin / super_admin / payment_admin).
@@ -1392,6 +1452,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         retrying={retryingDocId === r.id}
         retryError={retryErrors[r.id]}
         onRetryOcr={() => retryOcr(r.id)}
+        authenticityVerdict={authChecks[r.url]?.verdict ?? null}
+        authenticityPanel={
+          <AuthenticityPanel
+            imageUrl={r.url}
+            sourceKind="receipt"
+            partyId={payout.partyId}
+            payoutDocumentId={r.id}
+            initialCheck={authChecks[r.url] ?? null}
+            onResult={(check) =>
+              setAuthChecks((m) => ({ ...m, [r.url]: check }))
+            }
+          />
+        }
       />
     );
     // The deps list intentionally excludes the function references that
@@ -1415,6 +1488,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     retryingDocId,
     retryErrors,
     retryClearedErrors,
+    authChecks,
   ]);
 
   // culatello-92104: duplicates are evidence-only — exclude their OCR
@@ -3875,6 +3949,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         editorPane={lightboxEditorPane}
         onBeforeNavigate={lightboxOnBeforeNavigate}
         onDuplicateShortcut={lightboxOnDuplicateShortcut}
+        /* marinara-61455: only wire V when an editor (i.e. a receipt) is in view. */
+        onVerifyShortcut={lightboxEditorPane ? lightboxOnVerifyShortcut : undefined}
         /* coppa-92105: paint the lightbox photo pane with a DUPLICATE banner +
             diagonal-stripe overlay when the focused image is an admin-marked
             duplicate. Only fires for the receipt bucket because lightboxReceipt
@@ -3887,6 +3963,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         isIneligible={
           lightboxReceipt?.ineligible === true
           && lightboxReceipt?.isDuplicate !== true
+        }
+        /* marinara-61455: purple authenticity overlay on the photo pane when the
+            focused receipt image is flagged AI-generated / doctored. Orthogonal
+            to the duplicate / ineligible flags (can co-exist). */
+        authenticityVerdict={
+          lightboxReceipt ? (authChecks[lightboxReceipt.url]?.verdict ?? null) : null
         }
       />
     </div>

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -109,6 +109,17 @@ interface ReceiptEditorProps {
 
   /** Whether the draft differs from persisted values (drives Save button). */
   isDirty: boolean;
+
+  /**
+   * marinara-61455: image-authenticity (AI-generated / doctored) check. The
+   * panel itself (button + verdict + reasons) is rendered by the parent and
+   * passed in as a node so the editor stays presentational. `authenticityVerdict`
+   * drives the editor-pane purple banner + diagonal-stripe overlay (distinct
+   * from duplicate's red / ineligible's amber). Advisory only — never gates the
+   * editor. Both optional so non-receipt / non-admin callsites omit them.
+   */
+  authenticityPanel?: React.ReactNode;
+  authenticityVerdict?: 'authentic' | 'suspicious' | 'likely_fake' | null;
 }
 
 /**
@@ -168,7 +179,15 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   retryError,
   onRetryOcr,
   isDirty,
+  authenticityPanel,
+  authenticityVerdict,
 }) => {
+  // marinara-61455: only paint the purple authenticity treatment when the
+  // verdict actually flags the image (suspicious / likely_fake). 'authentic'
+  // and null leave the editor unstyled so it doesn't compete with the
+  // duplicate / ineligible signals.
+  const authFlagged =
+    authenticityVerdict === 'suspicious' || authenticityVerdict === 'likely_fake';
   const conf = doc.ocrConfidence ?? 0;
   const lowConf = conf > 0 && conf < 0.8;
   const lineSum = draftSubtotalSum(lineItemDrafts);
@@ -233,6 +252,21 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
           aria-hidden="true"
         />
       )}
+      {/* marinara-61455: purple authenticity overlay when the receipt image is
+          flagged AI-generated / doctored. 90° purple stripes — distinct from
+          duplicate (45° red) and ineligible (135° amber). Only when the image
+          isn't already duplicate/ineligible-painted so the patterns don't fight;
+          the authenticity panel below carries the detail in all cases. */}
+      {authFlagged && !isDuplicate && !isIneligible && (
+        <span
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              'repeating-linear-gradient(90deg, rgba(168,85,247,0.08) 0 6px, transparent 6px 14px)',
+          }}
+          aria-hidden="true"
+        />
+      )}
       {/* coppa-92105: DUPLICATE banner across the top of the editor when
           marked. Heavier than the per-row pill so it can't be missed even on
           a quick scan. */}
@@ -274,6 +308,12 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
           </span>
         )}
       </div>
+
+      {/* marinara-61455: image-authenticity panel (AI-generated / doctored
+          check). Rendered by the parent so the editor stays presentational.
+          Sits above the relative stripe overlay (z-10) so its buttons stay
+          clickable. */}
+      {authenticityPanel && <div className="relative z-10">{authenticityPanel}</div>}
 
       {/* caprino-92104: Amount + currency split into two visible rows.
           Top row = "Original amount" (the local-currency value the admin

--- a/frontend/src/components/payments-shared/AuthenticityPanel.tsx
+++ b/frontend/src/components/payments-shared/AuthenticityPanel.tsx
@@ -1,0 +1,215 @@
+import React, { useState } from 'react';
+import { Loader2, ShieldCheck, ShieldAlert, ShieldX, RefreshCw, Sparkles, Download, AlertTriangle } from 'lucide-react';
+import {
+  verifyImageAuthenticity,
+  type ImageAuthenticityCheck,
+  type ImageAuthenticityVerdict,
+} from '../../lib/api';
+
+/**
+ * marinara-61455: shared "Verify authenticity" panel used by both the receipt
+ * editor (in the lightbox) and the admin event-cover surface. Renders a
+ * "Verify authenticity" button when no check exists, and a verdict banner +
+ * reasons + a "Re-check" (force) button once a verdict is present.
+ *
+ * Advisory-only by design — the panel never disables a send / approve; it just
+ * surfaces the AI/doctored signal for a human reviewer. Purple palette (distinct
+ * from red=duplicate / amber=ineligible) so the three signals don't collide.
+ */
+
+export interface AuthenticityPanelProps {
+  imageUrl: string;
+  sourceKind: 'receipt' | 'event_image';
+  partyId?: string | null;
+  payoutDocumentId?: string | null;
+  /** Prior cached check, if the parent already loaded one. */
+  initialCheck?: ImageAuthenticityCheck | null;
+  /** Notified after a (re-)check completes so the parent can drive overlays. */
+  onResult?: (check: ImageAuthenticityCheck) => void;
+  /** Compact layout (smaller paddings) for tight surfaces like the event card. */
+  compact?: boolean;
+}
+
+const VERDICT_META: Record<
+  ImageAuthenticityVerdict,
+  { label: string; Icon: typeof ShieldCheck; classes: string; dot: string }
+> = {
+  authentic: {
+    label: 'Likely authentic',
+    Icon: ShieldCheck,
+    classes: 'bg-emerald-500/15 border-emerald-500/40 text-emerald-300',
+    dot: 'bg-emerald-500',
+  },
+  suspicious: {
+    label: 'Suspicious — needs review',
+    Icon: ShieldAlert,
+    classes: 'bg-purple-500/15 border-purple-500/40 text-purple-200',
+    dot: 'bg-purple-500',
+  },
+  likely_fake: {
+    label: 'Likely AI-generated / doctored',
+    Icon: ShieldX,
+    classes: 'bg-fuchsia-600/20 border-fuchsia-500/50 text-fuchsia-200',
+    dot: 'bg-fuchsia-500',
+  },
+};
+
+/** Pull a flat reason list out of the persisted `reasons` jsonb for display. */
+function extractReasons(reasons: unknown): string[] {
+  if (!reasons || typeof reasons !== 'object') return [];
+  const r = reasons as Record<string, unknown>;
+  const out: string[] = [];
+  if (Array.isArray(r.signals)) {
+    for (const s of r.signals) {
+      if (s && typeof s === 'object') {
+        const sig = s as Record<string, unknown>;
+        if (sig.fired === true && typeof sig.detail === 'string') {
+          out.push(sig.detail);
+        }
+      }
+    }
+  }
+  const vision = r.vision as Record<string, unknown> | undefined;
+  if (vision && Array.isArray(vision.observations)) {
+    for (const o of vision.observations) {
+      if (typeof o === 'string' && o.trim()) out.push(o.trim());
+    }
+  }
+  // De-dup while preserving order.
+  return Array.from(new Set(out)).slice(0, 12);
+}
+
+export const AuthenticityPanel: React.FC<AuthenticityPanelProps> = ({
+  imageUrl,
+  sourceKind,
+  partyId,
+  payoutDocumentId,
+  initialCheck = null,
+  onResult,
+  compact = false,
+}) => {
+  const [check, setCheck] = useState<ImageAuthenticityCheck | null>(initialCheck);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep local state in sync if the parent swaps the cached check (e.g. lightbox
+  // navigates to a different receipt).
+  React.useEffect(() => {
+    setCheck(initialCheck);
+    setError(null);
+  }, [initialCheck, imageUrl]);
+
+  async function run(force: boolean) {
+    setLoading(true);
+    setError(null);
+    try {
+      const { check: next } = await verifyImageAuthenticity({
+        imageUrl,
+        sourceKind,
+        partyId,
+        payoutDocumentId,
+        force,
+      });
+      setCheck(next);
+      onResult?.(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Authenticity check failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const pad = compact ? 'p-2' : 'p-3';
+
+  if (!check) {
+    return (
+      <div className={`rounded-lg border border-purple-500/30 bg-purple-500/5 ${pad} space-y-1.5`}>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs font-semibold text-purple-200 inline-flex items-center gap-1.5">
+            <Sparkles size={12} /> Image authenticity
+          </span>
+          <button
+            type="button"
+            onClick={() => run(false)}
+            disabled={loading}
+            className="px-2.5 py-1 rounded border border-purple-500/40 text-purple-200 text-xs disabled:opacity-40 inline-flex items-center gap-1.5 hover:bg-purple-500/10"
+            title="Run an AI-generated / doctored check on this image"
+          >
+            {loading ? <Loader2 size={12} className="animate-spin" /> : <ShieldCheck size={12} />}
+            Verify authenticity
+          </button>
+        </div>
+        <p className="text-[11px] text-white/40">
+          Advisory only — flags AI-generated / doctored images for review. Never auto-rejects.
+        </p>
+        {error && (
+          <div className="text-[11px] text-red-300 flex items-start gap-1.5">
+            <AlertTriangle size={11} className="flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const meta = VERDICT_META[check.verdict] ?? VERDICT_META.suspicious;
+  const { Icon } = meta;
+  const reasons = extractReasons(check.reasons);
+
+  return (
+    <div className={`rounded-lg border ${meta.classes} ${pad} space-y-2`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-bold uppercase tracking-wide inline-flex items-center gap-1.5">
+          <Icon size={13} />
+          {meta.label}
+        </span>
+        <span className="text-[11px] opacity-80">score {check.score}/100</span>
+      </div>
+
+      {reasons.length > 0 && (
+        <ul className="space-y-0.5">
+          {reasons.map((reason, i) => (
+            <li key={i} className="text-[11px] leading-snug opacity-90 flex items-start gap-1.5">
+              <span className={`inline-block w-1 h-1 rounded-full ${meta.dot} mt-1.5 flex-shrink-0`} />
+              <span>{reason}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 pt-0.5">
+        <button
+          type="button"
+          onClick={() => run(true)}
+          disabled={loading}
+          className="px-2.5 py-1 rounded border border-white/20 text-xs disabled:opacity-40 inline-flex items-center gap-1.5 hover:bg-white/10"
+          title="Re-run the check (bypasses the cache; costs an API call)"
+        >
+          {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+          Re-check
+        </button>
+        {check.elaArtifactUrl && (
+          <a
+            href={check.elaArtifactUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-2.5 py-1 rounded border border-white/20 text-xs inline-flex items-center gap-1.5 hover:bg-white/10"
+            title="Download the error-level-analysis overlay (tampered regions stand out)"
+          >
+            <Download size={12} /> ELA overlay
+          </a>
+        )}
+        <span className="text-[10px] opacity-60 ml-auto">
+          {check.provider} · {new Date(check.checkedAt).toLocaleDateString()}
+        </span>
+      </div>
+
+      {error && (
+        <div className="text-[11px] text-red-300 flex items-start gap-1.5">
+          <AlertTriangle size={11} className="flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -69,6 +69,12 @@ interface ReceiptLightboxProps {
    */
   onDuplicateShortcut?: () => void;
   /**
+   * marinara-61455: `V` keypress handler. Wired by PayoutReviewModal to run the
+   * image-authenticity check for the current receipt. Only fires when admin
+   * context provides this prop (same guard pattern as onDuplicateShortcut).
+   */
+  onVerifyShortcut?: () => void;
+  /**
    * coppa-92105: when true, render a heavy DUPLICATE banner across the top
    * of the photo + diagonal-stripe overlay across the image so admins can't
    * confuse a duplicate receipt for a valid one while reviewing it
@@ -83,6 +89,15 @@ interface ReceiptLightboxProps {
    * as false when also passing `isDuplicate=true`). Pure visual.
    */
   isIneligible?: boolean;
+  /**
+   * marinara-61455: when the current receipt's image is flagged AI-generated /
+   * doctored ('suspicious' | 'likely_fake'), paint the photo pane with a purple
+   * banner + 90° purple stripe overlay (distinct from duplicate red/45° and
+   * ineligible amber/135°). 'authentic' / undefined render nothing. Pure visual
+   * + advisory — never gates anything. Rendered alongside (not instead of) the
+   * duplicate / ineligible overlays since they're orthogonal signals.
+   */
+  authenticityVerdict?: 'authentic' | 'suspicious' | 'likely_fake' | null;
 }
 
 /** Some HEIC files come through with non-image/heic MIME types or no MIME at
@@ -105,9 +120,14 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   onIndexChange,
   onBeforeNavigate,
   onDuplicateShortcut,
+  onVerifyShortcut,
   isDuplicate = false,
   isIneligible = false,
+  authenticityVerdict = null,
 }) => {
+  // marinara-61455: only paint when the verdict actually flags the image.
+  const authFlagged =
+    authenticityVerdict === 'suspicious' || authenticityVerdict === 'likely_fake';
   // Index lives in this component so callers only need to pass the starting
   // image. Reset whenever the lightbox is (re-)opened so each open starts
   // from `initialIndex`.
@@ -190,11 +210,16 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
         if (editable) return;
         e.preventDefault();
         onDuplicateShortcut();
+      } else if ((e.key === 'v' || e.key === 'V') && onVerifyShortcut) {
+        // marinara-61455: V = run image-authenticity check on the current receipt.
+        if (editable) return;
+        e.preventDefault();
+        onVerifyShortcut();
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [isOpen, onClose, goPrev, goNext, hasMultiple, onDuplicateShortcut]);
+  }, [isOpen, onClose, goPrev, goNext, hasMultiple, onDuplicateShortcut, onVerifyShortcut]);
 
   const current = images[index];
   const heic = isHeic(current);
@@ -364,6 +389,31 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
                 style={{
                   backgroundImage:
                     'repeating-linear-gradient(135deg, rgba(245,158,11,0.18) 0 6px, transparent 6px 14px)',
+                }}
+              />
+            </>
+          )}
+          {/* marinara-61455: purple AUTHENTICITY banner + 90° stripe overlay
+              when the focused receipt image is flagged AI-generated / doctored.
+              Orthogonal to duplicate / ineligible — can co-exist; offset the
+              banner down a row so it doesn't overlap the duplicate/ineligible
+              pill when multiple flags are on. Pointer-events-none. */}
+          {authFlagged && (
+            <>
+              <div
+                className={`absolute ${
+                  isDuplicate || isIneligible ? 'top-10' : 'top-2'
+                } left-1/2 -translate-x-1/2 z-20 px-3 py-1 rounded-full bg-purple-600 text-white text-xs font-bold uppercase tracking-wide shadow-lg pointer-events-none`}
+              >
+                {authenticityVerdict === 'likely_fake'
+                  ? 'Likely AI / doctored'
+                  : 'Authenticity — needs review'}
+              </div>
+              <div
+                className="absolute inset-0 z-10 pointer-events-none"
+                style={{
+                  backgroundImage:
+                    'repeating-linear-gradient(90deg, rgba(168,85,247,0.16) 0 6px, transparent 6px 14px)',
                 }}
               />
             </>

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -5,3 +5,5 @@ export { CapInlineEditor } from './CapInlineEditor';
 export { formatPayoutAmount, formatUsd, formatOriginalCurrency } from './formatPayoutAmount';
 export { ReceiptLightbox } from './ReceiptLightbox';
 export type { ReceiptLightboxImage } from './ReceiptLightbox';
+export { AuthenticityPanel } from './AuthenticityPanel';
+export type { AuthenticityPanelProps } from './AuthenticityPanel';

--- a/frontend/src/components/underboss/EventCard.tsx
+++ b/frontend/src/components/underboss/EventCard.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Users, Camera, MapPin, Calendar, ExternalLink, Check, Plus, X, StickyNote, ChevronLeft, ChevronRight } from 'lucide-react';
 import { ProgressIndicator } from './ProgressIndicator';
 import { IconInput } from '../IconInput';
-import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, getPartyPhotos } from '../../lib/api';
+import { updateHostStatus, bulkUpdateEventTags, updateUnderbossNotes, getPartyPhotos, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
+import { AuthenticityPanel } from '../payments-shared';
 import { getGppPhotosForCity, getGppPhotoCounts } from '../../lib/gppPhotos';
 import type { UnderbossEvent, HostStatus } from '../../types';
 
@@ -309,6 +310,21 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
   // GPP photo count for the badge (fetched once, cached at module level)
   const [gppCount, setGppCount] = useState(0);
 
+  // marinara-61455: admin "Verify cover authenticity" — lazily load any cached
+  // verdict for the event cover when the photos section is expanded, so the
+  // panel shows a prior result without re-paying for the API call.
+  const [coverAuthCheck, setCoverAuthCheck] = useState<ImageAuthenticityCheck | null>(null);
+  const [coverAuthLoaded, setCoverAuthLoaded] = useState(false);
+  useEffect(() => {
+    if (!photosExpanded || coverAuthLoaded || !event.eventImageUrl) return;
+    setCoverAuthLoaded(true);
+    let cancelled = false;
+    getImageAuthenticityCheck(event.eventImageUrl)
+      .then((c) => { if (!cancelled) setCoverAuthCheck(c); })
+      .catch(() => { /* panel falls back to the un-checked state */ });
+    return () => { cancelled = true; };
+  }, [photosExpanded, coverAuthLoaded, event.eventImageUrl]);
+
   useEffect(() => {
     const cityName = event.name.replace(/^Global Pizza Party\s*/i, '').trim();
     if (!cityName) return;
@@ -575,6 +591,32 @@ export function EventCard({ event, showRegion, onEventUpdate, isSelected, onTogg
                   {t('eventRow.showAllPhotos', { count: displayPhotos.length })}
                 </button>
               )}
+            </div>
+          )}
+
+          {/* marinara-61455: admin "Verify cover authenticity" — runs the
+              AI-generated / doctored check on the event cover image. Advisory
+              only; the panel surfaces a verdict + reasons but never gates
+              anything. Only rendered when the event has a cover image. */}
+          {event.eventImageUrl && (
+            <div className="mt-3 pt-3 border-t border-theme-stroke/50 space-y-2">
+              <div className="flex items-center gap-2">
+                <img
+                  src={event.eventImageUrl}
+                  alt="Event cover"
+                  className="w-12 h-12 rounded object-cover border border-theme-stroke shrink-0"
+                  loading="lazy"
+                />
+                <span className="text-xs text-theme-text-muted">Event cover image</span>
+              </div>
+              <AuthenticityPanel
+                imageUrl={event.eventImageUrl}
+                sourceKind="event_image"
+                partyId={event.id}
+                initialCheck={coverAuthCheck}
+                onResult={setCoverAuthCheck}
+                compact
+              />
             </div>
           )}
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4726,6 +4726,63 @@ export async function markReceiptIneligible(
 }
 
 /**
+ * marinara-61455: image-authenticity (AI-generated / doctored) admin check.
+ *
+ * Manual, on-demand tool that judges whether a payment-receipt image or a host
+ * event-cover image is AI-generated or doctored. Returns a cached verdict +
+ * confidence + reasons. Advisory only — the verdict flags for human review, it
+ * never auto-rejects. Mirrors the `markReceiptDuplicate` thin-wrapper pattern.
+ */
+export type ImageAuthenticityVerdict = 'authentic' | 'suspicious' | 'likely_fake';
+
+export interface ImageAuthenticityCheck {
+  id: string;
+  imageUrl: string;
+  sourceKind: 'receipt' | 'event_image';
+  partyId: string | null;
+  payoutDocumentId: string | null;
+  verdict: ImageAuthenticityVerdict;
+  score: number;
+  reasons: unknown;
+  provider: string;
+  elaArtifactUrl: string | null;
+  checkedAt: string;
+  checkedBy: string | null;
+}
+
+/**
+ * Run (or return the cached) authenticity check for an image. Pass `force:true`
+ * to bypass the cache and re-run the scorer (costs an API call). Returns the
+ * persisted check row plus whether it came from cache.
+ */
+export async function verifyImageAuthenticity(params: {
+  imageUrl: string;
+  sourceKind: 'receipt' | 'event_image';
+  partyId?: string | null;
+  payoutDocumentId?: string | null;
+  force?: boolean;
+}): Promise<{ check: ImageAuthenticityCheck; cached: boolean }> {
+  return apiRequest<{ check: ImageAuthenticityCheck; cached: boolean }>(
+    '/api/admin/image-authenticity',
+    { method: 'POST', body: params },
+  );
+}
+
+/**
+ * Fetch the most recent cached authenticity check for an image, or `null` when
+ * none exists yet. Used to render a prior verdict on lightbox open without
+ * spending an API call.
+ */
+export async function getImageAuthenticityCheck(
+  imageUrl: string,
+): Promise<ImageAuthenticityCheck | null> {
+  const res = await apiRequest<{ check: ImageAuthenticityCheck | null }>(
+    `/api/admin/image-authenticity?imageUrl=${encodeURIComponent(imageUrl)}`,
+  );
+  return res.check;
+}
+
+/**
  * pancetta-92104: reset a single doc's OCR retry counter so the next backfill
  * call (or this call's inline run) re-attempts `analyzeReceipt` against the
  * receipt. Used to un-stick docs that hit the 3-attempt cap once the

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.100.1",
         "@prisma/client": "^6.8.2",
         "@privy-io/server-auth": "^1.32.5",
         "@supabase/supabase-js": "^2.49.1",
@@ -54,6 +55,27 @@
         "tsx": "^4.7.0",
         "typescript": "^5.5.3",
         "vitest": "^4.0.18"
+      }
+    },
+    "backend/node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "backend/node_modules/archiver": {
@@ -110,6 +132,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "backend/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "backend/node_modules/minimatch": {
@@ -20902,6 +20937,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/plans/marinara-61455-image-authenticity-check.md
+++ b/plans/marinara-61455-image-authenticity-check.md
@@ -1,0 +1,118 @@
+# marinara-61455: Image-authenticity check (AI-generated / doctored detection)
+
+## Goal
+Give admins a manual, on-demand "Verify authenticity" tool that judges whether a
+**payment-receipt image** or a **host-uploaded event image** is AI-generated or
+doctored. Returns a verdict + confidence + specific reasons, cached so re-opening
+doesn't re-pay for the API call. Human-in-the-loop — the verdict flags for review,
+it never auto-rejects.
+
+## Decisions (locked with Snax)
+1. **Vision provider:** reuse the existing OpenAI gpt-4o vision path (same code the
+   OCR service already uses) — no new dependency or secret. Wrapped behind a small
+   provider interface so a Claude / 3rd-party second opinion can be added later.
+2. **Storage:** a **separate `image_authenticity_checks` table** keyed by image URL —
+   do NOT widen `payout_documents` or `Party`.
+3. **Scope:** full — Phase 1 (metadata + vision + receipt-math) **and** Phase 2
+   (ELA overlay + Claude/3rd-party second opinion) in this task.
+
+## Detection method (layered, cheapest-first)
+No single technique is reliable, so the verdict composes several signals, mirroring
+the weighted-heuristic shape of `backend/src/lib/fakeDetection.ts`.
+
+### Pass 1 — Metadata / provenance (deterministic, ~free)
+- EXIF: camera make/model, capture time, GPS.
+- **Generator/editor software tags** — `DALL-E`, `Midjourney`, `Stable Diffusion`,
+  `Adobe Firefly`, `Photoshop`, `GIMP` → strong positive signal.
+- **C2PA / Content Credentials** manifest → near-definitive when present.
+- ⚠️ Presence is a strong signal; **absence is weak** (screenshots, chat-app
+  compression, and our Supabase upload re-encode all strip EXIF). Never condemn on
+  missing EXIF alone.
+
+### Pass 2 — LLM vision verdict (primary judgment, OpenAI gpt-4o)
+- Reuse `getOpenAI()` + the fetch-URL→base64 helper from
+  `backend/src/services/ocr.service.ts`.
+- Prompt for concrete tells: garbled/warped text & impossible glyphs (AI is bad at
+  the dense text on receipts), inconsistent lighting/shadows, melted edges,
+  duplicated patterns; doctoring tells: mismatched fonts/kerning on the amount field,
+  baseline misalignment, cloned regions, compression discontinuities.
+- Structured JSON out: `verdict` (authentic | suspicious | likely_fake),
+  `confidence` 0-100, `observations[]`.
+
+### Pass 3 — Receipt-math sanity (receipts only, ~free)
+- We already store `ocrLineItems` + `ocrAmount`. Line items not summing to the total
+  is a cheap, hard-to-fake tampering signal.
+
+### Pass 4 — ELA overlay (Phase 2, `sharp`, deterministic)
+- Recompress at a known quality, diff, surface as a **downloadable overlay artifact**
+  for the admin — NOT an auto-verdict (too noisy to score reliably).
+
+### Pass 5 — Second opinion (Phase 2, behind provider interface)
+- Claude vision (`@anthropic-ai/sdk` + `ANTHROPIC_API_KEY`) and/or a dedicated
+  detector (Hive / Sightengine) as a tie-breaker on `suspicious` verdicts. Off by
+  default; wired but gated behind env presence so Phase 1 ships without it.
+
+## Data model — new table
+`image_authenticity_checks`:
+- `id` pk
+- `image_url` text (the Supabase object URL checked) — unique-ish lookup key
+- `source_kind` text — `receipt` | `event_image`
+- `party_id` text/fk (nullable) — for filtering/joins
+- `payout_document_id` (nullable) — when source is a receipt
+- `verdict` text — authentic | suspicious | likely_fake
+- `score` int 0-100
+- `reasons` jsonb — per-pass signals + observations
+- `provider` text — openai | anthropic | sightengine
+- `ela_artifact_url` text (nullable) — Phase 2 overlay
+- `checked_at` timestamptz
+- `checked_by` text (admin email)
+
+⚠️ Per repo memory: **no Prisma auto-migration here** (`_prisma_migrations` doesn't
+exist). Apply the table to **prod** via Supabase MCP / `pg`+`DATABASE_URL` BEFORE
+merging code, and backend deploys from `master` only — previews talk to prod backend.
+Add the model to `schema.prisma` so the client types it, but the live DDL is manual.
+
+## Backend
+- `backend/src/lib/imageAuthenticity.ts` — weighted-signal scorer mirroring
+  `fakeDetection.ts` (per-pass functions → `{id,name,fired,weight,detail}` → capped
+  score → tiered verdict). Provider interface for the vision call.
+- `backend/src/lib/providers/` — `openaiVision.ts` (Phase 1), `anthropicVision.ts`
+  + `sightengine.ts` (Phase 2, env-gated, optional).
+- Endpoint `POST /api/admin/image-authenticity` — admin-gated via existing
+  `requireAuth` → `isAdmin(req.userEmail)` pattern (see `admin.routes.ts`). Body:
+  `{ imageUrl, sourceKind, partyId?, payoutDocumentId?, force? }`. Returns cached row
+  unless `force`. Persists to `image_authenticity_checks`.
+- Reuse the proven `fetch(url, {signal: AbortSignal.timeout()})` → base64 helper.
+
+## Frontend
+- Receipts: "Verify authenticity" button + verdict panel in `ReceiptEditor`
+  (mounted inside `ReceiptLightbox`), matching the existing duplicate/ineligible
+  toggle pattern — banner + distinctive stripe overlay (purple) + keyboard shortcut.
+  Show cached verdict if present; "Re-check" forces a fresh run.
+- Event images: same action on the admin event-image view (`Party.eventImageUrl`).
+- New API helpers in `frontend/src/lib/api.ts` mirroring `markReceiptDuplicate`.
+- Use existing components (no raw inputs/buttons) per project conventions.
+
+## Risks / caveats
+- **False positives** on legit photos (heavy compression, scans, dark restaurant
+  lighting). Verdict = "needs human review," never auto-reject. Manual-tool design
+  keeps a human in the loop by construction.
+- Absence-of-EXIF must not dominate the score (see Pass 1 caveat).
+- Per-check API cost is small; caching prevents repeats.
+- This is a dual-use signal, not proof — pair with existing fake-detection context.
+
+## Verification
+- `npx tsc --noEmit` in frontend — clean.
+- `npm run build` in backend — clean.
+- `image_authenticity_checks` table applied to prod via Supabase MCP before merge.
+- Manual: run a known AI-generated receipt → `likely_fake` with text-artifact reason;
+  a real phone photo of a receipt → `authentic`; a Photoshop-tampered total → flagged
+  via software tag and/or receipt-math mismatch; verdict caches and re-check forces
+  a fresh call.
+- ⚠️ The vision call is opaque to tsc — exercise the endpoint against a real image
+  before calling it done (per repo "verify by executing, not tsc" guidance).
+
+## Out of scope
+- Automated on-upload / cron scanning (this is manual-only by request).
+- GPP Drive photos, description-embedded images (event cover only for now).
+- Auto-reject / send-gate wiring (verdict is advisory; revisit after accuracy data).

--- a/supabase/migrations/20260604_marinara_61455_image_authenticity_checks.sql
+++ b/supabase/migrations/20260604_marinara_61455_image_authenticity_checks.sql
@@ -1,0 +1,48 @@
+-- marinara-61455: image-authenticity (AI-generated / doctored) admin check.
+--
+-- A SEPARATE table (do NOT widen payout_documents or parties) that caches the
+-- verdict of a manual, admin-triggered authenticity check on a payment-receipt
+-- image or a host event-cover image. Advisory only — never auto-rejects.
+--
+-- ⚠️ This repo has NO Prisma migration auto-apply (`_prisma_migrations` doesn't
+-- exist; SQL files under supabase/migrations/ do NOT run on backend deploy).
+-- Apply this to PROD via Supabase MCP / pg+DATABASE_URL BEFORE merging the code,
+-- and the backend deploys from `master` only (previews hit the prod backend).
+--
+-- FK notes (per repo memory: verify real table names before FK'ing):
+--   * parties.id           -> uuid PK, table is "parties" (has @@map).
+--   * payout_documents.id  -> uuid PK, table is "payout_documents" (has @@map).
+-- Both are soft FKs with ON DELETE SET NULL so deleting a party/receipt never
+-- cascades away the historical authenticity verdict (it stays as an audit row).
+
+CREATE TABLE IF NOT EXISTS image_authenticity_checks (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- The Supabase object URL that was checked. Lookup key for the cache.
+  image_url           text NOT NULL,
+  -- 'receipt' | 'event_image' — which surface the image came from.
+  source_kind         text NOT NULL,
+  -- Optional linkage for filtering / joins. Soft FKs (SET NULL on delete).
+  party_id            uuid REFERENCES parties(id) ON DELETE SET NULL,
+  payout_document_id  uuid REFERENCES payout_documents(id) ON DELETE SET NULL,
+  -- Tiered verdict: 'authentic' | 'suspicious' | 'likely_fake'.
+  verdict             text NOT NULL,
+  -- Composite weighted score, 0-100 (higher = more likely fake/doctored).
+  score               integer NOT NULL DEFAULT 0,
+  -- Per-signal flags + the vision model's structured observations (jsonb).
+  reasons             jsonb NOT NULL DEFAULT '[]'::jsonb,
+  -- Which vision provider produced the primary verdict ('openai' | 'anthropic' | ...).
+  provider            text NOT NULL DEFAULT 'openai',
+  -- Phase 2 ELA overlay artifact (downloadable PNG in the event-images bucket).
+  ela_artifact_url    text,
+  checked_at          timestamptz NOT NULL DEFAULT now(),
+  -- Admin email that triggered the check.
+  checked_by          text
+);
+
+-- Cache lookup is by image_url ("return the cached row unless force").
+CREATE INDEX IF NOT EXISTS idx_image_authenticity_checks_image_url
+  ON image_authenticity_checks (image_url);
+
+-- Filtering checks by party (e.g. all checks for a given event).
+CREATE INDEX IF NOT EXISTS idx_image_authenticity_checks_party_id
+  ON image_authenticity_checks (party_id);


### PR DESCRIPTION
## Summary

A manual, admin-triggered tool that judges whether a **payment-receipt image** or a **host event-cover image** is AI-generated or doctored. Returns a verdict (`authentic` | `suspicious` | `likely_fake`) + score + concrete reasons, cached per image URL so re-opening doesn't re-pay for the API call. **Advisory only — it flags for human review and never auto-rejects.**

## Approach

Weighted-signal scorer (`backend/src/lib/imageAuthenticity.ts`) mirroring `fakeDetection.ts`, composing several passes cheapest-first:
1. **Metadata / provenance** — scans for AI-generator (DALL·E / Midjourney / Stable Diffusion / Firefly …) and editor (Photoshop / GIMP …) software tags + C2PA / Content-Credentials presence. Presence is a strong positive signal; **absence of EXIF is intentionally low-weight** (re-encodes, screenshots, and chat compression all strip it).
2. **Vision verdict (primary)** — OpenAI gpt-4o, reusing `getOpenAI()` + the OCR service's fetch-URL→base64 pattern, forced to structured JSON `{verdict, confidence, observations[]}`.
3. **Receipt-math sanity** (receipts only) — OCR line items not summing to the total (within tolerance) flags tampering.
4. **ELA overlay (Phase 2)** — recompress + diff via `sharp`, upload the error-level-analysis PNG to the `event-images` bucket; downloadable artifact, **not** scored.
5. **Second opinion (Phase 2)** — env-gated `anthropicVision` + `sightengine` providers behind a provider interface; skipped silently unless their key is set.

`POST/GET /api/admin/image-authenticity` is admin-gated (`requireAuth` → `isAdmin`) and **path-scoped before the `/api/admin` catch-all**. Returns the cached row unless `force:true`.

Frontend: a shared `AuthenticityPanel` (purple verdict banner + reasons + Re-check + ELA download — purple to distinguish from red=duplicate / amber=ineligible) wired into the receipt editor (lightbox, with a `V` keyboard shortcut + purple photo-pane overlay) and into the underboss `EventCard` for the event cover.

## New table — apply to prod before merge

New SEPARATE table **`image_authenticity_checks`** (does NOT widen `payout_documents` or `Party`). Prisma model `ImageAuthenticityCheck` + raw SQL at `supabase/migrations/20260604_marinara_61455_image_authenticity_checks.sql`.

⚠️ **This repo has no Prisma migration auto-apply** — the SQL must be applied to **prod via Supabase MCP** before merge (backend deploys from `master` only; previews hit the prod backend).

## Dormant dependency

Adds **`@anthropic-ai/sdk`** to `backend/package.json`. The Claude second-opinion provider is **dormant until `ANTHROPIC_API_KEY` is set** — Phase 1 runs with only `OPENAI_API_KEY`. (Sightengine is likewise dormant behind `SIGHTENGINE_API_USER`/`_SECRET`.) The root `package-lock.json` diff (3 entries) is expected per npm workspaces.

## Verification

- `frontend`: `npx tsc --noEmit` clean; the 3 net-new files lint clean.
- `backend`: production code compiles clean (`tsc --noEmit` has only a pre-existing `auth.test.ts` `@types/jsonwebtoken` typing error that also reproduces on master, unrelated to this PR).
- ⚠️ The live vision endpoint was **not** exercised (no API key / running backend in this environment) — the OpenAI/Anthropic/Sightengine vision paths are unverified at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
