### PR TITLE
feat(pesto-92107): gate mailing address on W-8BEN(-E) behind checkbox

### DIFF
--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -135,6 +135,23 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
     !!(value.disregardedEntityName || value.usTin || value.giin || value.referenceNumbers),
   );
 
+  // pesto-92107: gate the mailing address block behind a checkbox. Default
+  // is unchecked = mailing fields hidden, which signals "use permanent
+  // residence" per IRS convention (the PDF generator already renders an
+  // empty mailing block in that case). If the saved draft already has
+  // mailing data in any structured field, auto-check the box on mount so
+  // the host sees it. Probes all five prosciutto-92107 structured fields.
+  const [showMailingAddress, setShowMailingAddress] = useState<boolean>(() => {
+    const v = value;
+    return Boolean(
+      (v.mailingAddress && v.mailingAddress.trim()) ||
+        (v.mailingCity && v.mailingCity.trim()) ||
+        (v.mailingStateProvince && v.mailingStateProvince.trim()) ||
+        (v.mailingPostalCode && v.mailingPostalCode.trim()) ||
+        (v.mailingCountry && v.mailingCountry.trim()),
+    );
+  });
+
   // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
   // fresh mount. Saved drafts with an existing date are left untouched; the
   // effect only fires once so subsequent user edits remain authoritative.
@@ -356,61 +373,98 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs text-theme-text-muted">Mailing address (if different)</p>
-        <LocationAutocomplete
-          value={value.mailingAddress ?? ''}
-          onChange={(v) => set('mailingAddress', v)}
-          onCitySelected={(cityData) => {
-            const nextAddress = cityData.street || value.mailingAddress || cityData.formattedName || '';
-            onChange({
-              ...value,
-              mailingAddress: nextAddress,
-              mailingCity: cityData.cityName || value.mailingCity || '',
-              mailingStateProvince: cityData.state || value.mailingStateProvince || '',
-              mailingPostalCode: cityData.postalCode || value.mailingPostalCode || '',
-              mailingCountry: cityData.country || value.mailingCountry || '',
-            });
+        {/* pesto-92107: gate the mailing address block behind a checkbox.
+            Most hosts use one address; surfacing both blocks by default
+            adds noise. Saved drafts with mailing data auto-check the box
+            on mount via the lazy initializer above. */}
+        <Checkbox
+          checked={showMailingAddress}
+          onChange={() => {
+            const next = !showMailingAddress;
+            setShowMailingAddress(next);
+            if (!next) {
+              // Clear any stale mailing values so they don't carry through
+              // to the submit payload after the host unchecks. Covers the
+              // full set of structured fields (prosciutto-92107) including
+              // the legacy `mailingAddress` line which doubles as street.
+              onChange({
+                ...value,
+                mailingAddress: '',
+                mailingCity: '',
+                mailingStateProvince: '',
+                mailingPostalCode: '',
+                mailingCountry: '',
+              });
+            }
           }}
           disabled={disabled}
-          placeholder="Street, apt / suite"
-          types={['geocode', 'establishment']}
+          label="I have a different mailing address"
+          labelClassName="text-xs text-theme-text"
         />
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="City or town"
-            value={value.mailingCity ?? ''}
-            onChange={(e) => set('mailingCity', e.target.value)}
-            disabled={disabled}
-          />
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="State or province"
-            value={value.mailingStateProvince ?? ''}
-            onChange={(e) => set('mailingStateProvince', e.target.value)}
-            disabled={disabled}
-          />
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="Postal code"
-            value={value.mailingPostalCode ?? ''}
-            onChange={(e) => set('mailingPostalCode', e.target.value)}
-            disabled={disabled}
-          />
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="Country"
-            value={value.mailingCountry ?? ''}
-            onChange={(e) => set('mailingCountry', e.target.value)}
-            disabled={disabled}
-          />
-        </div>
+        <p className="text-xs text-white/40">
+          Check this only if your mail goes somewhere different from your permanent residence above.
+        </p>
+        {showMailingAddress && (
+          <div className="space-y-2 pt-1">
+            {/* prosciutto-92107: Google Places autocomplete on the street
+                input. On pick, fills City / State or Province / Postal Code
+                / Country. Each field remains individually editable. */}
+            <LocationAutocomplete
+              value={value.mailingAddress ?? ''}
+              onChange={(v) => set('mailingAddress', v)}
+              onCitySelected={(cityData) => {
+                const nextAddress = cityData.street || value.mailingAddress || cityData.formattedName || '';
+                onChange({
+                  ...value,
+                  mailingAddress: nextAddress,
+                  mailingCity: cityData.cityName || value.mailingCity || '',
+                  mailingStateProvince: cityData.state || value.mailingStateProvince || '',
+                  mailingPostalCode: cityData.postalCode || value.mailingPostalCode || '',
+                  mailingCountry: cityData.country || value.mailingCountry || '',
+                });
+              }}
+              disabled={disabled}
+              placeholder="Street, apt / suite"
+              types={['geocode', 'establishment']}
+            />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="City or town"
+                value={value.mailingCity ?? ''}
+                onChange={(e) => set('mailingCity', e.target.value)}
+                disabled={disabled}
+              />
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="State or province"
+                value={value.mailingStateProvince ?? ''}
+                onChange={(e) => set('mailingStateProvince', e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="Postal code"
+                value={value.mailingPostalCode ?? ''}
+                onChange={(e) => set('mailingPostalCode', e.target.value)}
+                disabled={disabled}
+              />
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="Country"
+                value={value.mailingCountry ?? ''}
+                onChange={(e) => set('mailingCountry', e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       <IconInput

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { User, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle, Info } from 'lucide-react';
 import { IconInput } from '../../IconInput';
 import { Checkbox } from '../../Checkbox';
@@ -77,6 +77,25 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled,
   onChangeRef.current = onChange;
   const valueRef = useRef(value);
   valueRef.current = value;
+
+  // pesto-92107: gate the mailing address block behind a checkbox. Default
+  // is unchecked = mailing fields hidden, which signals "use permanent
+  // residence" per IRS convention (the PDF generator already renders an
+  // empty mailing block in that case). If the saved draft already has
+  // mailing data, auto-check the box on mount so the host sees it.
+  const [showMailingAddress, setShowMailingAddress] = useState<boolean>(() => {
+    const v = value;
+    return Boolean(
+      // prosciutto-92107: probe all structured mailing fields. `mailingAddress`
+      // (street) is kept as the street field on the type for back-compat with
+      // legacy drafts (single-line) and the new split-fields shape (line 1).
+      (v.mailingAddress && v.mailingAddress.trim()) ||
+        (v.mailingCity && v.mailingCity.trim()) ||
+        (v.mailingStateProvince && v.mailingStateProvince.trim()) ||
+        (v.mailingPostalCode && v.mailingPostalCode.trim()) ||
+        (v.mailingCountry && v.mailingCountry.trim()),
+    );
+  });
 
   // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
   // fresh mount. Saved drafts with an existing date are left untouched; the
@@ -255,61 +274,98 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled,
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs text-theme-text-muted">Mailing address (if different)</p>
-        <LocationAutocomplete
-          value={value.mailingAddress ?? ''}
-          onChange={(v) => set('mailingAddress', v)}
-          onCitySelected={(cityData) => {
-            const nextAddress = cityData.street || value.mailingAddress || cityData.formattedName || '';
-            onChange({
-              ...value,
-              mailingAddress: nextAddress,
-              mailingCity: cityData.cityName || value.mailingCity || '',
-              mailingStateProvince: cityData.state || value.mailingStateProvince || '',
-              mailingPostalCode: cityData.postalCode || value.mailingPostalCode || '',
-              mailingCountry: cityData.country || value.mailingCountry || '',
-            });
+        {/* pesto-92107: gate the mailing address block behind a checkbox.
+            Most hosts use one address; surfacing both blocks by default
+            adds noise. Saved drafts with mailing data auto-check the box
+            on mount via the lazy initializer above. */}
+        <Checkbox
+          checked={showMailingAddress}
+          onChange={() => {
+            const next = !showMailingAddress;
+            setShowMailingAddress(next);
+            if (!next) {
+              // Clear any stale mailing values so they don't carry through
+              // to the submit payload after the host unchecks. Covers the
+              // full set of structured fields (prosciutto-92107) including
+              // the legacy `mailingAddress` line which doubles as street.
+              onChange({
+                ...value,
+                mailingAddress: '',
+                mailingCity: '',
+                mailingStateProvince: '',
+                mailingPostalCode: '',
+                mailingCountry: '',
+              });
+            }
           }}
           disabled={disabled}
-          placeholder="Street, apt / suite"
-          types={['geocode', 'establishment']}
+          label="I have a different mailing address"
+          labelClassName="text-xs text-theme-text"
         />
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="City or town"
-            value={value.mailingCity ?? ''}
-            onChange={(e) => set('mailingCity', e.target.value)}
-            disabled={disabled}
-          />
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="State or province"
-            value={value.mailingStateProvince ?? ''}
-            onChange={(e) => set('mailingStateProvince', e.target.value)}
-            disabled={disabled}
-          />
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="Postal code"
-            value={value.mailingPostalCode ?? ''}
-            onChange={(e) => set('mailingPostalCode', e.target.value)}
-            disabled={disabled}
-          />
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="Country"
-            value={value.mailingCountry ?? ''}
-            onChange={(e) => set('mailingCountry', e.target.value)}
-            disabled={disabled}
-          />
-        </div>
+        <p className="text-xs text-white/40">
+          Check this only if your mail goes somewhere different from your permanent residence above.
+        </p>
+        {showMailingAddress && (
+          <div className="space-y-2 pt-1">
+            {/* prosciutto-92107: Google Places autocomplete on the street
+                input. On pick, fills City / State or Province / Postal Code
+                / Country. Each field remains individually editable. */}
+            <LocationAutocomplete
+              value={value.mailingAddress ?? ''}
+              onChange={(v) => set('mailingAddress', v)}
+              onCitySelected={(cityData) => {
+                const nextAddress = cityData.street || value.mailingAddress || cityData.formattedName || '';
+                onChange({
+                  ...value,
+                  mailingAddress: nextAddress,
+                  mailingCity: cityData.cityName || value.mailingCity || '',
+                  mailingStateProvince: cityData.state || value.mailingStateProvince || '',
+                  mailingPostalCode: cityData.postalCode || value.mailingPostalCode || '',
+                  mailingCountry: cityData.country || value.mailingCountry || '',
+                });
+              }}
+              disabled={disabled}
+              placeholder="Street, apt / suite"
+              types={['geocode', 'establishment']}
+            />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="City or town"
+                value={value.mailingCity ?? ''}
+                onChange={(e) => set('mailingCity', e.target.value)}
+                disabled={disabled}
+              />
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="State or province"
+                value={value.mailingStateProvince ?? ''}
+                onChange={(e) => set('mailingStateProvince', e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="Postal code"
+                value={value.mailingPostalCode ?? ''}
+                onChange={(e) => set('mailingPostalCode', e.target.value)}
+                disabled={disabled}
+              />
+              <IconInput
+                icon={MapPin}
+                type="text"
+                placeholder="Country"
+                value={value.mailingCountry ?? ''}
+                onChange={(e) => set('mailingCountry', e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary
- Hides the mailing address block on **W-8BEN** and **W-8BEN-E** behind an `I have a different mailing address` checkbox (default off).
- Most hosts use one address; surfacing both blocks by default is noise. Empty mailing fields = "use permanent residence" per IRS convention, which the PDF generator already renders correctly (Line 4 for BEN / Line 7 for BEN-E left blank).
- Unchecking after filling clears the stale mailing values from the submit payload (so toggling off doesn't carry data through).
- Saved drafts with mailing data populated auto-check the box on mount so the host sees their existing data.
- Coordinates with in-flight prosciutto-92107 (autocomplete + structured city/state/ZIP/country splits). This PR controls *visibility*; prosciutto controls *contents* — they touch different concerns and should compose cleanly. If prosciutto lands first, rebase will work transparently because the gating logic doesn't reference field structure.

## Test plan
- [ ] W-8BEN: checkbox unchecked on fresh form → mailing fields hidden; submit → payload has empty `mailingAddress` / `mailingCity` / `mailingCountry`.
- [ ] W-8BEN: check the box → mailing fields appear (Street + City/Country grid); fill them; submit → values present in payload.
- [ ] W-8BEN: fill mailing fields, then uncheck → fields disappear AND clear from `value`; next submit sends empty strings.
- [ ] W-8BEN: load a saved draft with mailing data → checkbox auto-checks on mount; section visible with prefilled data.
- [ ] W-8BEN-E: repeat the four scenarios above (corporate flow).
- [ ] PDF generation with empty mailing fields renders the Line 4 / Line 7 row with a blank value (already supported by `taxFormPdf.service.ts`).
- [ ] `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)