### PR TITLE
feat(diavola-83147): accent-insensitive search (frontend + backend)

### DIFF
--- a/backend/src/lib/accentSearch.ts
+++ b/backend/src/lib/accentSearch.ts
@@ -1,0 +1,29 @@
+import type { PrismaClient } from '@prisma/client';
+
+/**
+ * Returns ids of rows in `table` where ANY of `columns` accent-insensitively
+ * contains `needle` (case- and diacritic-insensitive). `table`/`columns` are
+ * caller-controlled identifiers (NOT user input); only `needle` is parameterized.
+ *
+ * Relies on the `unaccent` extension (enabled on prod, lives in the public
+ * schema so it's called UNQUALIFIED). `id` is cast to text so this works for
+ * both uuid-typed (Party) and text-typed (User) primary keys.
+ */
+export async function unaccentMatchIds(
+  prisma: PrismaClient,
+  table: string,
+  columns: string[],
+  needle: string,
+): Promise<string[]> {
+  const term = needle.trim();
+  if (!term) return [];
+  const like = `%${term.replace(/[\\%_]/g, (m) => '\\' + m)}%`;
+  const conds = columns
+    .map((c) => `unaccent(coalesce("${c}"::text, '')) ILIKE unaccent($1) ESCAPE '\\'`)
+    .join(' OR ');
+  const rows = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT id::text AS id FROM "${table}" WHERE ${conds}`,
+    like,
+  );
+  return rows.map((r) => r.id);
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -18,6 +18,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../config/database.js';
+import { unaccentMatchIds } from '../lib/accentSearch.js';
 import {
   requireAuth,
   AuthRequest,
@@ -531,7 +532,7 @@ async function assertWithinPartyCap(
 }
 
 /** Build a Prisma `where` clause from query-string filters. */
-function buildPayoutWhere(query: Request['query']): any {
+async function buildPayoutWhere(query: Request['query']): Promise<any> {
   const where: any = {};
 
   // coppa-92106: status accepts either a single status or a comma-separated
@@ -590,10 +591,16 @@ function buildPayoutWhere(query: Request['query']): any {
   const search = query.search;
   if (typeof search === 'string' && search.trim().length > 0) {
     const needle = search.trim();
+    // diavola-83147: accent-insensitive search. Prefilter party + host ids via
+    // the `unaccent` extension, then fold the FK `in` clauses into where.OR so
+    // `jose` matches `José`, `munchen` matches `München`, etc.
+    const [partyIds, hostIds] = await Promise.all([
+      unaccentMatchIds(prisma, 'parties', ['name'], needle),
+      unaccentMatchIds(prisma, 'User', ['name', 'email'], needle),
+    ]);
     where.OR = [
-      { host: { email: { contains: needle, mode: 'insensitive' as const } } },
-      { host: { name: { contains: needle, mode: 'insensitive' as const } } },
-      { party: { name: { contains: needle, mode: 'insensitive' as const } } },
+      { partyId: { in: partyIds } },
+      { hostUserId: { in: hostIds } },
     ];
   }
 
@@ -987,14 +994,12 @@ router.get(
       // Pull approved parties matching name / customUrl / inviteCode. Cap at 20.
       // Sorted createdAt DESC so the most recent approved events show first —
       // matches how admins typically remember "the event that was just approved".
+      // diavola-83147: accent-insensitive prefilter via the `unaccent` extension.
+      const ids = await unaccentMatchIds(prisma, 'parties', ['name', 'custom_url', 'invite_code'], rawQ);
       const parties = await prisma.party.findMany({
         where: {
           underbossStatus: 'approved',
-          OR: [
-            { name: { contains: rawQ, mode: 'insensitive' } },
-            { customUrl: { contains: rawQ, mode: 'insensitive' } },
-            { inviteCode: { contains: rawQ, mode: 'insensitive' } },
-          ],
+          id: { in: ids },
         },
         select: {
           id: true,
@@ -1110,7 +1115,7 @@ router.get(
   requireAnyAdminOrPaymentAdmin,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const where = buildPayoutWhere(req.query);
+      const where = await buildPayoutWhere(req.query);
       const rows = await prisma.payout.findMany({
         where,
         include: {
@@ -1846,7 +1851,7 @@ router.get(
   requireAdminOrRegionalUnderboss(),
   async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
-      const where = buildPayoutWhere(req.query);
+      const where = await buildPayoutWhere(req.query);
 
       // 1. Fetch every payout matching the filter set — no skip cursor in v1.
       //    Same include shape as the LIST endpoint so `serializePayout` returns
@@ -2352,7 +2357,7 @@ router.get(
   requireAdminOrRegionalUnderboss(),
   async (req: RegionalAuthRequest, res: Response, next: NextFunction) => {
     try {
-      const where = buildPayoutWhere(req.query);
+      const where = await buildPayoutWhere(req.query);
 
       const rawLimit = parseInt(String(req.query.limit ?? '50'), 10);
       const limit = Math.min(

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto';
 import { Prisma } from '@prisma/client';
 import jwt from 'jsonwebtoken';
 import { prisma } from '../config/database.js';
+import { unaccentMatchIds } from '../lib/accentSearch.js';
 import { AppError } from '../middleware/error.js';
 import { isAdmin, isUnderboss } from '../middleware/auth.js';
 import { getAutoCoHostPartners, addPartnerToParty } from '../helpers/partnerSync.js';
@@ -813,11 +814,21 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
     if (!includeAllStatuses) {
       where.cancelledAt = null;
     }
-    if (city) {
-      where.name = { contains: city as string, mode: 'insensitive' };
-    }
-    if (country) {
-      where.country = { contains: country as string, mode: 'insensitive' };
+    // diavola-83147: accent-insensitive city/country filter via the `unaccent`
+    // extension. Prefilter party ids and fold into where.id so `sao` matches
+    // `São Paulo`, `munchen` matches `München`, etc. When BOTH are provided,
+    // intersect the two id sets so the filters compose (don't overwrite).
+    if (city && country) {
+      const [cityIds, countryIds] = await Promise.all([
+        unaccentMatchIds(prisma, 'parties', ['name'], city as string),
+        unaccentMatchIds(prisma, 'parties', ['country'], country as string),
+      ]);
+      const countrySet = new Set(countryIds);
+      where.id = { in: cityIds.filter((id) => countrySet.has(id)) };
+    } else if (city) {
+      where.id = { in: await unaccentMatchIds(prisma, 'parties', ['name'], city as string) };
+    } else if (country) {
+      where.id = { in: await unaccentMatchIds(prisma, 'parties', ['country'], country as string) };
     }
     if (region) {
       where.region = region as string;

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -1,5 +1,6 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
+import { unaccentMatchIds } from '../lib/accentSearch.js';
 import { requireAuth, AuthRequest, isAdmin } from '../middleware/auth.js';
 import { requireUnderbossAuth, UnderbossAuthRequest } from '../middleware/underbossAuth.js';
 import { AppError } from '../middleware/error.js';
@@ -643,12 +644,11 @@ router.get('/outreach/parties-search', requireAuth, requireUnderbossAuth, async 
       return res.json({ parties: [] });
     }
 
+    // diavola-83147: accent-insensitive prefilter via the `unaccent` extension.
+    const ids = await unaccentMatchIds(prisma, 'parties', ['name', 'custom_url'], q);
     const parties = await prisma.party.findMany({
       where: {
-        OR: [
-          { name: { contains: q, mode: 'insensitive' } },
-          { customUrl: { contains: q, mode: 'insensitive' } },
-        ],
+        id: { in: ids },
       },
       select: {
         id: true,

--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -10,6 +10,7 @@ import { RejectedGuestsModal } from './RejectedGuestsModal';
 import { InvitedGuestsModal } from './InvitedGuestsModal';
 import { ImportGuestsModal } from './ImportGuestsModal';
 import { checkInGuest, getNotableGuestIds, addNotableAttendee, deleteNotableAttendeeByGuestId } from '../lib/api';
+import { normalizeText } from '../lib/normalizeText';
 
 export const GuestList: React.FC = () => {
   const { t } = useTranslation('host');
@@ -142,10 +143,10 @@ export const GuestList: React.FC = () => {
 
   const filteredGuests = useMemo(() => {
     if (!searchQuery.trim()) return guests;
-    const query = searchQuery.toLowerCase().trim();
+    const query = normalizeText(searchQuery.trim());
     return guests.filter(guest =>
-      guest.name.toLowerCase().includes(query) ||
-      (guest.email && guest.email.toLowerCase().includes(query))
+      normalizeText(guest.name).includes(query) ||
+      (guest.email && normalizeText(guest.email).includes(query))
     );
   }, [guests, searchQuery]);
 

--- a/frontend/src/components/report/BrowseGuestsModal.tsx
+++ b/frontend/src/components/report/BrowseGuestsModal.tsx
@@ -6,6 +6,7 @@ import { Guest } from '../../types';
 import { IconInput } from '../IconInput';
 import { addNotableAttendee, deleteNotableAttendeeByGuestId, getNotableGuestIds } from '../../lib/api';
 import { extractEmailDomain, getDomainFaviconUrl, isEmailProvider } from '../../utils/emailUtils';
+import { normalizeText } from '../../lib/normalizeText';
 
 interface BrowseGuestsModalProps {
   isOpen: boolean;
@@ -85,10 +86,10 @@ export function BrowseGuestsModal({ isOpen, onClose, guests, partyId, onChanged 
 
   const filteredDomains = useMemo(() => {
     if (!searchQuery.trim()) return domainGroups;
-    const q = searchQuery.toLowerCase().trim();
+    const q = normalizeText(searchQuery.trim());
     return domainGroups.filter(g =>
-      g.domain.toLowerCase().includes(q) ||
-      g.guests.some(guest => guest.name.toLowerCase().includes(q))
+      normalizeText(g.domain).includes(q) ||
+      g.guests.some(guest => normalizeText(guest.name).includes(q))
     );
   }, [domainGroups, searchQuery]);
 

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -10,6 +10,7 @@ import { bulkUpdateUnderbossStatus, bulkDeleteEvents, bulkUpdateEventTags } from
 import { triggerFlyerRegenForEvents } from '../flyer/autoRegenFlyer';
 import type { UnderbossEvent, UnderbossEventProgress } from '../../types';
 import { calculateTagSponsorshipTotal } from '../../utils/sponsorshipPricing';
+import { normalizeText } from '../../lib/normalizeText';
 
 interface EventTableProps {
   events: UnderbossEvent[];
@@ -162,16 +163,16 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     let result = events;
 
     if (search.trim()) {
-      const q = search.toLowerCase();
+      const q = normalizeText(search);
       result = result.filter(
         (e) =>
-          e.name.toLowerCase().includes(q) ||
-          e.host.name?.toLowerCase().includes(q) ||
-          e.host.email?.toLowerCase().includes(q) ||
-          e.address?.toLowerCase().includes(q) ||
-          e.venueName?.toLowerCase().includes(q) ||
-          e.country?.toLowerCase().includes(q) ||
-          e.region?.toLowerCase().includes(q)
+          normalizeText(e.name).includes(q) ||
+          normalizeText(e.host.name).includes(q) ||
+          normalizeText(e.host.email).includes(q) ||
+          normalizeText(e.address).includes(q) ||
+          normalizeText(e.venueName).includes(q) ||
+          normalizeText(e.country).includes(q) ||
+          normalizeText(e.region).includes(q)
       );
     }
 

--- a/frontend/src/components/underboss/FakeDetectionTable.tsx
+++ b/frontend/src/components/underboss/FakeDetectionTable.tsx
@@ -5,6 +5,7 @@ import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { fetchFakeDetection, updateUnderbossStatus } from '../../lib/api';
 import type { FakeDetectionResponse, FakeDetectionRow, FakeDetectionTier } from '../../types';
+import { normalizeText } from '../../lib/normalizeText';
 
 type ActionStatus = 'pending' | 'approved' | 'rejected';
 
@@ -217,15 +218,15 @@ export function FakeDetectionTable() {
     let rows = data.rows;
 
     if (search.trim()) {
-      const q = search.toLowerCase();
+      const q = normalizeText(search);
       rows = rows.filter(
         (r) =>
-          r.name.toLowerCase().includes(q) ||
-          r.customUrl?.toLowerCase().includes(q) ||
-          r.country?.toLowerCase().includes(q) ||
-          r.region?.toLowerCase().includes(q) ||
-          r.hostName?.toLowerCase().includes(q) ||
-          r.hostEmail?.toLowerCase().includes(q),
+          normalizeText(r.name).includes(q) ||
+          normalizeText(r.customUrl).includes(q) ||
+          normalizeText(r.country).includes(q) ||
+          normalizeText(r.region).includes(q) ||
+          normalizeText(r.hostName).includes(q) ||
+          normalizeText(r.hostEmail).includes(q),
       );
     }
 

--- a/frontend/src/lib/normalizeText.ts
+++ b/frontend/src/lib/normalizeText.ts
@@ -1,0 +1,14 @@
+// Common letters NFD does not decompose (no combining-mark form).
+const SPECIAL: Record<string, string> = {
+  ł: 'l', Ł: 'l', ø: 'o', Ø: 'o', đ: 'd', Đ: 'd', ð: 'd', Ð: 'd',
+  ı: 'i', İ: 'i', ß: 'ss', æ: 'ae', Æ: 'ae', œ: 'oe', Œ: 'oe', þ: 'th',
+};
+
+/** Lowercase + strip diacritics for accent-insensitive search/compare. */
+export function normalizeText(s: string | null | undefined): string {
+  return (s ?? '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip combining marks
+    .replace(/[łŁøØđĐðÐıİßæÆœŒþ]/g, (c) => SPECIAL[c] ?? c)
+    .toLowerCase();
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -40,6 +40,7 @@ import { formatUsd } from '../components/payments-shared';
 import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
 import { isSwcHubParty } from '../utils/swcHub';
 import { fetchSheetCities } from '../lib/cities';
+import { normalizeText } from '../lib/normalizeText';
 import {
   PayoutsFilterBar,
   PayoutsTable,
@@ -118,15 +119,15 @@ const SHOW_PREPAY_QUEUE = false;
 // so typing a city matches what's actually rendered in the table.
 function matchesPrepaySearch(row: PrepayQueueRow, q: string): boolean {
   if (!q) return true;
-  const needle = q.toLowerCase().trim();
+  const needle = normalizeText(q.trim());
   if (!needle) return true;
-  const nameStripped = row.party.name.replace(/^Global Pizza Party\s+/i, '').toLowerCase();
+  const nameStripped = normalizeText(row.party.name.replace(/^Global Pizza Party\s+/i, ''));
   if (nameStripped.includes(needle)) return true;
-  if (row.party.name.toLowerCase().includes(needle)) return true;
-  if (row.party.country?.toLowerCase().includes(needle)) return true;
+  if (normalizeText(row.party.name).includes(needle)) return true;
+  if (normalizeText(row.party.country).includes(needle)) return true;
   for (const c of row.candidates) {
-    if ((c.name ?? '').toLowerCase().includes(needle)) return true;
-    if (c.email.toLowerCase().includes(needle)) return true;
+    if (normalizeText(c.name).includes(needle)) return true;
+    if (normalizeText(c.email).includes(needle)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## diavola-83147 — accent-insensitive search

Searching plain ASCII letters now matches accented variants throughout the app, in both directions: `jose` matches `José`, `munchen` matches `München`, `sao` matches `São`.

### Frontend (shared util applied to 5 search sites)
New `frontend/src/lib/normalizeText.ts` — NFD-decompose + strip combining marks + map common non-decomposing letters (ł, ø, đ, ß, æ, œ, …) + lowercase. Applied to:
- `PaymentsAdminPage.tsx` — `matchesPrepaySearch` (party name/stripped-name/country + candidate name/email)
- `GuestList.tsx` — guest name + email filter
- `report/BrowseGuestsModal.tsx` — domain + guest name filter
- `underboss/EventTable.tsx` — name/host name/host email/address/venue/country/region
- `underboss/FakeDetectionTable.tsx` — name/customUrl/country/region/hostName/hostEmail

### Backend (unaccent prefilter on 4 endpoints)
New `backend/src/lib/accentSearch.ts` → `unaccentMatchIds(prisma, table, columns, needle)` runs `unaccent(coalesce(col::text,'')) ILIKE unaccent($1)` and returns matching row ids (id cast to text so it works for both uuid `parties` and text `User` PKs). Only the needle is parameterized; table/columns are caller-controlled identifiers. Folded into the existing Prisma queries as `{ id/FK: { in: ids } }`, preserving all other select/where/orderBy/take clauses:
1. `admin-payout.routes.ts` — `/payments` unified search (base `Payout`; prefilter `parties.name` → `partyId in`, `User.name`/`User.email` → `hostUserId in`)
2. `admin-payout.routes.ts` — party autocomplete (base `Party`; `name`/`custom_url`/`invite_code`)
3. `gpp.routes.ts` — map city/country filter (base `Party`; city→`name`, country→`country`; both provided → id-set intersection so they compose)
4. `underboss.routes.ts` — outreach parties-search (base `Party`; `name`/`custom_url`)

> The `unaccent` extension is **already enabled on prod** (public schema). It is called **unqualified** as `unaccent(...)`. No DB migration is included or required.

### Notes
- Table/FK names used: `parties` (Party, uuid id), `User` (capital-singular, no `@@map`, text id); Payout FKs `partyId`/`hostUserId`.
- `buildPayoutWhere` became `async` (3 call sites updated to `await`).
- Typechecks: frontend `tsc --noEmit` clean; backend has only pre-existing unrelated errors (missing `openai`/`@anthropic-ai/sdk` dev deps, `auth.test.ts`, `anthropicVision.ts`) — none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)