### PR TITLE
scamorza-58296: graceful receipt-OCR fallback + manual amount entry

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -573,11 +573,37 @@ router.post(
         where: { id: partyId },
         select: { country: true },
       });
-      const ocr = await analyzeReceipt({
-        imageUrl,
-        partyCountry: partyForCountry?.country ?? null,
-      });
-      const fx = await convertToUSD(ocr.amount, ocr.currency);
+      // scamorza-58296: graceful fallback. A transient OCR/FX failure used to
+      // bubble to next(error) → bare HTTP 500, dead-ending the host with an
+      // "internal server error" on the receipt row. Instead, catch here and
+      // return a shape-compatible 200 that flags OCR_FAILED so the frontend
+      // drops the host into a manual USD-amount entry field (mirrors the
+      // POST /payouts allSettled resilience for the preview path).
+      let ocr: Awaited<ReturnType<typeof analyzeReceipt>>;
+      let fx: Awaited<ReturnType<typeof convertToUSD>>;
+      try {
+        ocr = await analyzeReceipt({
+          imageUrl,
+          partyCountry: partyForCountry?.country ?? null,
+        });
+        fx = await convertToUSD(ocr.amount, ocr.currency);
+      } catch (err) {
+        console.warn(`[ocr-preview] OCR failed for party ${partyId}; returning manual-entry fallback.`, err);
+        return res.json({
+          amount: 0,
+          currency: 'USD',
+          originalAmount: 0,
+          originalCurrency: '',
+          exchangeRate: 0,
+          confidence: 0,
+          items: [],
+          lineItems: null,
+          ocrRaw: null,
+          fxSource: 'unresolved',
+          conversionNote: undefined,
+          ocrError: 'OCR_FAILED',
+        });
+      }
 
       // mortadella-92103: when FX can't resolve (no currency from OCR + no
       // country prior + no override), surface that to the host so they can

--- a/frontend/src/components/payouts/ReceiptUpload.tsx
+++ b/frontend/src/components/payouts/ReceiptUpload.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useState } from 'react';
-import { Loader2, X, Upload, Receipt as ReceiptIcon, AlertCircle, CheckCircle2, FileText } from 'lucide-react';
+import { Loader2, X, Upload, Receipt as ReceiptIcon, AlertCircle, CheckCircle2, FileText, DollarSign } from 'lucide-react';
 import { uploadPayoutPhoto } from '../../lib/supabase';
 import { previewReceiptOCR } from '../../lib/api';
 import { OcrPreviewResult } from '../../types';
 import { CurrencyOverrideSelect } from './CurrencyOverrideSelect';
+import { IconInput } from '../IconInput';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
 
 export interface ReceiptItem {
@@ -175,7 +176,35 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
                       <Loader2 size={12} className="animate-spin" /> Reading receipt…
                     </span>
                   )}
-                  {item.status === 'done' && item.ocr && (
+                  {/* scamorza-58296: automatic read failed (transient OCR
+                      error) — arrives as a 200 with ocrError='OCR_FAILED', so
+                      it lands in the done branch. Drop the host into a manual
+                      USD-amount entry instead of dead-ending. */}
+                  {item.status === 'done' && item.ocr?.ocrError === 'OCR_FAILED' && (
+                    <ManualAmountEntry
+                      amount={item.ocr.amount}
+                      onAmount={amount => {
+                        const valid = Number.isFinite(amount) && amount > 0;
+                        const next = updateItem(items, item.id, {
+                          ocr: {
+                            ...item.ocr!,
+                            amount,
+                            originalAmount: amount,
+                            originalCurrency: 'USD',
+                            exchangeRate: 1,
+                            confidence: 1,
+                            fxSource: 'usd-passthrough',
+                            // clear the failure flag once a valid amount is
+                            // entered so submit treats this as a normal USD
+                            // receipt rather than excluding it.
+                            ocrError: valid ? null : 'OCR_FAILED',
+                          },
+                        });
+                        onChange(next);
+                      }}
+                    />
+                  )}
+                  {item.status === 'done' && item.ocr && item.ocr.ocrError !== 'OCR_FAILED' && (
                     <span className="inline-flex items-center gap-2 flex-wrap">
                       <span className="inline-flex items-center gap-1">
                         {item.ocr.confidence >= 0.8
@@ -242,6 +271,45 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
 function updateItem(items: ReceiptItem[], id: string, patch: Partial<ReceiptItem>): ReceiptItem[] {
   return items.map(it => (it.id === id ? { ...it, ...patch } : it));
 }
+
+/**
+ * scamorza-58296: manual USD-amount entry shown when the automatic OCR read
+ * failed (transient error). The host types the receipt total themselves and we
+ * persist it through the normal submit-forwarding path as a USD-passthrough
+ * amount. Local text state so partial input ("12.") doesn't fight the parsed
+ * number on every keystroke.
+ */
+const ManualAmountEntry: React.FC<{
+  amount: number;
+  onAmount: (amount: number) => void;
+}> = ({ amount, onAmount }) => {
+  const [raw, setRaw] = useState(amount > 0 ? String(amount) : '');
+
+  return (
+    <span className="block w-full">
+      <div className="max-w-[12rem]">
+        <IconInput
+          icon={DollarSign}
+          type="text"
+          inputMode="decimal"
+          value={raw}
+          placeholder="Enter amount in USD"
+          onChange={e => {
+            const v = e.target.value;
+            // Allow only a number with an optional single decimal point.
+            if (v !== '' && !/^\d*\.?\d*$/.test(v)) return;
+            setRaw(v);
+            onAmount(parseFloat(v));
+          }}
+          className="py-1.5 text-sm"
+        />
+      </div>
+      <span className="block mt-1 text-xs text-theme-text-muted">
+        Couldn't read this receipt automatically — enter the amount in USD.
+      </span>
+    </span>
+  );
+};
 
 /**
  * bocconcino-92104: small thumbnail component for an in-progress upload. PDFs

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2351,6 +2351,9 @@ export interface OcrPreviewResult {
   // mortadella-92103: 'CURRENCY_UNRESOLVED' when OCR couldn't pick a code
   // and FX refused to passthrough. Frontend should surface a warning and
   // exclude the receipt from the auto-sum.
+  // scamorza-58296: 'OCR_FAILED' = automatic read failed (transient OCR
+  // error); host must enter the USD amount manually. Returned as a 200 so
+  // the receipt row never dead-ends on an internal server error.
   ocrError?: string | null;
 }
 

--- a/plans/scamorza-58296-ocr-preview-graceful-fallback.md
+++ b/plans/scamorza-58296-ocr-preview-graceful-fallback.md
@@ -1,0 +1,47 @@
+# scamorza-58296: graceful receipt-OCR preview fallback + manual amount entry
+
+## Problem
+A host on `/auburn` uploaded a receipt and the row showed "internal server error"
+with no way to proceed. Any transient OCR-call failure dead-ended the host.
+
+## Root cause
+`POST /:partyId/payouts/ocr-preview` in `backend/src/routes/payout.routes.ts`
+awaited `analyzeReceipt` + `convertToUSD` directly inside its `try`, and the only
+`catch` did `next(error)` → bare HTTP 500 → the frontend receipt row went to
+`status:'error'` ("internal server error") with no recovery path. The submit path
+(`POST /:partyId/payouts`) already degrades gracefully via `Promise.allSettled`;
+preview did not. The receipts/data/format are NOT the problem (gpt-4o reads them
+cleanly with the prod key) — only the lack of graceful handling.
+
+## Changes
+
+### 1. Backend — `backend/src/routes/payout.routes.ts` (ocr-preview handler)
+Auth/approval/url asserts unchanged (keep their 400/404 codes). Wrap ONLY the
+`analyzeReceipt` + `convertToUSD` block in a try/catch. On failure, do NOT call
+`next(error)`; return HTTP 200 with a shape-compatible body carrying
+`ocrError: 'OCR_FAILED'` (amount 0, fxSource 'unresolved', empty items/lineItems)
+so the frontend can drop into manual entry. Existing success/`unresolved`
+response block is untouched.
+
+### 2. Frontend types — `frontend/src/types.ts` (`OcrPreviewResult.ocrError`)
+Field already existed; documented the new `'OCR_FAILED'` value.
+
+### 3. Frontend client — `frontend/src/lib/api.ts` (`previewReceiptOCR`)
+Verify-only. `apiRequest` only throws on `!response.ok`, so a 200 carrying
+`ocrError` resolves normally. No code change.
+
+### 4. Frontend UI — `frontend/src/components/payouts/ReceiptUpload.tsx`
+An OCR failure now arrives as a 200 with `ocr.ocrError === 'OCR_FAILED'`, flowing
+into the `status:'done'` branch. For such rows, render an editable USD-amount
+`IconInput` (manual entry) instead of the green amount + confidence +
+CurrencyOverrideSelect. On change, update the item's `ocr` in-place:
+`amount`/`originalAmount` = typed number, `originalCurrency:'USD'`,
+`exchangeRate:1`, `confidence:1`, `fxSource:'usd-passthrough'`, and clear
+`ocrError` once a valid amount is entered so submit treats it as a normal USD
+receipt. The genuine `status:'error'` branch (network/auth/non-2xx) stays as-is.
+
+## Deploy ordering
+The backend change must be **merged + the backend deployed from master** before
+the manual-amount UI works on the preview, because preview frontends call the
+**production backend** (preview FE → prod BE). Until the backend deploys, a
+transient OCR failure on preview still returns a 500.


### PR DESCRIPTION
Fixes the /auburn internal-server-error on receipt upload.

**Root cause:** `POST /:partyId/payouts/ocr-preview` returned a bare 500 on any transient OCR/FX failure (`next(error)`), so the frontend receipt row showed "internal server error" with no recovery path. The submit path already degrades via `Promise.allSettled`; preview did not.

**Fix:** wrap only the `analyzeReceipt` + `convertToUSD` block in a try/catch and return a shape-compatible HTTP 200 with `ocrError: 'OCR_FAILED'`. The frontend then renders a manual USD-amount `IconInput` for those rows so the host enters the total themselves; it persists as a usd-passthrough amount through the normal submit path. Auth/approval/url asserts keep their original 400/404 codes.

**Files**
- `backend/src/routes/payout.routes.ts` — try/catch + 200 fallback
- `frontend/src/types.ts` — document `'OCR_FAILED'`
- `frontend/src/components/payouts/ReceiptUpload.tsx` — manual-amount entry UI
- `plans/scamorza-58296-ocr-preview-graceful-fallback.md`

**Deploy ordering:** the backend change must be **merged + the backend deployed from master** before the manual-amount UI works on the preview, because preview frontends call the **production backend** (preview FE → prod BE). Until then a transient OCR failure on preview still 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)