### PR TITLE
feat(crocchetta-92107): tax form date defaults to today

### DIFF
--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -85,6 +85,18 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
   const valueRef = useRef(value);
   valueRef.current = value;
 
+  // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
+  // fresh mount. Saved drafts with an existing date are left untouched; the
+  // effect only fires once so subsequent user edits remain authoritative.
+  useEffect(() => {
+    const v = valueRef.current;
+    if (!v.date || v.date.trim() === '') {
+      const today = new Date().toISOString().slice(0, 10);
+      onChangeRef.current({ ...v, date: today });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Default the treaty-claim country to the entity's country of incorporation
   // (most common case for an entity claiming treaty benefits). Host can edit.
   const treatyKey = (value.treatyCountry?.trim() || value.countryOfIncorporation?.trim() || '').trim();

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -46,6 +46,18 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
   const valueRef = useRef(value);
   valueRef.current = value;
 
+  // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
+  // fresh mount. Saved drafts with an existing date are left untouched; the
+  // effect only fires once so subsequent user edits remain authoritative.
+  useEffect(() => {
+    const v = valueRef.current;
+    if (!v.date || v.date.trim() === '') {
+      const today = new Date().toISOString().slice(0, 10);
+      onChangeRef.current({ ...v, date: today });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // The treaty-claim country defaults to permanentCountry (typical case:
   // host is claiming benefits under their country of residence's treaty).
   // We watch that field and auto-suggest article + rate + income type.

--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   User,
   Building2,
@@ -90,6 +90,17 @@ export const W9Form: React.FC<W9FormProps> = ({
   const [showExemptCodes, setShowExemptCodes] = useState<boolean>(
     !!(value.exemptPayeeCode || value.fatcaCode || value.accountNumbers),
   );
+
+  // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
+  // fresh mount. Saved drafts with an existing date are left untouched; the
+  // effect only fires once so subsequent user edits remain authoritative.
+  useEffect(() => {
+    if (!value.date || value.date.trim() === "") {
+      const today = new Date().toISOString().slice(0, 10);
+      onChange({ ...value, date: today });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const set = <K extends keyof W9FormData>(key: K, v: W9FormData[K]) =>
     onChange({ ...value, [key]: v });


### PR DESCRIPTION
## Summary
- W-9, W-8BEN, and W-8BEN-E signature Date field now pre-fills with today's date (YYYY-MM-DD) on fresh mount.
- One-shot mount `useEffect` only sets the date when the incoming `value.date` is empty, so saved drafts and subsequent user edits remain authoritative.
- Hook declared above any conditional logic in each component to keep React's hook-order rule satisfied.

## Test plan
- [ ] Open a fresh W-9: Date field pre-fills today's date.
- [ ] Open a fresh W-8BEN: Date field pre-fills today's date.
- [ ] Open a fresh W-8BEN-E: Date field pre-fills today's date.
- [ ] Edit the date to a past date, save draft, reopen: past date persists (not overwritten by today's).
- [ ] User can still clear/edit the field after mount.

Generated with [Claude Code](https://claude.com/claude-code)