### PR TITLE
feat(salame-92111): update tax forms to W-9 Rev. March 2024 + W-8 Rev. October 2021

### DIFF
--- a/backend/src/services/taxFormPdf.service.ts
+++ b/backend/src/services/taxFormPdf.service.ts
@@ -142,6 +142,11 @@ export interface W9FormData {
   ein?: string;
   signature: string;
   date: string;
+  // salame-92111: Line 3b (March 2024 W-9 revision) — entities providing this
+  // form to a partnership/trust/estate in which they hold an interest disclose
+  // whether they have any foreign partners, owners, or beneficiaries. Only
+  // meaningful when taxClassification is partnership / trust_estate / llc_p.
+  hasForeignPartnersOrOwners?: boolean;
 }
 
 // prosciutto-92107: compose "City, State ZIP" from the structured fields.
@@ -198,10 +203,18 @@ export async function generateW9PDF(data: W9FormData, refId: string): Promise<Bu
     font,
     color: rgb(0.85, 0.85, 0.85),
   });
-  page.drawText('Rev. October 2018', {
+  // salame-92111: bump revision to the current IRS Form W-9 (Rev. March 2024).
+  page.drawText('Rev. March 2024', {
     x: 340,
     y: 748,
     size: 8,
+    font,
+    color: rgb(0.7, 0.7, 0.7),
+  });
+  page.drawText('Go to www.irs.gov/FormW9 for instructions and the latest information.', {
+    x: 340,
+    y: 738,
+    size: 6.5,
     font,
     color: rgb(0.7, 0.7, 0.7),
   });
@@ -234,9 +247,11 @@ export async function generateW9PDF(data: W9FormData, refId: string): Promise<Bu
   });
   y -= 40;
 
-  // Line 3 - Tax classification
+  // Line 3a - Tax classification. salame-92111: header reworded to match the
+  // March 2024 W-9 revision (numbered 3a, with the "Check only ONE of the
+  // following seven boxes" callout).
   page.drawText(
-    '3  Check appropriate box for federal tax classification of the person whose name is entered on line 1:',
+    '3a Federal tax classification of the person whose name is entered on line 1. Check only ONE of the following seven boxes:',
     { x: 33, y: y - 2, size: 7, font: bold, color: rgb(0.3, 0.3, 0.3) },
   );
   y -= 16;
@@ -262,6 +277,38 @@ export async function generateW9PDF(data: W9FormData, refId: string): Promise<Bu
     cx += font.widthOfTextAtSize(cls.label, 8) + 28;
   }
   y -= 18;
+
+  // Line 3b - salame-92111: foreign partners/owners/beneficiaries checkbox.
+  // Per the March 2024 W-9 revision, this only applies when Line 3a is
+  // Partnership, Trust/Estate, or LLC taxed as Partnership / Trust. The PDF
+  // still renders the box even for individuals (matching the printed IRS
+  // form's layout); the checkbox is only marked when the data warrants it.
+  const isPartnershipOrTrust =
+    data.taxClassification === 'partnership'
+    || data.taxClassification === 'trust_estate'
+    || data.taxClassification === 'llc_p';
+  drawCheckbox(page, {
+    x: 33,
+    y,
+    checked: !!(isPartnershipOrTrust && data.hasForeignPartnersOrOwners),
+    label:
+      '3b If on line 3a you checked "Partnership," "Trust/estate," or "LLC" (Partnership/Trust), AND you are providing',
+    font,
+  });
+  y -= 10;
+  page.drawText(
+    '    this form to a partnership, trust, or estate in which you have an ownership interest, check this box if you have',
+    { x: 33, y: y - 2, size: 7, font, color: rgb(0.3, 0.3, 0.3) },
+  );
+  y -= 10;
+  page.drawText('    any foreign partners, owners, or beneficiaries. See instructions.', {
+    x: 33,
+    y: y - 2,
+    size: 7,
+    font,
+    color: rgb(0.3, 0.3, 0.3),
+  });
+  y -= 14;
 
   // Line 4 - Exemptions
   drawField(page, {
@@ -416,7 +463,22 @@ export async function generateW9PDF(data: W9FormData, refId: string): Promise<Bu
     boldFont: bold,
   });
 
-  // Footer
+  // Footer. salame-92111: include IRS-style revision footer (Cat. No. +
+  // Form W-9 (Rev. 3-2024)) in addition to our internal submission stamp.
+  page.drawText('Cat. No. 10231X', {
+    x: 30,
+    y: 42,
+    size: 7,
+    font,
+    color: rgb(0.4, 0.4, 0.4),
+  });
+  page.drawText('Form W-9 (Rev. 3-2024)', {
+    x: 480,
+    y: 42,
+    size: 7,
+    font: bold,
+    color: rgb(0.4, 0.4, 0.4),
+  });
   page.drawText(`Generated ${todayIso()}  |  Submission #${refId}`, {
     x: 30,
     y: 30,
@@ -489,6 +551,15 @@ export async function generateW8BENPDF(data: W8BENFormData, refId: string): Prom
     x: 340,
     y: 748,
     size: 8,
+    font,
+    color: rgb(0.6, 0.7, 0.8),
+  });
+  // salame-92111: instructions URL line, matches the official Rev. Oct 2021
+  // form header.
+  page.drawText('Go to www.irs.gov/FormW8BEN for instructions and the latest information.', {
+    x: 340,
+    y: 738,
+    size: 6.5,
     font,
     color: rgb(0.6, 0.7, 0.8),
   });
@@ -770,6 +841,22 @@ export async function generateW8BENPDF(data: W8BENFormData, refId: string): Prom
     boldFont: bold,
   });
 
+  // salame-92111: IRS-style revision footer (matches the published Rev. Oct
+  // 2021 form layout).
+  page.drawText('Cat. No. 25047Z', {
+    x: 30,
+    y: 42,
+    size: 7,
+    font,
+    color: rgb(0.4, 0.4, 0.4),
+  });
+  page.drawText('Form W-8BEN (Rev. 10-2021)', {
+    x: 470,
+    y: 42,
+    size: 7,
+    font: bold,
+    color: rgb(0.4, 0.4, 0.4),
+  });
   page.drawText(`Generated ${todayIso()}  |  Submission #${refId}`, {
     x: 30,
     y: 30,
@@ -865,6 +952,15 @@ export async function generateW8BENEPDF(data: W8BENEFormData, refId: string): Pr
     x: 340,
     y: 748,
     size: 8,
+    font,
+    color: rgb(0.6, 0.7, 0.8),
+  });
+  // salame-92111: instructions URL line, matches the official Rev. Oct 2021
+  // form header.
+  page.drawText('Go to www.irs.gov/FormW8BENE for instructions and the latest information.', {
+    x: 340,
+    y: 738,
+    size: 6.5,
     font,
     color: rgb(0.6, 0.7, 0.8),
   });
@@ -1264,13 +1360,42 @@ export async function generateW8BENEPDF(data: W8BENEFormData, refId: string): Pr
   });
 
   // Footer on both pages so the submission id is visible regardless of which
-  // page an admin downloads/prints in isolation.
+  // page an admin downloads/prints in isolation. salame-92111: also include
+  // IRS-style revision footer matching the official Rev. Oct 2021 form.
+  page.drawText('Cat. No. 59689N', {
+    x: 30,
+    y: 42,
+    size: 7,
+    font,
+    color: rgb(0.4, 0.4, 0.4),
+  });
+  page.drawText('Form W-8BEN-E (Rev. 10-2021)', {
+    x: 460,
+    y: 42,
+    size: 7,
+    font: bold,
+    color: rgb(0.4, 0.4, 0.4),
+  });
   page.drawText(`Generated ${todayIso()}  |  Submission #${refId}  |  Page 1 of 2`, {
     x: 30,
     y: 30,
     size: 7,
     font,
     color: rgb(0.6, 0.6, 0.6),
+  });
+  page2.drawText('Cat. No. 59689N', {
+    x: 30,
+    y: 42,
+    size: 7,
+    font,
+    color: rgb(0.4, 0.4, 0.4),
+  });
+  page2.drawText('Form W-8BEN-E (Rev. 10-2021)', {
+    x: 460,
+    y: 42,
+    size: 7,
+    font: bold,
+    color: rgb(0.4, 0.4, 0.4),
   });
   page2.drawText(`Generated ${todayIso()}  |  Submission #${refId}  |  Page 2 of 2`, {
     x: 30,

--- a/frontend/src/components/payouts/tax/W9Form.tsx
+++ b/frontend/src/components/payouts/tax/W9Form.tsx
@@ -45,6 +45,10 @@ export interface W9FormData {
   certify?: boolean;
   signature?: string;
   date?: string;
+  // salame-92111: Line 3b (March 2024 W-9 revision) — only meaningful when
+  // classification is Partnership / Trust-Estate / LLC taxed as Partnership.
+  // Stored in form_data; no schema change.
+  hasForeignPartnersOrOwners?: boolean;
 }
 
 interface W9FormProps {
@@ -396,6 +400,32 @@ export const W9Form: React.FC<W9FormProps> = ({
               Disregarded = single-member LLC. The IRS treats it as the
               owner; you'll enter the owner's name on Line 1 and the LLC's
               name on Line 2.
+            </p>
+          </div>
+        )}
+        {/* salame-92111: Line 3b — new in March 2024 W-9 revision. Only
+            renders for partnership / trust-estate / LLC taxed as partnership;
+            individuals and corps never see it. */}
+        {(category === "partnership"
+          || category === "trust_estate"
+          || (category === "llc" && llcSub === "p")) && (
+          <div className="mt-3 rounded-md border border-theme-stroke bg-theme-input/40 p-3">
+            <Checkbox
+              checked={!!value.hasForeignPartnersOrOwners}
+              onChange={() =>
+                set("hasForeignPartnersOrOwners", !value.hasForeignPartnersOrOwners)
+              }
+              label="Check if you have any foreign partners, owners, or beneficiaries"
+              labelClassName="text-sm text-theme-text"
+              disabled={disabled}
+            />
+            <p className="text-xs text-theme-text-muted mt-2">
+              Per the March 2024 W-9 revision (Line 3b). If on Line 3a you
+              checked Partnership, Trust/Estate, or LLC taxed as Partnership,
+              AND you are providing this form to a partnership, trust, or
+              estate in which you have an ownership interest, the IRS requires
+              you to disclose whether you have any foreign partners, owners,
+              or beneficiaries. See the W-9 instructions.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

- **W-9 -> Rev. March 2024**: header bumped from `Rev. October 2018`, new instructions URL, IRS-style footer (`Cat. No. 10231X` + `Form W-9 (Rev. 3-2024)`).
- **W-9 Line 3b (NEW substantive field)**: foreign partners / owners / beneficiaries checkbox required by the March 2024 revision for partnerships, trusts/estates, and LLCs taxed as partnerships. Conditionally renders in the host UI (only when classification is Partnership / Trust-Estate / LLC-P) and is drawn into the PDF at the appropriate spot. Stored as `form_data.hasForeignPartnersOrOwners` (boolean) - no schema migration needed.
- **W-8BEN & W-8BEN-E -> Rev. October 2021**: header was already on the right revision; this PR adds the missing `Go to www.irs.gov/FormW8BEN[E] for instructions and the latest information.` line and an IRS-style footer (`Cat. No.` + `Form W-8BEN (Rev. 10-2021)` / `Form W-8BEN-E (Rev. 10-2021)`, on both pages of the W-8BEN-E).

## Files

- `backend/src/services/taxFormPdf.service.ts` - W-9 / W-8BEN / W-8BEN-E header + footer + new Line 3b drawing logic. Added `hasForeignPartnersOrOwners?: boolean` to `W9FormData`.
- `frontend/src/components/payouts/tax/W9Form.tsx` - added `hasForeignPartnersOrOwners?: boolean` to the type and a conditional Line 3b `<Checkbox>` that renders only for the relevant classifications.

## Test plan

- [ ] Open a W-9 with classification = Partnership / Trust-Estate / LLC-P -> Line 3b checkbox visible.
- [ ] Change classification to Individual / C Corp / S Corp -> Line 3b checkbox disappears.
- [ ] Toggle Line 3b, save draft, reload -> checkbox state persists (round-trips through `form_data` jsonb).
- [ ] Download generated W-9 PDF -> header reads "Rev. March 2024", footer reads "Form W-9 (Rev. 3-2024)", Line 3b block visible with X when checked.
- [ ] Download generated W-8BEN PDF -> header reads "Rev. October 2021" + instructions URL; footer reads "Form W-8BEN (Rev. 10-2021)".
- [ ] Download generated W-8BEN-E PDF -> same updates on both pages.

Closes salame-92111.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>