### PR TITLE
fix(focaccina-92141): host photo uploads show "now visible" not "pending approval"

### DIFF
--- a/frontend/src/components/photos/PhotoGallery.tsx
+++ b/frontend/src/components/photos/PhotoGallery.tsx
@@ -485,6 +485,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({
               uploaderEmail={uploaderEmail}
               guestId={guestId}
               photoModeration={photoModeration}
+              isHost={isHost}
               availableTags={availableTags}
               onUploadComplete={handleUploadComplete}
               onClose={() => setShowUpload(false)}

--- a/frontend/src/components/photos/PhotoUpload.tsx
+++ b/frontend/src/components/photos/PhotoUpload.tsx
@@ -10,6 +10,7 @@ interface PhotoUploadProps {
   uploaderEmail?: string;
   guestId?: string;
   photoModeration?: boolean;
+  isHost?: boolean;
   availableTags?: string[];
   onUploadComplete?: (photo: Photo) => void;
   onClose?: () => void;
@@ -35,6 +36,7 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
   uploaderEmail,
   guestId,
   photoModeration = false,
+  isHost = false,
   availableTags = [],
   onUploadComplete,
   onClose,
@@ -447,15 +449,21 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
             {completeCount} {completeCount !== 1 ? 'files' : 'file'} uploaded successfully
           </p>
           {photoModeration && (
-            <p className="text-amber-400/80 text-sm mt-2">
-              Uploads will appear after the host approves them.
-            </p>
+            isHost ? (
+              <p className="text-green-400/80 text-sm mt-2">
+                Your photos are now visible on the event page.
+              </p>
+            ) : (
+              <p className="text-amber-400/80 text-sm mt-2">
+                Uploads will appear after the host approves them.
+              </p>
+            )
           )}
         </div>
       )}
 
-      {/* Moderation Notice */}
-      {photoModeration && files.length === 0 && (
+      {/* Moderation Notice — only for guests; host uploads are auto-approved */}
+      {photoModeration && !isHost && files.length === 0 && (
         <p className="mt-3 text-amber-400/70 text-xs text-center">
           Uploads are reviewed by the host before appearing in the gallery.
         </p>


### PR DESCRIPTION
Host uploads are auto-approved on the backend (`margherita-43821`: owner / co-host w/ canEdit / super-admin / GPP editor), so with photo moderation **on** a host's uploads are visible on the event page immediately. The post-upload copy still told them their photos were pending approval.

## Change
- `PhotoUpload` takes a new `isHost` prop (passed down from `PhotoGallery`, which already knows).
- When moderation is on **and** the uploader is a host: green **"Your photos are now visible on the event page."**
- Guests: unchanged amber "Uploads will appear after the host approves them."
- Pre-upload "Uploads are reviewed by the host…" notice is suppressed for hosts (it's wrong for them).

Frontend-only, no backend/DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)