### PR TITLE
romana-58218: no comma before supporters "+ N" tail

### DIFF
--- a/frontend/src/components/DonorHighlights.tsx
+++ b/frontend/src/components/DonorHighlights.tsx
@@ -54,7 +54,7 @@ export const DonorHighlights: React.FC<DonorHighlightsProps> = ({ stats }) => {
               );
             })}
             {moreCount > 0 && (
-              <span className="text-theme-text-muted">, {t('moreSupporters', { count: moreCount })}</span>
+              <span className="text-theme-text-muted"> {t('moreSupporters', { count: moreCount })}</span>
             )}
           </span>
         </div>


### PR DESCRIPTION
Remove the comma before the `+ N` tail in the inline donor list in `DonorHighlights.tsx`. The between-donor commas stay; only the pre-tail separator changes from `, ` to a leading space.

Rendered result: `Alice N. $500, Anon $300, Marco R. $250 + 6 ›`

String-literal-only change; no locale files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)