### PR TITLE
feat(marinara-71630): payout POST enforcement + super-admin server flag (P7b)

### DIFF
--- a/backend/src/lib/reimbursementOptions.ts
+++ b/backend/src/lib/reimbursementOptions.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ReimbursementOption, ReimbursementRules, CountryRule } from './privateConfig.js';
+import { isMercuryBlocked } from './mercuryBlockedCountries.js';
 
 /** A fully-resolved option ready to send to the frontend. */
 export interface ResolvedOption {
@@ -94,4 +95,41 @@ export function resolveReimbursementOptions(
     });
   }
   return out;
+}
+
+/**
+ * Resolve a party's reimbursement options WITH the compliance Mercury-block
+ * layer applied — the single source of truth shared by:
+ *   - `GET /api/parties/:id/reimbursement-options` (what the host picker sees), and
+ *   - the `PATCH /api/user/me` save-path gate (marinara-71630 P7b), which
+ *     rejects persisting a method this resolver reports as absent/disabled.
+ *
+ * Keeping both behind this helper guarantees the DECIDE path (GET) and the
+ * ENFORCE path (save) can't drift.
+ *
+ * The config resolver (`resolveReimbursementOptions`) matches country EXACTLY,
+ * but the Mercury sanctions gate must NORMALIZE (lowercase / strip
+ * parentheticals) so casing/parenthetical variants of a blocked country are
+ * still blocked. The sanctions list is compliance, not a private business
+ * secret, so it stays in code (`isMercuryBlocked`) and is layered over the
+ * config-resolved options here rather than encoded into `app_config`. Only the
+ * `mercury_card` entry is mutated, and only when it's present.
+ *
+ * Never throws. An empty/unseeded config yields `[]` (callers fail OPEN).
+ */
+export function resolvePartyReimbursementOptions(
+  party: ResolverParty,
+  rules: ReimbursementRules
+): ResolvedOption[] {
+  const options = resolveReimbursementOptions(party, rules);
+
+  if (isMercuryBlocked(party.country)) {
+    const mercury = options.find((o) => o.id === 'mercury_card');
+    if (mercury) {
+      mercury.enabled = false;
+      mercury.disabledReason = `Mercury cards are unavailable in ${party.country ?? 'your country'} due to compliance restrictions.`;
+    }
+  }
+
+  return options;
 }

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -18,8 +18,7 @@ import {
 import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
 import { getReimbursementRules, getGppGlobalEditors } from '../lib/privateConfig.js';
-import { resolveReimbursementOptions } from '../lib/reimbursementOptions.js';
-import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
+import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -2383,25 +2382,13 @@ router.get('/:id/reimbursement-options', async (req: AuthRequest, res: Response,
     if (!party) throw new AppError('Party not found', 404, 'NOT_FOUND');
 
     const rules = await getReimbursementRules();
-    const options = resolveReimbursementOptions(
+    // marinara-71630 P7b: resolve via the shared helper so the host picker (this
+    // GET) and the save-path gate (PATCH /api/user/me) apply identical
+    // config-resolution + Mercury-block layering and can never drift.
+    const options = resolvePartyReimbursementOptions(
       { country: party.country, eventTags: party.eventTags },
       rules
     );
-
-    // marinara-71630: the config resolver matches country EXACTLY, but the
-    // Mercury sanctions gate must NORMALIZE (lowercase / strip parentheticals)
-    // so casing/parenthetical variants of a blocked country are still blocked.
-    // The sanctions list is compliance, not a private business secret, so it
-    // stays in code (`isMercuryBlocked`) and is layered over the config-resolved
-    // options here rather than encoded into `app_config`. Only mutate the
-    // mercury_card entry if it's present; leave everything else untouched.
-    if (isMercuryBlocked(party.country)) {
-      const mercury = options.find((o) => o.id === 'mercury_card');
-      if (mercury) {
-        mercury.enabled = false;
-        mercury.disabledReason = `Mercury cards are unavailable in ${party.country ?? 'your country'} due to compliance restrictions.`;
-      }
-    }
 
     res.json({ options });
   } catch (error) {

--- a/backend/src/routes/user.routes.test.ts
+++ b/backend/src/routes/user.routes.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = 'test-secret';
+
+// Use vi.hoisted so the mocks can be referenced inside vi.mock factories.
+const mockPrisma = vi.hoisted(() => ({
+  user: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  party: {
+    findUnique: vi.fn(),
+  },
+  admin: {
+    findUnique: vi.fn(),
+  },
+}));
+
+vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
+
+// ENS resolution is mocked to a pass-through so usdc_base saves don't hit the
+// network. We only ever submit hex addresses in these tests.
+vi.mock('../services/ens.service.js', () => ({
+  resolveWalletInput: vi.fn(async (v: string) => v),
+}));
+
+// marinara-71630 P7b: control the reimbursement rules without seeding app_config.
+// We return rules where mercury_card is ENABLED at the config level so the test
+// proves the SAVE-path gate's isMercuryBlocked layering (via the shared
+// resolvePartyReimbursementOptions helper) is what rejects it. The real,
+// un-mocked isMercuryBlocked / normalizeCountry runs so normalization is tested.
+const mockGetReimbursementRules = vi.hoisted(() => vi.fn());
+vi.mock('../lib/privateConfig.js', () => ({
+  getReimbursementRules: mockGetReimbursementRules,
+}));
+
+// Caller is always allowed to edit the party in these tests (the auth gate is
+// covered elsewhere); we focus on the method-allowed enforcement.
+const mockCanUserEditParty = vi.hoisted(() => vi.fn(async () => true));
+vi.mock('../helpers/partyAccess.js', () => ({
+  canUserEditParty: mockCanUserEditParty,
+}));
+
+const parseAuth = (req: any) => {
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const decoded = jwt.verify(authHeader.split(' ')[1], JWT_SECRET) as any;
+      req.userId = decoded.userId;
+      req.userEmail = decoded.email;
+    } catch { /* ignore */ }
+  }
+};
+
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    parseAuth(req);
+    if (!req.userId) {
+      return _res.status(401).json({ error: { message: 'Unauthorized', code: 'UNAUTHORIZED' } });
+    }
+    next();
+  },
+  isSuperAdmin: async () => false,
+  AuthRequest: {},
+}));
+
+import userRoutes from './user.routes.js';
+import { errorHandler } from '../middleware/error.js';
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/user', userRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+function makeToken(userId: string, email: string) {
+  return jwt.sign({ userId, email }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+const PARTY_ID = '00000000-0000-0000-0000-000000000001';
+const USER_ID = 'user-123';
+const USER_EMAIL = 'host@example.com';
+
+// Rules with all three methods visible + enabled (no config-level disable). Any
+// blocking of mercury_card must come from the endpoint's isMercuryBlocked layer.
+const RULES_ALL_ENABLED = {
+  methods: [
+    { id: 'usdc_base', label: 'USDC on Base', kind: 'method' as const },
+    { id: 'mercury_card', label: 'Mercury virtual card', kind: 'method' as const },
+    { id: 'wire', label: 'Bank wire', kind: 'method' as const },
+  ],
+  default: ['usdc_base', 'mercury_card', 'wire'],
+  countryRules: [],
+};
+
+const UPDATED_USER = {
+  id: USER_ID,
+  email: USER_EMAIL,
+  name: 'Host',
+  preferredPayoutMethod: null,
+  payoutWalletAddress: null,
+  payoutBankDetails: null,
+};
+
+describe('PATCH /api/user/me — payout-method gating (marinara-71630 P7b)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanUserEditParty.mockResolvedValue(true);
+    mockPrisma.user.update.mockResolvedValue(UPDATED_USER);
+  });
+
+  function patch(body: any) {
+    const app = createTestApp();
+    const token = makeToken(USER_ID, USER_EMAIL);
+    return request(app)
+      .patch('/api/user/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body);
+  }
+
+  it('rejects mercury_card for a Mercury-blocked country (400 PAYOUT_METHOD_NOT_ALLOWED)', async () => {
+    mockGetReimbursementRules.mockResolvedValue(RULES_ALL_ENABLED);
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'Iran', eventTags: [] });
+
+    const res = await patch({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('PAYOUT_METHOD_NOT_ALLOWED');
+    expect(res.body.error.message).toContain('Mercury cards are unavailable');
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects mercury_card for a parenthetical/case country variant (normalization)', async () => {
+    mockGetReimbursementRules.mockResolvedValue(RULES_ALL_ENABLED);
+    // "Iran (Islamic Republic of Iran)" normalizes → "iran"; an exact-match
+    // config rule would NOT catch this, but isMercuryBlocked does.
+    mockPrisma.party.findUnique.mockResolvedValue({
+      country: 'Iran (Islamic Republic of Iran)',
+      eventTags: [],
+    });
+
+    const res = await patch({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('PAYOUT_METHOD_NOT_ALLOWED');
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an enabled method (usdc_base) for a blocked country (200)', async () => {
+    mockGetReimbursementRules.mockResolvedValue(RULES_ALL_ENABLED);
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'Iran', eventTags: [] });
+
+    const res = await patch({
+      preferredPayoutMethod: 'usdc_base',
+      payoutWalletAddress: '0x1111111111111111111111111111111111111111',
+      partyId: PARTY_ID,
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows mercury_card for a non-blocked country (200)', async () => {
+    mockGetReimbursementRules.mockResolvedValue(RULES_ALL_ENABLED);
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'United States', eventTags: [] });
+
+    const res = await patch({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a save with no partyId (legacy/global) without consulting rules (200)', async () => {
+    const res = await patch({ preferredPayoutMethod: 'mercury_card' });
+
+    expect(res.status).toBe(200);
+    expect(mockGetReimbursementRules).not.toHaveBeenCalled();
+    expect(mockPrisma.party.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails OPEN when the config is unseeded — even mercury_card in a blocked country (200)', async () => {
+    // Unseeded config → empty resolved options → no rules to enforce.
+    mockGetReimbursementRules.mockResolvedValue({ methods: [], default: [], countryRules: [] });
+    mockPrisma.party.findUnique.mockResolvedValue({ country: 'Iran', eventTags: [] });
+
+    const res = await patch({ preferredPayoutMethod: 'mercury_card', partyId: PARTY_ID });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,7 +1,10 @@
 import { Router, Response, NextFunction } from 'express';
 import { prisma } from '../config/database.js';
-import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { requireAuth, AuthRequest, isSuperAdmin } from '../middleware/auth.js';
 import { resolveWalletInput } from '../services/ens.service.js';
+import { canUserEditParty } from '../helpers/partyAccess.js';
+import { getReimbursementRules } from '../lib/privateConfig.js';
+import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
 
 const router = Router();
 
@@ -27,7 +30,14 @@ router.get('/me', async (req: AuthRequest, res: Response, next: NextFunction) =>
       },
     });
 
-    res.json({ user });
+    // marinara-71630 P7b: surface the server-side super-admin determination so
+    // the frontend can stop hardcoding the internal `hello@rarepizzas.com`
+    // identity (HostPage/EventPage). Computed via the EXISTING `isSuperAdmin`
+    // DB-backed rule (Admin table, role === 'super_admin') so it extends these
+    // controls to ALL Admin-table super_admins, not just one email.
+    const superAdmin = await isSuperAdmin(req.userEmail);
+
+    res.json({ user: user ? { ...user, isSuperAdmin: superAdmin } : user });
   } catch (error) {
     next(error);
   }
@@ -44,6 +54,10 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
       preferredPayoutMethod,
       payoutWalletAddress,
       payoutBankDetails,
+      // marinara-71630 P7b: PaymentDetailsCard sends the party in scope so the
+      // backend can hard-enforce party-scoped reimbursement-option gating on the
+      // SAVE path (the GET endpoint only DECIDES which methods are allowed).
+      partyId,
     } = req.body;
 
     // Validate payoutMethod if provided (DB CHECK constraint mirrors this).
@@ -74,6 +88,54 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
               code: 'INVALID_WALLET_ADDRESS',
             },
           });
+        }
+      }
+    }
+
+    // marinara-71630 P7b: hard-enforce party-scoped reimbursement-option gating
+    // on the SAVE path. The GET endpoint only DECIDES which methods a host may
+    // pick; a crafted request could otherwise persist a method this party isn't
+    // allowed to use (e.g. mercury_card for a Mercury-blocked country). When the
+    // request sets a non-null payout method AND names a partyId the caller can
+    // edit, resolve that party's allowed options (via the SAME shared helper the
+    // GET endpoint uses) and reject if the submitted method is absent or
+    // disabled. FAIL OPEN if the config is unseeded (empty resolved set) so a
+    // missing app_config row never blocks legitimate saves.
+    if (
+      preferredPayoutMethod !== undefined
+      && preferredPayoutMethod !== null
+      && partyId
+      && typeof partyId === 'string'
+    ) {
+      const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
+      if (canEdit) {
+        const party = await prisma.party.findUnique({
+          where: { id: partyId },
+          select: { country: true, eventTags: true },
+        });
+        if (party) {
+          const rules = await getReimbursementRules();
+          const options = resolvePartyReimbursementOptions(
+            { country: party.country, eventTags: party.eventTags },
+            rules
+          );
+          // Fail OPEN on an unseeded config: an empty resolved set means we have
+          // no rules to enforce, so don't block the save.
+          if (options.length > 0) {
+            const opt = options.find(
+              (o) => o.id === preferredPayoutMethod && o.kind === 'method'
+            );
+            if (!opt || !opt.enabled) {
+              return res.status(400).json({
+                error: {
+                  message:
+                    opt?.disabledReason ||
+                    `The payout method "${preferredPayoutMethod}" is not available for this event.`,
+                  code: 'PAYOUT_METHOD_NOT_ALLOWED',
+                },
+              });
+            }
+          }
         }
       }
     }

--- a/frontend/src/components/payouts/PaymentDetailsCard.tsx
+++ b/frontend/src/components/payouts/PaymentDetailsCard.tsx
@@ -156,6 +156,11 @@ export const PaymentDetailsCard: React.FC = () => {
       preferredPayoutMethod: method,
       payoutWalletAddress: method === 'usdc_base' ? walletAddress.trim() : null,
       payoutBankDetails: method === 'wire' ? bankDetails : null,
+      // marinara-71630 P7b: include the party in scope so the backend can
+      // hard-enforce party-scoped reimbursement-option gating on the save path
+      // (rejects e.g. mercury_card for a Mercury-blocked country). Omitted when
+      // there's no party (legacy/global save) — the backend then skips the gate.
+      ...(party?.id ? { partyId: party.id } : {}),
     };
   };
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -22,6 +22,11 @@ interface User {
   preferredPayoutMethod?: PayoutMethod | null;
   payoutWalletAddress?: string | null;
   payoutBankDetails?: BankDetails | null;
+  // marinara-71630 P7b: server-computed super-admin flag (DB Admin table,
+  // role === 'super_admin'). Hydrated from GET /api/user/me on mount; replaces
+  // the old hardcoded `hello@rarepizzas.com` email checks in HostPage/EventPage.
+  // Extends those controls to ALL Admin-table super_admins (approved widening).
+  isSuperAdmin?: boolean;
 }
 
 interface AuthContextType {
@@ -95,6 +100,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             preferredPayoutMethod: me.preferredPayoutMethod ?? null,
             payoutWalletAddress: me.payoutWalletAddress ?? null,
             payoutBankDetails: me.payoutBankDetails ?? null,
+            // marinara-71630 P7b: server-computed super-admin flag.
+            isSuperAdmin: me.isSuperAdmin === true,
           };
           try { localStorage.setItem('user', JSON.stringify(merged)); } catch { /* quota */ }
           return merged;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6275,6 +6275,9 @@ export interface UpdateUserMeInput {
   preferredPayoutMethod?: PayoutMethod | null;
   payoutWalletAddress?: string | null;
   payoutBankDetails?: BankDetails | null;
+  // marinara-71630 P7b: party in scope so the backend can hard-enforce
+  // party-scoped reimbursement-option gating on this save path.
+  partyId?: string;
 }
 
 /**

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -894,7 +894,7 @@ export function EventPage() {
               )}
 
               {/* Host Button - Desktop */}
-              {user && (user.id === event.userId || user.email?.toLowerCase() === 'hello@rarepizzas.com' || canEditAsCoHost) && (
+              {user && (user.id === event.userId || user.isSuperAdmin || canEditAsCoHost) && (
                 <div className="p-4 border-t border-theme-stroke">
                   <button
                     onClick={handleEditEvent}
@@ -1012,7 +1012,7 @@ export function EventPage() {
                 )}
 
                 {/* Host Button - Mobile */}
-                {user && (user.id === event.userId || user.email?.toLowerCase() === 'hello@rarepizzas.com' || canEditAsCoHost) && (
+                {user && (user.id === event.userId || user.isSuperAdmin || canEditAsCoHost) && (
                   <div className="p-4 border-b border-theme-stroke">
                     <button
                       onClick={handleEditEvent}

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -45,9 +45,6 @@ import { GPPDashboardTab, GPP27DashboardTab } from '../components/gpp-dashboard'
 import { PayoutsTab } from '../components/payouts';
 import { DayOfTab } from '../components/day-of';
 
-// Super admin email that can edit any party
-const SUPER_ADMIN_EMAIL = 'hello@rarepizzas.com';
-
 type TabType = 'dashboard' | 'party-guide' | 'details' | 'venue' | 'pizza' | 'guests' | 'photos' | 'partners' | 'music' | 'report' | 'staff' | 'displays' | 'raffle' | 'budget' | 'checklist' | 'survey' | 'gpp' | 'promo' | 'flyer' | 'print' | 'payments' | 'apps';
 
 const ALL_VALID_TABS: TabType[] = ['dashboard', 'party-guide', 'details', 'venue', 'pizza', 'guests', 'photos', 'partners', 'music', 'report', 'staff', 'displays', 'raffle', 'budget', 'checklist', 'survey', 'gpp', 'promo', 'flyer', 'print', 'payments', 'apps'];
@@ -73,7 +70,7 @@ function HostPageContent() {
 
   const canEdit = useMemo(() => {
     if (!party || !user) return false;
-    if (user.email.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
+    if (user.isSuperAdmin) return true;
     if (party.userId === user.id) return true;
     if (party.canEdit) return true; // Backend already verified co-host permissions
     return false;
@@ -97,7 +94,7 @@ function HostPageContent() {
   // Determine if this user is the owner or super admin (full access)
   const isOwnerOrAdmin = useMemo(() => {
     if (!party || !user) return false;
-    if (user.email.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
+    if (user.isSuperAdmin) return true;
     if (party.userId === user.id) return true;
     return false;
   }, [party, user]);


### PR DESCRIPTION
Phase 7b of marinara-71630. Two independent backend/auth hardening tasks. No SWC/swcHub code touched. No new app_config seeding required.

## Task B — backend POST enforcement of reimbursement-option gating
The GET endpoint DECIDES which payout methods a host may use, but the SAVE path didn't hard-enforce it — a crafted request could persist a disallowed method (e.g. `mercury_card` for a Mercury-blocked country). This closes that gap:

- Added `resolvePartyReimbursementOptions(party, rules)` in `backend/src/lib/reimbursementOptions.ts` — the single source of truth that layers the compliance `isMercuryBlocked` logic over the config-resolved options. Refactored `GET /api/parties/:id/reimbursement-options` to call it, so the DECIDE (GET) and ENFORCE (save) paths can't drift.
- `PATCH /api/user/me`: when the request sets a non-null payout method AND includes a `partyId` the caller can edit, it resolves that party's allowed options and rejects with **400 `PAYOUT_METHOD_NOT_ALLOWED`** if the submitted method is absent or `enabled:false`. **Fails OPEN** if the config is unseeded (empty resolved set) so a missing config row never blocks legitimate saves.
- Frontend: `PaymentDetailsCard` auto-save + `UpdateUserMeInput` now send `partyId`. No UX change (the frontend only ever offers enabled methods).
- New `backend/src/routes/user.routes.test.ts`: blocked-country mercury → 400; parenthetical/case variant (normalization) → 400; allowed method → 200; no partyId (legacy) → 200; unseeded-config fail-open → 200.

## Task C — de-hardcode super-admin frontend checks to a server flag
`HostPage.tsx` (`SUPER_ADMIN_EMAIL`) and `EventPage.tsx` (inline `=== 'hello@rarepizzas.com'`) hardcoded an internal identity. Switched these to the backend's existing super-admin determination:

- `GET /api/user/me` now returns `isSuperAdmin`, computed via the EXISTING `isSuperAdmin()` middleware (`prisma.admin.findUnique` → `role === 'super_admin'`) — no new criteria invented.
- `AuthContext` `User` type + `/me` hydration expose `isSuperAdmin`; the 3 hardcoded email comparisons (HostPage `canEdit` + `isOwnerOrAdmin`, EventPage desktop + mobile host buttons) now use the flag. Every other condition in those expressions is preserved. The `SUPER_ADMIN_EMAIL` const and `hello@rarepizzas.com` literals are removed.

**Intentional widening (approved):** behavior is identical for the existing hello@ account, and ADDITIONALLY any other `super_admin` in the Admin table now gets these host controls.

## Verify
- Backend `tsc --noEmit`: clean except known pre-existing `auth.test.ts` jwt error (and environment-only missing `openai`/`@anthropic-ai/sdk` deps, unrelated to this change).
- Frontend `tsc --noEmit -p frontend/tsconfig.json`: clean (exit 0).
- `reimbursementOptions` + `party.routes` + new `user.routes` tests: 41 passed.
- Grep-confirmed: no `hello@rarepizzas.com` / `SUPER_ADMIN_EMAIL` remain in HostPage/EventPage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)