### PR TITLE
diavola-58479: "Post about the party on socials" checklist item + compose modal

### DIFF
--- a/backend/scripts/backfill-social-post-checklist.cjs
+++ b/backend/scripts/backfill-social-post-checklist.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * diavola-58479: backfill the "Post about the party on socials" checklist item.
+ *
+ * Adds a new non-auto default checklist row (link_tab 'social-post' sentinel,
+ * sort_order 11, due 2026-06-08) and the matching checklist_defaults template row.
+ *
+ * ORDERING IS LOAD-BEARING — do not reorder the two steps:
+ *
+ *   (a) FIRST insert the new row into checklist_items for every party that is
+ *       ALREADY fully seeded (its is_default count >= the CURRENT checklist_defaults
+ *       count) and does NOT already have a row named 'Post about the party on socials'.
+ *   (b) THEN insert the checklist_defaults template row.
+ *
+ * Why this order: the seed endpoint (POST /:partyId/checklist/seed) reconciles by
+ * counting a party's is_default items against the checklist_defaults count. If that
+ * count drops below the template count it DELETES all default items and re-creates
+ * them — which wipes any manual completion the host ticked on the non-auto default
+ * rows (Find Partners, Select Pizzeria, etc.). By backfilling the parties FIRST,
+ * every already-seeded party reaches the new count at the same moment the template
+ * grows, so defaultCount is never < the template count and the destructive
+ * reconcile never fires.
+ *
+ * Parties not yet fully seeded are intentionally skipped: the seed endpoint will
+ * create all default rows (including this one) fresh on next load.
+ *
+ * Idempotent: re-running inserts nothing new (guarded by NOT EXISTS / ON CONFLICT
+ * DO NOTHING).
+ *
+ * Dry-run by default. Pass --apply to mutate.
+ *
+ * Usage:
+ *   node backend/scripts/backfill-social-post-checklist.cjs [--apply]
+ */
+
+const path = require('path');
+const fs = require('fs');
+const envCandidates = [
+  path.join(__dirname, '..', '.env'),
+  'C:/Users/samgo/OneDrive/Documents/PizzaDAO/Code/rsvpizza/backend/.env',
+];
+for (const p of envCandidates) {
+  if (fs.existsSync(p)) {
+    require('dotenv').config({ path: p });
+    if (process.env.DATABASE_URL) break;
+  }
+}
+
+const { Client } = require('pg');
+
+const APPLY = process.argv.includes('--apply');
+
+const ITEM = {
+  name: 'Post about the party on socials',
+  due_date: '2026-06-08',
+  is_auto: false,
+  auto_rule: null,
+  link_tab: 'social-post',
+  sort_order: 11,
+};
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL not found (looked in backend/.env). Aborting.');
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  console.log(`\ndiavola-58479 social-post backfill — ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+
+  try {
+    // Current template size — the per-party "fully seeded" threshold. Evaluated
+    // BEFORE step (b) inserts the new template row, so it reflects the old count.
+    const cntRes = await client.query(`SELECT COUNT(*)::int AS n FROM checklist_defaults`);
+    const threshold = cntRes.rows[0].n;
+    console.log(`Current checklist_defaults count (seeded-party threshold): ${threshold}`);
+
+    // ---- Preview: which parties qualify for step (a)? ----
+    const previewSql = `
+      SELECT p.id
+      FROM parties p
+      WHERE (
+        SELECT COUNT(*) FROM checklist_items ci
+        WHERE ci.party_id = p.id AND ci.is_default = true
+      ) >= $2
+      AND NOT EXISTS (
+        SELECT 1 FROM checklist_items ci2
+        WHERE ci2.party_id = p.id AND ci2.name = $1
+      )
+    `;
+    const preview = await client.query(previewSql, [ITEM.name, threshold]);
+    console.log(`Step (a): ${preview.rows.length} party(ies) need the new checklist row inserted.`);
+
+    const tmplPreview = await client.query(
+      `SELECT 1 FROM checklist_defaults WHERE name = $1`,
+      [ITEM.name],
+    );
+    const templateExists = tmplPreview.rows.length > 0;
+    console.log(`Step (b): checklist_defaults template row ${templateExists ? 'already exists (will skip)' : 'will be inserted'}.`);
+
+    if (!APPLY) {
+      console.log('\nDry-run only. Re-run with --apply to perform the inserts.\n');
+      return;
+    }
+
+    // ---- Step (a): insert per-party rows FIRST ----
+    const insertItemsSql = `
+      INSERT INTO checklist_items
+        (id, party_id, name, due_date, is_auto, auto_rule, link_tab, sort_order, is_default, completed, created_at, updated_at)
+      SELECT
+        gen_random_uuid(), p.id, $1, $2::date, $3, $4, $5, $6, true, false, now(), now()
+      FROM parties p
+      WHERE (
+        SELECT COUNT(*) FROM checklist_items ci
+        WHERE ci.party_id = p.id AND ci.is_default = true
+      ) >= $7
+      AND NOT EXISTS (
+        SELECT 1 FROM checklist_items ci2
+        WHERE ci2.party_id = p.id AND ci2.name = $1
+      )
+    `;
+    const itemsRes = await client.query(insertItemsSql, [
+      ITEM.name, ITEM.due_date, ITEM.is_auto, ITEM.auto_rule, ITEM.link_tab, ITEM.sort_order, threshold,
+    ]);
+    console.log(`Step (a) done: inserted ${itemsRes.rowCount} checklist_items row(s).`);
+
+    // ---- Step (b): insert checklist_defaults template AFTER the per-party rows ----
+    const insertTemplateSql = `
+      INSERT INTO checklist_defaults (name, due_date, is_auto, auto_rule, link_tab, sort_order)
+      VALUES ($1, $2::date, $3, $4, $5, $6)
+      ON CONFLICT (name) DO NOTHING
+    `;
+    const tmplRes = await client.query(insertTemplateSql, [
+      ITEM.name, ITEM.due_date, ITEM.is_auto, ITEM.auto_rule, ITEM.link_tab, ITEM.sort_order,
+    ]);
+    console.log(`Step (b) done: inserted ${tmplRes.rowCount} checklist_defaults row(s).`);
+
+    console.log('\nBackfill complete.\n');
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -20,7 +20,7 @@ const XIcon: React.FC<{ size: number }> = ({ size }) => (
 );
 
 /** Normalize a twitter handle: strip @, strip full URL prefixes */
-function normalizeHandle(raw: string): string {
+export function normalizeHandle(raw: string): string {
   return raw
     .replace(/^https?:\/\/(www\.)?(twitter\.com|x\.com)\//i, '')
     .replace(/^@/, '')

--- a/frontend/src/components/checklist/ChecklistTab.tsx
+++ b/frontend/src/components/checklist/ChecklistTab.tsx
@@ -14,6 +14,7 @@ import { ChecklistItemRow } from './ChecklistItemRow';
 import { ChecklistItemForm } from './ChecklistItemForm';
 import { FindVenueModal } from './FindVenueModal';
 import { EstimatedAttendanceModal } from './EstimatedAttendanceModal';
+import { SocialPostModal } from './SocialPostModal';
 import { usePizza } from '../../contexts/PizzaContext';
 
 interface ChecklistTabProps {
@@ -38,6 +39,7 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
   const [findVenueOpen, setFindVenueOpen] = useState(false);
   const [attendanceModalOpen, setAttendanceModalOpen] = useState(false);
+  const [socialModalOpen, setSocialModalOpen] = useState(false);
 
   const navigate = useNavigate();
   const { inviteCode } = useParams<{ inviteCode: string }>();
@@ -103,6 +105,7 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
   };
 
   const handleNavigate = (tab: string) => {
+    if (tab === 'social-post') { setSocialModalOpen(true); return; }
     if (tab === 'attendance') { setAttendanceModalOpen(true); return; }
     if (tab === 'venue') {
       setFindVenueOpen(true);
@@ -236,6 +239,14 @@ export const ChecklistTab: React.FC<ChecklistTabProps> = ({ partyId }) => {
         currentEstimate={party?.estimatedAttendance ?? null}
         onSaved={loadChecklist}
       />
+
+      {party && (
+        <SocialPostModal
+          open={socialModalOpen}
+          onClose={() => setSocialModalOpen(false)}
+          party={party}
+        />
+      )}
 
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (

--- a/frontend/src/components/checklist/SocialPostModal.tsx
+++ b/frontend/src/components/checklist/SocialPostModal.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Megaphone, Copy, Check, Download, Loader2 } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { normalizeHandle } from '../ShareRSVP';
+import { countryNameToFlag } from '../../utils/countryFlag';
+import { getPartyPhotos } from '../../lib/api';
+import type { Party, Photo } from '../../types';
+
+interface SocialPostModalProps {
+  open: boolean;
+  onClose: () => void;
+  party: Party;
+}
+
+// X (Twitter) icon — mirrors ShareRSVP's inline XIcon
+const XIcon: React.FC<{ size: number }> = ({ size }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+/**
+ * Build the partner @tags string. MIRRORS the guest "share on X" logic from
+ * RSVPPage.tsx (~lines 289-299) + ShareRSVP.tsx, adapted for the camelCase
+ * `Party` object (hostProfile / coHosts / host.twitter / host.showOnEvent).
+ */
+function buildPartnerTags(party: Party): string {
+  const rawHandles: string[] = [];
+  if (party.hostProfile?.twitter) rawHandles.push(party.hostProfile.twitter);
+  for (const host of party.coHosts ?? []) {
+    if (host.twitter && host.showOnEvent !== false) rawHandles.push(host.twitter);
+  }
+
+  // Always start with Pizza_DAO, then dedupe case-insensitively, drop empties.
+  const allHandles = ['Pizza_DAO', ...rawHandles];
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const raw of allHandles) {
+    const normalized = normalizeHandle(raw);
+    if (normalized && !seen.has(normalized.toLowerCase())) {
+      seen.add(normalized.toLowerCase());
+      unique.push(normalized);
+    }
+  }
+  return unique.map((h) => `@${h}`).join(' ');
+}
+
+function partyCity(party: Party): string {
+  if (party.city) return party.city;
+  return party.name.replace(/^Global Pizza Party\s*/i, '').trim() || party.name;
+}
+
+function buildDefaultText(party: Party): string {
+  const flag = countryNameToFlag(party.country);
+  const city = partyCity(party);
+  const tags = buildPartnerTags(party);
+  return (
+    `${flag}\u{1F355}\u{1F973}\n` +
+    `We had a blast celebrating Bitcoin Pizza Day in ${city}!\n` +
+    `\n` +
+    `Thanks ${tags} for supporting the event! See you next year!`
+  );
+}
+
+async function downloadImage(url: string, filename: string): Promise<void> {
+  const res = await fetch(url);
+  const blob = await res.blob();
+  const obj = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = obj;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(obj);
+}
+
+export function SocialPostModal({ open, onClose, party }: SocialPostModalProps) {
+  const [text, setText] = useState('');
+  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [loadingPhotos, setLoadingPhotos] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const city = useMemo(() => partyCity(party), [party]);
+
+  // Re-initialize the editable text whenever the modal (re)opens.
+  useEffect(() => {
+    if (open) {
+      setText(buildDefaultText(party));
+      setCopied(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, party.id]);
+
+  // Fetch photos on open.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoadingPhotos(true);
+    getPartyPhotos(party.id, { limit: 24 })
+      .then((res) => {
+        if (cancelled) return;
+        const items = (res?.photos ?? [])
+          .filter((p) => p.status === 'approved' && p.mimeType?.startsWith('image/'))
+          .sort((a, b) => Number(b.starred) - Number(a.starred));
+        setPhotos(items);
+        setLoadingPhotos(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPhotos([]);
+        setLoadingPhotos(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, party.id]);
+
+  // ESC closes
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const overLimit = text.length > 280;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // user can manually select
+    }
+  };
+
+  const handlePostOnX = () => {
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
+    window.open(url, '_blank', 'noopener');
+  };
+
+  const slug = city.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'party';
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl bg-theme-card border border-theme-stroke text-theme-text shadow-2xl p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute top-3 right-3 z-10 text-theme-text-faint hover:text-theme-text transition-colors"
+        >
+          <X size={20} />
+        </button>
+
+        <h2 className="text-lg font-semibold text-theme-text flex items-center gap-2 mb-1 pr-8">
+          <Megaphone size={18} />
+          Post about the party on socials
+        </h2>
+        <p className="text-sm text-theme-text-muted mb-4">
+          Share a recap and download your event photos to post.
+        </p>
+
+        {/* Editable post */}
+        <IconInput
+          icon={Megaphone}
+          multiline
+          rows={7}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Write your recap post…"
+        />
+        <div
+          className={`mt-1 mb-4 text-right text-xs ${
+            overLimit ? 'text-red-500' : 'text-theme-text-faint'
+          }`}
+        >
+          {text.length}/280
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-2 mb-5">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-theme-surface border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text text-sm"
+          >
+            {copied ? <Check size={16} /> : <Copy size={16} />}
+            {copied ? 'Copied' : 'Copy to clipboard'}
+          </button>
+          <button
+            type="button"
+            onClick={handlePostOnX}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-red-500 hover:bg-red-600 text-white font-semibold text-sm"
+          >
+            <XIcon size={14} />
+            Post on X
+          </button>
+        </div>
+
+        {/* Photos */}
+        <div>
+          <h3 className="text-sm font-medium text-theme-text mb-2">Event photos</h3>
+          {loadingPhotos ? (
+            <div className="flex justify-center py-6">
+              <Loader2 className="w-5 h-5 animate-spin text-theme-text-muted" />
+            </div>
+          ) : photos.length === 0 ? (
+            <p className="text-sm text-theme-text-muted py-4">No photos yet.</p>
+          ) : (
+            <div className="grid grid-cols-3 gap-2">
+              {photos.map((photo, i) => (
+                <div
+                  key={photo.id}
+                  className="relative group aspect-square rounded-lg overflow-hidden border border-theme-stroke"
+                >
+                  <img
+                    src={photo.thumbnailUrl || photo.url}
+                    alt={photo.caption || `Photo ${i + 1}`}
+                    className="w-full h-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      downloadImage(photo.url, `${slug}-bpd-2026-${i + 1}.jpg`).catch(() => {})
+                    }
+                    aria-label="Download photo"
+                    className="absolute bottom-1 right-1 w-7 h-7 flex items-center justify-center rounded-full bg-black/60 text-white opacity-0 group-hover:opacity-100 hover:bg-black/80 transition-opacity"
+                  >
+                    <Download size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
+++ b/frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx
@@ -8,6 +8,7 @@ import { HostResources } from './HostResources';
 import { HostsManager } from '../HostsManager';
 import { FindVenueModal } from '../checklist/FindVenueModal';
 import { EstimatedAttendanceModal } from '../checklist/EstimatedAttendanceModal';
+import { SocialPostModal } from '../checklist/SocialPostModal';
 import { DashboardKPIs } from './DashboardKPIs';
 import { PayoutStatusPill } from '../payments-shared/PayoutStatusPill';
 
@@ -24,6 +25,7 @@ export const GPPDashboardTab: React.FC = () => {
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [findVenueOpen, setFindVenueOpen] = useState(false);
   const [attendanceModalOpen, setAttendanceModalOpen] = useState(false);
+  const [socialModalOpen, setSocialModalOpen] = useState(false);
   // polpetta-49102: surface latest payouts on the dashboard so hosts don't
   // need to switch to the Payments tab to confirm a prepayment landed.
   const [recentPayouts, setRecentPayouts] = useState<Payout[]>([]);
@@ -88,6 +90,7 @@ export const GPPDashboardTab: React.FC = () => {
     'Select Pizzeria': MapPin,
     'Prepare for the Party': ClipboardCheck,
     'Post to Socials': Megaphone,
+    'Post about the party on socials': Megaphone,
     'Throw the Party': Rocket,
     'Get reviewed for funding': ShieldCheck,
     'Estimated Attendance': Users,
@@ -139,7 +142,8 @@ export const GPPDashboardTab: React.FC = () => {
         onClick: item.name === 'Build a Team' ? () => setHostsExpanded(prev => !prev) :
                  item.name === 'Find Partners' ? () => goToTab('partners') :
                  item.name === 'Find a Venue' ? () => setFindVenueOpen(true) :
-                 item.name === 'Estimated Attendance' ? () => setAttendanceModalOpen(true) : undefined,
+                 item.name === 'Estimated Attendance' ? () => setAttendanceModalOpen(true) :
+                 item.name === 'Post about the party on socials' ? () => setSocialModalOpen(true) : undefined,
         icon: ICON_MAP[item.name] ?? ClipboardCheck,
         dueDate: item.dueDate ? item.dueDate.split('T')[0] : null,
       };
@@ -507,6 +511,12 @@ export const GPPDashboardTab: React.FC = () => {
         partyId={party.id}
         currentEstimate={party.estimatedAttendance ?? null}
         onSaved={loadChecklist}
+      />
+
+      <SocialPostModal
+        open={socialModalOpen}
+        onClose={() => setSocialModalOpen(false)}
+        party={party}
       />
 
       {/* Host Resources */}

--- a/plans/diavola-58479-social-post-checklist.md
+++ b/plans/diavola-58479-social-post-checklist.md
@@ -1,0 +1,98 @@
+# diavola-58479 — "Post about the party on socials" checklist item + compose modal
+
+## Goal
+Add a host-dashboard checklist item **"Post about the party on socials"**, placed
+immediately **after** the "Estimated Attendance" item, that opens a **compose modal**.
+The modal shows the party's photos (with download) and a pre-filled, editable recap
+post the host can copy / post to X.
+
+### Template text
+```
+{country flag}🍕🥳
+We had a blast celebrating Bitcoin Pizza Day in {city}!
+
+Thanks {partner @tags} for supporting the event! See you next year!
+```
+- `{country flag}` → `countryNameToFlag(party.country)` (`frontend/src/utils/countryFlag.ts`), falls back to 🗺️.
+- `🍕🥳` → literal `\u{1F355}\u{1F973}` (matches the guest share-on-X house style).
+- `{city}` → `party.city`, fallback to `party.name.replace(/^Global Pizza Party\s*/i,'').trim()`.
+- `{partner @tags}` → **same handles as the guest "share on X" post** at the end of RSVP
+  (`RSVPPage.tsx:289-299` → `ShareRSVP.tsx`):
+  - host profile twitter (if present),
+  - each co-host with `twitter && showOnEvent !== false`,
+  - prepend `Pizza_DAO`, then normalize (strip `@`/URL) + dedupe via `normalizeHandle`,
+  - render each as `@handle` joined by spaces.
+  - If no partner handles resolve beyond `@Pizza_DAO`, still render `@Pizza_DAO`.
+
+## Background / key facts
+- Checklist items are DB-driven: `checklist_defaults` (template) → seeded per-party into
+  `checklist_items` by `POST /:partyId/checklist/seed` (backend/src/routes/checklist.routes.ts).
+- **Migrations do NOT auto-run** in this repo — the new `checklist_defaults` row must be
+  applied directly to the prod DB (Supabase MCP / pg).
+- Two renderers, both must be wired:
+  - `frontend/src/components/gpp-dashboard/GPPDashboardTab.tsx` — sorts items by **due date**;
+    opens modals via **name-based `onClick`** (see Estimated Attendance / Find a Venue).
+  - `frontend/src/components/checklist/ChecklistTab.tsx` — orders by `sort_order`; opens modals
+    via `handleNavigate(tab)` keyed on a sentinel `linkTab` (see `'attendance'`, `'venue'`).
+- To land **right after Estimated Attendance** (sort_order 10, due 2026-06-01) in BOTH renderers,
+  the new row needs `sort_order = 11` **and** a `due_date` later than 2026-06-01.
+
+## Changes
+
+### 1. DB — new checklist default
+New migration file `supabase/migrations/20260605_checklist_social_post.sql` (for the repo record)
+**and** apply the same INSERT to prod:
+```sql
+INSERT INTO checklist_defaults (name, due_date, is_auto, auto_rule, link_tab, sort_order) VALUES
+  ('Post about the party on socials', '2026-06-08', false, NULL, 'social-post', 11)
+ON CONFLICT DO NOTHING;
+```
+- `is_auto = false` → host can manually check it complete.
+- `link_tab = 'social-post'` → sentinel, intercepted by both renderers to open the modal (NOT a real tab/route).
+- Existing parties pick it up automatically: next checklist load sees
+  `existingDefaults < defaults.length` and re-seeds (deletes+reinserts default rows).
+  **Side effect to note:** re-seed resets manual `completed` state on default items for parties
+  not yet at full default count — same behavior the Estimated-Attendance addition caused. Acceptable.
+
+### 2. Frontend — new modal `frontend/src/components/checklist/SocialPostModal.tsx`
+Props: `{ open, onClose, party }` (full camelCase `Party`).
+- On open: fetch photos via `getPartyPhotos(party.id, { limit: ... })` and keep `status === 'approved'`
+  images (starred first). Fetch nothing else needed — partner handles + city + flag derive from `party`.
+- Build default post text from the template above; store in editable state.
+- UI (mirror `SuggestionModal` shell + `PostComposerPage` actions):
+  - Backdrop `fixed inset-0 z-50 bg-black/60 backdrop-blur-sm`, click-outside-to-close, `X` close button, `createPortal`.
+  - Title "Post about the party on socials".
+  - Photo grid: thumbnails of approved photos, each with a Download button
+    (use `PostComposerPage`'s `downloadImage(url, filename)` blob-fetch approach for cross-origin Supabase URLs).
+    Empty state: small "No photos yet" note.
+  - Editable post: `<IconInput multiline rows={7} icon={Megaphone} value=... onChange=... />` + char counter (280, red over).
+  - Buttons: **Copy to clipboard** (Copy/Check toggle, 2s reset) and **Post on X**
+    (`https://twitter.com/intent/tweet?text=` + `encodeURIComponent`).
+- Reuse/export `normalizeHandle` from `ShareRSVP.tsx` so handle formatting stays in sync with the guest post.
+
+### 3. Wire into `GPPDashboardTab.tsx`
+- `ICON_MAP`: `'Post about the party on socials': Megaphone` (or `Share2`).
+- Add state `socialModalOpen`; in the `checklist` map `onClick`, add
+  `item.name === 'Post about the party on socials' ? () => setSocialModalOpen(true) : ...`.
+  (name-based onClick takes precedence over `linkTab`, so the `'social-post'` sentinel won't navigate.)
+- Render `<SocialPostModal open={socialModalOpen} onClose={...} party={party} />`.
+
+### 4. Wire into `ChecklistTab.tsx`
+- Add state `socialModalOpen`; in `handleNavigate`, add
+  `if (tab === 'social-post') { setSocialModalOpen(true); return; }` (before the `inviteCode` navigate).
+- Render `<SocialPostModal open={socialModalOpen} onClose={...} party={party} />`.
+
+## Out of scope
+- No backend route changes (existing seed/toggle endpoints suffice).
+- No new storage/bucket changes.
+
+## Verification
+- `cd frontend && npx tsc --noEmit` (and backend tsc if touched — it isn't).
+- Vercel preview: open a host dashboard + the standalone checklist tab; confirm the new item
+  appears right after Estimated Attendance, opens the modal, photos load + download, template
+  renders correct flag/city/partner tags, copy + Post-on-X work.
+- After merge: apply the `checklist_defaults` INSERT to prod DB so the item shows on existing parties.
+
+## Sequencing
+1. Apply the `checklist_defaults` INSERT to **prod DB** (Snax-authorized) — frontend previews talk to prod backend/DB, so the item must exist there to render on previews.
+2. Implement frontend in a worktree branch off `origin/master`, draft PR, verify on Vercel preview.

--- a/supabase/migrations/20260605_checklist_social_post.sql
+++ b/supabase/migrations/20260605_checklist_social_post.sql
@@ -1,0 +1,19 @@
+-- diavola-58479: "Post about the party on socials" checklist item.
+--
+-- A new non-auto default checklist row placed after "Estimated Attendance"
+-- (sort_order 11, due 2026-06-08). link_tab 'social-post' is a SENTINEL, not a
+-- real tab/route — both checklist renderers (GPPDashboardTab name-based onClick,
+-- ChecklistTab handleNavigate) intercept it to open the new SocialPostModal.
+--
+-- IMPORTANT ordering note for the operator: before this checklist_defaults row is
+-- inserted in prod, run backend/scripts/backfill-social-post-checklist.cjs --apply
+-- so already-seeded parties get the new item directly. Otherwise the seed
+-- endpoint's reconcile (delete-and-recreate when a party's is_default count drops
+-- below the checklist_defaults count) would fire on every already-seeded party and
+-- wipe manual completion on the non-auto default items (Find Partners, Select
+-- Pizzeria, etc.). The backfill script performs both steps in the correct order;
+-- this file documents the template change for the migration history.
+
+INSERT INTO checklist_defaults (name, due_date, is_auto, auto_rule, link_tab, sort_order) VALUES
+  ('Post about the party on socials', '2026-06-08', false, NULL, 'social-post', 11)
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## What
Adds a new host-dashboard checklist item **"Post about the party on socials"**, placed right after **Estimated Attendance**, that opens a compose modal.

The modal shows the party''s approved photos (each with a download button) and an editable recap post pre-filled with:

```
{country flag}🍕🥳
We had a blast celebrating Bitcoin Pizza Day in {city}!

Thanks {partner @tags} for supporting the event! See you next year!
```

- Flag → `countryNameToFlag(party.country)`; city → `party.city` (fallback to event name).
- Partner `@tags` mirror the **guest share-on-X** handle pipeline exactly (host + co-hosts with `showOnEvent !== false`, prepend `@Pizza_DAO`, normalize + dedupe via the now-exported `normalizeHandle`).
- Copy-to-clipboard + Post-on-X buttons; 280-char counter.

## Wiring
- New `SocialPostModal.tsx` (host-side dark theme, portal + click-outside + ESC).
- `GPPDashboardTab` — ICON_MAP entry, name-based `onClick`, modal render.
- `ChecklistTab` — `handleNavigate(''social-post'')` intercept + guarded modal render.

## DB (operator step — not auto-applied)
New `checklist_defaults` row (`sort_order 11`, `due 2026-06-08`, `is_auto false`, sentinel `link_tab ''social-post''`).

Apply via `backend/scripts/backfill-social-post-checklist.cjs --apply`, which inserts the per-party `checklist_items` rows **before** the template row so the seed reconcile never deletes+recreates default rows (which would wipe hosts'' manual completion). `supabase/migrations/20260605_checklist_social_post.sql` documents the change.

## Test plan
- [ ] Item appears right after Estimated Attendance on the dashboard **and** the standalone checklist tab.
- [ ] Clicking it opens the modal; photos load + download works; template renders correct flag/city/partner tags.
- [ ] Copy + Post-on-X work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)