### PR TITLE
fix(lonza-92106): tax-form date autofill race condition

### DIFF
--- a/frontend/src/components/payouts/TaxFormSection.tsx
+++ b/frontend/src/components/payouts/TaxFormSection.tsx
@@ -80,10 +80,26 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
   }, [autoOpenFormType]);
 
   // Seed the editor with existing draft/submitted data when entering edit mode.
+  //
+  // lonza-92106: default the signature `date` field to today (YYYY-MM-DD) here
+  // — at the parent level — so the value is guaranteed to be populated BEFORE
+  // any of the form components mount. The prior approach (a mount-effect in
+  // each form component) raced with this draft-seed effect: the form mounted
+  // with empty value, the mount-effect synchronously called `onChange` with
+  // today, then this effect re-fired with the loaded draft (often `date=''`)
+  // and overwrote today. Centralising the default eliminates the race for
+  // both the no-draft-on-file case (empty `existing.formData`) and the
+  // saved-draft-with-blank-date case.
   useEffect(() => {
     if (!editingType) return;
     const existing = forms.find((f) => f.formType === editingType);
-    setDraftData((existing?.formData as Record<string, any>) || {});
+    const seeded: Record<string, any> = {
+      ...((existing?.formData as Record<string, any>) || {}),
+    };
+    if (!seeded.date || (typeof seeded.date === 'string' && seeded.date.trim() === '')) {
+      seeded.date = new Date().toISOString().slice(0, 10);
+    }
+    setDraftData(seeded);
   }, [editingType, forms]);
 
   const handlePick = (formType: TaxFormType) => {

--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -152,17 +152,10 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
     );
   });
 
-  // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
-  // fresh mount. Saved drafts with an existing date are left untouched; the
-  // effect only fires once so subsequent user edits remain authoritative.
-  useEffect(() => {
-    const v = valueRef.current;
-    if (!v.date || v.date.trim() === '') {
-      const today = new Date().toISOString().slice(0, 10);
-      onChangeRef.current({ ...v, date: today });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // lonza-92106: the today-default for the signature Date field is now seeded
+  // by the parent (TaxFormSection) before this component mounts, so we don't
+  // need (or want) a mount-effect here. The old child-side effect raced with
+  // the parent's draft fetch and got overwritten when the draft arrived.
 
   // Default the treaty-claim country to the entity's country of incorporation
   // (most common case for an entity claiming treaty benefits). Host can edit.

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -97,17 +97,10 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled,
     );
   });
 
-  // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
-  // fresh mount. Saved drafts with an existing date are left untouched; the
-  // effect only fires once so subsequent user edits remain authoritative.
-  useEffect(() => {
-    const v = valueRef.current;
-    if (!v.date || v.date.trim() === '') {
-      const today = new Date().toISOString().slice(0, 10);
-      onChangeRef.current({ ...v, date: today });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // lonza-92106: the today-default for the signature Date field is now seeded
+  // by the parent (TaxFormSection) before this component mounts, so we don't
+  // need (or want) a mount-effect here. The old child-side effect raced with
+  // the parent's draft fetch and got overwritten when the draft arrived.
 
   // The treaty-claim country defaults to permanentCountry (typical case:
   // host is claiming benefits under their country of residence's treaty).

--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   User,
   Building2,
@@ -258,16 +258,10 @@ export const W9Form: React.FC<W9FormProps> = ({
     !!(value.exemptPayeeCode || value.fatcaCode || value.accountNumbers),
   );
 
-  // crocchetta-92107: default the signature Date field to today (YYYY-MM-DD) on
-  // fresh mount. Saved drafts with an existing date are left untouched; the
-  // effect only fires once so subsequent user edits remain authoritative.
-  useEffect(() => {
-    if (!value.date || value.date.trim() === "") {
-      const today = new Date().toISOString().slice(0, 10);
-      onChange({ ...value, date: today });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // lonza-92106: the today-default for the signature Date field is now seeded
+  // by the parent (TaxFormSection) before this component mounts, so we don't
+  // need (or want) a mount-effect here. The old child-side effect raced with
+  // the parent's draft fetch and got overwritten when the draft arrived.
 
   const set = <K extends keyof W9FormData>(key: K, v: W9FormData[K]) =>
     onChange({ ...value, [key]: v });


### PR DESCRIPTION
## Summary

- `crocchetta-92107` added a mount `useEffect` in `W9Form` / `W8BENForm` / `W8BENEForm` to default the signature `date` field to today. The effect raced with `TaxFormSection`'s draft fetch: the form mounted with empty value, the mount-effect fired with `onChange({...empty, date: today})`, then the parent's draft-seed effect fired again with the loaded `formData` (often `date=''` for legacy drafts) and overwrote today. Net result: the Date field showed blank on screen.
- Move the today-default to the parent (`TaxFormSection`) where the draft is merged into `draftData` BEFORE any of the form components mount. The form components no longer manage the date default themselves.
- Removed the now-redundant mount-effect (and stale `useEffect` import in `W9Form`) from all three forms.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [ ] Manual: open a fresh tax form (no draft on file) -> Date field pre-fills today.
- [ ] Manual: open a saved draft with `date='2025-12-25'` -> Date field shows 2025-12-25 (preserved).
- [ ] Manual: open a saved draft with `date=''` -> Date field shows today (race fixed).
- [ ] Manual: switch between W-9 / W-8BEN / W-8BEN-E via the picker -> Date defaults to today on each editor entry.

Generated with Claude Code.