### PR TITLE
lasagna-49278: DB-driven config for RSVP opt-in checkboxes

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -1031,4 +1031,336 @@ router.patch('/experiments/flags/:key', requireAuth, async (req: AuthRequest, re
   }
 });
 
+// ── lasagna-49278: RSVP opt-in checkbox config admin ───────────────────────
+// CRUD over the `rsvp_checkboxes` table. Frontend renderer (RsvpCheckboxList)
+// reads rows directly from Supabase via anon SELECT; writes go through here.
+// Schema isn't in Prisma — we use $queryRawUnsafe / $executeRawUnsafe.
+
+// Hardcoded whitelist of allowed `opt_in_fields` values. Mirrors the 8
+// destination columns on `guests`. Adding a 9th = explicit deploy (new
+// Prisma field, new backend whitelist entry, new frontend setter mapping).
+const ALLOWED_OPT_IN_FIELDS = new Set([
+  'mailingListOptIn',
+  'swcOptIn',
+  'swcCaOptIn',
+  'swcAuOptIn',
+  'swcEuOptIn',
+  'swcUkOptIn',
+  'swcBrOptIn',
+  'ethconfOptIn',
+]);
+const ALLOWED_ACCENT_COLORS = new Set(['red', 'purple']);
+// The 8 seeded global IDs. DELETE without party_id on these is rejected —
+// callers must soft-disable (active=false) instead.
+const SEEDED_GLOBAL_IDS = new Set([
+  'mailing_list', 'swc_us', 'swc_ca', 'swc_au', 'swc_eu', 'swc_uk', 'swc_br', 'ethconf',
+]);
+
+interface RsvpCheckboxRow {
+  id: string;
+  party_id: string | null;
+  position: number;
+  active: boolean;
+  required_tags: string[];
+  excluded_tags: string[];
+  always_show: boolean;
+  opt_in_fields: string[];
+  combined_group: string | null;
+  label_i18n_key: string | null;
+  label_default: string | null;
+  label_overrides: Record<string, string>;
+  info_modal_i18n_ns: string | null;
+  info_modal_privacy_url: string | null;
+  info_modal_terms_url: string | null;
+  info_modal_terms_key: string | null;
+  modal_overrides: Record<string, unknown>;
+  accent_color: string;
+  updated_at: Date;
+  updated_by: string | null;
+}
+
+function validateOptInFields(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new AppError('opt_in_fields must be a non-empty array', 400, 'VALIDATION_ERROR');
+  }
+  const out: string[] = [];
+  for (const v of value) {
+    if (typeof v !== 'string' || !ALLOWED_OPT_IN_FIELDS.has(v)) {
+      throw new AppError(
+        `opt_in_fields includes invalid value '${String(v)}'. Allowed: ${Array.from(ALLOWED_OPT_IN_FIELDS).join(', ')}`,
+        400,
+        'VALIDATION_ERROR',
+      );
+    }
+    out.push(v);
+  }
+  return out;
+}
+
+function validateAccentColor(value: unknown): string {
+  if (typeof value !== 'string' || !ALLOWED_ACCENT_COLORS.has(value)) {
+    throw new AppError(
+      `accent_color must be one of ${Array.from(ALLOWED_ACCENT_COLORS).join(', ')}`,
+      400,
+      'VALIDATION_ERROR',
+    );
+  }
+  return value;
+}
+
+function asStringArray(value: unknown, fieldName: string): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new AppError(`${fieldName} must be an array of strings`, 400, 'VALIDATION_ERROR');
+  }
+  return value.map((v) => {
+    if (typeof v !== 'string') {
+      throw new AppError(`${fieldName} must be an array of strings`, 400, 'VALIDATION_ERROR');
+    }
+    return v;
+  });
+}
+
+function asNullableString(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new AppError(`${fieldName} must be a string or null`, 400, 'VALIDATION_ERROR');
+  }
+  return value;
+}
+
+function asObject(value: unknown, fieldName: string): Record<string, unknown> {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new AppError(`${fieldName} must be a JSON object`, 400, 'VALIDATION_ERROR');
+  }
+  return value as Record<string, unknown>;
+}
+
+// GET /api/admin/rsvp-checkboxes?party_id=<id>
+router.get('/rsvp-checkboxes', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const partyId = typeof req.query.party_id === 'string' ? req.query.party_id : null;
+    const rows = partyId
+      ? await prisma.$queryRawUnsafe<RsvpCheckboxRow[]>(
+          `SELECT id, party_id, position, active, required_tags, excluded_tags, always_show,
+                  opt_in_fields, combined_group,
+                  label_i18n_key, label_default, label_overrides,
+                  info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+                  modal_overrides, accent_color, updated_at, updated_by
+             FROM rsvp_checkboxes
+            WHERE party_id = $1::uuid
+            ORDER BY position`,
+          partyId,
+        )
+      : await prisma.$queryRawUnsafe<RsvpCheckboxRow[]>(
+          `SELECT id, party_id, position, active, required_tags, excluded_tags, always_show,
+                  opt_in_fields, combined_group,
+                  label_i18n_key, label_default, label_overrides,
+                  info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+                  modal_overrides, accent_color, updated_at, updated_by
+             FROM rsvp_checkboxes
+            ORDER BY party_id NULLS FIRST, position`,
+        );
+    res.set('Cache-Control', 'no-store');
+    res.json({ checkboxes: rows });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/admin/rsvp-checkboxes
+router.post('/rsvp-checkboxes', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const body = req.body ?? {};
+    if (typeof body.id !== 'string' || body.id.length === 0) {
+      throw new AppError('id is required', 400, 'VALIDATION_ERROR');
+    }
+    const optInFields = validateOptInFields(body.opt_in_fields);
+    const accentColor = validateAccentColor(body.accent_color ?? 'red');
+    const partyId = asNullableString(body.party_id, 'party_id');
+    const labelOverrides = asObject(body.label_overrides, 'label_overrides');
+    const modalOverrides = asObject(body.modal_overrides, 'modal_overrides');
+
+    const inserted = await prisma.$queryRawUnsafe<RsvpCheckboxRow[]>(
+      `INSERT INTO rsvp_checkboxes (
+         id, party_id, position, active,
+         required_tags, excluded_tags, always_show,
+         opt_in_fields, combined_group,
+         label_i18n_key, label_default, label_overrides,
+         info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+         modal_overrides, accent_color,
+         updated_at, updated_by
+       ) VALUES (
+         $1, $2::uuid, $3, $4,
+         $5::text[], $6::text[], $7,
+         $8::text[], $9,
+         $10, $11, $12::jsonb,
+         $13, $14, $15, $16,
+         $17::jsonb, $18,
+         now(), $19
+       )
+       RETURNING id, party_id, position, active, required_tags, excluded_tags, always_show,
+                 opt_in_fields, combined_group,
+                 label_i18n_key, label_default, label_overrides,
+                 info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+                 modal_overrides, accent_color, updated_at, updated_by`,
+      body.id,
+      partyId,
+      typeof body.position === 'number' ? body.position : 0,
+      body.active === false ? false : true,
+      asStringArray(body.required_tags, 'required_tags'),
+      asStringArray(body.excluded_tags, 'excluded_tags'),
+      body.always_show === true,
+      optInFields,
+      asNullableString(body.combined_group, 'combined_group'),
+      asNullableString(body.label_i18n_key, 'label_i18n_key'),
+      asNullableString(body.label_default, 'label_default'),
+      JSON.stringify(labelOverrides),
+      asNullableString(body.info_modal_i18n_ns, 'info_modal_i18n_ns'),
+      asNullableString(body.info_modal_privacy_url, 'info_modal_privacy_url'),
+      asNullableString(body.info_modal_terms_url, 'info_modal_terms_url'),
+      asNullableString(body.info_modal_terms_key, 'info_modal_terms_key'),
+      JSON.stringify(modalOverrides),
+      accentColor,
+      req.userEmail ?? null,
+    );
+    res.json({ checkbox: inserted[0] });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /api/admin/rsvp-checkboxes/:id?party_id=<id?>
+router.patch('/rsvp-checkboxes/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const { id } = req.params;
+    const partyId = typeof req.query.party_id === 'string' && req.query.party_id.length > 0
+      ? req.query.party_id
+      : (typeof req.body?.party_id === 'string' ? req.body.party_id : null);
+
+    // Validate any provided fields. Build a dynamic UPDATE set list.
+    const body = req.body ?? {};
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    const add = (sqlExpr: string, value: unknown) => {
+      params.push(value);
+      sets.push(`${sqlExpr} = $${params.length}`);
+    };
+
+    if (body.position !== undefined) add('position', typeof body.position === 'number' ? body.position : 0);
+    if (body.active !== undefined) add('active', body.active === true);
+    if (body.required_tags !== undefined) {
+      params.push(asStringArray(body.required_tags, 'required_tags'));
+      sets.push(`required_tags = $${params.length}::text[]`);
+    }
+    if (body.excluded_tags !== undefined) {
+      params.push(asStringArray(body.excluded_tags, 'excluded_tags'));
+      sets.push(`excluded_tags = $${params.length}::text[]`);
+    }
+    if (body.always_show !== undefined) add('always_show', body.always_show === true);
+    if (body.opt_in_fields !== undefined) {
+      params.push(validateOptInFields(body.opt_in_fields));
+      sets.push(`opt_in_fields = $${params.length}::text[]`);
+    }
+    if (body.combined_group !== undefined) add('combined_group', asNullableString(body.combined_group, 'combined_group'));
+    if (body.label_i18n_key !== undefined) add('label_i18n_key', asNullableString(body.label_i18n_key, 'label_i18n_key'));
+    if (body.label_default !== undefined) add('label_default', asNullableString(body.label_default, 'label_default'));
+    if (body.label_overrides !== undefined) {
+      params.push(JSON.stringify(asObject(body.label_overrides, 'label_overrides')));
+      sets.push(`label_overrides = $${params.length}::jsonb`);
+    }
+    if (body.info_modal_i18n_ns !== undefined) add('info_modal_i18n_ns', asNullableString(body.info_modal_i18n_ns, 'info_modal_i18n_ns'));
+    if (body.info_modal_privacy_url !== undefined) add('info_modal_privacy_url', asNullableString(body.info_modal_privacy_url, 'info_modal_privacy_url'));
+    if (body.info_modal_terms_url !== undefined) add('info_modal_terms_url', asNullableString(body.info_modal_terms_url, 'info_modal_terms_url'));
+    if (body.info_modal_terms_key !== undefined) add('info_modal_terms_key', asNullableString(body.info_modal_terms_key, 'info_modal_terms_key'));
+    if (body.modal_overrides !== undefined) {
+      params.push(JSON.stringify(asObject(body.modal_overrides, 'modal_overrides')));
+      sets.push(`modal_overrides = $${params.length}::jsonb`);
+    }
+    if (body.accent_color !== undefined) add('accent_color', validateAccentColor(body.accent_color));
+
+    // Always stamp updated_at + updated_by.
+    sets.push(`updated_at = now()`);
+    params.push(req.userEmail ?? null);
+    sets.push(`updated_by = $${params.length}`);
+
+    if (sets.length <= 2) {
+      // only the timestamp + actor — no actual field changes
+      throw new AppError('No fields to update', 400, 'VALIDATION_ERROR');
+    }
+
+    // WHERE clause: id + (party_id IS NULL or = $X)
+    params.push(id);
+    const idPlaceholder = `$${params.length}`;
+    let whereClause: string;
+    if (partyId) {
+      params.push(partyId);
+      whereClause = `id = ${idPlaceholder} AND party_id = $${params.length}::uuid`;
+    } else {
+      whereClause = `id = ${idPlaceholder} AND party_id IS NULL`;
+    }
+
+    const updated = await prisma.$queryRawUnsafe<RsvpCheckboxRow[]>(
+      `UPDATE rsvp_checkboxes SET ${sets.join(', ')}
+         WHERE ${whereClause}
+       RETURNING id, party_id, position, active, required_tags, excluded_tags, always_show,
+                 opt_in_fields, combined_group,
+                 label_i18n_key, label_default, label_overrides,
+                 info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+                 modal_overrides, accent_color, updated_at, updated_by`,
+      ...params,
+    );
+    if (updated.length === 0) {
+      throw new AppError('Checkbox row not found', 404, 'NOT_FOUND');
+    }
+    res.json({ checkbox: updated[0] });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/admin/rsvp-checkboxes/:id?party_id=<id?>
+router.delete('/rsvp-checkboxes/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!(await isAdmin(req.userEmail))) {
+      throw new AppError('Admin access required', 403, 'FORBIDDEN');
+    }
+    const { id } = req.params;
+    const partyId = typeof req.query.party_id === 'string' && req.query.party_id.length > 0
+      ? req.query.party_id
+      : null;
+
+    // Reject DELETE of seeded global rows — force soft-disable instead.
+    if (!partyId && SEEDED_GLOBAL_IDS.has(id)) {
+      throw new AppError(
+        'Use active=false to soft-disable seeded global rows (delete is reserved for custom checkboxes and per-event overrides)',
+        400,
+        'VALIDATION_ERROR',
+      );
+    }
+
+    const sql = partyId
+      ? `DELETE FROM rsvp_checkboxes WHERE id = $1 AND party_id = $2::uuid`
+      : `DELETE FROM rsvp_checkboxes WHERE id = $1 AND party_id IS NULL`;
+    const params: unknown[] = partyId ? [id, partyId] : [id];
+    const deleted = await prisma.$executeRawUnsafe(sql, ...params);
+    if (deleted === 0) {
+      throw new AppError('Checkbox row not found', 404, 'NOT_FOUND');
+    }
+    res.json({ deleted: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/frontend/src/components/RSVPFormStep1.tsx
+++ b/frontend/src/components/RSVPFormStep1.tsx
@@ -5,6 +5,9 @@ import { IconInput } from './IconInput';
 import { useTranslation } from 'react-i18next';
 import { TURTLES } from '../constants/options';
 import type { useRSVPForm } from '../hooks/useRSVPForm';
+// lasagna-49278: DB-driven opt-in checkbox renderer + config fetch hook.
+import { RsvpCheckboxList } from './RsvpCheckboxList';
+import { useRsvpCheckboxConfig } from '../hooks/useRsvpCheckboxConfig';
 
 interface RSVPFormStep1Props {
   form: ReturnType<typeof useRSVPForm>;
@@ -23,10 +26,14 @@ export function RSVPFormStep1({
   showWallet,
   showTurtleRoles,
 }: RSVPFormStep1Props) {
-  const { t } = useTranslation('rsvp');
+  const { t, i18n } = useTranslation('rsvp');
   const { t: tCommon } = useTranslation('common');
   const [turtleDropdownOpen, setTurtleDropdownOpen] = useState(false);
   const turtleRef = useRef<HTMLDivElement>(null);
+  // lasagna-49278: DB-driven config for the opt-in checkboxes. Replaces the
+  // 9 hardcoded blocks below the turtle dropdown. While `loading`, no
+  // checkboxes render (intentionally conservative — see plan §"Loading state").
+  const { config: rsvpCheckboxConfig } = useRsvpCheckboxConfig(form.eventId);
 
   // Close dropdown on click outside
   useEffect(() => {
@@ -152,76 +159,20 @@ export function RSVPFormStep1({
         </div>
       )}
 
-      {/* Combined PizzaDAO + SWC opt-in (variant arm of A/B test, any active SWC region) */}
-      {form.activeRegionConfig && form.optinAbVariant === 'variant' ? (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => form.setCombinedOptIn(!form.combinedOptIn)}
-              className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer flex-1"
-            >
-              {form.combinedOptIn ? (
-                <CheckSquare2 size={20} className="text-[#ff393a] flex-shrink-0" />
-              ) : (
-                <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-              )}
-              <span className="text-sm text-theme-text">
-                {t('step1.combinedOptIn')}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => form.setShowRegionalOptinAbModal(true)}
-              className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            >
-              <Info size={18} />
-            </button>
-          </div>
+      {/*
+        lasagna-49278: opt-in checkbox section. Two paths:
 
-          {form.showRegionalOptinAbModal && createPortal(
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
-              onClick={() => form.setShowRegionalOptinAbModal(false)}
-            >
-              <div
-                className="card p-6 max-w-md w-full relative"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <button
-                  onClick={() => form.setShowRegionalOptinAbModal(false)}
-                  className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
-                >
-                  <X size={20} />
-                </button>
-                <h3 className="text-lg font-bold text-theme-text mb-3">{t(`${form.activeRegionConfig.modalNamespace}.title`)}</h3>
-                <p className="text-sm text-theme-text-secondary leading-relaxed">
-                  {t(`${form.activeRegionConfig.modalNamespace}.description`)}{' '}
-                  <a
-                    href={form.activeRegionConfig.privacyUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t(`${form.activeRegionConfig.modalNamespace}.privacyPolicy`)}
-                  </a> and{' '}
-                  <a
-                    href={form.activeRegionConfig.termsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t(`${form.activeRegionConfig.modalNamespace}.${form.activeRegionConfig.termsKey}`)}
-                  </a>.
-                </p>
-              </div>
-            </div>,
-            document.body
-          )}
-        </>
-      ) : (
+          1. PRESERVATION BRANCH — re-submits by existing guests previously
+             bucketed into optin_ab_variant='control' still see the old
+             two-checkbox layout (mailing list + matching regional SWC).
+             This branch shrinks over time as 'control' churns out.
+
+          2. CONFIG-DRIVEN — everyone else (new RSVPs, variant re-submits,
+             non-SWC events) gets the DB-driven RsvpCheckboxList renderer.
+      */}
+      {form.activeRegionConfig && form.optinAbVariant === 'control' ? (
         <>
-          {/* PizzaDAO Newsletter opt-in */}
+          {/* PizzaDAO Newsletter opt-in (preservation) */}
           <button
             type="button"
             onClick={() => form.setMailingListOptIn(!form.mailingListOptIn)}
@@ -237,7 +188,7 @@ export function RSVPFormStep1({
             </span>
           </button>
 
-          {/* SWC checkbox + info modal (US) */}
+          {/* Matching regional SWC checkbox + info modal (preservation) */}
           {form.isSwcEvent && (
             <>
               <div className="flex items-center gap-2">
@@ -251,9 +202,7 @@ export function RSVPFormStep1({
                   ) : (
                     <Square size={20} className="text-theme-text-muted flex-shrink-0" />
                   )}
-                  <span className="text-sm text-theme-text">
-                    {t('step1.swcJoin')}
-                  </span>
+                  <span className="text-sm text-theme-text">{t('step1.swcJoin')}</span>
                 </button>
                 <button
                   type="button"
@@ -263,16 +212,12 @@ export function RSVPFormStep1({
                   <Info size={18} />
                 </button>
               </div>
-
               {form.showSwcInfoModal && createPortal(
                 <div
                   className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
                   onClick={() => form.setShowSwcInfoModal(false)}
                 >
-                  <div
-                    className="card p-6 max-w-md w-full relative"
-                    onClick={(e) => e.stopPropagation()}
-                  >
+                  <div className="card p-6 max-w-md w-full relative" onClick={(e) => e.stopPropagation()}>
                     <button
                       onClick={() => form.setShowSwcInfoModal(false)}
                       className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
@@ -282,20 +227,10 @@ export function RSVPFormStep1({
                     <h3 className="text-lg font-bold text-theme-text mb-3">{t('swcModal.title')}</h3>
                     <p className="text-sm text-theme-text-secondary leading-relaxed">
                       {t('swcModal.description')}{' '}
-                      <a
-                        href="https://www.standwithcrypto.org/privacy"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-purple-400 hover:text-purple-300 underline"
-                      >
+                      <a href="https://www.standwithcrypto.org/privacy" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline">
                         {t('swcModal.privacyPolicy')}
                       </a> and{' '}
-                      <a
-                        href="https://www.standwithcrypto.org/terms-of-service"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-purple-400 hover:text-purple-300 underline"
-                      >
+                      <a href="https://www.standwithcrypto.org/terms-of-service" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline">
                         {t('swcModal.termsConditions')}
                       </a>.
                     </p>
@@ -306,369 +241,13 @@ export function RSVPFormStep1({
             </>
           )}
         </>
-      )}
-
-      {/* SWC Canada checkbox + info modal */}
-      {form.isSwcCaEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => form.setSwcCaOptIn(!form.swcCaOptIn)}
-              className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer flex-1"
-            >
-              {form.swcCaOptIn ? (
-                <CheckSquare2 size={20} className="text-purple-500 flex-shrink-0" />
-              ) : (
-                <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-              )}
-              <span className="text-sm text-theme-text">
-                {t('step1.swcNotify')}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => form.setShowSwcCaInfoModal(true)}
-              className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            >
-              <Info size={18} />
-            </button>
-          </div>
-
-          {form.showSwcCaInfoModal && createPortal(
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
-              onClick={() => form.setShowSwcCaInfoModal(false)}
-            >
-              <div
-                className="card p-6 max-w-md w-full relative"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <button
-                  onClick={() => form.setShowSwcCaInfoModal(false)}
-                  className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
-                >
-                  <X size={20} />
-                </button>
-                <h3 className="text-lg font-bold text-theme-text mb-3">{t('swcCaModal.title')}</h3>
-                <p className="text-sm text-theme-text-secondary leading-relaxed">
-                  {t('swcCaModal.description')}{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/ca/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcCaModal.privacyPolicy')}
-                  </a> and{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/ca/terms-of-service"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcCaModal.termsOfService')}
-                  </a>.
-                </p>
-              </div>
-            </div>,
-            document.body
-          )}
-        </>
-      )}
-
-      {/* SWC Australia checkbox + info modal */}
-      {form.isSwcAuEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => form.setSwcAuOptIn(!form.swcAuOptIn)}
-              className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer flex-1"
-            >
-              {form.swcAuOptIn ? (
-                <CheckSquare2 size={20} className="text-purple-500 flex-shrink-0" />
-              ) : (
-                <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-              )}
-              <span className="text-sm text-theme-text">
-                {t('step1.swcNotify')}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => form.setShowSwcAuInfoModal(true)}
-              className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            >
-              <Info size={18} />
-            </button>
-          </div>
-
-          {form.showSwcAuInfoModal && createPortal(
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
-              onClick={() => form.setShowSwcAuInfoModal(false)}
-            >
-              <div
-                className="card p-6 max-w-md w-full relative"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <button
-                  onClick={() => form.setShowSwcAuInfoModal(false)}
-                  className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
-                >
-                  <X size={20} />
-                </button>
-                <h3 className="text-lg font-bold text-theme-text mb-3">{t('swcAuModal.title')}</h3>
-                <p className="text-sm text-theme-text-secondary leading-relaxed">
-                  {t('swcAuModal.description')}{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/au/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcAuModal.privacyPolicy')}
-                  </a> and{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/au/terms-of-service"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcAuModal.termsOfService')}
-                  </a>.
-                </p>
-              </div>
-            </div>,
-            document.body
-          )}
-        </>
-      )}
-
-      {/* SWC EU checkbox + info modal */}
-      {form.isSwcEuEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => form.setSwcEuOptIn(!form.swcEuOptIn)}
-              className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer flex-1"
-            >
-              {form.swcEuOptIn ? (
-                <CheckSquare2 size={20} className="text-purple-500 flex-shrink-0" />
-              ) : (
-                <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-              )}
-              <span className="text-sm text-theme-text">
-                {t('step1.swcNotify')}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => form.setShowSwcEuInfoModal(true)}
-              className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            >
-              <Info size={18} />
-            </button>
-          </div>
-
-          {form.showSwcEuInfoModal && createPortal(
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
-              onClick={() => form.setShowSwcEuInfoModal(false)}
-            >
-              <div
-                className="card p-6 max-w-md w-full relative"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <button
-                  onClick={() => form.setShowSwcEuInfoModal(false)}
-                  className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
-                >
-                  <X size={20} />
-                </button>
-                <h3 className="text-lg font-bold text-theme-text mb-3">{t('swcEuModal.title')}</h3>
-                <p className="text-sm text-theme-text-secondary leading-relaxed">
-                  {t('swcEuModal.description')}{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/eu/en/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcEuModal.privacyPolicy')}
-                  </a> and{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/eu/en/terms-of-service"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcEuModal.termsOfService')}
-                  </a>.
-                </p>
-              </div>
-            </div>,
-            document.body
-          )}
-        </>
-      )}
-
-      {/* SWC UK checkbox + info modal */}
-      {form.isSwcUkEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => form.setSwcUkOptIn(!form.swcUkOptIn)}
-              className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer flex-1"
-            >
-              {form.swcUkOptIn ? (
-                <CheckSquare2 size={20} className="text-purple-500 flex-shrink-0" />
-              ) : (
-                <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-              )}
-              <span className="text-sm text-theme-text">
-                {t('step1.swcNotify')}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => form.setShowSwcUkInfoModal(true)}
-              className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            >
-              <Info size={18} />
-            </button>
-          </div>
-
-          {form.showSwcUkInfoModal && createPortal(
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
-              onClick={() => form.setShowSwcUkInfoModal(false)}
-            >
-              <div
-                className="card p-6 max-w-md w-full relative"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <button
-                  onClick={() => form.setShowSwcUkInfoModal(false)}
-                  className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
-                >
-                  <X size={20} />
-                </button>
-                <h3 className="text-lg font-bold text-theme-text mb-3">{t('swcUkModal.title')}</h3>
-                <p className="text-sm text-theme-text-secondary leading-relaxed">
-                  {t('swcUkModal.description')}{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/gb/en/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcUkModal.privacyPolicy')}
-                  </a> and{' '}
-                  <a
-                    href="https://www.standwithcrypto.org/gb/en/terms-of-service"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcUkModal.termsOfService')}
-                  </a>.
-                </p>
-              </div>
-            </div>,
-            document.body
-          )}
-        </>
-      )}
-
-      {/* SWC Brazil checkbox + info modal */}
-      {form.isSwcBrEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => form.setSwcBrOptIn(!form.swcBrOptIn)}
-              className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer flex-1"
-            >
-              {form.swcBrOptIn ? (
-                <CheckSquare2 size={20} className="text-purple-500 flex-shrink-0" />
-              ) : (
-                <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-              )}
-              <span className="text-sm text-theme-text">
-                {t('step1.swcBrNotify')}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => form.setShowSwcBrInfoModal(true)}
-              className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
-            >
-              <Info size={18} />
-            </button>
-          </div>
-
-          {form.showSwcBrInfoModal && createPortal(
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
-              onClick={() => form.setShowSwcBrInfoModal(false)}
-            >
-              <div
-                className="card p-6 max-w-md w-full relative"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <button
-                  onClick={() => form.setShowSwcBrInfoModal(false)}
-                  className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
-                >
-                  <X size={20} />
-                </button>
-                <h3 className="text-lg font-bold text-theme-text mb-3">{t('swcBrModal.title')}</h3>
-                <p className="text-sm text-theme-text-secondary leading-relaxed">
-                  {t('swcBrModal.description')}{' '}
-                  <a
-                    href="https://www.juntosporcripto.org/br/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcBrModal.privacyPolicy')}
-                  </a> and{' '}
-                  <a
-                    href="https://www.juntosporcripto.org/br/terms-of-service"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-purple-400 hover:text-purple-300 underline"
-                  >
-                    {t('swcBrModal.termsOfService')}
-                  </a>.
-                </p>
-              </div>
-            </div>,
-            document.body
-          )}
-        </>
-      )}
-
-      {/* ETHConf discount opt-in */}
-      {form.isEthconfEvent && !(form.activeRegionConfig && form.optinAbVariant === 'variant') && (
-        <button
-          type="button"
-          onClick={() => form.setEthconfOptIn(!form.ethconfOptIn)}
-          className="flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer w-full"
-        >
-          {form.ethconfOptIn ? (
-            <CheckSquare2 size={20} className="text-[#ff393a] flex-shrink-0" />
-          ) : (
-            <Square size={20} className="text-theme-text-muted flex-shrink-0" />
-          )}
-          <span className="text-sm text-theme-text">
-            {t('step1.ethconfDiscount')}
-          </span>
-        </button>
+      ) : (
+        <RsvpCheckboxList
+          config={rsvpCheckboxConfig}
+          form={form}
+          eventTags={form.eventTags}
+          currentLocale={i18n.language}
+        />
       )}
 
       {/* Error display */}

--- a/frontend/src/components/RsvpCheckboxList.tsx
+++ b/frontend/src/components/RsvpCheckboxList.tsx
@@ -1,0 +1,285 @@
+// lasagna-49278: DB-driven renderer for the RSVP opt-in checkboxes.
+//
+// Pipeline:
+//   1. Filter rows: (always_show || required_tags ∩ eventTags ≠ ∅)
+//                && (excluded_tags ∩ eventTags === ∅)
+//                && active
+//   2. Group by combined_group (null = solo, non-null = grouped).
+//   3. Render one checkbox per group:
+//      - Label = spokesperson's resolved label.
+//        Spokesperson = lowest-position row in group.
+//        For combined groups with >1 row, force label key to step1.combinedOptIn
+//        (matches today's behavior).
+//      - Modal: if any in-group row has info_modal_i18n_ns set OR modal_overrides
+//        populated, render (i) button + portal modal. Per-locale resolution.
+//      - OnClick toggles ALL opt_in_fields across all in-group rows.
+//      - Checked when ALL in-group fields are true.
+//      - accent_color → Tailwind class (red → #ff393a, purple → purple-500).
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CheckSquare2, Square, Info, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { useRSVPForm } from '../hooks/useRSVPForm';
+import type { RsvpCheckboxConfig, ModalOverride } from '../hooks/useRsvpCheckboxConfig';
+
+interface Props {
+  config: RsvpCheckboxConfig[];
+  form: ReturnType<typeof useRSVPForm>;
+  eventTags: string[];
+  currentLocale: string;
+}
+
+// Resolves the accent color name to a Tailwind class.
+function accentClass(accent: string): string {
+  switch (accent) {
+    case 'purple': return 'text-purple-500';
+    case 'red':
+    default:       return 'text-[#ff393a]';
+  }
+}
+
+// Resolves modal-link color (for the privacy / terms anchors inside the modal).
+function modalLinkClass(accent: string): string {
+  switch (accent) {
+    case 'purple': return 'text-purple-400 hover:text-purple-300 underline';
+    case 'red':
+    default:       return 'text-red-400 hover:text-red-300 underline';
+  }
+}
+
+// Field-name -> form state field. Mirrors the 8 known opt-in slots in useRSVPForm.
+function isCheckedForField(form: ReturnType<typeof useRSVPForm>, field: string): boolean {
+  switch (field) {
+    case 'mailingListOptIn': return form.mailingListOptIn;
+    case 'swcOptIn':         return form.swcOptIn;
+    case 'swcCaOptIn':       return form.swcCaOptIn;
+    case 'swcAuOptIn':       return form.swcAuOptIn;
+    case 'swcEuOptIn':       return form.swcEuOptIn;
+    case 'swcUkOptIn':       return form.swcUkOptIn;
+    case 'swcBrOptIn':       return form.swcBrOptIn;
+    case 'ethconfOptIn':     return form.ethconfOptIn;
+    default:                 return false;
+  }
+}
+
+// Tag-set intersection.
+function intersects(a: string[] | null | undefined, b: string[] | null | undefined): boolean {
+  if (!a || !b || a.length === 0 || b.length === 0) return false;
+  const bset = new Set(b);
+  for (const x of a) if (bset.has(x)) return true;
+  return false;
+}
+
+// Returns the resolved label for one config row, in resolution order:
+//   1. label_overrides[currentLocale]
+//   2. t(label_i18n_key)
+//   3. label_default
+//   4. null (renderer hides the row)
+function resolveLabel(
+  row: RsvpCheckboxConfig,
+  t: (key: string) => string,
+  currentLocale: string,
+  forceCombinedKey: boolean,
+): string | null {
+  const effectiveKey = forceCombinedKey ? 'step1.combinedOptIn' : row.label_i18n_key;
+  const localeOverride = row.label_overrides?.[currentLocale];
+  if (typeof localeOverride === 'string' && localeOverride.length > 0) return localeOverride;
+  if (effectiveKey) {
+    const translated = t(effectiveKey);
+    if (translated && translated !== effectiveKey) return translated;
+  }
+  if (row.label_default && row.label_default.length > 0) return row.label_default;
+  return null;
+}
+
+interface ModalCopy {
+  title: string;
+  description: string;
+  privacyText: string | null;
+  termsText: string | null;
+  privacyUrl: string | null;
+  termsUrl: string | null;
+}
+
+// Resolves modal copy for a row (in the rendered locale). Returns null if the
+// row has no modal config.
+function resolveModalCopy(
+  row: RsvpCheckboxConfig,
+  t: (key: string) => string,
+  currentLocale: string,
+): ModalCopy | null {
+  const hasModal = !!row.info_modal_i18n_ns || (row.modal_overrides && Object.keys(row.modal_overrides).length > 0);
+  if (!hasModal) return null;
+
+  const localeOverride: ModalOverride = row.modal_overrides?.[currentLocale] ?? {};
+  const ns = row.info_modal_i18n_ns;
+
+  const tns = (sub: string) => {
+    if (!ns) return null;
+    const key = `${ns}.${sub}`;
+    const v = t(key);
+    return v && v !== key ? v : null;
+  };
+
+  const termsSubKey = row.info_modal_terms_key || 'termsConditions';
+
+  return {
+    title:       localeOverride.title       ?? tns('title')       ?? row.id,
+    description: localeOverride.description ?? tns('description') ?? '',
+    privacyText: localeOverride.privacyPolicy ?? tns('privacyPolicy'),
+    termsText:   (termsSubKey === 'termsOfService'
+                   ? (localeOverride.termsOfService ?? tns('termsOfService'))
+                   : (localeOverride.termsConditions ?? tns('termsConditions'))),
+    privacyUrl:  localeOverride.privacyUrl ?? row.info_modal_privacy_url ?? null,
+    termsUrl:    localeOverride.termsUrl   ?? row.info_modal_terms_url   ?? null,
+  };
+}
+
+export function RsvpCheckboxList({ config, form, eventTags, currentLocale }: Props) {
+  const { t } = useTranslation('rsvp');
+  const [openModalGroupKey, setOpenModalGroupKey] = useState<string | null>(null);
+
+  const tags = eventTags || [];
+
+  // Filter step.
+  const visible = config.filter((row) => {
+    if (!row.active) return false;
+    if (intersects(row.excluded_tags, tags)) return false;
+    if (row.always_show) return true;
+    if (intersects(row.required_tags, tags)) return true;
+    return false;
+  });
+
+  if (visible.length === 0) return null;
+
+  // Group step. combined_group=null → unique per-row key (so each renders solo).
+  const groupsByKey = new Map<string, RsvpCheckboxConfig[]>();
+  for (const row of visible) {
+    const key = row.combined_group ?? `__solo_${row.id}`;
+    const arr = groupsByKey.get(key) ?? [];
+    arr.push(row);
+    groupsByKey.set(key, arr);
+  }
+
+  // Sort each group by position; sort groups by their spokesperson's position.
+  const groups: Array<{ key: string; rows: RsvpCheckboxConfig[] }> = [];
+  for (const [key, rows] of groupsByKey) {
+    rows.sort((a, b) => a.position - b.position);
+    groups.push({ key, rows });
+  }
+  groups.sort((a, b) => a.rows[0].position - b.rows[0].position);
+
+  return (
+    <>
+      {groups.map(({ key: groupKey, rows }) => {
+        const spokesperson = rows[0];
+        const forceCombinedKey = rows.length > 1;
+        const label = resolveLabel(spokesperson, t, currentLocale, forceCombinedKey);
+        if (!label) {
+          console.warn('[RsvpCheckboxList] no resolvable label, hiding row(s):', rows.map((r) => r.id));
+          return null;
+        }
+
+        // Combined: collect all opt_in_fields across in-group rows.
+        const allFields: string[] = [];
+        for (const r of rows) for (const f of r.opt_in_fields) {
+          if (!allFields.includes(f)) allFields.push(f);
+        }
+        // Checked: all in-group fields true.
+        const checked = allFields.length > 0 && allFields.every((f) => isCheckedForField(form, f));
+
+        const toggle = () => {
+          const newValue = !checked;
+          for (const f of allFields) form.setOptInByField(f, newValue);
+        };
+
+        // Pick the row that supplies modal copy (the spokesperson if it has
+        // one, otherwise the first in-group row that does).
+        const modalRow =
+          (spokesperson.info_modal_i18n_ns || (spokesperson.modal_overrides && Object.keys(spokesperson.modal_overrides).length > 0))
+            ? spokesperson
+            : rows.find((r) => r.info_modal_i18n_ns || (r.modal_overrides && Object.keys(r.modal_overrides).length > 0));
+        const modalCopy = modalRow ? resolveModalCopy(modalRow, t, currentLocale) : null;
+        const accentForModal = modalRow ? modalRow.accent_color : spokesperson.accent_color;
+
+        const accentTextClass = accentClass(spokesperson.accent_color);
+        const isModalOpen = openModalGroupKey === groupKey;
+
+        return (
+          <React.Fragment key={groupKey}>
+            <div className={modalCopy ? 'flex items-center gap-2' : ''}>
+              <button
+                type="button"
+                onClick={toggle}
+                className={`flex items-center gap-3 p-4 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors cursor-pointer ${modalCopy ? 'flex-1' : 'w-full'}`}
+              >
+                {checked ? (
+                  <CheckSquare2 size={20} className={`${accentTextClass} flex-shrink-0`} />
+                ) : (
+                  <Square size={20} className="text-theme-text-muted flex-shrink-0" />
+                )}
+                <span className="text-sm text-theme-text text-left">{label}</span>
+              </button>
+              {modalCopy && (
+                <button
+                  type="button"
+                  onClick={() => setOpenModalGroupKey(groupKey)}
+                  className="p-3 bg-theme-surface rounded-xl border border-theme-stroke hover:bg-theme-surface-hover transition-colors text-theme-text-muted hover:text-theme-text"
+                >
+                  <Info size={18} />
+                </button>
+              )}
+            </div>
+
+            {modalCopy && isModalOpen && createPortal(
+              <div
+                className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+                onClick={() => setOpenModalGroupKey(null)}
+              >
+                <div
+                  className="card p-6 max-w-md w-full relative"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    onClick={() => setOpenModalGroupKey(null)}
+                    className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text transition-colors"
+                  >
+                    <X size={20} />
+                  </button>
+                  <h3 className="text-lg font-bold text-theme-text mb-3">{modalCopy.title}</h3>
+                  <p className="text-sm text-theme-text-secondary leading-relaxed">
+                    {modalCopy.description}
+                    {(modalCopy.privacyText || modalCopy.termsText) && ' '}
+                    {modalCopy.privacyText && modalCopy.privacyUrl && (
+                      <a
+                        href={modalCopy.privacyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={modalLinkClass(accentForModal)}
+                      >
+                        {modalCopy.privacyText}
+                      </a>
+                    )}
+                    {modalCopy.privacyText && modalCopy.termsText && ' and '}
+                    {modalCopy.termsText && modalCopy.termsUrl && (
+                      <a
+                        href={modalCopy.termsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={modalLinkClass(accentForModal)}
+                      >
+                        {modalCopy.termsText}
+                      </a>
+                    )}
+                    {(modalCopy.privacyText || modalCopy.termsText) && '.'}
+                  </p>
+                </div>
+              </div>,
+              document.body,
+            )}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/admin/RsvpCheckboxesTab.tsx
+++ b/frontend/src/components/admin/RsvpCheckboxesTab.tsx
@@ -1,0 +1,651 @@
+// lasagna-49278: Admin UI for managing DB-driven RSVP opt-in checkboxes.
+//
+// Lists all global rows (party_id IS NULL) with inline editing of every field.
+// "+ New checkbox" modal creates a new row (global by default; can target a
+// party). Per-event override picker accepts a party ID and shows that event's
+// override rows.
+//
+// Allowed `opt_in_fields` values are hardcoded here AND on the backend — this
+// list must stay in sync with backend ALLOWED_OPT_IN_FIELDS and useRSVPForm's
+// `setOptInByField` switch.
+import React, { useCallback, useEffect, useState } from 'react';
+import { Loader2, Plus, Trash2, RefreshCw, Save, RotateCcw, X } from 'lucide-react';
+import {
+  listRsvpCheckboxes,
+  createRsvpCheckbox,
+  updateRsvpCheckbox,
+  deleteRsvpCheckbox,
+  type RsvpCheckboxAdminRow,
+  type RsvpCheckboxAdminInput,
+} from '../../lib/api';
+import { Checkbox } from '../Checkbox';
+import { IconInput } from '../IconInput';
+import { FALLBACK_CONFIG, invalidateRsvpCheckboxConfigCache } from '../../hooks/useRsvpCheckboxConfig';
+
+const ALLOWED_OPT_IN_FIELDS = [
+  'mailingListOptIn',
+  'swcOptIn',
+  'swcCaOptIn',
+  'swcAuOptIn',
+  'swcEuOptIn',
+  'swcUkOptIn',
+  'swcBrOptIn',
+  'ethconfOptIn',
+] as const;
+
+const ACCENT_COLORS = ['red', 'purple'] as const;
+
+const SEEDED_GLOBAL_IDS = new Set(FALLBACK_CONFIG.map((r) => r.id));
+
+interface EditState {
+  position: string;
+  active: boolean;
+  required_tags: string;
+  excluded_tags: string;
+  always_show: boolean;
+  opt_in_fields: string[];
+  combined_group: string;
+  label_i18n_key: string;
+  label_default: string;
+  label_overrides: string;
+  info_modal_i18n_ns: string;
+  info_modal_privacy_url: string;
+  info_modal_terms_url: string;
+  info_modal_terms_key: string;
+  modal_overrides: string;
+  accent_color: string;
+}
+
+function rowToEdit(row: RsvpCheckboxAdminRow): EditState {
+  return {
+    position: String(row.position ?? 0),
+    active: !!row.active,
+    required_tags: (row.required_tags || []).join(', '),
+    excluded_tags: (row.excluded_tags || []).join(', '),
+    always_show: !!row.always_show,
+    opt_in_fields: [...(row.opt_in_fields || [])],
+    combined_group: row.combined_group ?? '',
+    label_i18n_key: row.label_i18n_key ?? '',
+    label_default: row.label_default ?? '',
+    label_overrides: JSON.stringify(row.label_overrides ?? {}, null, 2),
+    info_modal_i18n_ns: row.info_modal_i18n_ns ?? '',
+    info_modal_privacy_url: row.info_modal_privacy_url ?? '',
+    info_modal_terms_url: row.info_modal_terms_url ?? '',
+    info_modal_terms_key: row.info_modal_terms_key ?? '',
+    modal_overrides: JSON.stringify(row.modal_overrides ?? {}, null, 2),
+    accent_color: row.accent_color ?? 'red',
+  };
+}
+
+function editToPayload(s: EditState): RsvpCheckboxAdminInput {
+  const splitTags = (raw: string) =>
+    raw.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+  let labelOverrides: Record<string, string> = {};
+  let modalOverrides: Record<string, unknown> = {};
+  try {
+    if (s.label_overrides.trim()) labelOverrides = JSON.parse(s.label_overrides);
+  } catch (e) {
+    throw new Error(`label_overrides is not valid JSON: ${(e as Error).message}`);
+  }
+  try {
+    if (s.modal_overrides.trim()) modalOverrides = JSON.parse(s.modal_overrides);
+  } catch (e) {
+    throw new Error(`modal_overrides is not valid JSON: ${(e as Error).message}`);
+  }
+  return {
+    position: Number(s.position) || 0,
+    active: s.active,
+    required_tags: splitTags(s.required_tags),
+    excluded_tags: splitTags(s.excluded_tags),
+    always_show: s.always_show,
+    opt_in_fields: s.opt_in_fields,
+    combined_group: s.combined_group || null,
+    label_i18n_key: s.label_i18n_key || null,
+    label_default: s.label_default || null,
+    label_overrides: labelOverrides,
+    info_modal_i18n_ns: s.info_modal_i18n_ns || null,
+    info_modal_privacy_url: s.info_modal_privacy_url || null,
+    info_modal_terms_url: s.info_modal_terms_url || null,
+    info_modal_terms_key: s.info_modal_terms_key || null,
+    modal_overrides: modalOverrides,
+    accent_color: s.accent_color,
+  };
+}
+
+function emptyEdit(): EditState {
+  return {
+    position: '0',
+    active: true,
+    required_tags: '',
+    excluded_tags: '',
+    always_show: false,
+    opt_in_fields: [],
+    combined_group: '',
+    label_i18n_key: '',
+    label_default: '',
+    label_overrides: '{}',
+    info_modal_i18n_ns: '',
+    info_modal_privacy_url: '',
+    info_modal_terms_url: '',
+    info_modal_terms_key: '',
+    modal_overrides: '{}',
+    accent_color: 'red',
+  };
+}
+
+interface RowEditorProps {
+  row: RsvpCheckboxAdminRow;
+  onSaved: (row: RsvpCheckboxAdminRow) => void;
+  onDeleted: (id: string, partyId: string | null) => void;
+}
+
+function RowEditor({ row, onSaved, onDeleted }: RowEditorProps) {
+  const [edit, setEdit] = useState<EditState>(() => rowToEdit(row));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isSeededGlobal = !row.party_id && SEEDED_GLOBAL_IDS.has(row.id);
+
+  useEffect(() => setEdit(rowToEdit(row)), [row]);
+
+  async function save() {
+    setError(null);
+    setSaving(true);
+    try {
+      const payload = editToPayload(edit);
+      const updated = await updateRsvpCheckbox(row.id, row.party_id, payload);
+      onSaved(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function resetToDefault() {
+    if (!isSeededGlobal) return;
+    const seed = FALLBACK_CONFIG.find((r) => r.id === row.id);
+    if (!seed) return;
+    setError(null);
+    setSaving(true);
+    try {
+      const payload: RsvpCheckboxAdminInput = {
+        position: seed.position,
+        active: seed.active,
+        required_tags: seed.required_tags,
+        excluded_tags: seed.excluded_tags,
+        always_show: seed.always_show,
+        opt_in_fields: seed.opt_in_fields,
+        combined_group: seed.combined_group,
+        label_i18n_key: seed.label_i18n_key,
+        label_default: seed.label_default,
+        label_overrides: seed.label_overrides,
+        info_modal_i18n_ns: seed.info_modal_i18n_ns,
+        info_modal_privacy_url: seed.info_modal_privacy_url,
+        info_modal_terms_url: seed.info_modal_terms_url,
+        info_modal_terms_key: seed.info_modal_terms_key,
+        modal_overrides: seed.modal_overrides,
+        accent_color: seed.accent_color,
+      };
+      const updated = await updateRsvpCheckbox(row.id, null, payload);
+      onSaved(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function del() {
+    setError(null);
+    setSaving(true);
+    try {
+      await deleteRsvpCheckbox(row.id, row.party_id ?? undefined);
+      onDeleted(row.id, row.party_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const toggleField = (field: string) => {
+    setEdit((s) => ({
+      ...s,
+      opt_in_fields: s.opt_in_fields.includes(field)
+        ? s.opt_in_fields.filter((f) => f !== field)
+        : [...s.opt_in_fields, field],
+    }));
+  };
+
+  return (
+    <div className="border border-theme-stroke rounded-xl p-4 bg-theme-surface mb-3">
+      <div className="flex items-center gap-3 mb-3">
+        <span className="font-mono text-sm font-semibold text-theme-text">{row.id}</span>
+        {row.party_id && (
+          <span className="text-xs bg-purple-100 text-purple-700 px-2 py-0.5 rounded">override · party {row.party_id.slice(0, 8)}</span>
+        )}
+        {isSeededGlobal && (
+          <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">seeded</span>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          <Checkbox checked={edit.active} onChange={() => setEdit((s) => ({ ...s, active: !s.active }))} label="active" />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block text-xs text-theme-text-muted">
+          position
+          <IconInput
+            icon={Plus}
+            type="number"
+            value={edit.position}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, position: e.target.value }))}
+            placeholder="0"
+          />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          accent_color
+          <select
+            value={edit.accent_color}
+            onChange={(e) => setEdit((s) => ({ ...s, accent_color: e.target.value }))}
+            className="w-full text-sm bg-white/50 border border-theme-stroke rounded-lg px-3 py-2 text-theme-text"
+          >
+            {ACCENT_COLORS.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          required_tags (comma-separated; OR semantics)
+          <IconInput icon={Plus} type="text" value={edit.required_tags} placeholder="swc, ethconf"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, required_tags: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          excluded_tags (comma-separated)
+          <IconInput icon={Plus} type="text" value={edit.excluded_tags} placeholder=""
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, excluded_tags: e.target.value }))} />
+        </label>
+        <div className="block text-xs text-theme-text-muted col-span-full">
+          always_show
+          <div className="mt-1">
+            <Checkbox checked={edit.always_show} onChange={() => setEdit((s) => ({ ...s, always_show: !s.always_show }))} label={edit.always_show ? 'yes — renders on every event' : 'no — only when required_tags match'} />
+          </div>
+        </div>
+        <div className="block text-xs text-theme-text-muted col-span-full">
+          opt_in_fields (1+ required — destination columns this checkbox writes)
+          <div className="flex flex-wrap gap-2 mt-1">
+            {ALLOWED_OPT_IN_FIELDS.map((f) => (
+              <button
+                type="button"
+                key={f}
+                onClick={() => toggleField(f)}
+                className={`px-2 py-1 rounded text-xs font-mono ${edit.opt_in_fields.includes(f) ? 'bg-red-500/20 text-red-700 border border-red-500/30' : 'bg-theme-surface border border-theme-stroke text-theme-text-muted hover:bg-theme-surface-hover'}`}
+              >
+                {f}
+              </button>
+            ))}
+          </div>
+        </div>
+        <label className="block text-xs text-theme-text-muted col-span-full">
+          combined_group (group key — rows sharing one render as ONE combined checkbox)
+          <IconInput icon={Plus} type="text" value={edit.combined_group} placeholder="pizzadao_partners"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, combined_group: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          label_i18n_key
+          <IconInput icon={Plus} type="text" value={edit.label_i18n_key} placeholder="step1.mailingList"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, label_i18n_key: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          label_default (English literal)
+          <IconInput icon={Plus} type="text" value={edit.label_default} placeholder="Sign me up"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, label_default: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted col-span-full">
+          label_overrides (JSON: {`{"pt":"...","de":"..."}`})
+          <IconInput icon={Plus} multiline rows={3} value={edit.label_overrides} placeholder="{}"
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setEdit((s) => ({ ...s, label_overrides: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          info_modal_i18n_ns
+          <IconInput icon={Plus} type="text" value={edit.info_modal_i18n_ns} placeholder="swcModal"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, info_modal_i18n_ns: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          info_modal_terms_key
+          <select value={edit.info_modal_terms_key} onChange={(e) => setEdit((s) => ({ ...s, info_modal_terms_key: e.target.value }))}
+            className="w-full text-sm bg-white/50 border border-theme-stroke rounded-lg px-3 py-2 text-theme-text">
+            <option value="">—</option>
+            <option value="termsConditions">termsConditions</option>
+            <option value="termsOfService">termsOfService</option>
+          </select>
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          info_modal_privacy_url
+          <IconInput icon={Plus} type="url" value={edit.info_modal_privacy_url} placeholder="https://…/privacy"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, info_modal_privacy_url: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted">
+          info_modal_terms_url
+          <IconInput icon={Plus} type="url" value={edit.info_modal_terms_url} placeholder="https://…/terms"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, info_modal_terms_url: e.target.value }))} />
+        </label>
+        <label className="block text-xs text-theme-text-muted col-span-full">
+          modal_overrides (JSON: {`{"en":{"title":"...","description":"...","privacyUrl":"..."}}`})
+          <IconInput icon={Plus} multiline rows={4} value={edit.modal_overrides} placeholder="{}"
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setEdit((s) => ({ ...s, modal_overrides: e.target.value }))} />
+        </label>
+      </div>
+
+      {error && (
+        <p className="mt-3 text-sm text-red-600">{error}</p>
+      )}
+
+      <div className="flex items-center gap-2 mt-4">
+        <button onClick={save} disabled={saving} className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-[#E52828] text-white text-sm font-medium hover:bg-[#CC2020] transition-colors disabled:opacity-50">
+          {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+          Save
+        </button>
+        {isSeededGlobal && (
+          <button onClick={resetToDefault} disabled={saving} className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-white/60 border border-theme-stroke text-sm font-medium hover:bg-white/80 transition-colors disabled:opacity-50">
+            <RotateCcw size={14} />
+            Reset to defaults
+          </button>
+        )}
+        {(!isSeededGlobal || row.party_id) && (
+          <button onClick={del} disabled={saving} className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-red-50 border border-red-300 text-red-700 text-sm font-medium hover:bg-red-100 transition-colors disabled:opacity-50">
+            <Trash2 size={14} />
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface NewRowModalProps {
+  defaultPartyId?: string;
+  onClose: () => void;
+  onCreated: (row: RsvpCheckboxAdminRow) => void;
+}
+
+function NewRowModal({ defaultPartyId, onClose, onCreated }: NewRowModalProps) {
+  const [newId, setNewId] = useState('');
+  const [partyId, setPartyId] = useState(defaultPartyId ?? '');
+  const [edit, setEdit] = useState<EditState>(emptyEdit);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleField = (field: string) => {
+    setEdit((s) => ({
+      ...s,
+      opt_in_fields: s.opt_in_fields.includes(field)
+        ? s.opt_in_fields.filter((f) => f !== field)
+        : [...s.opt_in_fields, field],
+    }));
+  };
+
+  async function create() {
+    setError(null);
+    if (!newId.trim()) {
+      setError('id is required');
+      return;
+    }
+    if (edit.opt_in_fields.length === 0) {
+      setError('opt_in_fields must include at least one entry');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = editToPayload(edit);
+      const row = await createRsvpCheckbox({ ...payload, id: newId.trim(), party_id: partyId.trim() || null });
+      onCreated(row);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
+      <div className="card p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto relative" onClick={(e) => e.stopPropagation()}>
+        <button onClick={onClose} className="absolute top-3 right-3 text-theme-text-muted hover:text-theme-text">
+          <X size={20} />
+        </button>
+        <h3 className="text-lg font-bold text-theme-text mb-4">New checkbox</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <label className="block text-xs text-theme-text-muted">
+            id (stable handle)
+            <IconInput icon={Plus} type="text" value={newId} placeholder="my_partner_optin"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewId(e.target.value)} />
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            party_id (leave blank for global)
+            <IconInput icon={Plus} type="text" value={partyId} placeholder="UUID"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPartyId(e.target.value)} />
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            position
+            <IconInput icon={Plus} type="number" value={edit.position}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, position: e.target.value }))} />
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            accent_color
+            <select value={edit.accent_color} onChange={(e) => setEdit((s) => ({ ...s, accent_color: e.target.value }))}
+              className="w-full text-sm bg-white/50 border border-theme-stroke rounded-lg px-3 py-2 text-theme-text">
+              {ACCENT_COLORS.map((c) => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            required_tags
+            <IconInput icon={Plus} type="text" value={edit.required_tags} placeholder="swc, ethconf"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, required_tags: e.target.value }))} />
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            excluded_tags
+            <IconInput icon={Plus} type="text" value={edit.excluded_tags}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, excluded_tags: e.target.value }))} />
+          </label>
+          <div className="col-span-full">
+            <span className="block text-xs text-theme-text-muted mb-1">always_show</span>
+            <Checkbox checked={edit.always_show} onChange={() => setEdit((s) => ({ ...s, always_show: !s.always_show }))} label="render on every event" />
+          </div>
+          <div className="col-span-full">
+            <span className="block text-xs text-theme-text-muted mb-1">opt_in_fields</span>
+            <div className="flex flex-wrap gap-2">
+              {ALLOWED_OPT_IN_FIELDS.map((f) => (
+                <button type="button" key={f} onClick={() => toggleField(f)}
+                  className={`px-2 py-1 rounded text-xs font-mono ${edit.opt_in_fields.includes(f) ? 'bg-red-500/20 text-red-700 border border-red-500/30' : 'bg-theme-surface border border-theme-stroke text-theme-text-muted hover:bg-theme-surface-hover'}`}>
+                  {f}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="block text-xs text-theme-text-muted col-span-full">
+            combined_group
+            <IconInput icon={Plus} type="text" value={edit.combined_group}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, combined_group: e.target.value }))} />
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            label_i18n_key
+            <IconInput icon={Plus} type="text" value={edit.label_i18n_key}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, label_i18n_key: e.target.value }))} />
+          </label>
+          <label className="block text-xs text-theme-text-muted">
+            label_default
+            <IconInput icon={Plus} type="text" value={edit.label_default}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEdit((s) => ({ ...s, label_default: e.target.value }))} />
+          </label>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+        <div className="flex items-center gap-2 mt-4">
+          <button onClick={create} disabled={saving} className="px-4 py-2 rounded-lg bg-[#E52828] text-white text-sm font-medium hover:bg-[#CC2020] transition-colors disabled:opacity-50">
+            {saving ? 'Creating…' : 'Create'}
+          </button>
+          <button onClick={onClose} className="px-3 py-2 rounded-lg bg-white/60 border border-theme-stroke text-sm">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RsvpCheckboxesTab() {
+  const [globalRows, setGlobalRows] = useState<RsvpCheckboxAdminRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showNew, setShowNew] = useState(false);
+
+  // Per-event override state.
+  const [partyLookup, setPartyLookup] = useState('');
+  const [activePartyId, setActivePartyId] = useState<string | null>(null);
+  const [overrideRows, setOverrideRows] = useState<RsvpCheckboxAdminRow[]>([]);
+  const [overridesLoading, setOverridesLoading] = useState(false);
+  const [showNewForParty, setShowNewForParty] = useState(false);
+
+  const reloadGlobal = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await listRsvpCheckboxes();
+      // Filter to global rows only — the override picker handles per-party.
+      setGlobalRows(rows.filter((r) => !r.party_id).sort((a, b) => a.position - b.position));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const reloadOverrides = useCallback(async (partyId: string) => {
+    setOverridesLoading(true);
+    try {
+      const rows = await listRsvpCheckboxes(partyId);
+      setOverrideRows(rows.sort((a, b) => a.position - b.position));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setOverridesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { reloadGlobal(); }, [reloadGlobal]);
+
+  const handleSaved = (row: RsvpCheckboxAdminRow) => {
+    invalidateRsvpCheckboxConfigCache();
+    if (row.party_id) {
+      setOverrideRows((prev) => prev.map((r) => r.id === row.id && r.party_id === row.party_id ? row : r));
+    } else {
+      setGlobalRows((prev) => prev.map((r) => r.id === row.id && !r.party_id ? row : r));
+    }
+  };
+
+  const handleDeleted = (id: string, partyId: string | null) => {
+    invalidateRsvpCheckboxConfigCache();
+    if (partyId) {
+      setOverrideRows((prev) => prev.filter((r) => !(r.id === id && r.party_id === partyId)));
+    } else {
+      setGlobalRows((prev) => prev.filter((r) => !(r.id === id && !r.party_id)));
+    }
+  };
+
+  const handleCreated = (row: RsvpCheckboxAdminRow) => {
+    invalidateRsvpCheckboxConfigCache();
+    if (row.party_id) {
+      setOverrideRows((prev) => [...prev, row].sort((a, b) => a.position - b.position));
+    } else {
+      setGlobalRows((prev) => [...prev, row].sort((a, b) => a.position - b.position));
+    }
+    setShowNew(false);
+    setShowNewForParty(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 size={24} className="animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <h3 className="text-lg font-semibold text-theme-text">Global RSVP checkboxes ({globalRows.length})</h3>
+        <button onClick={reloadGlobal} className="ml-auto flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/60 border border-theme-stroke text-sm hover:bg-white/80">
+          <RefreshCw size={14} /> Refresh
+        </button>
+        <button onClick={() => setShowNew(true)} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-[#E52828] text-white text-sm font-medium hover:bg-[#CC2020]">
+          <Plus size={14} /> New checkbox
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 px-4 py-2 rounded-lg text-sm bg-red-100 text-red-700 border border-red-300">
+          {error}
+        </div>
+      )}
+
+      <p className="text-sm text-theme-text-muted mb-4">
+        These rows configure the opt-in checkboxes on the RSVP form. Per-event overrides below take precedence over the matching global row when a guest RSVPs to that event.
+      </p>
+
+      {globalRows.map((row) => (
+        <RowEditor key={`${row.id}|global`} row={row} onSaved={handleSaved} onDeleted={handleDeleted} />
+      ))}
+
+      {/* Per-event override picker */}
+      <div className="mt-8 border-t border-theme-stroke pt-6">
+        <h3 className="text-lg font-semibold text-theme-text mb-3">Per-event overrides</h3>
+        <p className="text-sm text-theme-text-muted mb-3">
+          Paste a party id (UUID) and click Load. Overrides shown below replace the matching global row for that event only.
+        </p>
+        <div className="flex items-center gap-2 mb-4">
+          <IconInput icon={Plus} type="text" value={partyLookup} placeholder="party UUID"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPartyLookup(e.target.value)} />
+          <button
+            onClick={() => {
+              const trimmed = partyLookup.trim();
+              if (!trimmed) return;
+              setActivePartyId(trimmed);
+              reloadOverrides(trimmed);
+            }}
+            className="px-4 py-2 rounded-lg bg-[#E52828] text-white text-sm font-medium hover:bg-[#CC2020]"
+          >
+            Load
+          </button>
+          {activePartyId && (
+            <button
+              onClick={() => setShowNewForParty(true)}
+              className="px-3 py-2 rounded-lg bg-white/60 border border-theme-stroke text-sm font-medium hover:bg-white/80"
+            >
+              <Plus size={14} className="inline mr-1" />
+              New override
+            </button>
+          )}
+        </div>
+
+        {overridesLoading ? (
+          <Loader2 size={20} className="animate-spin text-theme-text-muted" />
+        ) : (
+          activePartyId && (
+            <>
+              {overrideRows.length === 0 ? (
+                <p className="text-sm text-theme-text-faint">No override rows for party {activePartyId}.</p>
+              ) : (
+                overrideRows.map((row) => (
+                  <RowEditor key={`${row.id}|${row.party_id}`} row={row} onSaved={handleSaved} onDeleted={handleDeleted} />
+                ))
+              )}
+            </>
+          )
+        )}
+      </div>
+
+      {showNew && <NewRowModal onClose={() => setShowNew(false)} onCreated={handleCreated} />}
+      {showNewForParty && activePartyId && (
+        <NewRowModal defaultPartyId={activePartyId} onClose={() => setShowNewForParty(false)} onCreated={handleCreated} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -201,6 +201,24 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // lasagna-49278: generic setter used by the DB-driven RsvpCheckboxList
+  // renderer. Switch on field-name string and call the corresponding
+  // existing setter. Unknown fields are logged and ignored.
+  const setOptInByField = useCallback((field: string, value: boolean) => {
+    switch (field) {
+      case 'mailingListOptIn': setMailingListOptIn(value); break;
+      case 'swcOptIn':         setSwcOptIn(value); break;
+      case 'swcCaOptIn':       setSwcCaOptIn(value); break;
+      case 'swcAuOptIn':       setSwcAuOptIn(value); break;
+      case 'swcEuOptIn':       setSwcEuOptIn(value); break;
+      case 'swcUkOptIn':       setSwcUkOptIn(value); break;
+      case 'swcBrOptIn':       setSwcBrOptIn(value); break;
+      case 'ethconfOptIn':     setEthconfOptIn(value); break;
+      default:
+        console.warn('[useRSVPForm] setOptInByField: unknown field', field);
+    }
+  }, []);
+
   const setCombinedOptIn = useCallback((v: boolean) => {
     setMailingListOptIn(v);
     if (isEthconfEvent) setEthconfOptIn(v);
@@ -600,6 +618,7 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     setShowSwcBrInfoModal,
     ethconfOptIn,
     setEthconfOptIn,
+    setOptInByField,
     optinAbVariant,
     combinedOptIn,
     setCombinedOptIn,
@@ -686,6 +705,9 @@ export function useRSVPForm(options: UseRSVPFormOptions) {
     availableToppings: eventData.availableToppings,
     availableDietaryOptions: eventData.availableDietaryOptions,
     showToppingsOnRsvp: eventData.showToppingsOnRsvp ?? false,
+    // lasagna-49278: exposed for RsvpCheckboxList renderer.
+    eventId: eventData.id,
+    eventTags: eventData.eventTags || [],
 
     // Reset
     resetForm,

--- a/frontend/src/hooks/useRsvpCheckboxConfig.ts
+++ b/frontend/src/hooks/useRsvpCheckboxConfig.ts
@@ -1,0 +1,248 @@
+// lasagna-49278: DB-driven config for the RSVP opt-in checkboxes.
+//
+// Renderer (RsvpCheckboxList) calls useRsvpCheckboxConfig(partyId) on mount.
+// We fetch two sets:
+//   1. Global rows (party_id IS NULL) — cached at module level via a top-level
+//      promise. One fetch per browser session.
+//   2. Per-party overrides (party_id = <eventId>) — fetched once per partyId.
+// Merge: per-party override row replaces global row entirely (no field-level
+// merge — simpler, predictable).
+//
+// If the global fetch errors, fall back to FALLBACK_CONFIG (the 8 seed rows
+// hardcoded here). console.warn only — never surface to the user.
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+export interface RsvpCheckboxConfig {
+  id: string;
+  party_id: string | null;
+  position: number;
+  active: boolean;
+  required_tags: string[];
+  excluded_tags: string[];
+  always_show: boolean;
+  opt_in_fields: string[];
+  combined_group: string | null;
+  label_i18n_key: string | null;
+  label_default: string | null;
+  label_overrides: Record<string, string>;
+  info_modal_i18n_ns: string | null;
+  info_modal_privacy_url: string | null;
+  info_modal_terms_url: string | null;
+  info_modal_terms_key: string | null;
+  modal_overrides: Record<string, ModalOverride>;
+  accent_color: string;
+}
+
+export interface ModalOverride {
+  title?: string;
+  description?: string;
+  privacyPolicy?: string;
+  termsConditions?: string;
+  termsOfService?: string;
+  privacyUrl?: string;
+  termsUrl?: string;
+}
+
+const SELECT_COLS =
+  'id, party_id, position, active, required_tags, excluded_tags, always_show, ' +
+  'opt_in_fields, combined_group, ' +
+  'label_i18n_key, label_default, label_overrides, ' +
+  'info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key, ' +
+  'modal_overrides, accent_color';
+
+// Hardcoded fallback — mirrors the 8 seed rows in the migration. Returned if
+// the global fetch errors so RSVP keeps working. Also used by the admin
+// "reset to defaults" button.
+export const FALLBACK_CONFIG: RsvpCheckboxConfig[] = [
+  {
+    id: 'mailing_list', party_id: null, position: 10, active: true,
+    required_tags: [], excluded_tags: [], always_show: true,
+    opt_in_fields: ['mailingListOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.combinedOptIn',
+    label_default: "Sign up for PizzaDAO's mailing list",
+    label_overrides: {},
+    info_modal_i18n_ns: null, info_modal_privacy_url: null, info_modal_terms_url: null, info_modal_terms_key: null,
+    modal_overrides: {}, accent_color: 'red',
+  },
+  {
+    id: 'swc_us', party_id: null, position: 20, active: true,
+    required_tags: ['swc'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['swcOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.swcJoin',
+    label_default: 'Join Stand With Crypto and receive updates from the SWC Alliance',
+    label_overrides: {},
+    info_modal_i18n_ns: 'swcModal',
+    info_modal_privacy_url: 'https://www.standwithcrypto.org/privacy',
+    info_modal_terms_url: 'https://www.standwithcrypto.org/terms-of-service',
+    info_modal_terms_key: 'termsConditions',
+    modal_overrides: {}, accent_color: 'purple',
+  },
+  {
+    id: 'swc_ca', party_id: null, position: 21, active: true,
+    required_tags: ['swccanada'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['swcCaOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.swcNotify',
+    label_default: 'Notify me about Stand With Crypto Canada updates',
+    label_overrides: {},
+    info_modal_i18n_ns: 'swcCaModal',
+    info_modal_privacy_url: 'https://www.standwithcrypto.org/ca/privacy',
+    info_modal_terms_url: 'https://www.standwithcrypto.org/ca/terms-of-service',
+    info_modal_terms_key: 'termsOfService',
+    modal_overrides: {}, accent_color: 'purple',
+  },
+  {
+    id: 'swc_au', party_id: null, position: 22, active: true,
+    required_tags: ['swcau'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['swcAuOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.swcNotify',
+    label_default: 'Notify me about Stand With Crypto Australia updates',
+    label_overrides: {},
+    info_modal_i18n_ns: 'swcAuModal',
+    info_modal_privacy_url: 'https://www.standwithcrypto.org/au/privacy',
+    info_modal_terms_url: 'https://www.standwithcrypto.org/au/terms-of-service',
+    info_modal_terms_key: 'termsOfService',
+    modal_overrides: {}, accent_color: 'purple',
+  },
+  {
+    id: 'swc_eu', party_id: null, position: 23, active: true,
+    required_tags: ['swceu'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['swcEuOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.swcNotify',
+    label_default: 'Notify me about Stand With Crypto EU updates',
+    label_overrides: {},
+    info_modal_i18n_ns: 'swcEuModal',
+    info_modal_privacy_url: 'https://www.standwithcrypto.org/eu/en/privacy',
+    info_modal_terms_url: 'https://www.standwithcrypto.org/eu/en/terms-of-service',
+    info_modal_terms_key: 'termsOfService',
+    modal_overrides: {}, accent_color: 'purple',
+  },
+  {
+    id: 'swc_uk', party_id: null, position: 24, active: true,
+    required_tags: ['swcuk'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['swcUkOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.swcNotify',
+    label_default: 'Notify me about Stand With Crypto UK updates',
+    label_overrides: {},
+    info_modal_i18n_ns: 'swcUkModal',
+    info_modal_privacy_url: 'https://www.standwithcrypto.org/gb/en/privacy',
+    info_modal_terms_url: 'https://www.standwithcrypto.org/gb/en/terms-of-service',
+    info_modal_terms_key: 'termsOfService',
+    modal_overrides: {}, accent_color: 'purple',
+  },
+  {
+    id: 'swc_br', party_id: null, position: 25, active: true,
+    required_tags: ['swcbr'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['swcBrOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.swcBrNotify',
+    label_default: 'Notify me about Juntos por Cripto updates',
+    label_overrides: {},
+    info_modal_i18n_ns: 'swcBrModal',
+    info_modal_privacy_url: 'https://www.juntosporcripto.org/br/privacy',
+    info_modal_terms_url: 'https://www.juntosporcripto.org/br/terms-of-service',
+    info_modal_terms_key: 'termsOfService',
+    modal_overrides: {}, accent_color: 'purple',
+  },
+  {
+    id: 'ethconf', party_id: null, position: 30, active: true,
+    required_tags: ['ethconf'], excluded_tags: [], always_show: false,
+    opt_in_fields: ['ethconfOptIn'], combined_group: 'pizzadao_partners',
+    label_i18n_key: 'step1.ethconfDiscount',
+    label_default: 'I want a discount code for the ETHConf conference',
+    label_overrides: {},
+    info_modal_i18n_ns: null, info_modal_privacy_url: null, info_modal_terms_url: null, info_modal_terms_key: null,
+    modal_overrides: {}, accent_color: 'red',
+  },
+];
+
+// Module-level promise cache for the global fetch. One round-trip per session.
+let globalFetchPromise: Promise<RsvpCheckboxConfig[]> | null = null;
+
+function fetchGlobalConfig(): Promise<RsvpCheckboxConfig[]> {
+  if (globalFetchPromise) return globalFetchPromise;
+  globalFetchPromise = (async () => {
+    try {
+      const { data, error } = await supabase
+        .from('rsvp_checkboxes')
+        .select(SELECT_COLS)
+        .is('party_id', null)
+        .eq('active', true)
+        .order('position');
+      if (error || !data) {
+        console.warn('[useRsvpCheckboxConfig] global fetch failed, using fallback:', error);
+        return FALLBACK_CONFIG;
+      }
+      return data as RsvpCheckboxConfig[];
+    } catch (e) {
+      console.warn('[useRsvpCheckboxConfig] global fetch threw, using fallback:', e);
+      return FALLBACK_CONFIG;
+    }
+  })();
+  return globalFetchPromise;
+}
+
+async function fetchOverrides(partyId: string): Promise<RsvpCheckboxConfig[]> {
+  try {
+    const { data, error } = await supabase
+      .from('rsvp_checkboxes')
+      .select(SELECT_COLS)
+      .eq('party_id', partyId)
+      .eq('active', true)
+      .order('position');
+    if (error || !data) return [];
+    return data as RsvpCheckboxConfig[];
+  } catch {
+    return [];
+  }
+}
+
+/** Invalidate the module-level cache — used by the admin UI's refresh button. */
+export function invalidateRsvpCheckboxConfigCache() {
+  globalFetchPromise = null;
+}
+
+export function useRsvpCheckboxConfig(partyId: string | null | undefined): {
+  config: RsvpCheckboxConfig[];
+  loading: boolean;
+  error: Error | null;
+} {
+  const [config, setConfig] = useState<RsvpCheckboxConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const global = await fetchGlobalConfig();
+        const overrides = partyId ? await fetchOverrides(partyId) : [];
+        if (cancelled) return;
+
+        // Merge: per-party override row replaces global row entirely by id.
+        if (overrides.length === 0) {
+          setConfig(global);
+        } else {
+          const overrideById = new Map(overrides.map((r) => [r.id, r]));
+          const merged: RsvpCheckboxConfig[] = global.map((g) => overrideById.get(g.id) ?? g);
+          // Include override rows whose id isn't in the global set.
+          for (const o of overrides) {
+            if (!global.some((g) => g.id === o.id)) merged.push(o);
+          }
+          merged.sort((a, b) => a.position - b.position);
+          setConfig(merged);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e : new Error(String(e)));
+          setConfig(FALLBACK_CONFIG);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [partyId]);
+
+  return { config, loading, error };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4287,6 +4287,68 @@ export async function setExperimentFlag(key: string, enabled: boolean): Promise<
   }
 }
 
+// ── lasagna-49278: RSVP opt-in checkbox config admin ──
+// Same row shape as the renderer hook (frontend/src/hooks/useRsvpCheckboxConfig.ts).
+export interface RsvpCheckboxAdminRow {
+  id: string;
+  party_id: string | null;
+  position: number;
+  active: boolean;
+  required_tags: string[];
+  excluded_tags: string[];
+  always_show: boolean;
+  opt_in_fields: string[];
+  combined_group: string | null;
+  label_i18n_key: string | null;
+  label_default: string | null;
+  label_overrides: Record<string, string>;
+  info_modal_i18n_ns: string | null;
+  info_modal_privacy_url: string | null;
+  info_modal_terms_url: string | null;
+  info_modal_terms_key: string | null;
+  modal_overrides: Record<string, unknown>;
+  accent_color: string;
+  updated_at?: string;
+  updated_by?: string | null;
+}
+
+export type RsvpCheckboxAdminInput = Partial<Omit<RsvpCheckboxAdminRow, 'updated_at' | 'updated_by'>> & { id?: string };
+
+export async function listRsvpCheckboxes(partyId?: string): Promise<RsvpCheckboxAdminRow[]> {
+  const qs = partyId ? `?party_id=${encodeURIComponent(partyId)}` : '';
+  const res = await apiRequest<{ checkboxes: RsvpCheckboxAdminRow[] }>(`/api/admin/rsvp-checkboxes${qs}`);
+  return res.checkboxes;
+}
+
+export async function createRsvpCheckbox(body: RsvpCheckboxAdminInput): Promise<RsvpCheckboxAdminRow> {
+  const res = await apiRequest<{ checkbox: RsvpCheckboxAdminRow }>('/api/admin/rsvp-checkboxes', {
+    method: 'POST',
+    body,
+  });
+  return res.checkbox;
+}
+
+export async function updateRsvpCheckbox(
+  id: string,
+  partyId: string | null,
+  body: RsvpCheckboxAdminInput,
+): Promise<RsvpCheckboxAdminRow> {
+  const qs = partyId ? `?party_id=${encodeURIComponent(partyId)}` : '';
+  const res = await apiRequest<{ checkbox: RsvpCheckboxAdminRow }>(
+    `/api/admin/rsvp-checkboxes/${encodeURIComponent(id)}${qs}`,
+    { method: 'PATCH', body },
+  );
+  return res.checkbox;
+}
+
+export async function deleteRsvpCheckbox(id: string, partyId?: string): Promise<void> {
+  const qs = partyId ? `?party_id=${encodeURIComponent(partyId)}` : '';
+  await apiRequest<{ deleted: boolean }>(
+    `/api/admin/rsvp-checkboxes/${encodeURIComponent(id)}${qs}`,
+    { method: 'DELETE' },
+  );
+}
+
 // ── Guest Scorecard ──
 
 export interface ScorecardItem {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -8,6 +8,7 @@ import { IconInput } from '../components/IconInput';
 import { CopyEmailButton } from '../components/CopyEmailButton';
 import { FunnelTab } from '../components/underboss/FunnelTab';
 import { OptinABTab } from '../components/underboss/OptinABTab';
+import { RsvpCheckboxesTab } from '../components/admin/RsvpCheckboxesTab';
 import {
   Shield, ShieldCheck, UserPlus, Trash2, Loader2,
   Mail, User, Globe, Check, X, Pencil, ListChecks, Calendar, Tag, FileText, ChevronDown, ChevronUp, Download, Palette, DollarSign, ArrowRight,
@@ -122,7 +123,7 @@ export function AdminPage() {
   const [descMessage, setDescMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [showCustomized, setShowCustomized] = useState(false);
 
-  const [activeTab, setActiveTab] = useState<'admin' | 'experiments'>('admin');
+  const [activeTab, setActiveTab] = useState<'admin' | 'experiments' | 'rsvpCheckboxes'>('admin');
 
   const isSuperAdmin = currentRole === 'super_admin';
 
@@ -620,6 +621,19 @@ export function AdminPage() {
             >
               Experiments
               {activeTab === 'experiments' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
+            <button
+              onClick={() => setActiveTab('rsvpCheckboxes')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'rsvpCheckboxes'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              RSVP Checkboxes
+              {activeTab === 'rsvpCheckboxes' && (
                 <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
               )}
             </button>
@@ -1483,6 +1497,12 @@ export function AdminPage() {
           {activeTab === 'experiments' && (
             <section className="mb-10">
               <OptinABTab />
+            </section>
+          )}
+
+          {activeTab === 'rsvpCheckboxes' && (
+            <section className="mb-10">
+              <RsvpCheckboxesTab />
             </section>
           )}
         </div>

--- a/supabase/migrations/20260605_lasagna_49278_rsvp_checkboxes.sql
+++ b/supabase/migrations/20260605_lasagna_49278_rsvp_checkboxes.sql
@@ -1,0 +1,168 @@
+-- lasagna-49278: DB-driven config for the RSVP opt-in checkboxes.
+--
+-- Replaces 9 hardcoded checkbox blocks in `RSVPFormStep1.tsx` with rows in
+-- this table. Renderer fetches rows, filters by `required_tags` / `excluded_tags`,
+-- groups by `combined_group`, and renders one checkbox per row (or per group).
+--
+-- v1 ships 8 global seed rows (`party_id IS NULL`) — one per existing checkbox.
+-- Per-event override rows MAY be added later (`party_id REFERENCES parties(id)`);
+-- when present, they take precedence over the global row with the same `id`.
+--
+-- Destination columns on `guests` (`mailing_list_opt_in`, `swc_*_opt_in`,
+-- `ethconf_opt_in`) are NOT touched — `opt_in_fields` is a hardcoded
+-- whitelist mapping renderer-side checkbox handles to those existing columns.
+-- Adding a 9th destination column still requires a deploy.
+
+-- Postgres rejects NULLs in primary-key columns, so the natural composite key
+-- (id, party_id) can't be the PRIMARY KEY when party_id is nullable. We use a
+-- surrogate row PK and enforce uniqueness with two partial UNIQUE indexes:
+-- one over (id) for global rows (party_id IS NULL) and one over
+-- (id, party_id) for per-event overrides.
+CREATE TABLE IF NOT EXISTS rsvp_checkboxes (
+  row_pk                 bigserial PRIMARY KEY,
+  id                     text NOT NULL,
+  party_id               uuid REFERENCES parties(id) ON DELETE CASCADE,
+  position               int  NOT NULL DEFAULT 0,
+  active                 boolean NOT NULL DEFAULT true,
+
+  required_tags          text[] NOT NULL DEFAULT '{}',
+  excluded_tags          text[] NOT NULL DEFAULT '{}',
+  always_show            boolean NOT NULL DEFAULT false,
+
+  opt_in_fields          text[] NOT NULL,
+  combined_group         text,
+
+  label_i18n_key         text,
+  label_default          text,
+  label_overrides        jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  info_modal_i18n_ns     text,
+  info_modal_privacy_url text,
+  info_modal_terms_url   text,
+  info_modal_terms_key   text,
+  modal_overrides        jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  accent_color           text NOT NULL DEFAULT 'red',
+
+  updated_at             timestamptz NOT NULL DEFAULT now(),
+  updated_by             text
+);
+
+-- Per-event overrides: exactly one row per (id, party_id).
+CREATE UNIQUE INDEX IF NOT EXISTS rsvp_checkboxes_per_event_unique
+  ON rsvp_checkboxes (id, party_id) WHERE party_id IS NOT NULL;
+
+-- Indexes: renderer fetches global config once, then per-party overrides.
+CREATE INDEX IF NOT EXISTS rsvp_checkboxes_global_idx
+  ON rsvp_checkboxes (active, position) WHERE party_id IS NULL;
+CREATE INDEX IF NOT EXISTS rsvp_checkboxes_per_event_idx
+  ON rsvp_checkboxes (party_id, id) WHERE party_id IS NOT NULL;
+
+-- Column-level public read of fields the form needs. updated_at / updated_by
+-- stay admin-only via the backend endpoint.
+GRANT SELECT (
+  id, party_id, position, active, required_tags, excluded_tags, always_show,
+  opt_in_fields, combined_group,
+  label_i18n_key, label_default, label_overrides,
+  info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+  modal_overrides, accent_color
+) ON rsvp_checkboxes TO anon, authenticated;
+
+ALTER TABLE rsvp_checkboxes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone can read rsvp checkboxes" ON rsvp_checkboxes;
+CREATE POLICY "Anyone can read rsvp checkboxes"
+  ON rsvp_checkboxes FOR SELECT
+  USING (true);
+
+-- Primary key only enforces uniqueness on (id, party_id). The renderer
+-- requires the (id, NULL) "global" row to be unique; the partial unique
+-- index makes that explicit and lets the admin CRUD detect dupes.
+CREATE UNIQUE INDEX IF NOT EXISTS rsvp_checkboxes_global_id_unique
+  ON rsvp_checkboxes (id) WHERE party_id IS NULL;
+
+-- Seed: 8 global rows mirroring today's hardcoded behavior.
+-- Guard: only seed when the table is empty (so re-running the migration is a no-op).
+DO $seed$
+BEGIN
+IF NOT EXISTS (SELECT 1 FROM rsvp_checkboxes WHERE party_id IS NULL) THEN
+-- All combined_group='pizzadao_partners' so the renderer merges them per event.
+-- mailing_list.always_show=true; SWC rows only join when their tag is present.
+-- mailing_list.label_i18n_key='step1.combinedOptIn' so the renderer's
+-- spokesperson rule (lowest-position row in group) yields the combined label
+-- when there is more than one in-group row active for the event.
+
+INSERT INTO rsvp_checkboxes (
+  id, party_id, position, active,
+  required_tags, excluded_tags, always_show,
+  opt_in_fields, combined_group,
+  label_i18n_key, label_default, label_overrides,
+  info_modal_i18n_ns, info_modal_privacy_url, info_modal_terms_url, info_modal_terms_key,
+  modal_overrides, accent_color
+) VALUES
+  (
+    'mailing_list', NULL, 10, true,
+    '{}', '{}', true,
+    ARRAY['mailingListOptIn'], 'pizzadao_partners',
+    'step1.combinedOptIn', 'Sign up for PizzaDAO''s mailing list', '{}'::jsonb,
+    NULL, NULL, NULL, NULL,
+    '{}'::jsonb, 'red'
+  ),
+  (
+    'swc_us', NULL, 20, true,
+    ARRAY['swc'], '{}', false,
+    ARRAY['swcOptIn'], 'pizzadao_partners',
+    'step1.swcJoin', 'Join Stand With Crypto and receive updates from the SWC Alliance', '{}'::jsonb,
+    'swcModal', 'https://www.standwithcrypto.org/privacy', 'https://www.standwithcrypto.org/terms-of-service', 'termsConditions',
+    '{}'::jsonb, 'purple'
+  ),
+  (
+    'swc_ca', NULL, 21, true,
+    ARRAY['swccanada'], '{}', false,
+    ARRAY['swcCaOptIn'], 'pizzadao_partners',
+    'step1.swcNotify', 'Notify me about Stand With Crypto Canada updates', '{}'::jsonb,
+    'swcCaModal', 'https://www.standwithcrypto.org/ca/privacy', 'https://www.standwithcrypto.org/ca/terms-of-service', 'termsOfService',
+    '{}'::jsonb, 'purple'
+  ),
+  (
+    'swc_au', NULL, 22, true,
+    ARRAY['swcau'], '{}', false,
+    ARRAY['swcAuOptIn'], 'pizzadao_partners',
+    'step1.swcNotify', 'Notify me about Stand With Crypto Australia updates', '{}'::jsonb,
+    'swcAuModal', 'https://www.standwithcrypto.org/au/privacy', 'https://www.standwithcrypto.org/au/terms-of-service', 'termsOfService',
+    '{}'::jsonb, 'purple'
+  ),
+  (
+    'swc_eu', NULL, 23, true,
+    ARRAY['swceu'], '{}', false,
+    ARRAY['swcEuOptIn'], 'pizzadao_partners',
+    'step1.swcNotify', 'Notify me about Stand With Crypto EU updates', '{}'::jsonb,
+    'swcEuModal', 'https://www.standwithcrypto.org/eu/en/privacy', 'https://www.standwithcrypto.org/eu/en/terms-of-service', 'termsOfService',
+    '{}'::jsonb, 'purple'
+  ),
+  (
+    'swc_uk', NULL, 24, true,
+    ARRAY['swcuk'], '{}', false,
+    ARRAY['swcUkOptIn'], 'pizzadao_partners',
+    'step1.swcNotify', 'Notify me about Stand With Crypto UK updates', '{}'::jsonb,
+    'swcUkModal', 'https://www.standwithcrypto.org/gb/en/privacy', 'https://www.standwithcrypto.org/gb/en/terms-of-service', 'termsOfService',
+    '{}'::jsonb, 'purple'
+  ),
+  (
+    'swc_br', NULL, 25, true,
+    ARRAY['swcbr'], '{}', false,
+    ARRAY['swcBrOptIn'], 'pizzadao_partners',
+    'step1.swcBrNotify', 'Notify me about Juntos por Cripto updates', '{}'::jsonb,
+    'swcBrModal', 'https://www.juntosporcripto.org/br/privacy', 'https://www.juntosporcripto.org/br/terms-of-service', 'termsOfService',
+    '{}'::jsonb, 'purple'
+  ),
+  (
+    'ethconf', NULL, 30, true,
+    ARRAY['ethconf'], '{}', false,
+    ARRAY['ethconfOptIn'], 'pizzadao_partners',
+    'step1.ethconfDiscount', 'I want a discount code for the ETHConf conference', '{}'::jsonb,
+    NULL, NULL, NULL, NULL,
+    '{}'::jsonb, 'red'
+  );
+END IF;
+END $seed$;


### PR DESCRIPTION
## Summary

Kills the redeploy-for-checkbox-edit cycle (neapolitan-84274 / parmesan-98989 / mushroom-36006 / rigatoni-72401 / linguine-83104). The 8 RSVP opt-in checkboxes — mailing list, 6 SWC regions, ETHConf — now live in a new ``rsvp_checkboxes`` Supabase table. Frontend renderer fetches global + per-event override rows and renders the form. Admin UI on /admin lets Snax edit labels, URLs, render conditions, and accent colors without a deploy.

The 8 destination columns on ``guests`` (``mailing_list_opt_in``, ``swc_*_opt_in``, ``ethconf_opt_in``) stay where they are. Adding a 9th still requires a deploy.

## What changed

- **New** ``supabase/migrations/20260605_lasagna_49278_rsvp_checkboxes.sql`` — table, indexes, column-level GRANT, RLS, 8 seed rows. **Already applied to prod** (8 rows present).
- **New** ``frontend/src/hooks/useRsvpCheckboxConfig.ts`` — fetch + module-level cache + hardcoded fallback (the same 8 seed rows as TS constants).
- **New** ``frontend/src/components/RsvpCheckboxList.tsx`` — filter / group / render pipeline; resolves labels and modal copy with per-locale overrides.
- **New** ``frontend/src/components/admin/RsvpCheckboxesTab.tsx`` — admin CRUD UI; inline edit, "+ New checkbox", per-event override picker, "Reset to defaults" button per seeded row, cache-invalidation refresh.
- **Modified** ``frontend/src/components/RSVPFormStep1.tsx`` — replaces the 9 hardcoded checkbox blocks with ``<RsvpCheckboxList>``; preservation branch (legacy two-checkbox layout) kept for ``optin_ab_variant === 'control'`` re-submits.
- **Modified** ``frontend/src/hooks/useRSVPForm.ts`` — adds ``setOptInByField(field, value)`` generic setter; exposes ``eventId`` / ``eventTags`` from the form.
- **Modified** ``frontend/src/lib/api.ts`` — 4 admin client methods (list/create/update/delete).
- **Modified** ``backend/src/routes/admin.routes.ts`` — 4 admin endpoints (GET/POST/PATCH/DELETE ``/api/admin/rsvp-checkboxes``); validates ``opt_in_fields`` against an 8-value whitelist; rejects DELETE of seeded global rows (forces ``active=false``).
- **Modified** ``frontend/src/pages/AdminPage.tsx`` — new tab "RSVP Checkboxes".

## Deploy order (CRITICAL)

1. **Migration → prod** (already applied — 8 rows seeded).
2. **Backend deploy from master tip** (admin endpoints).
3. **Frontend deploy** (renderer flips on).

Backend MUST go live before frontend so the admin UI works; migration MUST be applied before backend so the table exists. The frontend hook has a hardcoded fallback covering the "DB fetch failed" path.

## Relationship to PR #870 (linguine-83104)

PR #870 makes the combined checkbox render on every event by tweaking ``RSVPFormStep1.tsx``. This PR fully replaces those same hardcoded blocks, so:
- If linguine merges before lasagna: lasagna rebases cleanly (same lines touched).
- If lasagna merges first: linguine becomes a no-op; close it.

## Plan reference

``plans/lasagna-49278-rsvp-checkboxes-db-config.md`` — full spec.

## Test plan

- [ ] Vercel preview loads /rsv.pizza/<known SWC event> in each of US/CA/AU/EU/UK/BR and ETHConf; verify labels, info modals, and accent colors match prod.
- [ ] RSVP on a vanilla event (no SWC tags) — only the mailing-list checkbox renders.
- [ ] Submit an RSVP and confirm the right ``guests.*_opt_in`` columns flip in Supabase.
- [ ] Open /admin → "RSVP Checkboxes" tab → edit ``mailing_list.label_default`` → save → reload RSVP form in incognito → confirm the new label renders.
- [ ] Run the win-condition SQL from the plan to prove no-deploy edits land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)