### PR TITLE
ricotta-58494: passive-harvest unknown group chat_ids in webhook (fill-if-empty, one write per group)

### DIFF
--- a/backend/src/routes/telegram-webhook.routes.ts
+++ b/backend/src/routes/telegram-webhook.routes.ts
@@ -141,9 +141,39 @@ router.post('/', async (req: Request, res: Response, _next: NextFunction) => {
           } catch (captureErr: any) {
             console.error('[Telegram Webhook] /register capture failed:', captureErr?.message || captureErr);
           }
+          // /register handled (with reply) — always 200, never fall through.
+          return res.status(200).json({ ok: true });
         }
-        // Group message handled (command or ignored non-command) — always 200,
-        // never fall through to the private-DM path.
+
+        // ── ricotta-58494: passive harvest ───────────────────────────────
+        // Privacy mode is OFF, so every group message already reaches us. For
+        // a non-`/register` group message we silently learn the group's
+        // chat_id the FIRST time we ever see it. To avoid a write firehose
+        // (the bot sits in 466+ groups), do ONE cheap indexed point lookup on
+        // the unique `chat_id`: if a capture row already exists this is a
+        // no-op (no re-upsert, no last_seen). Only a never-before-seen group
+        // triggers a single captureTelegramGroup() — which records it and, on
+        // a title→city match, fill-if-empty write-throughs to
+        // city_telegram_groups; unmatched groups become pending captures for
+        // the /underboss gap tab. No in-group reply (unlike /register).
+        try {
+          const existing = await prisma.telegramGroupCapture.findUnique({
+            where: { chatId: BigInt(msgChat.id) },
+            select: { id: true },
+          });
+          if (!existing) {
+            await captureTelegramGroup({
+              chatId: msgChat.id,
+              title: msgChat.title ?? null,
+              chatType: msgChat.type,
+            });
+          }
+        } catch (passiveErr: any) {
+          console.error('[Telegram Webhook] passive-harvest capture failed:', passiveErr?.message || passiveErr);
+        }
+
+        // Group message fully handled (passive capture or known-group no-op) —
+        // always 200, never fall through to the private-DM path.
         return res.status(200).json({ ok: true });
       }
     }


### PR DESCRIPTION
## What

Privacy mode is OFF, so every message in any group the bot already sits in already reaches our webhook. Today we ignore non-`/register` group messages (return 200, no capture). This adds a guarded **passive-harvest** branch that auto-collects the `chat_id` of every group the bot is already in.

## How

In `backend/src/routes/telegram-webhook.routes.ts`, for a group/supergroup `message` that is NOT the `/register` command:

1. **Cheap gate** — one indexed unique point lookup on `telegram_group_captures.chat_id`. If a row already exists → no-op, `return 200`. No re-upsert, no `last_seen` bump on every message (that's the firehose we avoid — the bot sits in 466+ groups).
2. **Never-before-seen group** → a single `captureTelegramGroup({ chatId, title, chatType })` call (silent, **no in-group reply** unlike `/register`). This records the group and, on a title→city match, **fill-if-empty** write-throughs to `city_telegram_groups` (never overwrites a different existing chat_id; conflicts stay pending). Unmatched groups become pending captures for the /underboss gap tab.
3. Always `return 200`.

Ordering preserved: `my_chat_member` → `/register` (command, with reply) → passive-capture (non-command group message) → existing private-DM fallthrough. A group update never falls into the private-DM path. All DB work is wrapped in try/catch and still returns a fast 2xx.

- **One write per never-seen group**; known groups cost exactly one indexed read.
- Relies on the existing `captureTelegramGroup` fill-if-empty guard — no new write logic.
- **No migration needed** (`telegram_group_captures` already exists, `chat_id` UNIQUE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)