### PR TITLE
stracchino-49640: fix payout submit 500 (sanitize OCR jsonb) + legible warnings

### DIFF
--- a/backend/src/lib/sanitizePg.ts
+++ b/backend/src/lib/sanitizePg.ts
@@ -1,16 +1,23 @@
 /**
- * stracchino-49640: strip characters Postgres rejects in jsonb / text columns —
- * NUL bytes ( ) and unpaired UTF-16 surrogates. gpt-4o OCR output of some
- * receipts contains these, which 500'd payout submission at the DB insert
- * (jsonb / text cannot represent   or a lone surrogate). Apply to every
- * free-form OCR-derived value before it is persisted.
+ * stracchino-49640: strip characters Postgres rejects in jsonb / text columns:
+ * NUL bytes (code point zero) and unpaired UTF-16 surrogates. gpt-4o OCR output
+ * of some receipts contains these, which 500'd payout submission at the DB
+ * insert (jsonb / text cannot represent a NUL or a lone surrogate). Apply to
+ * every free-form OCR-derived value before it is persisted.
  *
- * `\p{Cs}` with the /u flag matches ONLY unpaired surrogate code points — valid
- * astral characters (emoji etc.) are decoded as single non-Cs code points and
- * are preserved.
+ * The NUL matcher is built via String.fromCharCode(0) rather than a literal
+ * control char or a regex escape literal, because both have been corrupted by
+ * editor / transport transcoding (a literal NUL once silently became a space,
+ * which stripped every space from OCR text instead of removing NULs).
+ *
+ * The second replace uses the Cs Unicode property with the /u flag, which
+ * matches ONLY unpaired surrogate code points: valid astral characters (emoji
+ * etc.) decode as single non-surrogate code points and are preserved.
  */
+const NUL = String.fromCharCode(0);
+
 export function sanitizePgString(s: string): string {
-  return s.replace(/ /g, '').replace(/\p{Cs}/gu, '');
+  return s.split(NUL).join('').replace(/\p{Cs}/gu, '');
 }
 
 /** Recursively sanitize all strings inside a JSON-serializable value. */

--- a/backend/src/lib/sanitizePg.ts
+++ b/backend/src/lib/sanitizePg.ts
@@ -1,0 +1,28 @@
+/**
+ * stracchino-49640: strip characters Postgres rejects in jsonb / text columns —
+ * NUL bytes ( ) and unpaired UTF-16 surrogates. gpt-4o OCR output of some
+ * receipts contains these, which 500'd payout submission at the DB insert
+ * (jsonb / text cannot represent   or a lone surrogate). Apply to every
+ * free-form OCR-derived value before it is persisted.
+ *
+ * `\p{Cs}` with the /u flag matches ONLY unpaired surrogate code points — valid
+ * astral characters (emoji etc.) are decoded as single non-Cs code points and
+ * are preserved.
+ */
+export function sanitizePgString(s: string): string {
+  return s.replace(/ /g, '').replace(/\p{Cs}/gu, '');
+}
+
+/** Recursively sanitize all strings inside a JSON-serializable value. */
+export function sanitizeForPg<T>(value: T): T {
+  if (typeof value === 'string') return sanitizePgString(value) as unknown as T;
+  if (Array.isArray(value)) return value.map((v) => sanitizeForPg(v)) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitizeForPg(v);
+    }
+    return out as T;
+  }
+  return value;
+}

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -23,6 +23,7 @@ import { AppError } from '../middleware/error.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
+import { sanitizeForPg, sanitizePgString } from '../lib/sanitizePg.js';
 import { looksLikeEnsName, resolveWalletInput, resolveWalletInputWithMeta } from '../services/ens.service.js';
 import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
@@ -1146,9 +1147,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           originalAmount: new Decimal(fx.originalAmount),
           originalCurrency: unresolved ? null : (fx.originalCurrency ?? null),
           exchangeRate: unresolved ? null : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
-          ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
+          ocrRaw: sanitizeForPg({ ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } }),
           // formaggi-89172: structured per-line items for pizza-price analytics.
-          ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
+          ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? sanitizeForPg(ocr.lineItems) : null,
           ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
           sortOrder: idx,
           photoId: null,
@@ -1310,7 +1311,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     const adminNotesRaw = (req.body || {}).adminNotes;
     const initialAdminNotes =
       callerIsAdmin && typeof adminNotesRaw === 'string' && adminNotesRaw.trim().length > 0
-        ? adminNotesRaw.trim()
+        ? sanitizePgString(adminNotesRaw.trim())
         : null;
 
     // taleggio-30219: resolve the wallet input once, BEFORE the create, so
@@ -1437,7 +1438,7 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
             ? mercuryCardLast4.slice(-4)
             : null,
           hostNotes: typeof hostNotes === 'string' && hostNotes.trim().length > 0
-            ? hostNotes.trim()
+            ? sanitizePgString(hostNotes.trim())
             : null,
           // bismarck-92103: admin-supplied adminNotes (e.g. "Prepayment for X")
           // when an admin creates a prepayment on behalf of a cohost.
@@ -1774,7 +1775,7 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     }
     if (hostNotes !== undefined) {
       data.hostNotes = typeof hostNotes === 'string' && hostNotes.trim().length > 0
-        ? hostNotes.trim()
+        ? sanitizePgString(hostNotes.trim())
         : null;
     }
     if (finalAmountUsd !== undefined) {
@@ -1971,9 +1972,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           originalAmount: new Decimal(fx.originalAmount),
           originalCurrency: unresolved ? null : (fx.originalCurrency ?? null),
           exchangeRate: unresolved ? null : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
-          ocrRaw: { ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } },
+          ocrRaw: sanitizeForPg({ ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } }),
           // formaggi-89172: structured per-line items for pizza-price analytics.
-          ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? ocr.lineItems : null,
+          ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? sanitizeForPg(ocr.lineItems) : null,
           ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
           sortOrder: i,
           photoId: null,

--- a/frontend/src/components/payouts/NewPayoutForm.tsx
+++ b/frontend/src/components/payouts/NewPayoutForm.tsx
@@ -511,10 +511,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           The auto-sum excludes those receipts until the host picks a code via
           the per-row CurrencyOverrideSelect dropdown. */}
       {unresolvedReceiptCount > 0 && (
-        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-50">
           <div className="flex items-start gap-2.5">
-            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
-            <div className="flex-1 text-sm text-amber-100">
+            <AlertTriangle className="text-amber-600 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-800">
               {unresolvedReceiptCount === 1
                 ? "1 receipt's currency could not be detected. Use the currency picker on that row to set the correct currency — it isn't counted in the total yet."
                 : `${unresolvedReceiptCount} receipts' currencies could not be detected. Use the currency picker on those rows — they aren't counted in the total yet.`}
@@ -527,10 +527,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           enabled, admin reviews from /payments. Only renders when the party
           has an effective cap AND the typed amount exceeds it. */}
       {exceedsPartyCap && (
-        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-50">
           <div className="flex items-start gap-2.5">
-            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
-            <div className="flex-1 text-sm text-amber-100">
+            <AlertTriangle className="text-amber-600 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-800">
               Heads up: receipts total ${finalAmount.toFixed(2)}, but your reimbursement cap is ${effectiveCapUsd!.toFixed(2)}. We'll reimburse the cap; the receipts stay attached as evidence. Admin can approve more in special cases.
             </div>
           </div>
@@ -540,10 +540,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
       {/* speck-89172: $675 hard-ceiling amber warning. USDC execute caps at
           $675 per tx, so admin may need to split this into multiple sends. */}
       {exceedsHardCeiling && (
-        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-50">
           <div className="flex items-start gap-2.5">
-            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
-            <div className="flex-1 text-sm text-amber-100">
+            <AlertTriangle className="text-amber-600 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-800">
               Heads up: ${finalAmount.toFixed(2)} exceeds the ${PER_PAYMENT_HARD_CEILING_USD} per-payment maximum. Admin may need to split into multiple sends.
             </div>
           </div>
@@ -557,10 +557,10 @@ export const NewPayoutForm: React.FC<NewPayoutFormProps> = ({
           disabled until userMethodValid is true. Backend mirrors this gate
           (PAYMENT_METHOD_NOT_SET / PAYMENT_METHOD_INCOMPLETE). */}
       {!userMethodValid && (
-        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+        <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-50">
           <div className="flex items-start gap-2.5">
-            <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
-            <div className="flex-1 text-sm text-amber-100">
+            <AlertTriangle className="text-amber-600 mt-0.5 flex-shrink-0" size={16} />
+            <div className="flex-1 text-sm text-amber-800">
               {methodNoticeText}{' '}
               <a
                 href="#payment-details-card"


### PR DESCRIPTION
## Root cause
Payout submission 500'd ("Internal server error") for one host (GPP Lima) because the forwarded gpt-4o OCR payload (`ocrRaw` object + `ocrLineItems` array) was persisted into Postgres `jsonb` columns (`payout_documents.ocr_raw`, `ocr_line_items`) with **no sanitization**. Postgres `jsonb` and `text` cannot store NUL bytes (0x00) or unpaired UTF-16 surrogates. gpt-4o OCR of some receipts emits these, so `tx.payout.create` threw a non-P2002/P2025 Prisma error that fell through to the generic 500 handler. Payouts succeed for everyone else — it's data-specific.

Separately, the amber warning banners on the receipt form were illegible (near-white `text-amber-100` text on a translucent panel that washes out on the light GPP host theme).

## Changes
- **`backend/src/lib/sanitizePg.ts`** (new) — `sanitizePgString` strips NUL bytes + unpaired surrogates (`\p{Cs}` under `/u` matches only lone surrogates; valid astral chars/emoji are preserved); `sanitizeForPg` recurses over JSON-serializable values.
- **`backend/src/routes/payout.routes.ts`** — wrap `ocrRaw` / `ocrLineItems` with `sanitizeForPg(...)` at both document-construction sites (POST create + PATCH update), and sanitize the free-form text note fields (`hostNotes` in create + PATCH, admin-supplied `adminNotes` in create) with `sanitizePgString`. The `Prisma.JsonNull` final-persist lines read the already-sanitized values, so they're untouched. The `ocrRaw` on the OCR-preview route (~line 601) is only returned in the HTTP response, not persisted, so it's left as-is.
- **`frontend/src/components/payouts/NewPayoutForm.tsx`** — make the 4 amber notice cards solid light-amber panels with dark legible text (mirrors the provola-58213 fix on PayoutReviewModal): `text-amber-100` to `text-amber-800`, `text-amber-300` to `text-amber-600`, `bg-amber-500/10` to `bg-amber-50`. `border-l-amber-500` unchanged.

## NOTE on rollout
Preview frontends use the **production backend**, which only deploys from `master`. So the backend sanitizer (and thus the 500 fix) takes effect **only once this is merged to master and the backend redeploys** — it will NOT be resolved on the preview URL. The amber-warning fix IS a frontend change and is visible on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
