### PR TITLE
stracci-58471: sortable column headers on the /payments by-city table

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import {
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   Loader2,
   Paperclip,
   Flag,
@@ -30,6 +31,7 @@ import { IconInput } from '../IconInput';
 import type {
   AdminPayout,
   AdminPayoutEventPhoto,
+  AdminPayoutFilters,
   PartyPayoutsRow,
   PayoutDocument,
   PayoutStatus,
@@ -123,6 +125,14 @@ const PHOTO_PREVIEW_LIMIT = 4;
 
 interface PayoutsByPartyTableProps {
   rows: PartyPayoutsRow[];
+  /**
+   * stracci-58471: current sort order, used to render the asc/desc indicator
+   * on the (clickable) Event column header. Only the `name_*` values affect
+   * this column's chevron; other sorts leave it neutral.
+   */
+  sort?: AdminPayoutFilters['sort'];
+  /** stracci-58471: click handler for the Event header — toggles name sort. */
+  onSortByName?: () => void;
   selectedIds: Set<string>;
   onToggleSelect: (id: string) => void;
   /** Opens the per-payout review modal (same shape as PayoutsTable). */
@@ -2566,6 +2576,8 @@ function RollupTile({
 
 export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   rows,
+  sort,
+  onSortByName,
   selectedIds,
   onToggleSelect,
   onRowClick,
@@ -2927,7 +2939,28 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
           <thead>
             <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
               <th className="px-3 py-3 w-10"></th>
-              <th className="px-3 py-3 font-medium">Event</th>
+              {/* stracci-58471: clickable Event header — sorts rows by event name. */}
+              <th className="px-3 py-3 font-medium">
+                {onSortByName ? (
+                  <button
+                    type="button"
+                    onClick={onSortByName}
+                    className="inline-flex items-center gap-1 font-medium hover:text-theme-text transition-colors"
+                    title="Sort by event name"
+                  >
+                    Event
+                    {sort === 'name_asc' ? (
+                      <ChevronUp size={14} />
+                    ) : sort === 'name_desc' ? (
+                      <ChevronDown size={14} />
+                    ) : (
+                      <ChevronDown size={14} className="opacity-30" />
+                    )}
+                  </button>
+                ) : (
+                  'Event'
+                )}
+              </th>
               <th className="px-3 py-3 font-medium">Receipt total</th>
               <th className="px-3 py-3 font-medium">Approved</th>
               <th className="px-3 py-3 font-medium">Paid</th>

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -43,6 +43,7 @@ import {
   ReceiptLightbox,
   type ReceiptLightboxImage,
   formatUsd,
+  computePartyTotals,
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
 import { isSwcHubParty } from '../../utils/swcHub';
@@ -126,13 +127,22 @@ const PHOTO_PREVIEW_LIMIT = 4;
 interface PayoutsByPartyTableProps {
   rows: PartyPayoutsRow[];
   /**
-   * stracci-58471: current sort order, used to render the asc/desc indicator
-   * on the (clickable) Event column header. Only the `name_*` values affect
-   * this column's chevron; other sorts leave it neutral.
+   * stracci-58471: current sort order, used to render the asc/desc chevron on
+   * the clickable column headers (Event / Receipt total / Approved / Paid /
+   * Outstanding / Last activity). Sorts unrelated to a column leave every
+   * header neutral.
    */
   sort?: AdminPayoutFilters['sort'];
-  /** stracci-58471: click handler for the Event header — toggles name sort. */
-  onSortByName?: () => void;
+  /**
+   * stracci-58471: set the sort order from a header click. When omitted the
+   * headers render as plain (non-clickable) labels.
+   */
+  onSortChange?: (next: NonNullable<AdminPayoutFilters['sort']>) => void;
+  /**
+   * stracci-58471: the order a column returns to on its third click (after
+   * asc + desc). Defaults to `created_desc`.
+   */
+  defaultSort?: NonNullable<AdminPayoutFilters['sort']>;
   selectedIds: Set<string>;
   onToggleSelect: (id: string) => void;
   /** Opens the per-payout review modal (same shape as PayoutsTable). */
@@ -2574,10 +2584,63 @@ function RollupTile({
   );
 }
 
+/**
+ * stracci-58471: a clickable column header for the by-city table. Clicking
+ * cycles the column through its two directions then back to `defaultSort`:
+ *   • `firstDir='asc'`  → off → asc → desc → off   (used for the name column)
+ *   • `firstDir='desc'` → off → desc → asc → off   (used for amount/time columns,
+ *     where "biggest / most recent first" is the more useful opening click)
+ * Renders a plain label when `onSortChange` is absent.
+ */
+const SortHeader: React.FC<{
+  label: string;
+  asc: NonNullable<AdminPayoutFilters['sort']>;
+  desc: NonNullable<AdminPayoutFilters['sort']>;
+  firstDir: 'asc' | 'desc';
+  current?: AdminPayoutFilters['sort'];
+  defaultSort: NonNullable<AdminPayoutFilters['sort']>;
+  onSortChange?: (next: NonNullable<AdminPayoutFilters['sort']>) => void;
+  className?: string;
+}> = ({ label, asc, desc, firstDir, current, defaultSort, onSortChange, className }) => {
+  const thClass = `px-3 py-3 font-medium${className ? ` ${className}` : ''}`;
+  if (!onSortChange) {
+    return <th className={thClass}>{label}</th>;
+  }
+  const isAsc = current === asc;
+  const isDesc = current === desc;
+  const handleClick = () => {
+    if (firstDir === 'asc') {
+      onSortChange(isAsc ? desc : isDesc ? defaultSort : asc);
+    } else {
+      onSortChange(isDesc ? asc : isAsc ? defaultSort : desc);
+    }
+  };
+  return (
+    <th className={thClass}>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="inline-flex items-center gap-1 font-medium hover:text-theme-text transition-colors"
+        title={`Sort by ${label.toLowerCase()}`}
+      >
+        {label}
+        {isAsc ? (
+          <ChevronUp size={14} />
+        ) : isDesc ? (
+          <ChevronDown size={14} />
+        ) : (
+          <ChevronDown size={14} className="opacity-30" />
+        )}
+      </button>
+    </th>
+  );
+};
+
 export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   rows,
   sort,
-  onSortByName,
+  onSortChange,
+  defaultSort = 'created_desc',
   selectedIds,
   onToggleSelect,
   onRowClick,
@@ -2939,33 +3002,63 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
           <thead>
             <tr className="border-b border-theme-stroke text-theme-text-muted text-left">
               <th className="px-3 py-3 w-10"></th>
-              {/* stracci-58471: clickable Event header — sorts rows by event name. */}
-              <th className="px-3 py-3 font-medium">
-                {onSortByName ? (
-                  <button
-                    type="button"
-                    onClick={onSortByName}
-                    className="inline-flex items-center gap-1 font-medium hover:text-theme-text transition-colors"
-                    title="Sort by event name"
-                  >
-                    Event
-                    {sort === 'name_asc' ? (
-                      <ChevronUp size={14} />
-                    ) : sort === 'name_desc' ? (
-                      <ChevronDown size={14} />
-                    ) : (
-                      <ChevronDown size={14} className="opacity-30" />
-                    )}
-                  </button>
-                ) : (
-                  'Event'
-                )}
-              </th>
-              <th className="px-3 py-3 font-medium">Receipt total</th>
-              <th className="px-3 py-3 font-medium">Approved</th>
-              <th className="px-3 py-3 font-medium">Paid</th>
-              <th className="px-3 py-3 font-medium">Outstanding</th>
-              <th className="px-3 py-3 font-medium">Last activity</th>
+              {/* stracci-58471: every data column is sortable via its header.
+                  Names open A–Z; money + time columns open with the biggest /
+                  most-recent first. */}
+              <SortHeader
+                label="Event"
+                asc="name_asc"
+                desc="name_desc"
+                firstDir="asc"
+                current={sort}
+                defaultSort={defaultSort}
+                onSortChange={onSortChange}
+              />
+              <SortHeader
+                label="Receipt total"
+                asc="amount_asc"
+                desc="amount_desc"
+                firstDir="desc"
+                current={sort}
+                defaultSort={defaultSort}
+                onSortChange={onSortChange}
+              />
+              <SortHeader
+                label="Approved"
+                asc="approved_asc"
+                desc="approved_desc"
+                firstDir="desc"
+                current={sort}
+                defaultSort={defaultSort}
+                onSortChange={onSortChange}
+              />
+              <SortHeader
+                label="Paid"
+                asc="paid_asc"
+                desc="paid_desc"
+                firstDir="desc"
+                current={sort}
+                defaultSort={defaultSort}
+                onSortChange={onSortChange}
+              />
+              <SortHeader
+                label="Outstanding"
+                asc="outstanding_asc"
+                desc="outstanding_desc"
+                firstDir="desc"
+                current={sort}
+                defaultSort={defaultSort}
+                onSortChange={onSortChange}
+              />
+              <SortHeader
+                label="Last activity"
+                asc="activity_asc"
+                desc="activity_desc"
+                firstDir="desc"
+                current={sort}
+                defaultSort={defaultSort}
+                onSortChange={onSortChange}
+              />
             </tr>
           </thead>
           <tbody>
@@ -3067,21 +3160,15 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                   receiptUsdTotal += Number(amt) || 0;
                 }
               }
-              // bresaola-49340: proof-gate the completed contribution. Proofless
-              // completed rows (never-sent close-outs) are excluded from BOTH
-              // the committed and paid sums — mirroring how the per-row rollup
-              // drops proofless rows from approved AND paid, leaving outstanding
-              // unchanged. completedUsd still counts ALL completed; we subtract
-              // the proofless subset here for the money math.
-              const completedProvenUsd =
-                (row.aggregates.completedUsd ?? 0)
-                - (row.aggregates.completedNoProofUsd ?? 0);
-              const approvedSumUsd =
-                row.aggregates.approvedUsd
-                + row.aggregates.paidUsd
-                + completedProvenUsd;
-              const paidSumUsd = row.aggregates.paidUsd + completedProvenUsd;
-              const outstandingUsd = Math.max(0, approvedSumUsd - paidSumUsd);
+              // stracci-58471: Approved / Paid / Outstanding money math now lives
+              // in the shared computePartyTotals helper so the cells below and the
+              // page-level column-header sorts can't drift. (bresaola-49340: the
+              // completed contribution is proof-gated inside the helper.)
+              const {
+                approvedUsd: approvedSumUsd,
+                paidUsd: paidSumUsd,
+                outstandingUsd,
+              } = computePartyTotals(row);
 
               return (
                 <React.Fragment key={row.party.id}>

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -114,10 +114,16 @@ const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
   // here as a manual pick on the other views for completeness).
   { value: 'paid_at_desc', label: 'Most recently paid' },
   { value: 'paid_at_asc', label: 'Oldest payment first' },
-  // stracci-58471: event-name sort, also reachable by clicking the by-city
-  // table's Event column header.
+  // stracci-58471: column-header sorts for the by-city table, also reachable by
+  // clicking the Event / Approved / Paid / Outstanding column headers.
   { value: 'name_asc', label: 'Event name (A–Z)' },
   { value: 'name_desc', label: 'Event name (Z–A)' },
+  { value: 'approved_desc', label: 'Most approved' },
+  { value: 'approved_asc', label: 'Least approved' },
+  { value: 'paid_desc', label: 'Most paid' },
+  { value: 'paid_asc', label: 'Least paid' },
+  { value: 'outstanding_desc', label: 'Most outstanding' },
+  { value: 'outstanding_asc', label: 'Least outstanding' },
 ];
 const SORT_LABEL: Record<SortValue, string> = SORT_OPTIONS.reduce(
   (acc, opt) => ({ ...acc, [opt.value]: opt.label }),

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -114,6 +114,10 @@ const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
   // here as a manual pick on the other views for completeness).
   { value: 'paid_at_desc', label: 'Most recently paid' },
   { value: 'paid_at_asc', label: 'Oldest payment first' },
+  // stracci-58471: event-name sort, also reachable by clicking the by-city
+  // table's Event column header.
+  { value: 'name_asc', label: 'Event name (A–Z)' },
+  { value: 'name_desc', label: 'Event name (Z–A)' },
 ];
 const SORT_LABEL: Record<SortValue, string> = SORT_OPTIONS.reduce(
   (acc, opt) => ({ ...acc, [opt.value]: opt.label }),

--- a/frontend/src/components/payments-admin/paymentsFilterOptions.ts
+++ b/frontend/src/components/payments-admin/paymentsFilterOptions.ts
@@ -48,4 +48,10 @@ export const SORT_VALUES: SortValue[] = [
   'paid_at_asc',
   'name_asc',
   'name_desc',
+  'approved_asc',
+  'approved_desc',
+  'paid_asc',
+  'paid_desc',
+  'outstanding_asc',
+  'outstanding_desc',
 ];

--- a/frontend/src/components/payments-admin/paymentsFilterOptions.ts
+++ b/frontend/src/components/payments-admin/paymentsFilterOptions.ts
@@ -46,4 +46,6 @@ export const SORT_VALUES: SortValue[] = [
   'activity_asc',
   'paid_at_desc',
   'paid_at_asc',
+  'name_asc',
+  'name_desc',
 ];

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -7,3 +7,4 @@ export { ReceiptLightbox } from './ReceiptLightbox';
 export type { ReceiptLightboxImage } from './ReceiptLightbox';
 export { AuthenticityPanel } from './AuthenticityPanel';
 export type { AuthenticityPanelProps } from './AuthenticityPanel';
+export { computePartyTotals } from './partyTotals';

--- a/frontend/src/components/payments-shared/partyTotals.ts
+++ b/frontend/src/components/payments-shared/partyTotals.ts
@@ -1,0 +1,25 @@
+import type { PartyPayoutsRow } from '../../types';
+
+/**
+ * stracci-58471: the Approved / Paid / Outstanding money math for one by-city
+ * row, shared by the table cells (PayoutsByPartyTable) and the page-level sort
+ * comparators (PaymentsAdminPage) so a column and the sort behind its header
+ * can never disagree.
+ *
+ * bresaola-49340: the completed contribution is proof-gated — proofless
+ * completed rows (never-sent close-outs) are excluded from BOTH the committed
+ * (Approved) and Paid sums, which leaves Outstanding unchanged.
+ */
+export function computePartyTotals(row: PartyPayoutsRow): {
+  approvedUsd: number;
+  paidUsd: number;
+  outstandingUsd: number;
+} {
+  const completedProvenUsd =
+    (row.aggregates.completedUsd ?? 0) - (row.aggregates.completedNoProofUsd ?? 0);
+  const approvedUsd =
+    row.aggregates.approvedUsd + row.aggregates.paidUsd + completedProvenUsd;
+  const paidUsd = row.aggregates.paidUsd + completedProvenUsd;
+  const outstandingUsd = Math.max(0, approvedUsd - paidUsd);
+  return { approvedUsd, paidUsd, outstandingUsd };
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -686,6 +686,17 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         return sort === 'amount_asc' ? cmp : -cmp;
       });
     }
+    // stracci-58471: clicking the Event column header sorts by event name.
+    // Strip the "Global Pizza Party " prefix (mirrors the prepay-queue city
+    // sort) so cities order by their actual locality, not the constant prefix.
+    if (sort === 'name_asc' || sort === 'name_desc') {
+      const stripCity = (name: string) =>
+        name.replace(/^Global Pizza Party\s+/i, '').trim();
+      return [...rows].sort((a, b) => {
+        const cmp = stripCity(a.party.name).localeCompare(stripCity(b.party.name));
+        return sort === 'name_asc' ? cmp : -cmp;
+      });
+    }
     return rows;
   }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal]);
 
@@ -1296,6 +1307,21 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         {viewMode === 'by-city' ? (
           <PayoutsByPartyTable
             rows={displayedByPartyRows}
+            // stracci-58471: clickable Event header. Reflects the current sort
+            // (for the chevron) and cycles asc → desc → cleared (back to the
+            // default created_desc) on each click.
+            sort={filters.sort}
+            onSortByName={() =>
+              setFilters((prev) => ({
+                ...prev,
+                sort:
+                  prev.sort === 'name_asc'
+                    ? 'name_desc'
+                    : prev.sort === 'name_desc'
+                      ? 'created_desc'
+                      : 'name_asc',
+              }))
+            }
             fakeScores={fakeScores}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -37,7 +37,7 @@ import type {
   PrepayQueueRow,
   PrepayCandidate,
 } from '../types';
-import { formatUsd } from '../components/payments-shared';
+import { formatUsd, computePartyTotals } from '../components/payments-shared';
 import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
 import { isSwcHubParty } from '../utils/swcHub';
 import { fetchSheetCities } from '../lib/cities';
@@ -697,6 +697,36 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         return sort === 'name_asc' ? cmp : -cmp;
       });
     }
+    // stracci-58471: Last activity column header. The backend's by-party default
+    // is already activity-ordered, but we re-sort client-side so BOTH directions
+    // work and stay in lockstep with the lastActivityAt the column renders.
+    if (sort === 'activity_asc' || sort === 'activity_desc') {
+      const activity = (r: PartyPayoutsRow) =>
+        new Date(r.aggregates.lastActivityAt).getTime();
+      return [...rows].sort((a, b) =>
+        sort === 'activity_asc' ? activity(a) - activity(b) : activity(b) - activity(a),
+      );
+    }
+    // stracci-58471: Approved / Paid / Outstanding column headers. computePartyTotals
+    // is the same money math the table cells use, so each column sorts by exactly
+    // the dollar figure the admin sees in it.
+    if (
+      sort === 'approved_asc' ||
+      sort === 'approved_desc' ||
+      sort === 'paid_asc' ||
+      sort === 'paid_desc' ||
+      sort === 'outstanding_asc' ||
+      sort === 'outstanding_desc'
+    ) {
+      const pick = (r: PartyPayoutsRow) => {
+        const t = computePartyTotals(r);
+        if (sort.startsWith('approved')) return t.approvedUsd;
+        if (sort.startsWith('paid')) return t.paidUsd;
+        return t.outstandingUsd;
+      };
+      const asc = sort.endsWith('_asc');
+      return [...rows].sort((a, b) => (asc ? pick(a) - pick(b) : pick(b) - pick(a)));
+    }
     return rows;
   }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal]);
 
@@ -1307,21 +1337,13 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         {viewMode === 'by-city' ? (
           <PayoutsByPartyTable
             rows={displayedByPartyRows}
-            // stracci-58471: clickable Event header. Reflects the current sort
-            // (for the chevron) and cycles asc → desc → cleared (back to the
-            // default created_desc) on each click.
+            // stracci-58471: clickable column headers (Event / Receipt total /
+            // Approved / Paid / Outstanding / Last activity). `sort` drives the
+            // chevron; each header cycles its column through the two directions
+            // then back to `defaultSort` via onSortChange.
             sort={filters.sort}
-            onSortByName={() =>
-              setFilters((prev) => ({
-                ...prev,
-                sort:
-                  prev.sort === 'name_asc'
-                    ? 'name_desc'
-                    : prev.sort === 'name_desc'
-                      ? 'created_desc'
-                      : 'name_asc',
-              }))
-            }
+            defaultSort={DEFAULT_FILTERS.sort ?? 'created_desc'}
+            onSortChange={(next) => setFilters((prev) => ({ ...prev, sort: next }))}
             fakeScores={fakeScores}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2183,11 +2183,21 @@ export interface AdminPayoutFilters {
     // view ("show me every payment that actually went out, newest first").
     | 'paid_at_desc'
     | 'paid_at_asc'
-    // stracci-58471: order by event/city name (A–Z / Z–A). By-city view only —
-    // applied client-side in PaymentsAdminPage; the backend has no name sort and
-    // falls through to its activity order, which the client-side reorder wins over.
+    // stracci-58471: column-header sorts for the by-city table. All applied
+    // client-side in PaymentsAdminPage (the backend has no name/approved/paid/
+    // outstanding sort), so the client-side reorder wins over its activity order.
+    //  • name_*        — event/city name (A–Z / Z–A)
+    //  • approved_*    — Approved column total
+    //  • paid_*        — Paid column total
+    //  • outstanding_* — Outstanding column total
     | 'name_asc'
-    | 'name_desc';
+    | 'name_desc'
+    | 'approved_asc'
+    | 'approved_desc'
+    | 'paid_asc'
+    | 'paid_desc'
+    | 'outstanding_asc'
+    | 'outstanding_desc';
   /**
    * coppa-92106: when true, the backend applies the prosciutto-92106
    * "has proof of send" predicate so only proven payments

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2182,7 +2182,12 @@ export interface AdminPayoutFilters {
     // coppa-92106: order by actual paid_at timestamp for the Payments-ledger
     // view ("show me every payment that actually went out, newest first").
     | 'paid_at_desc'
-    | 'paid_at_asc';
+    | 'paid_at_asc'
+    // stracci-58471: order by event/city name (A–Z / Z–A). By-city view only —
+    // applied client-side in PaymentsAdminPage; the backend has no name sort and
+    // falls through to its activity order, which the client-side reorder wins over.
+    | 'name_asc'
+    | 'name_desc';
   /**
    * coppa-92106: when true, the backend applies the prosciutto-92106
    * "has proof of send" predicate so only proven payments


### PR DESCRIPTION
@
## What

Every data column on the `/payments` by-city table now sorts when you click its header: **Event, Receipt total, Approved, Paid, Outstanding, Last activity**.

- **Name** columns open **A–Z**; **money / time** columns open **biggest / most-recent first** (the more useful opening click).
- Each header cycles: 1st click → primary direction, 2nd → reverse, 3rd → back to the default sort (Newest first).
- The active column shows an up/down chevron; inactive headers show a dimmed chevron affordance.

## How

Wired into the **existing** client-side sort plumbing (`PaymentsAdminPage.displayedByPartyRows`) rather than a parallel system, so it composes with the filter bar and persists in URL state.

- `types.ts` — `AdminPayoutFilters[sort]` gains `name_*`, `approved_*`, `paid_*`, `outstanding_*`. (Receipt total reuses `amount_*`; Last activity reuses `activity_*`.)
- `PaymentsAdminPage` — comparators for the new dimensions; Last activity now sorts client-side so **both** directions work (the backend only emitted one activity order).
- `computePartyTotals()` — new shared helper in `payments-shared` holding the Approved/Paid/Outstanding money math, used by **both** the table cells and the sort comparators so a column and its sort can never drift (also de-dups the formula that was inlined before).
- `PayoutsByPartyTable` — reusable `SortHeader` component; replaces the earlier one-off `onSortByName` prop with a generic `onSortChange` + `defaultSort`.
- `paymentsFilterOptions` + `PayoutsFilterBar` — the new sorts are also dropdown options so URL state + the active-filter chip stay in sync.

Frontend-only; no backend or DB change.

## Why these columns
All six are now sortable for a consistent table. **Outstanding** is the most useful addition — it gives a one-click "who do we still owe the most" worklist. Approved/Paid round out the set.

## Test
- [ ] On the Vercel preview, open `/payments`. Click each header; confirm direction cycle, chevron, and that the order matches the column values.
- [ ] Confirm the filter-bar Sort dropdown reflects the header selection and vice-versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@