### PR TITLE
stracotto-58498: cancelling an event also un-approves it

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -8,6 +8,7 @@ import { triggerWebhook } from '../services/webhook.service.js';
 import { canUserEditParty, canUserAccessTab, VALID_TAB_IDS } from '../helpers/partyAccess.js';
 import { getUnderbossScope, partyMatchesScope } from '../helpers/underbossScope.js';
 import { setDeleteContext } from '../helpers/auditContext.js';
+import { writeStatusAudit } from '../helpers/statusAudit.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import {
   capValuesDiffer,
@@ -888,14 +889,35 @@ async function softCancelParty(
   userEmail: string | undefined,
   reason: string | null,
 ) {
-  return prisma.party.update({
-    where: { id: partyId },
-    data: {
-      cancelledAt: new Date(),
-      cancelledBy: userEmail || 'unknown',
-      cancellationReason:
-        reason && reason.trim() ? reason.trim().slice(0, 500) : null,
-    },
+  return prisma.$transaction(async (tx) => {
+    const current = await tx.party.findUnique({
+      where: { id: partyId },
+      select: { underbossStatus: true },
+    });
+    const downgrade =
+      !!current && ['approved', 'listed'].includes(current.underbossStatus);
+    const updated = await tx.party.update({
+      where: { id: partyId },
+      data: {
+        cancelledAt: new Date(),
+        cancelledBy: userEmail || 'unknown',
+        cancellationReason:
+          reason && reason.trim() ? reason.trim().slice(0, 500) : null,
+        ...(downgrade ? { underbossStatus: 'pending' } : {}),
+      },
+    });
+    if (downgrade) {
+      await writeStatusAudit(
+        tx,
+        partyId,
+        current!.underbossStatus,
+        'pending',
+        userEmail || 'unknown',
+        'owner',
+        'auto-unapproved on host cancel',
+      );
+    }
+    return updated;
   });
 }
 

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -1221,13 +1221,40 @@ router.delete('/events/bulk-delete', requireAuth, requireUnderbossAuth, async (r
     // ziti-58475: soft-cancel instead of hard delete. The party row, its
     // guests/sponsors/RSVPs, and the public URL all stay intact; events can be
     // reinstated. Only flip events that aren't already cancelled (idempotent).
-    const result = await prisma.party.updateMany({
+    const targets = await prisma.party.findMany({
       where: { id: { in: partyIds }, cancelledAt: null },
-      data: {
-        cancelledAt: new Date(),
-        cancelledBy: req.userEmail || 'underboss_bulk',
-        cancellationReason: null,
-      },
+      select: { id: true, underbossStatus: true },
+    });
+    const result = await prisma.$transaction(async (tx) => {
+      const cancelled = await tx.party.updateMany({
+        where: { id: { in: partyIds }, cancelledAt: null },
+        data: {
+          cancelledAt: new Date(),
+          cancelledBy: req.userEmail || 'underboss_bulk',
+          cancellationReason: null,
+        },
+      });
+      const toUnapprove = targets.filter((p) =>
+        ['approved', 'listed'].includes(p.underbossStatus),
+      );
+      if (toUnapprove.length) {
+        await tx.party.updateMany({
+          where: { id: { in: toUnapprove.map((p) => p.id) } },
+          data: { underbossStatus: 'pending' },
+        });
+        for (const p of toUnapprove) {
+          await writeStatusAudit(
+            tx,
+            p.id,
+            p.underbossStatus,
+            'pending',
+            req.userEmail || 'underboss_bulk',
+            'underboss',
+            'auto-unapproved on bulk cancel',
+          );
+        }
+      }
+      return cancelled;
     });
 
     res.json({ cancelled: result.count });

--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -471,11 +471,18 @@ export const EventDetailsTab: React.FC = () => {
       const success = await cancelParty(party.id, cancelReason);
       if (success) {
         const trimmed = cancelReason.trim().slice(0, 500) || null;
+        // stracotto-58498: cancelling un-approves an approved/listed event on
+        // the backend; mirror that optimistically so the UI never shows
+        // approved+cancelled.
+        const downgrade = ['approved', 'listed'].includes(
+          party.underbossStatus || '',
+        );
         // Merge in-place so the dashboard renders the cancelled state without
         // re-fetching — same pattern as `arugula-38633` v2 / `burrata-72104`.
         mergeParty({
           cancelledAt: new Date().toISOString(),
           cancellationReason: trimmed,
+          ...(downgrade ? { underbossStatus: 'pending' } : {}),
         });
         setShowCancelPrompt(false);
         setCancelReason('');


### PR DESCRIPTION
## What
When an event is cancelled, it no longer stays in the approved/listed (public) state.

- **Host cancel** (`POST /api/parties/:id/cancel` → `softCancelParty`) and **underboss bulk soft-delete** (`DELETE /api/underboss/events/bulk-delete`) now reset `underbossStatus` → `pending` when the event is currently `approved` or `listed`.
- `rejected`, `hidden`, and `pending` are **left untouched** (so a rejected scam event isn't bounced back into the queue).
- Each downgrade writes a `party_status_audit` row — `owner`-kind for host cancel, `underboss`-kind for bulk — reason `auto-unapproved on …`.
- Frontend host-cancel optimistic merge mirrors the reset so the UI never shows approved+cancelled.

Both backend handlers wrap the cancel + unapprove + audit in a single `$transaction`.

## Notes
- **Backend deploys from `master`** — the cancel→unapprove behavior is only live after merge + backend deploy, not on this preview (preview frontend hits the prod backend).
- **Backfill pending:** existing cancelled-but-`approved`/`listed` rows will be reset to `pending` via a one-time prod `UPDATE` after merge+deploy (separate, manual step).
- No schema/migration change.

Plan: `plans/stracotto-58498-cancel-unapproves.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)