### PR TITLE
feat(taleggio-71042): server-side HEIC->JPEG conversion fallback for lightbox

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
+    "heic-convert": "^2.1.0",
     "jsonwebtoken": "^9.0.2",
     "nanoid": "^5.0.5",
     "openai": "^6.38.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import eventRoutes from './routes/event.routes.js';
 import nftRoutes from './routes/nft.routes.js';
 import photoRoutes from './routes/photo.routes.js';
 import photoFeedRoutes from './routes/photo-feed.routes.js';
+import heicRoutes from './routes/heic.routes.js'; // taleggio-71042: server-side HEIC->JPEG convert
 import kitRoutes from './routes/kit.routes.js';
 import gppRoutes from './routes/gpp.routes.js';
 import gpp27Routes from './routes/gpp27.routes.js'; // soppressata-50927: admin-gated GPP27 (2027) create flow
@@ -175,6 +176,7 @@ app.use('/api/sponsor', sponsorDashboardRouter); // Sponsor dashboard (login-bas
 app.use('/api/shipping', shippingRoutes); // Shipping coordinator dashboard
 app.use('/api/tax-forms', taxFormRouter); // salame-92110: host tax-form upload (W-9 / W-8BEN / W-8BEN-E)
 app.use('/api/auth', authRoutes);
+app.use('/api/heic', heicRoutes); // taleggio-71042: public server-side HEIC->JPEG convert (no auth; SSRF-guarded)
 app.use('/api/photos', photoFeedRoutes); // margherita-43821: public global photos feed
 app.use('/api/payouts', payoutDocumentVoteRoutes); // napoletana-58210: vote on payout-sourced pizza photos
 app.use('/api/parties', photoRoutes); // Photo routes first (some are public)

--- a/backend/src/routes/heic.routes.ts
+++ b/backend/src/routes/heic.routes.ts
@@ -1,0 +1,89 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import sharp from 'sharp';
+import { AppError } from '../middleware/error.js';
+
+/**
+ * taleggio-71042: server-side HEIC -> JPEG conversion fallback.
+ *
+ * The client-side `heic2any` codec (frozen libheif WASM) throws on iPhone
+ * multi-image / HDR-gain-map HEICs, dropping the lightbox to its "Can't
+ * preview HEIC files" error card. `heic-convert` (pure-JS libheif, no native
+ * deps) decodes those files fine, so the frontend now points the HEIC <img>
+ * at this endpoint instead of decoding in the browser.
+ *
+ * `sharp` on Vercel can't *decode* HEIC (prebuilt binary excludes libheif),
+ * but it can process the already-decoded JPEG to normalize EXIF orientation
+ * and cap the response size -- which is why heic-convert does the decode step.
+ *
+ * Public endpoint (no auth): it only re-serves objects that are already
+ * publicly readable in our own Supabase storage, and an SSRF guard pins the
+ * fetch to that exact host + public-object path prefix.
+ */
+const router = Router();
+
+// Pin server-side fetches to our own public storage objects only.
+const ALLOWED_ORIGIN = 'https://znpiwdvvsqaxuskpfleo.supabase.co';
+const ALLOWED_PATH_PREFIX = '/storage/v1/object/public/';
+
+router.get(
+  '/convert',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const raw = req.query.url;
+      if (typeof raw !== 'string' || raw.length === 0) {
+        throw new AppError('Missing url parameter', 400, 'MISSING_URL');
+      }
+
+      // SSRF guard: only allow our exact storage origin + public-object path.
+      let parsed: URL;
+      try {
+        parsed = new URL(raw);
+      } catch {
+        throw new AppError('Invalid url parameter', 400, 'INVALID_URL');
+      }
+      if (
+        parsed.origin !== ALLOWED_ORIGIN ||
+        !parsed.pathname.startsWith(ALLOWED_PATH_PREFIX)
+      ) {
+        throw new AppError('url not allowed', 400, 'URL_NOT_ALLOWED');
+      }
+
+      // Fetch the HEIC bytes server-side (global fetch is available here).
+      const upstream = await fetch(parsed.toString());
+      if (!upstream.ok) {
+        throw new AppError(
+          `Upstream fetch failed (${upstream.status})`,
+          502,
+          'UPSTREAM_FETCH_FAILED'
+        );
+      }
+      const buffer = Buffer.from(await upstream.arrayBuffer());
+
+      // Decode HEIC -> JPEG, then normalize orientation + cap size via sharp.
+      // Any failure here (corrupt / unsupported source) -> 422 so the frontend
+      // shows its error card.
+      let outJpeg: Buffer;
+      try {
+        const convert = (await import('heic-convert')).default;
+        const jpeg = await convert({ buffer, format: 'JPEG', quality: 0.85 });
+        outJpeg = await sharp(Buffer.from(jpeg))
+          .rotate()
+          .resize({ width: 2400, withoutEnlargement: true })
+          .jpeg({ quality: 85 })
+          .toBuffer();
+      } catch {
+        throw new AppError('HEIC conversion failed', 422, 'HEIC_CONVERT_FAILED');
+      }
+
+      res.set('Content-Type', 'image/jpeg');
+      // Deterministic per source URL -- let the CDN + browser cache it so the
+      // ~1-3 s decode happens once.
+      res.set('Cache-Control', 'public, max-age=31536000, immutable');
+      res.send(outJpeg);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+export default router;

--- a/backend/src/types/heic-convert.d.ts
+++ b/backend/src/types/heic-convert.d.ts
@@ -1,0 +1,1 @@
+declare module 'heic-convert';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "@wagmi/connectors": "^5.11.2",
     "connectkit": "^1.9.1",
     "date-fns": "^4.1.0",
-    "heic2any": "^0.0.4",
     "html5-qrcode": "^2.3.8",
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -111,6 +111,11 @@ function isHeic(image: ReceiptLightboxImage | undefined): boolean {
   return name.endsWith('.heic') || name.endsWith('.heif');
 }
 
+// taleggio-71042: backend HEIC->JPEG convert endpoint base. Same VITE_API_URL
+// resolution as frontend/src/lib/api.ts so previews hit the prod backend and
+// local dev hits localhost:3006.
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:3006').trim();
+
 export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   isOpen,
   images,
@@ -224,43 +229,32 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
   const current = images[index];
   const heic = isHeic(current);
 
-  // stracciatella-71042: HEIC receipts can't render in an <img> natively, so
-  // decode them to a JPEG blob in-browser via heic2any (lazy-loaded so the WASM
-  // codec stays off the main bundle). Hook MUST live above the early return so
-  // the hook order stays stable (adding a hook below a conditional return has
-  // black-screened this app before).
-  const [heicState, setHeicState] = React.useState<
-    { status: 'idle' | 'loading' | 'ready' | 'error'; url?: string }
-  >({ status: 'idle' });
-
+  // taleggio-71042: HEIC receipts can't render in an <img> natively. The old
+  // client-side heic2any WASM decode threw on multi-image / HDR-gain-map iPhone
+  // HEICs, so we now point the <img> at the backend convert endpoint
+  // (/api/heic/convert), which decodes via the pure-JS heic-convert codec and
+  // returns a cached JPEG. The <img> onLoad / onError below drive this state
+  // machine. Hook MUST live above the early return so the hook order stays
+  // stable (adding a hook below a conditional return has black-screened this
+  // app before).
+  const [heicStatus, setHeicStatus] = React.useState<'loading' | 'ready' | 'error'>(
+    'loading'
+  );
+  // Reset to the loading spinner whenever the HEIC source changes (open or
+  // arrow-nav to a different HEIC) so a previously-decoded image doesn't flash
+  // its ready / error state onto the new file before the new <img> loads.
   useEffect(() => {
-    if (!isOpen || !heic || !current) { setHeicState({ status: 'idle' }); return; }
-    let cancelled = false;
-    let objectUrl: string | undefined;
-    setHeicState({ status: 'loading' });
-    (async () => {
-      try {
-        const res = await fetch(current.url);
-        if (!res.ok) throw new Error(`fetch ${res.status}`);
-        const blob = await res.blob();
-        const heic2any = (await import('heic2any')).default;
-        const out = await heic2any({ blob, toType: 'image/jpeg', quality: 0.92 });
-        const outBlob = Array.isArray(out) ? out[0] : out;
-        objectUrl = URL.createObjectURL(outBlob);
-        if (cancelled) { URL.revokeObjectURL(objectUrl); return; }
-        setHeicState({ status: 'ready', url: objectUrl });
-      } catch {
-        if (!cancelled) setHeicState({ status: 'error' });
-      }
-    })();
-    return () => {
-      cancelled = true;
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
+    if (isOpen && heic) setHeicStatus('loading');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, heic, current?.url]);
 
   if (!isOpen || count === 0 || !current) return null;
+
+  // taleggio-71042: HEIC files are served through the backend converter as
+  // JPEG. encodeURIComponent the storage URL so its query string survives.
+  const convertUrl = heic
+    ? `${API_URL}/api/heic/convert?url=${encodeURIComponent(current.url)}`
+    : '';
 
   // melanzane-92103: when the focused item is a video, render a <video> with
   // controls + autoplay so admins can scrub. `muted` is required for autoplay
@@ -419,38 +413,54 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
             </>
           )}
           {heic ? (
-            heicState.status === 'ready' && heicState.url ? (
-              /* stracciatella-71042: decoded HEIC -> JPEG blob URL, shown inline. */
-              <img
-                src={heicState.url}
-                alt={current.fileName}
-                className={`${mediaSizing} object-contain`}
-              />
-            ) : heicState.status === 'loading' ? (
-              <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
-                <div className="mx-auto h-8 w-8 rounded-full border-2 border-theme-stroke border-t-[#ff393a] animate-spin" />
-                <p className="text-sm font-semibold">Converting HEIC…</p>
-                <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
-              </div>
-            ) : (
-              /* error / idle — fall back to the original open-in-new-tab card. */
-              <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
-                <p className="text-sm font-semibold">Can't preview HEIC files</p>
-                <p className="text-xs text-theme-text-muted">
-                  Your browser doesn't render <span className="font-mono">.heic</span>{' '}
-                  images natively. Open the file in a new tab to download or view it.
-                </p>
-                <a
-                  href={current.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
-                >
-                  Open in new tab <ExternalLink size={14} />
-                </a>
-                <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
-              </div>
-            )
+            /* taleggio-71042: HEIC is converted server-side to JPEG and
+               served by /api/heic/convert. The <img> below always renders
+               (driving onLoad/onError); while it loads we overlay the
+               "Converting HEIC…" spinner, and only on a hard onError do we
+               fall back to the open-in-new-tab card. */
+            <div className="relative flex items-center justify-center">
+              {heicStatus !== 'error' && (
+                <img
+                  key={convertUrl}
+                  src={convertUrl}
+                  alt={current.fileName}
+                  onLoad={() => setHeicStatus('ready')}
+                  onError={() => setHeicStatus('error')}
+                  className={`${mediaSizing} object-contain ${
+                    heicStatus === 'ready' ? '' : 'invisible'
+                  }`}
+                />
+              )}
+              {heicStatus === 'loading' && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
+                    <div className="mx-auto h-8 w-8 rounded-full border-2 border-theme-stroke border-t-[#ff393a] animate-spin" />
+                    <p className="text-sm font-semibold">Converting HEIC…</p>
+                    <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
+                  </div>
+                </div>
+              )}
+              {heicStatus === 'error' && (
+                /* Conversion failed -- fall back to the open-in-new-tab card. */
+                <div className="bg-theme-surface text-theme-text rounded-2xl border border-theme-stroke px-6 py-8 max-w-md text-center space-y-3">
+                  <p className="text-sm font-semibold">Can't preview HEIC files</p>
+                  <p className="text-xs text-theme-text-muted">
+                    This <span className="font-mono">.heic</span> image couldn't be
+                    converted for preview. Open the file in a new tab to download or
+                    view it.
+                  </p>
+                  <a
+                    href={current.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-sm text-[#ff393a] hover:underline"
+                  >
+                    Open in new tab <ExternalLink size={14} />
+                  </a>
+                  <p className="text-xs text-theme-text-muted truncate">{current.fileName}</p>
+                </div>
+              )}
+            </div>
           ) : video ? (
             /* melanzane-92103: keying on src so swapping between videos via
                arrow nav cleanly remounts the <video> with the new source. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
+        "heic-convert": "^2.1.0",
         "jsonwebtoken": "^9.0.2",
         "nanoid": "^5.0.5",
         "openai": "^6.38.0",
@@ -241,7 +242,6 @@
         "@wagmi/connectors": "^5.11.2",
         "connectkit": "^1.9.1",
         "date-fns": "^4.1.0",
-        "heic2any": "^0.0.4",
         "html5-qrcode": "^2.3.8",
         "i18next": "^26.0.8",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -14759,11 +14759,40 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-convert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
+      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
+      "license": "ISC",
+      "dependencies": {
+        "heic-decode": "^2.0.0",
+        "jpeg-js": "^0.4.4",
+        "pngjs": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/heic-convert/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/heic-decode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.1.0.tgz",
+      "integrity": "sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==",
+      "license": "ISC",
+      "dependencies": {
+        "libheif-js": "^1.19.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/hey-listen": {
       "version": "1.0.8",
@@ -15483,6 +15512,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15743,6 +15778,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libheif-js": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
+      "integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/libphonenumber-js": {


### PR DESCRIPTION
## Summary
Multi-image / HDR-gain-map iPhone HEIC photos were dropping the `/payments` lightbox to its "Can't preview HEIC files" error card: the frozen client-side `heic2any` WASM codec throws on those files. This replaces the in-browser decode with a reliable, CDN-cacheable **server-side** conversion endpoint.

This is a **backend + frontend** change.

### Backend (`api.rsv.pizza`)
- New `GET /api/heic/convert?url=<encoded storage url>`:
  - Decodes HEIC via the pure-JS **`heic-convert`** codec (no native deps — `sharp` can't decode HEIC on Vercel), then normalizes EXIF orientation + caps size to 2400px wide via `sharp`, returns `image/jpeg` with `Cache-Control: public, max-age=31536000, immutable`.
  - **Public** (no auth) — it only re-serves already-public storage objects.
  - **SSRF-guarded**: accepts only URLs whose origin is exactly `https://znpiwdvvsqaxuskpfleo.supabase.co` AND whose path starts with `/storage/v1/object/public/` (WHATWG `URL` origin + pathname check) → otherwise 400. Upstream non-OK → 502; decode failure → 422 (so the frontend shows its error card).
- Added `backend/src/types/heic-convert.d.ts` (`declare module 'heic-convert';`) since the package ships no types.

### Frontend
- `ReceiptLightbox` now points the HEIC `<img>` at `/api/heic/convert`, driving a loading → ready → error state machine via `onLoad`/`onError`. The "Converting HEIC…" spinner shows while loading; the open-in-new-tab card shows **only** on a hard error. Hook ordering preserved (all hooks stay above the early return).
- Removed the `heic2any` dependency + its lazy `import` (lockfile updated at repo root — npm workspaces).

## Deploy ordering (important)
The convert endpoint is a **backend** change, and Vercel **previews talk to the prod backend**. So the Vercel preview won't render converted HEIC until `/api/heic/convert` is live on prod: **merge master → backend auto-deploys (~1 min) → preview (and prod) work.**

**No DB migration / backfill.**

## Verification
- `cd backend && npx tsc --noEmit` — clean (only a pre-existing, unrelated `auth.test.ts` error on master).
- `cd frontend && npx tsc --noEmit` — clean.
- After deploy: `curl -I "https://api.rsv.pizza/api/heic/convert?url=<public IMG_1815 url>"` → 200 `image/jpeg`; `url=https://example.com/x` → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)