### PR TITLE
feat(scarpetta-58472): admin/underboss-only /suggestions page

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -70,6 +70,7 @@ import ensRoutes from './routes/ens.routes.js';
 import { surveyPublicRouter, surveyHostRouter, cronRouter } from './routes/survey.routes.js';
 import reminderRoutes from './routes/reminder.routes.js';
 import { taxFormRouter, adminTaxFormRouter } from './routes/tax-form.routes.js';
+import suggestionsRoutes from './routes/suggestions.routes.js'; // scarpetta-58472: admin/underboss-only suggestions list
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -150,6 +151,7 @@ app.use('/api/admin/parties', adminPartyRoutes); // fontina-91827: admin party-m
 app.use('/api/admin/image-authenticity', imageAuthenticityRoutes); // marinara-61455: image-authenticity check — before /api/admin catch-all
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
+app.use('/api/suggestions', suggestionsRoutes); // scarpetta-58472: admin/underboss-only site-wide suggestions (view-only)
 app.use('/api/telegram/webhook', telegramWebhookRoutes); // Telegram inbound webhook (no auth — secret-token header gate)
 app.use('/api/underboss/telegram', telegramRoutes); // Telegram broadcast (before underboss catch-all)
 app.use('/api/underboss', underbossRoutes); // Underboss dashboard (token auth + admin routes)

--- a/backend/src/routes/suggestions.routes.ts
+++ b/backend/src/routes/suggestions.routes.ts
@@ -1,0 +1,28 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isAdmin, isUnderboss } from '../middleware/auth.js';
+
+const router = Router();
+
+// GET /api/suggestions — view-only list of site-wide suggestions.
+// Visible to full admins / super-admins and any active underboss.
+// Suggestions are GLOBAL (no partyId) — every allowed viewer sees ALL of them.
+router.get('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const email = req.userEmail?.toLowerCase();
+    const allowed = (await isAdmin(email)) || (await isUnderboss(email));
+    if (!allowed) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const suggestions = await prisma.suggestion.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({ suggestions });
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { DisplayPage } from './pages/DisplayPage';
 import { UnderbossDashboard } from './pages/UnderbossDashboard';
 import { ShippingDashboard } from './pages/ShippingDashboard';
 import { AdminPage } from './pages/AdminPage';
+import { SuggestionsPage } from './pages/SuggestionsPage';
 import { PaymentsAdminPage } from './pages/PaymentsAdminPage';
 import { LatamPaymentsPage } from './pages/LatamPaymentsPage';
 import { SouthAfricaPaymentsPage } from './pages/SouthAfricaPaymentsPage';
@@ -116,6 +117,8 @@ function App() {
             <Route path="/underboss/:region" element={<UnderbossDashboard />} />
             <Route path="/shipping" element={<ShippingDashboard />} />
             <Route path="/admin" element={<AdminPage />} />
+            {/* scarpetta-58472: admin/underboss-only suggestions list — before /:slug catch-all */}
+            <Route path="/suggestions" element={<SuggestionsPage />} />
             <Route path="/admin/logo-cleanup" element={<AdminLogoCleanup />} />
             <Route path="/partner" element={<PartnerDashboardPage />} />
             <Route path="/partner/report" element={<ConsolidatedReportPage />} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6255,3 +6255,14 @@ export async function rejectTaxForm(id: string, reason: string): Promise<TaxForm
   );
   return res.taxForm;
 }
+
+// scarpetta-58472: site-wide suggestions list (admin / underboss view-only).
+export interface Suggestion {
+  id: string; createdAt: string; body: string;
+  imageUrl: string | null; name: string | null; email: string | null;
+  pageUrl: string | null; status: string;
+  aiSummary: string | null; aiTags: string[] | null;
+}
+export async function fetchSuggestions() {
+  return apiRequest<{ suggestions: Suggestion[] }>('/api/suggestions');
+}

--- a/frontend/src/pages/SuggestionsPage.tsx
+++ b/frontend/src/pages/SuggestionsPage.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+import { ClickableEmail } from '../components/ClickableEmail';
+import { ReceiptLightbox } from '../components/payments-shared/ReceiptLightbox';
+import { Shield, Loader2, ExternalLink, Lightbulb, MessageSquare } from 'lucide-react';
+import { fetchSuggestions } from '../lib/api';
+import type { Suggestion } from '../lib/api';
+
+// scarpetta-58472: view-only list of site-wide suggestions. The backend
+// endpoint IS the access gate (admins / super-admins / active underbosses);
+// any error (403 / 401 / network) renders the Access-Denied screen.
+export function SuggestionsPage() {
+  const [loading, setLoading] = useState(true);
+  const [denied, setDenied] = useState(false);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetchSuggestions();
+        if (cancelled) return;
+        setSuggestions(res.suggestions);
+      } catch {
+        if (!cancelled) setDenied(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Header />
+        <div className="flex items-center justify-center py-32">
+          <Loader2 size={32} className="animate-spin text-gray-400" />
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (denied) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Header />
+        <div className="flex flex-col items-center justify-center px-4 py-32">
+          <Shield size={48} className="text-red-400/60 mb-4" />
+          <h1 className="text-2xl font-bold mb-2 text-gray-900">Access Denied</h1>
+          <p className="text-gray-500 text-center max-w-md">
+            You don't have permission to view suggestions. This page is for admins
+            and underbosses only.
+          </p>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Helmet>
+        <title>Suggestions | RSV.Pizza</title>
+      </Helmet>
+
+      <Header />
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
+        <div className="flex items-center gap-3 mb-8">
+          <div className="w-10 h-10 rounded-xl bg-amber-500/20 flex items-center justify-center">
+            <Lightbulb size={20} className="text-amber-500" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Suggestions</h1>
+            <p className="text-sm text-gray-500">
+              {suggestions.length} {suggestions.length === 1 ? 'suggestion' : 'suggestions'} submitted from across the site
+            </p>
+          </div>
+        </div>
+
+        {suggestions.length === 0 ? (
+          <div className="rounded-2xl border border-gray-200 bg-white p-12 text-center">
+            <MessageSquare size={40} className="mx-auto text-gray-300 mb-3" />
+            <h2 className="text-lg font-semibold text-gray-700 mb-1">No suggestions yet</h2>
+            <p className="text-sm text-gray-500">
+              When people submit suggestions, they'll show up here.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {suggestions.map((s) => {
+              const hasSubmitter = !!(s.name || s.email);
+              return (
+                <div
+                  key={s.id}
+                  className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 border border-gray-200 capitalize">
+                      {s.status}
+                    </span>
+                    <span className="text-xs text-gray-400 whitespace-nowrap">
+                      {new Date(s.createdAt).toLocaleDateString(undefined, {
+                        year: 'numeric', month: 'short', day: 'numeric',
+                      })}
+                    </span>
+                  </div>
+
+                  <p className="text-gray-900 text-base whitespace-pre-wrap break-words mb-4">
+                    {s.body}
+                  </p>
+
+                  {s.imageUrl && (
+                    <button
+                      type="button"
+                      onClick={() => setLightboxUrl(s.imageUrl)}
+                      className="block mb-4 rounded-xl overflow-hidden border border-gray-200 hover:opacity-90 transition-opacity"
+                      title="Click to enlarge"
+                    >
+                      <img
+                        src={s.imageUrl}
+                        alt="Suggestion attachment"
+                        className="max-h-48 w-auto object-cover"
+                      />
+                    </button>
+                  )}
+
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500">
+                    <span className="flex items-center gap-1.5">
+                      {hasSubmitter ? (
+                        <>
+                          {s.name && <span className="text-gray-700 font-medium">{s.name}</span>}
+                          {s.email && (
+                            <ClickableEmail email={s.email} className="text-gray-500" />
+                          )}
+                        </>
+                      ) : (
+                        <span className="italic text-gray-400">Anonymous</span>
+                      )}
+                    </span>
+
+                    {s.pageUrl && (
+                      <a
+                        href={s.pageUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-700 hover:underline"
+                      >
+                        submitted from {s.pageUrl}
+                        <ExternalLink size={12} className="opacity-60" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </main>
+
+      <Footer />
+
+      <ReceiptLightbox
+        isOpen={lightboxUrl != null}
+        images={lightboxUrl ? [{ url: lightboxUrl, fileName: 'Suggestion attachment' }] : []}
+        onClose={() => setLightboxUrl(null)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## What this does
Adds a new **`/suggestions`** page that lists rows from the global `suggestions` table. View-only — no edit/delete/status actions.

- **Backend**: new `backend/src/routes/suggestions.routes.ts` mounted at `/api/suggestions`. `GET /` requires auth, then gates on `isAdmin(email) || isUnderboss(email)` → 403 otherwise. Reads via the service-role Prisma client (`prisma.suggestion.findMany`, newest-first), since the table's RLS only allows anon INSERT (no SELECT).
- **Frontend**: new `SuggestionsPage.tsx` (Header + Footer shell, loading spinner, Access-Denied screen on any fetch error). `fetchSuggestions()` added to `lib/api.ts`. Route wired in `App.tsx` before the `/:slug` catch-all.

## Access gate
Visible ONLY to full admins / super-admins and any **active** underboss. The backend endpoint is the gate (it returns 403 for everyone else); the frontend renders the same Shield Access-Denied block whenever the fetch throws (403/401/network). Suggestions are **site-wide / global** (no partyId) — there is no city/region scoping, every allowed viewer sees all of them.

## View-only
The page only renders. Each card shows the suggestion body (prominent), submitter (`name`/`email` via `ClickableEmail`, or "Anonymous"), date, a "submitted from …" `pageUrl` link, a status badge, and an image thumbnail when `imageUrl` is set.

## Image thumbnail / lightbox
The image thumbnail is a button that opens the existing **`ReceiptLightbox`** (`payments-shared/ReceiptLightbox.tsx`) full-screen overlay (Esc / backdrop to close) rather than a raw new-tab pop. Reusing the repo's existing lightbox keeps behavior consistent.

## Deploy note
**The backend must be deployed from `master` before this page works on preview branches** — frontend previews hit the production backend, and `/api/suggestions` doesn't exist there until master ships. Preview URL: `https://rsvpizza-git-scarpetta-58472-suggestions-pizza-dao.vercel.app/suggestions`

## Verification
- Frontend `tsc --noEmit`: clean.
- Backend `tsc --noEmit`: clean for changed files (`prisma.suggestion` resolves after `prisma generate`). Two pre-existing, unrelated errors exist identically on `origin/master` (`lib/openai.ts` missing `openai` module in the shared node_modules; `middleware/auth.test.ts` jwt.sign overload).
- Frontend `vite build` could not complete in this environment due to a missing transitive dep in the shared monorepo `node_modules` (`@alloc/quick-lru`, same class as the noted `@walletconnect/utils` issue) — environmental; Vercel does a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)