### PR TITLE
montanara-58497: URL-persisted /underboss filters + DB-backed saved filter views

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2213,3 +2213,20 @@ model ImageAuthenticityCheck {
   @@index([partyId])
   @@map("image_authenticity_checks")
 }
+
+// montanara-58497: per-account saved filter views for the /payments + /underboss
+// admin dashboards. Keyed by the caller's auth email (lowercased) — no FK to
+// User. `params` is the serialized URL query string (page-agnostic) produced by
+// the page's own (de)serializer, so applying a view just replays the query.
+model SavedFilterView {
+  id        String   @id @default(uuid())
+  userEmail String   @map("user_email")
+  scope     String // 'payments' | 'underboss'
+  name      String
+  params    String // serialized URL query string (page-agnostic)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([userEmail, scope, name])
+  @@map("saved_filter_views")
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -76,6 +76,7 @@ import {
 import reminderRoutes from './routes/reminder.routes.js';
 import { taxFormRouter, adminTaxFormRouter } from './routes/tax-form.routes.js';
 import suggestionsRoutes from './routes/suggestions.routes.js'; // scarpetta-58472: admin/underboss-only suggestions list
+import savedViewsRoutes from './routes/saved-views.routes.js'; // montanara-58497: per-account saved filter views (/payments + /underboss)
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -159,6 +160,7 @@ app.use('/api/admin/survey-question-sets', surveyQuestionSetsAdminRouter); // pu
 app.use('/api/admin', adminRoutes);          // Admin management routes
 app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin management
 app.use('/api/suggestions', suggestionsRoutes); // scarpetta-58472: admin/underboss-only site-wide suggestions (view-only)
+app.use('/api/saved-views', savedViewsRoutes); // montanara-58497: per-account saved filter views (/payments + /underboss)
 app.use('/api/telegram/webhook', telegramWebhookRoutes); // Telegram inbound webhook (no auth — secret-token header gate)
 app.use('/api/underboss/telegram', telegramRoutes); // Telegram broadcast (before underboss catch-all)
 app.use('/api/underboss', underbossRoutes); // Underboss dashboard (token auth + admin routes)

--- a/backend/src/routes/saved-views.routes.ts
+++ b/backend/src/routes/saved-views.routes.ts
@@ -1,0 +1,83 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+
+// montanara-58497: per-account saved filter views for /payments + /underboss.
+// Owner key = req.userEmail (lowercased). No FK to User — views are keyed by
+// email string. `params` is the page's serialized URL query string.
+const router = Router();
+
+const SCOPES = new Set(['payments', 'underboss']);
+
+// GET /api/saved-views?scope=payments|underboss
+router.get('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userEmail = req.userEmail!.toLowerCase();
+    const scope = String(req.query.scope || '');
+    if (!SCOPES.has(scope)) {
+      throw new AppError('Invalid scope', 400, 'INVALID_SCOPE');
+    }
+
+    const views = await prisma.savedFilterView.findMany({
+      where: { userEmail, scope },
+      orderBy: { name: 'asc' },
+      select: { id: true, name: true, params: true, updatedAt: true },
+    });
+
+    res.json({ views });
+  } catch (e) {
+    next(e);
+  }
+});
+
+// POST /api/saved-views  body { scope, name, params }
+router.post('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userEmail = req.userEmail!.toLowerCase();
+    const { scope, name, params } = req.body || {};
+
+    if (!SCOPES.has(scope)) {
+      throw new AppError('Invalid scope', 400, 'INVALID_SCOPE');
+    }
+    const trimmedName = typeof name === 'string' ? name.trim() : '';
+    if (!trimmedName || trimmedName.length > 80) {
+      throw new AppError('Name must be 1–80 characters', 400, 'INVALID_NAME');
+    }
+    const paramsStr = typeof params === 'string' ? params : '';
+    if (paramsStr.length > 2000) {
+      throw new AppError('Params too long', 400, 'INVALID_PARAMS');
+    }
+
+    const view = await prisma.savedFilterView.upsert({
+      where: { userEmail_scope_name: { userEmail, scope, name: trimmedName } },
+      create: { userEmail, scope, name: trimmedName, params: paramsStr },
+      update: { params: paramsStr },
+      select: { id: true, name: true, params: true, updatedAt: true },
+    });
+
+    res.json(view);
+  } catch (e) {
+    next(e);
+  }
+});
+
+// DELETE /api/saved-views/:id
+router.delete('/:id', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userEmail = req.userEmail!.toLowerCase();
+    const { id } = req.params;
+
+    const existing = await prisma.savedFilterView.findUnique({ where: { id } });
+    if (!existing || existing.userEmail !== userEmail) {
+      throw new AppError('Not found', 404, 'NOT_FOUND');
+    }
+
+    await prisma.savedFilterView.delete({ where: { id } });
+    res.json({ ok: true });
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default router;

--- a/frontend/src/components/SavedViewsMenu.tsx
+++ b/frontend/src/components/SavedViewsMenu.tsx
@@ -1,0 +1,170 @@
+import { useState, useCallback } from 'react';
+import { Bookmark, ChevronDown, X, Loader2, Save } from 'lucide-react';
+import { IconInput } from './IconInput';
+import {
+  listSavedViews,
+  saveFilterView,
+  deleteSavedView,
+  type SavedView,
+  type SavedViewScope,
+} from '../lib/api';
+
+// montanara-58497: compact "Views" dropdown shared by /payments + /underboss.
+// Lists the caller's saved filter views (per-account, server-side), applies one
+// on click, and lets the caller save the CURRENT params under a name. `params`
+// is the page's serialized URL query string — fully page-agnostic here.
+interface SavedViewsMenuProps {
+  scope: SavedViewScope;
+  currentParams: string;
+  onApply: (params: string) => void;
+}
+
+export function SavedViewsMenu({ scope, currentParams, onApply }: SavedViewsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [views, setViews] = useState<SavedView[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newName, setNewName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await listSavedViews(scope);
+      setViews(list);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load views');
+    } finally {
+      setLoading(false);
+    }
+  }, [scope]);
+
+  function toggleOpen() {
+    setOpen((prev) => {
+      const next = !prev;
+      if (next) void refresh();
+      return next;
+    });
+  }
+
+  async function handleSave() {
+    const name = newName.trim();
+    if (!name || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await saveFilterView(scope, name, currentParams);
+      setNewName('');
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to save view');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeletingId(id);
+    setError(null);
+    try {
+      await deleteSavedView(id);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to delete view');
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={toggleOpen}
+        className="flex items-center gap-1.5 rounded-lg border border-theme-stroke bg-theme-surface px-3 py-1.5 text-sm text-theme-text-secondary transition-colors hover:border-theme-stroke-hover hover:text-theme-text"
+      >
+        <Bookmark size={14} />
+        Views
+        <ChevronDown size={14} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute top-full right-0 z-50 mt-1 w-72 rounded-lg border border-theme-stroke bg-theme-card py-1 shadow-xl">
+            {/* List */}
+            <div className="max-h-72 overflow-y-auto">
+              {loading ? (
+                <div className="flex items-center gap-2 px-3 py-3 text-sm text-theme-text-faint">
+                  <Loader2 size={14} className="animate-spin" /> Loading…
+                </div>
+              ) : views.length === 0 ? (
+                <div className="px-3 py-3 text-sm text-theme-text-faint">No saved views</div>
+              ) : (
+                views.map((view) => (
+                  <div
+                    key={view.id}
+                    className="flex items-center justify-between gap-2 px-3 py-2 transition-colors hover:bg-theme-surface"
+                  >
+                    <button
+                      onClick={() => {
+                        onApply(view.params);
+                        setOpen(false);
+                      }}
+                      className="flex-1 truncate text-left text-sm text-theme-text"
+                      title={view.name}
+                    >
+                      {view.name}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(view.id)}
+                      disabled={deletingId === view.id}
+                      className="shrink-0 p-0.5 text-theme-text-faint transition-colors hover:text-red-500 disabled:opacity-50"
+                      aria-label={`Delete ${view.name}`}
+                      title="Delete view"
+                    >
+                      {deletingId === view.id ? <Loader2 size={13} className="animate-spin" /> : <X size={13} />}
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+
+            {error && (
+              <div className="px-3 py-1.5 text-xs text-red-500">{error}</div>
+            )}
+
+            {/* Save current view */}
+            <div className="mt-1 border-t border-theme-stroke px-3 py-2">
+              <div className="flex items-center gap-2">
+                <div className="flex-1">
+                  <IconInput
+                    icon={Save}
+                    iconSize={13}
+                    type="text"
+                    value={newName}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewName(e.target.value)}
+                    onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                      if (e.key === 'Enter') void handleSave();
+                    }}
+                    placeholder="Save current view…"
+                    maxLength={80}
+                    className="rounded-lg border border-theme-stroke bg-theme-surface !pl-9 pr-2 py-1.5 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+                  />
+                </div>
+                <button
+                  onClick={() => void handleSave()}
+                  disabled={!newName.trim() || saving}
+                  className="shrink-0 rounded-lg bg-red-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-600 disabled:opacity-50"
+                >
+                  {saving ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -12,6 +12,10 @@ import type { UnderbossEvent, UnderbossEventProgress } from '../../types';
 import { calculateTagSponsorshipTotal } from '../../utils/sponsorshipPricing';
 import { usePricingConfig } from '../../hooks/usePricingConfig';
 import { normalizeText } from '../../lib/normalizeText';
+import {
+  type EventTableFilters,
+  DEFAULT_EVENT_TABLE_FILTERS,
+} from './underbossTableUrlState';
 
 interface EventTableProps {
   events: UnderbossEvent[];
@@ -22,6 +26,13 @@ interface EventTableProps {
   partnerTags?: string[];
   onFilteredEventsChange?: (events: UnderbossEvent[]) => void;
   isAdmin?: boolean;
+  // montanara-58497: controlled-filters mode. When BOTH are provided, all filter
+  // state is driven by `filters` and every setter routes through
+  // `onFiltersChange` so the parent (UnderbossDashboard) can sync it to the URL.
+  // When omitted (EventsMapPage), the component uses its internal useState and
+  // behaves exactly as before.
+  filters?: EventTableFilters;
+  onFiltersChange?: (next: EventTableFilters) => void;
 }
 
 type SortField = 'name' | 'date' | 'guestCount' | 'progress' | 'appealsFirst';
@@ -95,21 +106,29 @@ function FilterPill({
   );
 }
 
-export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, onTelegramBroadcast, partnerTags = [], onFilteredEventsChange, isAdmin }: EventTableProps) {
+export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, onTelegramBroadcast, partnerTags = [], onFilteredEventsChange, isAdmin, filters: controlledFilters, onFiltersChange }: EventTableProps) {
   const { t } = useTranslation('partner');
   // Private pricing config for the sponsorship-suggestion banner (marinara-71630 P5).
   const { config: pricingConfig } = usePricingConfig();
-  const [search, setSearch] = useState('');
-  const [sortField, setSortField] = useState<SortField>('date');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
-  const [regionFilter, setRegionFilter] = useState<string>('all');
-  const [rsvpComparator, setRsvpComparator] = useState<'>' | '<'>('>');
-  const [rsvpThreshold, setRsvpThreshold] = useState<string>('');
+
+  // montanara-58497: controlled-filters mode is active only when BOTH props are
+  // supplied. The internal useState below is kept in all cases (so hooks never
+  // run conditionally), but in controlled mode the effective filter VALUES are
+  // read from `controlledFilters` and every setter writes a full next-object via
+  // `onFiltersChange` instead of mutating internal state.
+  const isControlled = controlledFilters !== undefined && onFiltersChange !== undefined;
+
+  const [searchUncontrolled, setSearch] = useState('');
+  const [sortFieldUncontrolled, setSortField] = useState<SortField>('date');
+  const [sortDirUncontrolled, setSortDir] = useState<SortDir>('asc');
+  const [regionFilterUncontrolled, setRegionFilter] = useState<string>('all');
+  const [rsvpComparatorUncontrolled, setRsvpComparator] = useState<'>' | '<'>('>');
+  const [rsvpThresholdUncontrolled, setRsvpThreshold] = useState<string>('');
   // quattro-12847: client-side "Open appeals only" filter. Client-side keeps
   // the filter live (no refetch) and works against whatever `events` slice
   // the parent passes in. Backend supports an equivalent `appealsOnly=true`
   // query param for callers that want server-side narrowing.
-  const [appealsOnly, setAppealsOnly] = useState<boolean>(false);
+  const [appealsOnlyUncontrolled, setAppealsOnly] = useState<boolean>(false);
 
   // Selection state for bulk actions
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -135,8 +154,57 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   }, [events, selectedIds]);
 
   // Three-state progress filters: includes (must have) and excludes (must NOT have)
-  const [progressIncludes, setProgressIncludes] = useState<string[]>([]);
-  const [progressExcludes, setProgressExcludes] = useState<string[]>([]);
+  const [progressIncludesUncontrolled, setProgressIncludes] = useState<string[]>([]);
+  const [progressExcludesUncontrolled, setProgressExcludes] = useState<string[]>([]);
+
+  // Tri-state per-tag filter (provola-58497): include (require) / exclude / neutral.
+  const [tagIncludesUncontrolled, setTagIncludes] = useState<string[]>([]);
+  const [tagExcludesUncontrolled, setTagExcludes] = useState<string[]>([]);
+  // tagTouchOrder floats recently-interacted tags to the top of the dropdown.
+  // Purely cosmetic — internal in BOTH modes (never persisted to the URL).
+  const [tagTouchOrder, setTagTouchOrder] = useState<string[]>([]); // most-recently-touched first
+  const [showTagFilter, setShowTagFilter] = useState(false);
+
+  // montanara-58497: effective filter values — from props when controlled, else
+  // from internal state. All downstream JSX/memos read these.
+  const search = isControlled ? controlledFilters!.search : searchUncontrolled;
+  const sortField = isControlled ? controlledFilters!.sortField : sortFieldUncontrolled;
+  const sortDir = isControlled ? controlledFilters!.sortDir : sortDirUncontrolled;
+  const regionFilter = isControlled ? controlledFilters!.regionFilter : regionFilterUncontrolled;
+  const rsvpComparator = isControlled ? controlledFilters!.rsvpComparator : rsvpComparatorUncontrolled;
+  const rsvpThreshold = isControlled ? controlledFilters!.rsvpThreshold : rsvpThresholdUncontrolled;
+  const appealsOnly = isControlled ? controlledFilters!.appealsOnly : appealsOnlyUncontrolled;
+  const progressIncludes = isControlled ? controlledFilters!.progressIncludes : progressIncludesUncontrolled;
+  const progressExcludes = isControlled ? controlledFilters!.progressExcludes : progressExcludesUncontrolled;
+  const tagIncludes = isControlled ? controlledFilters!.tagIncludes : tagIncludesUncontrolled;
+  const tagExcludes = isControlled ? controlledFilters!.tagExcludes : tagExcludesUncontrolled;
+
+  // montanara-58497: in controlled mode, emit a full next-EventTableFilters built
+  // from the current effective values + a partial override.
+  function emit(patch: Partial<EventTableFilters>) {
+    onFiltersChange!({
+      search,
+      sortField,
+      sortDir,
+      progressIncludes,
+      progressExcludes,
+      regionFilter,
+      tagIncludes,
+      tagExcludes,
+      rsvpComparator,
+      rsvpThreshold,
+      appealsOnly,
+      ...patch,
+    });
+  }
+
+  // montanara-58497: mode-aware scalar setters used directly by the JSX so the
+  // markup doesn't need to branch on isControlled at every callsite.
+  const applySearch = (v: string) => (isControlled ? emit({ search: v }) : setSearch(v));
+  const applyRegionFilter = (v: string) => (isControlled ? emit({ regionFilter: v }) : setRegionFilter(v));
+  const applyRsvpComparator = (v: '>' | '<') => (isControlled ? emit({ rsvpComparator: v }) : setRsvpComparator(v));
+  const applyRsvpThreshold = (v: string) => (isControlled ? emit({ rsvpThreshold: v }) : setRsvpThreshold(v));
+  const applyAppealsOnly = (v: boolean) => (isControlled ? emit({ appealsOnly: v }) : setAppealsOnly(v));
 
   function getFilterState(key: string): 'neutral' | 'include' | 'exclude' {
     if (progressIncludes.includes(key)) return 'include';
@@ -145,21 +213,17 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   }
 
   function setFilterState(key: string, newState: 'neutral' | 'include' | 'exclude') {
-    setProgressIncludes((prev) => prev.filter((k) => k !== key));
-    setProgressExcludes((prev) => prev.filter((k) => k !== key));
-    if (newState === 'include') {
-      setProgressIncludes((prev) => [...prev, key]);
-    } else if (newState === 'exclude') {
-      setProgressExcludes((prev) => [...prev, key]);
+    const nextInc = progressIncludes.filter((k) => k !== key);
+    const nextExc = progressExcludes.filter((k) => k !== key);
+    if (newState === 'include') nextInc.push(key);
+    else if (newState === 'exclude') nextExc.push(key);
+    if (isControlled) {
+      emit({ progressIncludes: nextInc, progressExcludes: nextExc });
+    } else {
+      setProgressIncludes(nextInc);
+      setProgressExcludes(nextExc);
     }
   }
-
-  // Tri-state per-tag filter (provola-58497): include (require) / exclude / neutral.
-  // tagTouchOrder floats recently-interacted tags to the top of the dropdown.
-  const [tagIncludes, setTagIncludes] = useState<string[]>([]);
-  const [tagExcludes, setTagExcludes] = useState<string[]>([]);
-  const [tagTouchOrder, setTagTouchOrder] = useState<string[]>([]); // most-recently-touched first
-  const [showTagFilter, setShowTagFilter] = useState(false);
 
   function getTagFilterState(tag: string): 'neutral' | 'include' | 'exclude' {
     if (tagIncludes.includes(tag)) return 'include';
@@ -168,11 +232,17 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   }
 
   function setTagFilterState(tag: string, next: 'neutral' | 'include' | 'exclude') {
-    setTagIncludes((p) => p.filter((k) => k !== tag));
-    setTagExcludes((p) => p.filter((k) => k !== tag));
-    if (next === 'include') setTagIncludes((p) => [...p, tag]);
-    else if (next === 'exclude') setTagExcludes((p) => [...p, tag]);
+    const nextInc = tagIncludes.filter((k) => k !== tag);
+    const nextExc = tagExcludes.filter((k) => k !== tag);
+    if (next === 'include') nextInc.push(tag);
+    else if (next === 'exclude') nextExc.push(tag);
     setTagTouchOrder((p) => [tag, ...p.filter((k) => k !== tag)]); // float to top
+    if (isControlled) {
+      emit({ tagIncludes: nextInc, tagExcludes: nextExc });
+    } else {
+      setTagIncludes(nextInc);
+      setTagExcludes(nextExc);
+    }
   }
 
   function toggleSelect(id: string) {
@@ -334,6 +404,14 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   }
 
   function toggleSort(field: SortField) {
+    if (isControlled) {
+      if (sortField === field) {
+        emit({ sortDir: sortDir === 'asc' ? 'desc' : 'asc' });
+      } else {
+        emit({ sortField: field, sortDir: 'asc' });
+      }
+      return;
+    }
     if (sortField === field) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
@@ -378,7 +456,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           iconSize={14}
           type="text"
           value={search}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => applySearch(e.target.value)}
           placeholder={t('eventTable.searchPlaceholder')}
           className="bg-theme-surface border border-theme-stroke rounded-lg pr-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
         />
@@ -431,7 +509,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         {showRegion && (
           <select
             value={regionFilter}
-            onChange={(e) => setRegionFilter(e.target.value)}
+            onChange={(e) => applyRegionFilter(e.target.value)}
             className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-1.5 text-sm text-theme-text-secondary focus:outline-none focus:border-theme-stroke-hover"
           >
             <option value="all">{t('eventTable.countryAll')}</option>
@@ -465,9 +543,13 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
                     <div className="flex items-center justify-end px-3 py-1.5 border-b border-theme-stroke">
                       <button
                         onClick={() => {
-                          setTagIncludes([]);
-                          setTagExcludes([]);
                           setTagTouchOrder([]);
+                          if (isControlled) {
+                            emit({ tagIncludes: [], tagExcludes: [] });
+                          } else {
+                            setTagIncludes([]);
+                            setTagExcludes([]);
+                          }
                         }}
                         className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
                       >
@@ -527,7 +609,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         <div className="flex items-center gap-1">
           <select
             value={rsvpComparator}
-            onChange={(e) => setRsvpComparator(e.target.value as '>' | '<')}
+            onChange={(e) => applyRsvpComparator(e.target.value as '>' | '<')}
             className="bg-theme-surface border border-theme-stroke rounded-lg px-2 py-1.5 text-sm text-theme-text-secondary focus:outline-none focus:border-theme-stroke-hover"
             aria-label={t('eventTable.rsvpFilterLabel')}
           >
@@ -538,7 +620,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
             type="number"
             min={0}
             value={rsvpThreshold}
-            onChange={(e) => setRsvpThreshold(e.target.value)}
+            onChange={(e) => applyRsvpThreshold(e.target.value)}
             placeholder={t('eventTable.rsvpThresholdPlaceholder')}
             className="w-20 bg-theme-surface border border-theme-stroke rounded-lg px-2 py-1.5 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
             aria-label={t('eventTable.rsvpFilterLabel')}
@@ -548,7 +630,7 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         {/* quattro-12847: Open cap-appeals only + sort-by-appeals-first */}
         <Checkbox
           checked={appealsOnly}
-          onChange={() => setAppealsOnly((v) => !v)}
+          onChange={() => applyAppealsOnly(!appealsOnly)}
           label="Open appeals only"
           size={14}
           labelClassName="text-xs text-theme-text-secondary"
@@ -557,11 +639,11 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
           value={sortField === 'appealsFirst' ? 'appealsFirst' : 'default'}
           onChange={(e) => {
             const v = e.target.value;
-            if (v === 'appealsFirst') {
-              setSortField('appealsFirst');
-              setSortDir('asc');
+            const nextField: SortField = v === 'appealsFirst' ? 'appealsFirst' : 'date';
+            if (isControlled) {
+              emit({ sortField: nextField, sortDir: 'asc' });
             } else {
-              setSortField('date');
+              setSortField(nextField);
               setSortDir('asc');
             }
           }}
@@ -576,14 +658,19 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         {hasActiveFilters && (
           <button
             onClick={() => {
-              setProgressIncludes([]);
-              setProgressExcludes([]);
-              setRegionFilter('all');
-              setTagIncludes([]);
-              setTagExcludes([]);
               setTagTouchOrder([]);
-              setRsvpThreshold('');
-              setAppealsOnly(false);
+              if (isControlled) {
+                // Reset to the canonical defaults, preserving current semantics.
+                onFiltersChange!({ ...DEFAULT_EVENT_TABLE_FILTERS });
+              } else {
+                setProgressIncludes([]);
+                setProgressExcludes([]);
+                setRegionFilter('all');
+                setTagIncludes([]);
+                setTagExcludes([]);
+                setRsvpThreshold('');
+                setAppealsOnly(false);
+              }
             }}
             className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
           >

--- a/frontend/src/components/underboss/underbossTableUrlState.ts
+++ b/frontend/src/components/underboss/underbossTableUrlState.ts
@@ -1,0 +1,266 @@
+// montanara-58497: pure (no-React) (de)serializer for the /underboss EventTable
+// filter bar + the dashboard's active tab <-> URL query string. Wired into
+// UnderbossDashboard via react-router's useSearchParams so a refresh / shared
+// link restores the exact view. Mirrors paymentsUrlState.ts in style: kept
+// React-free so it can be unit-tested in isolation, and uses diff-against-
+// defaults so the default view produces an EMPTY query string and a mangled URL
+// can never crash the page (every enum/list is validated on parse).
+//
+// NOTE: the tag filter is the tri-state include/exclude model introduced in
+// provola-58497 (NOT a single `tagFilter` string). We persist the include +
+// exclude lists; tagTouchOrder (purely cosmetic dropdown ordering) is NOT
+// persisted — it's reconstructed from the active lists on apply.
+
+export type UnderbossTab =
+  | 'events'
+  | 'cities'
+  | 'partners'
+  | 'fake-detection'
+  | 'superlatives'
+  | 'survey'
+  | 'outreach'
+  | 'telegram-groups';
+
+const UNDERBOSS_TABS: UnderbossTab[] = [
+  'events',
+  'cities',
+  'partners',
+  'fake-detection',
+  'superlatives',
+  'survey',
+  'outreach',
+  'telegram-groups',
+];
+
+// The default tab UnderbossDashboard mounts on. Skipped from the query string.
+const DEFAULT_TAB: UnderbossTab = 'events';
+
+export type EventTableSortField =
+  | 'name'
+  | 'date'
+  | 'guestCount'
+  | 'progress'
+  | 'appealsFirst';
+
+const SORT_FIELDS: EventTableSortField[] = [
+  'name',
+  'date',
+  'guestCount',
+  'progress',
+  'appealsFirst',
+];
+
+export interface EventTableFilters {
+  search: string;
+  sortField: EventTableSortField;
+  sortDir: 'asc' | 'desc';
+  progressIncludes: string[];
+  progressExcludes: string[];
+  regionFilter: string; // country, 'all' default
+  tagIncludes: string[]; // tri-state tag filter (provola-58497)
+  tagExcludes: string[];
+  rsvpComparator: '>' | '<';
+  rsvpThreshold: string; // '' default
+  appealsOnly: boolean;
+}
+
+export const DEFAULT_EVENT_TABLE_FILTERS: EventTableFilters = {
+  search: '',
+  sortField: 'date',
+  sortDir: 'asc',
+  progressIncludes: [],
+  progressExcludes: [],
+  regionFilter: 'all',
+  tagIncludes: [],
+  tagExcludes: [],
+  rsvpComparator: '>',
+  rsvpThreshold: '',
+  appealsOnly: false,
+};
+
+// Allowed progress-filter keys: the PROGRESS_FILTER_KEYS in EventTable.tsx plus
+// the four status pills. Exported so EventTable can stay the single source of
+// truth in tandem; we validate every `inc`/`exc` segment against this set so a
+// hand-mangled URL can't inject an unknown key.
+export const ALLOWED_PROGRESS_KEYS = new Set<string>([
+  'hasPartyKit',
+  'hasCoHosts',
+  'hasVenue',
+  'hasBudget',
+  'hasSponsors',
+  'hasSocialPosts',
+  'hasThrown',
+  'hasEstimatedAttendance',
+  'hasSubmittedReceipt',
+  'hasSubmittedPaymentInfo',
+  'approved',
+  'rejected',
+  'hidden',
+  'listed',
+]);
+
+function sanitizeKeyList(raw: string | null): string[] {
+  if (!raw) return [];
+  const segs = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  // Keep only allowed keys; dedupe while preserving order.
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const s of segs) {
+    if (ALLOWED_PROGRESS_KEYS.has(s) && !seen.has(s)) {
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+// Tag lists are free-form (any string is a valid tag); we just trim + dedupe
+// and bound the count so a pathological URL can't blow up.
+function sanitizeTagList(raw: string | null): string[] {
+  if (!raw) return [];
+  const segs = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const s of segs) {
+    if (!seen.has(s)) {
+      seen.add(s);
+      out.push(s);
+    }
+    if (out.length >= 100) break;
+  }
+  return out;
+}
+
+/**
+ * Serialize the active EventTable filters + the dashboard tab to a
+ * URLSearchParams. A key is written ONLY when its value differs from the
+ * default, so the default view produces an empty query string.
+ */
+export function eventTableFiltersToSearchParams(
+  filters: EventTableFilters,
+  activeTab: UnderbossTab,
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (filters.search && filters.search.trim()) {
+    params.set('q', filters.search.trim());
+  }
+
+  const sort = `${filters.sortField}_${filters.sortDir}`;
+  if (sort !== `${DEFAULT_EVENT_TABLE_FILTERS.sortField}_${DEFAULT_EVENT_TABLE_FILTERS.sortDir}`) {
+    params.set('sort', sort);
+  }
+
+  if (filters.progressIncludes.length > 0) {
+    params.set('inc', filters.progressIncludes.join(','));
+  }
+  if (filters.progressExcludes.length > 0) {
+    params.set('exc', filters.progressExcludes.join(','));
+  }
+
+  if (filters.regionFilter && filters.regionFilter !== 'all') {
+    params.set('country', filters.regionFilter);
+  }
+
+  if (filters.tagIncludes.length > 0) {
+    params.set('tagInc', filters.tagIncludes.join(','));
+  }
+  if (filters.tagExcludes.length > 0) {
+    params.set('tagExc', filters.tagExcludes.join(','));
+  }
+
+  const threshold = filters.rsvpThreshold.trim();
+  if (threshold !== '' && Number.isFinite(Number(threshold))) {
+    const comparator = filters.rsvpComparator === '<' ? '<' : '>';
+    params.set('rsvp', `${comparator}${threshold}`);
+  }
+
+  if (filters.appealsOnly) {
+    params.set('appeals', '1');
+  }
+
+  if (activeTab !== DEFAULT_TAB) {
+    params.set('tab', activeTab);
+  }
+
+  return params;
+}
+
+/**
+ * Parse a URLSearchParams back into an EventTableFilters object + activeTab.
+ * Starts from DEFAULT_EVENT_TABLE_FILTERS and overlays each present param,
+ * validating enums / key sets so a hand-mangled URL can't crash the page.
+ *
+ * Returns `activeTab: null` when no `tab` param is present so the caller can
+ * keep its current default tab.
+ */
+export function searchParamsToEventTableFilters(
+  params: URLSearchParams,
+): { filters: EventTableFilters; activeTab: UnderbossTab | null } {
+  const filters: EventTableFilters = {
+    ...DEFAULT_EVENT_TABLE_FILTERS,
+    progressIncludes: [],
+    progressExcludes: [],
+    tagIncludes: [],
+    tagExcludes: [],
+  };
+
+  const q = params.get('q');
+  if (q) filters.search = q;
+
+  const sortRaw = params.get('sort');
+  if (sortRaw) {
+    const idx = sortRaw.lastIndexOf('_');
+    if (idx > 0) {
+      const field = sortRaw.slice(0, idx);
+      const dir = sortRaw.slice(idx + 1);
+      if (
+        (SORT_FIELDS as string[]).includes(field) &&
+        (dir === 'asc' || dir === 'desc')
+      ) {
+        filters.sortField = field as EventTableSortField;
+        filters.sortDir = dir;
+      }
+    }
+  }
+
+  filters.progressIncludes = sanitizeKeyList(params.get('inc'));
+  filters.progressExcludes = sanitizeKeyList(params.get('exc'));
+
+  const country = params.get('country');
+  if (country && country.trim()) filters.regionFilter = country.trim();
+
+  filters.tagIncludes = sanitizeTagList(params.get('tagInc'));
+  filters.tagExcludes = sanitizeTagList(params.get('tagExc'));
+
+  const rsvpRaw = params.get('rsvp');
+  if (rsvpRaw) {
+    const comparator = rsvpRaw[0];
+    if (comparator === '>' || comparator === '<') {
+      const rest = rsvpRaw.slice(1).trim();
+      const num = Number(rest);
+      if (rest !== '' && Number.isFinite(num)) {
+        filters.rsvpComparator = comparator;
+        filters.rsvpThreshold = rest;
+      }
+    }
+  }
+
+  if (params.has('appeals')) {
+    filters.appealsOnly = params.get('appeals') !== '0';
+  }
+
+  const tabRaw = params.get('tab');
+  const activeTab: UnderbossTab | null =
+    tabRaw && UNDERBOSS_TABS.includes(tabRaw as UnderbossTab)
+      ? (tabRaw as UnderbossTab)
+      : null;
+
+  return { filters, activeTab };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6754,3 +6754,40 @@ export interface Suggestion {
 export async function fetchSuggestions() {
   return apiRequest<{ suggestions: Suggestion[] }>('/api/suggestions');
 }
+
+// =============================================================================
+// Saved filter views (montanara-58497) — per-account, keyed by auth email.
+// `params` is the page's serialized URL query string (page-agnostic).
+// =============================================================================
+export type SavedViewScope = 'payments' | 'underboss';
+
+export interface SavedView {
+  id: string;
+  name: string;
+  params: string;
+  updatedAt: string;
+}
+
+export async function listSavedViews(scope: SavedViewScope): Promise<SavedView[]> {
+  const { views } = await apiRequest<{ views: SavedView[] }>(
+    `/api/saved-views?scope=${encodeURIComponent(scope)}`,
+  );
+  return views;
+}
+
+export async function saveFilterView(
+  scope: SavedViewScope,
+  name: string,
+  params: string,
+): Promise<SavedView> {
+  return apiRequest<SavedView>('/api/saved-views', {
+    method: 'POST',
+    body: { scope, name, params },
+  });
+}
+
+export async function deleteSavedView(id: string): Promise<void> {
+  await apiRequest<{ ok: boolean }>(`/api/saved-views/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet-async';
 import { ShieldX, Loader2, DollarSign, Download, Plus, Search } from 'lucide-react';
 import { Layout } from '../components/Layout';
 import { IconInput } from '../components/IconInput';
+import { SavedViewsMenu } from '../components/SavedViewsMenu';
 import {
   fetchAdminMe,
   fetchUnderbossMe,
@@ -1267,6 +1268,16 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
               Payments
             </button>
           </div>
+          {/* montanara-58497: per-account saved filter views */}
+          <SavedViewsMenu
+            scope="payments"
+            currentParams={filtersToSearchParams(filters, viewMode).toString()}
+            onApply={(p) => {
+              const { filters: f, viewMode: vm } = searchParamsToFilters(new URLSearchParams(p), regions);
+              setFilters((prev) => ({ ...prev, ...f }));
+              if (vm) setViewMode(vm);
+            }}
+          />
           </div>
         </div>
 

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, Check, Download } from 'lucide-react';
@@ -7,6 +8,15 @@ import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
 import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, SuperlativesTab, SurveyQuestionsTab, OutreachTab, TelegramGroupsTab } from '../components/underboss';
+import { SavedViewsMenu } from '../components/SavedViewsMenu';
+// montanara-58497: URL <-> EventTable filters + active tab (de)serializer so a
+// refresh / shared link restores the exact filtered view.
+import {
+  eventTableFiltersToSearchParams,
+  searchParamsToEventTableFilters,
+  type EventTableFilters,
+  type UnderbossTab,
+} from '../components/underboss/underbossTableUrlState';
 import { triggerFlyerRegenForEvents } from '../components/flyer/autoRegenFlyer';
 import { fetchUnderbossDashboard, fetchUnderbossMe, createUnderboss, fetchSponsorUsers } from '../lib/api';
 import type { UnderbossMeResponse } from '../lib/api';
@@ -95,8 +105,42 @@ export function UnderbossDashboard() {
   const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
   const [availableRegions, setAvailableRegions] = useState<string[]>([]);
 
+  // montanara-58497: the URL query string is the source of restore-on-load state
+  // for the active tab + EventTable filters. We parse it ONCE in the lazy
+  // useState initialisers below (via initialUrlStateRef); after mount the
+  // `activeTab` / `tableFilters` state is the single source of truth that PUSHES
+  // to the URL via the sync effect. We never read searchParams back into state on
+  // re-render (that would oscillate). selectedRegions/selectedCities are derived
+  // from the UB's server scope and are intentionally NOT persisted in the URL.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialUrlStateRef = useRef<ReturnType<typeof searchParamsToEventTableFilters> | null>(null);
+  if (initialUrlStateRef.current === null) {
+    initialUrlStateRef.current = searchParamsToEventTableFilters(searchParams);
+  }
+
   // Tab state
-  const [activeTab, setActiveTab] = useState<'events' | 'cities' | 'partners' | 'fake-detection' | 'superlatives' | 'survey' | 'outreach' | 'telegram-groups'>('events');
+  const [activeTab, setActiveTab] = useState<UnderbossTab>(
+    () => initialUrlStateRef.current!.activeTab ?? 'events',
+  );
+
+  // montanara-58497: EventTable filters live here now (controlled), so they can
+  // be serialized to the URL alongside the tab.
+  const [tableFilters, setTableFilters] = useState<EventTableFilters>(
+    () => initialUrlStateRef.current!.filters,
+  );
+
+  // ONE sync effect: serialize {tableFilters, activeTab} into the query string.
+  // tab + table filters share the same params object, so there must be exactly
+  // ONE writer (a second setSearchParams would clobber the first). replace:true
+  // keeps filter tweaks out of the back-stack; guarded so we only write when the
+  // serialized string actually changes.
+  useEffect(() => {
+    const next = eventTableFiltersToSearchParams(tableFilters, activeTab);
+    const nextStr = next.toString();
+    if (nextStr !== searchParams.toString()) {
+      setSearchParams(next, { replace: true });
+    }
+  }, [tableFilters, activeTab, searchParams, setSearchParams]);
 
   const [tableFilteredEvents, setTableFilteredEvents] = useState<UnderbossEvent[] | null>(null);
 
@@ -708,7 +752,31 @@ export function UnderbossDashboard() {
           </div>
 
           {activeTab === 'events' && (
-            <EventTable events={filteredData.events} showRegion={showRegionColumn} onEventUpdate={handleEventUpdate} onBulkAction={() => loadDashboard(true)} onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }} partnerTags={partnerTags} onFilteredEventsChange={setTableFilteredEvents} isAdmin={isAdmin} />
+            <>
+              <div className="flex items-center justify-end mb-3">
+                <SavedViewsMenu
+                  scope="underboss"
+                  currentParams={eventTableFiltersToSearchParams(tableFilters, activeTab).toString()}
+                  onApply={(p) => {
+                    const { filters: f, activeTab: tabFromView } = searchParamsToEventTableFilters(new URLSearchParams(p));
+                    setTableFilters(f);
+                    if (tabFromView) setActiveTab(tabFromView);
+                  }}
+                />
+              </div>
+              <EventTable
+                events={filteredData.events}
+                showRegion={showRegionColumn}
+                onEventUpdate={handleEventUpdate}
+                onBulkAction={() => loadDashboard(true)}
+                onTelegramBroadcast={(cities) => { setBroadcastCities(cities); setShowBroadcast(true); }}
+                partnerTags={partnerTags}
+                onFilteredEventsChange={setTableFilteredEvents}
+                isAdmin={isAdmin}
+                filters={tableFilters}
+                onFiltersChange={setTableFilters}
+              />
+            </>
           )}
 
           {activeTab === 'cities' && (


### PR DESCRIPTION
## Summary
Persists the **/underboss** EventTable filter set + active tab in the URL (refresh / shareable link restores the exact view, mirroring how /payments already does it), and adds a **DB-backed "Saved filter views"** feature to **both** /underboss and /payments (per-account, keyed by the caller's auth email).

## Part A — /underboss URL filter persistence
- New `frontend/src/components/underboss/underbossTableUrlState.ts` — React-free diff-against-defaults (de)serializer (`eventTableFiltersToSearchParams` / `searchParamsToEventTableFilters`). Validates enums + key sets so a mangled URL can't crash. Params: `q`, `sort`, `inc`, `exc`, `country`, `tagInc`, `tagExc`, `rsvp`, `appeals`, `tab`.
- `EventTable` gains optional `filters` / `onFiltersChange` props → **controlled mode** (opt-in). When omitted it behaves exactly as before (internal useState). No conditional hooks.
- `UnderbossDashboard` owns the URL: parse-once `useRef`, inits `activeTab` + `tableFilters` from the query string, single sync effect writes `setSearchParams(..., {replace:true})` only on change. `selectedRegions`/`selectedCities` are NOT persisted.

> Note: the brief's `tagFilter: string` was stale — the live tag filter is the tri-state `tagIncludes`/`tagExcludes` model (provola-58497). The filter type + URL params reflect that.

## Part B — DB-backed saved views
- Prisma model `SavedFilterView` (`saved_filter_views`), unique `(userEmail, scope, name)`.
- `backend/src/routes/saved-views.routes.ts` mounted at `/api/saved-views` (requireAuth, owner = lowercased email): GET (by scope), POST (upsert, validated), DELETE (404 if not owner).
- `frontend/src/lib/api.ts`: `listSavedViews` / `saveFilterView` / `deleteSavedView`.
- `frontend/src/components/SavedViewsMenu.tsx`: shared "Views" dropdown (lazy-load, apply, delete, save-current via IconInput). Wired into both pages.

## ⚠️ Requires prod DDL before it works on preview
```sql
CREATE TABLE saved_filter_views (
  id          text PRIMARY KEY,
  user_email  text NOT NULL,
  scope       text NOT NULL,
  name        text NOT NULL,
  params      text NOT NULL,
  created_at  timestamp(3) NOT NULL DEFAULT now(),
  updated_at  timestamp(3) NOT NULL
);
CREATE UNIQUE INDEX saved_filter_views_user_email_scope_name_key
  ON saved_filter_views (user_email, scope, name);
```

## tsc
- Frontend: clean.
- Backend: clean for these changes (pre-existing unrelated errors only: missing `openai`/`@anthropic-ai/sdk` modules offline + auth.test.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)