### PR TITLE
feat(pangrattato-58218): show visible-row count on /payments table

### DIFF
--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1028,6 +1028,17 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
   const viewerKind = role.viewerKind;
   const isUnderboss = viewerKind === 'underboss';
 
+  // Count of the rows actually rendered in the active table: cities in the
+  // by-city view, individual payouts in the by-payment / payments views. Sits
+  // next to the view toggle so the admin sees how many rows the current
+  // filters surface.
+  const visibleRowCount =
+    viewMode === 'by-city' ? displayedByPartyRows.length : payouts.length;
+  const visibleRowLabel =
+    viewMode === 'by-city'
+      ? `${visibleRowCount} ${visibleRowCount === 1 ? 'city' : 'cities'}`
+      : `${visibleRowCount} payment${visibleRowCount === 1 ? '' : 's'}`;
+
   return (
     <Layout>
       <Helmet>
@@ -1191,7 +1202,11 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             bar's sticky position.
             coppa-92106: third "Payments" tab shows the actual payments ledger
             (status=paid|completed, proven-only, sorted by paid_at DESC). */}
-        <div className="flex items-center justify-end gap-2 mb-3">
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <span className="text-sm font-medium text-theme-text-muted">
+            {loading ? '…' : visibleRowLabel}
+          </span>
+          <div className="flex items-center gap-2">
           <span className="text-xs uppercase tracking-wide text-theme-text-muted">View:</span>
           <div
             role="tablist"
@@ -1237,6 +1252,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             >
               Payments
             </button>
+          </div>
           </div>
         </div>
 


### PR DESCRIPTION
Shows a count of the rows currently rendered in the active `/payments` table, next to the view toggle:

- **By city** → `N cities` (counts `displayedByPartyRows`, after status/hide-US/scam/closed filters)
- **By payment / Payments** → `N payments` (counts loaded `payouts`)

Reads from the same arrays the tables consume, so it reflects the applied filters. Shows `…` while a load is in flight. In the paginated by-payment/Payments views the count reflects rows currently loaded (grows on "Load more").

🤖 Generated with [Claude Code](https://claude.com/claude-code)