### PR TITLE
sfincione-58500: admin add receipts & photos from /payments

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -6025,6 +6025,324 @@ router.post(
 );
 
 // ============================================
+// sfincione-58500: POST /api/admin/payouts/:id/documents
+//
+// Let a full payment admin attach a new receipt / pizza-proof / event-proof
+// document to an existing payout straight from the /payments review modal —
+// the same things a host can do via PATCH /api/payouts/:id, but admin-side and
+// per-document.
+//
+// Mirrors the host-PATCH attach path in payout.routes.ts (~L2346-2412):
+//   - pizza/event docs are mirrored into the gallery (`photos`) auto-approved
+//     + auto-starred, with the dedup pre-check on (partyId, fileSize, mimeType).
+//   - receipts are OCR'd inline (analyzeReceipt + convertToUSD), exactly like
+//     POST /documents/:docId/retry-ocr. OCR failures do NOT fail the request —
+//     the doc is persisted with an ocrError so the admin can fix it via the
+//     existing edit / retry-ocr controls.
+//
+// Auth: requireAuth + requireAnyAdminOrPaymentAdmin (admin / super_admin /
+// payment_admin). Regional underbosses are not permitted (the middleware
+// rejects them) — the frontend also hides the control for underboss viewers.
+//
+// Body: { kind: 'receipt'|'pizza'|'event', url, fileName, fileSize, mimeType }
+// Returns: { document: <serialized payout_documents row> }
+// ============================================
+
+const ADMIN_DOC_KINDS = ['receipt', 'pizza', 'event'] as const;
+type AdminDocKind = (typeof ADMIN_DOC_KINDS)[number];
+
+// sfincione-58500: replicated from payout.routes.ts (not exported there).
+// PDFs feed their sibling `.thumb.png` to the image-only OCR pipeline; images
+// use their canonical URL.
+function deriveAdminOcrUrl(doc: { url: string; mimeType?: string | null }): string {
+  const mime = (doc.mimeType || '').toLowerCase();
+  const looksLikePdf =
+    mime === 'application/pdf' || doc.url.toLowerCase().split('?')[0].endsWith('.pdf');
+  return looksLikePdf ? `${doc.url}.thumb.png` : doc.url;
+}
+
+// sfincione-58500: replicated from payout.routes.ts assertSupabasePayoutUrl —
+// only accept Supabase-Storage URLs under the payout's own folder so an admin
+// can't point OCR / the gallery at an arbitrary external URL.
+function assertSupabasePayoutDocUrl(imageUrl: unknown, partyId: string): string {
+  if (typeof imageUrl !== 'string' || imageUrl.length === 0) {
+    throw new AppError('url is required', 400, 'INVALID_IMAGE_URL');
+  }
+  let url: URL;
+  try {
+    url = new URL(imageUrl);
+  } catch {
+    throw new AppError('url is not a valid URL', 400, 'INVALID_IMAGE_URL');
+  }
+  if (!/\.supabase\.co$/.test(url.hostname)) {
+    throw new AppError('url must be hosted on Supabase Storage', 400, 'INVALID_IMAGE_URL');
+  }
+  const pathname = decodeURIComponent(url.pathname);
+  if (!pathname.includes('/event-images/')) {
+    throw new AppError('url must point into the event-images bucket', 400, 'INVALID_IMAGE_URL');
+  }
+  const expectedSegment = `/event-images/payouts/${partyId}/`;
+  if (!pathname.includes(expectedSegment)) {
+    throw new AppError(
+      `url must be under payouts/${partyId}/ in the event-images bucket`,
+      400,
+      'INVALID_IMAGE_URL_SCOPE',
+    );
+  }
+  return imageUrl;
+}
+
+router.post(
+  '/:id/documents',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const body = (req.body || {}) as {
+        kind?: unknown;
+        url?: unknown;
+        fileName?: unknown;
+        fileSize?: unknown;
+        mimeType?: unknown;
+      };
+
+      const kind = body.kind;
+      if (typeof kind !== 'string' || !(ADMIN_DOC_KINDS as readonly string[]).includes(kind)) {
+        throw new AppError(
+          `kind must be one of: ${ADMIN_DOC_KINDS.join(', ')}`,
+          400,
+          'VALIDATION_ERROR',
+        );
+      }
+      const docKind = kind as AdminDocKind;
+
+      const fileName = typeof body.fileName === 'string' && body.fileName.length > 0
+        ? body.fileName
+        : 'upload';
+      const fileSize = typeof body.fileSize === 'number' && Number.isFinite(body.fileSize)
+        ? body.fileSize
+        : 0;
+      const mimeType = typeof body.mimeType === 'string' && body.mimeType.length > 0
+        ? body.mimeType
+        : 'application/octet-stream';
+
+      const payout = await prisma.payout.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          partyId: true,
+          party: { select: { country: true } },
+        },
+      });
+      if (!payout) {
+        throw new AppError('Payout not found', 404, 'NOT_FOUND');
+      }
+
+      const partyId = payout.partyId;
+      const url = assertSupabasePayoutDocUrl(body.url, partyId);
+
+      const actor = await loadActor(req);
+      const uploaderUserId = req.userId ?? null;
+      const uploaderEmail = req.userEmail ?? null;
+
+      // sortOrder = (max existing doc sortOrder for this payout) + 1.
+      const maxAgg = await prisma.payoutDocument.aggregate({
+        where: { payoutId: payout.id },
+        _max: { sortOrder: true },
+      });
+      const sortOrder = (maxAgg._max.sortOrder ?? -1) + 1;
+
+      // For receipts: run OCR inline (mirrors POST /documents/:docId/retry-ocr).
+      // OCR fields default to "no result" and are overwritten on success.
+      let ocrAmount: Decimal | null = null;
+      let ocrCurrency: string | null = null;
+      let ocrConfidence: Decimal | null = null;
+      let originalAmount: Decimal | null = null;
+      let originalCurrency: string | null = null;
+      let exchangeRate: Decimal | null = null;
+      let ocrLineItems: Prisma.InputJsonValue | typeof Prisma.JsonNull = Prisma.JsonNull;
+      let ocrRaw: Prisma.InputJsonValue | typeof Prisma.JsonNull = Prisma.JsonNull;
+      let ocrError: string | null = null;
+      let ocrAttemptedAt: Date | null = null;
+      let ocrAttemptCount = 0;
+
+      if (docKind === 'receipt') {
+        const { analyzeReceipt } = await import('../services/ocr.service.js');
+        const { convertToUSD } = await import('../services/fx.service.js');
+        const ocrUrl = deriveAdminOcrUrl({ url, mimeType });
+        ocrAttemptedAt = new Date();
+        ocrAttemptCount = 1;
+        try {
+          const result = await analyzeReceipt({
+            imageUrl: ocrUrl,
+            partyCountry: payout.party?.country ?? null,
+          });
+          const fx = await convertToUSD(result.amount, result.currency);
+          const unresolved = fx.source === 'unresolved' || fx.usdAmount == null;
+          ocrLineItems = (result.lineItems ?? []) as unknown as Prisma.InputJsonValue;
+          ocrConfidence = new Decimal(result.confidence);
+          ocrRaw = {
+            ocr: result.raw,
+            fx: { source: fx.source, rate: fx.exchangeRate },
+          } as Prisma.InputJsonValue;
+          // Keep originalAmount even when unresolved so the admin sees what the
+          // receipt said and can pick the right currency in the edit modal.
+          originalAmount = new Decimal(fx.originalAmount);
+          ocrAmount = unresolved ? null : new Decimal(fx.usdAmount!);
+          ocrCurrency = unresolved ? null : fx.originalCurrency;
+          exchangeRate = unresolved
+            ? null
+            : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null);
+          ocrError = unresolved ? 'CURRENCY_UNRESOLVED' : null;
+        } catch (err: any) {
+          // Don't fail the request — persist the doc with the error so the
+          // admin can fix the amount via the existing edit / retry-ocr UI.
+          const msg = err?.message ? String(err.message) : String(err);
+          ocrError = msg.slice(0, 500);
+        }
+      }
+
+      const created = await prisma.$transaction(async (tx) => {
+        let photoId: string | null = null;
+
+        // pizza/event docs mirror into the gallery (photos) auto-approved +
+        // auto-starred, with the dedup pre-check from payout.routes.ts.
+        if (docKind === 'pizza' || docKind === 'event') {
+          const now = new Date();
+          const dup = await tx.photo.findFirst({
+            where: { partyId, fileSize, mimeType },
+            select: { id: true },
+          });
+          if (dup) {
+            photoId = dup.id;
+          } else {
+            const photo = await tx.photo.create({
+              data: {
+                partyId,
+                url,
+                fileName,
+                fileSize,
+                mimeType,
+                uploadedBy: null,
+                uploaderName: null,
+                uploaderEmail: uploaderEmail,
+                status: 'approved',
+                starred: true,
+                starredAt: now,
+                reviewedAt: now,
+                reviewedBy: uploaderUserId,
+              },
+              select: { id: true },
+            });
+            photoId = photo.id;
+          }
+        }
+
+        const row = await tx.payoutDocument.create({
+          data: {
+            partyId,
+            payoutId: payout.id,
+            kind: docKind,
+            url,
+            fileName,
+            fileSize,
+            mimeType,
+            sortOrder,
+            photoId,
+            uploadedByUserId: uploaderUserId,
+            uploadedByEmail: uploaderEmail,
+            ocrAmount,
+            ocrCurrency,
+            ocrConfidence,
+            originalAmount,
+            originalCurrency,
+            exchangeRate,
+            ocrLineItems,
+            ocrRaw,
+            ocrError,
+            ocrAttemptedAt,
+            ocrAttemptCount,
+          },
+          select: {
+            id: true,
+            kind: true,
+            url: true,
+            fileName: true,
+            fileSize: true,
+            mimeType: true,
+            ocrAmount: true,
+            ocrCurrency: true,
+            ocrConfidence: true,
+            originalAmount: true,
+            originalCurrency: true,
+            exchangeRate: true,
+            ocrLineItems: true,
+            isDuplicate: true,
+            ineligible: true,
+            ocrError: true,
+            sortOrder: true,
+            sourceReceiptIndex: true,
+            sourceReceiptCount: true,
+            boundingHint: true,
+            uploadedByUserId: true,
+          },
+        });
+
+        await tx.payoutAudit.create({
+          data: {
+            payoutId: payout.id,
+            action: 'edit_documents',
+            actorEmail: actor.email,
+            actorKind: actor.actorKind,
+            note: JSON.stringify({
+              scope: docKind === 'receipt' ? 'receipt' : 'photo',
+              documentId: row.id,
+              message: `admin added ${docKind} ${fileName}`,
+            }),
+          },
+        });
+
+        return row;
+      });
+
+      res.json({
+        document: {
+          id: created.id,
+          kind: created.kind,
+          url: created.url,
+          fileName: created.fileName,
+          fileSize: created.fileSize,
+          mimeType: created.mimeType,
+          ocrAmount: created.ocrAmount == null ? null : Number(created.ocrAmount),
+          ocrCurrency: created.ocrCurrency,
+          ocrConfidence:
+            created.ocrConfidence == null ? null : Number(created.ocrConfidence),
+          originalAmount:
+            created.originalAmount == null ? null : Number(created.originalAmount),
+          originalCurrency: created.originalCurrency,
+          exchangeRate:
+            created.exchangeRate == null ? null : Number(created.exchangeRate),
+          ocrLineItems: Array.isArray(created.ocrLineItems)
+            ? created.ocrLineItems
+            : null,
+          isDuplicate: created.isDuplicate === true,
+          ineligible: created.ineligible === true,
+          ocrError: created.ocrError,
+          sortOrder: created.sortOrder,
+          sourceReceiptIndex: created.sourceReceiptIndex ?? null,
+          sourceReceiptCount: created.sourceReceiptCount ?? null,
+          boundingHint: created.boundingHint ?? null,
+          uploadedByUserId: created.uploadedByUserId ?? null,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ============================================
 // crocchetta-92106 + crocchetta-92107: Telegram receipts reminder.
 //
 // Sends a Telegram nudge via the Molto Benny bot (`TELEGRAM_BOT_TOKEN`) to:

--- a/frontend/src/components/payments-admin/AdminAddAttachment.tsx
+++ b/frontend/src/components/payments-admin/AdminAddAttachment.tsx
@@ -1,0 +1,147 @@
+import React, { useRef, useState } from 'react';
+import { Loader2, Plus, AlertCircle } from 'lucide-react';
+import { uploadPayoutPhoto } from '../../lib/supabase';
+import { addAdminPayoutDocument } from '../../lib/api';
+
+/**
+ * sfincione-58500: a small self-contained uploader that lets a full payment
+ * admin attach a receipt / pizza-proof / event-proof to an existing payout
+ * straight from the /payments review modal.
+ *
+ * Upload flow: `uploadPayoutPhoto(file, partyId, payoutId, kind)` (the real
+ * payoutId is fine as the storage path segment) → `addAdminPayoutDocument(...)`
+ * → `onAdded()`. The backend OCRs receipts inline and mirrors pizza/event docs
+ * into the gallery, so callers just re-fetch the payout detail in `onAdded`.
+ *
+ * Rendered only for full payment admins — the parent hides it for regional
+ * underbosses.
+ */
+
+const RECEIPT_ACCEPT =
+  'image/jpeg,image/png,image/webp,image/heic,image/heif,application/pdf';
+const PHOTO_ACCEPT = 'image/jpeg,image/png,image/webp,image/heic,image/heif';
+
+interface AdminAddAttachmentProps {
+  payoutId: string;
+  partyId: string;
+  mode: 'receipt' | 'photo';
+  onAdded: () => void;
+}
+
+export const AdminAddAttachment: React.FC<AdminAddAttachmentProps> = ({
+  payoutId,
+  partyId,
+  mode,
+  onAdded,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  // photo mode picks between pizza / event proof; receipt mode is fixed.
+  const [photoKind, setPhotoKind] = useState<'pizza' | 'event'>('pizza');
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'reading'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const kind: 'receipt' | 'pizza' | 'event' =
+    mode === 'receipt' ? 'receipt' : photoKind;
+  const busy = status !== 'idle';
+
+  const handleFile = async (file: File) => {
+    setError(null);
+    setStatus('uploading');
+    try {
+      const uploaded = await uploadPayoutPhoto(file, partyId, payoutId, kind);
+      // Receipts get OCR'd server-side — surface a "reading" state so the
+      // admin knows the request is still in flight after the upload finishes.
+      if (kind === 'receipt') setStatus('reading');
+      await addAdminPayoutDocument(payoutId, {
+        kind,
+        url: uploaded.url,
+        fileName: uploaded.fileName,
+        fileSize: uploaded.fileSize,
+        mimeType: uploaded.mimeType,
+      });
+      setStatus('idle');
+      onAdded();
+    } catch (err) {
+      setStatus('idle');
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    }
+  };
+
+  const accept = mode === 'receipt' ? RECEIPT_ACCEPT : PHOTO_ACCEPT;
+  const buttonLabel =
+    mode === 'receipt' ? 'Add receipt' : 'Add photo';
+
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      <div className="flex items-center gap-2">
+        {/* photo mode: two-way kind picker (Pizza proof | Event proof). */}
+        {mode === 'photo' && (
+          <div className="inline-flex rounded-lg border border-theme-stroke overflow-hidden text-xs">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setPhotoKind('pizza')}
+              className={`px-2.5 py-1.5 transition-colors ${
+                photoKind === 'pizza'
+                  ? 'bg-[#ff393a] text-white'
+                  : 'bg-theme-surface text-theme-text-muted hover:text-theme-text'
+              }`}
+            >
+              Pizza proof
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setPhotoKind('event')}
+              className={`px-2.5 py-1.5 transition-colors ${
+                photoKind === 'event'
+                  ? 'bg-[#ff393a] text-white'
+                  : 'bg-theme-surface text-theme-text-muted hover:text-theme-text'
+              }`}
+            >
+              Event proof
+            </button>
+          </div>
+        )}
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleFile(f);
+            e.target.value = '';
+          }}
+        />
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => inputRef.current?.click()}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-theme-surface border border-theme-stroke text-theme-text hover:border-[#ff393a]/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {status === 'uploading' ? (
+            <>
+              <Loader2 size={13} className="animate-spin" /> Uploading…
+            </>
+          ) : status === 'reading' ? (
+            <>
+              <Loader2 size={13} className="animate-spin" /> Reading receipt…
+            </>
+          ) : (
+            <>
+              <Plus size={13} /> {buttonLabel}
+            </>
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <span className="inline-flex items-center gap-1 text-xs text-red-400">
+          <AlertCircle size={12} /> {error}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -21,6 +21,7 @@ import {
 } from '../payments-shared';
 import { ReceiptEditor, computeLineSubtotal } from './ReceiptEditor';
 import { TaxFormReviewPanel } from './TaxFormReviewPanel';
+import { AdminAddAttachment } from './AdminAddAttachment';
 
 /**
  * parmigiana-58291: strip the "Global Pizza Party " prefix from event names so
@@ -225,6 +226,14 @@ interface PayoutReviewModalProps {
    * Parent owns the modal state.
    */
   onMarkPartyPaid?: () => void;
+  /**
+   * sfincione-58500: called after an admin attaches a new receipt / pizza /
+   * event document to this payout via AdminAddAttachment. Parent should
+   * re-fetch the payout detail (getAdminPayout) + refresh the list so the new
+   * doc + recomputed receipt subtotal appear. Only invoked for full payment
+   * admins (the controls are hidden for underbosses).
+   */
+  onDocumentsChanged?: () => Promise<void> | void;
   busy?: boolean;
 }
 
@@ -251,6 +260,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   viewerRole = 'admin',
   onFlagReady,
   onMarkPartyPaid,
+  onDocumentsChanged,
   busy = false,
 }) => {
   // argentina-92103: underbosses lose Execute/Mark-paid affordances. The
@@ -1882,9 +1892,22 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             {/* focaccia-92104: Pizza photos — party.photos tagged
                 `Pizza` (default tagger) or `pizza-selfie` (EventPage). */}
             <div>
-              <h3 className="text-sm font-semibold text-theme-text mb-2">
-                Pizza photos ({pizzaPhotos.length})
-              </h3>
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <h3 className="text-sm font-semibold text-theme-text">
+                  Pizza photos ({pizzaPhotos.length})
+                </h3>
+                {/* sfincione-58500: full payment admins can attach a pizza- or
+                    event-proof photo (kind picker on the control). The backend
+                    mirrors it into the gallery. Hidden for underbosses. */}
+                {isAdminViewer && (
+                  <AdminAddAttachment
+                    payoutId={payout.id}
+                    partyId={payout.partyId}
+                    mode="photo"
+                    onAdded={() => onDocumentsChanged?.()}
+                  />
+                )}
+              </div>
               {pizzaPhotos.length === 0 ? (
                 <p className="text-sm text-theme-text-faint">No pizza photos yet.</p>
               ) : (
@@ -1950,9 +1973,21 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 PayoutDocuments. The per-receipt OCR list on the right is the
                 editable companion to these thumbnails. */}
             <div>
-              <h3 className="text-sm font-semibold text-theme-text mb-2">
-                Receipts ({receipts.length})
-              </h3>
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <h3 className="text-sm font-semibold text-theme-text">
+                  Receipts ({receipts.length})
+                </h3>
+                {/* sfincione-58500: full payment admins can attach a receipt
+                    here — OCR'd inline server-side. Hidden for underbosses. */}
+                {isAdminViewer && (
+                  <AdminAddAttachment
+                    payoutId={payout.id}
+                    partyId={payout.partyId}
+                    mode="receipt"
+                    onAdded={() => onDocumentsChanged?.()}
+                  />
+                )}
+              </div>
               {receipts.length === 0 ? (
                 <p className="text-sm text-theme-text-faint">No receipts attached.</p>
               ) : (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem, TaxForm, TaxFormType, TaxFormStatus } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem, PayoutDocument, TaxForm, TaxFormType, TaxFormStatus } from '../types';
 // pancetta-92103: region portal → underlying parties.region slug map. Used by
 // `buildPayoutQuery` to expand the /payments admin Regions multi-select into
 // the existing `?regions=` query the backend already accepts.
@@ -5109,6 +5109,29 @@ export async function retryPayoutDocumentOcr(
     `/api/admin/payouts/documents/${docId}/retry-ocr`,
     { method: 'POST', body: { runNow: opts?.runNow ?? true } },
   );
+}
+
+/**
+ * sfincione-58500: admin attaches a new receipt / pizza-proof / event-proof
+ * document to an existing payout from the /payments review modal. The backend
+ * OCRs receipts inline and mirrors pizza/event docs into the gallery, exactly
+ * like the host PATCH path. Returns the freshly-created PayoutDocument; callers
+ * re-fetch the payout detail to pick up recomputed receipt subtotals.
+ */
+export async function addAdminPayoutDocument(
+  payoutId: string,
+  body: {
+    kind: 'receipt' | 'pizza' | 'event';
+    url: string;
+    fileName: string;
+    fileSize: number;
+    mimeType: string;
+  },
+): Promise<{ document: PayoutDocument }> {
+  return apiRequest(`/api/admin/payouts/${payoutId}/documents`, {
+    method: 'POST',
+    body,
+  });
 }
 
 export async function approveAdminPayout(

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1869,6 +1869,18 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
               }
               await refresh();
             }}
+            // sfincione-58500: after an admin attaches a receipt/photo, re-fetch
+            // the detail so the new doc + recomputed receipt subtotal render,
+            // and refresh the list so the row's amount/cap state stays in sync.
+            onDocumentsChanged={async () => {
+              try {
+                const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
+                setDetail(fresh);
+              } catch {
+                /* ignore — modal keeps its current state on a refetch failure */
+              }
+              await refresh();
+            }}
           />
         )}
         {externalModalState.open && (


### PR DESCRIPTION
## What

Lets a full payment admin attach a **receipt**, **pizza-proof**, or **event-proof** document to an existing payout straight from the `/payments` review modal — the admin-side analogue of what a host can do via `PATCH /api/payouts/:id`.

## Backend

New route `POST /api/admin/payouts/:id/documents` (`requireAuth` + `requireAnyAdminOrPaymentAdmin` — regional underbosses are rejected). Body `{ kind: 'receipt'|'pizza'|'event', url, fileName, fileSize, mimeType }`. It mirrors the host-PATCH attach path:

- **pizza/event** → mirrored into the gallery (`photos`) auto-approved + auto-starred, with the `(partyId, fileSize, mimeType)` dedup pre-check; the `payout_documents` row stores the resulting `photoId`.
- **receipt** → OCR'd inline (`analyzeReceipt` + `convertToUSD`), exactly like `POST /documents/:docId/retry-ocr` (`Prisma.JsonNull` for JSON nulls, `CURRENCY_UNRESOLVED` when FX can't resolve). **OCR failures do not fail the request** — the doc persists with an `ocrError` so the admin can fix it via the existing edit / retry-ocr controls.
- `sortOrder` = max existing doc sortOrder + 1; URL validated as a Supabase Storage URL under `payouts/{partyId}/`; writes a `payout_audit` `edit_documents` row.

## Frontend

- `addAdminPayoutDocument()` in `lib/api.ts`.
- New `AdminAddAttachment` uploader: receipt mode (Uploading… → Reading receipt…) and photo mode with a **Pizza proof | Event proof** segmented picker.
- Wired into `PayoutReviewModal`'s Receipts + Pizza-photos headers, **hidden for underboss viewers** (`viewerRole`). `onDocumentsChanged` re-fetches the detail (`getAdminPayout`) + refreshes the list so the new doc + recomputed receipt subtotal appear.

## Deploy notes

- **No DB migration** — `payout_documents` and `photos` already have every column used.
- ⚠️ **The new backend endpoint must be merged to master before the preview UI works.** Preview frontends hit the production backend, so the add will 404 on the preview deploy until this merges and the backend redeploys from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)