### PR TITLE
feat(pepperoncino-58296): add WhatsApp to discovery options

### DIFF
--- a/backend/src/lib/surveyQuestions.ts
+++ b/backend/src/lib/surveyQuestions.ts
@@ -52,7 +52,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     type: 'multiple',
     multi: false,
     text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'The organizer', 'Brave Browser', 'Other'],
+    options: ['A friend', 'Twitter/X', 'WhatsApp', 'The organizer', 'Brave Browser', 'Other'],
     allowOther: true,
   },
   {

--- a/frontend/src/lib/surveyQuestions.ts
+++ b/frontend/src/lib/surveyQuestions.ts
@@ -52,7 +52,7 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
     type: 'multiple',
     multi: false,
     text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'The organizer', 'Brave Browser', 'Other'],
+    options: ['A friend', 'Twitter/X', 'WhatsApp', 'The organizer', 'Brave Browser', 'Other'],
     allowOther: true,
   },
   {


### PR DESCRIPTION
Adds `WhatsApp` to the post-event survey `discovery` question options, between `Twitter/X` and `The organizer`. 3 of the 5 `discovery_other` write-ins so far have been WhatsApp; promoting it from Other -> first-class option.

Additive (no version bump), mirrors backend + frontend canonical/mirror pair (same convention as bismarck-58295 Brave Browser).

Test: https://rsv.pizza/survey/041010e7-b32b-4040-b1d1-070d9c2806f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)