### PR TITLE
fix(coppa-92107): W-9 Line 2 explicitly optional for sole props/etc.

### DIFF
--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -166,13 +166,22 @@ const getLine1Helper = (
   return "Enter the entity's legal name as registered with the IRS — it must match its EIN.";
 };
 
+// coppa-92107: per the IRS instructions, Line 2 is only filled when the
+// operating / trade name differs from the Line 1 legal name. Sole props with
+// no DBA, single-member LLCs whose name matches the owner, corps without a
+// DBA, etc. should leave it blank. We mark every variant of the placeholder
+// with an explicit "(optional)" suffix EXCEPT the LLC disregarded-entity
+// path, where Line 2 is the place the IRS expects the LLC's name (so it's
+// effectively required *for that classification* — though we still don't
+// gate the submit on it, since the host might be a sole prop misclassified
+// as disregarded; leave the IRS to bounce that, not us).
 const getLine2Placeholder = (
   category: ClassCategory | "",
   llcSub: LlcSub | "",
 ): string => {
   if (category === "llc" && llcSub === "disregarded")
     return "LLC name (the disregarded entity)";
-  return "Business / DBA name (if different from above)";
+  return "Business / DBA name (optional — only if different from above)";
 };
 
 const getLine2Helper = (
@@ -180,11 +189,12 @@ const getLine2Helper = (
   llcSub: LlcSub | "",
 ): string | null => {
   if (category === "llc" && llcSub === "disregarded")
-    return "Enter the LLC's name here. Line 1 above must be the owner's name.";
+    return "The LLC's name. Required if the LLC name differs from the owner's name on Line 1.";
   if (category === "individual")
-    return "Optional. Only fill in if you operate under a DBA / trade name that differs from your legal name.";
+    return "Skip if you don't operate under a different business name (DBA).";
   if (!category) return null;
-  return "Optional. Only fill in if your operating / trade name differs from Line 1.";
+  // C/S corp, partnership, trust/estate, LLC taxed as C/S/P, other.
+  return "Skip if your operating name matches your legal name on Line 1.";
 };
 
 // Line 2 is hidden when it would never apply. Currently we always show it


### PR DESCRIPTION
## Summary

Per IRS instructions, Line 2 ("Business name / disregarded entity name") is only filled when the operating/trade name differs from the Line 1 legal name. Sole props with no DBA, single-member LLCs whose name matches the owner, corps without a DBA, etc. should leave it blank.

- Adds explicit `(optional — only if different from above)` suffix to the Line 2 placeholder (all classifications except LLC disregarded entity, where Line 2 is where the IRS expects the LLC's name)
- Updates helper text per classification:
  - Individual / sole prop: "Skip if you don't operate under a different business name (DBA)."
  - LLC disregarded entity: "The LLC's name. Required if the LLC name differs from the owner's name on Line 1."
  - All other (corp / partnership / trust / LLC taxed as C/S/P / other): "Skip if your operating name matches your legal name on Line 1."

## Verification

- Backend `assertSubmitValid` for `w9` already does NOT require `businessName` — no backend change needed (verified in `backend/src/routes/tax-form.routes.ts`).
- PDF generator handles empty `businessName` via `data.businessName || ''` — renders blank Line 2 cleanly (verified in `backend/src/services/taxFormPdf.service.ts`).
- No frontend client-side validation gates submit on Line 2 (only consumer is `W9Form.tsx`).
- `frontend/src/components/payouts/tax/W9Form.tsx` Line 2 `IconInput` was already missing the `required` prop — confirmed optional at the input level.

## Test plan

- [ ] Open W-9 → pick "Individual / sole proprietor" → leave Line 2 blank → submit succeeds, no validation error.
- [ ] Helper text under Line 2 reads "Skip if you don't operate under a different business name (DBA)."
- [ ] Placeholder reads "Business / DBA name (optional — only if different from above)".
- [ ] Pick LLC → Disregarded entity → Line 2 placeholder still reads "LLC name (the disregarded entity)" and helper reads "The LLC's name. Required if the LLC name differs from the owner's name on Line 1." (intentional — not gated, just guidance).
- [ ] Submitted W-9 PDF renders blank Line 2 cleanly (no placeholder text, no crash).

Generated with [Claude Code](https://claude.com/claude-code)