### PR TITLE
marzano-58293: 'nonhub' tag opts US cities out of SWC Hub gate (USDC)

### DIFF
--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -342,6 +342,9 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   // either the country='United States' OR an event_tags entry containing
   // 'SWC Hub' (case-insensitive).
   const swcHub = useMemo(() => {
+    // marzano-58293: 'nonhub' tag opts the party out of the SWC Hub gate (USDC
+    // treatment) — precedence over the country + 'swc hub' signals below.
+    if ((eventTags ?? []).some((t) => t && t.trim().toLowerCase() === 'nonhub')) return false;
     if (country && country.trim().toLowerCase() === 'united states') return true;
     return (eventTags ?? []).some((t) => t && t.toLowerCase().includes('swc hub'));
   }, [country, eventTags]);

--- a/frontend/src/utils/swcHub.ts
+++ b/frontend/src/utils/swcHub.ts
@@ -25,6 +25,16 @@ export function isSwcHubParty(
   party?: { country?: string | null; eventTags?: string[] | null } | null,
 ): boolean {
   if (!party) return false;
+  // marzano-58293: explicit per-party opt-out. A 'nonhub' tag forces USDC
+  // treatment — it takes precedence over BOTH the 'SWC Hub' tag and the
+  // US-country fallback below. Mirrors the existing `nonpres` opt-out
+  // precedent. Used to drop the SWC Hub reimbursement gate from US cities.
+  if (
+    Array.isArray(party.eventTags) &&
+    party.eventTags.some((t) => t != null && t.trim().toLowerCase() === 'nonhub')
+  ) {
+    return false;
+  }
   if (Array.isArray(party.eventTags) && party.eventTags.includes('SWC Hub')) return true;
   if (party.country === 'United States') return true;
   return false;


### PR DESCRIPTION
## What
Adds a per-party opt-out tag `'nonhub'`. When a party's `event_tags` contains `'nonhub'`, `isSwcHubParty()` returns `false`, so the SWC Hub reimbursement warning/ack/pill is dropped and the party pays out via USDC like any other. This overrides both the `'SWC Hub'` tag and the `country==='United States'` fallback.

## Why
US cities should pay out via USDC normally rather than being soft-blocked behind the "process through SWC" gate. A `'nonhub'` tag (mirroring the existing `nonpres` opt-out precedent) is reversible per-party and map-safe (`'nonhub'` doesn't contain `'swc'`, so the `/map` `%swc%` filter is unaffected).

## Changes
- `frontend/src/utils/swcHub.ts` — central `isSwcHubParty()` early-returns `false` on a `'nonhub'` tag.
- `frontend/src/components/payments-admin/SendPaymentModal.tsx` — same opt-out mirrored in its local `swcHub` derivation.

The `'SWC Hub'` tag is intentionally left in place. Frontend-only soft block — no backend change. A follow-up data backfill tags all US parties `'nonhub'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)