### PR TITLE
fix(bottarga-92106): TaxFormSection on host Payouts tab, not inside +New receipt

### DIFF
--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -10,7 +10,6 @@ import { ReceiptUpload, ReceiptItem } from './ReceiptUpload';
 import { PizzaPhotoUpload, PizzaPhotoItem } from './PizzaPhotoUpload';
 import { PayoutAmountSummary } from './PayoutAmountSummary';
 import { AppealCapModal } from './AppealCapModal';
-import { TaxFormSection } from './TaxFormSection';
 import { TaxFormType } from '../../types';
 
 /**
@@ -44,6 +43,14 @@ interface NewPayoutFormProps {
    * estimated-attendance section is hidden entirely.
    */
   expectedGuests?: number | null;
+  /**
+   * bottarga-92106: TaxFormSection now lives on the parent PayoutsTab. When
+   * the backend returns TAX_FORM_REQUIRED, this callback lets the parent
+   * auto-open the section to the requested form type. The form still scrolls
+   * to `#tax-form-section` (the section's id, which now sits above this form
+   * on the same tab).
+   */
+  onTaxFormRequired?: (formType: TaxFormType | null) => void;
 }
 
 /**
@@ -72,6 +79,7 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
   reimbursementCapAppealedAt,
   totalPaidUsd = 0,
   expectedGuests,
+  onTaxFormRequired,
 }) => {
   const { user } = useAuth();
   const { party } = usePizza();
@@ -136,11 +144,13 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  // salame-92110: when the backend returns TAX_FORM_REQUIRED, we surface a
-  // pointer at the TaxFormSection above and (optionally) auto-open a form
-  // type if the host has indicated one. Phase 1 doesn't auto-infer US vs
-  // foreign, so we leave the type null and the host picks.
-  const [taxFormAutoOpen, setTaxFormAutoOpen] = useState<TaxFormType | null>(null);
+  // bottarga-92106: TaxFormSection no longer lives inside this form — when the
+  // backend returns TAX_FORM_REQUIRED we forward the requested form type to
+  // the parent PayoutsTab via `onTaxFormRequired` so the section (rendered
+  // between PaymentDetailsCard and the receipts list) auto-opens the right
+  // editor. Then we scroll to `#tax-form-section`, which lives above this
+  // form on the same tab. Phase 1 still doesn't auto-infer US vs foreign;
+  // when the backend doesn't supply a type, the section stays on the picker.
 
   // mortadella-92103: exclude receipts whose currency couldn't be resolved
   // (the `$` ambiguity in non-USD countries) from the auto-sum. They keep
@@ -296,11 +306,14 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       });
       onCreated(created);
     } catch (err: any) {
-      // salame-92110: when the backend says a tax form is required, scroll
-      // the host up to the TaxFormSection instead of just showing a red error.
+      // salame-92110 / bottarga-92106: when the backend says a tax form is
+      // required, ask the parent PayoutsTab to auto-open the TaxFormSection
+      // (now rendered above this form, between PaymentDetailsCard and the
+      // receipts list) and scroll to it. The section's `id="tax-form-section"`
+      // is reachable cross-component since both live in the same tab.
       if (err?.code === 'TAX_FORM_REQUIRED') {
         const requiredType: TaxFormType | null = err?.requiredFormType ?? null;
-        setTaxFormAutoOpen(requiredType);
+        onTaxFormRequired?.(requiredType);
         setSubmitError(
           'A tax form is required before this payment can be submitted. Please complete the tax form above.',
         );
@@ -481,15 +494,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
         />
       </div>
 
-      {/* 4b. Tax form (salame-92110).
-          culatello-92106: only rendered when admin has flipped the per-event
-          `taxFormRequired` flag. When the flag is off (default for all events)
-          the section is hidden and the host can submit payouts without a form.
-          When the flag is on, the section is required + backend enforces
-          TAX_FORM_REQUIRED before the payout is accepted. */}
-      {party?.taxFormRequired === true && (
-        <TaxFormSection autoOpenFormType={taxFormAutoOpen} />
-      )}
+      {/* 4b. Tax form (salame-92110 / culatello-92106) moved to PayoutsTab
+          (bottarga-92106) so hosts can pre-fill the form without opening a
+          payout. TAX_FORM_REQUIRED errors here still scroll to it via the
+          shared #tax-form-section anchor in the same tab. */}
 
       {/* 5. Submit */}
       {submitError && (

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Info, BadgeDollarSign } from 'lucide-react';
-import { Payout } from '../../types';
+import { Payout, TaxFormType } from '../../types';
 import { listPayouts } from '../../lib/api';
 import { usePizza } from '../../contexts/PizzaContext';
 import { parsePartyKitCapFromTags } from '../../lib/reimbursementCap';
@@ -13,6 +13,7 @@ import { PrepayCheckbox } from './PrepayCheckbox';
 import { PaymentDetailsCard } from './PaymentDetailsCard';
 import { AppealCapModal } from './AppealCapModal';
 import { ReceiptsLibrary } from './ReceiptsLibrary';
+import { TaxFormSection } from './TaxFormSection';
 
 interface PayoutsTabProps {
   partyId: string;
@@ -62,6 +63,12 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   const [detailPayoutId, setDetailPayoutId] = useState<string | null>(null);
   // mascarpone-58927: inline appeal trigger in the green reimburse banner.
   const [showAppealModal, setShowAppealModal] = useState(false);
+  // bottarga-92106: TaxFormSection now lives on this tab (between
+  // PaymentDetailsCard and the receipts list) instead of inside NewPayoutForm
+  // so hosts can pre-fill the form before any payout exists. When
+  // NewPayoutForm's submit hits TAX_FORM_REQUIRED it forwards the requested
+  // form type up so the section auto-opens to the right editor.
+  const [taxFormAutoOpen, setTaxFormAutoOpen] = useState<TaxFormType | null>(null);
 
   const loadPayouts = useCallback(async () => {
     setLoading(true);
@@ -229,6 +236,18 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
       */}
       <PaymentDetailsCard />
 
+      {/*
+        bottarga-92106: Tax-form section moved out of NewPayoutForm so hosts
+        can see and pre-fill the form before opening a payout request. Only
+        renders when the per-event admin flag is on (default off). The
+        cross-component scroll target id="tax-form-section" inside the
+        component is reused by NewPayoutForm's TAX_FORM_REQUIRED error
+        handler — both live in this tab so scrollIntoView reaches it.
+      */}
+      {party?.taxFormRequired === true && (
+        <TaxFormSection autoOpenFormType={taxFormAutoOpen} />
+      )}
+
       {view === 'list' && (
         <>
           <div className="card p-6">
@@ -285,6 +304,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             reimbursementCapAppealedAt={reimbursementCapAppealedAt}
             totalPaidUsd={totalPaidUsd}
             expectedGuests={expectedGuests}
+            onTaxFormRequired={(t) => setTaxFormAutoOpen(t)}
           />
         </>
       )}


### PR DESCRIPTION
## Summary
- Move `TaxFormSection` out of `NewPayoutForm` and into `PayoutsTab`, rendered between `PaymentDetailsCard` and the receipts list whenever `party.taxFormRequired === true`. Hosts can now see and pre-fill the form (W-9 / W-8BEN / W-8BEN-E) without opening the '+ New receipt' flow.
- Lift the `taxFormAutoOpen` state up to `PayoutsTab` and pass `onTaxFormRequired` callback to `NewPayoutForm`. When the backend returns `TAX_FORM_REQUIRED`, the form forwards the requested type up and still calls `scrollIntoView` on `#tax-form-section` — both components share the same tab so the anchor resolves cleanly.
- No backend, schema, or admin-side changes. Internals of `TaxFormSection`, the admin `PayoutReviewModal`, and the per-event admin toggle are untouched.

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally).
- [ ] Open a host's Payouts tab for an event with `tax_form_required = true` — `TaxFormSection` appears between Payment Details and Receipts, in all states (picker, draft, submitted, verified, rejected).
- [ ] Open a host's Payouts tab for an event with `tax_form_required = false` — section is hidden.
- [ ] Open `+ New receipt` — `TaxFormSection` no longer renders inside the form.
- [ ] Try submitting a payout without a tax form (with `tax_form_required = true`) — backend rejects with `TAX_FORM_REQUIRED`; frontend auto-opens the requested type on the tab-level section and scrolls to it.
- [ ] `autoOpenFormType` query-param / admin deep-link path still routes to the correct form (W-9 / W-8BEN / W-8BEN-E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)