### PR TITLE
feat(pugliese-58297): move survey question config to DB + /underboss admin tab

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1692,6 +1692,44 @@ model QuizAnswer {
   @@map("quiz_answers")
 }
 
+// ============================================
+// Survey question config (pugliese-58297)
+// ============================================
+// DB-backed post-event survey question set. Previously a code constant in
+// backend/src/lib/surveyQuestions.ts. Service-role only.
+
+model SurveyQuestionSet {
+  id        String   @id
+  version   Int      @default(1)
+  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz
+
+  questions SurveyQuestion[]
+
+  @@map("survey_question_sets")
+}
+
+model SurveyQuestion {
+  id          String   // question slug (snake_case)
+  questionSet String   @map("question_set")
+  set         SurveyQuestionSet @relation(fields: [questionSet], references: [id])
+
+  position    Int
+  type        String   // 'rating' | 'yesno' | 'multiple' | 'text'
+  text        String
+  scale       Int?
+  multi       Boolean  @default(false)
+  allowOther  Boolean  @default(false) @map("allow_other")
+  options     Json     @default("[]")
+  active      Boolean  @default(true)
+
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime @updatedAt      @map("updated_at") @db.Timestamptz
+
+  @@id([questionSet, id])
+  @@unique([questionSet, position])
+  @@map("survey_questions")
+}
+
 model SlugAlias {
   oldSlug   String   @id @map("old_slug")
   partyId   String   @map("party_id") @db.Uuid

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -68,6 +68,10 @@ import citiesRoutes from './routes/cities.routes.js';
 import resendWebhookRouter from './routes/webhooks.resend.routes.js';
 import ensRoutes from './routes/ens.routes.js';
 import { surveyPublicRouter, surveyHostRouter, cronRouter } from './routes/survey.routes.js';
+import {
+  surveyQuestionsAdminRouter,
+  surveyQuestionSetsAdminRouter,
+} from './routes/admin/surveyQuestions.routes.js';
 import reminderRoutes from './routes/reminder.routes.js';
 import { taxFormRouter, adminTaxFormRouter } from './routes/tax-form.routes.js';
 import suggestionsRoutes from './routes/suggestions.routes.js'; // scarpetta-58472: admin/underboss-only suggestions list
@@ -149,6 +153,8 @@ app.use('/api/admin/payout-wallet', payoutWalletRouter); // coppa-91827: hot wal
 app.use('/api/admin/parties', partyMarkPaidRouter); // panettone-92103: party-level "mark party paid" bulk action — before /api/admin catch-all
 app.use('/api/admin/parties', adminPartyRoutes); // fontina-91827: admin party-management routes (transfer ownership) — before /api/admin catch-all
 app.use('/api/admin/image-authenticity', imageAuthenticityRoutes); // marinara-61455: image-authenticity check — before /api/admin catch-all
+app.use('/api/admin/survey-questions', surveyQuestionsAdminRouter); // pugliese-58297: survey question CRUD — before /api/admin catch-all
+app.use('/api/admin/survey-question-sets', surveyQuestionSetsAdminRouter); // pugliese-58297: survey question set version bump — before /api/admin catch-all
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/suggestions', suggestionsRoutes); // scarpetta-58472: admin/underboss-only site-wide suggestions (view-only)

--- a/backend/src/lib/surveyQuestions.ts
+++ b/backend/src/lib/surveyQuestions.ts
@@ -1,9 +1,14 @@
-// romana-61204: Canonical post-event guest survey question set.
+// pugliese-58297: post-event guest survey question set, loaded from the DB.
 //
-// This is the SINGLE SOURCE OF TRUTH for the question set on the backend.
-// It is MIRRORED in frontend/src/lib/surveyQuestions.ts — keep the two in sync.
-// Bump SURVEY_QUESTION_SET_VERSION whenever the set changes so stored responses
-// can be interpreted against the version they were collected under.
+// Previously this file held canonical question-set + version constants;
+// today the question set lives in the `survey_question_sets` + `survey_questions`
+// tables and is loaded via `loadQuestionSet()` (60s in-memory cache).
+//
+// The frontend `frontend/src/lib/surveyQuestions.ts` keeps only the shared
+// TypeScript types. The /api/survey/:token response continues to include the
+// full questionSet so SurveyPage renders against the current copy.
+
+import { prisma } from '../config/database.js';
 
 export type SurveyQuestionType = 'rating' | 'yesno' | 'multiple' | 'text';
 
@@ -17,60 +22,67 @@ export interface SurveyQuestion {
   allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
 
-export const SURVEY_QUESTION_SET_VERSION = 3;
+export type LoadedSet = {
+  version: number;
+  questions: SurveyQuestion[];
+};
 
-export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
-  {
-    id: 'attended',
-    type: 'yesno',
-    text: 'Did you attend the event?',
-  },
-  {
-    id: 'overall_rating',
-    type: 'rating',
-    scale: 5,
-    text: 'How would you rate the event overall?',
-  },
-  {
-    id: 'pizza_rating',
-    type: 'rating',
-    scale: 5,
-    text: 'How was the pizza?',
-  },
-  {
-    id: 'enough_pizza',
-    type: 'yesno',
-    text: 'Was there enough pizza?',
-  },
-  {
-    id: 'recommend',
-    type: 'yesno',
-    text: 'Would you come to another PizzaDAO event?',
-  },
-  {
-    id: 'discovery',
-    type: 'multiple',
-    multi: false,
-    text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'WhatsApp', 'The organizer', 'Brave Browser', 'Other'],
-    allowOther: true,
-  },
-  {
-    id: 'highlight',
-    type: 'multiple',
-    multi: true,
-    text: 'What did you enjoy most?',
-    options: ['The pizza', 'The people', 'The talks / program', 'The vibe'],
-  },
-  {
-    id: 'comments',
-    type: 'text',
-    text: "Anything else you'd like to share?",
-  },
-];
+// ---------------------------------------------------------------------------
+// In-memory cache: 60s TTL, keyed by question-set id.
+// `refresh: true` bypasses + repopulates. Errors are re-thrown (no fallback).
+// ---------------------------------------------------------------------------
+const CACHE_TTL_MS = 60_000;
+const cache: Map<string, { value: LoadedSet; expiresAt: number }> = new Map();
+
+export async function loadQuestionSet(
+  setId: string = 'default',
+  opts?: { refresh?: boolean }
+): Promise<LoadedSet> {
+  const now = Date.now();
+  if (!opts?.refresh) {
+    const hit = cache.get(setId);
+    if (hit && hit.expiresAt > now) return hit.value;
+  }
+
+  const set = await prisma.surveyQuestionSet.findUnique({
+    where: { id: setId },
+    include: {
+      questions: {
+        where: { active: true },
+        orderBy: { position: 'asc' },
+      },
+    },
+  });
+
+  if (!set) {
+    throw new Error(`Survey question set "${setId}" not found`);
+  }
+
+  const questions: SurveyQuestion[] = set.questions.map((q) => {
+    const out: SurveyQuestion = {
+      id: q.id,
+      type: q.type as SurveyQuestionType,
+      text: q.text,
+    };
+    if (q.scale !== null && q.scale !== undefined) out.scale = q.scale;
+    if (q.multi) out.multi = true;
+    if (q.allowOther) out.allowOther = true;
+    // `options` is stored as JSONB; treat missing/empty array as "no options".
+    if (Array.isArray(q.options) && q.options.length > 0) {
+      out.options = (q.options as unknown[]).filter(
+        (x): x is string => typeof x === 'string'
+      );
+    }
+    return out;
+  });
+
+  const value: LoadedSet = { version: set.version, questions };
+  cache.set(setId, { value, expiresAt: now + CACHE_TTL_MS });
+  return value;
+}
 
 /**
- * Validate + normalize a raw answers object against the canonical question set.
+ * Validate + normalize a raw answers object against a loaded question set.
  * - Drops unknown question ids.
  * - Enforces per-type shape:
  *     rating   -> integer in [1, scale]
@@ -82,13 +94,14 @@ export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
  * Returns the cleaned answers object that should be persisted.
  */
 export function validateSurveyAnswers(
-  raw: unknown
+  raw: unknown,
+  questionSet: SurveyQuestion[]
 ): Record<string, number | boolean | string | string[]> {
   const out: Record<string, number | boolean | string | string[]> = {};
   if (!raw || typeof raw !== 'object') return out;
   const input = raw as Record<string, unknown>;
 
-  for (const q of SURVEY_QUESTION_SET) {
+  for (const q of questionSet) {
     if (!(q.id in input)) continue;
     const v = input[q.id];
 

--- a/backend/src/routes/admin/surveyQuestions.routes.ts
+++ b/backend/src/routes/admin/surveyQuestions.routes.ts
@@ -1,0 +1,453 @@
+/**
+ * Admin CRUD for the post-event survey question set (pugliese-58297).
+ *
+ * Two routers are exported:
+ *  - `surveyQuestionsAdminRouter` → mounted at `/api/admin/survey-questions`
+ *  - `surveyQuestionSetsAdminRouter` → mounted at `/api/admin/survey-question-sets`
+ *
+ * Auth: requireAuth + isFullAdmin (admin OR super_admin). Mirrors the gate
+ * pattern used elsewhere under `/api/admin/*`. Both routers register BEFORE
+ * the generic `/api/admin` catch-all in index.ts so they aren't shadowed.
+ *
+ * Every write endpoint calls `loadQuestionSet(setId, { refresh: true })`
+ * BEFORE returning so the admin's next call (and the public flow) sees the
+ * change immediately, not after the 60s TTL.
+ */
+import { Router, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import { prisma } from '../../config/database.js';
+import { requireAuth, AuthRequest, isFullAdmin } from '../../middleware/auth.js';
+import { AppError } from '../../middleware/error.js';
+import { loadQuestionSet, SurveyQuestionType } from '../../lib/surveyQuestions.js';
+
+const VALID_TYPES: SurveyQuestionType[] = ['rating', 'yesno', 'multiple', 'text'];
+const ID_PATTERN = /^[a-z][a-z0-9_]*$/; // lowercase snake_case
+
+async function requireFullAdmin(
+  req: AuthRequest,
+  _res: Response,
+  next: NextFunction
+) {
+  try {
+    if (!(await isFullAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
+function normalizeSetId(raw: unknown): string {
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return 'default';
+}
+
+function sanitizeOptions(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((x): x is string => typeof x === 'string')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function validateTypeShape(
+  type: SurveyQuestionType,
+  body: {
+    scale?: unknown;
+    multi?: unknown;
+    allowOther?: unknown;
+    options?: unknown;
+  }
+): { scale: number | null; multi: boolean; allowOther: boolean; options: string[] } {
+  let scale: number | null = null;
+  let multi = false;
+  let allowOther = false;
+  let options: string[] = [];
+
+  if (type === 'rating') {
+    const n = Number(body.scale);
+    if (!Number.isInteger(n) || n < 2 || n > 10) {
+      throw new AppError('Rating scale must be an integer between 2 and 10', 400, 'VALIDATION_ERROR');
+    }
+    scale = n;
+  } else if (type === 'multiple') {
+    options = sanitizeOptions(body.options);
+    if (options.length === 0) {
+      throw new AppError('Multiple-choice question requires at least one option', 400, 'VALIDATION_ERROR');
+    }
+    multi = body.multi === true;
+    allowOther = body.allowOther === true;
+  }
+  // yesno + text take no extra fields.
+
+  return { scale, multi, allowOther, options };
+}
+
+// Serialize a Prisma SurveyQuestion row to the API shape (camelCase + omit null
+// scale / empty options, matching the frontend SurveyQuestion interface).
+function serializeQuestion(q: {
+  id: string;
+  position: number;
+  type: string;
+  text: string;
+  scale: number | null;
+  multi: boolean;
+  allowOther: boolean;
+  options: Prisma.JsonValue;
+  active: boolean;
+}) {
+  const out: Record<string, unknown> = {
+    id: q.id,
+    position: q.position,
+    type: q.type,
+    text: q.text,
+    multi: q.multi,
+    allowOther: q.allowOther,
+    active: q.active,
+    options: Array.isArray(q.options) ? q.options : [],
+  };
+  if (q.scale !== null && q.scale !== undefined) out.scale = q.scale;
+  return out;
+}
+
+// ===========================================================================
+// /api/admin/survey-questions
+// ===========================================================================
+const questionsRouter = Router();
+questionsRouter.use(requireAuth);
+questionsRouter.use(requireFullAdmin);
+
+// GET /api/admin/survey-questions?set=default
+//   Returns ALL questions (including inactive) ordered by position.
+questionsRouter.get(
+  '/',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const setId = normalizeSetId(req.query.set);
+
+      const set = await prisma.surveyQuestionSet.findUnique({
+        where: { id: setId },
+      });
+      if (!set) {
+        throw new AppError('Question set not found', 404, 'NOT_FOUND');
+      }
+
+      const rows = await prisma.surveyQuestion.findMany({
+        where: { questionSet: setId },
+        orderBy: { position: 'asc' },
+      });
+
+      res.json({
+        questionSet: setId,
+        version: set.version,
+        questions: rows.map(serializeQuestion),
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+// POST /api/admin/survey-questions
+//   Body: { questionSet?, id, type, text, scale?, multi?, allowOther?, options?, active?, position? }
+//   Position auto-assigned to next slot if not provided.
+questionsRouter.post(
+  '/',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body ?? {};
+      const setId = normalizeSetId(body.questionSet ?? body.set);
+
+      const set = await prisma.surveyQuestionSet.findUnique({
+        where: { id: setId },
+      });
+      if (!set) {
+        throw new AppError('Question set not found', 404, 'NOT_FOUND');
+      }
+
+      const id = typeof body.id === 'string' ? body.id.trim() : '';
+      if (!id || !ID_PATTERN.test(id)) {
+        throw new AppError(
+          'Question id must be lowercase snake_case (a-z, 0-9, _) starting with a letter',
+          400,
+          'VALIDATION_ERROR'
+        );
+      }
+
+      if (!VALID_TYPES.includes(body.type)) {
+        throw new AppError('Invalid question type', 400, 'VALIDATION_ERROR');
+      }
+      const type = body.type as SurveyQuestionType;
+
+      const text = typeof body.text === 'string' ? body.text.trim() : '';
+      if (!text) {
+        throw new AppError('Question text is required', 400, 'VALIDATION_ERROR');
+      }
+
+      const shape = validateTypeShape(type, body);
+
+      // Auto-assign next position if not supplied.
+      let position: number;
+      if (typeof body.position === 'number' && Number.isInteger(body.position) && body.position > 0) {
+        position = body.position;
+      } else {
+        const last = await prisma.surveyQuestion.findFirst({
+          where: { questionSet: setId },
+          orderBy: { position: 'desc' },
+          select: { position: true },
+        });
+        position = (last?.position ?? 0) + 1;
+      }
+
+      const active = body.active === undefined ? true : !!body.active;
+
+      const created = await prisma.surveyQuestion.create({
+        data: {
+          id,
+          questionSet: setId,
+          position,
+          type,
+          text,
+          scale: shape.scale,
+          multi: shape.multi,
+          allowOther: shape.allowOther,
+          options: shape.options,
+          active,
+        },
+      });
+
+      // Refresh cache so the public + admin flows see the change immediately.
+      await loadQuestionSet(setId, { refresh: true });
+
+      res.status(201).json({ question: serializeQuestion(created) });
+    } catch (err) {
+      // Translate unique-constraint violations into 400s.
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        return next(
+          new AppError(
+            'A question with that id or position already exists in this set',
+            400,
+            'DUPLICATE'
+          )
+        );
+      }
+      next(err);
+    }
+  }
+);
+
+// PATCH /api/admin/survey-questions/:id?set=default
+//   Partial update of any field. type changes re-validate the shape.
+questionsRouter.patch(
+  '/:id',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const setId = normalizeSetId(req.query.set);
+      const { id } = req.params;
+      const body = req.body ?? {};
+
+      const existing = await prisma.surveyQuestion.findUnique({
+        where: { questionSet_id: { questionSet: setId, id } },
+      });
+      if (!existing) {
+        throw new AppError('Question not found', 404, 'NOT_FOUND');
+      }
+
+      const data: Prisma.SurveyQuestionUpdateInput = {};
+
+      if (body.text !== undefined) {
+        const text = typeof body.text === 'string' ? body.text.trim() : '';
+        if (!text) throw new AppError('Question text cannot be empty', 400, 'VALIDATION_ERROR');
+        data.text = text;
+      }
+
+      if (body.active !== undefined) {
+        data.active = !!body.active;
+      }
+
+      // Type-aware fields. If the type itself is changing, validate the new
+      // shape against the new type using whatever scale/options/etc the client
+      // sent (or, fall back to the existing row's values).
+      const targetType: SurveyQuestionType =
+        body.type !== undefined && VALID_TYPES.includes(body.type)
+          ? (body.type as SurveyQuestionType)
+          : (existing.type as SurveyQuestionType);
+
+      if (body.type !== undefined) {
+        if (!VALID_TYPES.includes(body.type)) {
+          throw new AppError('Invalid question type', 400, 'VALIDATION_ERROR');
+        }
+        data.type = body.type;
+      }
+
+      const typeFieldsTouched =
+        body.type !== undefined ||
+        body.scale !== undefined ||
+        body.multi !== undefined ||
+        body.allowOther !== undefined ||
+        body.options !== undefined;
+
+      if (typeFieldsTouched) {
+        const merged = {
+          scale: body.scale !== undefined ? body.scale : existing.scale,
+          multi: body.multi !== undefined ? body.multi : existing.multi,
+          allowOther:
+            body.allowOther !== undefined ? body.allowOther : existing.allowOther,
+          options:
+            body.options !== undefined
+              ? body.options
+              : (existing.options as Prisma.JsonValue),
+        };
+        const shape = validateTypeShape(targetType, merged);
+        data.scale = shape.scale;
+        data.multi = shape.multi;
+        data.allowOther = shape.allowOther;
+        data.options = shape.options;
+      }
+
+      const updated = await prisma.surveyQuestion.update({
+        where: { questionSet_id: { questionSet: setId, id } },
+        data,
+      });
+
+      await loadQuestionSet(setId, { refresh: true });
+
+      res.json({ question: serializeQuestion(updated) });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+// POST /api/admin/survey-questions/reorder
+//   Body: { set?: 'default', orderedIds: string[] }
+//   Rewrites `position` to match the array order, in one transaction.
+//   Because of the unique (question_set, position) constraint we have to push
+//   rows into a temporary high range first to dodge transient collisions.
+questionsRouter.post(
+  '/reorder',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body ?? {};
+      const setId = normalizeSetId(body.set ?? body.questionSet);
+      const orderedIds = Array.isArray(body.orderedIds) ? body.orderedIds : [];
+
+      if (orderedIds.length === 0 || !orderedIds.every((x: unknown) => typeof x === 'string')) {
+        throw new AppError('orderedIds must be a non-empty array of strings', 400, 'VALIDATION_ERROR');
+      }
+
+      const existing = await prisma.surveyQuestion.findMany({
+        where: { questionSet: setId },
+        select: { id: true },
+      });
+      const existingIds = new Set(existing.map((q) => q.id));
+
+      if (orderedIds.length !== existing.length) {
+        throw new AppError(
+          'orderedIds must contain every question id in the set exactly once',
+          400,
+          'VALIDATION_ERROR'
+        );
+      }
+      const seen = new Set<string>();
+      for (const id of orderedIds) {
+        if (seen.has(id) || !existingIds.has(id)) {
+          throw new AppError(
+            'orderedIds must contain every question id in the set exactly once',
+            400,
+            'VALIDATION_ERROR'
+          );
+        }
+        seen.add(id);
+      }
+
+      // Two-pass update inside a transaction to dodge the (set, position) unique
+      // constraint during the swap.
+      const OFFSET = 10_000;
+      await prisma.$transaction(async (tx) => {
+        for (let i = 0; i < orderedIds.length; i += 1) {
+          await tx.surveyQuestion.update({
+            where: { questionSet_id: { questionSet: setId, id: orderedIds[i] } },
+            data: { position: OFFSET + i + 1 },
+          });
+        }
+        for (let i = 0; i < orderedIds.length; i += 1) {
+          await tx.surveyQuestion.update({
+            where: { questionSet_id: { questionSet: setId, id: orderedIds[i] } },
+            data: { position: i + 1 },
+          });
+        }
+      });
+
+      await loadQuestionSet(setId, { refresh: true });
+
+      res.json({ success: true });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+// ===========================================================================
+// /api/admin/survey-question-sets/:setId
+// ===========================================================================
+const setsRouter = Router();
+setsRouter.use(requireAuth);
+setsRouter.use(requireFullAdmin);
+
+// PATCH /api/admin/survey-question-sets/:setId
+//   Body: { version?: number }
+setsRouter.patch(
+  '/:setId',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { setId } = req.params;
+      const body = req.body ?? {};
+
+      const existing = await prisma.surveyQuestionSet.findUnique({
+        where: { id: setId },
+      });
+      if (!existing) {
+        throw new AppError('Question set not found', 404, 'NOT_FOUND');
+      }
+
+      const data: Prisma.SurveyQuestionSetUpdateInput = {
+        updatedAt: new Date(),
+      };
+
+      if (body.version !== undefined) {
+        const n = Number(body.version);
+        if (!Number.isInteger(n) || n < 1) {
+          throw new AppError('Version must be a positive integer', 400, 'VALIDATION_ERROR');
+        }
+        data.version = n;
+      }
+
+      const updated = await prisma.surveyQuestionSet.update({
+        where: { id: setId },
+        data,
+      });
+
+      await loadQuestionSet(setId, { refresh: true });
+
+      res.json({
+        questionSet: {
+          id: updated.id,
+          version: updated.version,
+          updatedAt: updated.updatedAt,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+export {
+  questionsRouter as surveyQuestionsAdminRouter,
+  setsRouter as surveyQuestionSetsAdminRouter,
+};

--- a/backend/src/routes/survey.routes.ts
+++ b/backend/src/routes/survey.routes.ts
@@ -16,8 +16,7 @@ import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
 import {
-  SURVEY_QUESTION_SET,
-  SURVEY_QUESTION_SET_VERSION,
+  loadQuestionSet,
   validateSurveyAnswers,
 } from '../lib/surveyQuestions.js';
 
@@ -204,13 +203,15 @@ publicRouter.get('/:token', async (req: Request, res: Response, next: NextFuncti
 
     const firstName = (guest.name || '').trim().split(/\s+/)[0] || '';
 
+    const set = await loadQuestionSet();
+
     res.json({
       eventName: guest.party.name,
       eventSlug: guest.party.customUrl || guest.party.inviteCode,
       firstName,
       surveyEnabled: guest.party.surveyEnabled,
-      questionSet: SURVEY_QUESTION_SET,
-      questionSetVersion: SURVEY_QUESTION_SET_VERSION,
+      questionSet: set.questions,
+      questionSetVersion: set.version,
       alreadySubmitted: !!guest.surveyResponse,
       answers: guest.surveyResponse?.answers ?? null,
     });
@@ -242,8 +243,12 @@ publicRouter.post('/:token', async (req: Request, res: Response, next: NextFunct
       throw new AppError('This survey is no longer accepting responses', 403, 'SURVEY_DISABLED');
     }
 
-    // Server-side validation against the canonical question set.
-    const answers = validateSurveyAnswers((req.body as { answers?: unknown })?.answers);
+    // Server-side validation against the loaded question set.
+    const set = await loadQuestionSet();
+    const answers = validateSurveyAnswers(
+      (req.body as { answers?: unknown })?.answers,
+      set.questions
+    );
 
     // Upsert keyed on guest_id (unique). Resubmit overwrites.
     await prisma.surveyResponse.upsert({
@@ -252,12 +257,12 @@ publicRouter.post('/:token', async (req: Request, res: Response, next: NextFunct
         partyId: guest.partyId,
         guestId: guest.id,
         email: guest.email || '',
-        questionSetVersion: SURVEY_QUESTION_SET_VERSION,
+        questionSetVersion: set.version,
         answers,
       },
       update: {
         answers,
-        questionSetVersion: SURVEY_QUESTION_SET_VERSION,
+        questionSetVersion: set.version,
         updatedAt: new Date(),
       },
     });
@@ -319,15 +324,16 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
     });
 
     const responseCount = responses.length;
+    const set = await loadQuestionSet();
 
-    // Build aggregation scaffolding from the canonical question set.
+    // Build aggregation scaffolding from the loaded question set.
     const ratings: Record<string, { sum: number; count: number; average: number | null }> = {};
     const yesno: Record<string, { yes: number; no: number }> = {};
     const multiple: Record<string, Record<string, number>> = {};
     const comments: Record<string, string[]> = {};
     const otherTexts: Record<string, string[]> = {};
 
-    for (const q of SURVEY_QUESTION_SET) {
+    for (const q of set.questions) {
       if (q.type === 'rating') ratings[q.id] = { sum: 0, count: 0, average: null };
       else if (q.type === 'yesno') yesno[q.id] = { yes: 0, no: 0 };
       else if (q.type === 'multiple') {
@@ -339,7 +345,7 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
 
     for (const r of responses) {
       const a = (r.answers ?? {}) as Record<string, unknown>;
-      for (const q of SURVEY_QUESTION_SET) {
+      for (const q of set.questions) {
         const v = a[q.id];
         if (v === undefined || v === null) continue;
         if (q.type === 'rating' && typeof v === 'number') {
@@ -360,7 +366,7 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
         }
       }
       // Collect "Other" custom-text free responses for any question with allowOther.
-      for (const q of SURVEY_QUESTION_SET) {
+      for (const q of set.questions) {
         if (!q.allowOther) continue;
         const otherRaw = a[`${q.id}_other`];
         if (typeof otherRaw === 'string') {
@@ -379,8 +385,8 @@ hostRouter.get('/:partyId/survey/results', async (req: AuthRequest, res: Respons
 
     res.json({
       responseCount,
-      questionSet: SURVEY_QUESTION_SET,
-      questionSetVersion: SURVEY_QUESTION_SET_VERSION,
+      questionSet: set.questions,
+      questionSetVersion: set.version,
       ratings,
       yesno,
       multiple,

--- a/frontend/src/components/underboss/SurveyQuestionsTab.tsx
+++ b/frontend/src/components/underboss/SurveyQuestionsTab.tsx
@@ -1,0 +1,789 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader2, ChevronUp, ChevronDown, Plus, X, Save } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { Checkbox } from '../Checkbox';
+import {
+  AdminSurveyQuestion,
+  AdminSurveyQuestionsResponse,
+  AdminSurveyQuestionInput,
+  listAdminSurveyQuestions,
+  createAdminSurveyQuestion,
+  updateAdminSurveyQuestion,
+  reorderAdminSurveyQuestions,
+  updateAdminSurveyQuestionSet,
+} from '../../lib/api';
+
+/**
+ * pugliese-58297: admin CRUD for the post-event guest survey question set.
+ *
+ * Single rendered tab on /underboss (gated to admin-only in UnderbossDashboard).
+ * Lists every question, supports inline reorder via up/down arrows, active
+ * toggle, and an expandable edit form for each row. Adds a footer panel for
+ * the version bump.
+ *
+ * Hard delete is intentionally not supported in the UI — admins flip `active`
+ * to hide a question, or run SQL when truly removing one. See plan.
+ */
+
+type DraftQuestion = {
+  id: string;
+  type: 'rating' | 'yesno' | 'multiple' | 'text';
+  text: string;
+  scale: number | null;
+  multi: boolean;
+  allowOther: boolean;
+  options: string[];
+  active: boolean;
+};
+
+const TYPE_LABELS: Record<DraftQuestion['type'], string> = {
+  rating: 'Rating',
+  yesno: 'Yes / No',
+  multiple: 'Multiple choice',
+  text: 'Free text',
+};
+
+function questionToDraft(q: AdminSurveyQuestion): DraftQuestion {
+  return {
+    id: q.id,
+    type: q.type,
+    text: q.text,
+    scale: q.scale ?? null,
+    multi: !!q.multi,
+    allowOther: !!q.allowOther,
+    options: Array.isArray(q.options) ? [...q.options] : [],
+    active: q.active,
+  };
+}
+
+export function SurveyQuestionsTab() {
+  // ---- Hooks (all above any early return — feedback_hooks_above_early_returns)
+  const [data, setData] = useState<AdminSurveyQuestionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, DraftQuestion>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [rowError, setRowError] = useState<Record<string, string | null>>({});
+
+  // "Add question" form
+  const [showAdd, setShowAdd] = useState(false);
+  const [addDraft, setAddDraft] = useState<DraftQuestion>({
+    id: '',
+    type: 'yesno',
+    text: '',
+    scale: null,
+    multi: false,
+    allowOther: false,
+    options: [],
+    active: true,
+  });
+  const [addSaving, setAddSaving] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  // Version editor
+  const [versionDraft, setVersionDraft] = useState<number | null>(null);
+  const [versionSaving, setVersionSaving] = useState(false);
+  const [versionError, setVersionError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await listAdminSurveyQuestions('default');
+      setData(res);
+      setVersionDraft(res.version);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load survey questions';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const orderedQuestions = useMemo(
+    () => (data?.questions ? [...data.questions].sort((a, b) => a.position - b.position) : []),
+    [data]
+  );
+
+  const handleExpand = useCallback(
+    (q: AdminSurveyQuestion) => {
+      setExpandedId((prev) => (prev === q.id ? null : q.id));
+      setDrafts((prev) => {
+        if (prev[q.id]) return prev;
+        return { ...prev, [q.id]: questionToDraft(q) };
+      });
+      setRowError((prev) => ({ ...prev, [q.id]: null }));
+    },
+    []
+  );
+
+  const updateDraft = useCallback(
+    (id: string, patch: Partial<DraftQuestion>) => {
+      setDrafts((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
+    },
+    []
+  );
+
+  const handleTypeChange = useCallback(
+    (id: string, nextType: DraftQuestion['type']) => {
+      const current = drafts[id];
+      if (!current) return;
+      if (current.type === 'multiple' && nextType !== 'multiple' && current.options.length > 0) {
+        const confirmed = window.confirm(
+          'Changing the type away from multiple-choice will discard the option list. Continue?'
+        );
+        if (!confirmed) return;
+      }
+      const patch: Partial<DraftQuestion> = { type: nextType };
+      if (nextType !== 'rating') patch.scale = null;
+      if (nextType !== 'multiple') {
+        patch.options = [];
+        patch.multi = false;
+        patch.allowOther = false;
+      } else if (current.scale === null) {
+        // leave as is
+      }
+      if (nextType === 'rating' && current.scale === null) {
+        patch.scale = 5;
+      }
+      updateDraft(id, patch);
+    },
+    [drafts, updateDraft]
+  );
+
+  const buildPayload = (d: DraftQuestion): Partial<AdminSurveyQuestionInput> => {
+    const payload: Partial<AdminSurveyQuestionInput> = {
+      type: d.type,
+      text: d.text,
+      active: d.active,
+    };
+    if (d.type === 'rating') {
+      payload.scale = d.scale ?? 5;
+    } else if (d.type === 'multiple') {
+      payload.options = d.options.filter((o) => o.trim().length > 0);
+      payload.multi = d.multi;
+      payload.allowOther = d.allowOther;
+    }
+    return payload;
+  };
+
+  const handleSaveRow = useCallback(
+    async (id: string) => {
+      const d = drafts[id];
+      if (!d) return;
+      setSaving((prev) => ({ ...prev, [id]: true }));
+      setRowError((prev) => ({ ...prev, [id]: null }));
+      try {
+        await updateAdminSurveyQuestion(id, buildPayload(d), 'default');
+        await load();
+        setExpandedId(null);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Save failed';
+        setRowError((prev) => ({ ...prev, [id]: message }));
+      } finally {
+        setSaving((prev) => ({ ...prev, [id]: false }));
+      }
+    },
+    [drafts, load]
+  );
+
+  const handleToggleActive = useCallback(
+    async (q: AdminSurveyQuestion) => {
+      setSaving((prev) => ({ ...prev, [q.id]: true }));
+      try {
+        await updateAdminSurveyQuestion(q.id, { active: !q.active }, 'default');
+        await load();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Toggle failed';
+        setRowError((prev) => ({ ...prev, [q.id]: message }));
+      } finally {
+        setSaving((prev) => ({ ...prev, [q.id]: false }));
+      }
+    },
+    [load]
+  );
+
+  const handleMove = useCallback(
+    async (id: string, direction: -1 | 1) => {
+      if (!data) return;
+      const ids = orderedQuestions.map((q) => q.id);
+      const idx = ids.indexOf(id);
+      if (idx < 0) return;
+      const swapIdx = idx + direction;
+      if (swapIdx < 0 || swapIdx >= ids.length) return;
+      const next = [...ids];
+      [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
+      try {
+        await reorderAdminSurveyQuestions(next, 'default');
+        await load();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Reorder failed';
+        setError(message);
+      }
+    },
+    [data, orderedQuestions, load]
+  );
+
+  const handleAddOption = useCallback(
+    (id: string) => {
+      const current = drafts[id];
+      if (!current) return;
+      updateDraft(id, { options: [...current.options, ''] });
+    },
+    [drafts, updateDraft]
+  );
+
+  const handleRemoveOption = useCallback(
+    (id: string, optIdx: number) => {
+      const current = drafts[id];
+      if (!current) return;
+      updateDraft(id, { options: current.options.filter((_, i) => i !== optIdx) });
+    },
+    [drafts, updateDraft]
+  );
+
+  const handleOptionChange = useCallback(
+    (id: string, optIdx: number, value: string) => {
+      const current = drafts[id];
+      if (!current) return;
+      const next = [...current.options];
+      next[optIdx] = value;
+      updateDraft(id, { options: next });
+    },
+    [drafts, updateDraft]
+  );
+
+  const handleCreate = useCallback(async () => {
+    setAddSaving(true);
+    setAddError(null);
+    try {
+      const payload: AdminSurveyQuestionInput = {
+        id: addDraft.id.trim(),
+        type: addDraft.type,
+        text: addDraft.text,
+        active: addDraft.active,
+        questionSet: 'default',
+      };
+      if (addDraft.type === 'rating') payload.scale = addDraft.scale ?? 5;
+      if (addDraft.type === 'multiple') {
+        payload.options = addDraft.options.filter((o) => o.trim().length > 0);
+        payload.multi = addDraft.multi;
+        payload.allowOther = addDraft.allowOther;
+      }
+      await createAdminSurveyQuestion(payload);
+      await load();
+      setShowAdd(false);
+      setAddDraft({
+        id: '',
+        type: 'yesno',
+        text: '',
+        scale: null,
+        multi: false,
+        allowOther: false,
+        options: [],
+        active: true,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Create failed';
+      setAddError(message);
+    } finally {
+      setAddSaving(false);
+    }
+  }, [addDraft, load]);
+
+  const handleSaveVersion = useCallback(async () => {
+    if (versionDraft === null || versionDraft === data?.version) return;
+    setVersionSaving(true);
+    setVersionError(null);
+    try {
+      await updateAdminSurveyQuestionSet('default', { version: versionDraft });
+      await load();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Save failed';
+      setVersionError(message);
+    } finally {
+      setVersionSaving(false);
+    }
+  }, [versionDraft, data?.version, load]);
+
+  // ---- Render (all hooks declared above)
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 size={28} className="animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="text-red-400 text-sm py-6">
+        {error}
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="text-left text-theme-text-muted border-b border-theme-stroke">
+            <tr>
+              <th className="py-2 pr-3 w-16">#</th>
+              <th className="py-2 pr-3">id / text</th>
+              <th className="py-2 pr-3">type</th>
+              <th className="py-2 pr-3">options</th>
+              <th className="py-2 pr-3 w-24">active</th>
+              <th className="py-2 pr-3 w-24"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {orderedQuestions.map((q, idx) => {
+              const expanded = expandedId === q.id;
+              const draft = drafts[q.id];
+              const rowErr = rowError[q.id];
+              const isSaving = saving[q.id];
+              return (
+                <FragmentRow
+                  key={q.id}
+                  q={q}
+                  idx={idx}
+                  total={orderedQuestions.length}
+                  expanded={expanded}
+                  draft={draft}
+                  rowError={rowErr ?? null}
+                  isSaving={!!isSaving}
+                  onExpand={() => handleExpand(q)}
+                  onMoveUp={() => handleMove(q.id, -1)}
+                  onMoveDown={() => handleMove(q.id, 1)}
+                  onToggleActive={() => handleToggleActive(q)}
+                  onSave={() => handleSaveRow(q.id)}
+                  onCancel={() => {
+                    setExpandedId(null);
+                    setDrafts((prev) => {
+                      const next = { ...prev };
+                      delete next[q.id];
+                      return next;
+                    });
+                  }}
+                  onTextChange={(value) => updateDraft(q.id, { text: value })}
+                  onTypeChange={(value) => handleTypeChange(q.id, value)}
+                  onScaleChange={(value) => updateDraft(q.id, { scale: value })}
+                  onMultiChange={(value) => updateDraft(q.id, { multi: value })}
+                  onAllowOtherChange={(value) => updateDraft(q.id, { allowOther: value })}
+                  onActiveChange={(value) => updateDraft(q.id, { active: value })}
+                  onAddOption={() => handleAddOption(q.id)}
+                  onRemoveOption={(optIdx) => handleRemoveOption(q.id, optIdx)}
+                  onOptionChange={(optIdx, value) => handleOptionChange(q.id, optIdx, value)}
+                />
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add question */}
+      <div className="border border-theme-stroke rounded-xl p-4">
+        {showAdd ? (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-theme-text">New question</h3>
+              <button
+                onClick={() => {
+                  setShowAdd(false);
+                  setAddError(null);
+                }}
+                className="text-theme-text-muted hover:text-theme-text-secondary"
+                aria-label="Cancel"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <IconInput
+              placeholder="id (lowercase snake_case, e.g. food_quality)"
+              value={addDraft.id}
+              onChange={(e) => setAddDraft({ ...addDraft, id: e.target.value })}
+              className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+            />
+            <div className="flex gap-2">
+              <select
+                value={addDraft.type}
+                onChange={(e) => {
+                  const nextType = e.target.value as DraftQuestion['type'];
+                  const patch: Partial<DraftQuestion> = { type: nextType };
+                  if (nextType !== 'rating') patch.scale = null;
+                  if (nextType !== 'multiple') {
+                    patch.options = [];
+                    patch.multi = false;
+                    patch.allowOther = false;
+                  }
+                  if (nextType === 'rating') patch.scale = addDraft.scale ?? 5;
+                  setAddDraft({ ...addDraft, ...patch });
+                }}
+                className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none"
+              >
+                {(Object.keys(TYPE_LABELS) as DraftQuestion['type'][]).map((t) => (
+                  <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+                ))}
+              </select>
+              {addDraft.type === 'rating' && (
+                <input
+                  type="number"
+                  min={2}
+                  max={10}
+                  value={addDraft.scale ?? 5}
+                  onChange={(e) => setAddDraft({ ...addDraft, scale: Number(e.target.value) })}
+                  className="w-24 bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+                />
+              )}
+            </div>
+            <IconInput
+              multiline
+              rows={2}
+              placeholder="Question prompt"
+              value={addDraft.text}
+              onChange={(e) => setAddDraft({ ...addDraft, text: e.target.value })}
+              className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+            />
+            {addDraft.type === 'multiple' && (
+              <OptionEditor
+                options={addDraft.options}
+                onAdd={() => setAddDraft({ ...addDraft, options: [...addDraft.options, ''] })}
+                onChange={(i, v) => {
+                  const next = [...addDraft.options];
+                  next[i] = v;
+                  setAddDraft({ ...addDraft, options: next });
+                }}
+                onRemove={(i) => setAddDraft({ ...addDraft, options: addDraft.options.filter((_, j) => j !== i) })}
+              />
+            )}
+            {addDraft.type === 'multiple' && (
+              <div className="flex flex-wrap gap-4">
+                <Checkbox
+                  checked={addDraft.multi}
+                  onChange={() => setAddDraft({ ...addDraft, multi: !addDraft.multi })}
+                  label="Multi-select"
+                />
+                <Checkbox
+                  checked={addDraft.allowOther}
+                  onChange={() => setAddDraft({ ...addDraft, allowOther: !addDraft.allowOther })}
+                  label='Allow "Other" free text'
+                />
+              </div>
+            )}
+            <Checkbox
+              checked={addDraft.active}
+              onChange={() => setAddDraft({ ...addDraft, active: !addDraft.active })}
+              label="Active"
+            />
+            {addError && <p className="text-sm text-red-400">{addError}</p>}
+            <div className="flex gap-2">
+              <button
+                onClick={handleCreate}
+                disabled={addSaving || !addDraft.id.trim() || !addDraft.text.trim()}
+                className="px-4 py-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+              >
+                {addSaving ? 'Saving...' : 'Create question'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowAdd(true)}
+            className="flex items-center gap-2 text-theme-text hover:text-theme-text-secondary text-sm font-medium"
+          >
+            <Plus size={16} /> Add question
+          </button>
+        )}
+      </div>
+
+      {/* Version footer */}
+      <div className="border border-theme-stroke rounded-xl p-4 flex flex-wrap items-center gap-3">
+        <div>
+          <p className="text-xs text-theme-text-muted">Question set version</p>
+          <p className="text-xs text-theme-text-faint mt-0.5">
+            Bump this when changes alter how answers should be interpreted; old responses
+            are tagged with the version they were collected under.
+          </p>
+        </div>
+        <input
+          type="number"
+          min={1}
+          value={versionDraft ?? data.version}
+          onChange={(e) => setVersionDraft(Number(e.target.value))}
+          className="w-24 bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+        />
+        <button
+          onClick={handleSaveVersion}
+          disabled={versionSaving || versionDraft === null || versionDraft === data.version}
+          className="px-3 py-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1"
+        >
+          <Save size={14} /> {versionSaving ? 'Saving...' : 'Save version'}
+        </button>
+        {versionError && <p className="text-sm text-red-400 basis-full">{versionError}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row component — uses a <tr> with an optional <tr> beneath for the edit form
+// (the wrapping React.Fragment is needed so the table semantics survive).
+// ---------------------------------------------------------------------------
+
+interface RowProps {
+  q: AdminSurveyQuestion;
+  idx: number;
+  total: number;
+  expanded: boolean;
+  draft: DraftQuestion | undefined;
+  rowError: string | null;
+  isSaving: boolean;
+  onExpand: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onToggleActive: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onTextChange: (value: string) => void;
+  onTypeChange: (value: DraftQuestion['type']) => void;
+  onScaleChange: (value: number) => void;
+  onMultiChange: (value: boolean) => void;
+  onAllowOtherChange: (value: boolean) => void;
+  onActiveChange: (value: boolean) => void;
+  onAddOption: () => void;
+  onRemoveOption: (idx: number) => void;
+  onOptionChange: (idx: number, value: string) => void;
+}
+
+function FragmentRow(props: RowProps) {
+  const {
+    q,
+    idx,
+    total,
+    expanded,
+    draft,
+    rowError,
+    isSaving,
+    onExpand,
+    onMoveUp,
+    onMoveDown,
+    onToggleActive,
+    onSave,
+    onCancel,
+    onTextChange,
+    onTypeChange,
+    onScaleChange,
+    onMultiChange,
+    onAllowOtherChange,
+    onActiveChange,
+    onAddOption,
+    onRemoveOption,
+    onOptionChange,
+  } = props;
+
+  const optionCount = Array.isArray(q.options) ? q.options.length : 0;
+  const textPreview = q.text.length > 80 ? `${q.text.slice(0, 80)}...` : q.text;
+
+  return (
+    <>
+      <tr className="border-b border-theme-stroke/60">
+        <td className="py-2 pr-3 align-top">
+          <div className="flex items-center gap-1">
+            <span className="text-theme-text-muted w-6">{q.position}</span>
+            <div className="flex flex-col">
+              <button
+                onClick={onMoveUp}
+                disabled={idx === 0}
+                className="text-theme-text-muted hover:text-theme-text disabled:opacity-30"
+                aria-label="Move up"
+              >
+                <ChevronUp size={14} />
+              </button>
+              <button
+                onClick={onMoveDown}
+                disabled={idx === total - 1}
+                className="text-theme-text-muted hover:text-theme-text disabled:opacity-30"
+                aria-label="Move down"
+              >
+                <ChevronDown size={14} />
+              </button>
+            </div>
+          </div>
+        </td>
+        <td className="py-2 pr-3 align-top">
+          <button
+            onClick={onExpand}
+            className="text-left hover:text-theme-text-secondary"
+          >
+            <div className="text-theme-text font-mono text-xs">{q.id}</div>
+            <div className="text-theme-text-muted text-xs mt-0.5">{textPreview}</div>
+          </button>
+        </td>
+        <td className="py-2 pr-3 align-top">
+          <span className="inline-block px-2 py-0.5 rounded-full bg-theme-surface text-theme-text text-xs border border-theme-stroke">
+            {TYPE_LABELS[q.type]}
+          </span>
+        </td>
+        <td className="py-2 pr-3 align-top text-theme-text-muted text-xs">
+          {q.type === 'multiple' ? `${optionCount} option${optionCount === 1 ? '' : 's'}` : '—'}
+        </td>
+        <td className="py-2 pr-3 align-top">
+          <Checkbox
+            checked={q.active}
+            onChange={onToggleActive}
+            label=""
+            disabled={isSaving}
+          />
+        </td>
+        <td className="py-2 pr-3 align-top">
+          <button
+            onClick={onExpand}
+            className="text-xs text-theme-text hover:text-theme-text-secondary underline"
+          >
+            {expanded ? 'Close' : 'Edit'}
+          </button>
+        </td>
+      </tr>
+
+      {expanded && draft && (
+        <tr>
+          <td colSpan={6} className="bg-theme-surface/40 px-3 py-4 border-b border-theme-stroke">
+            <div className="space-y-3 max-w-2xl">
+              <div>
+                <p className="text-xs text-theme-text-muted mb-1">id</p>
+                <input
+                  type="text"
+                  value={q.id}
+                  readOnly
+                  className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text-muted font-mono focus:outline-none"
+                />
+              </div>
+              <div className="flex gap-2 items-center">
+                <select
+                  value={draft.type}
+                  onChange={(e) => onTypeChange(e.target.value as DraftQuestion['type'])}
+                  className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none"
+                >
+                  {(Object.keys(TYPE_LABELS) as DraftQuestion['type'][]).map((t) => (
+                    <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+                  ))}
+                </select>
+                {draft.type === 'rating' && (
+                  <>
+                    <span className="text-xs text-theme-text-muted">scale</span>
+                    <input
+                      type="number"
+                      min={2}
+                      max={10}
+                      value={draft.scale ?? 5}
+                      onChange={(e) => onScaleChange(Number(e.target.value))}
+                      className="w-24 bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none focus:border-theme-stroke-hover"
+                    />
+                  </>
+                )}
+              </div>
+              <IconInput
+                multiline
+                rows={3}
+                placeholder="Question prompt"
+                value={draft.text}
+                onChange={(e) => onTextChange(e.target.value)}
+                className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+              />
+              {draft.type === 'multiple' && (
+                <>
+                  <OptionEditor
+                    options={draft.options}
+                    onAdd={onAddOption}
+                    onChange={onOptionChange}
+                    onRemove={onRemoveOption}
+                  />
+                  <div className="flex flex-wrap gap-4">
+                    <Checkbox
+                      checked={draft.multi}
+                      onChange={() => onMultiChange(!draft.multi)}
+                      label="Multi-select"
+                    />
+                    <Checkbox
+                      checked={draft.allowOther}
+                      onChange={() => onAllowOtherChange(!draft.allowOther)}
+                      label='Allow "Other" free text'
+                    />
+                  </div>
+                </>
+              )}
+              <Checkbox
+                checked={draft.active}
+                onChange={() => onActiveChange(!draft.active)}
+                label="Active"
+              />
+              {rowError && <p className="text-sm text-red-400">{rowError}</p>}
+              <div className="flex gap-2">
+                <button
+                  onClick={onSave}
+                  disabled={isSaving}
+                  className="px-4 py-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  {isSaving ? 'Saving...' : 'Save'}
+                </button>
+                <button
+                  onClick={onCancel}
+                  className="px-4 py-2 bg-theme-surface border border-theme-stroke hover:border-theme-stroke-hover text-theme-text text-sm font-medium rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+interface OptionEditorProps {
+  options: string[];
+  onAdd: () => void;
+  onChange: (idx: number, value: string) => void;
+  onRemove: (idx: number) => void;
+}
+
+function OptionEditor({ options, onAdd, onChange, onRemove }: OptionEditorProps) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-theme-text-muted">Options</p>
+      {options.length === 0 && (
+        <p className="text-xs text-theme-text-faint">No options yet.</p>
+      )}
+      {options.map((opt, i) => (
+        <div key={i} className="flex gap-2 items-center">
+          <IconInput
+            placeholder={`Option ${i + 1}`}
+            value={opt}
+            onChange={(e) => onChange(i, e.target.value)}
+            className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+          />
+          <button
+            onClick={() => onRemove(i)}
+            className="text-theme-text-muted hover:text-red-400"
+            aria-label={`Remove option ${i + 1}`}
+          >
+            <X size={16} />
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={onAdd}
+        className="text-xs text-theme-text hover:text-theme-text-secondary underline flex items-center gap-1"
+      >
+        <Plus size={12} /> Add option
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -10,6 +10,7 @@ export { FunnelTab } from './FunnelTab';
 export { CityScopePicker } from './CityScopePicker';
 export { FakeDetectionTable } from './FakeDetectionTable';
 export { SuperlativesTab } from './SuperlativesTab';
+export { SurveyQuestionsTab } from './SurveyQuestionsTab';
 export { OutreachTab } from './OutreachTab';
 export { ReimbursementCapCell } from './ReimbursementCapCell';
 export { AppealHistoryModal } from './AppealHistoryModal';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6187,6 +6187,85 @@ export async function getSurveyResults(partyId: string): Promise<SurveyResults> 
   });
 }
 
+// ---------------------------------------------------------------------------
+// pugliese-58297: admin survey-question CRUD
+// ---------------------------------------------------------------------------
+
+export interface AdminSurveyQuestion extends SurveyQuestion {
+  position: number;
+  active: boolean;
+}
+
+export interface AdminSurveyQuestionsResponse {
+  questionSet: string;
+  version: number;
+  questions: AdminSurveyQuestion[];
+}
+
+export async function listAdminSurveyQuestions(
+  set: string = 'default'
+): Promise<AdminSurveyQuestionsResponse> {
+  return apiRequest<AdminSurveyQuestionsResponse>(
+    `/api/admin/survey-questions?set=${encodeURIComponent(set)}`,
+    { method: 'GET', requireAuth: true }
+  );
+}
+
+export interface AdminSurveyQuestionInput {
+  id: string;
+  questionSet?: string;
+  type: 'rating' | 'yesno' | 'multiple' | 'text';
+  text: string;
+  scale?: number | null;
+  multi?: boolean;
+  allowOther?: boolean;
+  options?: string[];
+  active?: boolean;
+  position?: number;
+}
+
+export async function createAdminSurveyQuestion(
+  body: AdminSurveyQuestionInput
+): Promise<{ question: AdminSurveyQuestion }> {
+  return apiRequest<{ question: AdminSurveyQuestion }>('/api/admin/survey-questions', {
+    method: 'POST',
+    body,
+    requireAuth: true,
+  });
+}
+
+export async function updateAdminSurveyQuestion(
+  id: string,
+  body: Partial<AdminSurveyQuestionInput>,
+  set: string = 'default'
+): Promise<{ question: AdminSurveyQuestion }> {
+  return apiRequest<{ question: AdminSurveyQuestion }>(
+    `/api/admin/survey-questions/${encodeURIComponent(id)}?set=${encodeURIComponent(set)}`,
+    { method: 'PATCH', body, requireAuth: true }
+  );
+}
+
+export async function reorderAdminSurveyQuestions(
+  orderedIds: string[],
+  set: string = 'default'
+): Promise<{ success: boolean }> {
+  return apiRequest<{ success: boolean }>('/api/admin/survey-questions/reorder', {
+    method: 'POST',
+    body: { set, orderedIds },
+    requireAuth: true,
+  });
+}
+
+export async function updateAdminSurveyQuestionSet(
+  setId: string,
+  body: { version?: number }
+): Promise<{ questionSet: { id: string; version: number; updatedAt: string } }> {
+  return apiRequest<{ questionSet: { id: string; version: number; updatedAt: string } }>(
+    `/api/admin/survey-question-sets/${encodeURIComponent(setId)}`,
+    { method: 'PATCH', body, requireAuth: true }
+  );
+}
+
 // ============================================
 // Tax forms (salame-92110)
 // ============================================

--- a/frontend/src/lib/surveyQuestions.ts
+++ b/frontend/src/lib/surveyQuestions.ts
@@ -1,9 +1,9 @@
-// romana-61204: Canonical post-event guest survey question set (frontend mirror).
+// pugliese-58297: shared types for the post-event guest survey.
 //
-// This MIRRORS backend/src/lib/surveyQuestions.ts — keep the two in sync.
-// The server is the source of truth and re-validates every submission; this
-// copy is used only to render the form when the API hasn't supplied a set yet
-// and to type the answer shapes.
+// The question set itself is no longer a frontend constant — it is loaded
+// from the DB by the backend and delivered to SurveyPage via the
+// /api/survey/:token response (`surveyData.questionSet`). This file keeps
+// only the shape contracts so SurveyPage + types/api stay strongly typed.
 
 export type SurveyQuestionType = 'rating' | 'yesno' | 'multiple' | 'text';
 
@@ -16,58 +16,6 @@ export interface SurveyQuestion {
   options?: string[]; // for type 'multiple'
   allowOther?: boolean; // for type 'multiple' — when true and user picks "Other", a sibling `${id}_other` free-text field is persisted
 }
-
-export const SURVEY_QUESTION_SET_VERSION = 3;
-
-export const SURVEY_QUESTION_SET: SurveyQuestion[] = [
-  {
-    id: 'attended',
-    type: 'yesno',
-    text: 'Did you attend the event?',
-  },
-  {
-    id: 'overall_rating',
-    type: 'rating',
-    scale: 5,
-    text: 'How would you rate the event overall?',
-  },
-  {
-    id: 'pizza_rating',
-    type: 'rating',
-    scale: 5,
-    text: 'How was the pizza?',
-  },
-  {
-    id: 'enough_pizza',
-    type: 'yesno',
-    text: 'Was there enough pizza?',
-  },
-  {
-    id: 'recommend',
-    type: 'yesno',
-    text: 'Would you come to another PizzaDAO event?',
-  },
-  {
-    id: 'discovery',
-    type: 'multiple',
-    multi: false,
-    text: 'How did you hear about this event?',
-    options: ['A friend', 'Twitter/X', 'WhatsApp', 'The organizer', 'Brave Browser', 'Other'],
-    allowOther: true,
-  },
-  {
-    id: 'highlight',
-    type: 'multiple',
-    multi: true,
-    text: 'What did you enjoy most?',
-    options: ['The pizza', 'The people', 'The talks / program', 'The vibe'],
-  },
-  {
-    id: 'comments',
-    type: 'text',
-    text: "Anything else you'd like to share?",
-  },
-];
 
 export type SurveyAnswerValue = number | boolean | string | string[];
 export type SurveyAnswers = Record<string, SurveyAnswerValue>;

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -6,7 +6,7 @@ import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, C
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, SuperlativesTab, OutreachTab } from '../components/underboss';
+import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, SuperlativesTab, SurveyQuestionsTab, OutreachTab } from '../components/underboss';
 import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
@@ -96,7 +96,7 @@ export function UnderbossDashboard() {
   const [availableRegions, setAvailableRegions] = useState<string[]>([]);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection' | 'superlatives' | 'outreach'>('events');
+  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection' | 'superlatives' | 'survey' | 'outreach'>('events');
 
   const [tableFilteredEvents, setTableFilteredEvents] = useState<UnderbossEvent[] | null>(null);
 
@@ -664,6 +664,21 @@ export function UnderbossDashboard() {
                 )}
               </button>
             )}
+            {isAdmin && (
+              <button
+                onClick={() => setActiveTab('survey')}
+                className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                  activeTab === 'survey'
+                    ? 'text-theme-text'
+                    : 'text-theme-text-muted hover:text-theme-text-secondary'
+                }`}
+              >
+                {t('underbossDashboard.tabs.survey', 'Survey')}
+                {activeTab === 'survey' && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+                )}
+              </button>
+            )}
             <button
               onClick={() => setActiveTab('outreach')}
               className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
@@ -697,6 +712,10 @@ export function UnderbossDashboard() {
 
           {isAdmin && activeTab === 'superlatives' && (
             <SuperlativesTab />
+          )}
+
+          {isAdmin && activeTab === 'survey' && (
+            <SurveyQuestionsTab />
           )}
 
           {activeTab === 'outreach' && (

--- a/frontend/src/pages/UnderbossSurveyQuestions.tsx
+++ b/frontend/src/pages/UnderbossSurveyQuestions.tsx
@@ -1,0 +1,48 @@
+import { Loader2 } from 'lucide-react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+import { SurveyQuestionsTab } from '../components/underboss';
+import { useIsAdminOrUnderboss } from '../hooks/useIsAdminOrUnderboss';
+
+/**
+ * pugliese-58297: standalone admin page wrapper for the survey question CRUD
+ * UI. The same `SurveyQuestionsTab` component is also rendered as a tab on
+ * UnderbossDashboard — this page exists for direct URL access (and so
+ * permission rules can be applied page-level via `useIsAdminOrUnderboss`).
+ *
+ * Hooks order rule: every hook is declared above any conditional return.
+ */
+export function UnderbossSurveyQuestions() {
+  const allowed = useIsAdminOrUnderboss();
+
+  if (allowed === null) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 size={28} className="animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+
+  if (!allowed) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="flex-1 flex items-center justify-center px-4">
+          <p className="text-theme-text-muted">Not authorized.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col gpp-theme" style={{ background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)' }}>
+      <Header />
+      <main className="flex-1 max-w-6xl w-full mx-auto px-4 py-8">
+        <h1 className="text-2xl font-semibold text-theme-text mb-4">Survey questions</h1>
+        <SurveyQuestionsTab />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/supabase/migrations/20260605_pugliese_58297_survey_question_config.sql
+++ b/supabase/migrations/20260605_pugliese_58297_survey_question_config.sql
@@ -1,0 +1,61 @@
+-- pugliese-58297: move post-event survey question config from code constants to DB.
+--
+-- Two tables back the survey question set:
+--  * survey_question_sets — one row per set id (currently only 'default'); the
+--    `version` is bumped manually when the question set changes so old answers
+--    can be interpreted against the version they were collected under.
+--  * survey_questions     — the individual questions, ordered by `position`.
+--
+-- Access model: service-role only (no anon/authenticated GRANTs). Reads happen
+-- in the Express backend via Prisma + service-role connection; the public
+-- survey API still serializes the question set into the JSON response.
+
+CREATE TABLE IF NOT EXISTS survey_question_sets (
+  id          text PRIMARY KEY,
+  version     int  NOT NULL DEFAULT 1,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS survey_questions (
+  id            text NOT NULL,
+  question_set  text NOT NULL REFERENCES survey_question_sets(id),
+  position      int  NOT NULL,
+  type          text NOT NULL CHECK (type IN ('rating','yesno','multiple','text')),
+  text          text NOT NULL,
+  scale         int,
+  multi         boolean NOT NULL DEFAULT false,
+  allow_other   boolean NOT NULL DEFAULT false,
+  options       jsonb NOT NULL DEFAULT '[]'::jsonb,
+  active        boolean NOT NULL DEFAULT true,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (question_set, id),
+  UNIQUE (question_set, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_survey_questions_set_pos
+  ON survey_questions(question_set, position)
+  WHERE active;
+
+-- ---------------------------------------------------------------------------
+-- Seed: 1:1 migration of the current code constants in
+-- backend/src/lib/surveyQuestions.ts (SURVEY_QUESTION_SET_VERSION = 3, 8 Qs).
+-- Exact ids / text / options / scale / multi / allow_other preserved.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO survey_question_sets (id, version, updated_at)
+VALUES ('default', 3, now())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO survey_questions
+  (id, question_set, position, type, text, scale, multi, allow_other, options, active)
+VALUES
+  ('attended',        'default', 1, 'yesno',    'Did you attend the event?',                  NULL, false, false, '[]'::jsonb,                                                                              true),
+  ('overall_rating',  'default', 2, 'rating',   'How would you rate the event overall?',      5,    false, false, '[]'::jsonb,                                                                              true),
+  ('pizza_rating',    'default', 3, 'rating',   'How was the pizza?',                          5,    false, false, '[]'::jsonb,                                                                              true),
+  ('enough_pizza',    'default', 4, 'yesno',    'Was there enough pizza?',                     NULL, false, false, '[]'::jsonb,                                                                              true),
+  ('recommend',       'default', 5, 'yesno',    'Would you come to another PizzaDAO event?',   NULL, false, false, '[]'::jsonb,                                                                              true),
+  ('discovery',       'default', 6, 'multiple', 'How did you hear about this event?',          NULL, false, true,  '["A friend","Twitter/X","WhatsApp","The organizer","Brave Browser","Other"]'::jsonb,    true),
+  ('highlight',       'default', 7, 'multiple', 'What did you enjoy most?',                    NULL, true,  false, '["The pizza","The people","The talks / program","The vibe"]'::jsonb,                    true),
+  ('comments',        'default', 8, 'text',     'Anything else you''d like to share?',         NULL, false, false, '[]'::jsonb,                                                                              true)
+ON CONFLICT (question_set, id) DO NOTHING;


### PR DESCRIPTION
## Summary
Moves the post-event survey question configuration from hardcoded TS constants (`backend/src/lib/surveyQuestions.ts` + `frontend/src/lib/surveyQuestions.ts`) into two new tables (`survey_question_sets`, `survey_questions`) and ships a `/underboss` "Survey" admin tab for CRUD edits. After this PR, routine edits (add option, change copy, bump version) are SQL UPDATEs or admin-UI clicks — no backend redeploy.

The seed in the migration is a 1:1 copy of the 8 current questions in their current positions with `version = 3`, so the public survey API JSON shape is unchanged.

## Phase 1 — DB + backend refactor
- **Migration** `supabase/migrations/20260605_pugliese_58297_survey_question_config.sql`: two tables, service-role only (no anon/authenticated GRANTs). Seeds the existing 8 questions verbatim.
- **Prisma** `backend/prisma/schema.prisma`: new `SurveyQuestionSet` + `SurveyQuestion` models with composite id / unique-position / snake_case `@map`s.
- **Backend `surveyQuestions.ts`**: drops the `SURVEY_QUESTION_SET` / `SURVEY_QUESTION_SET_VERSION` constants. Adds `loadQuestionSet(setId, { refresh? })` with a 60s in-memory cache. `validateSurveyAnswers` is now pure and takes the loaded question set as an arg. DB errors propagate (no fallback — per spec, fail loud).
- **`survey.routes.ts`**: all three call sites switch to `await loadQuestionSet()`. Response shape unchanged.
- **Frontend `surveyQuestions.ts`**: shared types kept; constants removed.

## Phase 2 — Admin UI
- **Backend** `backend/src/routes/admin/surveyQuestions.routes.ts`, mounted at `/api/admin/survey-questions` + `/api/admin/survey-question-sets` BEFORE the `/api/admin` catch-all. Auth: `requireAuth + isFullAdmin` (admin OR super_admin). Endpoints:
  - `GET /api/admin/survey-questions?set=default` — all questions incl. inactive, ordered by position
  - `POST /api/admin/survey-questions` — create (lowercase snake_case id, type-shape validation, auto-assigns next `position`)
  - `PATCH /api/admin/survey-questions/:id?set=default` — partial update with type-shape revalidation
  - `POST /api/admin/survey-questions/reorder` — body `{ set, orderedIds }`, two-pass transactional swap dodges the unique constraint
  - `PATCH /api/admin/survey-question-sets/:setId` — version bump
  - Every write calls `loadQuestionSet(setId, { refresh: true })` BEFORE returning so the admin's next call (and the public flow) sees the change immediately, not after the 60s TTL.
- **Frontend** new `SurveyQuestionsTab` component (exposed both as the admin-only "Survey" tab on `UnderbossDashboard` and as a standalone `UnderbossSurveyQuestions` page gated by `useIsAdminOrUnderboss`). Uses `IconInput` / `Checkbox` per repo rules. Up/down arrows reorder. Active toggle is one-click (reversible — no confirm modal). Type-change away from `multiple` with a non-empty option list triggers a confirm (destructive content loss). Hard delete intentionally NOT in the UI. All hooks declared above any early return.

## Verification
- `cd frontend && npx tsc --noEmit` → clean (no errors).
- `cd backend && npx tsc --noEmit` → only the pre-existing `auth.test.ts` overload errors; no new errors introduced.
- `git grep "SURVEY_QUESTION_SET\b\|SURVEY_QUESTION_SET_VERSION\b"` → no matches; constants fully removed.

## Files touched
- backend/prisma/schema.prisma (+38)
- backend/src/index.ts (+6)
- backend/src/lib/surveyQuestions.ts (refactor: 100 lines net change)
- backend/src/routes/admin/surveyQuestions.routes.ts (+453, new)
- backend/src/routes/survey.routes.ts (+13 / -16)
- frontend/src/components/underboss/SurveyQuestionsTab.tsx (+789, new)
- frontend/src/components/underboss/index.ts (+1)
- frontend/src/lib/api.ts (+79)
- frontend/src/lib/surveyQuestions.ts (-51)
- frontend/src/pages/UnderbossDashboard.tsx (+22 / -1)
- frontend/src/pages/UnderbossSurveyQuestions.tsx (+48, new)
- supabase/migrations/20260605_pugliese_58297_survey_question_config.sql (+61, new)

## Deploy order
> ⚠️ Before this works in prod: (1) apply `supabase/migrations/20260605_pugliese_58297_survey_question_config.sql` to the prod DB, (2) merge this PR, (3) deploy the backend from master tip. Preview frontends hit the prod backend, so the survey endpoints 500 (`loadQuestionSet` throws against missing tables) until the migration is applied. The public survey API shape is unchanged — frontend behavior should be identical after deploy.

## Out of scope
- Per-event question overrides (schema reserves the `question_set` column; v1 uses `'default'` only).
- Backfilling existing `discovery_other` answers into first-class options.
- Hard delete from the admin UI.
- Audit log of who edited what.
- Result aggregation logic changes beyond switching to `loadQuestionSet`.
- Public survey page styling/UX changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)