### PR TITLE
focaccia-58215: supporters list — remove label, anchor to bottom of donate section

### DIFF
--- a/frontend/src/components/DonorHighlights.tsx
+++ b/frontend/src/components/DonorHighlights.tsx
@@ -26,7 +26,6 @@ export const DonorHighlights: React.FC<DonorHighlightsProps> = ({ stats }) => {
 
   const donors = stats.donors;
   const donorCount = stats.donorCount ?? donors.length;
-  const recipient = stats.recipient || t('thisEvent');
   const showAmounts = stats.amountsPublic === true;
 
   const inlineDonors = donors.slice(0, INLINE_DONORS);
@@ -34,10 +33,6 @@ export const DonorHighlights: React.FC<DonorHighlightsProps> = ({ stats }) => {
 
   return (
     <div className="mt-4 pt-4 border-t border-theme-stroke">
-      <p className="text-theme-text-muted text-xs font-medium mb-2">
-        {t('supportersOf', { recipient })}
-      </p>
-
       <button
         type="button"
         onClick={() => setOpen(true)}


### PR DESCRIPTION
## Summary
Small UI tweak to the donor **Supporters** list on the public EventPage donate section.

- Removed the "Supporters of …" eyebrow label paragraph from `DonorHighlights.tsx`. The clickable donor row is now the first child under the existing `border-t` separator.
- Removed the now-unused `recipient` const. `useTranslation` stays (still used by `moreSupporters`).
- The `supportersOf` i18n key remains in all 8 locale files (still used by `SupportersModal`) — harmless if otherwise unused.

## Bottom-of-section anchoring
No EventPage change was needed. `<DonorHighlights>` is already the **last child** of both donate `<div>`s (desktop ~L924 and mobile ~L1551), rendered after the Donate button and recipient `<p>`. Verified in place.

## Empty state
Unchanged: `DonorHighlights` returns `null` when no donors, and EventPage only renders it when `donationStats` is truthy — so the list hides while the Donate button still shows.

## Verification
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)