### PR TITLE
feat(bresaola-58502): click /payments Risk pill to see all fake-detection flags

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2247,8 +2247,10 @@ router.get(
 // payments-admin by-city table badges + the send-payment confirmation gate.
 //
 // Body: { partyIds: string[] }  (string array, capped at 500).
-// Response: { scores: Record<partyId, { score, tier, topFlags }> }
+// Response: { scores: Record<partyId, { score, tier, topFlags, flags }> }
 //   - `topFlags` = up to 3 fired-flag `detail` strings, highest weight first.
+//   - `flags` = EVERY fired flag as { detail, weight }, highest weight first
+//     (backs the clickable Risk pill popover on /payments — bresaola-58502).
 //   - tier `clean` entries (score < 10) are OMITTED to keep the payload small;
 //     the frontend badge self-hides for anything below `medium` anyway.
 //
@@ -2286,7 +2288,12 @@ router.post(
 
       const scores: Record<
         string,
-        { score: number; tier: string; topFlags: string[] }
+        {
+          score: number;
+          tier: string;
+          topFlags: string[];
+          flags: { detail: string; weight: number }[];
+        }
       > = {};
 
       if (partyIds.length > 0) {
@@ -2294,12 +2301,15 @@ router.post(
         for (const r of rows) {
           // Omit clean events to keep the payload small.
           if (r.tier === 'clean') continue;
-          const topFlags = r.flags
+          const firedSorted = r.flags
             .filter(f => f.fired)
-            .sort((a, b) => b.weight - a.weight)
-            .slice(0, 3)
-            .map(f => f.detail);
-          scores[r.id] = { score: r.score, tier: r.tier, topFlags };
+            .sort((a, b) => b.weight - a.weight);
+          const topFlags = firedSorted.slice(0, 3).map(f => f.detail);
+          const flags = firedSorted.map(f => ({
+            detail: f.detail,
+            weight: f.weight,
+          }));
+          scores[r.id] = { score: r.score, tier: r.tier, topFlags, flags };
         }
       }
 

--- a/frontend/src/components/payments-admin/FakeDetectionBadge.tsx
+++ b/frontend/src/components/payments-admin/FakeDetectionBadge.tsx
@@ -1,16 +1,23 @@
 /**
- * FakeDetectionBadge (bufalina-60733)
+ * FakeDetectionBadge (bufalina-60733; clickable popover bresaola-58502)
  *
  * Two-level caution badge for a GPP party's fake-detection risk score, shown
  * in the payments-admin by-city header pill strip next to the SWC Hub /
  * "Possible scam" pills.
  *
  * Renders NOTHING unless tier is `medium` (amber) or `high` (red) — clean/low
- * parties get no badge. Tooltip (native `title`) shows the score line plus the
- * top fired-flag details, one per line.
+ * parties get no badge.
  *
- * v1 is a non-link span (no deep link into the underboss queue).
+ * The pill is a button: clicking it opens a small popover (portaled to
+ * document.body so the table cells + Layout's `relative z-[1]` <main> don't
+ * clip it) listing every fired fake-detection flag with its weight. Falls back
+ * to `topFlags` (detail only) when the backend hasn't yet shipped the weighted
+ * `flags` array (preview frontends hit the prod backend).
+ *
+ * No deep link into the underboss queue (out of scope).
  */
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { AlertTriangle } from 'lucide-react';
 
 export interface FakeDetectionBadgeProps {
@@ -20,29 +27,128 @@ export interface FakeDetectionBadgeProps {
    *  nothing. */
   tier: string;
   topFlags: string[];
+  flags?: { detail: string; weight: number }[];
   customUrl?: string | null;
 }
+
+const POPOVER_WIDTH = 288; // w-72 = 18rem = 288px
 
 export function FakeDetectionBadge({
   score,
   tier,
   topFlags,
+  flags,
 }: FakeDetectionBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Position the popover just below-left of the pill, clamped to the viewport.
+  useEffect(() => {
+    if (!open) return;
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const left = Math.max(
+      8,
+      Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - 8),
+    );
+    setPos({ top: rect.bottom + 4, left });
+  }, [open]);
+
+  // Close on outside click, Escape, scroll, or resize.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (buttonRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    const onScrollOrResize = () => setOpen(false);
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('scroll', onScrollOrResize, true);
+      window.removeEventListener('resize', onScrollOrResize);
+    };
+  }, [open]);
+
   if (tier !== 'medium' && tier !== 'high') return null;
 
-  const className =
-    tier === 'high'
-      ? 'inline-flex items-center gap-1 text-[11px] text-red-500 px-1.5 py-0.5 rounded-full bg-red-500/10 border border-red-500/40'
-      : 'inline-flex items-center gap-1 text-[11px] text-amber-300 px-1.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/30';
+  const isHigh = tier === 'high';
 
-  const tooltip =
-    `Fake-detection risk ${score}/100 (${tier})` +
-    (topFlags.length > 0 ? '\n' + topFlags.map(f => `• ${f}`).join('\n') : '');
+  const className =
+    (isHigh
+      ? 'inline-flex items-center gap-1 text-[11px] text-red-500 px-1.5 py-0.5 rounded-full bg-red-500/10 border border-red-500/40'
+      : 'inline-flex items-center gap-1 text-[11px] text-amber-300 px-1.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/30') +
+    ' cursor-pointer focus:outline-none focus:ring-1 focus:ring-white/40';
+
+  const iconColor = isHigh ? 'text-red-500' : 'text-amber-300';
+  const hasWeighted = Array.isArray(flags) && flags.length > 0;
 
   return (
-    <span className={className} title={tooltip}>
-      <AlertTriangle size={11} />
-      Risk {score} ({tier})
-    </span>
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={className}
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+      >
+        <AlertTriangle size={11} />
+        Risk {score} ({tier})
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            className="fixed z-50 w-72 rounded-lg border border-white/10 bg-zinc-900 text-theme-text shadow-xl p-3 text-xs"
+            style={{ top: pos.top, left: pos.left }}
+          >
+            <div className={`flex items-center gap-1.5 font-medium mb-2 ${iconColor}`}>
+              <AlertTriangle size={13} />
+              Risk {score} ({tier})
+            </div>
+            {hasWeighted ? (
+              <ul className="space-y-1">
+                {flags!.map((f, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start justify-between gap-2"
+                  >
+                    <span className="text-white/80">{f.detail}</span>
+                    <span className="shrink-0 rounded bg-white/10 px-1 py-0.5 text-[10px] text-white/60">
+                      +{f.weight}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : topFlags.length > 0 ? (
+              <ul className="space-y-1">
+                {topFlags.map((f, i) => (
+                  <li key={i} className="text-white/80">
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-white/40">No flag details available.</div>
+            )}
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -761,6 +761,9 @@ export interface FakeDetectionScoreEntry {
   score: number;
   tier: string;
   topFlags: string[];
+  /** Every fired flag with its weight, highest first. Optional because preview
+   *  frontends hit the prod backend, which may not yet return this field. */
+  flags?: { detail: string; weight: number }[];
 }
 
 export type FakeDetectionScoreMap = Record<string, FakeDetectionScoreEntry>;


### PR DESCRIPTION
On `/payments`, the Risk pill (`FakeDetectionBadge`) is now clickable to open a small popover listing **all** fired fake-detection flags with their weights — previously only a native `title` tooltip with the top 3 detail strings.

## Changes (3 files)
1. **Backend** `admin-payout.routes.ts` — `POST /fake-detection-scores` now returns an `allFlags`-style `flags: { detail, weight }[]` array (every fired flag, weight desc) alongside the unchanged `topFlags`. Updated the handler's `scores` type annotation + route comments.
2. **Frontend** `lib/api.ts` — added optional `flags?: { detail; weight }[]` to `FakeDetectionScoreEntry` (optional since previews hit the prod backend before redeploy).
3. **Frontend** `FakeDetectionBadge.tsx` — pill is now a `<button>` (same amber/red tier styling) that toggles a `createPortal` popover positioned `fixed` below-left of the pill and clamped to the viewport. Lists each flag with a `+{weight}` badge; falls back to `topFlags` (detail only) when `flags` is absent, then a muted "No flag details available." Closes on outside click / Escape / scroll / resize. Kept the medium/high-only guard.

## Deploy note
The backend must deploy from master for the full weighted list to appear. Until then, frontend previews gracefully degrade to the `topFlags` detail-only list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)