### PR TITLE
guanciale-58491: DM all GPP hosts via bot (coverage + invite + all-hosts broadcast + email fallback)

### DIFF
--- a/backend/prisma/migrations/guanciale-58491-telegram-broadcast-log.sql
+++ b/backend/prisma/migrations/guanciale-58491-telegram-broadcast-log.sql
@@ -1,0 +1,27 @@
+-- guanciale-58491: audit log for host-DM / city-group Telegram broadcasts.
+-- The id doubles as the client-minted broadcastId double-send guard:
+-- the host-broadcast endpoint short-circuits if a row with that id exists.
+-- Apply manually to prod BEFORE merging (no Prisma auto-migrate in this repo).
+
+CREATE TABLE IF NOT EXISTS telegram_broadcast_log (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- caller identity, from req.underboss
+  actor_email    text NOT NULL,
+  -- 'admin' | 'underboss'
+  actor_kind     text NOT NULL,
+  -- logical channel, e.g. 'host_dm'
+  channel        text NOT NULL,
+  message        text NOT NULL,
+  -- how many recipients the broadcast targeted
+  audience_count integer NOT NULL,
+  sent_count     integer NOT NULL,
+  failed_count   integer NOT NULL,
+  -- how many 'not connected' hosts got the message text via email fallback
+  emailed_count  integer NOT NULL DEFAULT 0,
+  -- per-recipient results blob (same shape as the endpoint response)
+  results        jsonb NOT NULL,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS telegram_broadcast_log_created_at_idx
+  ON telegram_broadcast_log (created_at DESC);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2213,3 +2213,32 @@ model ImageAuthenticityCheck {
   @@index([partyId])
   @@map("image_authenticity_checks")
 }
+
+// guanciale-58491: audit log for host-DM (and city-group) broadcasts sent from
+// the /underboss Telegram broadcast tool. Each row records who sent a broadcast,
+// the message, the resolved counts (sent / failed / emailed), and the per-host
+// results. The `id` doubles as the client-minted `broadcastId` double-send guard:
+// the host-broadcast endpoint short-circuits if a row with the supplied id
+// already exists. Migration applied to prod manually before merge.
+model TelegramBroadcastLog {
+  id            String   @id @default(uuid()) @db.Uuid
+  // Caller identity (from req.underboss).
+  actorEmail    String   @map("actor_email")
+  // 'admin' | 'underboss'
+  actorKind     String   @map("actor_kind")
+  // Logical channel, e.g. "host_dm".
+  channel       String
+  message       String
+  // How many recipients the broadcast targeted.
+  audienceCount Int      @map("audience_count")
+  sentCount     Int      @map("sent_count")
+  failedCount   Int      @map("failed_count")
+  // How many "not connected" hosts got the message text via email fallback.
+  emailedCount  Int      @default(0) @map("emailed_count")
+  // Per-recipient results blob (same shape as the endpoint response).
+  results       Json
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([createdAt(sort: Desc)])
+  @@map("telegram_broadcast_log")
+}

--- a/backend/src/routes/telegram.routes.ts
+++ b/backend/src/routes/telegram.routes.ts
@@ -1,12 +1,22 @@
 import { Router, Response, NextFunction } from 'express';
+import { customAlphabet } from 'nanoid';
 import { prisma } from '../config/database.js';
 import { requireAuth } from '../middleware/auth.js';
 import { requireUnderbossAuth, UnderbossAuthRequest } from '../middleware/underbossAuth.js';
 import { AppError } from '../middleware/error.js';
-import { cityKeyFromPartyName, getGppRegionByCityKey } from '../helpers/underbossScope.js';
+import {
+  cityKeyFromPartyName,
+  getGppRegionByCityKey,
+  buildScopedWhereClause,
+  UnderbossScope,
+} from '../helpers/underbossScope.js';
 import { sendToCityGroup, persistCityGroupMigration } from '../services/cityTelegramGroup.js';
 import { withBennySignature } from '../lib/bennySignature.js';
 import { isValidAppTab } from '../lib/broadcastApps.js';
+import {
+  sendConnectInviteEmail,
+  sendBroadcastFallbackEmail,
+} from '../services/hostTelegramEmail.js';
 
 // Alias to keep the routes that were ported in from master readable.
 type UnderbossRequest = UnderbossAuthRequest;
@@ -82,6 +92,50 @@ function groupInBroadcastScope(
   const groupCity = (group.city || '').toLowerCase().trim();
   if (!groupCity) return false;
   return allowed.includes(groupCity);
+}
+
+// ─── guanciale-58491: "DM all GPP hosts" helpers ──────────────────────────
+
+// URL-safe nanoid for the host_telegram_link_token — matches the alphabet +
+// length used by host-telegram.routes.ts so minted tokens are interchangeable.
+const generateConnectToken = customAlphabet(
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+  10,
+);
+
+/**
+ * Adapt `req.underboss` (regions/cities arrays + '__admin__' sentinel) to the
+ * canonical `UnderbossScope` used by `buildScopedWhereClause`. This lets the
+ * new host endpoints push scope into the Prisma `where` (no JS post-filter),
+ * exactly like underboss.routes.ts.
+ */
+function scopeFromUnderboss(ub: { regions: string[]; cities?: string[] }): UnderbossScope {
+  if (ub.regions.includes('__admin__')) {
+    return { isAdmin: true, regions: [], cities: [] };
+  }
+  return { isAdmin: false, regions: ub.regions, cities: ub.cities || [] };
+}
+
+/** 'admin' | 'underboss' for the broadcast audit log. */
+function actorKindFromUnderboss(ub: { regions: string[] }): 'admin' | 'underboss' {
+  return ub.regions.includes('__admin__') ? 'admin' : 'underboss';
+}
+
+/** Strip the "Global Pizza Party " prefix for a compact city display name. */
+function cityDisplayName(name: string | null | undefined): string {
+  if (!name) return '';
+  return name.replace(/^Global Pizza Party\s+/i, '').trim() || name;
+}
+
+/**
+ * Build the in-scope GPP audience `where` clause. Mirrors the underboss.routes
+ * GPP filter (eventType='gpp', non-cancelled) and pushes the caller's scope
+ * into Prisma so out-of-scope rows are never fetched.
+ */
+function gppScopedWhere(scope: UnderbossScope) {
+  const scopedWhere = buildScopedWhereClause(scope);
+  const base = { eventType: 'gpp' as const, cancelledAt: null };
+  return scopedWhere ? { AND: [base, scopedWhere] } : base;
 }
 
 // POST /broadcast — Send message to multiple Telegram groups
@@ -271,10 +325,173 @@ router.post('/broadcast', requireAuth, requireUnderbossAuth, async (req: Underbo
   }
 });
 
+// GET /host-coverage — guanciale-58491: coverage report over the in-scope GPP
+// audience. Returns total / linked / unlinked counts plus the list of unlinked
+// hosts (those with no host_telegram_chat_id) so the UI can offer "email the
+// deeplink to N unlinked hosts". Scope is pushed into the Prisma where.
+router.get('/host-coverage', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const scope = scopeFromUnderboss(req.underboss!);
+    const parties = await prisma.party.findMany({
+      where: gppScopedWhere(scope),
+      select: {
+        id: true,
+        name: true,
+        city: true,
+        hostTelegramChatId: true,
+        user: { select: { name: true, email: true, telegram: true } },
+      },
+    });
+
+    let linked = 0;
+    let hasHandleNoChat = 0;
+    let noHandleNoChat = 0;
+    const unlinkedHosts: Array<{
+      partyId: string;
+      city: string;
+      hostName: string | null;
+      hostEmail: string | null;
+      hostTelegram: string | null;
+    }> = [];
+
+    for (const p of parties) {
+      const linkedHost = p.hostTelegramChatId !== null;
+      if (linkedHost) {
+        linked++;
+        continue;
+      }
+      const handle = p.user?.telegram || null;
+      if (handle) hasHandleNoChat++;
+      else noHandleNoChat++;
+      unlinkedHosts.push({
+        partyId: p.id,
+        city: p.city || cityDisplayName(p.name),
+        hostName: p.user?.name || null,
+        hostEmail: p.user?.email || null,
+        hostTelegram: handle,
+      });
+    }
+
+    res.json({
+      total: parties.length,
+      linked,
+      unlinked: parties.length - linked,
+      hasHandleNoChat,
+      noHandleNoChat,
+      unlinkedHosts,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /invite-unlinked — guanciale-58491: email every in-scope UNLINKED host
+// (with an email) their personal Telegram connect deeplink. Mints/reuses the
+// host_telegram_link_token (same logic as host-telegram.routes.ts). Idempotent-
+// friendly: reuses an existing token rather than rotating.
+router.post('/invite-unlinked', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const scope = scopeFromUnderboss(req.underboss!);
+    const botUsername = process.env.TELEGRAM_BOT_USERNAME || '';
+    if (!botUsername) {
+      throw new AppError('Telegram bot username not configured', 500, 'CONFIG_ERROR');
+    }
+
+    // In-scope, unlinked GPP hosts.
+    const parties = await prisma.party.findMany({
+      where: { AND: [gppScopedWhere(scope), { hostTelegramChatId: null }] },
+      select: {
+        id: true,
+        name: true,
+        city: true,
+        hostTelegramLinkToken: true,
+        user: { select: { name: true, email: true } },
+      },
+    });
+
+    let emailed = 0;
+    let skipped = 0; // had email but Resend rejected
+    let noEmail = 0;
+
+    for (const p of parties) {
+      const toEmail = p.user?.email || null;
+      if (!toEmail) {
+        noEmail++;
+        continue;
+      }
+
+      // Mint/reuse the connect token (idempotent — no rotate).
+      let token = p.hostTelegramLinkToken;
+      if (!token) {
+        token = generateConnectToken();
+        try {
+          await prisma.party.update({
+            where: { id: p.id },
+            data: { hostTelegramLinkToken: token },
+          });
+        } catch (err: any) {
+          console.warn(`[invite-unlinked] failed to mint token for party ${p.id}:`, err?.message || err);
+          skipped++;
+          continue;
+        }
+      }
+
+      const deeplink = `https://t.me/${botUsername}?start=${token}`;
+      const ok = await sendConnectInviteEmail({
+        toEmail,
+        hostName: p.user?.name || null,
+        cityName: p.city || cityDisplayName(p.name),
+        deeplink,
+      });
+      if (ok) emailed++;
+      else skipped++;
+
+      // Light rate-limit so a large invite batch doesn't burst Resend.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    console.log(`[invite-unlinked] ${req.underboss!.email}: emailed=${emailed} skipped=${skipped} noEmail=${noEmail} (of ${parties.length} unlinked)`);
+    res.json({ emailed, skipped, noEmail });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /host-audience — guanciale-58491: the full in-scope LINKED-host list,
+// independent of any client-passed event window. Used by the "All hosts"
+// broadcast entry point so the audience isn't limited to the page's events.
+router.get('/host-audience', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+  try {
+    const scope = scopeFromUnderboss(req.underboss!);
+    const parties = await prisma.party.findMany({
+      where: { AND: [gppScopedWhere(scope), { hostTelegramChatId: { not: null } }] },
+      select: {
+        id: true,
+        name: true,
+        city: true,
+        user: { select: { name: true, telegram: true } },
+      },
+      orderBy: { city: 'asc' },
+    });
+
+    res.json({
+      hosts: parties.map((p) => ({
+        partyId: p.id,
+        city: p.city || cityDisplayName(p.name),
+        hostName: p.user?.name || null,
+        hostTelegram: p.user?.telegram || null,
+        connected: true,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // POST /host-broadcast — Send DM to multiple host private chats
 router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: UnderbossRequest, res: Response, next: NextFunction) => {
   try {
-    const { hosts, message, parseMode, appTab } = req.body;
+    const { hosts, message, parseMode, appTab, broadcastId } = req.body;
 
     // parmigiano-58493: validate optional {appLink} target tab (hard 400 if bad).
     const validatedAppTab = validateAppTab(appTab);
@@ -282,8 +499,8 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
     if (!Array.isArray(hosts) || hosts.length === 0) {
       throw new AppError('hosts must be a non-empty array', 400, 'VALIDATION_ERROR');
     }
-    if (hosts.length > 500) {
-      throw new AppError('Maximum 500 hosts per request', 400, 'VALIDATION_ERROR');
+    if (hosts.length > 1000) {
+      throw new AppError('Maximum 1000 hosts per request', 400, 'VALIDATION_ERROR');
     }
 
     if (!message || typeof message !== 'string' || message.trim().length === 0) {
@@ -296,6 +513,30 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
     const validParseModes = ['HTML', 'Markdown', 'None', undefined];
     if (parseMode && !validParseModes.includes(parseMode)) {
       throw new AppError('parseMode must be "HTML", "Markdown", or "None"', 400, 'VALIDATION_ERROR');
+    }
+
+    // guanciale-58491: validate optional client-minted broadcastId (UUID). If a
+    // log row with this id already exists, short-circuit — double-send guard for
+    // accidental resubmits / retries. Return the persisted counts so the UI can
+    // still render the original result.
+    let broadcastIdValid: string | null = null;
+    if (broadcastId !== undefined && broadcastId !== null && broadcastId !== '') {
+      if (typeof broadcastId !== 'string' || !/^[0-9a-fA-F-]{36}$/.test(broadcastId)) {
+        throw new AppError('broadcastId must be a UUID', 400, 'VALIDATION_ERROR');
+      }
+      broadcastIdValid = broadcastId.toLowerCase();
+      const existing = await prisma.telegramBroadcastLog.findUnique({
+        where: { id: broadcastIdValid },
+      });
+      if (existing) {
+        return res.json({
+          results: Array.isArray(existing.results) ? existing.results : [],
+          sent: existing.sentCount,
+          failed: existing.failedCount,
+          emailed: existing.emailedCount,
+          duplicate: true,
+        });
+      }
     }
 
     const botToken = process.env.TELEGRAM_BOT_TOKEN;
@@ -312,21 +553,39 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
       throw new AppError('No valid partyIds in hosts array', 400, 'VALIDATION_ERROR');
     }
 
+    // guanciale-58491: pull ALL requested parties (not just connected ones) so
+    // the email-the-message fallback can reach hosts whose chat_id is null at
+    // send time. customUrl + inviteCode for {link}/{appLink}; user for email.
     const partyRows = await prisma.party.findMany({
-      where: { id: { in: partyIds }, hostTelegramChatId: { not: null } },
-      // parmigiano-58493: customUrl + inviteCode added for {link}/{appLink} tokens.
-      select: { id: true, hostTelegramChatId: true, name: true, customUrl: true, inviteCode: true },
+      where: { id: { in: partyIds } },
+      select: {
+        id: true,
+        hostTelegramChatId: true,
+        name: true,
+        customUrl: true,
+        inviteCode: true,
+        city: true,
+        user: { select: { name: true, email: true } },
+      },
     });
     const chatByPartyId = new Map<string, bigint>();
     const partyMetaById = new Map<string, { customUrl: string | null; inviteCode: string | null }>();
+    const hostContactById = new Map<string, { email: string | null; name: string | null; city: string }>();
     for (const row of partyRows) {
       if (row.hostTelegramChatId !== null) {
         chatByPartyId.set(row.id, row.hostTelegramChatId);
       }
       partyMetaById.set(row.id, { customUrl: row.customUrl, inviteCode: row.inviteCode });
+      hostContactById.set(row.id, {
+        email: row.user?.email || null,
+        name: row.user?.name || null,
+        city: row.city || cityDisplayName(row.name),
+      });
     }
 
-    console.log(`[Telegram Host Broadcast] ${req.underboss!.email} sending to ${hosts.length} hosts (${partyRows.length} connected) at ${new Date().toISOString()}`);
+    console.log(`[Telegram Host Broadcast] ${req.underboss!.email} sending to ${hosts.length} hosts (${chatByPartyId.size} connected) at ${new Date().toISOString()}`);
+
+    let emailedCount = 0;
 
     const results: Array<{
       partyId: string;
@@ -334,6 +593,7 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
       hostName: string;
       success: boolean;
       error?: string;
+      emailed?: boolean;
     }> = [];
 
     for (let i = 0; i < hosts.length; i++) {
@@ -347,24 +607,44 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
         continue;
       }
 
-      const chatId = chatByPartyId.get(partyId);
-      if (chatId === undefined) {
-        results.push({ partyId, city, hostName, success: false, error: 'Host has not connected Telegram' });
-        continue;
-      }
-
       // parmigiano-58493: resolve per-recipient link tokens from the host's party.
       const partyMeta = partyMetaById.get(partyId) ?? null;
       const linkUrl = publicEventLink(partyMeta);
       const appLinkUrl = appDeepLink(partyMeta, validatedAppTab);
 
-      // Replace template variables
-      let personalizedMessage = message;
-      personalizedMessage = personalizedMessage.replace(/\{city\}/g, city);
-      personalizedMessage = personalizedMessage.replace(/\{hostName\}/g, hostName);
-      // Substitute (and strip-if-unresolved) the per-recipient link tokens.
-      personalizedMessage = substituteLinkTokens(personalizedMessage, linkUrl, appLinkUrl);
-      personalizedMessage = withBennySignature(personalizedMessage);
+      // Replace template variables (shared by the Telegram + email paths). The
+      // email path uses this text WITHOUT the Benny signature (TG-only).
+      let baseMessage = message;
+      baseMessage = baseMessage.replace(/\{city\}/g, city);
+      baseMessage = baseMessage.replace(/\{hostName\}/g, hostName);
+      baseMessage = substituteLinkTokens(baseMessage, linkUrl, appLinkUrl);
+
+      const chatId = chatByPartyId.get(partyId);
+      if (chatId === undefined) {
+        // guanciale-58491: email-the-message fallback for not-connected hosts.
+        const contact = hostContactById.get(partyId);
+        let emailed = false;
+        if (contact?.email) {
+          emailed = await sendBroadcastFallbackEmail({
+            toEmail: contact.email,
+            hostName: contact.name ?? hostName,
+            cityName: city || contact.city,
+            message: baseMessage,
+          });
+          if (emailed) emailedCount++;
+        }
+        results.push({
+          partyId,
+          city,
+          hostName,
+          success: false,
+          error: emailed ? 'Not connected — emailed instead' : 'Host has not connected Telegram',
+          emailed,
+        });
+        continue;
+      }
+
+      const personalizedMessage = withBennySignature(baseMessage);
 
       try {
         const effectiveParseMode = parseMode && parseMode !== 'None' ? parseMode : undefined;
@@ -435,9 +715,32 @@ router.post('/host-broadcast', requireAuth, requireUnderbossAuth, async (req: Un
     const sent = results.filter((r) => r.success).length;
     const failed = results.filter((r) => !r.success).length;
 
-    console.log(`[Telegram Host Broadcast] Complete: ${sent} sent, ${failed} failed`);
+    console.log(`[Telegram Host Broadcast] Complete: ${sent} sent, ${failed} failed, ${emailedCount} emailed`);
 
-    res.json({ results, sent, failed });
+    // guanciale-58491: persist the broadcast to the audit log. Use the client-
+    // minted broadcastId as the row id (double-send guard); fall back to an
+    // auto-uuid when none was supplied. A log-write failure must NOT fail the
+    // already-sent broadcast, so it's wrapped + swallowed.
+    try {
+      await prisma.telegramBroadcastLog.create({
+        data: {
+          ...(broadcastIdValid ? { id: broadcastIdValid } : {}),
+          actorEmail: req.underboss!.email,
+          actorKind: actorKindFromUnderboss(req.underboss!),
+          channel: 'host_dm',
+          message,
+          audienceCount: hosts.length,
+          sentCount: sent,
+          failedCount: failed,
+          emailedCount,
+          results,
+        },
+      });
+    } catch (logErr: any) {
+      console.warn('[Telegram Host Broadcast] failed to persist log:', logErr?.message || logErr);
+    }
+
+    res.json({ results, sent, failed, emailed: emailedCount });
   } catch (error) {
     next(error);
   }

--- a/backend/src/services/hostTelegramEmail.ts
+++ b/backend/src/services/hostTelegramEmail.ts
@@ -1,0 +1,110 @@
+/**
+ * guanciale-58491: Resend email paths for the "DM all GPP hosts" feature.
+ *
+ * Two fallbacks, both via Resend (RESEND_API_KEY, from `noreply@rsv.pizza`),
+ * mirroring `payoutEmailNotify.ts`:
+ *
+ *   1. sendConnectInviteEmail  — for an UNLINKED host: email their personal
+ *      `https://t.me/<bot>?start=<token>` deeplink so they can connect the bot.
+ *   2. sendBroadcastFallbackEmail — for a SELECTED host who turned out not to
+ *      be connected at send time: email the broadcast message text so they
+ *      still receive the announcement.
+ *
+ * Both return a boolean (sent / not-sent) and never throw — a Resend outage
+ * must not break the broadcast loop. Hosts without an email are skipped by the
+ * caller (the caller already filters), but we double-check here too.
+ *
+ * NOTE: `withBennySignature` is intentionally NOT applied to email bodies — it
+ * is a Telegram-only convention (see telegram.routes.ts).
+ */
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const FROM = 'RSV.Pizza <noreply@rsv.pizza>';
+
+/** Minimal HTML escape for user-authored text dropped into an email body. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+async function resendSend(to: string, subject: string, html: string): Promise<boolean> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return false;
+  try {
+    const resp = await fetch(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from: FROM, to, subject, html }),
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      console.warn(`[hostTelegramEmail] Resend ${resp.status}: ${body.slice(0, 200)}`);
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    console.warn('[hostTelegramEmail] Resend send failed:', err?.message || err);
+    return false;
+  }
+}
+
+/**
+ * Email an unlinked host the personal Telegram connect deeplink. Returns true
+ * if the email was accepted by Resend.
+ */
+export async function sendConnectInviteEmail(params: {
+  toEmail: string;
+  hostName?: string | null;
+  cityName?: string | null;
+  deeplink: string;
+}): Promise<boolean> {
+  const { toEmail, hostName, cityName, deeplink } = params;
+  if (!toEmail || !deeplink) return false;
+
+  const greet = hostName ? escapeHtml(hostName) : 'there';
+  const cityLine = cityName
+    ? ` for <b>${escapeHtml(cityName)}</b>`
+    : '';
+  const subject = '🍕 Connect Telegram to get PizzaDAO host announcements';
+  const html = `<p>Hey ${greet},</p>
+<p>Connect your Telegram${cityLine} so PizzaDAO can send you host announcements and reminders directly via @MoltoBeneBot.</p>
+<p><a href="${deeplink}">Tap here to connect on Telegram</a></p>
+<p style="color:#888;font-size:12px;">If the button doesn't work, open this link in Telegram: ${escapeHtml(deeplink)}</p>
+<p>— Pizza DAO</p>`;
+
+  return resendSend(toEmail, subject, html);
+}
+
+/**
+ * Email a not-connected host the broadcast message text (email-the-message
+ * fallback). The message is the same text that connected hosts received over
+ * Telegram (already token-substituted by the caller). Returns true if accepted.
+ */
+export async function sendBroadcastFallbackEmail(params: {
+  toEmail: string;
+  hostName?: string | null;
+  cityName?: string | null;
+  message: string;
+}): Promise<boolean> {
+  const { toEmail, hostName, cityName, message } = params;
+  if (!toEmail || !message) return false;
+
+  const greet = hostName ? escapeHtml(hostName) : 'there';
+  const cityName2 = cityName ? escapeHtml(cityName) : '';
+  const subject = cityName2
+    ? `🍕 PizzaDAO host announcement — ${cityName2}`
+    : '🍕 PizzaDAO host announcement';
+  // Preserve the message's line breaks in HTML.
+  const body = escapeHtml(message).replace(/\n/g, '<br>');
+  const html = `<p>Hey ${greet},</p>
+<p>${body}</p>
+<p style="color:#888;font-size:12px;">You're getting this by email because your Telegram isn't connected to @MoltoBeneBot yet. Connect it to receive these directly on Telegram next time.</p>
+<p>— Pizza DAO</p>`;
+
+  return resendSend(toEmail, subject, html);
+}

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -9,7 +9,12 @@ import {
   sendTelegramBroadcast,
   sendHostTelegramBroadcast,
   fetchCityTelegramGroups,
+  fetchHostAudience,
+  fetchHostCoverage,
+  inviteUnlinkedHosts,
   BroadcastResult,
+  HostCoverageResponse,
+  HostAudienceRow,
 } from '../../lib/api';
 import type { UnderbossEvent } from '../../types';
 import { GPP_REGIONS } from '../../types';
@@ -42,6 +47,8 @@ interface SendStats {
   sent: number;
   failed: number;
   blockedHosts: number;
+  // guanciale-58491: not-connected hosts who got the message via email fallback.
+  emailed: number;
 }
 
 // Tag results with their bucket so the "Both" mode can render two sections.
@@ -137,19 +144,32 @@ interface TelegramBroadcastProps {
   onClose: () => void;
   preSelectedCities?: string[];
   events?: UnderbossEvent[];
+  // guanciale-58491: when true, the modal opens in "All hosts" mode — it loads
+  // the full in-scope linked-host audience from the backend (host-audience)
+  // rather than deriving hosts from the page's `events`, defaults the recipient
+  // toggle to "hosts", and shows the coverage panel.
+  allHostsMode?: boolean;
 }
 
 type ViewState = 'compose' | 'sending' | 'results';
 
-export function TelegramBroadcast({ onClose, preSelectedCities, events }: TelegramBroadcastProps) {
+export function TelegramBroadcast({ onClose, preSelectedCities, events, allHostsMode }: TelegramBroadcastProps) {
   const { t } = useTranslation('partner');
   // Data loading
   const [groups, setGroups] = useState<TelegramGroup[]>([]);
   const [loadingGroups, setLoadingGroups] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  // Recipient mode (groups, hosts, or both)
-  const [recipientMode, setRecipientMode] = useState<RecipientMode>('groups');
+  // guanciale-58491: "All hosts" mode — full in-scope audience loaded server-side.
+  const [audienceHosts, setAudienceHosts] = useState<HostAudienceRow[]>([]);
+  // Coverage panel data + the invite-deeplink action state.
+  const [coverage, setCoverage] = useState<HostCoverageResponse | null>(null);
+  const [inviting, setInviting] = useState(false);
+  const [inviteResult, setInviteResult] = useState<{ emailed: number; skipped: number; noEmail: number } | null>(null);
+
+  // Recipient mode (groups, hosts, or both). In all-hosts mode we default to
+  // the hosts tab since that's the point of the entry.
+  const [recipientMode, setRecipientMode] = useState<RecipientMode>(allHostsMode ? 'hosts' : 'groups');
 
   // Selection & filtering
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -167,7 +187,7 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
   // State flow
   const [viewState, setViewState] = useState<ViewState>('compose');
   const [results, setResults] = useState<TaggedResult[]>([]);
-  const [sendStats, setSendStats] = useState<SendStats>({ sent: 0, failed: 0, blockedHosts: 0 });
+  const [sendStats, setSendStats] = useState<SendStats>({ sent: 0, failed: 0, blockedHosts: 0, emailed: 0 });
 
   // Test message (groups + hosts share these states; the active chat/party is keyed by id)
   const [testingChatId, setTestingChatId] = useState<string | null>(null);
@@ -213,6 +233,49 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
     }
     load();
   }, []);
+
+  // guanciale-58491: in "All hosts" mode, load the full in-scope linked-host
+  // audience + coverage report from the backend (scoped server-side). These run
+  // independently of the city-group load above.
+  useEffect(() => {
+    if (!allHostsMode) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [aud, cov] = await Promise.all([fetchHostAudience(), fetchHostCoverage()]);
+        if (cancelled) return;
+        setAudienceHosts(aud);
+        setCoverage(cov);
+      } catch (err: any) {
+        if (!cancelled) setLoadError(err?.message || 'Failed to load host audience');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [allHostsMode]);
+
+  // Email the connect deeplink to every in-scope unlinked host (with an email).
+  const handleInviteUnlinked = async () => {
+    setInviting(true);
+    setInviteResult(null);
+    try {
+      const r = await inviteUnlinkedHosts();
+      setInviteResult(r);
+      // Refresh coverage so the linked/unlinked counts reflect any change.
+      try {
+        const cov = await fetchHostCoverage();
+        setCoverage(cov);
+      } catch {
+        /* non-fatal */
+      }
+    } catch (err: any) {
+      setInviteResult({ emailed: 0, skipped: 0, noEmail: 0 });
+      setLoadError(err?.message || 'Failed to send invites');
+    } finally {
+      setInviting(false);
+    }
+  };
 
   // Get unique regions for filter
   const regions = useMemo(() => {
@@ -295,16 +358,29 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
   // host has either a Telegram handle or a connected bot chat_id are included
   // (others have no way for an underboss to reach them via this tool).
   const hostRows = useMemo<HostRow[]>(() => {
-    if (!events || events.length === 0) return [];
-    let rows: HostRow[] = events
-      .filter(e => e.host && (e.hostTelegram || e.hostTelegramConnected))
-      .map(e => ({
-        partyId: e.id,
-        city: extractCityFromEvent(e),
-        hostName: e.host?.name || (t('telegram.unknownHost') as string),
-        hostTelegram: e.hostTelegram || null,
-        connected: !!e.hostTelegramConnected,
+    let rows: HostRow[];
+    if (allHostsMode) {
+      // guanciale-58491: source the audience from the backend (already the full
+      // in-scope linked-host list, not limited to the page's events).
+      rows = audienceHosts.map(h => ({
+        partyId: h.partyId,
+        city: h.city,
+        hostName: h.hostName || (t('telegram.unknownHost') as string),
+        hostTelegram: h.hostTelegram,
+        connected: h.connected,
       }));
+    } else {
+      if (!events || events.length === 0) return [];
+      rows = events
+        .filter(e => e.host && (e.hostTelegram || e.hostTelegramConnected))
+        .map(e => ({
+          partyId: e.id,
+          city: extractCityFromEvent(e),
+          hostName: e.host?.name || (t('telegram.unknownHost') as string),
+          hostTelegram: e.hostTelegram || null,
+          connected: !!e.hostTelegramConnected,
+        }));
+    }
 
     // Mirror the groups list: filter by pre-selected cities when present.
     if (preSelectedCities && preSelectedCities.length > 0) {
@@ -321,7 +397,7 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
     }
 
     return rows;
-  }, [events, preSelectedCities, search, t]);
+  }, [allHostsMode, audienceHosts, events, preSelectedCities, search, t]);
 
   // Auto-select hosts whose event city matches one of the pre-selected cities,
   // but only those that are actually connected (disabled checkboxes can't be
@@ -449,10 +525,18 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
 
     setViewState('sending');
 
+    // guanciale-58491: mint a client-side broadcastId per send so the backend
+    // can short-circuit accidental double-sends (double-click / retry).
+    const broadcastId =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
     const allResults: TaggedResult[] = [];
     let totalSent = 0;
     let totalFailed = 0;
     let blockedHostCount = 0;
+    let emailedCount = 0;
 
     if (recipientMode === 'groups' || recipientMode === 'both') {
       if (selectedGroups.length > 0) {
@@ -470,10 +554,11 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
     if (recipientMode === 'hosts' || recipientMode === 'both') {
       if (selectedHostsPayload.length > 0) {
         try {
-          const r = await sendHostTelegramBroadcast(selectedHostsPayload, message, parseMode, selectedAppTab || null);
+          const r = await sendHostTelegramBroadcast(selectedHostsPayload, message, parseMode, selectedAppTab || null, broadcastId);
           allResults.push(...r.results.map(res => ({ ...res, kind: 'host' as const })));
           totalSent += r.sent;
           totalFailed += r.failed;
+          emailedCount += r.emailed ?? 0;
           blockedHostCount = r.results.filter(
             x => x.error === 'Host blocked the bot — disconnected'
           ).length;
@@ -484,7 +569,7 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
     }
 
     setResults(allResults);
-    setSendStats({ sent: totalSent, failed: totalFailed, blockedHosts: blockedHostCount });
+    setSendStats({ sent: totalSent, failed: totalFailed, blockedHosts: blockedHostCount, emailed: emailedCount });
     setViewState('results');
   };
 
@@ -592,6 +677,60 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
           {/* Compose view */}
           {!loadingGroups && !loadError && viewState === 'compose' && (
             <div className="space-y-6">
+              {/* guanciale-58491: coverage panel (all-hosts mode). "X of Y hosts
+                  linked" + a button to email the connect deeplink to unlinked hosts. */}
+              {allHostsMode && coverage && (
+                <div className="bg-theme-surface border border-theme-stroke rounded-xl px-4 py-3">
+                  <div className="flex items-center justify-between gap-3 flex-wrap">
+                    <div>
+                      <p className="text-sm font-medium text-theme-text">
+                        {t('telegram.coverage.summary', {
+                          linked: coverage.linked,
+                          total: coverage.total,
+                          defaultValue: '{{linked}} of {{total}} hosts linked to Telegram',
+                        })}
+                      </p>
+                      {coverage.unlinked > 0 && (
+                        <p className="text-xs text-theme-text-faint mt-0.5">
+                          {t('telegram.coverage.unlinkedDetail', {
+                            withHandle: coverage.hasHandleNoChat,
+                            noHandle: coverage.noHandleNoChat,
+                            defaultValue: '{{withHandle}} have a TG handle but no bot link · {{noHandle}} have neither',
+                          })}
+                        </p>
+                      )}
+                    </div>
+                    {coverage.unlinked > 0 && (
+                      <button
+                        type="button"
+                        onClick={handleInviteUnlinked}
+                        disabled={inviting}
+                        className="flex items-center gap-2 bg-theme-card hover:bg-theme-surface border border-theme-stroke disabled:opacity-40 disabled:cursor-not-allowed text-theme-text px-3 py-2 rounded-lg text-xs font-medium transition-colors"
+                      >
+                        {inviting ? (
+                          <Loader2 size={12} className="animate-spin" />
+                        ) : (
+                          <Send size={12} />
+                        )}
+                        {t('telegram.coverage.inviteButton', {
+                          count: coverage.unlinked,
+                          defaultValue: 'Email deeplink to {{count}} unlinked hosts',
+                        })}
+                      </button>
+                    )}
+                  </div>
+                  {inviteResult && (
+                    <div className="mt-2 px-3 py-2 rounded-lg text-xs bg-blue-500/10 text-blue-600">
+                      {t('telegram.coverage.inviteResult', {
+                        emailed: inviteResult.emailed,
+                        noEmail: inviteResult.noEmail,
+                        defaultValue: 'Emailed {{emailed}} hosts · {{noEmail}} had no email on file',
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
+
               {/* Recipients toggle (sausage-24183) */}
               <div className="flex items-center gap-1 bg-theme-surface border border-theme-stroke rounded-xl p-1 w-fit">
                 {(['groups', 'hosts', 'both'] as const).map(mode => (
@@ -1124,6 +1263,16 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events }: Telegr
                   <div className="text-2xl font-bold text-red-500">{sendStats.failed}</div>
                   <div className="text-xs text-theme-text-faint">{t('telegram.failed')}</div>
                 </div>
+                {/* guanciale-58491: email-the-message fallback count */}
+                {sendStats.emailed > 0 && (
+                  <>
+                    <div className="w-px h-10 bg-theme-stroke" />
+                    <div className="text-center">
+                      <div className="text-2xl font-bold text-blue-500">{sendStats.emailed}</div>
+                      <div className="text-xs text-theme-text-faint">{t('telegram.emailed', 'emailed')}</div>
+                    </div>
+                  </>
+                )}
               </div>
 
               {/* Results list — split into Groups / Hosts sections when mode is "both" */}

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -115,6 +115,7 @@
   },
   "underbossDashboard": {
     "title": "Underboss Dashboard",
+    "dmAllHosts": "DM all hosts",
     "loginPrompt": "Please log in to access the underboss dashboard.",
     "logIn": "Log In",
     "loadingDashboard": "Loading dashboard...",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -383,6 +383,14 @@
     "formatMarkdown": "Markdown",
     "sent": "Sent",
     "failed": "Failed",
+    "emailed": "Emailed",
+    "coverage": {
+      "summary": "{{linked}} of {{total}} hosts linked to Telegram",
+      "unlinkedDetail": "{{withHandle}} have a TG handle but no bot link · {{noHandle}} have neither",
+      "inviteButton": "Email deeplink to {{count}} unlinked host",
+      "inviteButton_other": "Email deeplink to {{count}} unlinked hosts",
+      "inviteResult": "Emailed {{emailed}} hosts · {{noEmail}} had no email on file"
+    },
     "searchPlaceholder": "Search city, country, or underboss...",
     "regionAll": "All Regions",
     "noGroupsMatch": "No groups match your search",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3684,6 +3684,61 @@ export interface BroadcastResponse {
   results: BroadcastResult[];
   sent: number;
   failed: number;
+  // guanciale-58491: how many not-connected hosts got the message via email
+  // fallback (present on host-broadcast responses only).
+  emailed?: number;
+  // guanciale-58491: true when a broadcastId matched an existing log row and the
+  // send was short-circuited (double-send guard).
+  duplicate?: boolean;
+}
+
+// guanciale-58491: host-DM coverage report over the in-scope GPP audience.
+export interface HostCoverageUnlinked {
+  partyId: string;
+  city: string;
+  hostName: string | null;
+  hostEmail: string | null;
+  hostTelegram: string | null;
+}
+
+export interface HostCoverageResponse {
+  total: number;
+  linked: number;
+  unlinked: number;
+  hasHandleNoChat: number;
+  noHandleNoChat: number;
+  unlinkedHosts: HostCoverageUnlinked[];
+}
+
+// guanciale-58491: a linked host in the in-scope audience (for "All hosts").
+export interface HostAudienceRow {
+  partyId: string;
+  city: string;
+  hostName: string | null;
+  hostTelegram: string | null;
+  connected: boolean;
+}
+
+export async function fetchHostCoverage(): Promise<HostCoverageResponse> {
+  return apiRequest<HostCoverageResponse>('/api/underboss/telegram/host-coverage', {
+    method: 'GET',
+  });
+}
+
+export async function inviteUnlinkedHosts(): Promise<{
+  emailed: number;
+  skipped: number;
+  noEmail: number;
+}> {
+  return apiRequest('/api/underboss/telegram/invite-unlinked', { method: 'POST' });
+}
+
+export async function fetchHostAudience(): Promise<HostAudienceRow[]> {
+  const res = await apiRequest<{ hosts: HostAudienceRow[] }>(
+    '/api/underboss/telegram/host-audience',
+    { method: 'GET' },
+  );
+  return res.hosts;
 }
 
 export async function sendTelegramBroadcast(
@@ -3723,11 +3778,13 @@ export async function sendHostTelegramBroadcast(
   message: string,
   parseMode: 'HTML' | 'Markdown' | 'None' = 'None',
   // parmigiano-58493: chosen app tab for the {appLink} token (null = none).
-  appTab: string | null = null
+  appTab: string | null = null,
+  // guanciale-58491: client-minted UUID double-send guard (null = none).
+  broadcastId: string | null = null
 ): Promise<BroadcastResponse> {
   return apiRequest<BroadcastResponse>('/api/underboss/telegram/host-broadcast', {
     method: 'POST',
-    body: { hosts, message, parseMode, appTab },
+    body: { hosts, message, parseMode, appTab, broadcastId },
   });
 }
 

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, Check, Download } from 'lucide-react';
+import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, Check, Download, Send } from 'lucide-react';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
@@ -103,6 +103,9 @@ export function UnderbossDashboard() {
   // Telegram broadcast modal state
   const [showBroadcast, setShowBroadcast] = useState(false);
   const [broadcastCities, setBroadcastCities] = useState<string[]>([]);
+  // guanciale-58491: "DM all GPP hosts" entry point — opens the broadcast in
+  // hosts mode with the full in-scope audience loaded server-side.
+  const [broadcastAllHosts, setBroadcastAllHosts] = useState(false);
 
   // Partner tags for EventRow indicator
   const [partnerTags, setPartnerTags] = useState<string[]>([]);
@@ -586,7 +589,16 @@ export function UnderbossDashboard() {
 
         {/* Events / Cities Tabs */}
         <section>
-          <div className="border-b border-theme-stroke mb-4 flex gap-6">
+          <div className="border-b border-theme-stroke mb-4 flex gap-6 items-center">
+            {/* guanciale-58491: "DM all GPP hosts" entry point — loads the full
+                in-scope audience server-side (not just the page's events). */}
+            <button
+              onClick={() => { setBroadcastCities([]); setBroadcastAllHosts(true); setShowBroadcast(true); }}
+              className="ml-auto order-last flex items-center gap-2 bg-[#E52828] hover:bg-[#cc2222] text-white px-3 py-1.5 rounded-lg text-sm font-medium transition-colors self-center mb-2"
+            >
+              <Send size={14} />
+              {t('underbossDashboard.dmAllHosts', 'DM all hosts')}
+            </button>
             <button
               onClick={() => setActiveTab('events')}
               className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
@@ -746,7 +758,7 @@ export function UnderbossDashboard() {
       <Footer />
 
       {/* Telegram Broadcast Modal */}
-      {showBroadcast && <TelegramBroadcast onClose={() => { setShowBroadcast(false); setBroadcastCities([]); }} preSelectedCities={broadcastCities} events={filteredData?.events ?? []} />}
+      {showBroadcast && <TelegramBroadcast onClose={() => { setShowBroadcast(false); setBroadcastCities([]); setBroadcastAllHosts(false); }} preSelectedCities={broadcastCities} events={filteredData?.events ?? []} allHostsMode={broadcastAllHosts} />}
 
       {/* Add Underboss Modal */}
       {showAddUnderboss && createPortal(


### PR DESCRIPTION
## What's new

Completes the "DM all GPP hosts via @MoltoBeneBot" feature. Scope is **admin + region/city UBs (scoped)**; email fallback is **BOTH** (deeplink invite + email-the-message).

### 4 backend endpoints (`backend/src/routes/telegram.routes.ts`)
All `requireAuth` + `requireUnderbossAuth`, scoped server-side via the canonical `buildScopedWhereClause` (admin = all GPP, region UB = their regions, city UB = their cities). Scope is pushed into the Prisma `where` — no JS post-filter. Audience = `eventType='gpp'` + `cancelledAt: null` (mirrors underboss.routes GPP filter).

- **`GET /host-coverage`** — over the in-scope GPP audience: `{ total, linked, unlinked, hasHandleNoChat, noHandleNoChat, unlinkedHosts[] }`. `linked = hostTelegramChatId != null`.
- **`POST /invite-unlinked`** — for each in-scope unlinked host **with an email**, mints/reuses their `host_telegram_link_token` (same logic as `host-telegram.routes.ts`, no rotate → idempotent) and emails the personal `https://t.me/<bot>?start=<token>` deeplink. Returns `{ emailed, skipped, noEmail }`.
- **`GET /host-audience`** — the full in-scope **linked**-host list (not limited to any client-passed events), for the "All hosts" launch.
- **`POST /host-broadcast` (extended)** — keeps all existing behavior (server-side chat_id resolve, 100ms rate-limit, Benny signature, 403 auto-disconnect) and adds:
  - optional client-minted **`broadcastId` (UUID)** → if a `telegram_broadcast_log` row with that id exists, short-circuit and return the stored counts (**double-send guard**)
  - persists a **`TelegramBroadcastLog`** row after sending (actor email/kind, message, counts, results) — wrapped so a log failure never fails an already-sent broadcast
  - **email-the-message fallback**: selected hosts whose chat_id is null at send time are emailed the (token-substituted) message text and counted as `emailedCount`

### Email paths (`backend/src/services/hostTelegramEmail.ts`)
Both reuse **Resend** (`RESEND_API_KEY`, from `noreply@rsv.pizza`), mirroring `payoutEmailNotify.ts`. `sendConnectInviteEmail` (deeplink) and `sendBroadcastFallbackEmail` (message text). Never throw (return bool); `withBennySignature` is **not** applied (Telegram-only).

### Schema / migration
New Prisma model `TelegramBroadcastLog` → `@@map("telegram_broadcast_log")`, `@@index([createdAt(sort: Desc)])`. The `id` doubles as the `broadcastId` double-send key. Migration: `backend/prisma/migrations/guanciale-58491-telegram-broadcast-log.sql` (`CREATE TABLE IF NOT EXISTS` + index).

> ⚠️ **The migration must be applied to prod by the main session BEFORE merge.** This repo has no Prisma auto-apply, and previews + prod share one DB. Without the table, `/host-broadcast` log-writes are swallowed (non-fatal) but the `broadcastId` double-send guard won't engage.

### Frontend
- **Coverage panel** in `TelegramBroadcast.tsx` (all-hosts mode): "X of Y hosts linked" + "Email deeplink to N unlinked hosts" button (calls `invite-unlinked`, shows result, refreshes coverage).
- **"DM all hosts" entry point** wired in `UnderbossDashboard.tsx` (tab-bar button) → opens the broadcast in `hosts` mode with the audience loaded from `host-audience` (server-scoped, not the page's `events`).
- Client-minted `broadcastId` per send; **emailed** count shown alongside sent/failed in results.
- api.ts wrappers: `fetchHostCoverage`, `inviteUnlinkedHosts`, `fetchHostAudience`; `sendHostTelegramBroadcast` extended with `broadcastId`.

## Idempotency
`invite-unlinked` reuses an existing connect token (no rotate) so re-running it doesn't churn tokens. `host-broadcast`'s `broadcastId` row-existence check guards against double-sends from double-clicks/retries.

## Request-duration / cap note
The host loop is sequential with a 100ms/msg rate-limit. The per-request cap was raised from **500 → 1000** hosts. At 1000 hosts that's ~100s+ of wall time (plus ~50ms/host for email fallbacks), which approaches typical serverless limits for very large in-scope audiences. If the global audience grows past that, the send should be **chunked** client-side (multiple calls, each with its own `broadcastId`) or moved to a background job. Flagging for review — current GPP audience is comfortably under the cap.

## tsc
Backend + frontend `npx tsc --noEmit` clean (besides the known pre-existing `auth.test.ts` jwt error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)