### PR TITLE
feat(casatiello-58291): USDC-only payout picker + SWC Hub login for US events

### DIFF
--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Loader2, Check, AlertCircle } from 'lucide-react';
+import { Loader2, Check, AlertCircle, ExternalLink } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePizza } from '../../contexts/PizzaContext';
-import { BankDetails, PayoutMethod } from '../../types';
+import { PayoutMethod } from '../../types';
 import {
   updateUserMe,
   getPaymentOptIn,
@@ -10,12 +10,6 @@ import {
   removePaymentOptIn,
 } from '../../lib/api';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
-import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
-
-const EMPTY_BANK: BankDetails = {};
-
-// Loose email check — same shape used elsewhere in the app (e.g. invite forms).
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
 
@@ -41,14 +35,14 @@ export const PaymentDetailsCard: React.FC = () => {
   // Local mirrors of the user's persisted values. These drive PayoutMethodPicker
   // directly so the UI updates instantly; the debounced save flushes to the
   // backend ~1s after the host stops typing.
+  // casatiello-58291: usdc_base is the only host-facing payout method now, so
+  // we default to it (rather than null) when the user has no saved method —
+  // the debounced autosave will then persist usdc_base.
   const [method, setMethod] = useState<PayoutMethod | null>(
-    user?.preferredPayoutMethod ?? null
+    user?.preferredPayoutMethod ?? 'usdc_base'
   );
   const [walletAddress, setWalletAddress] = useState<string>(
     user?.payoutWalletAddress ?? ''
-  );
-  const [bankDetails, setBankDetails] = useState<BankDetails>(
-    user?.payoutBankDetails ?? EMPTY_BANK
   );
 
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
@@ -60,8 +54,10 @@ export const PaymentDetailsCard: React.FC = () => {
   // Only resync when the user-record value differs from local — otherwise we'd
   // clobber in-flight edits. Done per-field for clarity.
   useEffect(() => {
-    if (user?.preferredPayoutMethod !== undefined && method === null) {
-      setMethod(user.preferredPayoutMethod ?? null);
+    // casatiello-58291: when the user has no saved method we keep the
+    // usdc_base default; only adopt the persisted value if it exists.
+    if (user?.preferredPayoutMethod) {
+      setMethod(user.preferredPayoutMethod);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.preferredPayoutMethod]);
@@ -73,39 +69,17 @@ export const PaymentDetailsCard: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.payoutWalletAddress]);
 
-  useEffect(() => {
-    if (
-      user?.payoutBankDetails !== undefined
-      && !bankDetails.email
-      && !bankDetails.accountHolderName
-      && !bankDetails.bankName
-    ) {
-      setBankDetails(user.payoutBankDetails ?? EMPTY_BANK);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.payoutBankDetails]);
-
-  // Validity mirror of NewPayoutForm's old methodValid — used to gate the
-  // debounced save (don't push half-typed wire details to the backend).
+  // casatiello-58291: usdc_base is the only host-facing method, so validity is
+  // just "is the wallet a valid hex/ENS value".
   const methodValid = useMemo(() => {
-    if (method == null) return false;
-    if (method === 'usdc_base') {
-      // nduja-92103: accept hex OR ENS (matches PayoutMethodPicker
-      // taleggio-30219). Strict 0x-only check silently grayed out
-      // the autosave for hosts typing puebla.eth-style names.
-      const trimmed = walletAddress.trim();
-      const isHex = /^0x[0-9a-fA-F]{40}$/.test(trimmed);
-      const isEns = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(trimmed);
-      return isHex || isEns;
-    }
-    if (method === 'wire') {
-      // arugula-38633 (follow-up): wire is now a single email field —
-      // our bank emails the host to complete the transaction.
-      const email = bankDetails.email?.trim() ?? '';
-      return EMAIL_REGEX.test(email);
-    }
-    return true; // mercury_card has no extra required fields
-  }, [method, walletAddress, bankDetails]);
+    // nduja-92103: accept hex OR ENS (matches PayoutMethodPicker
+    // taleggio-30219). Strict 0x-only check silently grayed out
+    // the autosave for hosts typing puebla.eth-style names.
+    const trimmed = walletAddress.trim();
+    const isHex = /^0x[0-9a-fA-F]{40}$/.test(trimmed);
+    const isEns = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(trimmed);
+    return isHex || isEns;
+  }, [walletAddress]);
 
   // Debounced auto-save. We track the "intended" payload in a ref so the
   // timeout callback always reads the latest values without re-creating the
@@ -121,38 +95,25 @@ export const PaymentDetailsCard: React.FC = () => {
     if (method == null) return null;
     return {
       preferredPayoutMethod: method,
-      payoutWalletAddress: method === 'usdc_base' ? walletAddress.trim() : null,
-      payoutBankDetails: method === 'wire' ? bankDetails : null,
+      payoutWalletAddress: walletAddress.trim(),
+      payoutBankDetails: null,
     };
   };
 
   // Track previous values so the auto-save only fires on actual change (not
   // on the initial setState from hydration).
   const prevSnapshot = useRef<string>(JSON.stringify({
-    method: user?.preferredPayoutMethod ?? null,
+    method: user?.preferredPayoutMethod ?? 'usdc_base',
     walletAddress: user?.payoutWalletAddress ?? '',
-    bankDetails: user?.payoutBankDetails ?? EMPTY_BANK,
   }));
 
   useEffect(() => {
-    const snapshot = JSON.stringify({ method, walletAddress, bankDetails });
+    const snapshot = JSON.stringify({ method, walletAddress });
     if (snapshot === prevSnapshot.current) return;
     prevSnapshot.current = snapshot;
     isDirty.current = true;
 
-    // pepperoni-47301: never autosave `mercury_card` when the party's country
-    // is on Mercury's restricted list — the per-party payout submission would
-    // be rejected by the backend anyway. Surface the reason locally so the
-    // host knows to pick another method.
-    if (method === 'mercury_card' && isMercuryBlocked(party?.country)) {
-      setSaveStatus('error');
-      setSaveError(
-        `Mercury cards are unavailable in ${party?.country ?? 'your country'}. Pick another method.`
-      );
-      return;
-    }
-
-    // Don't fire the save until the method-specific fields are valid.
+    // Don't fire the save until the wallet field is valid.
     if (!methodValid) {
       setSaveStatus('pending');
       return;
@@ -205,11 +166,11 @@ export const PaymentDetailsCard: React.FC = () => {
     // We intentionally exclude buildPayload from deps — it closes over the
     // latest values via the surrounding effect.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [method, walletAddress, bankDetails, methodValid]);
+  }, [method, walletAddress, methodValid]);
 
-  // PayoutMethodPicker requires non-null method. For the empty state we let
-  // the user pick a method first; the picker still renders all three radios.
-  const pickerMethod: PayoutMethod = method ?? 'mercury_card';
+  // casatiello-58291: PayoutMethodPicker requires non-null method; usdc_base is
+  // the only host-facing method now.
+  const pickerMethod: PayoutMethod = method ?? 'usdc_base';
 
   // ============================================
   // bufala-83291: per-event payment opt-in
@@ -220,6 +181,12 @@ export const PaymentDetailsCard: React.FC = () => {
   // Submitting on event X does not opt the host in on event Y.
   const partyId = party?.id ?? null;
   const partyName = party?.name ?? 'this event';
+
+  // casatiello-58291: US events bypass the USDC picker entirely and use the
+  // SWC Hub login flow instead. `parties.country` is the full English name
+  // (not ISO-2), and the Hub-readiness flag is the literal `'hub'` event tag.
+  const isUS = party?.country === 'United States';
+  const hasHubTag = (party?.eventTags ?? []).includes('hub');
   const [optInLoaded, setOptInLoaded] = useState(false);
   const [optedIn, setOptedIn] = useState(false);
   const [optedInAt, setOptedInAt] = useState<string | null>(null);
@@ -333,108 +300,149 @@ export const PaymentDetailsCard: React.FC = () => {
             Payment details
           </h3>
         </div>
-        <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
-          {saveStatus === 'saving' && (
-            <>
-              <Loader2 size={12} className="animate-spin text-theme-text-muted" />
-              <span className="text-theme-text-muted">Saving…</span>
-            </>
-          )}
-          {saveStatus === 'saved' && (
-            <>
-              <Check size={12} className="text-emerald-500" />
-              <span className="text-emerald-500">Saved</span>
-            </>
-          )}
-          {saveStatus === 'pending' && method != null && (
-            <span className="text-theme-text-muted">Editing…</span>
-          )}
-          {saveStatus === 'error' && (
-            <>
-              <AlertCircle size={12} className="text-[#ff393a]" />
-              <span className="text-[#ff393a]">Save failed</span>
-            </>
-          )}
-        </div>
+        {!isUS && (
+          <div className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+            {saveStatus === 'saving' && (
+              <>
+                <Loader2 size={12} className="animate-spin text-theme-text-muted" />
+                <span className="text-theme-text-muted">Saving…</span>
+              </>
+            )}
+            {saveStatus === 'saved' && (
+              <>
+                <Check size={12} className="text-emerald-500" />
+                <span className="text-emerald-500">Saved</span>
+              </>
+            )}
+            {saveStatus === 'pending' && method != null && (
+              <span className="text-theme-text-muted">Editing…</span>
+            )}
+            {saveStatus === 'error' && (
+              <>
+                <AlertCircle size={12} className="text-[#ff393a]" />
+                <span className="text-[#ff393a]">Save failed</span>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
-      <PayoutMethodPicker
-        method={pickerMethod}
-        onMethodChange={(next) => {
-          setMethod(next);
-          // When switching methods we DON'T wipe the other method's stored
-          // details — they stay so the host can swap back without retyping.
-        }}
-        walletAddress={walletAddress}
-        onWalletAddressChange={setWalletAddress}
-        bankDetails={bankDetails}
-        onBankDetailsChange={setBankDetails}
-        userEmail={user?.email}
-        reimbursementCapUsd={party?.effectiveReimbursementCapUsd ?? null}
-      />
-
-      {saveError && (
-        <p className="text-xs text-[#ff393a] mt-2">{saveError}</p>
-      )}
-
-      {/*
-        bufala-83291: per-event Submit. The autosave above keeps the user's
-        global default in sync; this section ALSO opts them in for THIS event.
-        Without an opt-in row the host won't appear on /payments as a prepay
-        candidate even if their global payment method is set.
-      */}
-      {partyId && optInLoaded && (
-        <div className="mt-5 border-t border-white/10 pt-4">
-          {!optedIn ? (
-            <div>
-              <button
-                type="button"
-                onClick={handleSubmitOptIn}
-                disabled={submitDisabled}
-                className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {optInPending ? (
-                  <>
-                    <Loader2 size={14} className="animate-spin" />
-                    Submitting…
-                  </>
-                ) : (
-                  'Submit my payment details for this event'
-                )}
-              </button>
-              <p className="text-xs text-white/40 mt-2">
-                Submitting opts you in to receive payment for {partyName}. You'll
-                only be paid for events you submit for.
-              </p>
-              {!methodValid && (
-                <p className="text-xs text-white/40 mt-1">
-                  Choose a payout method above before submitting.
-                </p>
-              )}
-            </div>
+      {isUS ? (
+        /*
+          casatiello-58291: US events are reimbursed through the SWC Hub, not
+          the USDC picker. Hosts log in to the Hub to manage payment there.
+          The Hub link is only enabled once the event carries the `hub` tag
+          (i.e. it's been added to the Hub); otherwise we show a Pending state.
+        */
+        <div>
+          {hasHubTag ? (
+            <a
+              href="https://www.swchub.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2"
+            >
+              <ExternalLink size={14} />
+              {user?.email ? `Login to SWC Hub with ${user.email}` : 'Login to SWC Hub'}
+            </a>
           ) : (
             <div>
-              <div className="flex items-center gap-2 text-sm text-emerald-500">
-                <Check size={16} />
-                <span>
-                  Submitted for {partyName}
-                  {optedInLabel ? ` on ${optedInLabel}` : ''}
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled
+                  className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 opacity-50 cursor-not-allowed"
+                >
+                  <ExternalLink size={14} />
+                  {user?.email ? `Login to SWC Hub with ${user.email}` : 'Login to SWC Hub'}
+                </button>
+                <span className="text-[10px] uppercase tracking-wide font-semibold text-amber-300 bg-amber-300/10 rounded-full px-2 py-0.5">
+                  Pending
                 </span>
               </div>
-              <button
-                type="button"
-                onClick={handleRemoveOptIn}
-                disabled={optInPending}
-                className="mt-2 text-xs text-white/50 hover:text-white/80 underline disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {optInPending ? 'Removing…' : "Remove me from this event's payments"}
-              </button>
+              <p className="text-xs text-white/40 mt-2">
+                Your event hasn't been added to the SWC Hub yet — check back soon.
+              </p>
             </div>
           )}
-          {optInError && (
-            <p className="text-xs text-[#ff393a] mt-2">{optInError}</p>
-          )}
         </div>
+      ) : (
+        <>
+          <PayoutMethodPicker
+            method={pickerMethod}
+            onMethodChange={(next) => {
+              setMethod(next);
+              // When switching methods we DON'T wipe the other method's stored
+              // details — they stay so the host can swap back without retyping.
+            }}
+            walletAddress={walletAddress}
+            onWalletAddressChange={setWalletAddress}
+          />
+
+          {saveError && (
+            <p className="text-xs text-[#ff393a] mt-2">{saveError}</p>
+          )}
+
+          {/*
+            bufala-83291: per-event Submit. The autosave above keeps the user's
+            global default in sync; this section ALSO opts them in for THIS event.
+            Without an opt-in row the host won't appear on /payments as a prepay
+            candidate even if their global payment method is set.
+          */}
+          {partyId && optInLoaded && (
+            <div className="mt-5 border-t border-white/10 pt-4">
+              {!optedIn ? (
+                <div>
+                  <button
+                    type="button"
+                    onClick={handleSubmitOptIn}
+                    disabled={submitDisabled}
+                    className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {optInPending ? (
+                      <>
+                        <Loader2 size={14} className="animate-spin" />
+                        Submitting…
+                      </>
+                    ) : (
+                      'Submit my payment details for this event'
+                    )}
+                  </button>
+                  <p className="text-xs text-white/40 mt-2">
+                    Submitting opts you in to receive payment for {partyName}. You'll
+                    only be paid for events you submit for.
+                  </p>
+                  {!methodValid && (
+                    <p className="text-xs text-white/40 mt-1">
+                      Choose a payout method above before submitting.
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div>
+                  <div className="flex items-center gap-2 text-sm text-emerald-500">
+                    <Check size={16} />
+                    <span>
+                      Submitted for {partyName}
+                      {optedInLabel ? ` on ${optedInLabel}` : ''}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleRemoveOptIn}
+                    disabled={optInPending}
+                    className="mt-2 text-xs text-white/50 hover:text-white/80 underline disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {optInPending ? 'Removing…' : "Remove me from this event's payments"}
+                  </button>
+                </div>
+              )}
+              {optInError && (
+                <p className="text-xs text-[#ff393a] mt-2">{optInError}</p>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { CreditCard, Banknote, Coins, Mail, Wallet } from 'lucide-react';
-import { PayoutMethod, BankDetails } from '../../types';
+import { Coins, Wallet } from 'lucide-react';
+import { PayoutMethod } from '../../types';
 import { IconInput } from '../IconInput';
 import { resolveEnsName } from '../../lib/api';
-import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
-import { usePizza } from '../../contexts/PizzaContext';
 
 // taleggio-30219: mirror of backend `looksLikeEnsName` — accepts dotted
 // names like `vitalik.eth` or `alice.cb.id` and rejects 0x… inputs.
@@ -27,44 +25,35 @@ interface PayoutMethodPickerProps {
 
   walletAddress: string;
   onWalletAddressChange: (v: string) => void;
-
-  bankDetails: BankDetails;
-  onBankDetailsChange: (b: BankDetails) => void;
-
-  /** Email shown to user for the Mercury card destination + prefilled for wire. */
-  userEmail?: string;
-  /**
-   * arugula-38633 (follow-up): the host's effective reimbursement cap. Used in
-   * the Mercury copy so the host understands the card has a LIMIT, not a fixed
-   * per-receipt amount. When null, we omit the dollar amount entirely.
-   */
-  reimbursementCapUsd?: number | null;
 }
 
 /**
- * Radio picker for payout method, with method-specific sub-form.
+ * casatiello-58291: USDC-on-Base is now the ONLY host-facing payout method.
+ * Mercury card + Bank wire were removed from this picker (they remain valid
+ * `PayoutMethod` union members so historical payout rows still render in the
+ * admin views). With a single method there's no radio choice to make — we
+ * render a fixed "USDC on Base" header followed by the wallet sub-form.
  *
- *   mercury_card → just a confirmation that we'll email a virtual card
- *   wire         → single email field (our bank emails the host to complete)
- *   usdc_base    → wallet address IconInput
+ *   usdc_base → wallet address IconInput (with live ENS preview)
  */
 export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
   method,
   onMethodChange,
   walletAddress,
   onWalletAddressChange,
-  bankDetails,
-  onBankDetailsChange,
-  userEmail,
-  reimbursementCapUsd,
 }) => {
+  // Ensure the (only) method is selected. The consumer seeds this, but if a
+  // historical row had mercury_card/wire we still surface the USDC sub-form.
+  React.useEffect(() => {
+    if (method !== 'usdc_base') {
+      onMethodChange('usdc_base');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [method]);
+
   // taleggio-30219: debounced ENS preview state for the USDC sub-form.
   const [ensPreview, setEnsPreview] = React.useState<EnsPreviewState>({ kind: 'idle' });
   React.useEffect(() => {
-    if (method !== 'usdc_base') {
-      setEnsPreview({ kind: 'idle' });
-      return;
-    }
     const trimmed = walletAddress.trim();
     if (!trimmed || !looksLikeEnsName(trimmed)) {
       setEnsPreview({ kind: 'idle' });
@@ -85,169 +74,54 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [method, walletAddress]);
-
-  // For wire: prefill the field from the user's auth email if no saved value.
-  // We mirror this into bankDetails on first render of the wire branch so the
-  // auto-save persists it even if the host doesn't touch the field.
-  const wireEmail = bankDetails.email ?? userEmail ?? '';
-  React.useEffect(() => {
-    if (method !== 'wire') return;
-    if (bankDetails.email !== undefined) return; // already set (incl. empty string)
-    if (!userEmail) return;
-    onBankDetailsChange({ ...bankDetails, email: userEmail });
-    // We only want to seed on the first transition into wire mode; deps below
-    // intentionally exclude bankDetails/onBankDetailsChange so we don't loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [method, userEmail]);
-
-  // pepperoni-47301: Mercury card payout is unavailable in sanctioned/restricted
-  // countries. We read the party's country from PizzaContext and gate the
-  // Mercury Option below. Falls back to false when there's no party (e.g.
-  // unlikely render outside an event context).
-  const { party } = usePizza();
-  const mercuryBlocked = isMercuryBlocked(party?.country);
-  const mercuryDisabledReason = mercuryBlocked
-    ? `Mercury cards are unavailable in ${party?.country ?? 'your country'} due to compliance restrictions.`
-    : undefined;
-
-  const Option: React.FC<{
-    value: PayoutMethod;
-    icon: React.ReactNode;
-    title: string;
-    description: string;
-    disabled?: boolean;
-    disabledReason?: string;
-  }> = ({ value, icon, title, description, disabled, disabledReason }) => {
-    const active = method === value;
-    return (
-      <button
-        type="button"
-        disabled={disabled}
-        title={disabled ? disabledReason : undefined}
-        onClick={() => {
-          if (disabled) return;
-          onMethodChange(value);
-        }}
-        className={`w-full text-left rounded-xl border p-4 transition-colors ${
-          disabled
-            ? 'border-theme-stroke bg-theme-surface opacity-60 cursor-not-allowed'
-            : active
-              ? 'border-[#ff393a] bg-[#ff393a]/5'
-              : 'border-theme-stroke bg-theme-surface hover:border-theme-stroke-strong'
-        }`}
-      >
-        <div className="flex items-start gap-3">
-          <div className={`mt-0.5 ${active && !disabled ? 'text-[#ff393a]' : 'text-theme-text-muted'}`}>
-            {icon}
-          </div>
-          <div className="flex-1">
-            <div className="text-sm font-semibold text-theme-text">{title}</div>
-            <div className="text-xs text-theme-text-muted mt-0.5">{description}</div>
-            {disabled && disabledReason && (
-              <div className="text-[10px] text-amber-300 mt-1">{disabledReason}</div>
-            )}
-          </div>
-          <div
-            className={`mt-1 w-4 h-4 rounded-full border-2 flex-shrink-0 ${
-              active && !disabled ? 'border-[#ff393a]' : 'border-theme-stroke'
-            }`}
-          >
-            {active && !disabled && <div className="w-2 h-2 rounded-full bg-[#ff393a] m-0.5" />}
-          </div>
-        </div>
-      </button>
-    );
-  };
+  }, [walletAddress]);
 
   return (
     <div className="space-y-4">
-      <div className="grid sm:grid-cols-3 gap-3">
-        <Option
-          value="usdc_base"
-          icon={<Coins size={18} />}
-          title="USDC on Base"
-          description="Onchain payment to your wallet."
-        />
-        <Option
-          value="mercury_card"
-          icon={<CreditCard size={18} />}
-          title="Mercury virtual card"
-          description="We issue you a debit card for the exact amount."
-          disabled={mercuryBlocked}
-          disabledReason={mercuryDisabledReason}
-        />
-        <Option
-          value="wire"
-          icon={<Banknote size={18} />}
-          title="Bank wire"
-          description="We send a wire to your bank account."
-        />
+      <div className="w-full rounded-xl border border-[#ff393a] bg-[#ff393a]/5 p-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 text-[#ff393a]">
+            <Coins size={18} />
+          </div>
+          <div className="flex-1">
+            <div className="text-sm font-semibold text-theme-text">USDC on Base</div>
+            <div className="text-xs text-theme-text-muted mt-0.5">
+              Onchain payment to your wallet.
+            </div>
+          </div>
+        </div>
       </div>
 
-      {method === 'mercury_card' && (
-        <div className="rounded-xl border border-theme-stroke bg-theme-surface p-4 text-sm text-theme-text-secondary">
-          <p>
-            We'll issue you a Mercury virtual debit card
-            {typeof reimbursementCapUsd === 'number' && reimbursementCapUsd > 0 ? (
-              <>
-                {' '}with a limit of{' '}
-                <span className="text-theme-text font-semibold">${reimbursementCapUsd.toFixed(2)}</span>
-              </>
-            ) : null}
-            .
-          </p>
-        </div>
-      )}
-
-      {method === 'usdc_base' && (
-        <div className="space-y-2">
-          <IconInput
-            icon={Wallet}
-            type="text"
-            placeholder="Your wallet address or ENS name (0x… or alice.eth)"
-            value={walletAddress}
-            onChange={e => onWalletAddressChange(e.target.value)}
-            required
-          />
-          {/* taleggio-30219: live ENS preview. Hidden when the input is 0x or empty. */}
-          {ensPreview.kind === 'resolving' && (
-            <p className="text-xs text-theme-text-muted">
-              Resolving <span className="font-mono">{ensPreview.name}</span>…
-            </p>
-          )}
-          {ensPreview.kind === 'resolved' && (
-            <p className="text-xs text-theme-text-muted">
-              → <span className="font-mono">{ensPreview.address.slice(0, 6)}…{ensPreview.address.slice(-4)}</span>
-            </p>
-          )}
-          {ensPreview.kind === 'error' && (
-            <p className="text-xs text-red-400">
-              Could not resolve "<span className="font-mono">{ensPreview.name}</span>"
-            </p>
-          )}
+      <div className="space-y-2">
+        <IconInput
+          icon={Wallet}
+          type="text"
+          placeholder="Your wallet address or ENS name (0x… or alice.eth)"
+          value={walletAddress}
+          onChange={e => onWalletAddressChange(e.target.value)}
+          required
+        />
+        {/* taleggio-30219: live ENS preview. Hidden when the input is 0x or empty. */}
+        {ensPreview.kind === 'resolving' && (
           <p className="text-xs text-theme-text-muted">
-            USDC on Base ({/* link omitted intentionally */}
-            <span className="font-mono">0x8335…2913</span>). ENS names resolve against Ethereum mainnet. Double-check the resolved address — onchain transfers can't be reversed.
+            Resolving <span className="font-mono">{ensPreview.name}</span>…
           </p>
-        </div>
-      )}
-
-      {method === 'wire' && (
-        <div className="space-y-2">
-          <IconInput
-            icon={Mail}
-            type="email"
-            placeholder="Email for bank correspondence"
-            value={wireEmail}
-            onChange={e => onBankDetailsChange({ ...bankDetails, email: e.target.value })}
-            required
-          />
+        )}
+        {ensPreview.kind === 'resolved' && (
           <p className="text-xs text-theme-text-muted">
-            We'll send you an email from our bank to complete the transaction.
+            → <span className="font-mono">{ensPreview.address.slice(0, 6)}…{ensPreview.address.slice(-4)}</span>
           </p>
-        </div>
-      )}
+        )}
+        {ensPreview.kind === 'error' && (
+          <p className="text-xs text-red-400">
+            Could not resolve "<span className="font-mono">{ensPreview.name}</span>"
+          </p>
+        )}
+        <p className="text-xs text-theme-text-muted">
+          USDC on Base ({/* link omitted intentionally */}
+          <span className="font-mono">0x8335…2913</span>). ENS names resolve against Ethereum mainnet. Double-check the resolved address — onchain transfers can't be reversed.
+        </p>
+      </div>
     </div>
   );
 };

--- a/plans/casatiello-58291-swc-hub-reimbursement.md
+++ b/plans/casatiello-58291-swc-hub-reimbursement.md
@@ -1,0 +1,57 @@
+# casatiello-58291 — USDC-only host payout picker + SWC Hub login for US events
+
+## Scope
+Two reimbursement-flow changes on the HOST-FACING Payments tab (the
+`PaymentDetailsCard` at the top of the Payments tab — NOT the admin `/payments`
+page).
+
+## Change A — USDC-only payout method picker
+File: `frontend/src/components/payouts/PayoutMethodPicker.tsx`
+
+- Removed the "Mercury virtual card" (`mercury_card`) and "Bank wire" (`wire`)
+  radio options and their conditional sub-forms.
+- USDC on Base is now the only method. Since a single radio is pointless, the
+  3-column grid is gone; we render a single full-width "USDC on Base" header
+  card (kept visually selected) followed by the existing wallet `IconInput`,
+  live ENS preview, and helper text.
+- A small effect forces `method` back to `usdc_base` if a historical row had
+  another value, so the wallet sub-form always shows.
+- Removed now-unused imports (`CreditCard`, `Banknote`, `Mail`,
+  `isMercuryBlocked`, `usePizza`, `BankDetails`) and props (`bankDetails`,
+  `onBankDetailsChange`, `userEmail`, `reimbursementCapUsd`). The reduced props
+  are `method`, `onMethodChange`, `walletAddress`, `onWalletAddressChange`.
+- The `PayoutMethod` type in `types.ts` is UNCHANGED — `mercury_card`/`wire`
+  remain valid union members so historical payout rows still render in admin
+  views.
+
+## Change B — US events use the SWC Hub login
+File: `frontend/src/components/payouts/PaymentDetailsCard.tsx`
+
+- Compute `isUS = party?.country === 'United States'` (parties.country is the
+  full English name) and `hasHubTag = (party?.eventTags ?? []).includes('hub')`.
+- When `isUS`: hide the picker and the per-event opt-in submit section, and
+  render a single SWC Hub block instead:
+  - `hasHubTag` → enabled anchor styled like `btn-primary`, linking to
+    `https://www.swchub.org/` (`target="_blank" rel="noopener noreferrer"`),
+    labeled `Login to SWC Hub with {user.email}` (falls back to
+    `Login to SWC Hub` when no email).
+  - not `hasHubTag` → same label as a disabled button
+    (`opacity-50 cursor-not-allowed`) with a "Pending" badge and helper text:
+    "Your event hasn't been added to the SWC Hub yet — check back soon."
+  - The Saving/Saved status indicator is hidden for US events.
+- When NOT `isUS` (non-US flow preserved):
+  - `PayoutMethodPicker` is passed the reduced prop set.
+  - `method` state and `pickerMethod` fallback default to `'usdc_base'` so the
+    debounced autosave persists usdc_base for hosts with no saved method.
+  - `methodValid` simplified to the wallet hex/ENS check only; `buildPayload`
+    always sends `payoutWalletAddress` + `payoutBankDetails: null`. The
+    mercury/wire/EMAIL_REGEX/bankDetails paths were removed.
+  - Per-event opt-in submit flow and debounced autosave to `updateUserMe` are
+    intact.
+- Removed now-dead imports (`isMercuryBlocked`, `BankDetails`, `EMAIL_REGEX`)
+  and the `bankDetails` state + hydration effect.
+
+## Correctness
+- All React hooks remain above any early return (Rules of Hooks); `isUS`/
+  `hasHubTag` are plain derivations, not hooks.
+- `cd frontend && npx tsc --noEmit` → exit 0 (clean).


### PR DESCRIPTION
## Summary
Two reimbursement-flow changes on the HOST-FACING Payments tab (`PaymentDetailsCard`, not the admin `/payments` page).

### Change A — USDC-only host payout method picker
`frontend/src/components/payouts/PayoutMethodPicker.tsx`
- Removed the **Mercury virtual card** (`mercury_card`) and **Bank wire** (`wire`) radio options and their sub-forms.
- USDC on Base is now the only method: dropped the 3-column radio grid in favor of a single full-width "USDC on Base" header card + the existing wallet `IconInput`, live ENS preview, and helper text.
- Reduced props to `method` / `onMethodChange` / `walletAddress` / `onWalletAddressChange`; removed now-unused imports (`CreditCard`, `Banknote`, `Mail`, `isMercuryBlocked`, `usePizza`, `BankDetails`).
- The `PayoutMethod` type is **unchanged** — `mercury_card`/`wire` stay valid union members so historical payout rows still render in admin views.

### Change B — US events: SWC Hub login button
`frontend/src/components/payouts/PaymentDetailsCard.tsx`
- `isUS = party?.country === 'United States'`; `hasHubTag = (party?.eventTags ?? []).includes('hub')`.
- When `isUS`: hide the picker + per-event opt-in section, render an SWC Hub block labeled `Login to SWC Hub with {email}`:
  - `hasHubTag` → enabled `btn-primary` anchor to `https://www.swchub.org/` (`target="_blank" rel="noopener noreferrer"`).
  - otherwise → disabled button (`opacity-50 cursor-not-allowed`) + "Pending" badge + helper text.
- When not `isUS`: picker now USDC-only; `method`/`pickerMethod` default to `usdc_base`; `methodValid`/`buildPayload` simplified (removed wire/mercury/EMAIL_REGEX/bankDetails); per-event opt-in + debounced autosave preserved.

### Verification
- All hooks remain above any early return.
- `cd frontend && npx tsc --noEmit` → exit 0 (clean).

**Vercel preview:** https://rsvpizza-git-casatiello-58291-swc-hub-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)