### PR TITLE
gricia-58502: log Event Assistant queries + results (test phase)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2276,3 +2276,32 @@ model SavedFilterView {
   @@unique([userEmail, scope, name])
   @@map("saved_filter_views")
 }
+
+// gricia-58502: query/result log for the Event Assistant (test phase). One row
+// per proposal, written best-effort at proposal time and updated via the
+// /assistant/feedback endpoint with the host's accepted/rejected keys + apply
+// outcome. NO foreign keys on purpose — party_id/user_id are plain text so a
+// deleted party/user never blocks or cascades into the log. Created in prod
+// manually before merge (no migration auto-apply in this repo).
+model EventAssistantLog {
+  id                 String    @id @default(uuid())
+  partyId            String    @map("party_id")
+  userId             String?   @map("user_id")
+  instruction        String
+  history            Json?
+  proposedChanges    Json      @map("proposed_changes")
+  clarifyingQuestion String?   @map("clarifying_question")
+  model              String
+  promptTokens       Int?      @map("prompt_tokens")
+  completionTokens   Int?      @map("completion_tokens")
+  latencyMs          Int?      @map("latency_ms")
+  acceptedKeys       Json?     @map("accepted_keys")
+  rejectedKeys       Json?     @map("rejected_keys")
+  applied            Boolean   @default(false)
+  applyError         String?   @map("apply_error")
+  appliedAt          DateTime? @map("applied_at")
+  createdAt          DateTime  @default(now()) @map("created_at")
+
+  @@index([partyId])
+  @@map("event_assistant_log")
+}

--- a/backend/src/routes/eventAssistant.routes.ts
+++ b/backend/src/routes/eventAssistant.routes.ts
@@ -121,7 +121,114 @@ router.post(
         conversationHistory: history,
       });
 
-      res.json(result);
+      // gricia-58502: best-effort query/result log. NEVER fail the request on a
+      // logging error — wrap the insert and swallow any failure. `proposalId`
+      // is the created row id (or null if the insert failed) so the frontend
+      // can later report accepted/rejected keys + apply outcome via /feedback.
+      let proposalId: string | null = null;
+      try {
+        const logRow = await prisma.eventAssistantLog.create({
+          data: {
+            partyId: id,
+            userId: req.userId ?? null,
+            instruction,
+            history: history.length > 0 ? (history as unknown as object) : undefined,
+            proposedChanges: result.proposedChanges as unknown as object,
+            clarifyingQuestion: result.clarifyingQuestion ?? null,
+            model: result.model,
+            promptTokens: result.usage.promptTokens ?? null,
+            completionTokens: result.usage.completionTokens ?? null,
+            latencyMs: result.latencyMs,
+          },
+          select: { id: true },
+        });
+        proposalId = logRow.id;
+      } catch (logErr) {
+        console.error('[eventAssistant] failed to write proposal log (continuing):', logErr);
+      }
+
+      res.json({
+        assistantMessage: result.assistantMessage,
+        clarifyingQuestion: result.clarifyingQuestion,
+        proposedChanges: result.proposedChanges,
+        proposalId,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// gricia-58502: feedback endpoint. The frontend reports which proposed keys the
+// host accepted/rejected and whether the apply (trusted PATCH) succeeded. Same
+// guards as the assistant route: path-scoped requireAuth (above) + canUserEditParty
+// + the Philadelphia ASSISTANT_ENABLED_SLUGS gate. Everything is best-effort: a
+// missing/foreign proposalId is a 204 no-op (never a 500), and the update is
+// wrapped so logging never breaks the host's flow.
+const MAX_APPLY_ERROR_LEN = 1000;
+
+router.post(
+  '/:id/assistant/feedback',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { id } = req.params;
+      const { proposalId, acceptedKeys, rejectedKeys, applied, error } = req.body || {};
+
+      if (typeof proposalId !== 'string' || proposalId.trim().length === 0) {
+        // Nothing to attribute the feedback to — no-op.
+        return res.status(204).end();
+      }
+
+      const canEdit = await canUserEditParty(id, req.userId, req.userEmail);
+      if (!canEdit) {
+        throw new AppError('Party not found', 404, 'NOT_FOUND');
+      }
+
+      // Same test-rollout gate as the assistant route.
+      const slugRow = await prisma.party.findUnique({
+        where: { id },
+        select: { customUrl: true, inviteCode: true },
+      });
+      const cu = slugRow?.customUrl?.toLowerCase();
+      const ic = slugRow?.inviteCode?.toLowerCase();
+      const assistantEnabled =
+        (!!cu && ASSISTANT_ENABLED_SLUGS.has(cu)) || (!!ic && ASSISTANT_ENABLED_SLUGS.has(ic));
+      if (!assistantEnabled) {
+        throw new AppError('Party not found', 404, 'NOT_FOUND');
+      }
+
+      // Best-effort update — never throw a 500 from here.
+      try {
+        const logRow = await prisma.eventAssistantLog.findUnique({
+          where: { id: proposalId },
+          select: { id: true, partyId: true },
+        });
+        // No such row, or it belongs to a different party → silent no-op.
+        if (!logRow || logRow.partyId !== id) {
+          return res.status(204).end();
+        }
+
+        const isApplied = applied === true;
+        const applyError =
+          typeof error === 'string' && error.length > 0
+            ? error.slice(0, MAX_APPLY_ERROR_LEN)
+            : null;
+
+        await prisma.eventAssistantLog.update({
+          where: { id: proposalId },
+          data: {
+            acceptedKeys: Array.isArray(acceptedKeys) ? (acceptedKeys as unknown as object) : undefined,
+            rejectedKeys: Array.isArray(rejectedKeys) ? (rejectedKeys as unknown as object) : undefined,
+            applied: isApplied,
+            applyError,
+            appliedAt: isApplied ? new Date() : null,
+          },
+        });
+      } catch (updateErr) {
+        console.error('[eventAssistant] failed to write feedback (continuing):', updateErr);
+      }
+
+      res.json({ ok: true });
     } catch (error) {
       next(error);
     }

--- a/backend/src/services/eventAssistant.service.ts
+++ b/backend/src/services/eventAssistant.service.ts
@@ -28,6 +28,15 @@ import {
 const MAX_INSTRUCTION_LEN = 2000;
 const MAX_HISTORY_TURNS = 8; // host+assistant messages retained for follow-ups
 
+// gricia-58502: single source of truth for the model id, so the value we log
+// always matches the value we send to OpenAI.
+const ASSISTANT_MODEL = 'gpt-4o-mini';
+
+// gricia-58502: metadata returned on the short-circuit paths that never reach
+// the OpenAI call (no tokens, no real latency). Keeps the result shape uniform
+// so the route's logging code can read `model`/`usage`/`latencyMs` everywhere.
+const NO_CALL_META = { model: ASSISTANT_MODEL, usage: {}, latencyMs: 0 } as const;
+
 export interface AssistantHistoryTurn {
   role: 'user' | 'assistant';
   content: string;
@@ -37,6 +46,12 @@ export interface EventAssistantResult {
   assistantMessage: string;
   clarifyingQuestion?: string;
   proposedChanges: Array<ProposedChange & { reason?: string }>;
+  // gricia-58502: observability metadata for the query/result log. The model
+  // string + OpenAI token usage + measured round-trip latency (ms). `usage`
+  // fields are optional because the OpenAI response may omit `usage`.
+  model: string;
+  usage: { promptTokens?: number; completionTokens?: number };
+  latencyMs: number;
 }
 
 /* --------------------------- current snapshot ----------------------------- */
@@ -272,12 +287,12 @@ export async function runEventAssistant(params: {
   const instruction = (params.instruction ?? '').trim().slice(0, MAX_INSTRUCTION_LEN);
 
   if (!instruction) {
-    return { assistantMessage: 'Tell me what you would like to change about your event.', proposedChanges: [] };
+    return { assistantMessage: 'Tell me what you would like to change about your event.', proposedChanges: [], ...NO_CALL_META };
   }
 
   const party = await prisma.party.findUnique({ where: { id: partyId } });
   if (!party) {
-    return { assistantMessage: 'Event not found.', proposedChanges: [] };
+    return { assistantMessage: 'Event not found.', proposedChanges: [], ...NO_CALL_META };
   }
 
   const timezone = (party as any).timezone || 'UTC';
@@ -290,8 +305,10 @@ export async function runEventAssistant(params: {
 
   const tool = buildToolSchema(role);
 
+  // gricia-58502: measure round-trip latency around the OpenAI call only.
+  const startedAt = Date.now();
   const response = await getOpenAI().chat.completions.create({
-    model: 'gpt-4o-mini',
+    model: ASSISTANT_MODEL,
     messages: [
       // Static prefix (cacheable): behavioral system prompt + tool schema.
       { role: 'system', content: buildSystemPrompt(role) },
@@ -303,6 +320,14 @@ export async function runEventAssistant(params: {
     tool_choice: { type: 'function', function: { name: 'propose_event_changes' } },
     max_tokens: 1500,
   });
+  const latencyMs = Date.now() - startedAt;
+
+  // gricia-58502: token usage for the log (may be absent on the response).
+  const usage: { promptTokens?: number; completionTokens?: number } = {
+    promptTokens: response.usage?.prompt_tokens,
+    completionTokens: response.usage?.completion_tokens,
+  };
+  const callMeta = { model: ASSISTANT_MODEL, usage, latencyMs };
 
   const toolCall = response.choices[0]?.message?.tool_calls?.[0];
   // The SDK tool-call type is a union (function | custom); narrow to function.
@@ -311,6 +336,7 @@ export async function runEventAssistant(params: {
       assistantMessage:
         "I couldn't turn that into a concrete change. Try rephrasing, e.g. \"change the venue name to The Pizza Loft\".",
       proposedChanges: [],
+      ...callMeta,
     };
   }
 
@@ -321,6 +347,7 @@ export async function runEventAssistant(params: {
     return {
       assistantMessage: 'Sorry — I had trouble formatting that change. Please try again.',
       proposedChanges: [],
+      ...callMeta,
     };
   }
 
@@ -382,7 +409,7 @@ export async function runEventAssistant(params: {
     });
   }
 
-  return { assistantMessage, clarifyingQuestion, proposedChanges };
+  return { assistantMessage, clarifyingQuestion, proposedChanges, ...callMeta };
 }
 
 /* -------------------------------- helpers --------------------------------- */

--- a/frontend/src/components/EventAssistant.tsx
+++ b/frontend/src/components/EventAssistant.tsx
@@ -5,6 +5,7 @@ import { IconInput } from './IconInput';
 import { Checkbox } from './Checkbox';
 import {
   eventAssistant,
+  eventAssistantFeedback,
   updatePartyApi,
   type AssistantProposedChange,
   type AssistantHistoryTurn,
@@ -41,6 +42,8 @@ export const EventAssistant: React.FC = () => {
   const [instruction, setInstruction] = useState('');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [proposed, setProposed] = useState<AssistantProposedChange[]>([]);
+  // gricia-58502: log row id for the current proposal, echoed back on apply.
+  const [proposalId, setProposalId] = useState<string | null>(null);
   const [accepted, setAccepted] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -57,6 +60,7 @@ export const EventAssistant: React.FC = () => {
     setError(null);
     setApplied(false);
     setProposed([]);
+    setProposalId(null);
     setAccepted({});
 
     const history: AssistantHistoryTurn[] = messages.map((m) => ({ role: m.role, content: m.content }));
@@ -70,6 +74,7 @@ export const EventAssistant: React.FC = () => {
         : res.assistantMessage;
       setMessages((prev) => [...prev, { role: 'assistant', content: assistantText }]);
       setProposed(res.proposedChanges || []);
+      setProposalId(res.proposalId ?? null);
       // Default every proposed change to ON.
       const initial: Record<string, boolean> = {};
       for (const c of res.proposedChanges || []) initial[c.key] = true;
@@ -89,6 +94,12 @@ export const EventAssistant: React.FC = () => {
     setError(null);
     setApplied(false);
 
+    // gricia-58502: accepted = toggled ON, rejected = toggled OFF. Captured
+    // before we clear `proposed`/`accepted` so the feedback call has them.
+    const acceptedKeys = proposed.filter((c) => accepted[c.key]).map((c) => c.key);
+    const rejectedKeys = proposed.filter((c) => !accepted[c.key]).map((c) => c.key);
+    const pid = proposalId;
+
     // Build a camelCase patch for the trusted PATCH path. updatePartyApi throws
     // on failure (e.g. custom_url uniqueness), so we surface the message inline.
     const camelPatch: Record<string, unknown> = {};
@@ -100,6 +111,7 @@ export const EventAssistant: React.FC = () => {
       mergeParty(camelPatch as Partial<Party>);
       setApplied(true);
       setProposed([]);
+      setProposalId(null);
       setAccepted({});
       setMessages((prev) => [
         ...prev,
@@ -108,8 +120,28 @@ export const EventAssistant: React.FC = () => {
           content: `Applied ${toApply.length} change${toApply.length === 1 ? '' : 's'}.`,
         },
       ]);
+      // gricia-58502: fire-and-forget success feedback (best-effort, never
+      // awaited in a blocking way; eventAssistantFeedback swallows errors).
+      if (pid) {
+        void eventAssistantFeedback(party.id, {
+          proposalId: pid,
+          acceptedKeys,
+          rejectedKeys,
+          applied: true,
+        });
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to apply changes.');
+      // gricia-58502: record the apply failure (best-effort, fire-and-forget).
+      if (pid) {
+        void eventAssistantFeedback(party.id, {
+          proposalId: pid,
+          acceptedKeys,
+          rejectedKeys,
+          applied: false,
+          error: e instanceof Error ? e.message : 'Failed to apply changes.',
+        });
+      }
     } finally {
       setApplying(false);
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -411,6 +411,10 @@ export interface EventAssistantResponse {
   assistantMessage: string;
   clarifyingQuestion?: string;
   proposedChanges: AssistantProposedChange[];
+  // gricia-58502: server-side log row id for this proposal (null if logging
+  // failed). Echo it back via `eventAssistantFeedback` to record the host's
+  // accepted/rejected keys + apply outcome.
+  proposalId?: string | null;
 }
 
 export interface AssistantHistoryTurn {
@@ -432,6 +436,31 @@ export async function eventAssistant(
     method: 'POST',
     body: { instruction, conversationHistory: history },
   });
+}
+
+/**
+ * gricia-58502: report Event Assistant feedback — which proposed keys the host
+ * accepted/rejected and whether applying them succeeded. Best-effort and
+ * fire-and-forget: errors are swallowed so logging never affects the host's UX.
+ */
+export async function eventAssistantFeedback(
+  partyId: string,
+  body: {
+    proposalId: string;
+    acceptedKeys: string[];
+    rejectedKeys: string[];
+    applied: boolean;
+    error?: string;
+  },
+): Promise<void> {
+  try {
+    await apiRequest(`/api/parties/${partyId}/assistant/feedback`, {
+      method: 'POST',
+      body,
+    });
+  } catch {
+    // Swallow — feedback logging is non-load-bearing.
+  }
 }
 
 /**


### PR DESCRIPTION
## What
Persists every Event Assistant interaction during the Philadelphia test so we can build an eval set and spot systematic failures **before widening**. Data collection only — the model does not learn from this on its own.

## How
- New Prisma model **`EventAssistantLog`** (`event_assistant_log`, no FKs, indexed on `party_id`).
- `runEventAssistant` now returns `model`, token `usage`, and `latencyMs`.
- `POST /api/parties/:id/assistant` writes a **best-effort** log row at proposal time (instruction, history, full proposed diff, tokens, latency) and returns a `proposalId`.
- New **`POST /api/parties/:id/assistant/feedback`** (same guards incl. the Philadelphia gate) records `acceptedKeys`/`rejectedKeys`/`applied`/`applyError` on that row. Missing or foreign `proposalId` returns 204 no-op.
- Frontend stores `proposalId` and fires `eventAssistantFeedback` **fire-and-forget** after Apply (success + catch).

**Best-effort everywhere:** every log write is wrapped in try/catch and never throws to the user; frontend feedback is non-awaited and swallows its own errors.

## Deploy order (must)
The `event_assistant_log` table must be **created in prod BEFORE merge** — the new endpoints reference it the moment the backend deploys. SQL is in `plans/gricia-58502-assistant-logging.md`. No FK, so it is a standalone additive table.

## Privacy
Logs the host's own instruction + event snapshot (may contain names/addresses/emails). Test-phase, single event. Add a retention policy before any broad rollout.

## Test
- `prisma validate`/`generate` ok; backend + frontend tsc clean (touched files); vitest drift guard 12/12.

Plan: `plans/gricia-58502-assistant-logging.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
