### PR TITLE
panuozzo-92114: persist /payments filters in URL

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -10,6 +10,9 @@ import {
   PAYMENTS_REGION_SCOPES,
   type PaymentsRegionPortal,
 } from '../../utils/regions';
+// panuozzo-92114: canonical filter VALUE lists live in the React-free options
+// module so PayoutsFilterBar and the URL (de)serializer can't drift.
+import type { SortValue, StatusTabValue } from './paymentsFilterOptions';
 
 interface PayoutsFilterBarProps {
   filters: AdminPayoutFilters;
@@ -49,7 +52,10 @@ interface PayoutsFilterBarProps {
 
 // ciabatta-92110: `'closed'` is a party-level pseudo-status (filters on
 // parties.payments_closed_at), so the tab value type widens beyond PayoutStatus.
-const STATUS_TABS: Array<{ value: PayoutStatus | 'all' | 'closed'; label: string }> = [
+// panuozzo-92114: values are validated against STATUS_TAB_VALUES in
+// paymentsFilterOptions.ts (the URL serializer's source of truth) — keep this
+// list and that one in sync.
+const STATUS_TABS: Array<{ value: StatusTabValue; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'pending', label: 'Pending' },
   { value: 'approved', label: 'Approved' },
@@ -91,7 +97,6 @@ const PURPOSE_OPTIONS: Array<{ value: PayoutPurpose | 'all'; label: string }> = 
 // lievito-92103: `activity_desc` / `activity_asc` expose the by-city default
 // (lastActivityAt) as an explicit picker entry, and also order the per-payout
 // view by `updatedAt`. Useful for surfacing stale cities first.
-type SortValue = NonNullable<AdminPayoutFilters['sort']>;
 const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
   { value: 'created_desc', label: 'Newest first' },
   { value: 'created_asc', label: 'Oldest first' },

--- a/frontend/src/components/payments-admin/paymentsFilterOptions.ts
+++ b/frontend/src/components/payments-admin/paymentsFilterOptions.ts
@@ -1,0 +1,49 @@
+// panuozzo-92114: canonical filter-option VALUE lists for the admin /payments
+// filter bar. Extracted into a React-free module so both the rendering
+// component (PayoutsFilterBar.tsx) and the URL-state (de)serializer
+// (paymentsUrlState.ts) import the same source of truth — no duplicate-and-drift
+// — and so the serializer's unit tests don't transitively pull in the
+// payments-shared barrel (which imports pdfjs and needs a DOM).
+//
+// Display labels stay in PayoutsFilterBar.tsx / payments-shared because they're
+// only needed at render time; the serializer only validates against the values.
+import type { PayoutMethod, PayoutPurpose, PayoutStatus, AdminPayoutFilters } from '../../types';
+
+// ciabatta-92110: `'closed'` is a party-level pseudo-status (filters on
+// parties.payments_closed_at), so the tab value type widens beyond PayoutStatus.
+export type StatusTabValue = PayoutStatus | 'all' | 'closed';
+
+export const STATUS_TAB_VALUES: StatusTabValue[] = [
+  'all',
+  'pending',
+  'approved',
+  'queued',
+  'paid',
+  'rejected',
+  'failed',
+  'withdrawn',
+  'completed',
+  'closed',
+];
+
+export const METHOD_VALUES: Array<PayoutMethod | 'all'> = [
+  'all',
+  'usdc_base',
+  'mercury_card',
+  'wire',
+];
+
+export const PURPOSE_VALUES: Array<PayoutPurpose | 'all'> = ['all', 'event', 'shipping'];
+
+export type SortValue = NonNullable<AdminPayoutFilters['sort']>;
+
+export const SORT_VALUES: SortValue[] = [
+  'created_desc',
+  'created_asc',
+  'amount_desc',
+  'amount_asc',
+  'activity_desc',
+  'activity_asc',
+  'paid_at_desc',
+  'paid_at_asc',
+];

--- a/frontend/src/components/payments-admin/paymentsUrlState.test.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filtersToSearchParams,
+  searchParamsToFilters,
+  type ViewMode,
+} from './paymentsUrlState';
+import type { AdminPayoutFilters } from '../../types';
+
+// panuozzo-92114: mirrors DEFAULT_FILTERS in PaymentsAdminPage.tsx.
+const DEFAULT_FILTERS: AdminPayoutFilters = {
+  status: 'all',
+  payoutMethod: 'all',
+  currency: 'all',
+  country: 'all',
+  tag: 'all',
+  purpose: 'all',
+  hideClosed: true,
+  hideScams: true,
+  sort: 'created_desc',
+};
+
+describe('filtersToSearchParams', () => {
+  it('emits an empty query string for the default view', () => {
+    const params = filtersToSearchParams(DEFAULT_FILTERS, 'by-city');
+    expect(params.toString()).toBe('');
+  });
+
+  it('only emits keys that differ from defaults', () => {
+    const params = filtersToSearchParams(
+      { ...DEFAULT_FILTERS, payoutMethod: 'wire', search: 'austin' },
+      'by-city',
+    );
+    expect(params.get('method')).toBe('wire');
+    expect(params.get('q')).toBe('austin');
+    expect(params.get('status')).toBeNull();
+    expect(params.get('view')).toBeNull();
+  });
+
+  it('emits a comma-list status', () => {
+    const params = filtersToSearchParams(
+      { ...DEFAULT_FILTERS, status: 'paid,completed' },
+      'by-city',
+    );
+    expect(params.get('status')).toBe('paid,completed');
+  });
+
+  it('emits view only when non-default', () => {
+    expect(filtersToSearchParams(DEFAULT_FILTERS, 'by-payment').get('view')).toBe('by-payment');
+    expect(filtersToSearchParams(DEFAULT_FILTERS, 'payments').get('view')).toBe('payments');
+    expect(filtersToSearchParams(DEFAULT_FILTERS, 'by-city').get('view')).toBeNull();
+  });
+
+  it('joins regionPortals with commas', () => {
+    const params = filtersToSearchParams(
+      { ...DEFAULT_FILTERS, regionPortals: ['latam', 'na'] },
+      'by-city',
+    );
+    expect(params.get('regions')).toBe('latam,na');
+  });
+
+  it('default-TRUE booleans: only emits =0 when turned OFF', () => {
+    // default (true) -> no key
+    expect(filtersToSearchParams(DEFAULT_FILTERS, 'by-city').get('hideClosed')).toBeNull();
+    expect(filtersToSearchParams(DEFAULT_FILTERS, 'by-city').get('hideScams')).toBeNull();
+    // turned off -> =0
+    const off = filtersToSearchParams(
+      { ...DEFAULT_FILTERS, hideClosed: false, hideScams: false },
+      'by-city',
+    );
+    expect(off.get('hideClosed')).toBe('0');
+    expect(off.get('hideScams')).toBe('0');
+  });
+});
+
+describe('searchParamsToFilters', () => {
+  it('round-trips serialize -> parse -> equals (admin, no regions)', () => {
+    const original: AdminPayoutFilters = {
+      ...DEFAULT_FILTERS,
+      status: 'paid,completed',
+      payoutMethod: 'wire',
+      partyId: 'abc123',
+      search: 'austin',
+      tag: 'pfp',
+      purpose: 'shipping',
+      regionPortals: ['latam', 'na'],
+      dateFrom: '2026-01-01',
+      dateTo: '2026-02-01',
+      sort: 'amount_desc',
+      hideClosed: false,
+      hideScams: false,
+    };
+    const viewMode: ViewMode = 'payments';
+    const params = filtersToSearchParams(original, viewMode);
+    const { filters, viewMode: parsedView } = searchParamsToFilters(params, undefined);
+
+    expect(parsedView).toBe('payments');
+    expect(filters.status).toBe('paid,completed');
+    expect(filters.payoutMethod).toBe('wire');
+    expect(filters.partyId).toBe('abc123');
+    expect(filters.search).toBe('austin');
+    expect(filters.tag).toBe('pfp');
+    expect(filters.purpose).toBe('shipping');
+    expect(filters.regionPortals).toEqual(['latam', 'na']);
+    expect(filters.dateFrom).toBe('2026-01-01');
+    expect(filters.dateTo).toBe('2026-02-01');
+    expect(filters.sort).toBe('amount_desc');
+    expect(filters.hideClosed).toBe(false);
+    expect(filters.hideScams).toBe(false);
+  });
+
+  it('empty params -> defaults, viewMode null', () => {
+    const { filters, viewMode } = searchParamsToFilters(new URLSearchParams(), undefined);
+    expect(filters.status).toBe('all');
+    expect(filters.payoutMethod).toBe('all');
+    expect(filters.hideClosed).toBe(true);
+    expect(filters.hideScams).toBe(true);
+    expect(filters.sort).toBe('created_desc');
+    expect(viewMode).toBeNull();
+  });
+
+  it('default-TRUE boolean: =0 parses to false', () => {
+    const { filters } = searchParamsToFilters(
+      new URLSearchParams('hideClosed=0&hideScams=0'),
+      undefined,
+    );
+    expect(filters.hideClosed).toBe(false);
+    expect(filters.hideScams).toBe(false);
+  });
+
+  it('unknown enum values silently fall back to defaults', () => {
+    const { filters, viewMode } = searchParamsToFilters(
+      new URLSearchParams('sort=bogus&method=carrierpigeon&purpose=nope&status=fake&view=galaxy'),
+      undefined,
+    );
+    expect(filters.sort).toBe('created_desc');
+    expect(filters.payoutMethod).toBe('all');
+    expect(filters.purpose).toBe('all');
+    expect(filters.status).toBe('all');
+    expect(viewMode).toBeNull();
+  });
+
+  it('partially-invalid comma status falls back to default', () => {
+    const { filters } = searchParamsToFilters(
+      new URLSearchParams('status=paid,bogus'),
+      undefined,
+    );
+    expect(filters.status).toBe('all');
+  });
+
+  it('ignores ?regions= when a portal regions arg is supplied (hard scope wins)', () => {
+    const { filters } = searchParamsToFilters(
+      new URLSearchParams('regions=na,europe'),
+      ['south-america', 'central-america'],
+    );
+    // regionPortals must NOT be set from the URL on a regional portal...
+    expect(filters.regionPortals).toBeUndefined();
+    // ...and the hard scope is re-injected from the arg.
+    expect(filters.regions).toEqual(['south-america', 'central-america']);
+  });
+
+  it('honors ?regions= only on admin /payments (regions arg undefined)', () => {
+    const { filters } = searchParamsToFilters(
+      new URLSearchParams('regions=latam,na'),
+      undefined,
+    );
+    expect(filters.regionPortals).toEqual(['latam', 'na']);
+    expect(filters.regions).toBeUndefined();
+  });
+});

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -1,0 +1,182 @@
+// panuozzo-92114: pure (no-React) (de)serializer for the /payments filter bar +
+// view-mode toggle <-> URL query string. Wired into PaymentsAdminPage via
+// react-router's useSearchParams so a refresh / shared link restores the exact
+// view. Kept React-free so it can be unit-tested in isolation.
+//
+// Design: diff-against-defaults. We only emit a query key when its value
+// differs from DEFAULT_FILTERS, which keeps URLs short and makes "no params" a
+// faithful representation of the default view. The two default-TRUE booleans
+// (hideClosed / hideScams) are the sharp edge here — see filtersToSearchParams.
+import type { AdminPayoutFilters } from '../../types';
+// Source-of-truth filter value lists (React-free; shared with PayoutsFilterBar).
+import {
+  STATUS_TAB_VALUES,
+  METHOD_VALUES as METHOD_OPTION_VALUES,
+  PURPOSE_VALUES as PURPOSE_OPTION_VALUES,
+  SORT_VALUES as SORT_OPTION_VALUES,
+  type SortValue,
+} from './paymentsFilterOptions';
+
+export type ViewMode = 'by-city' | 'by-payment' | 'payments';
+
+const VIEW_MODES: ViewMode[] = ['by-city', 'by-payment', 'payments'];
+
+// panuozzo-92114: must mirror DEFAULT_FILTERS in PaymentsAdminPage.tsx for the
+// diff-against-defaults logic. We intentionally only list the fields this
+// module serializes (the user-facing ones); prop-derived / plumbing fields
+// (regions, cursor, limit, provenOnly, currency) are never touched here.
+const DEFAULTS = {
+  status: 'all' as NonNullable<AdminPayoutFilters['status']>,
+  payoutMethod: 'all' as NonNullable<AdminPayoutFilters['payoutMethod']>,
+  tag: 'all',
+  purpose: 'all' as NonNullable<AdminPayoutFilters['purpose']>,
+  sort: 'created_desc' as SortValue,
+  hideClosed: true,
+  hideScams: true,
+};
+const DEFAULT_VIEW: ViewMode = 'by-city';
+
+// Source-of-truth value sets, derived from the canonical lists in
+// paymentsFilterOptions.ts so they can never drift from the rendered controls.
+const STATUS_VALUES = new Set<string>(STATUS_TAB_VALUES.map(String));
+const METHOD_VALUES = new Set<string>(METHOD_OPTION_VALUES.map(String));
+const PURPOSE_VALUES = new Set<string>(PURPOSE_OPTION_VALUES.map(String));
+const SORT_VALUES = new Set<string>(SORT_OPTION_VALUES.map(String));
+
+/**
+ * Serialize the active filters + view mode to a URLSearchParams. A key is
+ * written ONLY when its value differs from the default, so the default view
+ * produces an empty query string. Booleans use `0`/`1`; the default-TRUE
+ * booleans are therefore only emitted as `=0` when the user turns them OFF.
+ */
+export function filtersToSearchParams(
+  filters: AdminPayoutFilters,
+  viewMode: ViewMode,
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  const status = filters.status ?? DEFAULTS.status;
+  if (status !== DEFAULTS.status) params.set('status', String(status));
+
+  const method = filters.payoutMethod ?? DEFAULTS.payoutMethod;
+  if (method !== DEFAULTS.payoutMethod) params.set('method', String(method));
+
+  if (filters.partyId && filters.partyId.trim()) params.set('partyId', filters.partyId.trim());
+  if (filters.search && filters.search.trim()) params.set('q', filters.search.trim());
+
+  const tag = filters.tag ?? DEFAULTS.tag;
+  if (tag !== DEFAULTS.tag) params.set('tag', String(tag));
+
+  const purpose = filters.purpose ?? DEFAULTS.purpose;
+  if (purpose !== DEFAULTS.purpose) params.set('purpose', String(purpose));
+
+  // regionPortals: admin /payments multi-select only. Empty/undefined = no key.
+  if (Array.isArray(filters.regionPortals) && filters.regionPortals.length > 0) {
+    params.set('regions', filters.regionPortals.join(','));
+  }
+
+  if (filters.dateFrom) params.set('from', filters.dateFrom);
+  if (filters.dateTo) params.set('to', filters.dateTo);
+
+  const sort = filters.sort ?? DEFAULTS.sort;
+  if (sort !== DEFAULTS.sort) params.set('sort', String(sort));
+
+  // Default-TRUE booleans: only emit when the user turned them OFF.
+  if (filters.hideClosed === false) params.set('hideClosed', '0');
+  if (filters.hideScams === false) params.set('hideScams', '0');
+
+  if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
+
+  return params;
+}
+
+/**
+ * Parse a URLSearchParams back into a filters object + view mode. Starts from
+ * DEFAULT_FILTERS (re-derived from `DEFAULTS` here is NOT enough — the caller
+ * passes the real default object via this module's shape) and overlays each
+ * present param, validating enums so a hand-mangled URL can't crash the page.
+ *
+ * `regions` (prop-derived hard scope) is NEVER read from the URL — it is
+ * re-injected from the `regions` arg, so a regional underboss can't widen their
+ * scope by editing the query string.
+ *
+ * Returns `viewMode: null` when no `view` param is present so the caller can
+ * fall back to localStorage.
+ */
+export function searchParamsToFilters(
+  params: URLSearchParams,
+  regions: string[] | undefined,
+): { filters: AdminPayoutFilters; viewMode: ViewMode | null } {
+  const filters: AdminPayoutFilters = {
+    status: DEFAULTS.status,
+    payoutMethod: DEFAULTS.payoutMethod,
+    currency: 'all',
+    country: 'all',
+    tag: DEFAULTS.tag,
+    purpose: DEFAULTS.purpose,
+    hideClosed: DEFAULTS.hideClosed,
+    hideScams: DEFAULTS.hideScams,
+    sort: DEFAULTS.sort,
+    ...(regions ? { regions } : {}),
+  };
+
+  // status — may be a single value OR a comma list (e.g. `paid,completed`).
+  // Validate every segment against STATUS_TABS; ignore the whole param if any
+  // segment is unknown so a mangled URL falls back to the default.
+  const statusRaw = params.get('status');
+  if (statusRaw) {
+    const segs = statusRaw.split(',').map((s) => s.trim()).filter(Boolean);
+    if (segs.length > 0 && segs.every((s) => STATUS_VALUES.has(s))) {
+      filters.status = segs.join(',');
+    }
+  }
+
+  const methodRaw = params.get('method');
+  if (methodRaw && METHOD_VALUES.has(methodRaw)) {
+    filters.payoutMethod = methodRaw as AdminPayoutFilters['payoutMethod'];
+  }
+
+  const partyId = params.get('partyId');
+  if (partyId) filters.partyId = partyId;
+
+  const q = params.get('q');
+  if (q) filters.search = q;
+
+  const tag = params.get('tag');
+  if (tag) filters.tag = tag;
+
+  const purposeRaw = params.get('purpose');
+  if (purposeRaw && PURPOSE_VALUES.has(purposeRaw)) {
+    filters.purpose = purposeRaw as AdminPayoutFilters['purpose'];
+  }
+
+  // regionPortals — admin /payments only. The regions arg is the prop-derived
+  // hard scope; on a regional portal we never let the URL set regionPortals
+  // either (the portal owns scope), so only honor it when regions is undefined.
+  const regionsRaw = params.get('regions');
+  if (regionsRaw && !regions) {
+    const list = regionsRaw.split(',').map((s) => s.trim()).filter(Boolean);
+    if (list.length > 0) filters.regionPortals = list;
+  }
+
+  const from = params.get('from');
+  if (from) filters.dateFrom = from;
+  const to = params.get('to');
+  if (to) filters.dateTo = to;
+
+  const sortRaw = params.get('sort');
+  if (sortRaw && SORT_VALUES.has(sortRaw)) {
+    filters.sort = sortRaw as SortValue;
+  }
+
+  // Default-TRUE booleans: when the param is present, `0` => false, anything
+  // else => true. Absent => leave the default (true).
+  if (params.has('hideClosed')) filters.hideClosed = params.get('hideClosed') !== '0';
+  if (params.has('hideScams')) filters.hideScams = params.get('hideScams') !== '0';
+
+  const viewRaw = params.get('view');
+  const viewMode: ViewMode | null =
+    viewRaw && VIEW_MODES.includes(viewRaw as ViewMode) ? (viewRaw as ViewMode) : null;
+
+  return { filters, viewMode };
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { ShieldX, Loader2, DollarSign, Download, Plus, Search } from 'lucide-react';
 import { Layout } from '../components/Layout';
@@ -59,6 +60,13 @@ import {
   MarkPartyPaidModal,
 } from '../components/payments-admin';
 import type { BulkSendResult } from '../lib/api';
+// panuozzo-92114: URL <-> filter/view-mode (de)serializer so a refresh / shared
+// link restores the exact filtered view.
+import {
+  filtersToSearchParams,
+  searchParamsToFilters,
+  type ViewMode as PaymentsViewMode,
+} from '../components/payments-admin/paymentsUrlState';
 
 /**
  * argentina-92103: viewer-role state. The full /payments dashboard accepts
@@ -168,9 +176,30 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   const isRegionalPortal = !!regions;
 
   const [role, setRole] = useState<RoleState>({ kind: 'loading' });
-  const [filters, setFilters] = useState<AdminPayoutFilters>(() =>
-    regions ? { ...DEFAULT_FILTERS, regions } : DEFAULT_FILTERS,
-  );
+
+  // panuozzo-92114: the URL query string is the source of restore-on-load state
+  // for filters + view mode. We parse it ONCE in the lazy useState initialisers
+  // below; after mount, `filters`/`viewMode` state is the single source of truth
+  // that PUSHES to the URL via the sync effect. We never read searchParams back
+  // into state on re-render (that would oscillate).
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Capture the initial parse once so both lazy initialisers agree even though
+  // useState runs them in declaration order. (searchParams is stable on mount.)
+  const initialUrlStateRef = useRef<ReturnType<typeof searchParamsToFilters> | null>(null);
+  if (initialUrlStateRef.current === null) {
+    initialUrlStateRef.current = searchParamsToFilters(searchParams, regions);
+  }
+
+  const [filters, setFilters] = useState<AdminPayoutFilters>(() => {
+    const parsed = initialUrlStateRef.current!;
+    // searchParamsToFilters already merged in `regions` when present, so this is
+    // a complete filters object equivalent to {...DEFAULT_FILTERS, ...url, regions}.
+    // Keep any DEFAULT_FILTERS-only fields (currency etc.) the serializer doesn't
+    // model by layering it underneath.
+    return regions
+      ? { ...DEFAULT_FILTERS, ...parsed.filters, regions }
+      : { ...DEFAULT_FILTERS, ...parsed.filters };
+  });
 
   // etruria-92103: primary view is `by-city` (one row per party with status
   // aggregates, click to expand). `by-payment` keeps the existing per-row
@@ -181,9 +210,15 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   // per status=paid|completed payment, proof-gated (prosciutto-92106), sorted
   // by paid_at DESC. Distinct from `by-payment` which shows every payout
   // regardless of status.
-  type ViewMode = 'by-city' | 'by-payment' | 'payments';
+  // panuozzo-92114: keep this local alias equal to the exported ViewMode so the
+  // (de)serializer and this component never drift.
+  type ViewMode = PaymentsViewMode;
   const VIEW_MODE_LS_KEY = 'paymentsAdminViewMode';
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    // panuozzo-92114: URL `?view=` wins (shared/refreshed link), then the
+    // admin's sticky localStorage default, then the by-city fallback.
+    const fromUrl = initialUrlStateRef.current?.viewMode;
+    if (fromUrl) return fromUrl;
     if (typeof window === 'undefined') return 'by-city';
     try {
       const stored = window.localStorage.getItem(VIEW_MODE_LS_KEY);
@@ -202,6 +237,19 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
       /* ignore */
     }
   }, [viewMode]);
+
+  // panuozzo-92114: push filters + view mode into the URL query string so a
+  // refresh / shared link restores the exact view. Uses replace:true (matches
+  // LeaderboardPage) so filter tweaks don't flood the back-stack. Guarded so we
+  // only call setSearchParams when the serialized string actually changes,
+  // avoiding redundant churn / render loops.
+  useEffect(() => {
+    const next = filtersToSearchParams(filters, viewMode);
+    const nextStr = next.toString();
+    if (nextStr !== searchParams.toString()) {
+      setSearchParams(next, { replace: true });
+    }
+  }, [filters, viewMode, searchParams, setSearchParams]);
 
   const [payouts, setPayouts] = useState<AdminPayout[]>([]);
   // etruria-92103: by-city grouped rows from /by-party. Empty when viewing
@@ -1101,7 +1149,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         <PayoutsFilterBar
           filters={filters}
           onChange={setFilters}
-          onReset={() => setFilters(DEFAULT_FILTERS)}
+          // panuozzo-92114: re-inject the hard `regions` scope on regional
+          // portals so Reset can't silently widen a regional underboss's view.
+          // The URL sync effect then clears the query string automatically.
+          onReset={() => setFilters(regions ? { ...DEFAULT_FILTERS, regions } : DEFAULT_FILTERS)}
           availableTags={availableTags}
           // pinsa-92103: Hide closed cities only makes sense on the by-city
           // view (paymentsClosedAt is a party-level signal). The per-payment


### PR DESCRIPTION
## Summary
Persists the `/payments` filter-bar selections **and** the view-mode toggle in the URL query string (via react-router `useSearchParams`), so a refresh or shared link restores the exact filtered view. Applies to admin `/payments` and all 7 regional sub-portals (`/payments/latam|na|europe|asia|india|africa|southafrica`).

- New React-free **diff-against-defaults** (de)serializer `paymentsUrlState.ts` — only writes a key when it differs from `DEFAULT_FILTERS`, so the default view = empty query string.
- **Default-TRUE booleans handled correctly**: `hideClosed`/`hideScams` only emit `=0` when the user turns them OFF (the #1 correctness trap).
- **Enum validation** against canonical value lists (extracted into shared, React-free `paymentsFilterOptions.ts`, imported by both `PayoutsFilterBar` and the serializer — no duplicate-and-drift). A mangled URL (`?sort=bogus`) silently falls back to default instead of crashing.
- The prop-derived `regions` hard scope is **never read from the URL**, so a regional underboss can't widen scope by editing the query string. `regions=` from the URL is only honored on admin `/payments` (maps to `regionPortals`).
- URL is parsed **once** in the lazy `useState` initialisers; after mount, state pushes to the URL via a single guarded effect (`replace: true`, no-op when serialized string is unchanged) — no render loop.
- localStorage view-mode default preserved as a fallback for param-less visits; `Reset` re-injects `regions` on regional portals.

## Test checklist
- [x] `npx tsc --noEmit` — clean
- [x] `paymentsUrlState.test.ts` — 13 passing: full round-trip, default-true-boolean off→`=0`→false, unknown-enum fallback, partially-invalid comma status, and `regions` ignored when a portal `regions` arg is supplied.
- [ ] Manual: tweak filters on `/payments`, refresh → view restored
- [ ] Manual: `/payments/latam` — Reset keeps regional scope; editing `?regions=` doesn't widen scope

## Vercel preview
https://rsvpizza-git-panuozzo-92114-payments-url-filters-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)