### PR TITLE
feat(mortadella-92107): auto-suggest US tax treaty values by country

### DIFF
--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { Building2, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle } from 'lucide-react';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Building2, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle, Info } from 'lucide-react';
 import { IconInput } from '../../IconInput';
 import { Checkbox } from '../../Checkbox';
+import { lookupTreaty, normalizeCountryCode } from '../../../utils/taxTreaties';
 
 export type W8BENEEntityType =
   | 'corporation'
@@ -34,6 +35,17 @@ export interface W8BENEFormData {
   giin?: string;
   foreignTin?: string;
   referenceNumbers?: string;
+  // Part III — Claim of Tax Treaty Benefits
+  treatyCountry?: string;
+  articleParagraph?: string;
+  withholdingRate?: string;
+  incomeType?: string;
+  treatyExplanation?: string;
+  /**
+   * mortadella-92107: tracks the country we last auto-filled treaty values
+   * for so host edits aren't overwritten on re-render or draft reload.
+   */
+  treatyAutoFilledFor?: string;
   certify?: boolean;
   signature?: string;
   signerCapacity?: string;
@@ -67,6 +79,49 @@ const CHAPTER4: Array<{ value: W8BENEChapter4Status; label: string; hint?: strin
 ];
 
 export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disabled }) => {
+  // ----- hooks (declared above any early returns per react-hooks rules) -----
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  // Default the treaty-claim country to the entity's country of incorporation
+  // (most common case for an entity claiming treaty benefits). Host can edit.
+  const treatyKey = (value.treatyCountry?.trim() || value.countryOfIncorporation?.trim() || '').trim();
+  const treatyEntry = useMemo(() => lookupTreaty(treatyKey), [treatyKey]);
+  const treatyCode = useMemo(() => normalizeCountryCode(treatyKey), [treatyKey]);
+
+  useEffect(() => {
+    if (disabled) return;
+    if (!treatyKey) return;
+    const cacheKey = treatyCode || treatyKey.toLowerCase();
+    const v = valueRef.current;
+    if (v.treatyAutoFilledFor === cacheKey) return;
+    if (!treatyEntry) {
+      onChangeRef.current({ ...v, treatyAutoFilledFor: cacheKey });
+      return;
+    }
+    if (!treatyEntry.hasTreaty) {
+      onChangeRef.current({
+        ...v,
+        treatyCountry: v.treatyCountry ?? v.countryOfIncorporation ?? '',
+        articleParagraph: '',
+        withholdingRate: '',
+        incomeType: '',
+        treatyAutoFilledFor: cacheKey,
+      });
+      return;
+    }
+    onChangeRef.current({
+      ...v,
+      treatyCountry: v.treatyCountry || v.countryOfIncorporation || '',
+      articleParagraph: treatyEntry.article ?? '',
+      withholdingRate: String(treatyEntry.otherIncomeRate),
+      incomeType: 'Other income',
+      treatyAutoFilledFor: cacheKey,
+    });
+  }, [treatyKey, treatyCode, treatyEntry, disabled]);
+
   const set = <K extends keyof W8BENEFormData>(key: K, v: W8BENEFormData[K]) =>
     onChange({ ...value, [key]: v });
 
@@ -89,7 +144,11 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
           type="text"
           placeholder="Country of incorporation"
           value={value.countryOfIncorporation ?? ''}
-          onChange={(e) => set('countryOfIncorporation', e.target.value)}
+          onChange={(e) => {
+            // Resetting the cache lets the treaty effect re-evaluate when the
+            // host changes the country (unless they've manually set treatyCountry).
+            onChange({ ...value, countryOfIncorporation: e.target.value, treatyAutoFilledFor: undefined });
+          }}
           disabled={disabled}
           required
         />
@@ -255,6 +314,82 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
           placeholder="Reference number(s)"
           value={value.referenceNumbers ?? ''}
           onChange={(e) => set('referenceNumbers', e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      {/* Part III — Claim of Tax Treaty Benefits */}
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-muted">Part III — Claim of tax treaty benefits (optional)</p>
+        <p className="text-[11px] text-theme-text-muted/80 leading-relaxed">
+          This is general guidance based on IRS Publication 901, not tax advice. Consult a tax
+          professional if you're unsure.
+        </p>
+        <IconInput
+          icon={Globe}
+          type="text"
+          placeholder="Country for tax treaty claim"
+          value={value.treatyCountry ?? ''}
+          onChange={(e) =>
+            onChange({ ...value, treatyCountry: e.target.value, treatyAutoFilledFor: undefined })
+          }
+          disabled={disabled}
+        />
+        {treatyKey && treatyEntry?.hasTreaty && (
+          <div className="flex items-start gap-1.5 text-[11px] text-theme-text-muted">
+            <Info size={12} className="mt-0.5 flex-shrink-0" />
+            <span>
+              Auto-filled based on {treatyKey}'s US tax treaty (Other income at{' '}
+              {treatyEntry.otherIncomeRate}% under {treatyEntry.article}). Edit if needed.
+              {treatyEntry.notes ? ` ${treatyEntry.notes}` : ''}
+            </span>
+          </div>
+        )}
+        {treatyKey && treatyEntry && !treatyEntry.hasTreaty && (
+          <div className="card p-2.5 border-l-4 border-l-amber-500 bg-amber-500/10">
+            <div className="flex items-start gap-2 text-[11px] text-amber-100">
+              <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
+              <span>
+                No US tax treaty in force with {treatyKey} — leave the treaty fields blank; default
+                30% withholding applies if classified as US-source income.
+                {treatyEntry.notes ? ` ${treatyEntry.notes}` : ''}
+              </span>
+            </div>
+          </div>
+        )}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <IconInput
+            icon={Hash}
+            type="text"
+            placeholder="Article + paragraph"
+            value={value.articleParagraph ?? ''}
+            onChange={(e) => set('articleParagraph', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={Hash}
+            type="text"
+            placeholder="Withholding rate (%)"
+            value={value.withholdingRate ?? ''}
+            onChange={(e) => set('withholdingRate', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={Hash}
+            type="text"
+            placeholder="Type of income"
+            value={value.incomeType ?? ''}
+            onChange={(e) => set('incomeType', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+        <IconInput
+          icon={Hash}
+          multiline
+          rows={2}
+          placeholder="Explanation for treaty claim (optional)"
+          value={value.treatyExplanation ?? ''}
+          onChange={(e) => set('treatyExplanation', e.target.value)}
           disabled={disabled}
         />
       </div>

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { User, Globe, MapPin, Hash, FileSignature, CalendarDays } from 'lucide-react';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { User, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle, Info } from 'lucide-react';
 import { IconInput } from '../../IconInput';
 import { Checkbox } from '../../Checkbox';
+import { lookupTreaty, normalizeCountryCode } from '../../../utils/taxTreaties';
 
 export interface W8BENFormData {
   name?: string;
@@ -21,6 +22,12 @@ export interface W8BENFormData {
   withholdingRate?: string;
   incomeType?: string;
   treatyExplanation?: string;
+  /**
+   * mortadella-92107: tracks the last country we ran auto-fill against so we
+   * don't re-overwrite host edits after the host typed over a suggested value.
+   * Stored in the saved form data so draft round-trips behave the same.
+   */
+  treatyAutoFilledFor?: string;
   certify?: boolean;
   signature?: string;
   date?: string;
@@ -33,8 +40,62 @@ interface W8BENFormProps {
 }
 
 export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled }) => {
+  // ----- hooks (must stay above any early returns per react-hooks rules) -----
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  // The treaty-claim country defaults to permanentCountry (typical case:
+  // host is claiming benefits under their country of residence's treaty).
+  // We watch that field and auto-suggest article + rate + income type.
+  const treatyKey = (value.treatyCountry?.trim() || value.permanentCountry?.trim() || '').trim();
+  const treatyEntry = useMemo(() => lookupTreaty(treatyKey), [treatyKey]);
+  const treatyCode = useMemo(() => normalizeCountryCode(treatyKey), [treatyKey]);
+
+  useEffect(() => {
+    if (disabled) return;
+    if (!treatyKey) return;
+    // Identify the country canonically (ISO-2) so retyping the same country
+    // in a different form doesn't re-trigger auto-fill.
+    const cacheKey = treatyCode || treatyKey.toLowerCase();
+    const v = valueRef.current;
+    if (v.treatyAutoFilledFor === cacheKey) return;
+    if (!treatyEntry) {
+      // Unknown country — mark cache so we don't loop, but don't touch fields.
+      onChangeRef.current({ ...v, treatyAutoFilledFor: cacheKey });
+      return;
+    }
+    if (!treatyEntry.hasTreaty) {
+      // No treaty — clear any auto-filled values; surface the amber note via render.
+      onChangeRef.current({
+        ...v,
+        treatyCountry: v.treatyCountry ?? v.permanentCountry ?? '',
+        articleParagraph: '',
+        withholdingRate: '',
+        incomeType: '',
+        treatyAutoFilledFor: cacheKey,
+      });
+      return;
+    }
+    onChangeRef.current({
+      ...v,
+      treatyCountry: v.treatyCountry || v.permanentCountry || '',
+      articleParagraph: treatyEntry.article ?? '',
+      withholdingRate: String(treatyEntry.otherIncomeRate),
+      incomeType: 'Other income',
+      treatyAutoFilledFor: cacheKey,
+    });
+  }, [treatyKey, treatyCode, treatyEntry, disabled]);
+
   const set = <K extends keyof W8BENFormData>(key: K, v: W8BENFormData[K]) =>
     onChange({ ...value, [key]: v });
+
+  // When the host edits the treaty-claim country directly, reset the cache so
+  // the effect re-runs against the new country.
+  const setTreatyCountry = (v: string) => {
+    onChange({ ...value, treatyCountry: v, treatyAutoFilledFor: undefined });
+  };
 
   return (
     <div className="space-y-4">
@@ -83,7 +144,11 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
             type="text"
             placeholder="Country"
             value={value.permanentCountry ?? ''}
-            onChange={(e) => set('permanentCountry', e.target.value)}
+            onChange={(e) => {
+              // Clearing the cache lets the effect re-evaluate against the
+              // new country if treatyCountry hasn't been overridden.
+              onChange({ ...value, permanentCountry: e.target.value, treatyAutoFilledFor: undefined });
+            }}
             disabled={disabled}
             required
           />
@@ -161,14 +226,40 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
 
       <div className="space-y-2">
         <p className="text-xs text-theme-text-muted">Tax treaty claim (optional)</p>
+        <p className="text-[11px] text-theme-text-muted/80 leading-relaxed">
+          This is general guidance based on IRS Publication 901, not tax advice. Consult a tax
+          professional if you're unsure.
+        </p>
         <IconInput
           icon={Globe}
           type="text"
           placeholder="Country for tax treaty claim"
           value={value.treatyCountry ?? ''}
-          onChange={(e) => set('treatyCountry', e.target.value)}
+          onChange={(e) => setTreatyCountry(e.target.value)}
           disabled={disabled}
         />
+        {treatyKey && treatyEntry?.hasTreaty && (
+          <div className="flex items-start gap-1.5 text-[11px] text-theme-text-muted">
+            <Info size={12} className="mt-0.5 flex-shrink-0" />
+            <span>
+              Auto-filled based on {treatyKey}'s US tax treaty (Other income at{' '}
+              {treatyEntry.otherIncomeRate}% under {treatyEntry.article}). Edit if needed.
+              {treatyEntry.notes ? ` ${treatyEntry.notes}` : ''}
+            </span>
+          </div>
+        )}
+        {treatyKey && treatyEntry && !treatyEntry.hasTreaty && (
+          <div className="card p-2.5 border-l-4 border-l-amber-500 bg-amber-500/10">
+            <div className="flex items-start gap-2 text-[11px] text-amber-100">
+              <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
+              <span>
+                No US tax treaty in force with {treatyKey} — leave the treaty fields blank; default
+                30% withholding applies if classified as US-source income.
+                {treatyEntry.notes ? ` ${treatyEntry.notes}` : ''}
+              </span>
+            </div>
+          </div>
+        )}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <IconInput
             icon={Hash}

--- a/frontend/src/utils/taxTreaties.ts
+++ b/frontend/src/utils/taxTreaties.ts
@@ -1,0 +1,310 @@
+/**
+ * mortadella-92107: Static IRS Publication 901-derived map of foreign
+ * countries to their US income-tax treaty status, used to auto-suggest
+ * Part II (W-8BEN) / Part III (W-8BEN-E) treaty-claim values when a host
+ * picks their country of residence.
+ *
+ * Values cover the "Other income" article (typically Article 21/22 — the
+ * residual category that catches PizzaDAO honoraria/reimbursement-style
+ * payments to foreign hosts with no US permanent establishment). The
+ * rate is the reduced withholding rate; for most countries with a treaty
+ * the rate is 0%.
+ *
+ * This is general guidance, not tax advice. Hosts can override every
+ * auto-filled field. Treaty entries reflect treaties in force as of
+ * the IRS Publication 901 (Rev. 2024) tables.
+ */
+
+export type TaxTreatyEntry = {
+  /** True if a US income-tax treaty is in force with this country. */
+  hasTreaty: boolean;
+  /** Treaty article that covers "Other income" (e.g. "Article 21"). */
+  article?: string;
+  /** Reduced withholding % on "Other income" with no US permanent establishment. */
+  otherIncomeRate: number;
+  /** Optional human-readable note shown next to the auto-fill suggestion. */
+  notes?: string;
+};
+
+/**
+ * Keyed by ISO 3166-1 alpha-2 country code. Use `lookupTreaty(country)`
+ * to resolve either a code or a full English country name.
+ */
+export const TAX_TREATY_DATA: Record<string, TaxTreatyEntry> = {
+  // Europe — treaty countries (0% on Other Income, no US PE)
+  GB: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  IE: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  FR: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  DE: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  NL: { hasTreaty: true, article: 'Article 23', otherIncomeRate: 0 },
+  BE: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  ES: { hasTreaty: true, article: 'Article 23', otherIncomeRate: 0 },
+  IT: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  CH: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  AT: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  SE: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  NO: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  DK: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  FI: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  IS: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  CZ: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  SK: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  SI: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  PL: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  HU: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  BG: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  RO: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  LV: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  LT: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  EE: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  LU: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  GR: { hasTreaty: true, article: 'Article XIV', otherIncomeRate: 0 },
+  TR: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  RU: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0, notes: 'US-Russia treaty status is subject to ongoing review — verify before relying on it.' },
+  UA: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  CY: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  MT: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+
+  // Americas — treaty countries
+  CA: { hasTreaty: true, article: 'Article XXII', otherIncomeRate: 0 },
+  MX: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  TT: { hasTreaty: true, article: 'Article 26', otherIncomeRate: 0 },
+  JM: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  BB: { hasTreaty: true, article: 'Article 23', otherIncomeRate: 0 },
+  VE: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+
+  // Asia / Oceania — treaty countries
+  AU: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  NZ: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  JP: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  KR: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  IN: { hasTreaty: true, article: 'Article 23', otherIncomeRate: 0 },
+  PH: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  ID: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  TH: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  CN: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0, notes: 'PRC mainland only — Hong Kong and Taiwan do not share this treaty.' },
+  LK: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  BD: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  IL: { hasTreaty: true, article: 'Article 27', otherIncomeRate: 0 },
+
+  // Africa — treaty countries
+  ZA: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+  EG: { hasTreaty: true, article: 'Article 24', otherIncomeRate: 0 },
+  MA: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  TN: { hasTreaty: true, article: 'Article 22', otherIncomeRate: 0 },
+  KZ: { hasTreaty: true, article: 'Article 21', otherIncomeRate: 0 },
+
+  // No US treaty in force — leave blank, default 30% withholding applies
+  BR: { hasTreaty: false, otherIncomeRate: 30 },
+  AR: { hasTreaty: false, otherIncomeRate: 30 },
+  CL: { hasTreaty: false, otherIncomeRate: 30 },
+  PE: { hasTreaty: false, otherIncomeRate: 30, notes: 'A US-Peru treaty has been negotiated but is not in force.' },
+  CO: { hasTreaty: false, otherIncomeRate: 30 },
+  UY: { hasTreaty: false, otherIncomeRate: 30 },
+  BO: { hasTreaty: false, otherIncomeRate: 30 },
+  PY: { hasTreaty: false, otherIncomeRate: 30 },
+  EC: { hasTreaty: false, otherIncomeRate: 30 },
+  CR: { hasTreaty: false, otherIncomeRate: 30 },
+  PA: { hasTreaty: false, otherIncomeRate: 30 },
+  GT: { hasTreaty: false, otherIncomeRate: 30 },
+  HN: { hasTreaty: false, otherIncomeRate: 30 },
+  NI: { hasTreaty: false, otherIncomeRate: 30 },
+  SV: { hasTreaty: false, otherIncomeRate: 30 },
+  DO: { hasTreaty: false, otherIncomeRate: 30 },
+
+  NG: { hasTreaty: false, otherIncomeRate: 30 },
+  GH: { hasTreaty: false, otherIncomeRate: 30 },
+  KE: { hasTreaty: false, otherIncomeRate: 30 },
+  UG: { hasTreaty: false, otherIncomeRate: 30 },
+  TZ: { hasTreaty: false, otherIncomeRate: 30 },
+  ET: { hasTreaty: false, otherIncomeRate: 30 },
+  DZ: { hasTreaty: false, otherIncomeRate: 30 },
+  BW: { hasTreaty: false, otherIncomeRate: 30 },
+  CI: { hasTreaty: false, otherIncomeRate: 30 },
+  SN: { hasTreaty: false, otherIncomeRate: 30 },
+  CM: { hasTreaty: false, otherIncomeRate: 30 },
+  GA: { hasTreaty: false, otherIncomeRate: 30 },
+  TD: { hasTreaty: false, otherIncomeRate: 30 },
+  ML: { hasTreaty: false, otherIncomeRate: 30 },
+  BF: { hasTreaty: false, otherIncomeRate: 30 },
+  NE: { hasTreaty: false, otherIncomeRate: 30 },
+  TG: { hasTreaty: false, otherIncomeRate: 30 },
+  BJ: { hasTreaty: false, otherIncomeRate: 30 },
+  MW: { hasTreaty: false, otherIncomeRate: 30 },
+  ZW: { hasTreaty: false, otherIncomeRate: 30 },
+  ZM: { hasTreaty: false, otherIncomeRate: 30 },
+
+  VN: { hasTreaty: false, otherIncomeRate: 30 },
+  KH: { hasTreaty: false, otherIncomeRate: 30 },
+  LA: { hasTreaty: false, otherIncomeRate: 30 },
+  MM: { hasTreaty: false, otherIncomeRate: 30 },
+  MN: { hasTreaty: false, otherIncomeRate: 30 },
+  HK: { hasTreaty: false, otherIncomeRate: 30, notes: 'Hong Kong is not covered by the US-China treaty.' },
+  TW: { hasTreaty: false, otherIncomeRate: 30, notes: 'Taiwan is not covered by the US-China treaty.' },
+
+  SA: { hasTreaty: false, otherIncomeRate: 30, notes: 'No general income-tax treaty; limited treaty covers shipping/air only.' },
+  AE: { hasTreaty: false, otherIncomeRate: 30, notes: 'No general income-tax treaty; limited treaty covers shipping/air only.' },
+  LB: { hasTreaty: false, otherIncomeRate: 30 },
+};
+
+// -------- Country-name → ISO-2 normalisation --------
+
+/**
+ * Pulled from `countryFlag.NAME_TO_CODE` minimal subset for the treaty-mapped
+ * countries — kept inline so this module is dependency-free and can be unit
+ * tested in isolation. `lookupTreaty` falls through to a case-insensitive
+ * direct match against this map.
+ */
+const NAME_TO_CODE: Record<string, string> = {
+  // Europe
+  'united kingdom': 'GB', 'uk': 'GB', 'great britain': 'GB', 'england': 'GB',
+  'scotland': 'GB', 'wales': 'GB', 'northern ireland': 'GB',
+  'ireland': 'IE', 'éire': 'IE', 'eire': 'IE',
+  'france': 'FR',
+  'germany': 'DE', 'deutschland': 'DE',
+  'netherlands': 'NL', 'the netherlands': 'NL', 'holland': 'NL',
+  'belgium': 'BE',
+  'spain': 'ES', 'españa': 'ES', 'espana': 'ES',
+  'italy': 'IT', 'italia': 'IT',
+  'switzerland': 'CH', 'schweiz': 'CH', 'suisse': 'CH', 'svizzera': 'CH',
+  'austria': 'AT', 'österreich': 'AT', 'osterreich': 'AT',
+  'sweden': 'SE', 'sverige': 'SE',
+  'norway': 'NO', 'norge': 'NO',
+  'denmark': 'DK', 'danmark': 'DK',
+  'finland': 'FI', 'suomi': 'FI',
+  'iceland': 'IS', 'ísland': 'IS', 'island': 'IS',
+  'czech republic': 'CZ', 'czechia': 'CZ', 'česko': 'CZ', 'cesko': 'CZ',
+  'slovakia': 'SK', 'slovak republic': 'SK',
+  'slovenia': 'SI',
+  'poland': 'PL', 'polska': 'PL',
+  'hungary': 'HU', 'magyarország': 'HU',
+  'bulgaria': 'BG',
+  'romania': 'RO',
+  'latvia': 'LV',
+  'lithuania': 'LT',
+  'estonia': 'EE',
+  'luxembourg': 'LU',
+  'greece': 'GR',
+  'turkey': 'TR', 'türkiye': 'TR', 'turkiye': 'TR',
+  'russia': 'RU', 'russian federation': 'RU',
+  'ukraine': 'UA',
+  'cyprus': 'CY',
+  'malta': 'MT',
+
+  // Americas
+  'canada': 'CA',
+  'mexico': 'MX', 'méxico': 'MX',
+  'trinidad and tobago': 'TT',
+  'jamaica': 'JM',
+  'barbados': 'BB',
+  'venezuela': 'VE',
+  'brazil': 'BR', 'brasil': 'BR',
+  'argentina': 'AR',
+  'chile': 'CL',
+  'peru': 'PE', 'perú': 'PE',
+  'colombia': 'CO',
+  'uruguay': 'UY',
+  'bolivia': 'BO',
+  'paraguay': 'PY',
+  'ecuador': 'EC',
+  'costa rica': 'CR',
+  'panama': 'PA', 'panamá': 'PA',
+  'guatemala': 'GT',
+  'honduras': 'HN',
+  'nicaragua': 'NI',
+  'el salvador': 'SV',
+  'dominican republic': 'DO',
+
+  // Asia / Oceania
+  'australia': 'AU',
+  'new zealand': 'NZ',
+  'japan': 'JP', '日本': 'JP',
+  'south korea': 'KR', 'korea, republic of': 'KR', 'republic of korea': 'KR', 'korea': 'KR',
+  'india': 'IN',
+  'philippines': 'PH',
+  'indonesia': 'ID',
+  'thailand': 'TH',
+  'china': 'CN', "people's republic of china": 'CN', 'prc': 'CN',
+  'sri lanka': 'LK',
+  'bangladesh': 'BD',
+  'israel': 'IL',
+  'vietnam': 'VN', 'viet nam': 'VN',
+  'cambodia': 'KH',
+  'laos': 'LA', "lao people's democratic republic": 'LA',
+  'myanmar': 'MM', 'burma': 'MM',
+  'mongolia': 'MN',
+  'hong kong': 'HK',
+  'taiwan': 'TW',
+  'saudi arabia': 'SA',
+  'united arab emirates': 'AE', 'uae': 'AE',
+  'lebanon': 'LB',
+
+  // Africa
+  'south africa': 'ZA',
+  'egypt': 'EG',
+  'morocco': 'MA',
+  'tunisia': 'TN',
+  'kazakhstan': 'KZ',
+  'nigeria': 'NG',
+  'ghana': 'GH',
+  'kenya': 'KE',
+  'uganda': 'UG',
+  'tanzania': 'TZ',
+  'ethiopia': 'ET',
+  'algeria': 'DZ',
+  'botswana': 'BW',
+  "côte d'ivoire": 'CI', "cote d'ivoire": 'CI', 'ivory coast': 'CI',
+  'senegal': 'SN',
+  'cameroon': 'CM',
+  'gabon': 'GA',
+  'chad': 'TD',
+  'mali': 'ML',
+  'burkina faso': 'BF',
+  'niger': 'NE',
+  'togo': 'TG',
+  'benin': 'BJ',
+  'malawi': 'MW',
+  'zimbabwe': 'ZW',
+  'zambia': 'ZM',
+};
+
+/**
+ * Resolve a free-text country value (full English name, native variant, or
+ * ISO-2 code) to an entry in `TAX_TREATY_DATA`. Returns `null` if the input
+ * is empty or doesn't match any known country.
+ */
+export function lookupTreaty(country: string | undefined | null): TaxTreatyEntry | null {
+  if (!country) return null;
+  const raw = country.trim();
+  if (!raw) return null;
+
+  // Direct ISO-2 match (case-insensitive)
+  const upper = raw.toUpperCase();
+  if (upper.length === 2 && TAX_TREATY_DATA[upper]) {
+    return TAX_TREATY_DATA[upper];
+  }
+
+  // Name-based normalisation
+  const lower = raw.toLowerCase();
+  const code = NAME_TO_CODE[lower];
+  if (code && TAX_TREATY_DATA[code]) {
+    return TAX_TREATY_DATA[code];
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a country to its canonical ISO-2 code (no treaty lookup). Used by
+ * the form to detect whether a typed/selected country is one we recognise at
+ * all (vs. an arbitrary free-text string we can't map).
+ */
+export function normalizeCountryCode(country: string | undefined | null): string | null {
+  if (!country) return null;
+  const raw = country.trim();
+  if (!raw) return null;
+  const upper = raw.toUpperCase();
+  if (upper.length === 2 && TAX_TREATY_DATA[upper]) return upper;
+  const lower = raw.toLowerCase();
+  return NAME_TO_CODE[lower] || null;
+}


### PR DESCRIPTION
## Summary

- **W-8BEN Part II / W-8BEN-E Part III** treaty-claim fields now auto-fill based on the host's country of residence (or country of incorporation, for entities). Picks Article + 0% Other Income for the ~50 countries with a US treaty in force, surfaces an amber "no treaty" warning for the rest.
- **New static map** at `frontend/src/utils/taxTreaties.ts` keyed by ISO-2 code with a built-in name normaliser (handles full English name, common aliases, native variants).
- **Auto-fill is suggestion only** — every field stays editable, and a tracker (`treatyAutoFilledFor`) prevents re-overwriting after host edits or draft reloads.
- **Disclaimer** noting this is IRS Pub 901 guidance, not tax advice.

## Why

Today the treaty fields are blank free-text inputs — host has to know IRS treaty articles + rates. For most PizzaDAO foreign-host payments, the answer is the same (Article 21/22, Other income, 0%) so we can default that sensibly and let the host override.

## Notes

- Frontend-only. No schema, no backend, no PDF generator changes — existing field names (`treatyCountry`, `articleParagraph`, `withholdingRate`, `incomeType`, `treatyExplanation`) flow through `saveTaxFormDraft` and `submitTaxForm` unchanged.
- W-8BEN-E previously had no treaty section in the form data; Part III fields are added to `W8BENEFormData` and rendered. PDF generator already skips Parts II-XXVIII; values are saved with the draft but not rendered to PDF yet (out of scope).

## Test plan

- [ ] `cd frontend && npx tsc --noEmit` clean (verified locally).
- [ ] On preview: open Payouts > Tax form > W-8BEN, type "United Kingdom" as permanent country -> treaty fields auto-fill "Article 22 / 0 / Other income".
- [ ] Type "Brazil" -> amber "No US tax treaty in force" note appears; treaty fields stay blank.
- [ ] Override an auto-filled value (e.g. set rate to 5) -> value persists through draft save + reload + submit.
- [ ] Switch to W-8BEN-E, repeat with country of incorporation = "Germany" -> Part III auto-fills "Article 21 / 0 / Other income".

Closes mortadella-92107.

Generated with [Claude Code](https://claude.com/claude-code)