### PR TITLE
pesto-58496: broadcast link-unresolved warning + app-catalog drift test

### DIFF
--- a/backend/src/lib/broadcastApps.ts
+++ b/backend/src/lib/broadcastApps.ts
@@ -8,6 +8,10 @@
  * frontend/src/lib/appDefinitions.ts. The frontend is the UX source of truth;
  * the backend only needs the set of valid `tab` values to validate an incoming
  * `appTab` so a literal {appLink} token can never ship to a recipient.
+ *
+ * pesto-58496: this frontend⊆backend invariant is ENFORCED by the unit test
+ * frontend/src/lib/broadcastAppCatalog.test.ts (it imports this file directly).
+ * If you add a BROADCAST_APPS entry whose tab isn't here, that test fails.
  */
 export const BROADCAST_APP_TABS: readonly string[] = [
   'partners',

--- a/backend/src/routes/telegram.routes.ts
+++ b/backend/src/routes/telegram.routes.ts
@@ -140,6 +140,10 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
     // ONE party matches a cityKey — ambiguous/no match leaves the token to be
     // stripped, so a broadcast never ships the wrong event's link.
     const usesLinkToken = /\{link\}|\{appLink\}/.test(message);
+    // pesto-58496: track each token independently so per-recipient results can
+    // flag when a USED token resolved to empty (link not added for that city).
+    const usesLink = /\{link\}/.test(message);
+    const usesAppLink = /\{appLink\}/.test(message);
     const partyByCityKey = new Map<string, { customUrl: string | null; inviteCode: string | null } | null>();
     if (usesLinkToken) {
       const cityKeys = Array.from(
@@ -172,7 +176,7 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
       }
     }
 
-    const results: Array<{ chatId: string; city: string; success: boolean; error?: string }> = [];
+    const results: Array<{ chatId: string; city: string; success: boolean; error?: string; linkResolved?: boolean }> = [];
 
     for (let i = 0; i < groups.length; i++) {
       const group = groups[i];
@@ -187,6 +191,11 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
       const linkedParty = usesLinkToken ? (partyByCityKey.get((city || '').toLowerCase().trim()) ?? null) : null;
       const linkUrl = publicEventLink(linkedParty);
       const appLinkUrl = appDeepLink(linkedParty, validatedAppTab);
+
+      // pesto-58496: flag a recipient when a USED link token resolved to empty
+      // (the link was stripped, so this recipient got the message without it).
+      // If the message uses no link tokens, never flag (leave true).
+      const linkResolved = !((usesLink && !linkUrl) || (usesAppLink && !appLinkUrl));
 
       // Replace template variables
       let personalizedMessage = message;
@@ -236,14 +245,14 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
             // the group's cityKey (already lowercased) so this updates the
             // existing row rather than creating an orphan. region set in-helper.
             await persistCityGroupMigration((city || '').toLowerCase().trim(), newChatId);
-            results.push({ chatId, city: city || '', success: true, error: `Migrated to ${newChatId} (saved automatically)` });
+            results.push({ chatId, city: city || '', success: true, error: `Migrated to ${newChatId} (saved automatically)`, linkResolved });
           } else {
-            results.push({ chatId, city: city || '', success: false, error: telegramResult.description || 'Failed after migration retry' });
+            results.push({ chatId, city: city || '', success: false, error: telegramResult.description || 'Failed after migration retry', linkResolved });
           }
         } else if (telegramResult.ok) {
-          results.push({ chatId, city: city || '', success: true });
+          results.push({ chatId, city: city || '', success: true, linkResolved });
         } else {
-          results.push({ chatId, city: city || '', success: false, error: telegramResult.description || 'Unknown Telegram error' });
+          results.push({ chatId, city: city || '', success: false, error: telegramResult.description || 'Unknown Telegram error', linkResolved });
         }
       } catch (err: any) {
         results.push({
@@ -251,6 +260,7 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
           city: city || '',
           success: false,
           error: err.message || 'Network error',
+          linkResolved,
         });
       }
 
@@ -312,6 +322,11 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
       throw new AppError('No valid partyIds in hosts array', 400, 'VALIDATION_ERROR');
     }
 
+    // pesto-58496: track each link token independently so per-recipient results
+    // can flag when a USED token resolved to empty (link not added).
+    const usesLink = /\{link\}/.test(message);
+    const usesAppLink = /\{appLink\}/.test(message);
+
     const partyRows = await prisma.party.findMany({
       where: { id: { in: partyIds }, hostTelegramChatId: { not: null } },
       // parmigiano-58493: customUrl + inviteCode added for {link}/{appLink} tokens.
@@ -334,6 +349,7 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
       hostName: string;
       success: boolean;
       error?: string;
+      linkResolved?: boolean;
     }> = [];
 
     for (let i = 0; i < hosts.length; i++) {
@@ -357,6 +373,9 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
       const partyMeta = partyMetaById.get(partyId) ?? null;
       const linkUrl = publicEventLink(partyMeta);
       const appLinkUrl = appDeepLink(partyMeta, validatedAppTab);
+
+      // pesto-58496: flag a recipient when a USED link token resolved to empty.
+      const linkResolved = !((usesLink && !linkUrl) || (usesAppLink && !appLinkUrl));
 
       // Replace template variables
       let personalizedMessage = message;
@@ -384,7 +403,7 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
         const telegramResult = await telegramResponse.json();
 
         if (telegramResult.ok) {
-          results.push({ partyId, city, hostName, success: true });
+          results.push({ partyId, city, hostName, success: true, linkResolved });
         } else {
           const description: string = telegramResult.description || 'Unknown Telegram error';
           const errorCode: number = telegramResult.error_code || telegramResponse.status;
@@ -411,9 +430,10 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
               hostName,
               success: false,
               error: 'Host blocked the bot — disconnected',
+              linkResolved,
             });
           } else {
-            results.push({ partyId, city, hostName, success: false, error: description });
+            results.push({ partyId, city, hostName, success: false, error: description, linkResolved });
           }
         }
       } catch (err: any) {
@@ -423,6 +443,7 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
           hostName,
           success: false,
           error: err?.message || 'Network error',
+          linkResolved,
         });
       }
 

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -545,6 +545,11 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
     }
   };
 
+  // pesto-58496: count recipients flagged with linkResolved === false. Only the
+  // explicit boolean false counts — undefined (older prod backend) is ignored so
+  // previews against the old backend never surface a spurious warning.
+  const linkMissingCount = results.filter((r) => r.linkResolved === false).length;
+
   return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
@@ -1113,6 +1118,20 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                 </div>
               )}
 
+              {/* pesto-58496: warn when any recipient got the message without a
+                  USED link token resolving. Only react to explicit === false so
+                  an older prod backend (field undefined) shows no warning. */}
+              {linkMissingCount > 0 && (
+                <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3">
+                  <div className="flex items-start gap-2">
+                    <AlertCircle size={16} className="text-amber-500 flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-amber-600">
+                      {t('telegram.results.linkMissingWarning', { count: linkMissingCount })}
+                    </p>
+                  </div>
+                </div>
+              )}
+
               {/* Summary */}
               <div className="flex items-center gap-4 justify-center py-4">
                 <div className="text-center">
@@ -1153,6 +1172,11 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                                 )}
                               </div>
                               <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
+                              {r.linkResolved === false && (
+                                <span className="text-xs text-amber-500 whitespace-nowrap">
+                                  {t('telegram.results.linkNotAdded')}
+                                </span>
+                              )}
                               {r.error && (
                                 <span className="text-xs text-red-400 max-w-[200px] truncate" title={r.error}>
                                   {r.error}
@@ -1196,6 +1220,11 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                                   )}
                                 </div>
                                 <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
+                                {r.linkResolved === false && (
+                                  <span className="text-xs text-amber-500 whitespace-nowrap">
+                                    {t('telegram.results.linkNotAdded')}
+                                  </span>
+                                )}
                                 {r.error && (
                                   <span className={`text-xs max-w-[200px] truncate ${isBlocked ? 'text-yellow-600' : 'text-red-400'}`} title={r.error}>
                                     {r.error}
@@ -1237,6 +1266,11 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                             )}
                           </div>
                           <span className="text-sm text-theme-text flex-1">{r.city || r.chatId}</span>
+                          {r.linkResolved === false && (
+                            <span className="text-xs text-amber-500 whitespace-nowrap">
+                              {t('telegram.results.linkNotAdded')}
+                            </span>
+                          )}
                           {r.error && (
                             <span className={`text-xs max-w-[200px] truncate ${isBlocked ? 'text-yellow-600' : 'text-red-400'}`} title={r.error}>
                               {r.error}

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -415,7 +415,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "eventRow": {

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -436,7 +436,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "hostConnect": {

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -415,7 +415,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "eventRow": {

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -415,7 +415,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "eventRow": {

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -415,7 +415,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "eventRow": {

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -415,7 +415,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "eventRow": {

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -415,7 +415,10 @@
       "groupsSection": "Group chats",
       "hostsSection": "Host DMs",
       "blockedWarning": "{{count}} host blocked the bot and was disconnected. Consider reaching out another way.",
-      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way."
+      "blockedWarning_other": "{{count}} hosts blocked the bot and were disconnected. Consider reaching out another way.",
+      "linkNotAdded": "link not added",
+      "linkMissingWarning": "{{count}} recipient received the message without the link.",
+      "linkMissingWarning_other": "{{count}} recipients received the message without the link."
     }
   },
   "eventRow": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3678,6 +3678,10 @@ export interface BroadcastResult {
   city: string;
   success: boolean;
   error?: string;
+  // pesto-58496: false when a USED {link}/{appLink} token resolved to empty for
+  // this recipient (message sent without the link). Older prod backends omit
+  // this field entirely — undefined must NOT be treated as a warning.
+  linkResolved?: boolean;
 }
 
 export interface BroadcastResponse {

--- a/frontend/src/lib/appDefinitions.ts
+++ b/frontend/src/lib/appDefinitions.ts
@@ -52,6 +52,10 @@ export const PINNABLE_APPS: PinnableApp[] = [
  * app's `tab` value (host app URL is /host/:inviteCode/:tab), NOT its id. Keep
  * the `tab` values in sync with the backend BROADCAST_APP_TABS catalog in
  * backend/src/lib/broadcastApps.ts.
+ *
+ * pesto-58496: this frontend⊆backend invariant is ENFORCED by the unit test
+ * frontend/src/lib/broadcastAppCatalog.test.ts. Every tab below must pass the
+ * backend's isValidAppTab; the test fails if you add one the backend rejects.
  */
 export interface BroadcastApp {
   name: string;

--- a/frontend/src/lib/broadcastAppCatalog.test.ts
+++ b/frontend/src/lib/broadcastAppCatalog.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { BROADCAST_APPS } from './appDefinitions';
+// pesto-58496: drift guard. The backend's broadcastApps catalog is the
+// validation authority for the {appLink} token (an unrecognized tab is a hard
+// 400). This file is intentionally dependency-free so it resolves cleanly into
+// the frontend vitest run via a relative cross-package import.
+import { isValidAppTab, BROADCAST_APP_TABS } from '../../../backend/src/lib/broadcastApps';
+
+describe('broadcast app catalog drift guard', () => {
+  it('every frontend BROADCAST_APPS tab is accepted by the backend isValidAppTab', () => {
+    const offenders = BROADCAST_APPS.filter((app) => !isValidAppTab(app.tab)).map((app) => app.tab);
+    expect(offenders).toEqual([]);
+  });
+
+  it('every frontend BROADCAST_APPS tab is present in BROADCAST_APP_TABS', () => {
+    const backendTabs = new Set(BROADCAST_APP_TABS);
+    const offenders = BROADCAST_APPS.filter((app) => !backendTabs.has(app.tab)).map((app) => app.tab);
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two small polish items on the already-merged `{link}`/`{appLink}` Telegram broadcast tokens.

## Item 1 — surface "link not added" end-to-end
- **Backend** (`telegram.routes.ts`, both `/broadcast` and `/host-broadcast`): hoisted `usesLink`/`usesAppLink` out of the per-recipient loop and set `linkResolved: false` on a result row when a **used** token resolved to empty (`(usesLink && !linkUrl) || (usesAppLink && !appLinkUrl)`), else `true`. If the message uses no link tokens the flag stays `true`. Send behavior is unchanged — additive flag only.
- **`api.ts`**: added `linkResolved?: boolean` to `BroadcastResult`.
- **`TelegramBroadcast.tsx`**: per-row amber "link not added" note beside the row status (all three renderers: groups/hosts sections + single-list), plus a summary banner above the list ("N recipients received the message without the link").
- **Preview-safety**: UI reacts only to explicit `=== false`. Against the older prod backend the field is `undefined`, which renders normally with NO warning.
- **i18n**: added `telegram.results.linkNotAdded` + `linkMissingWarning`/`_other` to the `partner` namespace across en/de/es/fr/ja/pt/zh (ko relies on en fallback, matching the existing `blockedWarning` placeholder pattern in those files).

## Item 2 — frontend ⊆ backend app-catalog drift guard
- Confirmed every `BROADCAST_APPS[].tab` is in `BROADCAST_APP_TABS` (true today).
- Added frontend vitest `frontend/src/lib/broadcastAppCatalog.test.ts` that imports `BROADCAST_APPS` from `appDefinitions.ts` AND `isValidAppTab`/`BROADCAST_APP_TABS` from the backend dependency-free `backend/src/lib/broadcastApps.ts`, asserting every broadcast tab passes `isValidAppTab`.
- **The cross-package relative import worked** under vitest (no fallback to a shared extracted module needed).
- Updated the "keep in sync" comments in both catalog files to point at the test. `PINNABLE_APPS` left untouched.

## Test / build results
- New test: `vitest run src/lib/broadcastAppCatalog.test.ts` -> **2 passed**.
- Backend `tsc --noEmit`: 0 errors in touched files (`telegram.routes.ts`, `broadcastApps.ts`). The 4 repo-wide errors are pre-existing (missing `openai`/`@anthropic-ai/sdk` deps in the worktree + a pre-existing test overload), unrelated.
- Frontend `vite build` could not run in this worktree: `react-router-dom` is not installed in any reachable `node_modules` (pre-existing environment gap; the package is genuinely absent, unrelated to these changes which touch no routing). Vitest transpiled/type-erased all touched TS successfully.
- The repo's `i18n-keys` parity test fails on `admin:underbossDashboard.tabs.{bestOf,survey,telegramGroups}` — **pre-existing on `origin/master`** (those keys are absent from `en/admin.json` on master). My new `partner` keys are NOT flagged.

Screenshots not needed (small UI note + count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
