### PR TITLE
fix(pomodoro-61456): drop receipt date from AI image-authenticity judgment

### DIFF
--- a/backend/src/lib/providers/types.ts
+++ b/backend/src/lib/providers/types.ts
@@ -54,6 +54,8 @@ Look for concrete tells:
 
 Be calibrated: heavy compression, scanner artifacts, dark restaurant lighting, and screenshots are NOT by themselves evidence of fakery. Only flag concrete, image-grounded tells. When unsure, prefer "suspicious" over "likely_fake".
 
+Ignore the receipt's printed date, time, and any timestamps entirely — they are NOT evidence of fakery. Never flag a date for being recent, old, or in the future; date plausibility is out of scope. Judge authenticity only from image-forensic tells.
+
 Return ONLY a JSON object:
 {
   "verdict": "authentic" | "suspicious" | "likely_fake",
@@ -63,7 +65,7 @@ Return ONLY a JSON object:
 
 export function visionUserPrompt(ctx: VisionContext): string {
   return ctx.sourceKind === 'receipt'
-    ? 'Judge whether this receipt image is AI-generated or doctored. Pay special attention to the legibility and consistency of the printed text and the total/amount fields.'
+    ? 'Judge whether this receipt image is AI-generated or doctored. Pay special attention to the legibility and consistency of the printed text and the total/amount fields. Disregard the printed date and any timestamps — they are not a forgery signal.'
     : 'Judge whether this event-cover image is AI-generated or doctored.';
 }
 


### PR DESCRIPTION
## Problem

The image-authenticity ("AI detection") check runs gpt-4o vision on receipt images to flag forgeries. The vision prompt never grounds the model with today's date, so the model treats a receipt's printed date (e.g. `5/22/2026`) as "in the future" and reports it as a forgery tell — a **false positive on every recent receipt**.

## Fix

Rather than plumb a current date into the prompt, we **remove the date from the judgment entirely** — date plausibility is out of scope for image forensics. Edited only `backend/src/lib/providers/types.ts`:

- `VISION_SYSTEM_PROMPT`: added an explicit instruction to ignore printed dates, times, and timestamps, and never to flag a date for being recent/old/future.
- `visionUserPrompt` (receipt branch): added "Disregard the printed date and any timestamps — they are not a forgery signal." The `event_image` branch is unchanged.

No changes to `VisionContext`, the providers, or `imageAuthenticity.ts` — no date plumbing needed.

## Deploy notes

Backend-only change. Must merge to `master` to take effect; the backend auto-deploys on master push. Frontend previews talk to the production backend, so this won't be observable on the preview frontend until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)