### PR TITLE
diavola-58479: social-post template copy — randomized recap adjective + drop "!"

### DIFF
--- a/frontend/src/components/checklist/SocialPostModal.tsx
+++ b/frontend/src/components/checklist/SocialPostModal.tsx
@@ -56,11 +56,7 @@ const RECAP_ADJECTIVES = [
   'great',
   'awesome',
   'a blast',
-  'incredible',
   'epic',
-  'unforgettable',
-  'legendary',
-  'delicious',
 ];
 
 function buildDefaultText(party: Party): string {

--- a/frontend/src/components/checklist/SocialPostModal.tsx
+++ b/frontend/src/components/checklist/SocialPostModal.tsx
@@ -59,7 +59,7 @@ function buildDefaultText(party: Party): string {
     `${flag}\u{1F355}\u{1F973}\n` +
     `We had a blast celebrating Bitcoin Pizza Day in ${city}!\n` +
     `\n` +
-    `Thanks ${tags} for supporting the event! See you next year!`
+    `Thanks ${tags} for supporting the event. See you next year!`
   );
 }
 

--- a/frontend/src/components/checklist/SocialPostModal.tsx
+++ b/frontend/src/components/checklist/SocialPostModal.tsx
@@ -51,13 +51,26 @@ function partyCity(party: Party): string {
   return party.name.replace(/^Global Pizza Party\s*/i, '').trim() || party.name;
 }
 
+// Picked at random each time the modal opens; host can edit before posting.
+const RECAP_ADJECTIVES = [
+  'great',
+  'awesome',
+  'a blast',
+  'incredible',
+  'epic',
+  'unforgettable',
+  'legendary',
+  'delicious',
+];
+
 function buildDefaultText(party: Party): string {
   const flag = countryNameToFlag(party.country);
   const city = partyCity(party);
   const tags = buildPartnerTags(party);
+  const adjective = RECAP_ADJECTIVES[Math.floor(Math.random() * RECAP_ADJECTIVES.length)];
   return (
     `${flag}\u{1F355}\u{1F973}\n` +
-    `We had a blast celebrating Bitcoin Pizza Day in ${city}!\n` +
+    `Bitcoin Pizza Day ${city} was ${adjective}!\n` +
     `\n` +
     `Thanks ${tags} for supporting the event. See you next year!`
   );


### PR DESCRIPTION
Follow-ups to #855 (social-post composer template in `SocialPostModal.tsx`):

1. **Line 2 → randomized recap adjective.** `We had a blast celebrating Bitcoin Pizza Day in {city}!` → `Bitcoin Pizza Day {city} was {adjective}!`, where `{adjective}` is picked at random from: great, awesome, a blast, incredible, epic, unforgettable, legendary, delicious. Re-rolls each time the composer opens; host can edit before posting.
2. **Line 4** — dropped the exclamation after "supporting the event" (now a period).

Example:
```
🇺🇸🍕🥳
Bitcoin Pizza Day Philadelphia was legendary!

Thanks @Pizza_DAO … for supporting the event. See you next year!
```

No logic change beyond the template string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)