### PR TITLE
montanara-58499: portal /payments external + send modals above the footer

### DIFF
--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   X,
   DollarSign,
@@ -336,7 +337,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     }
   }
 
-  return (
+  const body = (
     <div
       className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
       onClick={onClose}
@@ -778,6 +779,8 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
       </form>
     </div>
   );
+
+  return createPortal(body, document.body);
 };
 
 const MethodOption: React.FC<{

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   X,
   DollarSign,
@@ -512,7 +513,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
     }
   }
 
-  return (
+  const body = (
     <div
       className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4"
       onClick={onClose}
@@ -904,6 +905,8 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
       </form>
     </div>
   );
+
+  return createPortal(body, document.body);
 };
 
 const MethodOption: React.FC<{


### PR DESCRIPTION
@
## Problem
On `/payments`, the **Record External Payment** and **Send Payment** modals render *beneath* the global footer + corner links, so their `Cancel` / submit buttons can't be clicked when the page is scrolled to the bottom.

## Root cause
`Layout.tsx` renders content in `<main className="flex-1 relative z-[1]">`. The `relative z-[1]` establishes a **stacking context**, so a `fixed z-50` modal child is ranked only *within* `main` — it can never paint above `main`'s own `z-1`. `<Footer>` and `<CornerLinks>` are **siblings** of `main` at the same `z-1`, later in the DOM, so they paint over the whole `main` subtree (incl. the modal) wherever they overlap on screen. A tall modal (`max-h-[95vh]`) reaches the footer's region when scrolled down → footer wins the clicks.

Every other `payments-admin/` modal already escapes this via `createPortal(body, document.body)`. The only two that didn't were `ExternalPaymentModal` and `SendPaymentModal`.

## Fix
Wrap both modals' returned trees in `createPortal(body, document.body)`, mirroring `RejectReasonModal.tsx` exactly. No markup/class/handler/logic changes — 3 lines added per file. `Layout.tsx` untouched (its `z-[1]` sits above the GPP cloud background on purpose).

## Verify on preview
On `/payments`, scroll to the bottom, open **Record External Payment** and **Send Payment** — both should center over the footer with clickable buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@