### PR TITLE
feat(prosciutto-92107): tax form address autocomplete + split city/state/ZIP/country

### DIFF
--- a/backend/src/routes/tax-form.routes.ts
+++ b/backend/src/routes/tax-form.routes.ts
@@ -83,7 +83,18 @@ function assertSubmitValid(formType: TaxFormType, data: any): void {
     requireField('name');
     requireField('taxClassification');
     requireField('address');
-    requireField('cityStateZip');
+    // prosciutto-92107: accept either the new structured fields (city + state
+    // + zipCode) or the legacy combined cityStateZip field. New form submits
+    // populate the structured fields; older drafts pre-dating this change
+    // still validate via the legacy fallback so the host can submit their
+    // saved draft without re-typing.
+    const hasStructured =
+      typeof data.city === 'string' && data.city.trim()
+      && typeof data.state === 'string' && data.state.trim()
+      && typeof data.zipCode === 'string' && data.zipCode.trim();
+    if (!hasStructured) {
+      requireField('cityStateZip');
+    }
     requireField('signature');
     requireField('date');
     // Exactly one of SSN / EIN must be present.

--- a/backend/src/services/taxFormPdf.service.ts
+++ b/backend/src/services/taxFormPdf.service.ts
@@ -129,12 +129,49 @@ export interface W9FormData {
   exemptPayeeCode?: string;
   fatcaCode?: string;
   address: string;
-  cityStateZip: string;
+  // prosciutto-92107: structured address fields. The generator prefers these
+  // when present and falls back to the legacy `cityStateZip` for pre-existing
+  // drafts that haven't been re-saved.
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  /** @deprecated kept for back-compat with pre-prosciutto submits. */
+  cityStateZip?: string;
   accountNumbers?: string;
   ssn?: string;
   ein?: string;
   signature: string;
   date: string;
+}
+
+// prosciutto-92107: compose "City, State ZIP" from the structured fields.
+// Falls back to the legacy combined string if the structured fields aren't
+// populated (e.g. an older draft submitted unchanged).
+function formatW9CityStateZip(data: W9FormData): string {
+  const city = data.city?.trim();
+  const state = data.state?.trim();
+  const zip = data.zipCode?.trim();
+  if (city || state || zip) {
+    const cityState = [city, state].filter((s): s is string => !!s && s.length > 0).join(', ');
+    return [cityState, zip].filter((s): s is string => !!s && s.length > 0).join(' ');
+  }
+  return data.cityStateZip?.trim() || '';
+}
+
+// prosciutto-92107: compose "City, State/Province Postal" for the W-8 forms'
+// "City or town" PDF box. The official W-8BEN / W-8BEN-E IRS forms only
+// expose a single line for city + state/province + postal, so we collapse
+// the structured fields back into one line at render time.
+function formatW8CityLine(
+  city?: string,
+  stateProvince?: string,
+  postalCode?: string,
+): string {
+  const c = city?.trim();
+  const sp = stateProvince?.trim();
+  const pc = postalCode?.trim();
+  const cityState = [c, sp].filter((s): s is string => !!s && s.length > 0).join(', ');
+  return [cityState, pc].filter((s): s is string => !!s && s.length > 0).join(' ');
 }
 
 export async function generateW9PDF(data: W9FormData, refId: string): Promise<Buffer> {
@@ -262,14 +299,16 @@ export async function generateW9PDF(data: W9FormData, refId: string): Promise<Bu
   });
   y -= 40;
 
-  // Line 6 - City, state, ZIP
+  // Line 6 - City, state, ZIP. prosciutto-92107: composed from structured
+  // city/state/zipCode fields when present (new submits), falling back to the
+  // legacy combined `cityStateZip` for older drafts.
   drawField(page, {
     x: 30,
     y,
     width: 552,
     height: 36,
     label: '6  City, state, and ZIP code',
-    value: data.cityStateZip,
+    value: formatW9CityStateZip(data),
     font,
     boldFont: bold,
   });
@@ -397,9 +436,16 @@ export interface W8BENFormData {
   citizenship: string;
   permanentAddress: string;
   permanentCity: string;
+  // prosciutto-92107: structured address fields. Optional — the W-8BEN PDF
+  // box for "City or town" rolls state/province + postal code into the city
+  // line when those are populated.
+  permanentStateProvince?: string;
+  permanentPostalCode?: string;
   permanentCountry: string;
   mailingAddress?: string;
   mailingCity?: string;
+  mailingStateProvince?: string;
+  mailingPostalCode?: string;
   mailingCountry?: string;
   usTin?: string;
   foreignTin?: string;
@@ -503,8 +549,15 @@ export async function generateW8BENPDF(data: W8BENFormData, refId: string): Prom
     y,
     width: 276,
     height: 32,
-    label: '    City or town',
-    value: data.permanentCity,
+    label: '    City or town, state/province, postal code',
+    // prosciutto-92107: collapse structured fields back into the single PDF
+    // line the IRS form provides. Fallback to plain city when state/postal
+    // weren't provided (older drafts).
+    value: formatW8CityLine(
+      data.permanentCity,
+      data.permanentStateProvince,
+      data.permanentPostalCode,
+    ),
     font,
     boldFont: bold,
   });
@@ -532,14 +585,18 @@ export async function generateW8BENPDF(data: W8BENFormData, refId: string): Prom
   });
   y -= 40;
 
-  if (data.mailingCity || data.mailingCountry) {
+  if (data.mailingCity || data.mailingCountry || data.mailingPostalCode) {
     drawField(page, {
       x: 30,
       y,
       width: 276,
       height: 32,
-      label: '    City or town',
-      value: data.mailingCity || '',
+      label: '    City or town, state/province, postal code',
+      value: formatW8CityLine(
+        data.mailingCity,
+        data.mailingStateProvince,
+        data.mailingPostalCode,
+      ),
       font,
       boldFont: bold,
     });
@@ -751,9 +808,15 @@ export interface W8BENEFormData {
   chapter4Status: W8BENEChapter4Status;
   permanentAddress: string;
   permanentCity: string;
+  // prosciutto-92107: structured address fields (same shape as W-8BEN). The
+  // city box of the rendered PDF collapses these back into one line.
+  permanentStateProvince?: string;
+  permanentPostalCode?: string;
   permanentCountry: string;
   mailingAddress?: string;
   mailingCity?: string;
+  mailingStateProvince?: string;
+  mailingPostalCode?: string;
   mailingCountry?: string;
   usTin?: string;
   giin?: string;
@@ -938,8 +1001,14 @@ export async function generateW8BENEPDF(data: W8BENEFormData, refId: string): Pr
     y,
     width: 276,
     height: 32,
-    label: '    City or town',
-    value: data.permanentCity,
+    label: '    City or town, state/province, postal code',
+    // prosciutto-92107: collapse structured fields back into the single PDF
+    // line the IRS form provides.
+    value: formatW8CityLine(
+      data.permanentCity,
+      data.permanentStateProvince,
+      data.permanentPostalCode,
+    ),
     font,
     boldFont: bold,
   });
@@ -968,14 +1037,18 @@ export async function generateW8BENEPDF(data: W8BENEFormData, refId: string): Pr
   });
   y -= 40;
 
-  if (data.mailingCity || data.mailingCountry) {
+  if (data.mailingCity || data.mailingCountry || data.mailingPostalCode) {
     drawField(page, {
       x: 30,
       y,
       width: 276,
       height: 32,
-      label: '    City or town',
-      value: data.mailingCity || '',
+      label: '    City or town, state/province, postal code',
+      value: formatW8CityLine(
+        data.mailingCity,
+        data.mailingStateProvince,
+        data.mailingPostalCode,
+      ),
       font,
       boldFont: bold,
     });

--- a/frontend/src/components/LocationAutocomplete.tsx
+++ b/frontend/src/components/LocationAutocomplete.tsx
@@ -5,7 +5,13 @@ export interface CityData {
   cityName: string;      // "New York"
   country: string;       // "United States"
   countryCode: string;   // "US"
-  state?: string;        // "NY"
+  state?: string;        // "NY" (administrative_area_level_1 short_name)
+  // prosciutto-92107: structured street + postal code, parsed from Google Places
+  // address_components. Tax forms (W-9 / W-8BEN / W-8BEN-E) wire the
+  // LocationAutocomplete onto their street-address input and split the
+  // returned components into separate City / State / ZIP / Country inputs.
+  street?: string;       // "123 Main St" (street_number + route)
+  postalCode?: string;   // "94103"
   lat: number;
   lng: number;
   formattedName: string; // "New York, NY, USA"
@@ -201,11 +207,19 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
             const getComponent = (type: string) =>
               components.find(c => c.types.includes(type));
 
-            const cityComponent = getComponent('locality') || getComponent('sublocality') || getComponent('administrative_area_level_1');
+            const cityComponent = getComponent('locality') || getComponent('postal_town') || getComponent('sublocality') || getComponent('administrative_area_level_1');
             const countryComponent = getComponent('country');
             const stateComponent = getComponent('administrative_area_level_1');
+            // prosciutto-92107: street = street_number + route; postal_code
+            // optional (not present on every pick — e.g. broad city-level picks).
+            const streetNumberComponent = getComponent('street_number');
+            const routeComponent = getComponent('route');
+            const postalCodeComponent = getComponent('postal_code');
+            const street = [streetNumberComponent?.long_name, routeComponent?.long_name]
+              .filter((p): p is string => !!p && p.length > 0)
+              .join(' ');
 
-            if (cityComponent || countryComponent) {
+            if (cityComponent || countryComponent || street) {
               const lat = place.geometry?.location?.lat();
               const lng = place.geometry?.location?.lng();
               onCitySelectedRef.current({
@@ -213,6 +227,8 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
                 country: countryComponent?.long_name || '',
                 countryCode: countryComponent?.short_name || '',
                 state: stateComponent?.short_name,
+                street: street || undefined,
+                postalCode: postalCodeComponent?.long_name || undefined,
                 lat: typeof lat === 'number' ? lat : 0,
                 lng: typeof lng === 'number' ? lng : 0,
                 formattedName: selectedAddress,

--- a/frontend/src/components/payouts/TaxFormSection.tsx
+++ b/frontend/src/components/payouts/TaxFormSection.tsx
@@ -144,6 +144,19 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
     setStatusMessage(null);
   };
 
+  // prosciutto-92107: mirror handleSwitchFromW9 for the reverse path. Surfaced
+  // from W-8BEN / W-8BEN-E when the host picks a US permanent-residence
+  // country (W-8 forms are for foreign persons / entities only). Discards the
+  // partial draft for the same reason — the W-8 treaty / chapter4 fields
+  // don't translate to W-9.
+  const handleSwitchToW9 = (_target: 'w9') => {
+    setDraftData({});
+    setEditingType('w9');
+    setPickerOpen(false);
+    setError(null);
+    setStatusMessage(null);
+  };
+
   const renderEditor = () => {
     if (!editingType) return null;
     const editorBody =
@@ -154,9 +167,17 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
           onSwitchFormType={handleSwitchFromW9}
         />
       ) : editingType === 'w8ben' ? (
-        <W8BENForm value={draftData as W8BENFormData} onChange={(v) => setDraftData(v)} />
+        <W8BENForm
+          value={draftData as W8BENFormData}
+          onChange={(v) => setDraftData(v)}
+          onSwitchFormType={handleSwitchToW9}
+        />
       ) : (
-        <W8BENEForm value={draftData as W8BENEFormData} onChange={(v) => setDraftData(v)} />
+        <W8BENEForm
+          value={draftData as W8BENEFormData}
+          onChange={(v) => setDraftData(v)}
+          onSwitchFormType={handleSwitchToW9}
+        />
       );
     return (
       <div className="space-y-4">

--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -2,7 +2,27 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import { Building2, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle, Info } from 'lucide-react';
 import { IconInput } from '../../IconInput';
 import { Checkbox } from '../../Checkbox';
+import { LocationAutocomplete } from '../../LocationAutocomplete';
 import { lookupTreaty, normalizeCountryCode } from '../../../utils/taxTreaties';
+
+// prosciutto-92107: case-insensitive US match for the permanent-residence
+// warning. The IRS treats US territories the same way for W-8 purposes.
+const US_COUNTRY_NAMES = new Set([
+  'united states',
+  'united states of america',
+  'usa',
+  'us',
+  'puerto rico',
+  'guam',
+  'u.s. virgin islands',
+  'us virgin islands',
+  'american samoa',
+  'northern mariana islands',
+]);
+const isUSCountry = (country?: string | null): boolean => {
+  if (!country) return false;
+  return US_COUNTRY_NAMES.has(country.trim().toLowerCase());
+};
 
 export type W8BENEEntityType =
   | 'corporation'
@@ -27,9 +47,14 @@ export interface W8BENEFormData {
   chapter4Status?: W8BENEChapter4Status;
   permanentAddress?: string;
   permanentCity?: string;
+  // prosciutto-92107: split address into structured fields.
+  permanentStateProvince?: string;
+  permanentPostalCode?: string;
   permanentCountry?: string;
   mailingAddress?: string;
   mailingCity?: string;
+  mailingStateProvince?: string;
+  mailingPostalCode?: string;
   mailingCountry?: string;
   usTin?: string;
   giin?: string;
@@ -56,6 +81,12 @@ interface W8BENEFormProps {
   value: W8BENEFormData;
   onChange: (next: W8BENEFormData) => void;
   disabled?: boolean;
+  /**
+   * prosciutto-92107: surfaced when the picked permanent-residence country is
+   * the United States — W-8BEN-E is for foreign entities only. Parent should
+   * discard the W-8BEN-E draft and switch the editor to W-9.
+   */
+  onSwitchFormType?: (target: 'w9') => void;
 }
 
 const ENTITY_TYPES: Array<{ value: W8BENEEntityType; label: string }> = [
@@ -78,7 +109,7 @@ const CHAPTER4: Array<{ value: W8BENEChapter4Status; label: string; hint?: strin
   { value: 'ffi', label: 'FFI', hint: 'Foreign financial institution — paper form required.' },
 ];
 
-export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disabled }) => {
+export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disabled, onSwitchFormType }) => {
   // ----- hooks (declared above any early returns per react-hooks rules) -----
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
@@ -231,14 +262,26 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
 
       <div className="space-y-2">
         <p className="text-xs text-theme-text-muted">Permanent residence address</p>
-        <IconInput
-          icon={MapPin}
-          type="text"
-          placeholder="Street, apt / suite"
+        {/* prosciutto-92107: Google Places autocomplete on the street input.
+            On pick, fills City / State or Province / Postal Code / Country.
+            Each field remains individually editable. */}
+        <LocationAutocomplete
           value={value.permanentAddress ?? ''}
-          onChange={(e) => set('permanentAddress', e.target.value)}
+          onChange={(v) => set('permanentAddress', v)}
+          onCitySelected={(cityData) => {
+            const nextAddress = cityData.street || value.permanentAddress || cityData.formattedName || '';
+            onChange({
+              ...value,
+              permanentAddress: nextAddress,
+              permanentCity: cityData.cityName || value.permanentCity || '',
+              permanentStateProvince: cityData.state || value.permanentStateProvince || '',
+              permanentPostalCode: cityData.postalCode || value.permanentPostalCode || '',
+              permanentCountry: cityData.country || value.permanentCountry || '',
+            });
+          }}
           disabled={disabled}
-          required
+          placeholder="Street, apt / suite"
+          types={['geocode', 'establishment']}
         />
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <IconInput
@@ -253,6 +296,24 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
           <IconInput
             icon={MapPin}
             type="text"
+            placeholder="State or province"
+            value={value.permanentStateProvince ?? ''}
+            onChange={(e) => set('permanentStateProvince', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Postal code"
+            value={value.permanentPostalCode ?? ''}
+            onChange={(e) => set('permanentPostalCode', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
             placeholder="Country"
             value={value.permanentCountry ?? ''}
             onChange={(e) => set('permanentCountry', e.target.value)}
@@ -260,17 +321,50 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
             required
           />
         </div>
+        {isUSCountry(value.permanentCountry) && (
+          <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mt-2">
+            <div className="flex items-start gap-2.5">
+              <AlertTriangle size={16} className="text-amber-300 mt-0.5 flex-shrink-0" />
+              <div className="flex-1">
+                <div className="text-xs text-amber-100 [.gpp-theme_&]:text-amber-900">
+                  <strong>W-8BEN-E is for foreign entities.</strong> Your
+                  permanent residence can't be in the United States. If the
+                  entity is a US person, use W-9 instead.
+                </div>
+                {onSwitchFormType && (
+                  <button
+                    type="button"
+                    onClick={() => onSwitchFormType('w9')}
+                    className="mt-2 text-xs px-3 py-1.5 rounded bg-amber-500/20 hover:bg-amber-500/30 text-amber-100 font-medium border border-amber-500/40 [.gpp-theme_&]:text-amber-900 [.gpp-theme_&]:bg-amber-500/30 [.gpp-theme_&]:hover:bg-amber-500/40 [.gpp-theme_&]:border-amber-700/40"
+                  >
+                    Switch to W-9
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="space-y-2">
         <p className="text-xs text-theme-text-muted">Mailing address (if different)</p>
-        <IconInput
-          icon={MapPin}
-          type="text"
-          placeholder="Street, apt / suite"
+        <LocationAutocomplete
           value={value.mailingAddress ?? ''}
-          onChange={(e) => set('mailingAddress', e.target.value)}
+          onChange={(v) => set('mailingAddress', v)}
+          onCitySelected={(cityData) => {
+            const nextAddress = cityData.street || value.mailingAddress || cityData.formattedName || '';
+            onChange({
+              ...value,
+              mailingAddress: nextAddress,
+              mailingCity: cityData.cityName || value.mailingCity || '',
+              mailingStateProvince: cityData.state || value.mailingStateProvince || '',
+              mailingPostalCode: cityData.postalCode || value.mailingPostalCode || '',
+              mailingCountry: cityData.country || value.mailingCountry || '',
+            });
+          }}
           disabled={disabled}
+          placeholder="Street, apt / suite"
+          types={['geocode', 'establishment']}
         />
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <IconInput
@@ -279,6 +373,24 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
             placeholder="City or town"
             value={value.mailingCity ?? ''}
             onChange={(e) => set('mailingCity', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="State or province"
+            value={value.mailingStateProvince ?? ''}
+            onChange={(e) => set('mailingStateProvince', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Postal code"
+            value={value.mailingPostalCode ?? ''}
+            onChange={(e) => set('mailingPostalCode', e.target.value)}
             disabled={disabled}
           />
           <IconInput

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import { User, Globe, MapPin, Hash, FileSignature, CalendarDays, AlertTriangle, Info } from 'lucide-react';
 import { IconInput } from '../../IconInput';
 import { Checkbox } from '../../Checkbox';
+import { LocationAutocomplete } from '../../LocationAutocomplete';
 import { lookupTreaty, normalizeCountryCode } from '../../../utils/taxTreaties';
 
 export interface W8BENFormData {
@@ -9,9 +10,14 @@ export interface W8BENFormData {
   citizenship?: string;
   permanentAddress?: string;
   permanentCity?: string;
+  // prosciutto-92107: split address into structured fields.
+  permanentStateProvince?: string;
+  permanentPostalCode?: string;
   permanentCountry?: string;
   mailingAddress?: string;
   mailingCity?: string;
+  mailingStateProvince?: string;
+  mailingPostalCode?: string;
   mailingCountry?: string;
   usTin?: string;
   foreignTin?: string;
@@ -37,9 +43,35 @@ interface W8BENFormProps {
   value: W8BENFormData;
   onChange: (next: W8BENFormData) => void;
   disabled?: boolean;
+  /**
+   * prosciutto-92107: surfaced when the picked permanent-residence country is
+   * the United States — W-8BEN is for foreign persons only. Parent component
+   * should discard the W-8BEN draft and switch the editor to W-9.
+   */
+  onSwitchFormType?: (target: 'w9') => void;
 }
 
-export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled }) => {
+// prosciutto-92107: case-insensitive US match. Google Places returns
+// "United States"; the IRS treats territories (PR, GU, USVI) as US for W-9 vs
+// W-8 purposes too — keep the list small but cover the common picks.
+const US_COUNTRY_NAMES = new Set([
+  'united states',
+  'united states of america',
+  'usa',
+  'us',
+  'puerto rico',
+  'guam',
+  'u.s. virgin islands',
+  'us virgin islands',
+  'american samoa',
+  'northern mariana islands',
+]);
+const isUSCountry = (country?: string | null): boolean => {
+  if (!country) return false;
+  return US_COUNTRY_NAMES.has(country.trim().toLowerCase());
+};
+
+export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled, onSwitchFormType }) => {
   // ----- hooks (must stay above any early returns per react-hooks rules) -----
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
@@ -132,14 +164,28 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
 
       <div className="space-y-2">
         <p className="text-xs text-theme-text-muted">Permanent residence address</p>
-        <IconInput
-          icon={MapPin}
-          type="text"
-          placeholder="Street, apt / suite"
+        {/* prosciutto-92107: Google Places autocomplete on the street input.
+            On pick, fills City / State or Province / Postal Code / Country.
+            Each field remains individually editable. */}
+        <LocationAutocomplete
           value={value.permanentAddress ?? ''}
-          onChange={(e) => set('permanentAddress', e.target.value)}
+          onChange={(v) => set('permanentAddress', v)}
+          onCitySelected={(cityData) => {
+            const nextAddress = cityData.street || value.permanentAddress || cityData.formattedName || '';
+            onChange({
+              ...value,
+              permanentAddress: nextAddress,
+              permanentCity: cityData.cityName || value.permanentCity || '',
+              permanentStateProvince: cityData.state || value.permanentStateProvince || '',
+              permanentPostalCode: cityData.postalCode || value.permanentPostalCode || '',
+              permanentCountry: cityData.country || value.permanentCountry || '',
+              // Re-evaluate treaty auto-fill against the newly picked country.
+              treatyAutoFilledFor: undefined,
+            });
+          }}
           disabled={disabled}
-          required
+          placeholder="Street, apt / suite"
+          types={['geocode', 'establishment']}
         />
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <IconInput
@@ -150,6 +196,24 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
             onChange={(e) => set('permanentCity', e.target.value)}
             disabled={disabled}
             required
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="State or province"
+            value={value.permanentStateProvince ?? ''}
+            onChange={(e) => set('permanentStateProvince', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Postal code"
+            value={value.permanentPostalCode ?? ''}
+            onChange={(e) => set('permanentPostalCode', e.target.value)}
+            disabled={disabled}
           />
           <IconInput
             icon={MapPin}
@@ -165,17 +229,50 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
             required
           />
         </div>
+        {isUSCountry(value.permanentCountry) && (
+          <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10 mt-2">
+            <div className="flex items-start gap-2.5">
+              <AlertTriangle size={16} className="text-amber-300 mt-0.5 flex-shrink-0" />
+              <div className="flex-1">
+                <div className="text-xs text-amber-100 [.gpp-theme_&]:text-amber-900">
+                  <strong>W-8BEN is for foreign persons.</strong> Your permanent
+                  residence can't be in the United States. If you're a US person,
+                  use W-9 instead.
+                </div>
+                {onSwitchFormType && (
+                  <button
+                    type="button"
+                    onClick={() => onSwitchFormType('w9')}
+                    className="mt-2 text-xs px-3 py-1.5 rounded bg-amber-500/20 hover:bg-amber-500/30 text-amber-100 font-medium border border-amber-500/40 [.gpp-theme_&]:text-amber-900 [.gpp-theme_&]:bg-amber-500/30 [.gpp-theme_&]:hover:bg-amber-500/40 [.gpp-theme_&]:border-amber-700/40"
+                  >
+                    Switch to W-9
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="space-y-2">
         <p className="text-xs text-theme-text-muted">Mailing address (if different)</p>
-        <IconInput
-          icon={MapPin}
-          type="text"
-          placeholder="Street, apt / suite"
+        <LocationAutocomplete
           value={value.mailingAddress ?? ''}
-          onChange={(e) => set('mailingAddress', e.target.value)}
+          onChange={(v) => set('mailingAddress', v)}
+          onCitySelected={(cityData) => {
+            const nextAddress = cityData.street || value.mailingAddress || cityData.formattedName || '';
+            onChange({
+              ...value,
+              mailingAddress: nextAddress,
+              mailingCity: cityData.cityName || value.mailingCity || '',
+              mailingStateProvince: cityData.state || value.mailingStateProvince || '',
+              mailingPostalCode: cityData.postalCode || value.mailingPostalCode || '',
+              mailingCountry: cityData.country || value.mailingCountry || '',
+            });
+          }}
           disabled={disabled}
+          placeholder="Street, apt / suite"
+          types={['geocode', 'establishment']}
         />
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <IconInput
@@ -184,6 +281,24 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled 
             placeholder="City or town"
             value={value.mailingCity ?? ''}
             onChange={(e) => set('mailingCity', e.target.value)}
+            disabled={disabled}
+          />
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="State or province"
+            value={value.mailingStateProvince ?? ''}
+            onChange={(e) => set('mailingStateProvince', e.target.value)}
+            disabled={disabled}
+          />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <IconInput
+            icon={MapPin}
+            type="text"
+            placeholder="Postal code"
+            value={value.mailingPostalCode ?? ''}
+            onChange={(e) => set('mailingPostalCode', e.target.value)}
             disabled={disabled}
           />
           <IconInput

--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { IconInput } from "../../IconInput";
 import { Checkbox } from "../../Checkbox";
+import { LocationAutocomplete } from "../../LocationAutocomplete";
 
 export interface W9FormData {
   name?: string;
@@ -29,6 +30,14 @@ export interface W9FormData {
   exemptPayeeCode?: string;
   fatcaCode?: string;
   address?: string;
+  // prosciutto-92107: split address into structured fields. Old drafts that
+  // saved `cityStateZip` are still accepted server-side via the back-compat
+  // shim, but new submits prefer city/state/zipCode for autofill round-trip
+  // and a cleaner PDF render.
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  /** @deprecated kept on the type for back-compat with pre-prosciutto drafts. */
   cityStateZip?: string;
   accountNumbers?: string;
   ssn?: string;
@@ -415,24 +424,59 @@ export const W9Form: React.FC<W9FormProps> = ({
             </div>
           )}
 
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="Address (number, street, apt / suite)"
+          {/* prosciutto-92107: Google Places autocomplete on the street input.
+              On pick, fills City / State / ZIP from address_components; each
+              field is still individually editable afterwards. */}
+          <LocationAutocomplete
             value={value.address ?? ""}
-            onChange={(e) => set("address", e.target.value)}
-            disabled={disabled}
-            required
+            onChange={(v) => set("address", v)}
+            onCitySelected={(cityData) => {
+              // Compose street if Google parsed one, otherwise leave the
+              // formatted address the user already saw in the input.
+              const nextAddress = cityData.street || value.address || cityData.formattedName || "";
+              // W-9 is US-only — ignore country, keep state as 2-letter code.
+              onChange({
+                ...value,
+                address: nextAddress,
+                city: cityData.cityName || value.city || "",
+                state: cityData.state || value.state || "",
+                zipCode: cityData.postalCode || value.zipCode || "",
+              });
+            }}
+            placeholder="Address (number, street, apt / suite)"
+            // Allow both establishment + geocode picks so users can pick "123
+            // Main St" or "Acme Corp" (the latter still yields address parts).
+            types={['geocode', 'establishment']}
           />
-          <IconInput
-            icon={MapPin}
-            type="text"
-            placeholder="City, state, and ZIP code"
-            value={value.cityStateZip ?? ""}
-            onChange={(e) => set("cityStateZip", e.target.value)}
-            disabled={disabled}
-            required
-          />
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <IconInput
+              icon={MapPin}
+              type="text"
+              placeholder="City"
+              value={value.city ?? ""}
+              onChange={(e) => set("city", e.target.value)}
+              disabled={disabled}
+              required
+            />
+            <IconInput
+              icon={MapPin}
+              type="text"
+              placeholder="State (e.g. CA)"
+              value={value.state ?? ""}
+              onChange={(e) => set("state", e.target.value)}
+              disabled={disabled}
+              required
+            />
+            <IconInput
+              icon={MapPin}
+              type="text"
+              placeholder="ZIP code"
+              value={value.zipCode ?? ""}
+              onChange={(e) => set("zipCode", e.target.value)}
+              disabled={disabled}
+              required
+            />
+          </div>
 
           <div>
             <p className="text-xs text-theme-text-muted mb-2">


### PR DESCRIPTION
## Summary

- Wires `LocationAutocomplete` (Google Places, post-marinara-92106) onto the street-address input of W-9, W-8BEN (permanent + mailing), and W-8BEN-E (permanent + mailing). On pick, populates separate **City / State or Province / Postal Code / Country** fields. All fields stay individually editable.
- W-9 now stores `city` / `state` / `zipCode` instead of a single combined `cityStateZip`. Old drafts that still carry `cityStateZip` keep validating + rendering (back-compat in both validator and PDF).
- W-8BEN / W-8BEN-E gain `permanentStateProvince` / `permanentPostalCode` + matching mailing fields, surfaced in the form UI and collapsed back into the single PDF "City or town" box at render time.
- Surfaces an amber "W-8 is for foreign persons / entities" warning + a one-click "Switch to W-9" button whenever the picked permanent-residence country is the United States (or a US territory).
- `LocationAutocomplete.CityData` extended with optional `street` + `postalCode` parsed from `address_components` (`street_number` + `route`, `postal_code`). Existing consumers (EventDetailsTab, GPP pages, VenueForm) keep working — the new fields are optional.

## Test plan

- [ ] Open W-9 -> type address -> Google suggestions appear -> pick one -> Address / City / State / ZIP all populate -> submit -> PDF renders correctly.
- [ ] Open W-8BEN -> autocomplete fills street + city + state/province + postal code + country on the permanent residence block.
- [ ] Pick a US country for W-8BEN permanent residence -> amber warning appears with "Switch to W-9" button -> clicking it switches the editor.
- [ ] Repeat for W-8BEN-E (entity + mailing address).
- [ ] Confirm legacy drafts with only `cityStateZip` still submit + render (PDF falls back to combined field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)