### PR TITLE
feat(marinara-71630): backend-decided reimbursement options (P1)

### DIFF
--- a/backend/src/config/seed.example.json
+++ b/backend/src/config/seed.example.json
@@ -2,12 +2,18 @@
   "_readme": "marinara-71630 P0 private-config seed template. These are NON-SENSITIVE PLACEHOLDER values that only document the SHAPE of each app_config entry. To seed real values: (1) copy this file to seed.private.json (gitignored), (2) fill in the real production values, (3) run `npm run seed:private-config` from the backend dir. If seed.private.json is absent the runner falls back to THIS file and seeds placeholders (with a loud warning). Keys map 1:1 to app_config rows; each value is stored JSON-stringified in the `value` column.",
 
   "private.reimbursement_rules": {
+    "_note": "PLACEHOLDER reimbursement rules documenting SHAPE only. Real method ids (usdc_base/mercury_card/wire), the real SWC-hub copy + URL, and the real country/tag rules are seeded separately and NOT committed. `kind:'method'` = selectable payout method; `kind:'external'` = informational card (non-selectable, optional `url`). countryRules match when party.country === match.country OR match.tag is in party.eventTags; `visible` restricts to exactly those ids, `disable` greys out an id with a reason.",
     "methods": [
-      { "id": "example_usdc", "label": "Example USDC payout" },
-      { "id": "example_paypal", "label": "Example PayPal payout" }
+      { "id": "usdc_base", "label": "Example USDC payout", "description": "Onchain payment to your wallet.", "kind": "method" },
+      { "id": "mercury_card", "label": "Example virtual card", "description": "We issue you a debit card.", "kind": "method" },
+      { "id": "wire", "label": "Example bank wire", "description": "We send a wire to your bank.", "kind": "method" },
+      { "id": "swc_hub", "label": "Example regional hub", "description": "Your regional hub coordinates reimbursement for events here.", "kind": "external", "url": "" }
     ],
+    "default": ["usdc_base", "mercury_card", "wire"],
     "countryRules": [
-      { "match": { "country": "Exampleland" }, "allow": ["example_usdc"] }
+      { "match": { "country": "Exampleland" }, "visible": ["swc_hub"] },
+      { "match": { "tag": "example-hub" }, "visible": ["swc_hub"] },
+      { "match": { "country": "Blockistan" }, "disable": [{ "id": "mercury_card", "reason": "Virtual cards are unavailable in Blockistan due to compliance restrictions." }] }
     ]
   },
 

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -106,14 +106,50 @@ export async function getConfig<T>(key: string, fallback: T): Promise<T> {
 // fallback. Real values are seeded to `app_config` in production.
 // ---------------------------------------------------------------------------
 
+/**
+ * One configurable reimbursement option.
+ *
+ * `kind: 'method'` options (e.g. usdc_base / mercury_card / wire) are real,
+ * selectable payout methods the host can pick and submit receipts against.
+ * `kind: 'external'` options (e.g. an SWC-hub informational card) are NOT
+ * selectable payout methods — the frontend renders them as informational
+ * cards (optionally with a link via `url`) and must never set `method` to
+ * their id.
+ */
+export interface ReimbursementOption {
+  id: string;
+  label: string;
+  description?: string;
+  kind: 'method' | 'external';
+  url?: string;
+}
+
+/**
+ * A country/tag-scoped override of the visible/enabled options.
+ *
+ * Matches a party when `party.country === match.country` OR `match.tag` is
+ * present in `party.eventTags`.
+ *  - `visible` (if set) restricts the shown options to exactly these ids
+ *    (preserving `methods[]` order) — e.g. US → `['swc_hub']`.
+ *  - `disable` marks shown-but-disabled options with a reason (e.g.
+ *    mercury_card in Mercury-blocked countries).
+ */
+export interface CountryRule {
+  match: { country?: string; tag?: string };
+  visible?: string[];
+  disable?: Array<{ id: string; reason: string }>;
+}
+
 export interface ReimbursementRules {
-  methods: Array<{ id: string; label: string }>;
-  countryRules: Array<{ match: { country?: string; tag?: string }; allow: string[] }>;
+  methods: ReimbursementOption[];
+  default: string[];
+  countryRules: CountryRule[];
 }
 
 export function getReimbursementRules(): Promise<ReimbursementRules> {
   return getConfig<ReimbursementRules>(KEYS.reimbursementRules, {
     methods: [],
+    default: [],
     countryRules: [],
   });
 }

--- a/backend/src/lib/reimbursementOptions.test.ts
+++ b/backend/src/lib/reimbursementOptions.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { resolveReimbursementOptions } from './reimbursementOptions.js';
+import type { ReimbursementRules } from './privateConfig.js';
+
+const RULES: ReimbursementRules = {
+  methods: [
+    { id: 'usdc_base', label: 'USDC on Base', kind: 'method' },
+    { id: 'mercury_card', label: 'Mercury virtual card', kind: 'method' },
+    { id: 'wire', label: 'Bank wire', kind: 'method' },
+    { id: 'swc_hub', label: 'Pay via your hub', description: 'Your hub handles it.', kind: 'external', url: '' },
+  ],
+  default: ['usdc_base', 'mercury_card', 'wire'],
+  countryRules: [
+    // country match → restrict to the external hub card only
+    { match: { country: 'Exampleland' }, visible: ['swc_hub'] },
+    // country match → mercury disabled with a reason
+    {
+      match: { country: 'Blockistan' },
+      disable: [{ id: 'mercury_card', reason: 'Mercury unavailable in Blockistan.' }],
+    },
+    // tag match → restrict to the hub card
+    { match: { tag: 'hub-only' }, visible: ['swc_hub'] },
+  ],
+};
+
+describe('resolveReimbursementOptions', () => {
+  it('no match → returns the default methods in methods[] order, all enabled', () => {
+    const out = resolveReimbursementOptions({ country: 'Nowhereland', eventTags: [] }, RULES);
+    expect(out.map((o) => o.id)).toEqual(['usdc_base', 'mercury_card', 'wire']);
+    expect(out.every((o) => o.enabled)).toBe(true);
+    expect(out.every((o) => o.disabledReason === undefined)).toBe(true);
+  });
+
+  it('a visible rule → restricts to exactly that id', () => {
+    const out = resolveReimbursementOptions({ country: 'Exampleland' }, RULES);
+    expect(out.map((o) => o.id)).toEqual(['swc_hub']);
+    expect(out[0].kind).toBe('external');
+    expect(out[0].enabled).toBe(true);
+  });
+
+  it('a disable rule → method present but enabled:false with reason', () => {
+    const out = resolveReimbursementOptions({ country: 'Blockistan' }, RULES);
+    expect(out.map((o) => o.id)).toEqual(['usdc_base', 'mercury_card', 'wire']);
+    const mercury = out.find((o) => o.id === 'mercury_card')!;
+    expect(mercury.enabled).toBe(false);
+    expect(mercury.disabledReason).toBe('Mercury unavailable in Blockistan.');
+    // others stay enabled
+    expect(out.find((o) => o.id === 'usdc_base')!.enabled).toBe(true);
+  });
+
+  it('tag match path → restricts via eventTags', () => {
+    const out = resolveReimbursementOptions({ country: 'Nowhereland', eventTags: ['hub-only'] }, RULES);
+    expect(out.map((o) => o.id)).toEqual(['swc_hub']);
+  });
+
+  it('empty/unseeded config → returns []', () => {
+    const out = resolveReimbursementOptions(
+      { country: 'Anywhere' },
+      { methods: [], default: [], countryRules: [] }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('visible ids not present in methods are dropped', () => {
+    const rules: ReimbursementRules = {
+      methods: [{ id: 'usdc_base', label: 'USDC', kind: 'method' }],
+      default: ['usdc_base'],
+      countryRules: [{ match: { country: 'X' }, visible: ['ghost', 'usdc_base'] }],
+    };
+    const out = resolveReimbursementOptions({ country: 'X' }, rules);
+    expect(out.map((o) => o.id)).toEqual(['usdc_base']);
+  });
+});

--- a/backend/src/lib/reimbursementOptions.ts
+++ b/backend/src/lib/reimbursementOptions.ts
@@ -1,0 +1,97 @@
+/**
+ * Reimbursement-option resolver (marinara-71630 P1).
+ *
+ * The BACKEND decides which payout options a party host may see; the frontend
+ * just renders whatever it's handed. This pure function takes a party's
+ * country/tags plus the private `reimbursement_rules` config (loaded from
+ * `app_config` via {@link ../lib/privateConfig.getReimbursementRules}) and
+ * resolves the concrete list of options to show, in the configured order, each
+ * annotated with whether it is enabled.
+ *
+ * It hardcodes NO country logic — all country/tag rules live in config.
+ */
+
+import type { ReimbursementOption, ReimbursementRules, CountryRule } from './privateConfig.js';
+
+/** A fully-resolved option ready to send to the frontend. */
+export interface ResolvedOption {
+  id: string;
+  label: string;
+  description?: string;
+  kind: 'method' | 'external';
+  url?: string;
+  enabled: boolean;
+  /** Present only when `enabled === false`; explains why. */
+  disabledReason?: string;
+}
+
+/** Minimal party shape the resolver needs. */
+export interface ResolverParty {
+  country?: string | null;
+  eventTags?: string[] | null;
+}
+
+function ruleMatches(rule: CountryRule, party: ResolverParty): boolean {
+  const { country, tag } = rule.match || {};
+  if (country && party.country && country === party.country) return true;
+  if (tag && Array.isArray(party.eventTags) && party.eventTags.includes(tag)) return true;
+  return false;
+}
+
+/**
+ * Resolve the visible/enabled reimbursement options for a party.
+ *
+ * Algorithm:
+ *  1. Start from `rules.default` (ids).
+ *  2. For each matching country rule, in array order:
+ *     - if `visible` is set, restrict to those ids (intersected with the
+ *       configured methods, so unknown ids are dropped);
+ *     - collect `disable` entries into an id → reason map.
+ *  3. Emit, in `rules.methods` order, one entry per surviving visible id,
+ *     marking it disabled if it appears in the disable map.
+ *
+ * Never throws. An empty/unseeded config yields `[]`.
+ */
+export function resolveReimbursementOptions(
+  party: ResolverParty,
+  rules: ReimbursementRules
+): ResolvedOption[] {
+  const methods: ReimbursementOption[] = Array.isArray(rules?.methods) ? rules.methods : [];
+  const byId = new Map(methods.map((m) => [m.id, m]));
+
+  let visibleIds: string[] = Array.isArray(rules?.default) ? [...rules.default] : [];
+  const disabledMap = new Map<string, string>();
+
+  const countryRules: CountryRule[] = Array.isArray(rules?.countryRules) ? rules.countryRules : [];
+  for (const rule of countryRules) {
+    if (!ruleMatches(rule, party)) continue;
+    if (Array.isArray(rule.visible)) {
+      // Restrict to exactly the rule's ids, keeping only ids we have a method for.
+      visibleIds = rule.visible.filter((id) => byId.has(id));
+    }
+    if (Array.isArray(rule.disable)) {
+      for (const d of rule.disable) {
+        if (d && d.id) disabledMap.set(d.id, d.reason);
+      }
+    }
+  }
+
+  const visibleSet = new Set(visibleIds);
+
+  // Emit in methods[] order, one per visible id.
+  const out: ResolvedOption[] = [];
+  for (const m of methods) {
+    if (!visibleSet.has(m.id)) continue;
+    const reason = disabledMap.get(m.id);
+    out.push({
+      id: m.id,
+      label: m.label,
+      description: m.description,
+      kind: m.kind,
+      url: m.url,
+      enabled: reason === undefined,
+      ...(reason !== undefined ? { disabledReason: reason } : {}),
+    });
+  }
+  return out;
+}

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -15,6 +15,8 @@ import {
 } from '../helpers/reimbursementCapAudit.js';
 import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
+import { getReimbursementRules } from '../lib/privateConfig.js';
+import { resolveReimbursementOptions } from '../lib/reimbursementOptions.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -2329,6 +2331,38 @@ router.delete('/:partyId/payment-opt-in', async (req: AuthRequest, res: Response
     });
 
     res.json({ optedIn: false });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/parties/:id/reimbursement-options
+// marinara-71630 P1: the BACKEND decides which payout options the host sees,
+// driven by private `app_config` rules (country/tag scoped). The host-facing
+// picker renders whatever this returns. On a config miss the rules fallback is
+// empty → `{ options: [] }`; the frontend falls back to its three built-in
+// methods so the picker never renders empty. Never 500s on missing config.
+router.get('/:id/reimbursement-options', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.params;
+    if (!req.userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+    const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
+    if (!canEdit) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+    const party = await prisma.party.findUnique({
+      where: { id },
+      select: { country: true, eventTags: true },
+    });
+    if (!party) throw new AppError('Party not found', 404, 'NOT_FOUND');
+
+    const rules = await getReimbursementRules();
+    const options = resolveReimbursementOptions(
+      { country: party.country, eventTags: party.eventTags },
+      rules
+    );
+
+    res.json({ options });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -8,9 +8,10 @@ import {
   getPaymentOptIn,
   submitPaymentOptIn,
   removePaymentOptIn,
+  fetchReimbursementOptions,
+  ResolvedReimbursementOption,
 } from '../../lib/api';
 import { PayoutMethodPicker } from './PayoutMethodPicker';
-import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
 
 const EMPTY_BANK: BankDetails = {};
 
@@ -37,6 +38,38 @@ type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
 export const PaymentDetailsCard: React.FC = () => {
   const { user, setUser } = useAuth();
   const { party } = usePizza();
+
+  // marinara-71630 P1: the BACKEND decides which payout options are available
+  // for this party (country/tag-driven config). We fetch them once here and
+  // share them with the picker (so it doesn't double-fetch) AND drive the
+  // save-guard below from them — block saving a method whose resolved option is
+  // absent or disabled, replacing the old frontend `isMercuryBlocked` logic.
+  // When the fetch fails / config is unseeded we leave this null and the
+  // picker's own fallback (three enabled methods) governs, so the save-guard
+  // simply allows the save (matches the picker's enabled state).
+  const [resolvedOptions, setResolvedOptions] = useState<ResolvedReimbursementOption[] | null>(null);
+  useEffect(() => {
+    const partyId = party?.id;
+    if (!partyId) {
+      setResolvedOptions(null);
+      return;
+    }
+    let cancelled = false;
+    fetchReimbursementOptions(partyId)
+      .then((opts) => {
+        if (cancelled) return;
+        // Empty (unseeded) → null so the save-guard defers to the picker
+        // fallback (all three methods enabled).
+        setResolvedOptions(opts.length > 0 ? opts : null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setResolvedOptions(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [party?.id]);
 
   // Local mirrors of the user's persisted values. These drive PayoutMethodPicker
   // directly so the UI updates instantly; the debounced save flushes to the
@@ -140,16 +173,23 @@ export const PaymentDetailsCard: React.FC = () => {
     prevSnapshot.current = snapshot;
     isDirty.current = true;
 
-    // pepperoni-47301: never autosave `mercury_card` when the party's country
-    // is on Mercury's restricted list — the per-party payout submission would
-    // be rejected by the backend anyway. Surface the reason locally so the
-    // host knows to pick another method.
-    if (method === 'mercury_card' && isMercuryBlocked(party?.country)) {
-      setSaveStatus('error');
-      setSaveError(
-        `Mercury cards are unavailable in ${party?.country ?? 'your country'}. Pick another method.`
-      );
-      return;
+    // marinara-71630 P1: never autosave a method the BACKEND has decided is
+    // unavailable for this party — the resolved option is either absent
+    // (restricted away) or disabled (e.g. Mercury in a blocked country). The
+    // per-party payout submission would be rejected anyway. Surface the
+    // server-provided reason so the host knows to pick another method. When
+    // `resolvedOptions` is null (unseeded config / fetch failed) we skip this
+    // guard and defer to the picker's all-enabled fallback.
+    if (method != null && resolvedOptions) {
+      const opt = resolvedOptions.find((o) => o.id === method && o.kind === 'method');
+      if (!opt || !opt.enabled) {
+        setSaveStatus('error');
+        setSaveError(
+          opt?.disabledReason ??
+            `This payout method isn't available for ${party?.country ?? 'your country'}. Pick another method.`
+        );
+        return;
+      }
     }
 
     // Don't fire the save until the method-specific fields are valid.
@@ -205,7 +245,7 @@ export const PaymentDetailsCard: React.FC = () => {
     // We intentionally exclude buildPayload from deps — it closes over the
     // latest values via the surrounding effect.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [method, walletAddress, bankDetails, methodValid]);
+  }, [method, walletAddress, bankDetails, methodValid, resolvedOptions]);
 
   // PayoutMethodPicker requires non-null method. For the empty state we let
   // the user pick a method first; the picker still renders all three radios.
@@ -371,6 +411,7 @@ export const PaymentDetailsCard: React.FC = () => {
         onBankDetailsChange={setBankDetails}
         userEmail={user?.email}
         reimbursementCapUsd={party?.effectiveReimbursementCapUsd ?? null}
+        options={resolvedOptions}
       />
 
       {saveError && (

--- a/frontend/src/components/payouts/PayoutMethodPicker.tsx
+++ b/frontend/src/components/payouts/PayoutMethodPicker.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { CreditCard, Banknote, Coins, Mail, Wallet } from 'lucide-react';
+import { CreditCard, Banknote, Coins, Mail, Wallet, ExternalLink, Loader2 } from 'lucide-react';
 import { PayoutMethod, BankDetails } from '../../types';
 import { IconInput } from '../IconInput';
-import { resolveEnsName } from '../../lib/api';
-import { isMercuryBlocked } from '../../lib/mercuryBlockedCountries';
+import {
+  resolveEnsName,
+  fetchReimbursementOptions,
+  ResolvedReimbursementOption,
+} from '../../lib/api';
 import { usePizza } from '../../contexts/PizzaContext';
 
 // taleggio-30219: mirror of backend `looksLikeEnsName` — accepts dotted
@@ -14,6 +17,25 @@ function looksLikeEnsName(input: string): boolean {
   if (!trimmed || trimmed.startsWith('0x')) return false;
   return ENS_NAME_RE.test(trimmed);
 }
+
+// marinara-71630 P1: the backend decides which options the host sees. This
+// array is a FALLBACK ONLY — used when the reimbursement-options fetch fails
+// or returns [] (config not seeded yet, e.g. on preview before prod is
+// seeded), so the picker never renders empty. The three built-in methods are
+// shown all-enabled. Once config is seeded these come from the server instead.
+const FALLBACK_OPTIONS: ResolvedReimbursementOption[] = [
+  { id: 'usdc_base', label: 'USDC on Base', description: 'Onchain payment to your wallet.', kind: 'method', enabled: true },
+  { id: 'mercury_card', label: 'Mercury virtual card', description: 'We issue you a debit card for the exact amount.', kind: 'method', enabled: true },
+  { id: 'wire', label: 'Bank wire', description: 'We send a wire to your bank account.', kind: 'method', enabled: true },
+];
+
+// Icon per known method id. Unknown ids (future config-driven methods) get a
+// neutral default so the picker stays robust.
+const METHOD_ICONS: Record<string, React.ReactNode> = {
+  usdc_base: <Coins size={18} />,
+  mercury_card: <CreditCard size={18} />,
+  wire: <Banknote size={18} />,
+};
 
 type EnsPreviewState =
   | { kind: 'idle' }
@@ -39,14 +61,27 @@ interface PayoutMethodPickerProps {
    * per-receipt amount. When null, we omit the dollar amount entirely.
    */
   reimbursementCapUsd?: number | null;
+  /**
+   * marinara-71630 P1: optional pre-resolved options. When provided, the picker
+   * uses these instead of fetching (lets a parent — e.g. PaymentDetailsCard —
+   * share a single fetch for both the picker UI and its save-guard). When
+   * omitted, the picker fetches them itself.
+   */
+  options?: ResolvedReimbursementOption[] | null;
 }
 
 /**
  * Radio picker for payout method, with method-specific sub-form.
  *
+ * marinara-71630 P1: the BACKEND now decides which options the host sees
+ * (country/tag-driven private config); this component just renders them.
+ *
  *   mercury_card → just a confirmation that we'll email a virtual card
  *   wire         → single email field (our bank emails the host to complete)
  *   usdc_base    → wallet address IconInput
+ *
+ * Options with `kind:'external'` (e.g. an SWC-hub card) are rendered as
+ * non-selectable informational cards and never set `method`.
  */
 export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
   method,
@@ -57,7 +92,56 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
   onBankDetailsChange,
   userEmail,
   reimbursementCapUsd,
+  options: optionsProp,
 }) => {
+  const { party } = usePizza();
+  const partyId = party?.id ?? null;
+
+  // marinara-71630 P1: fetch server-decided options (unless a parent passed
+  // them in). Falls back to the three built-in methods on failure/empty.
+  const [fetchedOptions, setFetchedOptions] = React.useState<ResolvedReimbursementOption[] | null>(null);
+  const [optionsLoading, setOptionsLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    if (optionsProp !== undefined && optionsProp !== null) {
+      // Parent supplies options; don't fetch.
+      return;
+    }
+    if (!partyId) {
+      setFetchedOptions(null);
+      return;
+    }
+    let cancelled = false;
+    setOptionsLoading(true);
+    fetchReimbursementOptions(partyId)
+      .then((opts) => {
+        if (cancelled) return;
+        // Empty (unseeded config) → fall back to the three built-in methods.
+        setFetchedOptions(opts.length > 0 ? opts : FALLBACK_OPTIONS);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFetchedOptions(FALLBACK_OPTIONS);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setOptionsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [partyId, optionsProp]);
+
+  // Resolve the options to render: parent-provided (fall back when empty) →
+  // self-fetched → still loading.
+  const options: ResolvedReimbursementOption[] | null =
+    optionsProp !== undefined && optionsProp !== null
+      ? (optionsProp.length > 0 ? optionsProp : FALLBACK_OPTIONS)
+      : fetchedOptions;
+
+  const methodOptions = (options ?? []).filter((o) => o.kind === 'method');
+  const externalOptions = (options ?? []).filter((o) => o.kind === 'external');
+
   // taleggio-30219: debounced ENS preview state for the USDC sub-form.
   const [ensPreview, setEnsPreview] = React.useState<EnsPreviewState>({ kind: 'idle' });
   React.useEffect(() => {
@@ -100,16 +184,6 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
     // intentionally exclude bankDetails/onBankDetailsChange so we don't loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [method, userEmail]);
-
-  // pepperoni-47301: Mercury card payout is unavailable in sanctioned/restricted
-  // countries. We read the party's country from PizzaContext and gate the
-  // Mercury Option below. Falls back to false when there's no party (e.g.
-  // unlikely render outside an event context).
-  const { party } = usePizza();
-  const mercuryBlocked = isMercuryBlocked(party?.country);
-  const mercuryDisabledReason = mercuryBlocked
-    ? `Mercury cards are unavailable in ${party?.country ?? 'your country'} due to compliance restrictions.`
-    : undefined;
 
   const Option: React.FC<{
     value: PayoutMethod;
@@ -160,30 +234,72 @@ export const PayoutMethodPicker: React.FC<PayoutMethodPickerProps> = ({
     );
   };
 
+  if (options === null) {
+    // Still loading the server-decided options.
+    return (
+      <div className="flex items-center gap-2 text-sm text-theme-text-muted py-4">
+        <Loader2 size={16} className="animate-spin" />
+        <span>Loading payout options…</span>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <div className="grid sm:grid-cols-3 gap-3">
-        <Option
-          value="usdc_base"
-          icon={<Coins size={18} />}
-          title="USDC on Base"
-          description="Onchain payment to your wallet."
-        />
-        <Option
-          value="mercury_card"
-          icon={<CreditCard size={18} />}
-          title="Mercury virtual card"
-          description="We issue you a debit card for the exact amount."
-          disabled={mercuryBlocked}
-          disabledReason={mercuryDisabledReason}
-        />
-        <Option
-          value="wire"
-          icon={<Banknote size={18} />}
-          title="Bank wire"
-          description="We send a wire to your bank account."
-        />
-      </div>
+      {methodOptions.length > 0 && (
+        <div
+          className={`grid gap-3 ${
+            methodOptions.length >= 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2'
+          }`}
+        >
+          {methodOptions.map((opt) => (
+            <Option
+              key={opt.id}
+              value={opt.id as PayoutMethod}
+              icon={METHOD_ICONS[opt.id] ?? <Coins size={18} />}
+              title={opt.label}
+              description={opt.description ?? ''}
+              disabled={!opt.enabled}
+              disabledReason={opt.disabledReason}
+            />
+          ))}
+        </div>
+      )}
+
+      {/*
+        marinara-71630 P1: external (informational) options — e.g. an SWC-hub
+        card. NOT selectable payout methods: they never set `method`. Render
+        label + description, plus an external link when a url is configured.
+      */}
+      {externalOptions.map((opt) => (
+        <div
+          key={opt.id}
+          className="rounded-xl border border-theme-stroke bg-theme-surface p-4"
+        >
+          <div className="text-sm font-semibold text-theme-text">{opt.label}</div>
+          {opt.description && (
+            <div className="text-xs text-theme-text-muted mt-1">{opt.description}</div>
+          )}
+          {opt.url && (
+            <a
+              href={opt.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-[#ff393a] hover:underline"
+            >
+              Learn more
+              <ExternalLink size={12} />
+            </a>
+          )}
+        </div>
+      ))}
+
+      {optionsLoading && (
+        <div className="flex items-center gap-2 text-xs text-theme-text-muted">
+          <Loader2 size={12} className="animate-spin" />
+          <span>Updating options…</span>
+        </div>
+      )}
 
       {method === 'mercury_card' && (
         <div className="rounded-xl border border-theme-stroke bg-theme-surface p-4 text-sm text-theme-text-secondary">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5990,6 +5990,39 @@ export async function removePaymentOptIn(
   );
 }
 
+// ============================================
+// marinara-71630 P1: backend-decided reimbursement options
+// ============================================
+// The backend resolves which payout options a host may see (from private
+// app_config country/tag rules); the frontend just renders them. Mirror of the
+// backend `ResolvedOption` shape (backend/src/lib/reimbursementOptions.ts) —
+// keep in sync.
+
+export interface ResolvedReimbursementOption {
+  id: string;
+  label: string;
+  description?: string;
+  /** 'method' → selectable payout method; 'external' → informational card only. */
+  kind: 'method' | 'external';
+  url?: string;
+  enabled: boolean;
+  disabledReason?: string;
+}
+
+/**
+ * Fetch the server-decided reimbursement options for a party. Host-only
+ * (requires edit access). Returns `[]` when config is unseeded — callers
+ * should fall back to a built-in default so the picker never renders empty.
+ */
+export async function fetchReimbursementOptions(
+  partyId: string
+): Promise<ResolvedReimbursementOption[]> {
+  const res = await apiRequest<{ options: ResolvedReimbursementOption[] }>(
+    `/api/parties/${partyId}/reimbursement-options`
+  );
+  return res.options ?? [];
+}
+
 /**
  * taleggio-30219: resolve an ENS name (e.g. `vitalik.eth`) to its 0x address
  * via the backend's mainnet-resolver utility endpoint. Returns null on any


### PR DESCRIPTION
## marinara-71630 Phase 1 — reimbursement-options flip (STACKED on Phase 0)

> Base branch is `marinara-71630-private-config` (Phase 0), **not** master. This is a stacked PR — Phase 0 must merge first.

### The flip: backend decides, frontend renders
Previously the host-facing payout picker hardcoded three options (usdc_base / mercury_card / wire) and gated Mercury via a 40-country frontend block-list (`mercuryBlockedCountries.ts`) + `party.country` logic. This moves that decision to the **backend**, driven by private `app_config` rules:

- New `GET /api/parties/:id/reimbursement-options` (host-only, `canUserEditParty` gate) loads the party's `country` + `eventTags`, runs the pure `resolveReimbursementOptions()` resolver against the private `reimbursement_rules` config, and returns `{ options: ResolvedOption[] }`.
- `PayoutMethodPicker.tsx` now renders whatever the endpoint hands it: `kind:'method'` options keep their existing radio + sub-form behavior (wallet / wire email / Mercury confirmation), respecting `enabled`/`disabledReason`; `kind:'external'` options (e.g. an SWC-hub card) render as non-selectable informational cards with an optional link.
- `PaymentDetailsCard.tsx` drives its save-guard from the resolved options (blocks saving a method that's absent or `enabled:false`, surfacing the server reason) instead of `isMercuryBlocked`.
- Both host files drop the `isMercuryBlocked` import. No frontend country logic remains in the host picker.

### Fallback-to-three-methods safety
On preview (and until prod config is seeded), the config is empty → the resolver yields `{ options: [] }`. The picker treats empty/failed as a signal to fall back to a hardcoded array of the **three built-in methods, all enabled**, so the picker never renders empty. The save-guard defers to that fallback (allows the save) when options are unseeded. The endpoint never 500s on missing config.

### Real rules are seeded to prod separately
No real country/Mercury/SWC data is committed. `seed.example.json`'s `private.reimbursement_rules` entry was updated to the new shape with **obviously-fake placeholders** (`Exampleland`, `Blockistan`, empty hub `url`). Real methods, the real SWC-hub copy/URL, and the real country/tag rules are seeded to `app_config` by the main session. **Full end-to-end verification is therefore post-merge + post-seed.**

### Verification
- New unit test `backend/src/lib/reimbursementOptions.test.ts` — 6 cases (no-match→default, `visible`→restrict, `disable`→enabled:false+reason, tag-match, empty config→[], unknown-id drop). `npx vitest run` → 6/6 pass.
- Backend `tsc --noEmit`: clean except the pre-existing `src/middleware/auth.test.ts` jwt-typings error on origin/master (not mine).
- Frontend `tsc --noEmit -p tsconfig.json`: clean.

### `mercuryBlockedCountries.ts` NOT deleted
The frontend module is still imported by admin components `CreatePrepaymentModal.tsx` and `SendPaymentModal.tsx`, so it stays. Only the two host-side imports were removed. The backend twin is untouched.

### Deferred follow-ups (out of scope this phase)
- Admin-side migration: `swcHub.ts` + admin payment components (SwcHubWarning in PayoutReviewModal/BulkSendModal/ExternalPaymentModal/MarkPartyPaidModal) still use hardcoded country logic → move to config in a later phase.
- Backend POST payout submission/enforcement still validates country/method independently — not yet config-driven.
- Once admin migrates off `mercuryBlockedCountries.ts`, the frontend module + its backend twin can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
