### PR TITLE
feat(culatello-92107): redirect foreign hosts off W-9 to W-8BEN(-E)

### DIFF
--- a/frontend/src/components/payouts/TaxFormSection.tsx
+++ b/frontend/src/components/payouts/TaxFormSection.tsx
@@ -132,11 +132,27 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
     );
   }
 
+  // culatello-92107: When a host filling out a W-9 realizes they're foreign,
+  // jump them to the right W-8 form. Discard partial W-9 data — the SSN /
+  // EIN / exempt-code fields don't translate to W-8BEN(-E), and the parent
+  // banner is explicit that they picked the wrong form.
+  const handleSwitchFromW9 = (target: 'w8ben' | 'w8bene') => {
+    setDraftData({});
+    setEditingType(target);
+    setPickerOpen(false);
+    setError(null);
+    setStatusMessage(null);
+  };
+
   const renderEditor = () => {
     if (!editingType) return null;
     const editorBody =
       editingType === 'w9' ? (
-        <W9Form value={draftData as W9FormData} onChange={(v) => setDraftData(v)} />
+        <W9Form
+          value={draftData as W9FormData}
+          onChange={(v) => setDraftData(v)}
+          onSwitchFormType={handleSwitchFromW9}
+        />
       ) : editingType === 'w8ben' ? (
         <W8BENForm value={draftData as W8BENFormData} onChange={(v) => setDraftData(v)} />
       ) : (

--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -8,6 +8,7 @@ import {
   CalendarDays,
   ChevronDown,
   ChevronRight,
+  AlertCircle,
 } from "lucide-react";
 import { IconInput } from "../../IconInput";
 import { Checkbox } from "../../Checkbox";
@@ -41,6 +42,13 @@ interface W9FormProps {
   value: W9FormData;
   onChange: (next: W9FormData) => void;
   disabled?: boolean;
+  /**
+   * culatello-92107: Called when the host realizes mid-edit that the W-9
+   * isn't the right form for them (they're not a US person). The parent
+   * should discard the current W-9 draft and switch the active editor to
+   * W-8BEN (individual) or W-8BEN-E (entity).
+   */
+  onSwitchFormType?: (target: 'w8ben' | 'w8bene') => void;
 }
 
 const TAX_CLASS_OPTIONS: Array<{
@@ -73,6 +81,7 @@ export const W9Form: React.FC<W9FormProps> = ({
   value,
   onChange,
   disabled,
+  onSwitchFormType,
 }) => {
   // Derive initial TIN type from whichever value is populated.
   // Default to 'ssn' (most common for individual hosts).
@@ -98,6 +107,35 @@ export const W9Form: React.FC<W9FormProps> = ({
 
   return (
     <div className="space-y-4">
+      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 mb-4 flex items-start gap-3">
+        <AlertCircle className="text-amber-400 shrink-0 mt-0.5" size={18} />
+        <div className="flex-1">
+          <p className="text-sm font-medium text-amber-200">
+            W-9 is only for US persons
+          </p>
+          <p className="text-xs text-amber-100 mt-1">
+            Use W-9 if you're a US citizen, US resident, US LLC, or US corporation —
+            regardless of where the event is hosted. If you live or are based outside
+            the US, use W-8BEN (individual) or W-8BEN-E (entity) instead.
+          </p>
+          <div className="flex gap-2 mt-3">
+            <button
+              type="button"
+              onClick={() => onSwitchFormType?.('w8ben')}
+              className="text-xs px-3 py-1.5 rounded bg-amber-500/20 hover:bg-amber-500/30 text-amber-100 font-medium border border-amber-500/40"
+            >
+              Switch to W-8BEN (individual)
+            </button>
+            <button
+              type="button"
+              onClick={() => onSwitchFormType?.('w8bene')}
+              className="text-xs px-3 py-1.5 rounded bg-amber-500/20 hover:bg-amber-500/30 text-amber-100 font-medium border border-amber-500/40"
+            >
+              Switch to W-8BEN-E (entity)
+            </button>
+          </div>
+        </div>
+      </div>
       <div>
         <IconInput
           icon={User}


### PR DESCRIPTION
## Summary
- Adds an amber info banner at the top of `W9Form` warning that the W-9 is for US persons only.
- Banner includes one-click 'Switch to W-8BEN (individual)' and 'Switch to W-8BEN-E (entity)' buttons so foreign hosts who mis-picked aren't trapped scrolling through a form they shouldn't fill.
- Wires a new optional `onSwitchFormType` callback from `W9Form` up to `TaxFormSection`, which discards the partial W-9 draft and flips the active editor to the chosen W-8 form.

## Why
Foreign hosts who pick W-9 by mistake end up entering SSN/EIN/exempt codes that don't apply to them and get rejected at admin verify. Surfacing the redirect at the top of the form (rather than after they've filled it out) prevents the bad-data submit cycle.

## Test plan
- [ ] Open the W-9 form (Payouts -> Tax form -> pick W-9). Banner appears at the top above all fields.
- [ ] Click 'Switch to W-8BEN (individual)' -> active editor becomes the W-8BEN form, W-9 draft data is cleared.
- [ ] Click 'Switch to W-8BEN-E (entity)' from a fresh W-9 -> active editor becomes the W-8BEN-E form, W-9 draft data is cleared.
- [ ] W-8BEN and W-8BEN-E forms render unchanged (no banner there).
- [ ] `npx tsc --noEmit` clean.

Generated with [Claude Code](https://claude.com/claude-code)