### PR TITLE
calzone-50114: hide internal event_tags from public endpoints + auto-tag paid on close-out

### DIFF
--- a/backend/src/lib/eventTags.test.ts
+++ b/backend/src/lib/eventTags.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isInternalTag,
+  publicTags,
+  INTERNAL_EVENT_TAGS,
+  withPaidTag,
+  withoutPaidTag,
+} from './eventTags.js';
+
+describe('isInternalTag', () => {
+  it('flags the known internal control tags', () => {
+    for (const t of ['possible-scam', 'paid', 'prepay', 'go', 'nonpres', 'missed', 'nonhub']) {
+      expect(isInternalTag(t)).toBe(true);
+    }
+  });
+
+  it('is case-insensitive for known tags', () => {
+    expect(isInternalTag('PAID')).toBe(true);
+    expect(isInternalTag('NonHub')).toBe(true);
+  });
+
+  it('trims whitespace', () => {
+    expect(isInternalTag('  paid  ')).toBe(true);
+  });
+
+  it('flags numeric reimbursement-cap tags', () => {
+    expect(isInternalTag('500')).toBe(true);
+    expect(isInternalTag('450.00')).toBe(true);
+    expect(isInternalTag('350.5')).toBe(true);
+  });
+
+  it('flags the gpp2027 pre-launch gate marker (any case)', () => {
+    expect(isInternalTag('gpp2027')).toBe(true);
+    expect(isInternalTag('GPP2027')).toBe(true);
+  });
+
+  it('does NOT flag public season/program tags', () => {
+    for (const t of ['swc', 'swcbr', 'SWC Hub', 'wpc', 'ens', 'Global Pizza Party', 'gpp2026']) {
+      expect(isInternalTag(t)).toBe(false);
+    }
+  });
+
+  it('does NOT flag non-string input', () => {
+    // @ts-expect-error runtime guard
+    expect(isInternalTag(null)).toBe(false);
+    // @ts-expect-error runtime guard
+    expect(isInternalTag(42)).toBe(false);
+  });
+});
+
+describe('publicTags', () => {
+  it('strips internal tags and keeps public ones', () => {
+    const input = [
+      // internal — should be stripped
+      'possible-scam', 'paid', 'prepay', 'go', 'nonpres', 'missed', 'nonhub',
+      '500', '450.00', 'gpp2027',
+      // public — should survive
+      'swc', 'swcbr', 'SWC Hub', 'wpc', 'ens', 'Global Pizza Party', 'gpp2026',
+    ];
+    expect(publicTags(input)).toEqual([
+      'swc', 'swcbr', 'SWC Hub', 'wpc', 'ens', 'Global Pizza Party', 'gpp2026',
+    ]);
+  });
+
+  it('returns [] for null', () => {
+    expect(publicTags(null)).toEqual([]);
+  });
+
+  it('returns [] for undefined', () => {
+    expect(publicTags(undefined)).toEqual([]);
+  });
+
+  it('returns [] for a non-array', () => {
+    // @ts-expect-error runtime guard
+    expect(publicTags('paid')).toEqual([]);
+  });
+
+  it('returns [] for an empty array', () => {
+    expect(publicTags([])).toEqual([]);
+  });
+
+  it('preserves order of surviving tags', () => {
+    expect(publicTags(['gpp2026', 'paid', 'swc'])).toEqual(['gpp2026', 'swc']);
+  });
+});
+
+// calzone-50114 Part B: the 'paid' close-out tag logic used by the
+// admin-payout mark-paid / reopen handlers.
+describe('withPaidTag (close-out)', () => {
+  it('appends paid when absent', () => {
+    expect(withPaidTag(['gpp2026', 'swc'])).toEqual(['gpp2026', 'swc', 'paid']);
+  });
+
+  it('is idempotent when already paid', () => {
+    expect(withPaidTag(['gpp2026', 'paid'])).toEqual(['gpp2026', 'paid']);
+    // repeated close-out does not duplicate the tag
+    expect(withPaidTag(withPaidTag(['swc']))).toEqual(['swc', 'paid']);
+  });
+
+  it('handles null/undefined/empty by producing just paid', () => {
+    expect(withPaidTag(null)).toEqual(['paid']);
+    expect(withPaidTag(undefined)).toEqual(['paid']);
+    expect(withPaidTag([])).toEqual(['paid']);
+  });
+});
+
+describe('withoutPaidTag (re-open)', () => {
+  it('removes the paid tag, preserving others', () => {
+    expect(withoutPaidTag(['gpp2026', 'paid', 'swc'])).toEqual(['gpp2026', 'swc']);
+  });
+
+  it('is a no-op when paid absent', () => {
+    expect(withoutPaidTag(['gpp2026', 'swc'])).toEqual(['gpp2026', 'swc']);
+  });
+
+  it('handles null/undefined/empty', () => {
+    expect(withoutPaidTag(null)).toEqual([]);
+    expect(withoutPaidTag(undefined)).toEqual([]);
+    expect(withoutPaidTag([])).toEqual([]);
+  });
+
+  it('round-trips: close-out then re-open restores original (paid absent)', () => {
+    const original = ['gpp2026', 'swc'];
+    expect(withoutPaidTag(withPaidTag(original))).toEqual(original);
+  });
+});
+
+describe('INTERNAL_EVENT_TAGS export', () => {
+  it('contains the documented control tags', () => {
+    expect(INTERNAL_EVENT_TAGS.has('nonhub')).toBe(true);
+    expect(INTERNAL_EVENT_TAGS.has('possible-scam')).toBe(true);
+  });
+});

--- a/backend/src/lib/eventTags.ts
+++ b/backend/src/lib/eventTags.ts
@@ -1,0 +1,61 @@
+/**
+ * calzone-50114: internal vs. public event_tags.
+ *
+ * `parties.event_tags` is overloaded as both a public taxonomy (season/program
+ * markers like 'gpp2026', 'swc', 'SWC Hub', 'wpc', 'ens', 'Global Pizza Party')
+ * AND a private control channel for admin/underboss workflows (scam flags,
+ * payout state, reimbursement caps, pre-launch gates). The control tags must
+ * never reach a public PublicEvent / GPP payload.
+ *
+ * `publicTags()` is applied ONLY at public response boundaries. Admin /
+ * underboss / payments / partner / report / leaderboard routes keep the raw
+ * tag list.
+ */
+
+export const INTERNAL_EVENT_TAGS = new Set<string>([
+  'possible-scam', // manual /payments scam flag
+  'paid',          // payout closed out (auto-tagged on mark-paid close-out)
+  'prepay',        // payout workflow state
+  'go',            // payout workflow state
+  'nonpres',       // admin-only "not a presidential/SWC city" gate marker
+  'missed',        // payout workflow state
+  // marzano-58293: admin-only per-party SWC-Hub-gate opt-out (USDC). Mirrors
+  // 'nonpres' — used only in the payments-admin UI + swcHub helper, never
+  // surfaced publicly.
+  'nonhub',
+]);
+
+const INTERNAL_TAG_PATTERNS: RegExp[] = [
+  // numeric reimbursement-cap tags. Matches helpers/reimbursementCap.ts
+  // (`^\d+(\.\d{1,2})?$`): '200', '500', '350.50'.
+  /^\d+(\.\d{1,2})?$/,
+  /^gpp2027$/i, // pre-launch year gate marker
+];
+
+export function isInternalTag(tag: string): boolean {
+  if (typeof tag !== 'string') return false;
+  const t = tag.trim();
+  if (INTERNAL_EVENT_TAGS.has(t) || INTERNAL_EVENT_TAGS.has(t.toLowerCase())) return true;
+  return INTERNAL_TAG_PATTERNS.some((re) => re.test(t));
+}
+
+export function publicTags(tags: string[] | null | undefined): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags.filter((t) => !isInternalTag(t));
+}
+
+/**
+ * calzone-50114: idempotently append the internal 'paid' tag (used by the
+ * admin-payout close-out handler). Repeat calls are a no-op.
+ */
+export function withPaidTag(tags: string[] | null | undefined): string[] {
+  return Array.from(new Set([...(tags ?? []), 'paid']));
+}
+
+/**
+ * calzone-50114: remove the internal 'paid' tag (used when an admin re-opens a
+ * closed-out city).
+ */
+export function withoutPaidTag(tags: string[] | null | undefined): string[] {
+  return (tags ?? []).filter((t) => t !== 'paid');
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -49,6 +49,7 @@ import {
   type RegionalAuthRequest,
 } from '../middleware/regionalUnderboss.js';
 import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
+import { withPaidTag, withoutPaidTag } from '../lib/eventTags.js';
 import { sendToCityGroup } from '../services/cityTelegramGroup.js';
 import { cityKeyFromPartyName } from '../helpers/underbossScope.js';
 
@@ -6623,6 +6624,7 @@ partyMarkPaidRouter.post(
           // pinsa-92103: needed so we don't double-stamp paymentsClosedAt
           // on a city that's already marked closed.
           paymentsClosedAt: true,
+          eventTags: true,
         },
       });
       if (!party) {
@@ -6739,7 +6741,10 @@ partyMarkPaidRouter.post(
           const closedAt = new Date();
           const updated = await prisma.party.update({
             where: { id: partyId },
-            data: { paymentsClosedAt: closedAt },
+            data: {
+              paymentsClosedAt: closedAt,
+              eventTags: withPaidTag(party.eventTags),
+            },
             select: { id: true, name: true, paymentsClosedAt: true },
           });
           res.json({
@@ -6965,7 +6970,10 @@ partyMarkPaidRouter.post(
           if (remainingInflight === 0) {
             await tx.party.update({
               where: { id: partyId },
-              data: { paymentsClosedAt: now },
+              data: {
+                paymentsClosedAt: now,
+                eventTags: withPaidTag(party.eventTags),
+              },
             });
           }
         }
@@ -7031,7 +7039,7 @@ partyMarkPaidRouter.post(
 
       const party = await prisma.party.findUnique({
         where: { id: partyId },
-        select: { id: true, name: true, paymentsClosedAt: true },
+        select: { id: true, name: true, paymentsClosedAt: true, eventTags: true },
       });
       if (!party) {
         throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
@@ -7084,7 +7092,10 @@ partyMarkPaidRouter.post(
 
         await tx.party.update({
           where: { id: partyId },
-          data: { paymentsClosedAt: null },
+          data: {
+            paymentsClosedAt: null,
+            eventTags: withoutPaidTag(party.eventTags),
+          },
         });
       });
 

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -6,6 +6,7 @@ import { GPP_GLOBAL_EDITORS } from '../helpers/partyAccess.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { resolveGppByYear, isGpp27Hidden } from '../helpers/gpp27.js';
 import { optionalAuth, AuthRequest } from '../middleware/auth.js';
+import { publicTags } from '../lib/eventTags.js';
 
 const PIZZADAO_AVATAR_URL = 'https://znpiwdvvsqaxuskpfleo.supabase.co/storage/v1/object/public/profile-pictures/cmkgpzby50002f8y1d8md1dzn/1768937020563.jpg';
 
@@ -372,7 +373,8 @@ router.get('/:slug', optionalAuth, async (req: AuthRequest, res: Response, next:
         selectedPizzerias: party.selectedPizzerias,
         eventType: party.eventType,
         underbossStatus: party.underbossStatus,
-        eventTags: party.eventTags,
+        // calzone-50114: strip internal control tags from the public payload.
+        eventTags: publicTags(party.eventTags),
         donationEnabled: party.donationEnabled,
         donationRecipient: party.donationRecipient,
         donationRecipientUrl: party.donationRecipientUrl,

--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -11,6 +11,7 @@ import { geocodeCity } from '../lib/geocode.js';
 import { haversineKm } from '../lib/distance.js';
 import { getCountryCode } from '../lib/countryCode.js';
 import { getScoringWeights } from '../lib/privateConfig.js';
+import { publicTags, isInternalTag } from '../lib/eventTags.js';
 
 const router = Router();
 
@@ -622,7 +623,7 @@ router.post('/events', async (req: Request, res: Response, next: NextFunction) =
         name: party.name,
         inviteCode: party.inviteCode,
         eventType: party.eventType,
-        eventTags: party.eventTags,
+        eventTags: publicTags(party.eventTags),
       },
       hostPageUrl,
       eventPageUrl,
@@ -713,7 +714,7 @@ function formatGppEvent(event: any, callerIsModerator = false) {
     longitude: event.longitude,
     eventImageUrl: event.eventImageUrl,
     eventType: event.eventType,
-    eventTags: event.eventTags,
+    eventTags: publicTags(event.eventTags),
     createdAt: event.createdAt,
     hostName: 'PizzaDAO',
     guestCount: event._count?.guests ?? 0,
@@ -850,7 +851,7 @@ router.get('/events', async (req: Request, res: Response, next: NextFunction) =>
         SELECT DISTINCT t AS tag FROM parties, unnest(event_tags) t
         WHERE t LIKE '%swc%' AND t <> 'swc'
       `;
-      const swcTags = swcTagRows.map(r => r.tag);
+      const swcTags = swcTagRows.map(r => r.tag).filter((t) => !isInternalTag(t));
       where = {
         eventType: 'gpp',
         underbossStatus: 'approved',


### PR DESCRIPTION
@
## Summary
`parties.event_tags` is a freeform `text[]` mixing **public** tags (`Global Pizza Party`, `wpc`, `ens`, `swc`/`swc*`, `SWC Hub`, `gpp2026`, …) with **internal** tags (`possible-scam`, `paid`, `prepay`, `go`, `nonpres`, `nonhub`, `missed`, numeric reimbursement caps, `gpp2027`). The full array was being returned by the public event API and the public map. This PR has two parts:

### A. Stop leaking internal tags from public endpoints
- New `backend/src/lib/eventTags.ts` — `INTERNAL_EVENT_TAGS` denylist + `isInternalTag()` / `publicTags()` (denylist, not allowlist, because tags are freeform and an allowlist would silently hide newly-coined public tags). Internal patterns cover numeric cap tags and `gpp2027`.
- `publicTags()` applied at the **public payload boundaries only**: `event.routes.ts` PublicEvent response, `gpp.routes.ts` `formatGppEvent` + create-event response; the swc raw-SQL tag list is also filtered. Admin/payments/underboss/partner/report/leaderboard/photo-feed/sponsor payloads are **untouched** (admins keep seeing raw tags).

### B. Auto-tag `paid` on close-out
- In `admin-payout.routes.ts` mark-paid handler: append `paid` to `event_tags` idempotently at both sites that set `payments_closed_at`, and remove `paid` at the re-open site (clears `payments_closed_at`).

## Files
- `backend/src/lib/eventTags.ts` (new) + `eventTags.test.ts` (new, 21 tests)
- `backend/src/routes/event.routes.ts`, `gpp.routes.ts`, `admin-payout.routes.ts`

## Notes
- **Backend-only** — the frontend Vercel preview will NOT exercise this (backend deploys only from `master`). Verified via `npx tsc --noEmit` (clean for changed files) + `vitest` (new suite 21/21; the one pre-existing tsc error in `auth.test.ts` and 4 pre-existing test failures in `rsvp.routes`/`photo.routes` reproduce on a clean master and are unrelated).
- `nonhub` (added by #862) classified internal and added to the denylist.
- No DB migration. **Sequencing:** after merge + backend deploy, run the one-time `paid` backfill on already-closed cities — doing it before this deploys would leak `paid` publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@