### PR TITLE
fix(calzone-58294): OCR currency prior resolves full-name countries (Togo→XOF)

### DIFF
--- a/backend/src/services/ocr.service.test.ts
+++ b/backend/src/services/ocr.service.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { buildSystemPrompt } from './ocr.service.js';
+
+describe('buildSystemPrompt country currency prior', () => {
+  // calzone-58294: `parties.country` stores full English names, not ISO-2.
+  // The prior must resolve those via getCountryCode rather than slicing.
+  it('resolves full-name countries to their primary currency', () => {
+    expect(buildSystemPrompt('Togo')).toContain('XOF');
+    expect(buildSystemPrompt('Mexico')).toContain('MXN');
+    expect(buildSystemPrompt('United States')).toContain('USD');
+  });
+
+  it('still accepts a bare ISO-2 code (back-compat)', () => {
+    expect(buildSystemPrompt('TG')).toContain('XOF');
+    expect(buildSystemPrompt('mx')).toContain('MXN');
+  });
+
+  it('omits the country prior when country is unknown/empty', () => {
+    const prompt = buildSystemPrompt('Atlantis');
+    expect(prompt).not.toContain('the primary currency in');
+    expect(buildSystemPrompt(null)).not.toContain('the primary currency in');
+    expect(buildSystemPrompt(undefined)).not.toContain('the primary currency in');
+  });
+
+  it('does not mis-key "Togo" as Tonga (TO)', () => {
+    // "Togo".slice(0,2) === "TO" (Tonga, absent from the map) was the bug.
+    const prompt = buildSystemPrompt('Togo');
+    expect(prompt).toContain('this receipt is from TG');
+  });
+});

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -15,6 +15,7 @@
  */
 
 import { getOpenAI } from '../lib/openai.js';
+import { getCountryCode } from '../lib/countryCode.js';
 
 // formaggi-89172: allowed categories. Keep in sync with the system prompt
 // and the sanitizer below. `other` is the safe fallback for anything else.
@@ -93,7 +94,7 @@ export const COUNTRY_TO_PRIMARY_CURRENCY: Record<string, string> = {
   CM: 'XAF', CF: 'XAF', TD: 'XAF', GQ: 'XAF', GA: 'XAF', CG: 'XAF',
 };
 
-function buildSystemPrompt(partyCountry?: string | null): string {
+export function buildSystemPrompt(partyCountry?: string | null): string {
   const base = `You are a receipt analysis assistant. Extract the total amount and per-line items from the receipt image.
 Return ONLY a JSON object with these fields:
 - amount: number (the total amount paid, as a decimal number)
@@ -119,9 +120,15 @@ Always return valid JSON.`;
   // mortadella-92103: country prior. When the host's event has a known country
   // and that country has a single dominant ISO-4217 currency, prefer it for
   // ambiguous-symbol receipts (the `$` problem in MX/AR/CL/CO/UY/...).
-  const code = typeof partyCountry === 'string'
-    ? partyCountry.trim().toUpperCase().slice(0, 2)
-    : '';
+  // calzone-58294: `parties.country` stores full English names (e.g. "Togo"),
+  // not ISO-2. Naively slicing the first 2 chars mis-keyed the lookup
+  // ("Togo"->"TO"=Tonga, "Mexico"->"ME"=Montenegro, "United States"->"UN") so
+  // the prior never fired. Reuse the canonical name->ISO-2 normalizer, and keep
+  // a back-compat fallback for any legacy caller that passes a bare ISO-2 code.
+  const raw = typeof partyCountry === 'string' ? partyCountry.trim() : '';
+  const code =
+    getCountryCode(raw) ??
+    (/^[A-Za-z]{2}$/.test(raw) ? raw.toUpperCase() : '');
   const primary = code ? COUNTRY_TO_PRIMARY_CURRENCY[code] : undefined;
   if (code && primary) {
     return `${base}\n\nContext: this receipt is from ${code}; the primary currency in ${code} is ${primary}. If the printed currency symbol is ambiguous (e.g. just "$"), prefer ${primary}. Only return USD if the receipt clearly shows USD (e.g. "USD", "US$", or an unambiguous US-based merchant).`;
@@ -193,9 +200,11 @@ function sanitizeLineItems(raw: unknown): OcrLineItem[] {
  * wrap in `Promise.allSettled` so one bad receipt doesn't fail the whole batch.
  */
 /**
- * mortadella-92103: now accepts an optional `partyCountry` (ISO-2). When the
- * receipt symbol is ambiguous, the country prior steers OCR toward the local
- * primary currency instead of silently defaulting to USD.
+ * mortadella-92103: now accepts an optional `partyCountry` (a full English
+ * country name as stored on `parties.country`, e.g. "Togo", or a bare ISO-2
+ * code). When the receipt symbol is ambiguous, the country prior steers OCR
+ * toward the local primary currency instead of silently defaulting to USD.
+ * calzone-58294: normalized via getCountryCode so full names resolve correctly.
  *
  * Back-compat shim: callers passing a string (legacy `analyzeReceipt(url)`)
  * still work — the function accepts either a string or `{ imageUrl, partyCountry }`.

--- a/plans/calzone-58294-ocr-country-currency-normalize.md
+++ b/plans/calzone-58294-ocr-country-currency-normalize.md
@@ -1,0 +1,49 @@
+# calzone-58294 — OCR currency prior resolves full-name countries (Togo→XOF)
+
+## Problem
+`backend/src/services/ocr.service.ts` builds the receipt-OCR currency prior in
+`buildSystemPrompt(partyCountry)` by slicing the first 2 chars of the country
+and upper-casing:
+
+```js
+const code = partyCountry.trim().toUpperCase().slice(0, 2);
+const primary = code ? COUNTRY_TO_PRIMARY_CURRENCY[code] : undefined;
+```
+
+`COUNTRY_TO_PRIMARY_CURRENCY` is keyed by ISO-3166-1 alpha-2 codes
+(`TG: 'XOF'`). But `parties.country` stores the **full English name** ("Togo"),
+and the callers (`payout.routes.ts`, `admin-payout.routes.ts`) pass
+`party.country` straight through. `"Togo".slice(0,2)` = `"TO"` (Tonga, not in
+the map) so the prior never fired. Same breakage for "Mexico"→"ME",
+"United States"→"UN", etc. — i.e. essentially every full-name country.
+
+## Fix
+Reuse the existing canonical normalizer `getCountryCode()` from
+`backend/src/lib/countryCode.ts` (free-text name → ISO-2, already contains
+`'togo': 'TG'` + the CFA countries) instead of slicing:
+
+```js
+const raw = typeof partyCountry === 'string' ? partyCountry.trim() : '';
+const code =
+  getCountryCode(raw) ??
+  (/^[A-Za-z]{2}$/.test(raw) ? raw.toUpperCase() : '');
+const primary = code ? COUNTRY_TO_PRIMARY_CURRENCY[code] : undefined;
+```
+
+The regex fallback keeps back-compat for any legacy caller passing a bare
+2-letter ISO-2 code. The rest of `buildSystemPrompt` (prompt interpolation of
+`code`/`primary`) is unchanged. Updated the stale "(ISO-2)" JSDoc.
+
+Scope: this one file only. No call sites, `fx.service.ts`, or frontend touched.
+
+## Verification
+- `cd backend && npx tsc --noEmit` — clean (only pre-existing unrelated
+  `auth.test.ts` jsonwebtoken-typings error remains, present on origin/master).
+- Added `backend/src/services/ocr.service.test.ts` (vitest, mirrors
+  `countryCode.test.ts`): asserts the prompt for "Togo" contains "XOF", "Mexico"
+  → "MXN", "United States" → "USD", bare "TG"/"mx" still resolve, and unknown/
+  null/empty omit the prior. 4 tests pass.
+
+## Notes
+Backend-only fix — won't show on the frontend Vercel preview. Goes live when
+merged to master (backend auto-deploys from master push).


### PR DESCRIPTION
## Problem
The receipt-OCR currency prior in `buildSystemPrompt(partyCountry)` derived the country code by slicing the first 2 chars of the country and upper-casing:

```js
const code = partyCountry.trim().toUpperCase().slice(0, 2);
```

`COUNTRY_TO_PRIMARY_CURRENCY` is keyed by ISO-3166-1 alpha-2 codes (`TG: 'XOF'`), but `parties.country` stores the **full English name** ("Togo") and callers (`payout.routes.ts`, `admin-payout.routes.ts`) pass it straight through. `"Togo".slice(0,2)` = `"TO"` (Tonga, not in the map) so the prior never fired. Same breakage for "Mexico"→"ME", "United States"→"UN" — essentially every full-name country, so XOF/MXN/USD auto-detection silently never applied.

## Fix
Reuse the existing canonical normalizer `getCountryCode()` (`backend/src/lib/countryCode.ts`, free-text name → ISO-2, already contains `togo: TG` + the CFA countries) instead of slicing, with a regex back-compat fallback for any legacy caller passing a bare ISO-2 code:

```js
const raw = typeof partyCountry === 'string' ? partyCountry.trim() : '';
const code =
  getCountryCode(raw) ??
  (/^[A-Za-z]{2}$/.test(raw) ? raw.toUpperCase() : '');
```

Scope: only `backend/src/services/ocr.service.ts` (plus a new test). No call sites, `fx.service.ts`, or frontend touched. Stale "(ISO-2)" JSDoc updated.

## Verification
- `cd backend && npx tsc --noEmit` — clean for the changed files (one pre-existing, unrelated `auth.test.ts` jsonwebtoken-typings error remains, identical on origin/master).
- Added `backend/src/services/ocr.service.test.ts` (vitest, mirrors `countryCode.test.ts`): "Togo"→XOF, "Mexico"→MXN, "United States"→USD, bare "TG"/"mx" resolve, unknown/null/empty omit the prior. **4 tests pass.**

Backend-only fix — won't appear on the frontend Vercel preview; goes live when merged (backend auto-deploys from master).

Plan: `plans/calzone-58294-ocr-country-currency-normalize.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)