### PR TITLE
calzone-58298: localize PayoutsTab + ExpectedGuestsCard

### DIFF
--- a/frontend/src/components/payouts/ExpectedGuestsCard.tsx
+++ b/frontend/src/components/payouts/ExpectedGuestsCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Users, Check, X, Loader2, Pencil } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { updateParty } from '../../lib/supabase';
@@ -25,6 +26,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
   partyId,
   expectedGuests,
 }) => {
+  const { t } = useTranslation('host');
   const { party, loadParty, guests } = usePizza();
   const rsvpCount = guests?.length ?? 0;
   // calzone-58297: after the event date passes, "expected" guests are really
@@ -66,7 +68,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
     const trimmed = value.trim();
     const parsed = trimmed === '' ? null : parseInt(trimmed, 10);
     if (parsed != null && (!Number.isFinite(parsed) || parsed < 1)) {
-      setError('Enter a positive number');
+      setError(t('payouts.errorPositiveNumber'));
       return;
     }
     setSaving(true);
@@ -74,7 +76,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
     try {
       const ok = await updateParty(partyId, { expected_guests: parsed });
       if (!ok) {
-        setError('Failed to save');
+        setError(t('payouts.errorFailedToSave'));
         return;
       }
       // Reload party so every consumer (NewPayoutForm prompt, pizza order
@@ -84,7 +86,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
       }
       setEditing(false);
     } catch (err: any) {
-      setError(err?.message || 'Failed to save');
+      setError(err?.message || t('payouts.errorFailedToSave'));
     } finally {
       setSaving(false);
     }
@@ -105,7 +107,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
           </div>
           <div>
             <div className="text-xs uppercase tracking-wide text-theme-text-muted">
-              {eventHasHappened ? 'Estimated guests' : 'Expected guests'}
+              {t(eventHasHappened ? 'payouts.estimatedGuestsTitle' : 'payouts.expectedGuestsTitle')}
             </div>
             {hasValue && !editing ? (
               <div className="text-lg font-semibold text-theme-text leading-tight">
@@ -114,8 +116,8 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
             ) : (
               <div className="text-sm text-theme-text-muted leading-tight">
                 {hasValue
-                  ? 'Update your estimate'
-                  : eventHasHappened ? 'Set estimated guests' : 'Set expected guests'}
+                  ? t('payouts.updateYourEstimate')
+                  : t(eventHasHappened ? 'payouts.setEstimatedGuests' : 'payouts.setExpectedGuests')}
               </div>
             )}
           </div>
@@ -129,7 +131,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
                   icon={Users}
                   type="number"
                   min={1}
-                  placeholder="e.g. 50"
+                  placeholder={t('payouts.guestsPlaceholder')}
                   value={value}
                   onChange={e => setValue(e.target.value)}
                   disabled={saving}
@@ -173,7 +175,7 @@ export const ExpectedGuestsCard: React.FC<ExpectedGuestsCardProps> = ({
 
       {/* RSVP count hint — helps the host estimate */}
       <p className="text-xs text-theme-text-muted mt-2">
-        {rsvpCount === 1 ? '1 RSVP' : `${rsvpCount} RSVPs`} so far.
+        {t('payouts.rsvpHint', { count: rsvpCount })}
       </p>
 
       {error && (

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Plus, Loader2, AlertCircle, RefreshCw, ArrowLeft, Info, BadgeDollarSign } from 'lucide-react';
 import { Payout, TaxFormType } from '../../types';
 import { listPayouts, fetchPayoutSubmissionReadiness } from '../../lib/api';
@@ -55,6 +56,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   reimbursementCapAppealedAt,
   expectedGuests,
 }) => {
+  const { t } = useTranslation('host');
   const { party } = usePizza();
   const partyKitCapUsd = parsePartyKitCapFromTags(party?.eventTags);
   const [view, setView] = useState<View>('list');
@@ -194,13 +196,13 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
 
         if (needsExpectedGuests || needsLocation) {
           // calzone-58297: relabel "expected" → "estimated" after the event.
-          const guestsLabel = eventHasHappened ? 'estimated guests' : 'expected guests';
+          const guestsLabel = t(eventHasHappened ? 'payouts.bannerEstimatedGuests' : 'payouts.bannerExpectedGuests');
           const msg =
             needsExpectedGuests && needsLocation
-              ? `Set your ${guestsLabel} and your location to get your funding approved.`
+              ? t('payouts.bannerSetGuestsAndLocation', { guests: guestsLabel })
               : needsExpectedGuests
-                ? `Set your ${guestsLabel} to get your funding approved.`
-                : 'Set your location to get your funding approved.';
+                ? t('payouts.bannerSetGuests', { guests: guestsLabel })
+                : t('payouts.bannerSetLocation');
           return (
             <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
               <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
@@ -213,11 +215,12 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             <div className="card p-4 sm:p-5 border-l-4 border-l-emerald-500 flex items-start gap-3">
               <BadgeDollarSign size={20} className="text-emerald-500 mt-0.5 flex-shrink-0" />
               <div className="text-sm font-medium text-theme-text">
-                We'll reimburse you for up to ${effectiveReimbursementCapUsd!.toFixed(2)}
-                {partyKitCapUsd != null && (
-                  <> of pizza and up to ${partyKitCapUsd.toFixed(2)} of party kit expenses</>
-                )}
-                .
+                {partyKitCapUsd != null
+                  ? t('payouts.capReimburseWithKit', {
+                      cap: effectiveReimbursementCapUsd!.toFixed(2),
+                      kitCap: partyKitCapUsd.toFixed(2),
+                    })
+                  : t('payouts.capReimburse', { cap: effectiveReimbursementCapUsd!.toFixed(2) })}
                 {/*
                   mascarpone-58927: surface the cap-appeal trigger here so it's
                   discoverable without opening NewPayoutForm. AppealCapModal
@@ -228,7 +231,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
                   onClick={() => setShowAppealModal(true)}
                   className="text-emerald-300 hover:underline ml-2 text-sm"
                 >
-                  Appeal
+                  {t('payouts.appeal')}
                 </button>
               </div>
             </div>
@@ -238,13 +241,13 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           <div className="card p-4 sm:p-5 border-l-4 border-l-amber-500 flex items-start gap-3">
             <Info size={20} className="text-amber-500 mt-0.5 flex-shrink-0" />
             <div className="text-sm font-medium text-theme-text">
-              Your underboss is reviewing your event to set your payment cap.
+              {t('payouts.underbossReviewing')}
               {(() => {
                 const contact = getUnderbossContact(party?.country);
                 if (!contact) return null;
                 return (
                   <>
-                    {' '}Reach them on Telegram:{' '}
+                    {' '}{t('payouts.reachOnTelegram')}{' '}
                     <a
                       href={contact.url}
                       target="_blank"
@@ -279,21 +282,21 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           <div className="card p-6">
             <div className="flex items-center justify-between mb-2">
               <div>
-                <h2 className="text-lg font-semibold text-theme-text">Receipts</h2>
+                <h2 className="text-lg font-semibold text-theme-text">{t('payouts.receiptsHeader')}</h2>
               </div>
               <button
                 onClick={() => setView('new')}
                 className="btn-primary inline-flex items-center gap-2 text-sm px-4 py-2 whitespace-nowrap"
               >
                 <Plus size={16} />
-                New receipt
+                {t('payouts.newReceipt')}
               </button>
             </div>
             {/* Set host expectations on payout timing — most payouts land ~7
                 days after a receipt is submitted. */}
             <div className="flex items-start gap-2 text-xs text-theme-text-muted">
               <Info size={14} className="mt-0.5 flex-shrink-0" />
-              <span>Most payments will take ~7 days from receipt submission.</span>
+              <span>{t('payouts.payoutTimingNote')}</span>
             </div>
           </div>
 
@@ -325,7 +328,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             className="inline-flex items-center gap-2 text-sm text-theme-text-secondary hover:text-theme-text transition-colors"
           >
             <ArrowLeft size={16} />
-            Back to receipts
+            {t('payouts.backToReceipts')}
           </button>
           <NewPayoutForm
             partyId={partyId}
@@ -362,7 +365,7 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
       */}
       <PaymentDetailsCard
         disabled={!paymentDetailsUnlocked}
-        disabledReason="Designate your group, box stack, and pizza photos and upload a receipt to enter your payment details."
+        disabledReason={t('payouts.paymentDetailsLocked')}
       />
 
       {detailPayoutId && (

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -851,6 +851,24 @@
       "invalidType": "Nicht unterstützter Dateityp. Verwende JPEG, PNG, WebP, GIF oder HEIC.",
       "tooLarge": "Datei zu groß. Maximale Größe ist 25 MB.",
       "uploadFailed": "Hochladen fehlgeschlagen. Bitte versuche es erneut."
-    }
+    },
+    "updateYourEstimate": "Schätzung aktualisieren",
+    "guestsPlaceholder": "z. B. 50",
+    "rsvpHint_one": "Bisher {{count}} Zusage.",
+    "rsvpHint_other": "Bisher {{count}} Zusagen.",
+    "errorPositiveNumber": "Gib eine positive Zahl ein",
+    "errorFailedToSave": "Speichern fehlgeschlagen",
+    "bannerSetGuestsAndLocation": "Lege deine {{guests}} und deinen Ort fest, um deine Finanzierung genehmigen zu lassen.",
+    "bannerSetGuests": "Lege deine {{guests}} fest, um deine Finanzierung genehmigen zu lassen.",
+    "bannerSetLocation": "Lege deinen Ort fest, um deine Finanzierung genehmigen zu lassen.",
+    "capReimburse": "Wir erstatten dir bis zu {{cap}} $.",
+    "capReimburseWithKit": "Wir erstatten dir bis zu {{cap}} $ für Pizza und bis zu {{kitCap}} $ für Party-Kit-Ausgaben.",
+    "appeal": "Einspruch",
+    "underbossReviewing": "Dein Underboss prüft dein Event, um dein Zahlungslimit festzulegen.",
+    "reachOnTelegram": "Erreiche ihn auf Telegram:",
+    "receiptsHeader": "Belege",
+    "newReceipt": "Neuer Beleg",
+    "payoutTimingNote": "Die meisten Zahlungen dauern ca. 7 Tage ab Einreichung des Belegs.",
+    "backToReceipts": "Zurück zu den Belegen"
   }
 }

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -970,6 +970,24 @@
       "invalidType": "Unsupported file type. Use JPEG, PNG, WebP, GIF, or HEIC.",
       "tooLarge": "File too large. Maximum size is 25 MB.",
       "uploadFailed": "Upload failed. Please try again."
-    }
+    },
+    "updateYourEstimate": "Update your estimate",
+    "guestsPlaceholder": "e.g. 50",
+    "rsvpHint_one": "{{count}} RSVP so far.",
+    "rsvpHint_other": "{{count}} RSVPs so far.",
+    "errorPositiveNumber": "Enter a positive number",
+    "errorFailedToSave": "Failed to save",
+    "bannerSetGuestsAndLocation": "Set your {{guests}} and your location to get your funding approved.",
+    "bannerSetGuests": "Set your {{guests}} to get your funding approved.",
+    "bannerSetLocation": "Set your location to get your funding approved.",
+    "capReimburse": "We'll reimburse you for up to ${{cap}}.",
+    "capReimburseWithKit": "We'll reimburse you for up to ${{cap}} of pizza and up to ${{kitCap}} of party kit expenses.",
+    "appeal": "Appeal",
+    "underbossReviewing": "Your underboss is reviewing your event to set your payment cap.",
+    "reachOnTelegram": "Reach them on Telegram:",
+    "receiptsHeader": "Receipts",
+    "newReceipt": "New receipt",
+    "payoutTimingNote": "Most payments will take ~7 days from receipt submission.",
+    "backToReceipts": "Back to receipts"
   }
 }

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -851,6 +851,24 @@
       "invalidType": "Tipo de archivo no compatible. Usa JPEG, PNG, WebP, GIF o HEIC.",
       "tooLarge": "Archivo demasiado grande. El tamaño máximo es 25 MB.",
       "uploadFailed": "Error al subir. Inténtalo de nuevo."
-    }
+    },
+    "updateYourEstimate": "Actualizar tu estimación",
+    "guestsPlaceholder": "p. ej. 50",
+    "rsvpHint_one": "{{count}} confirmación hasta ahora.",
+    "rsvpHint_other": "{{count}} confirmaciones hasta ahora.",
+    "errorPositiveNumber": "Introduce un número positivo",
+    "errorFailedToSave": "Error al guardar",
+    "bannerSetGuestsAndLocation": "Establece tus {{guests}} y tu ubicación para que se apruebe tu financiación.",
+    "bannerSetGuests": "Establece tus {{guests}} para que se apruebe tu financiación.",
+    "bannerSetLocation": "Establece tu ubicación para que se apruebe tu financiación.",
+    "capReimburse": "Te reembolsaremos hasta {{cap}} $.",
+    "capReimburseWithKit": "Te reembolsaremos hasta {{cap}} $ de pizza y hasta {{kitCap}} $ de gastos del kit de fiesta.",
+    "appeal": "Apelar",
+    "underbossReviewing": "Tu underboss está revisando tu evento para establecer tu límite de pago.",
+    "reachOnTelegram": "Contáctalo en Telegram:",
+    "receiptsHeader": "Recibos",
+    "newReceipt": "Nuevo recibo",
+    "payoutTimingNote": "La mayoría de los pagos tardan ~7 días desde el envío del recibo.",
+    "backToReceipts": "Volver a los recibos"
   }
 }

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -851,6 +851,24 @@
       "invalidType": "Type de fichier non pris en charge. Utilisez JPEG, PNG, WebP, GIF ou HEIC.",
       "tooLarge": "Fichier trop volumineux. La taille maximale est de 25 Mo.",
       "uploadFailed": "Échec du téléversement. Veuillez réessayer."
-    }
+    },
+    "updateYourEstimate": "Mettre à jour votre estimation",
+    "guestsPlaceholder": "p. ex. 50",
+    "rsvpHint_one": "{{count}} confirmation pour le moment.",
+    "rsvpHint_other": "{{count}} confirmations pour le moment.",
+    "errorPositiveNumber": "Saisissez un nombre positif",
+    "errorFailedToSave": "Échec de l'enregistrement",
+    "bannerSetGuestsAndLocation": "Définissez vos {{guests}} et votre lieu pour faire approuver votre financement.",
+    "bannerSetGuests": "Définissez vos {{guests}} pour faire approuver votre financement.",
+    "bannerSetLocation": "Définissez votre lieu pour faire approuver votre financement.",
+    "capReimburse": "Nous vous rembourserons jusqu'à {{cap}} $.",
+    "capReimburseWithKit": "Nous vous rembourserons jusqu'à {{cap}} $ de pizza et jusqu'à {{kitCap}} $ de frais de kit de fête.",
+    "appeal": "Faire appel",
+    "underbossReviewing": "Votre underboss examine votre événement pour définir votre plafond de paiement.",
+    "reachOnTelegram": "Contactez-le sur Telegram :",
+    "receiptsHeader": "Reçus",
+    "newReceipt": "Nouveau reçu",
+    "payoutTimingNote": "La plupart des paiements prennent environ 7 jours à compter de la soumission du reçu.",
+    "backToReceipts": "Retour aux reçus"
   }
 }

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -851,6 +851,24 @@
       "invalidType": "対応していないファイル形式です。JPEG、PNG、WebP、GIF、HEIC を使用してください。",
       "tooLarge": "ファイルが大きすぎます。最大サイズは25 MBです。",
       "uploadFailed": "アップロードに失敗しました。もう一度お試しください。"
-    }
+    },
+    "updateYourEstimate": "見積もりを更新",
+    "guestsPlaceholder": "例：50",
+    "rsvpHint_one": "現在 {{count}} 件のRSVP。",
+    "rsvpHint_other": "現在 {{count}} 件のRSVP。",
+    "errorPositiveNumber": "正の数を入力してください",
+    "errorFailedToSave": "保存に失敗しました",
+    "bannerSetGuestsAndLocation": "資金の承認を受けるには、{{guests}}と開催地を設定してください。",
+    "bannerSetGuests": "資金の承認を受けるには、{{guests}}を設定してください。",
+    "bannerSetLocation": "資金の承認を受けるには、開催地を設定してください。",
+    "capReimburse": "最大 {{cap}} ドルまで払い戻します。",
+    "capReimburseWithKit": "ピザ代として最大 {{cap}} ドル、パーティーキット費用として最大 {{kitCap}} ドルまで払い戻します。",
+    "appeal": "異議申し立て",
+    "underbossReviewing": "アンダーボスがあなたのイベントを審査し、支払い上限を設定しています。",
+    "reachOnTelegram": "Telegramで連絡：",
+    "receiptsHeader": "領収書",
+    "newReceipt": "新しい領収書",
+    "payoutTimingNote": "ほとんどの支払いは、領収書の提出から約7日かかります。",
+    "backToReceipts": "領収書に戻る"
   }
 }

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -807,6 +807,24 @@
       "invalidType": "지원되지 않는 파일 형식입니다. JPEG, PNG, WebP, GIF 또는 HEIC를 사용하세요.",
       "tooLarge": "파일이 너무 큽니다. 최대 크기는 25MB입니다.",
       "uploadFailed": "업로드에 실패했습니다. 다시 시도하세요."
-    }
+    },
+    "updateYourEstimate": "추정치 업데이트",
+    "guestsPlaceholder": "예: 50",
+    "rsvpHint_one": "현재까지 {{count}}건의 RSVP.",
+    "rsvpHint_other": "현재까지 {{count}}건의 RSVP.",
+    "errorPositiveNumber": "양수를 입력하세요",
+    "errorFailedToSave": "저장하지 못했습니다",
+    "bannerSetGuestsAndLocation": "자금 승인을 받으려면 {{guests}}와 위치를 설정하세요.",
+    "bannerSetGuests": "자금 승인을 받으려면 {{guests}}를 설정하세요.",
+    "bannerSetLocation": "자금 승인을 받으려면 위치를 설정하세요.",
+    "capReimburse": "최대 {{cap}}달러까지 환급해 드립니다.",
+    "capReimburseWithKit": "피자 비용으로 최대 {{cap}}달러, 파티 키트 비용으로 최대 {{kitCap}}달러까지 환급해 드립니다.",
+    "appeal": "이의 제기",
+    "underbossReviewing": "언더보스가 결제 한도를 설정하기 위해 이벤트를 검토하고 있습니다.",
+    "reachOnTelegram": "텔레그램으로 연락하세요:",
+    "receiptsHeader": "영수증",
+    "newReceipt": "새 영수증",
+    "payoutTimingNote": "대부분의 결제는 영수증 제출 후 약 7일이 걸립니다.",
+    "backToReceipts": "영수증으로 돌아가기"
   }
 }

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -851,6 +851,24 @@
       "invalidType": "Tipo de arquivo não compatível. Use JPEG, PNG, WebP, GIF ou HEIC.",
       "tooLarge": "Arquivo muito grande. O tamanho máximo é 25 MB.",
       "uploadFailed": "Falha no envio. Tente novamente."
-    }
+    },
+    "updateYourEstimate": "Atualizar sua estimativa",
+    "guestsPlaceholder": "ex.: 50",
+    "rsvpHint_one": "{{count}} confirmação até agora.",
+    "rsvpHint_other": "{{count}} confirmações até agora.",
+    "errorPositiveNumber": "Insira um número positivo",
+    "errorFailedToSave": "Falha ao salvar",
+    "bannerSetGuestsAndLocation": "Defina seus {{guests}} e seu local para ter seu financiamento aprovado.",
+    "bannerSetGuests": "Defina seus {{guests}} para ter seu financiamento aprovado.",
+    "bannerSetLocation": "Defina seu local para ter seu financiamento aprovado.",
+    "capReimburse": "Reembolsaremos você em até {{cap}} $.",
+    "capReimburseWithKit": "Reembolsaremos você em até {{cap}} $ de pizza e até {{kitCap}} $ de despesas do kit de festa.",
+    "appeal": "Recorrer",
+    "underbossReviewing": "Seu underboss está analisando seu evento para definir seu limite de pagamento.",
+    "reachOnTelegram": "Fale com ele no Telegram:",
+    "receiptsHeader": "Recibos",
+    "newReceipt": "Novo recibo",
+    "payoutTimingNote": "A maioria dos pagamentos leva cerca de 7 dias após o envio do recibo.",
+    "backToReceipts": "Voltar aos recibos"
   }
 }

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -851,6 +851,24 @@
       "invalidType": "不支持的文件类型。请使用 JPEG、PNG、WebP、GIF 或 HEIC。",
       "tooLarge": "文件过大。最大为 25 MB。",
       "uploadFailed": "上传失败。请重试。"
-    }
+    },
+    "updateYourEstimate": "更新你的估计",
+    "guestsPlaceholder": "例如 50",
+    "rsvpHint_one": "目前已有 {{count}} 份回复。",
+    "rsvpHint_other": "目前已有 {{count}} 份回复。",
+    "errorPositiveNumber": "请输入正数",
+    "errorFailedToSave": "保存失败",
+    "bannerSetGuestsAndLocation": "设置你的{{guests}}和地点，以获得资金批准。",
+    "bannerSetGuests": "设置你的{{guests}}，以获得资金批准。",
+    "bannerSetLocation": "设置你的地点，以获得资金批准。",
+    "capReimburse": "我们将为你报销最多 {{cap}} 美元。",
+    "capReimburseWithKit": "我们将为你报销最多 {{cap}} 美元的披萨费用和最多 {{kitCap}} 美元的派对套件费用。",
+    "appeal": "申诉",
+    "underbossReviewing": "你的 underboss 正在审核你的活动以设置付款上限。",
+    "reachOnTelegram": "通过 Telegram 联系他：",
+    "receiptsHeader": "收据",
+    "newReceipt": "新收据",
+    "payoutTimingNote": "大多数付款将在提交收据后约 7 天内完成。",
+    "backToReceipts": "返回收据"
   }
 }


### PR DESCRIPTION
Follow-up to calzone-58297. `PayoutsTab.tsx` and `ExpectedGuestsCard.tsx` rendered hardcoded English (including the calzone-58297 "expected/estimated guests" relabel), so non-English hosts saw English. Both now use `useTranslation('host')` + `t('payouts.*')`, matching sibling components `NewPayoutForm` / `EventPhotosCard`.

Frontend-only string-substitution pass — all conditional/logic branches unchanged.

## Files changed
- `frontend/src/components/payouts/ExpectedGuestsCard.tsx`
- `frontend/src/components/payouts/PayoutsTab.tsx`
- `frontend/src/i18n/locales/{de,en,es,fr,ja,ko,pt,zh}/host.json`

## Reused existing keys (calzone-58297, not duplicated)
`expectedGuestsTitle`, `estimatedGuestsTitle`, `setExpectedGuests`, `setEstimatedGuests`, `paymentDetailsLocked`, `bannerExpectedGuests`, `bannerEstimatedGuests`.

## New keys (under `payouts`, added to all 8 locales)
- ExpectedGuestsCard: `updateYourEstimate`, `guestsPlaceholder`, `rsvpHint_one`, `rsvpHint_other`, `errorPositiveNumber`, `errorFailedToSave`
- PayoutsTab banners: `bannerSetGuestsAndLocation`, `bannerSetGuests`, `bannerSetLocation`
- PayoutsTab cap banner: `capReimburse`, `capReimburseWithKit`, `appeal`
- PayoutsTab underboss notice: `underbossReviewing`, `reachOnTelegram`
- PayoutsTab receipts UI: `receiptsHeader`, `newReceipt`, `payoutTimingNote`, `backToReceipts`

The cap banner uses two full-sentence variants (`capReimburse` / `capReimburseWithKit`) instead of a concatenated optional clause + bare period, so punctuation/word-order is correct per language. The banner funding sentences interpolate the localized `bannerExpectedGuests`/`bannerEstimatedGuests` fragment via `{{guests}}`. RSVP hint uses i18next `_one`/`_other` plurals.

`npx tsc --noEmit` clean. All 18 new keys present in all 8 host.json files.

Plan: `plans/calzone-58298-payments-i18n.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)