### PR TITLE
feat(marinara-71630): private-config loader + seed scaffolding (P0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ dist-ssr
 backend/prisma/*.db
 backend/prisma/migrations/*.sql
 
+# Private config — real values seeded to app_config, never committed (marinara-71630)
+backend/src/config/seed.private.json
+
 .vercel
 .env*.local
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest",
     "nft:backfill": "tsx scripts/backfill-nft-mints.ts",
     "email:backfill": "tsx scripts/backfill-email-status.ts",
+    "seed:private-config": "tsx src/config/seedPrivateConfig.ts",
     "check:schema-drift": "node ../scripts/check-schema-drift.js"
   },
   "dependencies": {

--- a/backend/src/config/seed.example.json
+++ b/backend/src/config/seed.example.json
@@ -1,0 +1,41 @@
+{
+  "_readme": "marinara-71630 P0 private-config seed template. These are NON-SENSITIVE PLACEHOLDER values that only document the SHAPE of each app_config entry. To seed real values: (1) copy this file to seed.private.json (gitignored), (2) fill in the real production values, (3) run `npm run seed:private-config` from the backend dir. If seed.private.json is absent the runner falls back to THIS file and seeds placeholders (with a loud warning). Keys map 1:1 to app_config rows; each value is stored JSON-stringified in the `value` column.",
+
+  "private.reimbursement_rules": {
+    "methods": [
+      { "id": "example_usdc", "label": "Example USDC payout" },
+      { "id": "example_paypal", "label": "Example PayPal payout" }
+    ],
+    "countryRules": [
+      { "match": { "country": "Exampleland" }, "allow": ["example_usdc"] }
+    ]
+  },
+
+  "private.payout_caps": {
+    "_note": "PLACEHOLDER caps. Real production caps are seeded separately and are NOT committed. The loader treats 0 as 'unconfigured'.",
+    "perSubmissionMaxUsd": 100,
+    "perAddressHardCapUsd": 100,
+    "perTxCapUsd": 100,
+    "dailyCapUsd": 100,
+    "w9ThresholdUsd": 100
+  },
+
+  "private.fraud_weights": {
+    "_note": "SECRET in production (backend-only, never shipped to frontend). Placeholder here is empty/zero.",
+    "weights": {},
+    "tiers": { "high": 0, "medium": 0, "low": 0 }
+  },
+
+  "private.sponsors": {
+    "sponsors": [
+      { "name": "Example Sponsor One", "tier": "gold", "logoUrl": "https://example.com/logo1.png", "url": "https://example.com" },
+      { "name": "Example Sponsor Two", "tier": "silver", "logoUrl": "https://example.com/logo2.png", "url": "https://example.com" }
+    ]
+  },
+
+  "private.scoring_weights": {
+    "_note": "PLACEHOLDER scoring weights documenting shape only.",
+    "leaderboard": { "exampleSignal": 0 },
+    "pizzeria": { "exampleSignal": 0 }
+  }
+}

--- a/backend/src/config/seedPrivateConfig.ts
+++ b/backend/src/config/seedPrivateConfig.ts
@@ -1,0 +1,87 @@
+/**
+ * Private-config seed runner (marinara-71630 P0).
+ *
+ * Reads seed.private.json (real values, gitignored). If that file is absent,
+ * it falls back to seed.example.json and seeds PLACEHOLDER values with a loud
+ * warning. For each top-level key it upserts a row into `app_config` with the
+ * value JSON-stringified.
+ *
+ * Run with: `npm run seed:private-config` (from the backend dir).
+ *
+ * Meta keys beginning with "_" (e.g. "_readme", "_note") are skipped — they
+ * document the template and are not real config rows. (Note: nested "_note"
+ * fields inside a value object ARE preserved as-is, since the whole object is
+ * stored verbatim.)
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { prisma } from './database.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const PRIVATE_PATH = join(__dirname, 'seed.private.json');
+const EXAMPLE_PATH = join(__dirname, 'seed.example.json');
+
+async function main(): Promise<void> {
+  let sourcePath: string;
+  let usingPlaceholders: boolean;
+
+  if (existsSync(PRIVATE_PATH)) {
+    sourcePath = PRIVATE_PATH;
+    usingPlaceholders = false;
+  } else {
+    sourcePath = EXAMPLE_PATH;
+    usingPlaceholders = true;
+  }
+
+  if (usingPlaceholders) {
+    console.warn(
+      '\n*****************************************************************\n' +
+        '*  WARNING: seed.private.json not found.                        *\n' +
+        '*  Seeding PLACEHOLDER values from seed.example.json.           *\n' +
+        '*  These are NOT real production values. Copy seed.example.json *\n' +
+        '*  to seed.private.json and fill in real values for prod.       *\n' +
+        '*****************************************************************\n'
+    );
+  }
+
+  const raw = readFileSync(sourcePath, 'utf8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+  const written: string[] = [];
+  const skipped: string[] = [];
+
+  for (const [key, val] of Object.entries(parsed)) {
+    if (key.startsWith('_')) {
+      skipped.push(key);
+      continue;
+    }
+
+    const value = JSON.stringify(val);
+    await prisma.appConfig.upsert({
+      where: { key },
+      update: { value, updatedAt: new Date() },
+      create: { key, value },
+    });
+    written.push(key);
+  }
+
+  console.log(`\nSeeded ${written.length} app_config key(s) from ${sourcePath}:`);
+  for (const k of written) console.log(`  ✓ ${k}`);
+  if (skipped.length) {
+    console.log(`Skipped ${skipped.length} meta key(s): ${skipped.join(', ')}`);
+  }
+  if (usingPlaceholders) {
+    console.warn('\nReminder: PLACEHOLDER values were seeded. Do NOT run this against prod.');
+  }
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch((err) => {
+    console.error('[seedPrivateConfig] seed failed:', err);
+    process.exitCode = 1;
+    prisma.$disconnect().catch(() => {});
+  });

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -1,0 +1,181 @@
+/**
+ * Private-config loader (marinara-71630 P0).
+ *
+ * The repo is going open-source, so private business config (payout caps,
+ * reimbursement rules, fraud-detection weights, sponsors, scoring weights)
+ * must NOT live in committed source. Instead, real values live ONLY in the
+ * `app_config` DB table (Prisma model `AppConfig`), seeded to production
+ * out-of-band. The fallbacks committed in this file are deliberately
+ * NON-SENSITIVE placeholders that document the shape of each config.
+ *
+ * Notes / threat model:
+ * - `app_config` keeps these values out of git; it is NOT a runtime secret
+ *   store (it is plain DB rows readable by anything with DB access).
+ * - Values that are truly secret (e.g. fraud-detection weights, which an
+ *   attacker could game) are backend-only and MUST NEVER be shipped to the
+ *   frontend bundle. Backend decides, frontend renders.
+ * - Values are stored in the `value` column as JSON strings.
+ *
+ * This is Phase 0: infrastructure only, no consumers yet. Nothing reads from
+ * this module — it exists so later phases can migrate hardcoded config here.
+ */
+
+import { prisma } from '../config/database.js';
+
+/** Canonical `app_config` keys for each private-config domain. */
+const KEYS = {
+  reimbursementRules: 'private.reimbursement_rules',
+  payoutCaps: 'private.payout_caps',
+  fraudWeights: 'private.fraud_weights',
+  sponsors: 'private.sponsors',
+  scoringWeights: 'private.scoring_weights',
+} as const;
+
+// ---------------------------------------------------------------------------
+// In-process cache (60s TTL)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  value: unknown;
+  expires: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** Drop a single key from the in-process cache. */
+export function invalidate(key: string): void {
+  cache.delete(key);
+}
+
+/** Drop the entire in-process cache. */
+export function invalidateAll(): void {
+  cache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Core loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a private-config value from `app_config` by key.
+ *
+ * Returns the JSON-parsed `value`, or `fallback` on a cache/DB miss or a
+ * JSON parse error. Never throws — config loading must never break a request.
+ * Results are cached in-process for {@link CACHE_TTL_MS}.
+ */
+export async function getConfig<T>(key: string, fallback: T): Promise<T> {
+  const now = Date.now();
+
+  const cached = cache.get(key);
+  if (cached && cached.expires > now) {
+    return cached.value as T;
+  }
+
+  let row: { value: string } | null = null;
+  try {
+    row = await prisma.appConfig.findUnique({ where: { key } });
+  } catch (err) {
+    console.warn(`[privateConfig] DB read failed for key "${key}"; using fallback.`, err);
+    return fallback;
+  }
+
+  if (!row) {
+    // Miss: cache the fallback so we don't hammer the DB for unseeded keys.
+    cache.set(key, { value: fallback, expires: now + CACHE_TTL_MS });
+    return fallback;
+  }
+
+  let parsed: T;
+  try {
+    parsed = JSON.parse(row.value) as T;
+  } catch (err) {
+    console.warn(`[privateConfig] JSON parse failed for key "${key}"; using fallback.`, err);
+    return fallback;
+  }
+
+  cache.set(key, { value: parsed, expires: now + CACHE_TTL_MS });
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Typed domain accessors
+//
+// Each accessor pairs a typed interface with a NON-SENSITIVE placeholder
+// fallback. Real values are seeded to `app_config` in production.
+// ---------------------------------------------------------------------------
+
+export interface ReimbursementRules {
+  methods: Array<{ id: string; label: string }>;
+  countryRules: Array<{ match: { country?: string; tag?: string }; allow: string[] }>;
+}
+
+export function getReimbursementRules(): Promise<ReimbursementRules> {
+  return getConfig<ReimbursementRules>(KEYS.reimbursementRules, {
+    methods: [],
+    countryRules: [],
+  });
+}
+
+export interface PayoutCaps {
+  perSubmissionMaxUsd: number;
+  perAddressHardCapUsd: number;
+  perTxCapUsd: number;
+  dailyCapUsd: number;
+  w9ThresholdUsd: number;
+}
+
+/**
+ * Payout caps. Fallback is intentionally all-zero: a zero cap means
+ * "config not seeded; treat as unconfigured". Consumers (later phases) MUST
+ * treat 0 as unconfigured rather than as a literal $0 cap. The real
+ * production caps are seeded to `app_config` and never committed here.
+ */
+export function getPayoutCaps(): Promise<PayoutCaps> {
+  return getConfig<PayoutCaps>(KEYS.payoutCaps, {
+    perSubmissionMaxUsd: 0,
+    perAddressHardCapUsd: 0,
+    perTxCapUsd: 0,
+    dailyCapUsd: 0,
+    w9ThresholdUsd: 0,
+  });
+}
+
+export interface FraudWeights {
+  weights: Record<string, number>;
+  tiers: { high: number; medium: number; low: number };
+}
+
+/**
+ * Fraud-detection weights. SECRET — backend-only, must never reach the
+ * frontend bundle (an attacker who knows the weights can game the scorer).
+ */
+export function getFraudWeights(): Promise<FraudWeights> {
+  return getConfig<FraudWeights>(KEYS.fraudWeights, {
+    weights: {},
+    tiers: { high: 0, medium: 0, low: 0 },
+  });
+}
+
+export interface Sponsors {
+  sponsors: Array<{ name: string; tier?: string; logoUrl?: string; url?: string }>;
+}
+
+export function getSponsors(): Promise<Sponsors> {
+  return getConfig<Sponsors>(KEYS.sponsors, { sponsors: [] });
+}
+
+export interface ScoringWeights {
+  leaderboard: Record<string, number>;
+  pizzeria: Record<string, number>;
+}
+
+export function getScoringWeights(): Promise<ScoringWeights> {
+  return getConfig<ScoringWeights>(KEYS.scoringWeights, {
+    leaderboard: {},
+    pizzeria: {},
+  });
+}
+
+export { KEYS as PRIVATE_CONFIG_KEYS };


### PR DESCRIPTION
## Phase 0 — private-config infrastructure (no behavior change)

First phase of the `marinara-71630` open-source prep refactor. Moves the *capability* for private business config out of committed source and into the existing `app_config` DB table, **without** migrating any consumer yet.

### What's added
- **`backend/src/lib/privateConfig.ts`** — typed, `app_config`-backed config loader:
  - `getConfig<T>(key, fallback)` reads the `app_config` row, `JSON.parse`s `value`, and returns the parsed value. Returns `fallback` on miss, DB error, or parse error — **never throws**.
  - **In-process cache** (`Map`) with a 60s TTL; `invalidate(key)` / `invalidateAll()` exported.
  - Typed domain accessors with **non-sensitive placeholder fallbacks**: `getReimbursementRules()`, `getPayoutCaps()`, `getFraudWeights()`, `getSponsors()`, `getScoringWeights()`. Config keys are centralized in a `KEYS` const (`private.*`).
- **`backend/src/config/seed.example.json`** (committed) — documents the SHAPE of each `app_config` entry with obviously-fake placeholder values + a `_readme`.
- **`backend/src/config/seedPrivateConfig.ts`** — seed runner: reads `seed.private.json` (gitignored real values), falls back to `seed.example.json` with a loud PLACEHOLDER warning, and `upsert`s each top-level key into `app_config`. Run via `npm run seed:private-config`.
- **`.gitignore`** — ignores `backend/src/config/seed.private.json`.

### Design principle: backend decides, frontend renders
Real values live **only** in `app_config`, seeded to prod separately (out of band) — never committed. Committed fallbacks are non-sensitive placeholders (e.g. payout caps default to `0` = "unconfigured", not the real numbers). `app_config` keeps values out of git but is **not** a runtime secret store; truly-secret config (fraud-detection weights) is backend-only and must never reach the frontend bundle.

### No consumers yet
This phase is infrastructure only. **Nothing reads from `privateConfig.ts`** — no existing route, service, or frontend file was touched. Later phases migrate hardcoded config to call these accessors.

### Verification
- `npx tsc` (CI's `prisma generate && tsc`) on the two new files + full dependency graph with the exact CI compiler options: **0 errors**.
- The only build error in the tree (`src/middleware/auth.test.ts`, a jsonwebtoken typings overload) is **pre-existing on `origin/master`** and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)