### PR TITLE
rigatoni-72401: Ship combined PizzaDAO+SWC opt-in checkbox to all SWC events

### DIFF
--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -193,22 +193,11 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
   const [showRegionalOptinAbModal, setShowRegionalOptinAbModal] = useState(false);
 
   useEffect(() => {
-    if (optinAbVariant !== null) return; // preservation path already set
+    if (optinAbVariant !== null) return; // preserve existing-guest bucket if any
     if (!activeRegionConfig) return;     // not an SWC event
-    // pizzaiolo-63884: pilot mode — only events explicitly tagged 'optin-ab-test'
-    // participate in the experiment, even when the region's kill-switch flag is ON.
-    // Remove this gate (or remove the tag from each pilot event) to fan out to all
-    // region-tagged events.
-    const tags = eventData.eventTags || [];
-    if (!tags.includes('optin-ab-test')) return;
-    let cancelled = false;
-    (async () => {
-      const enabled = await getExperimentFlag(activeRegionConfig.flagKey);
-      if (cancelled) return;
-      if (!enabled) return;
-      setOptinAbVariant(Math.random() < 0.5 ? 'control' : 'variant');
-    })();
-    return () => { cancelled = true; };
+    // rigatoni-72401: A/B test concluded — every SWC event ships the combined checkbox.
+    // Kill-switch flag + pilot tag remain in DB for emergency rollback, but no longer gate the UI.
+    setOptinAbVariant('variant');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/i18n/locales/de/rsvp.json
+++ b/frontend/src/i18n/locales/de/rsvp.json
@@ -9,6 +9,7 @@
     "roleQuestion": "Welcher Ninja Turtle sind Sie am ähnlichsten?",
     "mailingList": "PizzaDAO-Mailingliste beitreten",
     "swcJoin": "Stand with Crypto beitreten",
+    "combinedOptIn": "Hören Sie von PizzaDAO + unseren Partnern",
     "swcNotify": "Benachrichtigen Sie mich über Stand With Crypto Events.",
     "swcBrNotify": "Benachrichtigen Sie mich über Veranstaltungen von Juntos por Cripto.",
     "ethconfDiscount": "ETHConf-Rabatt zusenden",

--- a/frontend/src/i18n/locales/es/rsvp.json
+++ b/frontend/src/i18n/locales/es/rsvp.json
@@ -9,6 +9,7 @@
     "roleQuestion": "¿A cuál(es) tortuga(s) ninja te pareces más?",
     "mailingList": "Unirme a la lista de correo de PizzaDAO",
     "swcJoin": "Unirme a Stand with Crypto",
+    "combinedOptIn": "Recibe novedades de PizzaDAO + nuestros socios",
     "swcNotify": "Notificarme sobre eventos de Stand With Crypto.",
     "swcBrNotify": "Notifícame sobre eventos de Juntos por Cripto.",
     "ethconfDiscount": "Enviarme un descuento de ETHConf",

--- a/frontend/src/i18n/locales/fr/rsvp.json
+++ b/frontend/src/i18n/locales/fr/rsvp.json
@@ -9,6 +9,7 @@
     "roleQuestion": "À quelle(s) tortue(s) ninja ressemblez-vous le plus ?",
     "mailingList": "Rejoindre la liste de diffusion PizzaDAO",
     "swcJoin": "Rejoindre Stand with Crypto",
+    "combinedOptIn": "Recevoir des nouvelles de PizzaDAO + nos partenaires",
     "swcNotify": "Me notifier des événements Stand With Crypto.",
     "swcBrNotify": "Informez-moi des événements de Juntos por Cripto.",
     "ethconfDiscount": "M'envoyer une réduction ETHConf",

--- a/frontend/src/i18n/locales/ja/rsvp.json
+++ b/frontend/src/i18n/locales/ja/rsvp.json
@@ -9,6 +9,7 @@
     "roleQuestion": "あなたはどの忍者タートルに似ていますか？",
     "mailingList": "PizzaDAOのメーリングリストに参加",
     "swcJoin": "Stand with Cryptoに参加",
+    "combinedOptIn": "PizzaDAOとパートナーからのお知らせを受け取る",
     "swcNotify": "Stand With Cryptoイベントについて通知を受け取る。",
     "swcBrNotify": "Juntos por Cripto のイベントについて通知してください。",
     "ethconfDiscount": "ETHConf割引を送ってほしい",

--- a/frontend/src/i18n/locales/ko/rsvp.json
+++ b/frontend/src/i18n/locales/ko/rsvp.json
@@ -9,6 +9,7 @@
     "roleQuestion": "어떤 닌자 거북이와 가장 닮았나요?",
     "mailingList": "PizzaDAO 메일링 리스트에 가입",
     "swcJoin": "Stand with Crypto에 가입",
+    "combinedOptIn": "PizzaDAO 및 파트너의 소식 받기",
     "swcNotify": "Stand With Crypto 이벤트에 대해 알려주세요.",
     "swcBrNotify": "Juntos por Cripto 이벤트에 대해 알려주세요.",
     "ethconfDiscount": "ETHConf 할인을 보내주세요",

--- a/frontend/src/i18n/locales/zh/rsvp.json
+++ b/frontend/src/i18n/locales/zh/rsvp.json
@@ -9,6 +9,7 @@
     "roleQuestion": "你最像哪只忍者龟？",
     "mailingList": "订阅 PizzaDAO 邮件列表",
     "swcJoin": "加入 Stand with Crypto",
+    "combinedOptIn": "接收来自 PizzaDAO 与合作伙伴的消息",
     "swcNotify": "通知我 Stand With Crypto 活动。",
     "swcBrNotify": "通知我有关 Juntos por Cripto 活动的信息。",
     "ethconfDiscount": "给我发送 ETHConf 折扣",


### PR DESCRIPTION
## Context

The parmesan-98989 A/B test ran for ~3 weeks across US, EU, UK, AU. US (n=1,355) and EU (n=866) are well-powered and both show **no PizzaDAO opt-in cost** from the merged checkbox; SWC opt-in trends up. UK/AU still small but directionally consistent. CA/BR have no data yet but the merge is safe to roll out everywhere.

**Decision (Snax, 2026-06-05):** Ship the variant to all 6 SWC regions in all 8 locales. Keep A/B infra in place but dormant (kill switch can still flip back; column stays for history).

## Summary of changes

- **`frontend/src/hooks/useRSVPForm.ts`** — replace the pilot-tag + flag-fetch + random-roll bucketing effect with an unconditional `setOptinAbVariant('variant')` for any SWC-tagged event. Existing-guest preservation branch in the `useState` initializer is untouched, so guests already bucketed into `'control'` continue to see the two-checkbox UI on re-submit. The `getExperimentFlag` import stays for future experiments.
- **6 locale files** (`de`, `es`, `fr`, `ja`, `ko`, `zh`) — add `combinedOptIn` key under `step1`, mirroring `en/rsvp.json` placement between `swcJoin` and `swcNotify`. `pt` already had it.

## What's NOT changed

- Control codepath in `RSVPFormStep1.tsx` (still needed for existing-guest re-submits with `'control'` variant).
- Backend, Prisma schema, admin `OptinABTab`.
- `optin_ab_variant` column or `experiment_flags` rows (kill-switch + history remain).

Plan: `plans/rigatoni-72401-ship-combined-optin.md`

## Test plan

- [ ] Open any SWC-tagged event (e.g. `swc`) on preview — RSVP form shows ONE combined checkbox + (i) modal.
- [ ] Open a non-SWC event on preview — RSVP form shows only the PizzaDAO checkbox (unchanged baseline).
- [ ] Open in fresh incognito (no `existingGuest.optinAbVariant`) — always variant.
- [ ] Locale spot check (fr/de/zh/ja/ko/es) — combined-checkbox label renders in the local language.
- [ ] Post-deploy SQL check: `SELECT optin_ab_variant, COUNT(*) FROM guests WHERE submitted_via='link' AND created_at >= '2026-06-05' GROUP BY 1;` — `variant` should dominate; `control` should not grow except from existing-guest re-submits.