### PR TITLE
feat(cipolla-92140): underboss Receipt + Payment-info filter pills

### DIFF
--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -65,6 +65,14 @@ function computeProgress(party: any, underbossEmails: string[] = []) {
     hasSocialPosts: !!(party.xPostUrl || party.farcasterPostUrl),
     hasThrown: eventPassed && checkedInCount > 0,
     hasEstimatedAttendance: party.estimatedAttendance != null,
+    hasSubmittedReceipt:
+      Array.isArray(party.payouts) &&
+      party.payouts.some((p: any) =>
+        Array.isArray(p.documents) &&
+        p.documents.some((d: any) => d.kind === 'receipt')),
+    hasSubmittedPaymentInfo:
+      Array.isArray(party.payouts) &&
+      party.payouts.some((p: any) => p.payoutMethod != null),
   };
 }
 
@@ -824,6 +832,12 @@ router.get('/:region', requireAuth, requireUnderbossAuth, async (req: UnderbossR
         },
         partyKit: { select: { status: true } },
         sponsors: { select: { status: true, amount: true } },
+        payouts: {
+          select: {
+            payoutMethod: true,
+            documents: { select: { kind: true } },
+          },
+        },
         _count: {
           select: {
             guests: true,
@@ -924,6 +938,12 @@ router.get('/:region/events', requireAuth, requireUnderbossAuth, async (req: Und
           },
           partyKit: { select: { status: true } },
           sponsors: { select: { status: true, amount: true } },
+          payouts: {
+            select: {
+              payoutMethod: true,
+              documents: { select: { kind: true } },
+            },
+          },
           _count: {
             select: {
               guests: true,
@@ -1011,6 +1031,12 @@ router.get('/:region/events/:partyId', requireAuth, requireUnderbossAuth, async 
         sponsors: {
           select: { id: true, name: true, status: true, amount: true, sponsorshipType: true },
           orderBy: { createdAt: 'desc' },
+        },
+        payouts: {
+          select: {
+            payoutMethod: true,
+            documents: { select: { kind: true } },
+          },
         },
         budgetItems: {
           // provolone-58931: exclude soft-deleted budget items from the UB detail view.

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -37,6 +37,8 @@ const PROGRESS_FILTER_KEYS: { key: keyof UnderbossEventProgress; labelKey: strin
   { key: 'hasSocialPosts', labelKey: 'progress.social' },
   { key: 'hasThrown', labelKey: 'progress.thrown' },
   { key: 'hasEstimatedAttendance', labelKey: 'progress.estimate' },
+  { key: 'hasSubmittedReceipt', labelKey: 'progress.receipt' },
+  { key: 'hasSubmittedPaymentInfo', labelKey: 'progress.payment' },
 ];
 
 function countProgress(event: UnderbossEvent): number {

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -36,7 +36,9 @@
     "partners": "Partner",
     "social": "Social",
     "thrown": "Durchgeführt",
-    "estimate": "Schätzung"
+    "estimate": "Schätzung",
+    "receipt": "Beleg",
+    "payment": "Zahlungsdaten"
   },
   "eventCard": {
     "hostedBy": "Veranstaltet von {{name}}",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -36,7 +36,9 @@
     "partners": "Partners",
     "social": "Social",
     "thrown": "Thrown",
-    "estimate": "Estimate"
+    "estimate": "Estimate",
+    "receipt": "Receipt",
+    "payment": "Payment info"
   },
   "eventCard": {
     "hostedBy": "Hosted by {{name}}",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -36,7 +36,9 @@
     "partners": "Socios",
     "social": "Social",
     "thrown": "Realizado",
-    "estimate": "Estimación"
+    "estimate": "Estimación",
+    "receipt": "Recibo",
+    "payment": "Datos de pago"
   },
   "eventCard": {
     "hostedBy": "Organizado por {{name}}",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -36,7 +36,9 @@
     "partners": "Partenaires",
     "social": "Réseaux",
     "thrown": "Réalisé",
-    "estimate": "Estimation"
+    "estimate": "Estimation",
+    "receipt": "Reçu",
+    "payment": "Infos paiement"
   },
   "eventCard": {
     "hostedBy": "Organisé par {{name}}",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -36,7 +36,9 @@
     "partners": "パートナー",
     "social": "ソーシャル",
     "thrown": "開催済み",
-    "estimate": "予想人数"
+    "estimate": "予想人数",
+    "receipt": "領収書",
+    "payment": "支払情報"
   },
   "eventCard": {
     "hostedBy": "主催：{{name}}",

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -36,7 +36,9 @@
     "partners": "파트너",
     "social": "소셜",
     "thrown": "개최됨",
-    "estimate": "예상 인원"
+    "estimate": "예상 인원",
+    "receipt": "영수증",
+    "payment": "결제 정보"
   },
   "eventCard": {
     "hostedBy": "{{name}} 주최",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -36,7 +36,9 @@
     "partners": "Parceiros",
     "social": "Social",
     "thrown": "Realizado",
-    "estimate": "Estimativa"
+    "estimate": "Estimativa",
+    "receipt": "Recibo",
+    "payment": "Dados de pagamento"
   },
   "eventCard": {
     "hostedBy": "Organizado por {{name}}",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -36,7 +36,9 @@
     "partners": "合作伙伴",
     "social": "社交",
     "thrown": "已举办",
-    "estimate": "预估人数"
+    "estimate": "预估人数",
+    "receipt": "收据",
+    "payment": "付款信息"
   },
   "eventCard": {
     "hostedBy": "由 {{name}} 主办",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1116,6 +1116,8 @@ export interface UnderbossEventProgress {
   hasSocialPosts: boolean;
   hasThrown: boolean;
   hasEstimatedAttendance: boolean;
+  hasSubmittedReceipt: boolean;
+  hasSubmittedPaymentInfo: boolean;
 }
 
 export interface UnderbossEvent {


### PR DESCRIPTION
Adds two three-state filter pills to the `/underboss` EventTable:

- **Receipt** — party has a payout with a `receipt` document (`payout_documents.kind = 'receipt'`)
- **Payment info** — party has a payout with a payout method set (`payouts.payout_method` non-null)

## Changes
- **Backend** (`underboss.routes.ts`): `computeProgress` gains `hasSubmittedReceipt` + `hasSubmittedPaymentInfo`, computed defensively from `party.payouts`. The three `party.findMany`/`findFirst` queries that feed `formatEvent`/`computeProgress` (dashboard, paginated events, single-event detail) each gain a lightweight `payouts: { select: { payoutMethod, documents: { select: { kind } } } }` include. `computeStats` is untouched.
- **Frontend**: extends `UnderbossEventProgress` (types.ts), adds the two entries to `PROGRESS_FILTER_KEYS` (EventTable.tsx), and adds `progress.receipt` + `progress.payment` to the progress i18n block in all 8 locales.

## No DB migration
Reads only existing tables/columns (`payouts`, `payout_documents.kind`, `payouts.payout_method`). No schema change, no SQL.

## Preview caveat
Frontend previews talk to the **production backend**, which only deploys from `master`. Until this merges and the backend redeploys, `hasSubmittedReceipt`/`hasSubmittedPaymentInfo` will be absent from the API response and both pills will read all-false on the preview URL. They light up once master ships.

## Verification
- `frontend` `npx tsc --noEmit`: clean.
- `backend` `npx tsc --noEmit`: no new errors from this change. Pre-existing baseline errors (missing `openai`/`@anthropic-ai/sdk` modules in this worktree, `donation.routes.ts` Prisma-client drift from the diavola-49622 tip) are identical with and without this diff.
- All 8 `partner.json` files validated as parseable JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)