### PR TITLE
salsiccia-58492: require host Telegram in GPP27 create flow

### DIFF
--- a/backend/src/routes/gpp27.routes.ts
+++ b/backend/src/routes/gpp27.routes.ts
@@ -166,6 +166,9 @@ router.post('/events', requireAuth, async (req: AuthRequest, res: Response, next
     if (!email || typeof email !== 'string' || !email.includes('@')) {
       throw new AppError('Valid email is required', 400, 'VALIDATION_ERROR');
     }
+    if (!telegram || typeof telegram !== 'string' || telegram.trim().length === 0) {
+      throw new AppError('Telegram is required', 400, 'VALIDATION_ERROR');
+    }
 
     const normalizedCity = city.trim();
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6383,7 +6383,7 @@ export interface Gpp27CreateEventInput {
   city: string;
   hostName: string;
   email: string;
-  telegram?: string;
+  telegram: string;
   country?: string;
   countryCode?: string;
   cityFormattedName?: string;

--- a/frontend/src/pages/GPP27CreatePage.tsx
+++ b/frontend/src/pages/GPP27CreatePage.tsx
@@ -110,8 +110,8 @@ export function GPP27CreatePage() {
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     setCreateError(null);
-    if (!city.trim() || !hostName.trim() || !email.trim()) {
-      setCreateError('City, host name, and email are required.');
+    if (!city.trim() || !hostName.trim() || !email.trim() || !telegram.trim()) {
+      setCreateError('City, host name, email, and Telegram are required.');
       return;
     }
     setSubmitting(true);
@@ -120,7 +120,7 @@ export function GPP27CreatePage() {
         city: city.trim(),
         hostName: hostName.trim(),
         email: email.trim(),
-        telegram: telegram.trim() || undefined,
+        telegram: telegram.trim(),
         timezone: timezone || undefined,
         ...(cityData && {
           country: cityData.country,
@@ -271,7 +271,7 @@ export function GPP27CreatePage() {
                 icon={Send}
                 value={telegram}
                 onChange={(e) => setTelegram(e.target.value)}
-                placeholder="Host Telegram (optional)"
+                placeholder="Host Telegram"
               />
 
               {createError && (


### PR DESCRIPTION
Make the host Telegram field **required** in the GPP27 (`/gpp27`) signup/create flow across all three layers. The old 2026 `/gpp` flow is untouched.

- `frontend/src/lib/api.ts` — `Gpp27CreateEventInput.telegram` changed from optional to required (`telegram: string`).
- `frontend/src/pages/GPP27CreatePage.tsx` — placeholder now "Host Telegram" (dropped "(optional)"), submit always sends `telegram: telegram.trim()`, and the `handleCreate` required-field guard now includes `!telegram.trim()` with a matching inline error.
- `backend/src/routes/gpp27.routes.ts` — `POST /events` now returns 400 "Telegram is required" alongside the existing email/hostName checks.

Preview: https://rsvpizza-git-salsiccia-58492-tg-required-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)