### PR TITLE
feat(calzone-58293): inline reimbursement-cap editor in /payments By-city view

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -44,6 +44,7 @@ import {
   type ReceiptLightboxImage,
   formatUsd,
   computePartyTotals,
+  CapInlineEditor,
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
 import { isSwcHubParty } from '../../utils/swcHub';
@@ -2652,6 +2653,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onAddExternalPayment,
   onSendPayment,
   onScamFlagChanged,
+  onCapUpdated,
   onTagsChanged,
   onTgReminderResult,
   onTgWalletReminderResult,
@@ -3278,6 +3280,22 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                               : 'Tax forms: off'}
                           </button>
                         )}
+                        {/* calzone-58293: inline reimbursement-cap editor in the By-city header so
+                            admins can raise/clear the party's cap without leaving /payments. Saves to
+                            parties.reimbursement_cap_usd (admin + underboss, scope-checked server-side).
+                            stopPropagation so editing doesn't toggle the row expand. */}
+                        <span
+                          className="inline-flex items-center gap-1 text-[11px] text-theme-text-muted"
+                          onClick={(e) => e.stopPropagation()}
+                          title="Reimbursement cap (validated value or max numeric event_tag)"
+                        >
+                          <CapInlineEditor
+                            partyId={row.party.id}
+                            currentCapUsd={row.party.effectiveReimbursementCapUsd ?? null}
+                            onUpdated={() => onCapUpdated?.(row.party.id)}
+                          />
+                          <span>cap</span>
+                        </span>
                         {/* bottarga-92104: red "Possible scam" pill — visible
                             in the city header next to other status pills when
                             the `possible-scam` tag is present on the party.


### PR DESCRIPTION
## What

Surfaces the existing `CapInlineEditor` in the `/payments` **By city** view so admins/underbosses can raise (or lower/clear) a party's reimbursement cap inline — without bouncing to `/underboss`. Previously this editor only appeared in the **By payment** view, so when a send/approve hit `PARTY_CAP_EXCEEDED` in the By-city view there was no way to adjust the cap from there.

## How

One file changed: `frontend/src/components/payments-admin/PayoutsByPartyTable.tsx` (+18).

- The `onCapUpdated` prop was already declared in the props interface and already passed by the parent (`onCapUpdated={() => refresh()}`) — it was just never destructured/rendered. This wires it up.
- Renders `CapInlineEditor` as a `$<cap> ✎ cap` pill in the city-header pill strip (next to "Tax forms"), with `stopPropagation` so editing doesn't toggle row expand.
- Saves to `parties.reimbursement_cap_usd` via the existing `updatePartyApi` PATCH (admin + underboss only, scope-checked server-side).

## Scope

- **Frontend-only.** No backend changes, no DB migration — the cap PATCH endpoint + auth already exist.
- Chosen approach: raise the **stored** cap (persistent). Did **not** add the per-send `allowOverPartyCap` one-off bypass ack.

Plan: `plans/calzone-58293-payments-cap-override.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)