### PR TITLE
feat(marinara-71630): admin SWC rules to config + payout POST enforcement + super-admin flag (P7)

### DIFF
--- a/backend/src/config/seed.example.json
+++ b/backend/src/config/seed.example.json
@@ -94,5 +94,12 @@
   },
 
   "_note_gpp_global_editors": "PLACEHOLDER global-editor allowlist (marinara-71630 P6) documenting SHAPE only — an OBVIOUSLY-FAKE example email. Real emails are seeded separately and NOT committed. A plain string[] of emails that get invisible editor access to ALL GPP events (they don't appear in any party's co_hosts). Access checks compare emails case-INSENSITIVELY. Empty list = no one gets global-editor rights (safe fallback); normal owner/co-host/underboss/admin checks still apply.",
-  "private.gpp_global_editors": ["editor@example.com"]
+  "private.gpp_global_editors": ["editor@example.com"],
+
+  "_note_swc_hub_rules": "PLACEHOLDER SWC-hub party rules (marinara-71630 P7) documenting SHAPE only — OBVIOUSLY-FAKE values. Real values are seeded separately and NOT committed. Drives the payments-admin SWC warning (frontend-only admin ACK, not an enforcement gate). `countries` + `tags` flag a party SWC-hub (the matcher in swcHub.ts matches countries EXACTLY by name and tags EXACTLY); `excludeTags` force a party OUT of the gate and take precedence (matched case-INSENSITIVELY + trimmed, so seed exclude values lowercased). Empty lists = nothing flagged SWC-hub (safe fallback; the soft warning simply doesn't appear).",
+  "private.swc_hub_rules": {
+    "countries": ["Exampleland"],
+    "tags": ["Example Hub"],
+    "excludeTags": ["nonhub"]
+  }
 }

--- a/backend/src/lib/privateConfig.test.ts
+++ b/backend/src/lib/privateConfig.test.ts
@@ -17,6 +17,7 @@ import {
   getReimbursementCapBands,
   getSponsorshipPricing,
   getGppGlobalEditors,
+  getSwcHubRules,
   invalidateAll,
   PRIVATE_CONFIG_KEYS,
 } from './privateConfig.js';
@@ -201,5 +202,45 @@ describe('getGppGlobalEditors', () => {
   it('falls back to [] when the stored value is not valid JSON', async () => {
     mockPrisma.appConfig.findUnique.mockResolvedValue({ value: 'not-json[' });
     expect(await getGppGlobalEditors()).toEqual([]);
+  });
+});
+
+// marinara-71630 P7: SWC-hub party rules accessor. Cover read-through and the
+// SAFE (empty = nothing flagged SWC) fallback.
+describe('getSwcHubRules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateAll();
+  });
+
+  it('reads the rules from app_config when present', async () => {
+    const seeded = {
+      countries: ['United States'],
+      tags: ['SWC Hub'],
+      excludeTags: ['nonhub'],
+    };
+    mockPrisma.appConfig.findUnique.mockResolvedValue({ value: JSON.stringify(seeded) });
+
+    const rules = await getSwcHubRules();
+
+    expect(rules).toEqual(seeded);
+    expect(mockPrisma.appConfig.findUnique).toHaveBeenCalledWith({
+      where: { key: PRIVATE_CONFIG_KEYS.swcHubRules },
+    });
+  });
+
+  it('falls back to EMPTY lists (nothing flagged SWC-hub) when absent', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue(null);
+    expect(await getSwcHubRules()).toEqual({ countries: [], tags: [], excludeTags: [] });
+  });
+
+  it('falls back to empty rules (never throws) when the DB read fails', async () => {
+    mockPrisma.appConfig.findUnique.mockRejectedValue(new Error('db down'));
+    expect(await getSwcHubRules()).toEqual({ countries: [], tags: [], excludeTags: [] });
+  });
+
+  it('falls back to empty rules when the stored value is not valid JSON', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue({ value: 'not-json{' });
+    expect(await getSwcHubRules()).toEqual({ countries: [], tags: [], excludeTags: [] });
   });
 });

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -34,6 +34,7 @@ const KEYS = {
   reimbursementCapBands: 'private.reimbursement_cap_bands',
   sponsorshipPricing: 'private.sponsorship_pricing',
   gppGlobalEditors: 'private.gpp_global_editors',
+  swcHubRules: 'private.swc_hub_rules',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -377,6 +378,44 @@ export function getSponsorshipPricing(): Promise<SponsorshipPricing> {
  */
 export function getGppGlobalEditors(): Promise<string[]> {
   return getConfig<string[]>(KEYS.gppGlobalEditors, []);
+}
+
+// ---------------------------------------------------------------------------
+// SWC-hub party rules (marinara-71630 P7)
+//
+// Which parties are SWC-hub-routed (reimbursement handled through SWC, not
+// rsv.pizza) used to be hardcoded in the OPEN frontend (`frontend/src/utils/
+// swcHub.ts`): country === 'United States', the 'SWC Hub' event tag, and a
+// 'nonhub' exclusion tag. Those business literals move here, into `app_config`
+// (key `private.swc_hub_rules`), out of the open-source bundle. The non-secret
+// MATCHING logic stays in `swcHub.ts`; this just supplies the data.
+// ---------------------------------------------------------------------------
+
+export interface SwcHubRules {
+  /** Country names that flag a party as SWC-hub (matched per swcHub.ts). */
+  countries: string[];
+  /** Event tags that flag a party as SWC-hub. */
+  tags: string[];
+  /** Event tags that force a party OUT of the SWC-hub gate (takes precedence). */
+  excludeTags: string[];
+}
+
+/**
+ * SWC-hub party matching rules consumed by the payments-admin SWC warning.
+ *
+ * Fallback = EMPTY lists (`{ countries: [], tags: [], excludeTags: [] }`). This
+ * is FAIL-SAFE: with no rules NOTHING is flagged SWC-hub, so the worst case is
+ * "the SWC admin warning doesn't appear until config is seeded" — the SWC
+ * warning is a frontend-only admin ACK (not an enforcement gate), so an
+ * unseeded config simply means the soft warning doesn't block a send, never an
+ * over-broad block. Real values are seeded to `app_config` out-of-band.
+ */
+export function getSwcHubRules(): Promise<SwcHubRules> {
+  return getConfig<SwcHubRules>(KEYS.swcHubRules, {
+    countries: [],
+    tags: [],
+    excludeTags: [],
+  });
 }
 
 export { KEYS as PRIVATE_CONFIG_KEYS };

--- a/backend/src/lib/reimbursementOptions.ts
+++ b/backend/src/lib/reimbursementOptions.ts
@@ -12,6 +12,8 @@
  */
 
 import type { ReimbursementOption, ReimbursementRules, CountryRule } from './privateConfig.js';
+import { getReimbursementRules } from './privateConfig.js';
+import { isMercuryBlocked } from './mercuryBlockedCountries.js';
 
 /** A fully-resolved option ready to send to the frontend. */
 export interface ResolvedOption {
@@ -94,4 +96,41 @@ export function resolveReimbursementOptions(
     });
   }
   return out;
+}
+
+/**
+ * Resolve a party's reimbursement options with the SAME layering the
+ * `GET /api/parties/:id/reimbursement-options` endpoint applies:
+ *  1. config-resolved options ({@link resolveReimbursementOptions} over
+ *     {@link getReimbursementRules}), then
+ *  2. the code-side Mercury sanctions gate ({@link isMercuryBlocked}) layered on
+ *     top — if the party's country is Mercury-blocked, the `mercury_card` entry
+ *     (when present) is forced `enabled:false` with a compliance reason.
+ *
+ * This is the single source of truth for "which payout methods may this party
+ * use", shared by the GET endpoint (display) and the PATCH /api/user/me save
+ * guard (enforcement) so they can never drift. Never throws — an unseeded
+ * config yields `[]`.
+ */
+export async function resolvePartyReimbursementOptions(
+  party: ResolverParty,
+): Promise<ResolvedOption[]> {
+  const rules = await getReimbursementRules();
+  const options = resolveReimbursementOptions(party, rules);
+
+  // marinara-71630: the config resolver matches country EXACTLY, but the
+  // Mercury sanctions gate must NORMALIZE (lowercase / strip parentheticals) so
+  // casing/parenthetical variants of a blocked country are still blocked. The
+  // sanctions list is compliance, not a private business secret, so it stays in
+  // code (`isMercuryBlocked`) and is layered over the config-resolved options
+  // here. Only mutate the mercury_card entry if it's present.
+  if (isMercuryBlocked(party.country)) {
+    const mercury = options.find((o) => o.id === 'mercury_card');
+    if (mercury) {
+      mercury.enabled = false;
+      mercury.disabledReason = `Mercury cards are unavailable in ${party.country ?? 'your country'} due to compliance restrictions.`;
+    }
+  }
+
+  return options;
 }

--- a/backend/src/routes/config.routes.ts
+++ b/backend/src/routes/config.routes.ts
@@ -16,6 +16,7 @@ import {
   getReimbursementTiers,
   getReimbursementCapBands,
   getPayoutCaps,
+  getSwcHubRules,
 } from '../lib/privateConfig.js';
 
 /**
@@ -116,13 +117,24 @@ router.get(
   requirePaymentsAdminOrUnderboss,
   async (_req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const caps = await getPayoutCaps();
+      // marinara-71630 P7: bundle the SWC-hub matching rules into this same
+      // payments-admin endpoint. The SWC warning (SwcHubWarning) renders on the
+      // exact same /payments modals as the cap warning, for the exact same
+      // viewer set (payments-admin OR underboss), so it reuses this gate rather
+      // than adding a sibling endpoint. The rules are non-secret business data
+      // (country/tag lists) moved out of the open-source frontend bundle.
+      const [caps, swcHub] = await Promise.all([getPayoutCaps(), getSwcHubRules()]);
       // Only the two caps the frontend modals actually use for UX. The rest of
       // PayoutCaps (per-tx, daily, w9 threshold, hard ceiling) stay backend-only.
       res.json({
         payoutCaps: {
           perSubmissionMaxUsd: caps.perSubmissionMaxUsd,
           perAddressHardCapUsd: caps.perAddressHardCapUsd,
+        },
+        swcHub: {
+          countries: swcHub.countries,
+          tags: swcHub.tags,
+          excludeTags: swcHub.excludeTags,
         },
       });
     } catch (error) {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -16,9 +16,8 @@ import {
 } from '../helpers/reimbursementCapAudit.js';
 import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
-import { getReimbursementRules, getGppGlobalEditors } from '../lib/privateConfig.js';
-import { resolveReimbursementOptions } from '../lib/reimbursementOptions.js';
-import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
+import { getGppGlobalEditors } from '../lib/privateConfig.js';
+import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -2360,26 +2359,13 @@ router.get('/:id/reimbursement-options', async (req: AuthRequest, res: Response,
     });
     if (!party) throw new AppError('Party not found', 404, 'NOT_FOUND');
 
-    const rules = await getReimbursementRules();
-    const options = resolveReimbursementOptions(
-      { country: party.country, eventTags: party.eventTags },
-      rules
-    );
-
-    // marinara-71630: the config resolver matches country EXACTLY, but the
-    // Mercury sanctions gate must NORMALIZE (lowercase / strip parentheticals)
-    // so casing/parenthetical variants of a blocked country are still blocked.
-    // The sanctions list is compliance, not a private business secret, so it
-    // stays in code (`isMercuryBlocked`) and is layered over the config-resolved
-    // options here rather than encoded into `app_config`. Only mutate the
-    // mercury_card entry if it's present; leave everything else untouched.
-    if (isMercuryBlocked(party.country)) {
-      const mercury = options.find((o) => o.id === 'mercury_card');
-      if (mercury) {
-        mercury.enabled = false;
-        mercury.disabledReason = `Mercury cards are unavailable in ${party.country ?? 'your country'} due to compliance restrictions.`;
-      }
-    }
+    // Resolve config options + the code-side Mercury sanctions gate via the
+    // shared helper (same layering the PATCH /api/user/me save guard enforces,
+    // so display + enforcement can't drift).
+    const options = await resolvePartyReimbursementOptions({
+      country: party.country,
+      eventTags: party.eventTags,
+    });
 
     res.json({ options });
   } catch (error) {

--- a/backend/src/routes/user.routes.test.ts
+++ b/backend/src/routes/user.routes.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = 'test-secret';
+
+// marinara-71630 P7: cover the PATCH /api/user/me payout-method SAVE guard.
+// The GET /reimbursement-options endpoint DECIDES which methods a host may use;
+// this test proves the SAVE path now hard-rejects a disallowed method (e.g.
+// mercury_card for a Mercury-blocked country) with a 400, while leaving every
+// legitimate save (an allowed method, or no partyId) untouched.
+
+const mockPrisma = vi.hoisted(() => ({
+  user: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  party: {
+    findUnique: vi.fn(),
+  },
+}));
+
+vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
+
+// ENS resolution is exercised only for usdc_base; stub it so wire/mercury saves
+// don't touch the network. Returns the input unchanged when it looks like 0x.
+vi.mock('../services/ens.service.js', () => ({
+  resolveWalletInput: vi.fn(async (input: string) => input),
+}));
+
+// Control the per-party edit gate directly (auth logic is orthogonal to the
+// payout-method enforcement under test).
+const mockCanUserEditParty = vi.hoisted(() => vi.fn());
+vi.mock('../helpers/partyAccess.js', () => ({
+  canUserEditParty: mockCanUserEditParty,
+}));
+
+// Drive the config resolver deterministically. We return rules where
+// mercury_card is visible + enabled at the config level (no country rule
+// disables it) so the test proves the code-side isMercuryBlocked layering
+// inside resolvePartyReimbursementOptions is what rejects the save. The real
+// (un-mocked) resolveReimbursementOptions + isMercuryBlocked run.
+const mockGetReimbursementRules = vi.hoisted(() => vi.fn());
+vi.mock('../lib/privateConfig.js', () => ({
+  getReimbursementRules: mockGetReimbursementRules,
+}));
+
+const parseAuth = (req: any) => {
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const decoded = jwt.verify(authHeader.split(' ')[1], JWT_SECRET) as any;
+      req.userId = decoded.userId;
+      req.userEmail = decoded.email;
+    } catch {
+      /* ignore */
+    }
+  }
+};
+
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    parseAuth(req);
+    if (!req.userId) {
+      return res.status(401).json({ error: { message: 'Unauthorized', code: 'UNAUTHORIZED' } });
+    }
+    next();
+  },
+  AuthRequest: {},
+}));
+
+import userRoutes from './user.routes.js';
+import { errorHandler } from '../middleware/error.js';
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/user', userRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+function makeToken(userId: string, email: string) {
+  return jwt.sign({ userId, email }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+const USER_ID = 'host-user-123';
+const EMAIL = 'host@example.com';
+const PARTY_ID = '00000000-0000-0000-0000-000000000001';
+
+const RULES_MERCURY_ENABLED = {
+  methods: [
+    { id: 'usdc_base', label: 'USDC on Base', kind: 'method' as const },
+    { id: 'mercury_card', label: 'Mercury virtual card', kind: 'method' as const },
+    { id: 'wire', label: 'Bank wire', kind: 'method' as const },
+  ],
+  default: ['usdc_base', 'mercury_card', 'wire'],
+  countryRules: [],
+};
+
+describe('PATCH /api/user/me - payout method save guard (marinara-71630 P7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUserEditParty.mockResolvedValue(true);
+    mockGetReimbursementRules.mockResolvedValue(RULES_MERCURY_ENABLED);
+    mockPrisma.user.update.mockResolvedValue({
+      id: USER_ID,
+      email: EMAIL,
+      name: null,
+      defaultAddress: null,
+      preferredPayoutMethod: null,
+      payoutWalletAddress: null,
+      payoutBankDetails: null,
+    });
+  });
+
+  it('rejects mercury_card for a Mercury-blocked country with 400', async () => {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, EMAIL);
+    // The party is in a Mercury-blocked country (Iran). resolvePartyReimbursementOptions
+    // layers isMercuryBlocked → mercury_card resolves enabled:false.
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'Iran', eventTags: [] });
+
+    const res = await request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('PAYOUT_METHOD_NOT_ALLOWED');
+    // The save must NOT have persisted.
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a parenthetical/cased variant of a blocked country (normalization)', async () => {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, EMAIL);
+    // Exact-match config wouldn't catch this; isMercuryBlocked normalizes it.
+    mockPrisma.party.findUnique.mockResolvedValue({
+      country: 'Iran (Islamic Republic of Iran)',
+      eventTags: [],
+    });
+
+    const res = await request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('PAYOUT_METHOD_NOT_ALLOWED');
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('allows mercury_card for a non-blocked country (normal save → 200)', async () => {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, EMAIL);
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'United States', eventTags: [] });
+    mockPrisma.user.update.mockResolvedValue({
+      id: USER_ID,
+      email: EMAIL,
+      name: null,
+      defaultAddress: null,
+      preferredPayoutMethod: 'mercury_card',
+      payoutWalletAddress: null,
+      payoutBankDetails: null,
+    });
+
+    const res = await request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.preferredPayoutMethod).toBe('mercury_card');
+    expect(mockPrisma.user.update).toHaveBeenCalled();
+  });
+
+  it('allows an allowed method (usdc_base) for any country (200)', async () => {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, EMAIL);
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'Iran', eventTags: [] });
+    mockPrisma.user.update.mockResolvedValue({
+      id: USER_ID,
+      email: EMAIL,
+      name: null,
+      defaultAddress: null,
+      preferredPayoutMethod: 'usdc_base',
+      payoutWalletAddress: '0x1111111111111111111111111111111111111111',
+      payoutBankDetails: null,
+    });
+
+    const res = await request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        preferredPayoutMethod: 'usdc_base',
+        payoutWalletAddress: '0x1111111111111111111111111111111111111111',
+        partyId: PARTY_ID,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.preferredPayoutMethod).toBe('usdc_base');
+    expect(mockPrisma.user.update).toHaveBeenCalled();
+  });
+
+  it('skips the gate (legacy save) when no partyId is supplied → 200', async () => {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, EMAIL);
+    mockPrisma.user.update.mockResolvedValue({
+      id: USER_ID,
+      email: EMAIL,
+      name: null,
+      defaultAddress: null,
+      preferredPayoutMethod: 'mercury_card',
+      payoutWalletAddress: null,
+      payoutBankDetails: null,
+    });
+
+    const res = await request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ preferredPayoutMethod: 'mercury_card' });
+
+    expect(res.status).toBe(200);
+    // No party lookup or gate when partyId is absent.
+    expect(mockPrisma.party.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.user.update).toHaveBeenCalled();
+  });
+
+  it('fails open when config is unseeded (resolver returns []) → 200', async () => {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, EMAIL);
+    // Empty rules → resolvePartyReimbursementOptions returns [] → gate is skipped.
+    mockGetReimbursementRules.mockResolvedValue({ methods: [], default: [], countryRules: [] });
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'Iran', eventTags: [] });
+    mockPrisma.user.update.mockResolvedValue({
+      id: USER_ID,
+      email: EMAIL,
+      name: null,
+      defaultAddress: null,
+      preferredPayoutMethod: 'mercury_card',
+      payoutWalletAddress: null,
+      payoutBankDetails: null,
+    });
+
+    const res = await request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.user.update).toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -2,6 +2,8 @@ import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { resolveWalletInput } from '../services/ens.service.js';
+import { canUserEditParty } from '../helpers/partyAccess.js';
+import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
 
 const router = Router();
 
@@ -44,6 +46,15 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
       preferredPayoutMethod,
       payoutWalletAddress,
       payoutBankDetails,
+      // marinara-71630 P7: the party this payout method is being configured for.
+      // Optional — when present (PaymentDetailsCard always sends it) and a
+      // payout method is being SET, the backend hard-enforces that the method is
+      // actually allowed for that party (config-resolved options + the Mercury
+      // sanctions gate, the SAME layering GET /reimbursement-options uses). This
+      // closes the gap where a crafted request could persist a disallowed method
+      // (e.g. mercury_card for a Mercury-blocked country). Legitimate saves from
+      // the card pass unchanged — the picker only ever offers enabled methods.
+      partyId,
     } = req.body;
 
     // Validate payoutMethod if provided (DB CHECK constraint mirrors this).
@@ -55,6 +66,54 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
       return res.status(400).json({
         error: { message: 'Invalid preferredPayoutMethod', code: 'VALIDATION_ERROR' },
       });
+    }
+
+    // marinara-71630 P7: hard-enforce the per-party reimbursement-option gating
+    // on the SAVE path. The GET /reimbursement-options endpoint DECIDES which
+    // methods a host may use, but until now nothing rejected a save of a
+    // disallowed method. When a non-null method is being set AND a partyId is
+    // supplied, resolve that party's allowed options and reject if the method is
+    // absent from the list or present-but-disabled. We only gate when partyId is
+    // provided (the legacy user-pref save without a party context is unchanged),
+    // and only when the caller can edit that party (so this never leaks party
+    // existence). On a config miss the resolver returns [] → we skip the gate
+    // (fail-open) so an unseeded config never blocks legitimate saves; the
+    // frontend already only offers enabled methods.
+    if (
+      preferredPayoutMethod !== undefined
+      && preferredPayoutMethod !== null
+      && partyId
+    ) {
+      const canEdit = await canUserEditParty(String(partyId), req.userId, req.userEmail);
+      if (canEdit) {
+        const party = await prisma.party.findUnique({
+          where: { id: String(partyId) },
+          select: { country: true, eventTags: true },
+        });
+        if (party) {
+          const options = await resolvePartyReimbursementOptions({
+            country: party.country,
+            eventTags: party.eventTags,
+          });
+          // Only enforce when the config actually resolved options for this
+          // party (non-empty). An empty list means unseeded config → fail-open.
+          if (options.length > 0) {
+            const opt = options.find(
+              (o) => o.id === preferredPayoutMethod && o.kind === 'method',
+            );
+            if (!opt || !opt.enabled) {
+              return res.status(400).json({
+                error: {
+                  message:
+                    opt?.disabledReason ??
+                    `The payout method "${preferredPayoutMethod}" isn't available for this event. Pick an allowed method.`,
+                  code: 'PAYOUT_METHOD_NOT_ALLOWED',
+                },
+              });
+            }
+          }
+        }
+      }
     }
 
     // taleggio-30219: resolve ENS → 0x before storing the user-default

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -4,6 +4,7 @@ import { X, Send, Loader2, CheckCircle2, XCircle, ExternalLink, AlertTriangle } 
 import { Checkbox } from '../Checkbox';
 import { SwcHubWarning } from './SwcHubWarning';
 import { isSwcHubParty } from '../../utils/swcHub';
+import { useSwcHubRules } from '../../hooks/useSwcHubRules';
 import type { AdminPayout, WalletPaidTotal } from '../../types';
 import { bulkExecutePayouts, fetchWalletPaidTotal, type BulkSendResult } from '../../lib/api';
 
@@ -35,6 +36,8 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
   onCancel,
   onComplete,
 }) => {
+  // marinara-71630 P7: SWC-hub rules from config (same payments-admin endpoint).
+  const { rules: swcHubRules } = useSwcHubRules();
   const [phase, setPhase] = useState<Phase>('idle');
   const [results, setResults] = useState<BulkSendResult[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -234,13 +237,13 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
     const swcHubRowIds = new Set<string>();
     const swcHubParties = new Set<string>();
     for (const p of eligible) {
-      if (isSwcHubParty(p.party)) {
+      if (isSwcHubParty(p.party, swcHubRules)) {
         swcHubRowIds.add(p.id);
         if (p.party?.id) swcHubParties.add(p.party.id);
       }
     }
     return { swcHubRowIds, swcHubPartyCount: swcHubParties.size };
-  }, [eligible]);
+  }, [eligible, swcHubRules]);
 
   // Close on Escape (only when not sending — never cancel an in-flight batch)
   useEffect(() => {

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../lib/api';
 import { uploadPayoutPhoto } from '../../lib/supabase';
 import { usePayoutCaps } from '../../hooks/usePayoutCaps';
+import { useSwcHubRules } from '../../hooks/useSwcHubRules';
 import type { ExternalPaymentInput, PayoutMethod } from '../../types';
 
 /**
@@ -174,6 +175,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
   // marinara-71630 P6: per-submission soft cap fetched from app_config (not
   // hardcoded). High neutral sentinel while unknown → warning stays inert.
   const { caps: payoutCaps } = usePayoutCaps();
+  // marinara-71630 P7: SWC-hub rules from config (same payments-admin endpoint).
+  const { rules: swcHubRules } = useSwcHubRules();
   const perSubmissionMaxUsd =
     payoutCaps?.perSubmissionMaxUsd ?? Number.POSITIVE_INFINITY;
 
@@ -200,7 +203,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
 
   // parmigiana-92104: derive SWC Hub status from the selected party (clean
   // when nothing's selected yet).
-  const swcHub = isSwcHubParty(selectedParty);
+  const swcHub = isSwcHubParty(selectedParty, swcHubRules);
 
   const canSubmit = useMemo(() => {
     if (!partyId.trim()) return false;

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -8,6 +8,7 @@ import { isSwcHubParty } from '../../utils/swcHub';
 import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, markReceiptDuplicate, markReceiptIneligible, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { usePayoutCaps } from '../../hooks/usePayoutCaps';
+import { useSwcHubRules } from '../../hooks/useSwcHubRules';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
 import type { AdminPayoutDetail, PayoutAuditEntry, WalletPaidTotal, ReceiptLineItem, ReceiptLineItemCategory } from '../../types';
 import {
@@ -250,6 +251,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // hardcoded). High neutral sentinel while unknown → the amber warning below
   // is inert until the real cap loads.
   const { caps: payoutCaps } = usePayoutCaps();
+  // marinara-71630 P7: SWC-hub country/tag rules now come from config (served on
+  // the same payments-admin endpoint as the caps). While unresolved (null) the
+  // matcher treats the party as NOT-SWC, so the warning simply doesn't block.
+  const { rules: swcHubRules } = useSwcHubRules();
   const perSubmissionMaxUsd =
     payoutCaps?.perSubmissionMaxUsd ?? Number.POSITIVE_INFINITY;
   // Flag-ready inline error (mirrors the unapproveError pattern).
@@ -432,7 +437,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // the override. Revert-to-pending and revert-to-approved are NOT gated
   // (those are rollback actions, not reimbursement). Reset on every modal
   // close/reopen by the parent (PayoutReviewModal is re-mounted per payout).
-  const swcHub = isSwcHubParty(payout.party);
+  const swcHub = isSwcHubParty(payout.party, swcHubRules);
   const [swcAck, setSwcAck] = useState(false);
   // Re-sync the ack on payout swap (parent reload after refresh()) so admins
   // don't carry an ack across distinct payouts displayed in the same modal.

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -48,6 +48,7 @@ import {
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
 import { isSwcHubParty } from '../../utils/swcHub';
+import { useSwcHubRules } from '../../hooks/useSwcHubRules';
 import { isVideoFile } from '../../lib/mediaUtils';
 import {
   updatePayoutDocument,
@@ -2653,6 +2654,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   busyRowId,
   loading,
 }) => {
+  // marinara-71630 P7: SWC-hub rules from config (same payments-admin endpoint).
+  const { rules: swcHubRules } = useSwcHubRules();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   // bottarga-92104: optimistic-override map for the `possible-scam` tag so the
   // pill + menu label flip immediately on click without waiting for a parent
@@ -3192,7 +3195,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                             table-level actions aren't disabled here — the per-
                             action modals (PayoutReviewModal, MarkPartyPaidModal)
                             are the canonical gate point. */}
-                        {isSwcHubParty(row.party) && (
+                        {isSwcHubParty(row.party, swcHubRules) && (
                           <span
                             className="inline-flex items-center gap-1 text-[11px] text-amber-300 px-1.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/30"
                             title="SWC Hub party — reimbursement should be processed via SWC, not rsv.pizza"

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -27,6 +27,7 @@ import {
   type ApprovedPartySearchResult,
 } from '../../lib/api';
 import { usePayoutCaps } from '../../hooks/usePayoutCaps';
+import { useSwcHubRules } from '../../hooks/useSwcHubRules';
 import type { PayoutMethod, WalletPaidTotal } from '../../types';
 
 /**
@@ -136,6 +137,11 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   // marinara-71630 P6 — per-submission cap from private config (was hardcoded
   // in the bundle). Neutral fallback while loading/on error → warning is inert.
   const { caps: payoutCaps } = usePayoutCaps();
+  // marinara-71630 P7: SWC-hub country/tag rules from config (same payments-admin
+  // endpoint as the caps). The local memo below applies the SAME looser
+  // (case-insensitive) matching this modal has always used, now against the
+  // configured rule values. While unresolved (null) nothing is flagged SWC.
+  const { rules: swcHubRules } = useSwcHubRules();
   const perSubmissionMaxUsd =
     payoutCaps?.perSubmissionMaxUsd ?? Number.POSITIVE_INFINITY;
 
@@ -349,16 +355,31 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
       ? Math.max(0, paidTotalUsd + amountNum - effectiveReimbursementCapUsd)
       : 0;
 
-  // SWC Hub derivation — mirrors isSwcHubParty's two-input shape. We accept
-  // either the country='United States' OR an event_tags entry containing
-  // 'SWC Hub' (case-insensitive).
+  // SWC Hub derivation — mirrors isSwcHubParty's two-input shape, but keeps this
+  // modal's historically LOOSER (case-insensitive) matching: country matched
+  // case-insensitively/trimmed, tag matched via case-insensitive `includes`.
+  // marinara-71630 P7: the country/tag/exclude literals now come from config
+  // (swcHubRules) instead of being hardcoded. The normalization below is
+  // UNCHANGED so behavior is preserved; null rules → not-SWC (safe default).
   const swcHub = useMemo(() => {
-    // marzano-58293: 'nonhub' tag opts the party out of the SWC Hub gate (USDC
-    // treatment) — precedence over the country + 'swc hub' signals below.
-    if ((eventTags ?? []).some((t) => t && t.trim().toLowerCase() === 'nonhub')) return false;
-    if (country && country.trim().toLowerCase() === 'united states') return true;
-    return (eventTags ?? []).some((t) => t && t.toLowerCase().includes('swc hub'));
-  }, [country, eventTags]);
+    if (!swcHubRules) return false;
+    const tags = eventTags ?? [];
+    const excludeTags = swcHubRules.excludeTags ?? [];
+    // marzano-58293: an exclude tag (e.g. 'nonhub') opts the party out of the
+    // SWC Hub gate (USDC treatment) — precedence over the country + tag signals.
+    if (
+      excludeTags.length > 0 &&
+      tags.some(
+        (t) => t && excludeTags.includes(t.trim().toLowerCase()),
+      )
+    ) {
+      return false;
+    }
+    const countries = (swcHubRules.countries ?? []).map((c) => c.trim().toLowerCase());
+    if (country && countries.includes(country.trim().toLowerCase())) return true;
+    const ruleTags = (swcHubRules.tags ?? []).map((t) => t.toLowerCase());
+    return tags.some((t) => t && ruleTags.some((rt) => t.toLowerCase().includes(rt)));
+  }, [country, eventTags, swcHubRules]);
 
   // Mercury blocked-country gate — same source as CreatePrepaymentModal
   // (pepperoni-47301). Disables the Mercury option, doesn't bypass.

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -156,6 +156,11 @@ export const PaymentDetailsCard: React.FC = () => {
       preferredPayoutMethod: method,
       payoutWalletAddress: method === 'usdc_base' ? walletAddress.trim() : null,
       payoutBankDetails: method === 'wire' ? bankDetails : null,
+      // marinara-71630 P7: send the party so the backend can hard-enforce the
+      // per-party reimbursement-option gating on save (rejects a disallowed
+      // method with 400). The client-side guard above already blocks this, but
+      // the server is now the authority — closing the crafted-request gap.
+      ...(party?.id ? { partyId: party.id } : {}),
     };
   };
 

--- a/frontend/src/hooks/payoutConfigCache.ts
+++ b/frontend/src/hooks/payoutConfigCache.ts
@@ -1,0 +1,67 @@
+import {
+  fetchPayoutConfig,
+  type PayoutConfigResponse,
+  type PayoutCapsConfig,
+  type SwcHubRulesConfig,
+} from '../lib/api';
+
+/**
+ * marinara-71630 P6/P7 — shared module-level cache for GET /api/config/payout-caps.
+ *
+ * That endpoint now returns BOTH the payout caps (P6) and the SWC-hub matching
+ * rules (P7). `usePayoutCaps` and `useSwcHubRules` are both rendered on
+ * /payments, so they share this single cached request rather than each firing
+ * their own. The in-flight promise is cached at module scope so several modals
+ * mounting together hit the network once; the resolved value is memoized so late
+ * subscribers resolve on the next tick.
+ *
+ * Fallbacks are NEUTRAL / EMPTY (never the real values) so an unseeded config or
+ * a fetch failure is SAFE: caps stay inert (high sentinel → UX warning/clamp is
+ * a no-op) and the SWC rules flag NOTHING (the admin ack warning simply doesn't
+ * appear). Both are UX-only — the backend remains the enforcement authority.
+ */
+
+/** Neutral cap fallback — high sentinel so the UX warning/clamp is inert. */
+export const NEUTRAL_PAYOUT_CAPS: PayoutCapsConfig = {
+  perSubmissionMaxUsd: Number.POSITIVE_INFINITY,
+  perAddressHardCapUsd: Number.POSITIVE_INFINITY,
+};
+
+/** Empty SWC-hub rules fallback — nothing is flagged SWC-hub. */
+export const EMPTY_SWC_HUB_RULES: SwcHubRulesConfig = {
+  countries: [],
+  tags: [],
+  excludeTags: [],
+};
+
+const NEUTRAL_CONFIG: PayoutConfigResponse = {
+  payoutCaps: NEUTRAL_PAYOUT_CAPS,
+  swcHub: EMPTY_SWC_HUB_RULES,
+};
+
+let cachedPromise: Promise<PayoutConfigResponse> | null = null;
+let cachedConfig: PayoutConfigResponse | null = null;
+
+/** Resolve the combined payout config, sharing one request across all consumers. */
+export function loadPayoutConfig(): Promise<PayoutConfigResponse> {
+  if (!cachedPromise) {
+    cachedPromise = fetchPayoutConfig()
+      .then((cfg) => {
+        cachedConfig = cfg;
+        return cfg;
+      })
+      .catch((err) => {
+        console.warn('[payoutConfigCache] failed to load payout config; using neutral fallback', err);
+        cachedConfig = NEUTRAL_CONFIG;
+        // Reset so a later mount can retry (e.g. transient 401/network).
+        cachedPromise = null;
+        return NEUTRAL_CONFIG;
+      });
+  }
+  return cachedPromise;
+}
+
+/** Synchronously-available resolved config, or null while still loading. */
+export function getCachedPayoutConfig(): PayoutConfigResponse | null {
+  return cachedConfig;
+}

--- a/frontend/src/hooks/usePayoutCaps.ts
+++ b/frontend/src/hooks/usePayoutCaps.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
-import { fetchPayoutCaps, type PayoutCapsConfig } from '../lib/api';
+import type { PayoutCapsConfig } from '../lib/api';
+import {
+  loadPayoutConfig,
+  getCachedPayoutConfig,
+  NEUTRAL_PAYOUT_CAPS,
+} from './payoutConfigCache';
 
 /**
  * marinara-71630 P6 — shared loader for the payments-admin payout caps that
@@ -8,9 +13,9 @@ import { fetchPayoutCaps, type PayoutCapsConfig } from '../lib/api';
  * numbers now live in `app_config` (private.payout_caps) and are served by
  * GET /api/config/payout-caps (payments-admin OR underboss gated).
  *
- * Caching: the fetch fires ONCE process-wide. The in-flight promise is cached at
- * module scope so several modals mounting together share a single request. The
- * resolved value is memoized so late subscribers resolve on the next tick.
+ * marinara-71630 P7: that endpoint now also carries the SWC-hub rules, so the
+ * underlying cached request is shared via `payoutConfigCache` with
+ * `useSwcHubRules` — both hooks resolve from one network request.
  *
  * Fallback: on any fetch failure (and while loading) the hook resolves to a
  * NEUTRAL cap, NOT the real production value. The backend is the enforcement
@@ -27,33 +32,7 @@ import { fetchPayoutCaps, type PayoutCapsConfig } from '../lib/api';
  * the backend rejects any over-cap amount regardless of what the frontend shows.
  */
 
-/** Neutral, non-secret fallback. High sentinel → UX warning/clamp is inert until the real cap loads. */
-export const NEUTRAL_PAYOUT_CAPS: PayoutCapsConfig = {
-  perSubmissionMaxUsd: Number.POSITIVE_INFINITY,
-  perAddressHardCapUsd: Number.POSITIVE_INFINITY,
-};
-
-// Module-level cache: shared across every hook consumer for the page lifetime.
-let cachedPromise: Promise<PayoutCapsConfig> | null = null;
-let cachedCaps: PayoutCapsConfig | null = null;
-
-function loadPayoutCaps(): Promise<PayoutCapsConfig> {
-  if (!cachedPromise) {
-    cachedPromise = fetchPayoutCaps()
-      .then((caps) => {
-        cachedCaps = caps;
-        return caps;
-      })
-      .catch((err) => {
-        console.warn('[usePayoutCaps] failed to load payout caps; using neutral fallback', err);
-        cachedCaps = NEUTRAL_PAYOUT_CAPS;
-        // Reset so a later mount can retry the fetch (e.g. transient 401/network).
-        cachedPromise = null;
-        return NEUTRAL_PAYOUT_CAPS;
-      });
-  }
-  return cachedPromise;
-}
+export { NEUTRAL_PAYOUT_CAPS };
 
 export interface UsePayoutCapsResult {
   caps: PayoutCapsConfig | null;
@@ -66,17 +45,20 @@ export interface UsePayoutCapsResult {
  * resolves.
  */
 export function usePayoutCaps(): UsePayoutCapsResult {
-  const [caps, setCaps] = useState<PayoutCapsConfig | null>(cachedCaps);
+  const [caps, setCaps] = useState<PayoutCapsConfig | null>(
+    getCachedPayoutConfig()?.payoutCaps ?? null,
+  );
 
   useEffect(() => {
-    if (cachedCaps) {
+    const cached = getCachedPayoutConfig();
+    if (cached) {
       // Already resolved (another consumer beat us to it).
-      setCaps(cachedCaps);
+      setCaps(cached.payoutCaps);
       return;
     }
     let active = true;
-    loadPayoutCaps().then((c) => {
-      if (active) setCaps(c);
+    loadPayoutConfig().then((cfg) => {
+      if (active) setCaps(cfg.payoutCaps);
     });
     return () => {
       active = false;

--- a/frontend/src/hooks/useSwcHubRules.ts
+++ b/frontend/src/hooks/useSwcHubRules.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import type { SwcHubRulesConfig } from '../lib/api';
+import {
+  loadPayoutConfig,
+  getCachedPayoutConfig,
+  EMPTY_SWC_HUB_RULES,
+} from './payoutConfigCache';
+
+/**
+ * marinara-71630 P7 — shared loader for the SWC-hub matching rules that used to
+ * be hardcoded country/tag literals in the OPEN frontend (`swcHub.ts`:
+ * 'United States', 'SWC Hub', the 'nonhub' exclusion). The real values now live
+ * in `app_config` (private.swc_hub_rules) and are served by GET
+ * /api/config/payout-caps — the same payments-admin endpoint the cap warning
+ * uses (same gate, same /payments modals), so the request is shared via
+ * `payoutConfigCache` with `usePayoutCaps`.
+ *
+ * Fallback: on any fetch failure (and while loading) the hook resolves to EMPTY
+ * rules, so NOTHING is flagged SWC-hub. This is the SAFE default — the SWC
+ * warning is a frontend-only admin ACK (not an enforcement gate), so an
+ * unseeded config simply means the soft warning doesn't appear and the send
+ * isn't blocked, never an over-broad block.
+ */
+
+export { EMPTY_SWC_HUB_RULES };
+
+export interface UseSwcHubRulesResult {
+  /**
+   * The SWC-hub rules, or null while loading. Consumers that pass this into
+   * `isSwcHubParty` can pass it directly — a null/undefined rules arg makes the
+   * matcher return false (NOT-SWC), which is the safe "rules unresolved" state.
+   */
+  rules: SwcHubRulesConfig | null;
+  loading: boolean;
+}
+
+/**
+ * Returns the shared SWC-hub rules. `rules` is null while loading; pass it
+ * straight into `isSwcHubParty(party, rules)` — the matcher treats a null rules
+ * arg as NOT-SWC, the safe default while the config resolves.
+ */
+export function useSwcHubRules(): UseSwcHubRulesResult {
+  const [rules, setRules] = useState<SwcHubRulesConfig | null>(
+    getCachedPayoutConfig()?.swcHub ?? null,
+  );
+
+  useEffect(() => {
+    const cached = getCachedPayoutConfig();
+    if (cached) {
+      setRules(cached.swcHub);
+      return;
+    }
+    let active = true;
+    loadPayoutConfig().then((cfg) => {
+      if (active) setRules(cfg.swcHub);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { rules, loading: rules === null };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6126,6 +6126,16 @@ export interface UpdateUserMeInput {
   preferredPayoutMethod?: PayoutMethod | null;
   payoutWalletAddress?: string | null;
   payoutBankDetails?: BankDetails | null;
+  /**
+   * marinara-71630 P7: the event this payout method is being configured for.
+   * When set alongside a non-null `preferredPayoutMethod`, the backend
+   * hard-enforces that the method is allowed for that party (config-resolved
+   * options + the Mercury sanctions gate) and rejects a disallowed method with
+   * a 400 `PAYOUT_METHOD_NOT_ALLOWED`. PaymentDetailsCard always sends it so the
+   * crafted-request gap is closed; legitimate saves (the picker only offers
+   * enabled methods) are unaffected.
+   */
+  partyId?: string;
 }
 
 /**
@@ -6264,15 +6274,57 @@ export interface PayoutCapsConfig {
 }
 
 /**
+ * marinara-71630 P7 — SWC-hub matching rules served alongside the payout caps.
+ *
+ * The country/tag literals that drive the payments-admin SWC warning used to be
+ * hardcoded in the open-source frontend (`frontend/src/utils/swcHub.ts`). They
+ * now live in `app_config` (private.swc_hub_rules) and are served by the SAME
+ * GET /api/config/payout-caps endpoint (same payments-admin gate, same modals).
+ * Callers should go through the `useSwcHubRules` hook.
+ */
+export interface SwcHubRulesConfig {
+  /** Country names that flag a party SWC-hub (matched EXACTLY by swcHub.ts). */
+  countries: string[];
+  /** Event tags that flag a party SWC-hub (matched EXACTLY). */
+  tags: string[];
+  /** Event tags that force a party OUT of the gate (matched case-insensitively). */
+  excludeTags: string[];
+}
+
+/** Combined payload of GET /api/config/payout-caps. */
+export interface PayoutConfigResponse {
+  payoutCaps: PayoutCapsConfig;
+  swcHub: SwcHubRulesConfig;
+}
+
+/**
+ * Fetch the combined payments-admin payout config (caps + SWC-hub rules) in a
+ * single request. The `usePayoutCaps` / `useSwcHubRules` hooks each project out
+ * the slice they need and share the underlying network request via a module
+ * cache.
+ */
+export async function fetchPayoutConfig(): Promise<PayoutConfigResponse> {
+  return apiRequest<PayoutConfigResponse>('/api/config/payout-caps');
+}
+
+/**
  * Fetch the payments-admin payout caps. Callers should go through the
  * `usePayoutCaps` hook, which caches the result across components and supplies a
  * NEUTRAL fallback (never the real number) while loading / on error.
  */
 export async function fetchPayoutCaps(): Promise<PayoutCapsConfig> {
-  const res = await apiRequest<{ payoutCaps: PayoutCapsConfig }>(
-    '/api/config/payout-caps',
-  );
+  const res = await fetchPayoutConfig();
   return res.payoutCaps;
+}
+
+/**
+ * Fetch the payments-admin SWC-hub rules. Callers should go through the
+ * `useSwcHubRules` hook, which caches the result and supplies an EMPTY-rules
+ * fallback (nothing flagged SWC) while loading / on error.
+ */
+export async function fetchSwcHubRules(): Promise<SwcHubRulesConfig> {
+  const res = await fetchPayoutConfig();
+  return res.swcHub;
 }
 
 /**

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -40,6 +40,7 @@ import type {
 import { formatUsd, computePartyTotals } from '../components/payments-shared';
 import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../utils/regions';
 import { isSwcHubParty } from '../utils/swcHub';
+import { useSwcHubRules } from '../hooks/useSwcHubRules';
 import { normalizeText } from '../lib/normalizeText';
 import {
   PayoutsFilterBar,
@@ -162,6 +163,9 @@ function computeReceiptsTotalUsd(row: PartyPayoutsRow): number {
 }
 
 export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPageProps = {}) {
+  // marinara-71630 P7: SWC-hub country/tag rules from config (served on the same
+  // payments-admin endpoint as the caps). Passed into isSwcHubParty below.
+  const { rules: swcHubRules } = useSwcHubRules();
   // argentina-92103: stable region list to thread into API calls + filter
   // defaults. `undefined` when running as the unscoped /payments dashboard.
   const regions = useMemo(
@@ -1175,7 +1179,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                     // parmigiana-92104: PrepayQueueRow.party already carries
                     // country + eventTags so we can resolve the flag here and
                     // let MarkPartyPaidModal stay decoupled from the row shape.
-                    isSwcHub: isSwcHubParty(row.party),
+                    isSwcHub: isSwcHubParty(row.party, swcHubRules),
                   })
                 }
               />
@@ -1341,7 +1345,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 // parmigiana-92104: PartyPayoutsRow.party carries
                 // country + eventTags — resolve the SWC Hub flag here so the
                 // modal stays decoupled from the row shape.
-                isSwcHub: isSwcHubParty(row?.party),
+                isSwcHub: isSwcHubParty(row?.party, swcHubRules),
               });
             }}
             // Undo an accidental close. The table owns the reopenParty call +
@@ -1842,7 +1846,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 partyNameHint: detail.party.name,
                 // parmigiana-92104: PayoutReviewModal's `payout.party` has
                 // country + eventTags surfaced — propagate the SWC Hub flag.
-                isSwcHub: isSwcHubParty(detail.party),
+                isSwcHub: isSwcHubParty(detail.party, swcHubRules),
               })
             }
             // tagliatelle-49102: after a tag mutation, refresh the payouts

--- a/frontend/src/utils/swcHub.ts
+++ b/frontend/src/utils/swcHub.ts
@@ -7,35 +7,69 @@
  * the target party is an SWC Hub party — the action buttons stay disabled
  * until the admin ticks the ack.
  *
- * Signals (either is sufficient):
- *   1. `event_tags` includes the literal string 'SWC Hub' (preferred — also
- *      catches any non-US SWC Hub events the admins might tag in the future).
- *   2. `country` === 'United States'.
+ * marinara-71630 P7: the COUNTRY/TAG literals that used to be hardcoded here
+ * (country === 'United States', the 'SWC Hub' tag, the 'nonhub' exclusion tag)
+ * moved into `app_config` (key `private.swc_hub_rules`) so they're out of the
+ * open-source frontend bundle. They're served to the payments-admin viewer set
+ * via GET /api/config/payout-caps and reach this matcher through a config hook
+ * (`useSwcHubRules`). This file keeps only the (non-secret) MATCHING logic and
+ * takes the rule data as an argument.
  *
- * Both signals exist in prod (the 151 US parties were just bulk-tagged with
- * 'SWC Hub'); either is sufficient. The `country` fallback keeps the gate
- * working for any US party that's missed the bulk-tag for whatever reason.
+ * Signals (either is sufficient, unless an exclude tag is present):
+ *   1. `event_tags` includes one of `rules.tags` (e.g. 'SWC Hub') — also
+ *      catches any non-US SWC Hub events the admins might tag in the future.
+ *   2. `country` is one of `rules.countries` (e.g. 'United States').
+ * An `event_tags` entry matching one of `rules.excludeTags` (e.g. 'nonhub')
+ * forces the party OUT of the gate and takes precedence over both signals.
  *
  * Frontend-only soft block — there is no API-level gate. The admin can still
  * proceed by acknowledging the warning. Use at every admin reimbursement
  * entry point (PayoutReviewModal, BulkSendModal, ExternalPaymentModal,
  * MarkPartyPaidModal).
+ *
+ * The `rules` argument matches the EXACT normalization the previous hardcoded
+ * logic used, so behavior is preserved when seeded with the equivalent values:
+ *   - countries: matched EXACTLY (`country === c`) — was `=== 'United States'`.
+ *   - tags: matched EXACTLY (`eventTags.includes(t)`) — was `includes('SWC Hub')`.
+ *   - excludeTags: matched case-INSENSITIVELY and trimmed
+ *     (`t.trim().toLowerCase() === ex`) — was the 'nonhub' opt-out. Seed
+ *     excludeTags values already lowercased (e.g. 'nonhub').
+ *
+ * When `rules` is undefined (config still loading / unresolved) NOTHING is
+ * flagged SWC — the SAFE default for a soft admin ack (the warning simply
+ * doesn't block; the backend is not an enforcement point here).
  */
+export interface SwcHubRules {
+  countries: string[];
+  tags: string[];
+  excludeTags: string[];
+}
+
 export function isSwcHubParty(
   party?: { country?: string | null; eventTags?: string[] | null } | null,
+  rules?: SwcHubRules | null,
 ): boolean {
   if (!party) return false;
-  // marzano-58293: explicit per-party opt-out. A 'nonhub' tag forces USDC
-  // treatment — it takes precedence over BOTH the 'SWC Hub' tag and the
-  // US-country fallback below. Mirrors the existing `nonpres` opt-out
-  // precedent. Used to drop the SWC Hub reimbursement gate from US cities.
-  if (
-    Array.isArray(party.eventTags) &&
-    party.eventTags.some((t) => t != null && t.trim().toLowerCase() === 'nonhub')
-  ) {
-    return false;
+  if (!rules) return false;
+  const tags = Array.isArray(party.eventTags) ? party.eventTags : [];
+  // marzano-58293: explicit per-party opt-out. An exclude tag (e.g. 'nonhub')
+  // forces USDC treatment — it takes precedence over BOTH the tag and the
+  // country signals below. Mirrors the existing `nonpres` opt-out precedent.
+  // Matched case-insensitively + trimmed, exactly as the old 'nonhub' check.
+  const excludeTags = Array.isArray(rules.excludeTags) ? rules.excludeTags : [];
+  if (excludeTags.length > 0) {
+    const present = tags.some(
+      (t) =>
+        t != null &&
+        excludeTags.includes(t.trim().toLowerCase()),
+    );
+    if (present) return false;
   }
-  if (Array.isArray(party.eventTags) && party.eventTags.includes('SWC Hub')) return true;
-  if (party.country === 'United States') return true;
+  // Tag signal — matched EXACTLY (preserves the old `includes('SWC Hub')`).
+  const ruleTags = Array.isArray(rules.tags) ? rules.tags : [];
+  if (ruleTags.some((t) => tags.includes(t))) return true;
+  // Country signal — matched EXACTLY (preserves the old `=== 'United States'`).
+  const countries = Array.isArray(rules.countries) ? rules.countries : [];
+  if (party.country != null && countries.includes(party.country)) return true;
   return false;
 }


### PR DESCRIPTION
Phase 7 of the marinara-71630 private-config refactor: three deferred hardening follow-ups, all **behavior-preserving**.

## Task A — admin SWC-hub country/tag rules → config
Moved the hardcoded SWC-hub literals out of the OPEN frontend (`swcHub.ts`) into `app_config` (`private.swc_hub_rules`), keeping the non-secret matching logic.
- `privateConfig.ts`: `KEYS.swcHubRules` + `getSwcHubRules()` (fallback `{countries:[],tags:[],excludeTags:[]}` → nothing flagged SWC, safe).
- `GET /api/config/payout-caps` now also returns an `swcHub` block (same payments-admin gate + viewer set the SWC modals already use).
- `isSwcHubParty(party, rules)` keeps the matcher, removes all literals. Matching preserved EXACTLY: country matched exactly, `SWC Hub` tag matched exactly (`includes`), `nonhub` exclude matched case-insensitively + trimmed (precedence). Null rules → not-SWC (safe; the warning is an admin ACK, not enforcement).
- New `useSwcHubRules` hook + shared `payoutConfigCache` so caps + rules resolve from ONE request. All consumers updated: PayoutReviewModal, BulkSendModal, ExternalPaymentModal, MarkPartyPaidModal (via PaymentsAdminPage), PayoutsByPartyTable, and SendPaymentModal's local memo (its looser case-insensitive matching kept).
- `seed.example.json`: fake `private.swc_hub_rules` placeholder.

**Confirmed seed JSON** for prod (derived from current swcHub.ts): `{"countries":["United States"],"tags":["SWC Hub"],"excludeTags":["nonhub"]}` — country/tag values must match the matcher's EXACT casing; `excludeTags` lowercased.

## Task B — backend POST enforcement of reimbursement-option gating
The save path is `PATCH /api/user/me` (user-level payout prefs). Added `resolvePartyReimbursementOptions()` (config resolve + `isMercuryBlocked` layering — the same layering the GET endpoint uses; GET refactored to share it). When a non-null `preferredPayoutMethod` is saved WITH a `partyId` and the caller can edit that party, the method is rejected with **400 `PAYOUT_METHOD_NOT_ALLOWED`** if it's absent or `enabled:false`. Fail-open on unseeded config (empty resolved list). PaymentDetailsCard now sends `partyId`. Legitimate saves (the picker only offers enabled methods) are unaffected. New `user.routes.test.ts` covers blocked-country mercury → 400, normalization variant → 400, allowed method → 200, no-partyId legacy → 200, unseeded fail-open → 200.

## Task C — STOP (not implemented)
The backend super-admin rule is `isSuperAdmin(email)` → `prisma.admin.findUnique({where:{email}})` with `role === 'super_admin'` — a **DB Admin table that may contain MORE emails** than `hello@rarepizzas.com`. Surfacing it as a flag and replacing the 3 hardcoded email comparisons (HostPage `canEdit`/`isOwnerOrAdmin`, EventPage host buttons) would **widen** who is treated as super-admin if the table has more than one super_admin row. Per the brief this is a STOP-and-report: gating was left UNCHANGED pending confirmation of the intended super-admin set with the main session. (Subagents can't read the prod Admin table to verify equivalence.)

## Notes
- `private.swc_hub_rules` is **seeded to prod by the main session before merge**.
- Backend `tsc` clean except the known pre-existing `auth.test.ts` jwt error; frontend `tsc` clean. 60/60 tests pass (privateConfig + reimbursementOptions + party.routes + new user.routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)