### PR TITLE
fix(calzone-58291): open Actions tag submenus upward so they stay on-screen

### DIFF
--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -646,7 +646,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                       {t('eventTable.addTag')} &rarr;
                     </button>
                     {showTagSubmenu === 'add' && (
-                      <div className="absolute left-full top-0 ml-1 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[160px]">
+                      <div className="absolute left-full bottom-0 ml-1 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[160px]">
                         {['review', 'swc', 'Global Pizza Party'].map((tag) => (
                           <button
                             key={tag}
@@ -725,7 +725,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                       {t('eventTable.removeTag')} &rarr;
                     </button>
                     {showTagSubmenu === 'remove' && (
-                      <div className="absolute left-full top-0 ml-1 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[160px]">
+                      <div className="absolute left-full bottom-0 ml-1 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[160px]">
                         {/* Show tags that exist on selected events */}
                         {(() => {
                           const selectedEvents = events.filter(e => selectedIds.has(e.id));


### PR DESCRIPTION
## Problem
On `/underboss`, the bulk **Actions ▸ Add Tag / Remove Tag** flyouts were anchored `top-0` (grew downward). When the events table has **only one row** it is short, so the Actions dropdown sits near the bottom of the viewport and the submenu spilled off the bottom of the screen — the tag options (`review` / `swc` / `Global Pizza Party`) couldn't be reached.

## Fix
Anchor both tag submenus to `bottom-0` so they grow **upward** from the (bottom-most) menu items, keeping them on-screen. Pure CSS-class change, no logic touched.

## Test
- One-row table → Actions ▸ Add Tag / Remove Tag flyout now opens upward and stays fully visible.
- Multi-row table → flyout still fully visible (items are lower on screen, plenty of room above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
