### PR TITLE
montanara-83726: Molto Benny signs every Telegram message with 👁️🍕👁️

### DIFF
--- a/backend/src/lib/bennySignature.test.ts
+++ b/backend/src/lib/bennySignature.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { BENNY_SIGNATURE, withBennySignature } from './bennySignature.js';
+
+describe('withBennySignature', () => {
+  it('appends the signature on its own line', () => {
+    expect(withBennySignature('Pizza payment sent!')).toBe(
+      `Pizza payment sent!\n\n${BENNY_SIGNATURE}`,
+    );
+  });
+  it('is idempotent', () => {
+    const once = withBennySignature('hi');
+    expect(withBennySignature(once)).toBe(once);
+  });
+  it('treats trailing whitespace after an existing signature as already signed', () => {
+    const signed = `hi\n\n${BENNY_SIGNATURE}\n`;
+    expect(withBennySignature(signed)).toBe(signed);
+  });
+  it('tolerates empty input', () => {
+    expect(withBennySignature('')).toBe(`\n\n${BENNY_SIGNATURE}`);
+  });
+});

--- a/backend/src/lib/bennySignature.ts
+++ b/backend/src/lib/bennySignature.ts
@@ -1,0 +1,18 @@
+/**
+ * montanara-83726: Molto Benny's sign-off.
+ *
+ * Every Telegram message the Molto Benny bot sends — /underboss broadcasts,
+ * /payments payout + team notifications, host announcements, and the bot's own
+ * command replies — ends with this signature so Benny always signs off with his
+ * eyes-on-the-pizza mark.
+ *
+ * Idempotent: text that already ends with the signature is returned unchanged,
+ * so callers composing pre-signed text never double up.
+ */
+export const BENNY_SIGNATURE = '👁️🍕👁️';
+
+export function withBennySignature(text: string): string {
+  const base = typeof text === 'string' ? text : '';
+  if (base.trimEnd().endsWith(BENNY_SIGNATURE)) return base;
+  return `${base}\n\n${BENNY_SIGNATURE}`;
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -19,6 +19,7 @@ import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../config/database.js';
 import { unaccentMatchIds } from '../lib/accentSearch.js';
+import { withBennySignature } from '../lib/bennySignature.js';
 import {
   requireAuth,
   AuthRequest,
@@ -6010,7 +6011,7 @@ async function sendTelegramMessage(
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         chat_id: chatId,
-        text,
+        text: withBennySignature(text),
         disable_web_page_preview: true,
       }),
     });

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -2,6 +2,7 @@ import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest, isSuperAdmin, isAdmin, isUnderboss, isPaymentAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
+import { withBennySignature } from '../lib/bennySignature.js';
 import { sendApprovalEmail, sendPromotionEmail } from './rsvp.routes.js';
 import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS, GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
@@ -2071,7 +2072,7 @@ router.post('/:partyId/announce', async (req: AuthRequest, res: Response, next: 
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               chat_id: party.hostTelegramChatId.toString(),
-              text: message,
+              text: withBennySignature(message),
               parse_mode: 'Markdown',
             }),
           });

--- a/backend/src/routes/telegram-webhook.routes.ts
+++ b/backend/src/routes/telegram-webhook.routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
+import { withBennySignature } from '../lib/bennySignature.js';
 
 const router = Router();
 
@@ -29,7 +30,7 @@ async function sendMessage(
     await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ chat_id: chatId, text }),
+      body: JSON.stringify({ chat_id: chatId, text: withBennySignature(text) }),
     });
   } catch (err: any) {
     console.error('[Telegram Webhook] sendMessage failed:', err?.message || err);

--- a/backend/src/routes/telegram.routes.ts
+++ b/backend/src/routes/telegram.routes.ts
@@ -3,6 +3,7 @@ import { prisma } from '../config/database.js';
 import { requireAuth } from '../middleware/auth.js';
 import { requireUnderbossAuth, UnderbossAuthRequest } from '../middleware/underbossAuth.js';
 import { AppError } from '../middleware/error.js';
+import { withBennySignature } from '../lib/bennySignature.js';
 
 // Alias to keep the routes that were ported in from master readable.
 type UnderbossRequest = UnderbossAuthRequest;
@@ -94,6 +95,7 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
       let personalizedMessage = message;
       personalizedMessage = personalizedMessage.replace(/\{city\}/g, city || '');
       personalizedMessage = personalizedMessage.replace(/\{country\}/g, country || '');
+      personalizedMessage = withBennySignature(personalizedMessage);
 
       try {
         const effectiveParseMode = parseMode && parseMode !== 'None' ? parseMode : undefined;
@@ -245,6 +247,7 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
       let personalizedMessage = message;
       personalizedMessage = personalizedMessage.replace(/\{city\}/g, city);
       personalizedMessage = personalizedMessage.replace(/\{hostName\}/g, hostName);
+      personalizedMessage = withBennySignature(personalizedMessage);
 
       try {
         const effectiveParseMode = parseMode && parseMode !== 'None' ? parseMode : undefined;
@@ -366,7 +369,7 @@ router.post('/host-test', requireAuth, requireUnderbossAuth, async (req: Underbo
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chat_id: party.hostTelegramChatId.toString(),
-            text: message,
+            text: withBennySignature(message),
             ...(effectiveParseMode && { parse_mode: effectiveParseMode }),
           }),
         }
@@ -445,7 +448,7 @@ router.post('/test', requireAuth, requireUnderbossAuth, async (req: UnderbossAut
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chat_id: chatId,
-            text: message,
+            text: withBennySignature(message),
             ...(effectiveParseMode && { parse_mode: effectiveParseMode }),
           }),
         }
@@ -464,7 +467,7 @@ router.post('/test', requireAuth, requireUnderbossAuth, async (req: UnderbossAut
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               chat_id: newChatId,
-              text: message,
+              text: withBennySignature(message),
               ...(effectiveParseMode && { parse_mode: effectiveParseMode }),
             }),
           }

--- a/backend/src/services/paymentsTeamNotify.ts
+++ b/backend/src/services/paymentsTeamNotify.ts
@@ -19,6 +19,7 @@
  * block an approve/flag action.
  */
 import { prisma } from '../config/database.js';
+import { withBennySignature } from '../lib/bennySignature.js';
 
 type NotifyKind = 'approved' | 'flag_ready';
 
@@ -62,7 +63,7 @@ export async function notifyPaymentsTeam(opts: {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           chat_id: tgChat,
-          text,
+          text: withBennySignature(text),
           parse_mode: 'Markdown',
           disable_web_page_preview: true,
         }),

--- a/backend/src/services/payoutTelegramNotify.ts
+++ b/backend/src/services/payoutTelegramNotify.ts
@@ -16,6 +16,7 @@
  * skipped (Mercury already emails the host their card details).
  */
 import { prisma } from '../config/database.js';
+import { withBennySignature } from '../lib/bennySignature.js';
 
 const BOT_API = 'https://api.telegram.org';
 
@@ -69,7 +70,7 @@ export async function notifyHostOfPaymentExecution(
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         chat_id: chatId.toString(),
-        text,
+        text: withBennySignature(text),
         parse_mode: 'Markdown',
         disable_web_page_preview: true,
       }),


### PR DESCRIPTION
## What
Every Telegram message the **Molto Benny** bot sends now ends with his signature:

```
<message body>

👁️🍕👁️
```

## Surfaces covered
- `/underboss` broadcasts — `/broadcast`, `/host-broadcast`, `/host-test`, `/test`
- `/payments` — host payout paid/failed DMs (`payoutTelegramNotify`), payments-team approve/flag alerts (`paymentsTeamNotify`, Telegram only — email unchanged), receipt-reminder nudge (`admin-payout` `sendTelegramMessage`)
- Host day-of announce (`party.routes`, Telegram only)
- The bot's own command replies — connect / disconnect / help (`telegram-webhook`)

## How
New shared `backend/src/lib/bennySignature.ts` exporting `withBennySignature()`, applied at each send site (or the per-file central send helper). Idempotent — already-signed text is returned unchanged. Unit tests in `bennySignature.test.ts`.

Plain emoji + newlines are safe under both `parse_mode: HTML` and `Markdown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)