### PR TITLE
feat(marinara-71630): LLM model names tunable via config (P9)

### DIFF
--- a/backend/src/config/seed.example.json
+++ b/backend/src/config/seed.example.json
@@ -97,5 +97,13 @@
   "private.gpp_global_editors": ["editor@example.com"],
 
   "_note_operational_limits": "Operational quota limits (marinara-71630 P8). UNLIKE the private.* keys above these are NOT secret — they're just tunable operational quotas, so the REAL values (importHardCap 2000, photoPerUserPerEvent 30) are shown here. The in-code fallback in privateConfig.ts IS the current value, so behavior is identical with or without this row; seeding it just lets the team OVERRIDE the quotas without a deploy. importHardCap = max guests per bulk-import request; photoPerUserPerEvent = max photos one user may have (pending+approved) on a single event.",
-  "operational.limits": { "importHardCap": 2000, "photoPerUserPerEvent": 30 }
+  "operational.limits": { "importHardCap": 2000, "photoPerUserPerEvent": 30 },
+
+  "_note_llm_models": "LLM model identifiers per AI use-case (marinara-71630 P9). NOT secret — these are just model names, so the REAL current production models are shown here. The in-code fallback in privateConfig.ts IS the current value, so behavior is identical with or without this row; seeding it just lets the team swap a model or roll one back WITHOUT a deploy (model deprecation cadence > deploy cadence). Kept as four SEPARATE keys even though ocr/visionPrimary currently share gpt-4o — they must be able to diverge. The per-use-case tier distinction is intentional: assistant deliberately uses the cheaper gpt-4o-mini. ocr = receipt OCR (OpenAI); visionPrimary = primary receipt-image authenticity vision verdict (OpenAI); assistant = event-edit assistant (OpenAI tool-calling, cheaper tier); visionSecondOpinion = dormant second-opinion vision provider (Anthropic).",
+  "llm.models": {
+    "ocr": "gpt-4o",
+    "visionPrimary": "gpt-4o",
+    "assistant": "gpt-4o-mini",
+    "visionSecondOpinion": "claude-3-5-sonnet-latest"
+  }
 }

--- a/backend/src/lib/privateConfig.test.ts
+++ b/backend/src/lib/privateConfig.test.ts
@@ -18,6 +18,7 @@ import {
   getSponsorshipPricing,
   getGppGlobalEditors,
   getOperationalLimits,
+  getLlmModels,
   invalidateAll,
   PRIVATE_CONFIG_KEYS,
 } from './privateConfig.js';
@@ -248,5 +249,67 @@ describe('getOperationalLimits', () => {
       importHardCap: 2000,
       photoPerUserPerEvent: 30,
     });
+  });
+});
+
+// marinara-71630 P9: LLM model identifiers accessor. NON-SECRET — the fallback
+// IS the current production model per use-case, so behavior is identical with or
+// without a row; the row only lets the team swap/roll-back a model without a
+// deploy. Four separate keys (ocr/visionPrimary may diverge); the assistant tier
+// is intentionally the cheaper gpt-4o-mini.
+describe('getLlmModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateAll();
+  });
+
+  it('returns the seeded config values when an app_config row is present', async () => {
+    const seeded = {
+      ocr: 'gpt-4o-2024-11-20',
+      visionPrimary: 'gpt-4.1',
+      assistant: 'gpt-4o-mini-2024-07-18',
+      visionSecondOpinion: 'claude-3-7-sonnet-latest',
+    };
+    mockPrisma.appConfig.findUnique.mockResolvedValue({ value: JSON.stringify(seeded) });
+
+    const models = await getLlmModels();
+
+    expect(models).toEqual(seeded);
+    expect(mockPrisma.appConfig.findUnique).toHaveBeenCalledWith({
+      where: { key: PRIVATE_CONFIG_KEYS.llmModels },
+    });
+  });
+
+  it('falls back to the CURRENT production models when the row is absent', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue(null);
+    expect(await getLlmModels()).toEqual({
+      ocr: 'gpt-4o',
+      visionPrimary: 'gpt-4o',
+      assistant: 'gpt-4o-mini',
+      visionSecondOpinion: 'claude-3-5-sonnet-latest',
+    });
+  });
+
+  it('preserves the per-use-case tier distinction in the fallback', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue(null);
+    const models = await getLlmModels();
+    // The four are SEPARATE keys; the assistant deliberately runs on the cheaper
+    // mini tier and must NOT be collapsed into one global model.
+    expect(models.assistant).toBe('gpt-4o-mini');
+    expect(models.assistant).not.toBe(models.ocr);
+    expect(models.assistant).not.toBe(models.visionPrimary);
+  });
+
+  it('falls back to current models (never throws) when the DB read fails', async () => {
+    mockPrisma.appConfig.findUnique.mockRejectedValue(new Error('db down'));
+    const models = await getLlmModels();
+    expect(models.ocr).toBe('gpt-4o');
+    expect(models.visionSecondOpinion).toBe('claude-3-5-sonnet-latest');
+  });
+
+  it('falls back to current models when the stored value is not valid JSON', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue({ value: 'not-json{' });
+    const models = await getLlmModels();
+    expect(models.assistant).toBe('gpt-4o-mini');
   });
 });

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -35,6 +35,7 @@ const KEYS = {
   sponsorshipPricing: 'private.sponsorship_pricing',
   gppGlobalEditors: 'private.gpp_global_editors',
   operationalLimits: 'operational.limits',
+  llmModels: 'llm.models',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -409,6 +410,51 @@ export function getOperationalLimits(): Promise<OperationalLimits> {
   return getConfig<OperationalLimits>(KEYS.operationalLimits, {
     importHardCap: 2000,
     photoPerUserPerEvent: 30,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// LLM model identifiers (marinara-71630 P9)
+//
+// The model names used by each AI use-case (receipt OCR, primary receipt-image
+// vision verdict, the event-edit assistant, and the dormant second-opinion
+// vision provider). Moved out of hardcoded `model: '...'` literals scattered
+// across the OCR / vision / assistant code so a model can be swapped or rolled
+// back via an `app_config` row WITHOUT a deploy — model deprecation cadence is
+// faster than our deploy cadence.
+// ---------------------------------------------------------------------------
+
+export interface LlmModels {
+  /** Receipt OCR (OpenAI chat-completions vision, json_object). */
+  ocr: string;
+  /** Primary receipt-image authenticity vision verdict (OpenAI). */
+  visionPrimary: string;
+  /** Event-edit assistant (OpenAI tool-calling). Intentionally the cheaper tier. */
+  assistant: string;
+  /** Dormant second-opinion vision provider (Anthropic). */
+  visionSecondOpinion: string;
+}
+
+/**
+ * LLM model identifiers per use-case. NON-SECRET — these are just the model
+ * names, not sensitive config.
+ *
+ * Fallback = the CURRENT production models. Because the fallback IS the live
+ * value, behavior is identical whether or not an `app_config` row exists;
+ * seeding the `llm.models` row simply lets the team swap a model or roll one
+ * back WITHOUT shipping a deploy (model deprecation cadence > deploy cadence).
+ *
+ * The four are kept as SEPARATE keys even though `ocr` and `visionPrimary`
+ * currently share `gpt-4o` — they must be able to diverge independently. The
+ * per-use-case tier distinction is intentional: the assistant deliberately runs
+ * on the cheaper `gpt-4o-mini` and must NOT be collapsed into one global model.
+ */
+export function getLlmModels(): Promise<LlmModels> {
+  return getConfig<LlmModels>(KEYS.llmModels, {
+    ocr: 'gpt-4o',
+    visionPrimary: 'gpt-4o',
+    assistant: 'gpt-4o-mini',
+    visionSecondOpinion: 'claude-3-5-sonnet-latest',
   });
 }
 

--- a/backend/src/lib/providers/anthropicVision.ts
+++ b/backend/src/lib/providers/anthropicVision.ts
@@ -11,6 +11,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { getLlmModels } from '../privateConfig.js';
 import {
   VisionProvider,
   VisionResult,
@@ -51,9 +52,10 @@ export const anthropicVisionProvider: VisionProvider = {
 
   async analyze(imageDataUrl: string, ctx: VisionContext): Promise<VisionResult> {
     const { mediaType, data } = parseDataUrl(imageDataUrl);
+    const secondOpinionModel = (await getLlmModels()).visionSecondOpinion;
 
     const response = await getAnthropic().messages.create({
-      model: 'claude-3-5-sonnet-latest',
+      model: secondOpinionModel,
       max_tokens: 800,
       system: VISION_SYSTEM_PROMPT,
       messages: [

--- a/backend/src/lib/providers/openaiVision.ts
+++ b/backend/src/lib/providers/openaiVision.ts
@@ -6,6 +6,7 @@
  */
 
 import { getOpenAI } from '../openai.js';
+import { getLlmModels } from '../privateConfig.js';
 import {
   VisionProvider,
   VisionResult,
@@ -23,8 +24,9 @@ export const openaiVisionProvider: VisionProvider = {
   },
 
   async analyze(imageDataUrl: string, ctx: VisionContext): Promise<VisionResult> {
+    const visionModel = (await getLlmModels()).visionPrimary;
     const response = await getOpenAI().chat.completions.create({
-      model: 'gpt-4o',
+      model: visionModel,
       messages: [
         { role: 'system', content: VISION_SYSTEM_PROMPT },
         {

--- a/backend/src/services/eventAssistant.service.ts
+++ b/backend/src/services/eventAssistant.service.ts
@@ -16,6 +16,7 @@
 
 import { prisma } from '../config/database.js';
 import { getOpenAI } from '../lib/openai.js';
+import { getLlmModels } from '../lib/privateConfig.js';
 import {
   buildToolSchema,
   validatePatch,
@@ -289,9 +290,10 @@ export async function runEventAssistant(params: {
     .map((t) => ({ role: t.role, content: t.content.slice(0, MAX_INSTRUCTION_LEN) }));
 
   const tool = buildToolSchema(role);
+  const assistantModel = (await getLlmModels()).assistant;
 
   const response = await getOpenAI().chat.completions.create({
-    model: 'gpt-4o-mini',
+    model: assistantModel,
     messages: [
       // Static prefix (cacheable): behavioral system prompt + tool schema.
       { role: 'system', content: buildSystemPrompt(role) },

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -16,6 +16,7 @@
 
 import { getOpenAI } from '../lib/openai.js';
 import { getCountryCode } from '../lib/countryCode.js';
+import { getLlmModels } from '../lib/privateConfig.js';
 
 // formaggi-89172: allowed categories. Keep in sync with the system prompt
 // and the sanitizer below. `other` is the safe fallback for anything else.
@@ -347,9 +348,10 @@ export async function analyzeReceiptMulti(
   const imageUrl = typeof arg === 'string' ? arg : arg.imageUrl;
   const partyCountry = typeof arg === 'string' ? null : (arg.partyCountry ?? null);
   const base64Image = await imageUrlToBase64DataUrl(imageUrl);
+  const ocrModel = (await getLlmModels()).ocr;
 
   const response = await getOpenAI().chat.completions.create({
-    model: 'gpt-4o',
+    model: ocrModel,
     messages: [
       { role: 'system', content: buildMultiSystemPrompt(partyCountry) },
       {


### PR DESCRIPTION
@
## What

Phase 9 of `marinara-71630`: move the hardcoded LLM model identifiers out of source and into the config layer (`app_config` key `llm.models`), so a model can be **swapped or rolled back without a deploy**. Model deprecation cadence outpaces our deploy cadence — when an OpenAI/Anthropic model is retired we want to repoint via a DB row, not a release.

## Behavior-preserving

The fallback **IS the current production model** per use-case (these are non-secret model names, not sensitive config). Behavior is identical whether or not an `app_config` row exists; seeding the row simply lets the team override without a deploy. Same pattern as P8 `operational.limits`.

## Consolidation: 5 literals across 4 files → `llm.models`

| File:line (model literal) | New key |
|---|---|
| `ocr.service.ts` `analyzeReceiptMulti` (was `model: gpt-4o`) | `ocr` |
| `providers/openaiVision.ts` `analyze` (was `model: gpt-4o`) | `visionPrimary` |
| `services/eventAssistant.service.ts` (was `model: gpt-4o-mini`) | `assistant` |
| `providers/anthropicVision.ts` `analyze` (was `model: claude-3-5-sonnet-latest`) | `visionSecondOpinion` |

(`analyzeReceipt` is now a thin wrapper over `analyzeReceiptMulti`, so the OCR model literal exists in only one place after stracciatella-92114 — the historical "two" OCR sites collapsed to one.)

## Tier / divergence preservation

- Four **separate** keys even though `ocr`/`visionPrimary` currently both resolve to `gpt-4o` — they must be able to diverge independently.
- The per-use-case **tier distinction is preserved**: the assistant intentionally runs on the cheaper `gpt-4o-mini`; not collapsed into one global model. A test asserts `assistant === gpt-4o-mini` and `assistant !== ocr/visionPrimary`.
- `max_tokens` / `temperature` / `response_format` left inline (out of scope). Bland AI voice config untouched (not an LLM model).

## Tests

- Added `getLlmModels` cases to `privateConfig.test.ts` (seeded read-through, 4-field current-models fallback, tier-distinction, DB-fail + bad-JSON fallbacks).
- Backend `tsc --noEmit` clean except the known pre-existing `auth.test.ts` jwt overload error.
- `privateConfig` + all privateConfig-consuming route/helper tests + `ocr.service` tests green (101 passed).
- Grep-confirmed: no remaining hardcoded `gpt-4o` / `gpt-4o-mini` / `claude-3-5-sonnet-latest` `model:` literals in the codebase.

## Follow-up (main session)

Seed the `llm.models` row in prod (values committed in `seed.example.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@