### PR TITLE
feat(marinara-71630): import + photo quota limits tunable via config (P8)

### DIFF
--- a/backend/src/config/seed.example.json
+++ b/backend/src/config/seed.example.json
@@ -94,5 +94,8 @@
   },
 
   "_note_gpp_global_editors": "PLACEHOLDER global-editor allowlist (marinara-71630 P6) documenting SHAPE only — an OBVIOUSLY-FAKE example email. Real emails are seeded separately and NOT committed. A plain string[] of emails that get invisible editor access to ALL GPP events (they don't appear in any party's co_hosts). Access checks compare emails case-INSENSITIVELY. Empty list = no one gets global-editor rights (safe fallback); normal owner/co-host/underboss/admin checks still apply.",
-  "private.gpp_global_editors": ["editor@example.com"]
+  "private.gpp_global_editors": ["editor@example.com"],
+
+  "_note_operational_limits": "Operational quota limits (marinara-71630 P8). UNLIKE the private.* keys above these are NOT secret — they're just tunable operational quotas, so the REAL values (importHardCap 2000, photoPerUserPerEvent 30) are shown here. The in-code fallback in privateConfig.ts IS the current value, so behavior is identical with or without this row; seeding it just lets the team OVERRIDE the quotas without a deploy. importHardCap = max guests per bulk-import request; photoPerUserPerEvent = max photos one user may have (pending+approved) on a single event.",
+  "operational.limits": { "importHardCap": 2000, "photoPerUserPerEvent": 30 }
 }

--- a/backend/src/lib/privateConfig.test.ts
+++ b/backend/src/lib/privateConfig.test.ts
@@ -17,6 +17,7 @@ import {
   getReimbursementCapBands,
   getSponsorshipPricing,
   getGppGlobalEditors,
+  getOperationalLimits,
   invalidateAll,
   PRIVATE_CONFIG_KEYS,
 } from './privateConfig.js';
@@ -201,5 +202,51 @@ describe('getGppGlobalEditors', () => {
   it('falls back to [] when the stored value is not valid JSON', async () => {
     mockPrisma.appConfig.findUnique.mockResolvedValue({ value: 'not-json[' });
     expect(await getGppGlobalEditors()).toEqual([]);
+  });
+});
+
+// marinara-71630 P8: operational quota limits accessor. NON-SECRET — the
+// fallback IS the current real value (2000 / 30), so behavior is identical
+// with or without a row; the row only lets the team override without a deploy.
+describe('getOperationalLimits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateAll();
+  });
+
+  it('returns the seeded config values when an app_config row is present', async () => {
+    const seeded = { importHardCap: 5000, photoPerUserPerEvent: 50 };
+    mockPrisma.appConfig.findUnique.mockResolvedValue({ value: JSON.stringify(seeded) });
+
+    const limits = await getOperationalLimits();
+
+    expect(limits).toEqual(seeded);
+    expect(mockPrisma.appConfig.findUnique).toHaveBeenCalledWith({
+      where: { key: PRIVATE_CONFIG_KEYS.operationalLimits },
+    });
+  });
+
+  it('falls back to the CURRENT real values (2000 / 30) when the row is absent', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue(null);
+    expect(await getOperationalLimits()).toEqual({
+      importHardCap: 2000,
+      photoPerUserPerEvent: 30,
+    });
+  });
+
+  it('falls back to current values (never throws) when the DB read fails', async () => {
+    mockPrisma.appConfig.findUnique.mockRejectedValue(new Error('db down'));
+    expect(await getOperationalLimits()).toEqual({
+      importHardCap: 2000,
+      photoPerUserPerEvent: 30,
+    });
+  });
+
+  it('falls back to current values when the stored value is not valid JSON', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue({ value: 'not-json{' });
+    expect(await getOperationalLimits()).toEqual({
+      importHardCap: 2000,
+      photoPerUserPerEvent: 30,
+    });
   });
 });

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -34,6 +34,7 @@ const KEYS = {
   reimbursementCapBands: 'private.reimbursement_cap_bands',
   sponsorshipPricing: 'private.sponsorship_pricing',
   gppGlobalEditors: 'private.gpp_global_editors',
+  operationalLimits: 'operational.limits',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -377,6 +378,38 @@ export function getSponsorshipPricing(): Promise<SponsorshipPricing> {
  */
 export function getGppGlobalEditors(): Promise<string[]> {
   return getConfig<string[]>(KEYS.gppGlobalEditors, []);
+}
+
+// ---------------------------------------------------------------------------
+// Operational quota limits (marinara-71630 P8)
+//
+// Host-facing operational quotas (bulk-import hard cap, per-user-per-event
+// photo cap). Unlike the `private.*` keys above these are NOT secret — they're
+// just operational knobs. They live here so the team can OVERRIDE them via an
+// `app_config` row WITHOUT a deploy.
+// ---------------------------------------------------------------------------
+
+export interface OperationalLimits {
+  /** Max guests accepted in a single bulk-import request. */
+  importHardCap: number;
+  /** Max photos one user may have (pending+approved) on a single event. */
+  photoPerUserPerEvent: number;
+}
+
+/**
+ * Operational quota limits. NON-SECRET — these are tunable operational
+ * quotas, not sensitive config.
+ *
+ * Fallback = the CURRENT real values (importHardCap 2000, photoPerUserPerEvent
+ * 30). Because the fallback IS the live value, behavior is identical whether or
+ * not an `app_config` row exists; seeding the `operational.limits` row simply
+ * lets the team OVERRIDE these quotas without shipping a deploy.
+ */
+export function getOperationalLimits(): Promise<OperationalLimits> {
+  return getConfig<OperationalLimits>(KEYS.operationalLimits, {
+    importHardCap: 2000,
+    photoPerUserPerEvent: 30,
+  });
 }
 
 export { KEYS as PRIVATE_CONFIG_KEYS };

--- a/backend/src/routes/party.routes.test.ts
+++ b/backend/src/routes/party.routes.test.ts
@@ -73,8 +73,15 @@ vi.mock('./rsvp.routes.js', () => ({
 // isMercuryBlocked layering is what disables it. The real (un-mocked)
 // isMercuryBlocked / normalizeCountry is exercised so normalization is tested.
 const mockGetReimbursementRules = vi.hoisted(() => vi.fn());
+// marinara-71630 P8: the bulk-import handler now resolves its hard cap from
+// getOperationalLimits(). Stub it with the current real values so the import
+// tests (and the "> 2000" cap test) exercise the production cap.
+const mockGetOperationalLimits = vi.hoisted(() =>
+  vi.fn(async () => ({ importHardCap: 2000, photoPerUserPerEvent: 30 }))
+);
 vi.mock('../lib/privateConfig.js', () => ({
   getReimbursementRules: mockGetReimbursementRules,
+  getOperationalLimits: mockGetOperationalLimits,
 }));
 
 const parseAuth = (req: any) => {

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -17,7 +17,7 @@ import {
 } from '../helpers/reimbursementCapAudit.js';
 import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
-import { getReimbursementRules, getGppGlobalEditors } from '../lib/privateConfig.js';
+import { getReimbursementRules, getGppGlobalEditors, getOperationalLimits } from '../lib/privateConfig.js';
 import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
 
 // Helper function to get party with ownership check
@@ -1525,7 +1525,6 @@ router.post('/:id/guests', async (req: AuthRequest, res: Response, next: NextFun
 // supabase_realtime fan-out burst.
 const IMPORT_SOURCE_ALLOWLIST = ['luma', 'meetup', 'eventbrite', 'csv'] as const;
 type ImportSource = typeof IMPORT_SOURCE_ALLOWLIST[number];
-const IMPORT_HARD_CAP = 2000;
 const IMPORT_CHUNK_SIZE = 50;
 const IMPORT_CHUNK_GAP_MS = 100;
 const IMPORT_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -1533,6 +1532,12 @@ const IMPORT_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 router.post('/:id/guests/import', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { id } = req.params;
+
+    // marinara-71630 P8: the bulk-import hard cap is a tunable operational
+    // quota resolved from config (fallback = current value 2000), so it can be
+    // overridden without a deploy. Templated into the cap-exceeded message so
+    // the message always reflects the configured value.
+    const importHardCap = (await getOperationalLimits()).importHardCap;
 
     // Verify ownership or super admin
     const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
@@ -1566,9 +1571,9 @@ router.post('/:id/guests/import', async (req: AuthRequest, res: Response, next: 
     if (!Array.isArray(guests) || guests.length === 0) {
       throw new AppError('guests must be a non-empty array', 400, 'VALIDATION_ERROR');
     }
-    if (guests.length > IMPORT_HARD_CAP) {
+    if (guests.length > importHardCap) {
       throw new AppError(
-        `Max ${IMPORT_HARD_CAP} guests per import; split the file into multiple uploads`,
+        `Max ${importHardCap} guests per import; split the file into multiple uploads`,
         400,
         'VALIDATION_ERROR'
       );

--- a/backend/src/routes/photo.routes.test.ts
+++ b/backend/src/routes/photo.routes.test.ts
@@ -20,6 +20,11 @@ const mockPrisma = vi.hoisted(() => ({
     count: vi.fn(() => Promise.resolve(0)),
   },
   guest: { findFirst: vi.fn() },
+  // marinara-71630 P8: the upload handler now resolves its per-user photo cap
+  // from getOperationalLimits(), which reads app_config. Default to no row so
+  // the loader falls back to the current real value (30) — the behavior the
+  // upload tests assume.
+  appConfig: { findUnique: vi.fn(() => Promise.resolve(null)) },
 }));
 
 vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));

--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -5,6 +5,7 @@ import { requireAuth, optionalAuth, isSuperAdmin, AuthRequest } from '../middlew
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
 import { autoCompleteScorecardItem } from './scorecard.routes.js';
+import { getOperationalLimits } from '../lib/privateConfig.js';
 
 const router = Router();
 
@@ -571,12 +572,17 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
       }
     }
 
-    // nduja-58296: per-user 30-photo cap per event. Identify the uploader by
+    // nduja-58296: per-user photo cap per event. Identify the uploader by
     // userId, guestId, or lowercased email — any match counts. Pending +
     // approved count; rejected photos do not (so a host can clean up bad
     // uploads to make room). If we can't identify the uploader at all, skip
     // the check rather than reject an otherwise valid upload.
-    const PHOTO_LIMIT_PER_USER_PER_EVENT = 30;
+    //
+    // marinara-71630 P8: the cap is a tunable operational quota resolved from
+    // config (fallback = current value 30) so it can be overridden without a
+    // deploy. The enforced value AND the user-facing error copy are both driven
+    // from this single resolved number so they can never drift.
+    const photoLimitPerUserPerEvent = (await getOperationalLimits()).photoPerUserPerEvent;
     const uploaderUserId = req.userId || null;
     const uploaderGuestId = verifiedGuestId || null;
     const uploaderEmailLower = (uploaderEmail || '').toLowerCase() || null;
@@ -595,9 +601,9 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
           OR: uploaderClauses,
         },
       });
-      if (existingCount >= PHOTO_LIMIT_PER_USER_PER_EVENT) {
+      if (existingCount >= photoLimitPerUserPerEvent) {
         throw new AppError(
-          '30 photo limit per user. Remove photos to make room',
+          `${photoLimitPerUserPerEvent} photo limit per user. Remove photos to make room`,
           400,
           'PHOTO_LIMIT_REACHED'
         );


### PR DESCRIPTION
## What

Move two host-facing operational quota limits into the config layer so they can be tuned **without a deploy**:

- **Bulk-import hard cap** — `backend/src/routes/party.routes.ts` (was `const IMPORT_HARD_CAP = 2000`)
- **Per-user-per-event photo cap** — `backend/src/routes/photo.routes.ts` (was `const PHOTO_LIMIT_PER_USER_PER_EVENT = 30`)

## Why this is behavior-preserving

These are **NON-SECRET operational quotas**, not sensitive config. So unlike the `private.*` keys, the in-code fallback in `getOperationalLimits()` **IS the current real value** (`importHardCap: 2000`, `photoPerUserPerEvent: 30`). Behavior is identical whether or not an `operational.limits` row exists in `app_config` — the row simply lets the team **override** the quotas without shipping a deploy.

Both the enforced value AND the user-facing error copy are driven from the single resolved config number, so the message and the enforced limit can never drift.

## Changes

- `privateConfig.ts`: new `KEYS.operationalLimits = 'operational.limits'` (a plain `operational.*` key, not `private.*`) + `getOperationalLimits()` accessor with fallback `{ importHardCap: 2000, photoPerUserPerEvent: 30 }`.
- `party.routes.ts`: resolve `importHardCap` at the import handler entry; cap-exceeded message templates the configured value.
- `photo.routes.ts`: resolve `photoLimitPerUserPerEvent` in the cap block; enforced value + `"... photo limit per user ..."` copy both use it.
- `seed.example.json`: adds `operational.limits` with the real values (fine — non-secret).
- Tests: `getOperationalLimits` coverage in `privateConfig.test.ts`; route test mocks updated for the new accessor.

## Verify

- Backend `tsc --noEmit` clean except the known pre-existing `auth.test.ts` jwt error.
- `privateConfig.test.ts` (19) + `party.routes.test.ts` (29) green. `photo.routes.test.ts` has 3 pre-existing failures unrelated to this change (confirmed identical on `origin/master`).

## Follow-up (main session)

Seed `operational.limits` = `{ importHardCap: 2000, photoPerUserPerEvent: 30 }` so the override knob is live (optional — fallback already matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)