### PR TITLE
porcini-58296: fix admin /payments Send-payment regression (RECEIPT_ATTESTATION_REQUIRED)

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -974,7 +974,11 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     // coordinators via a separate flow with no event photos and no receipt
     // attestation, so this gate would always block them. Mirrored client-side
     // as a disabled submit button; enforced here so an API bypass still fails.
-    if (!isShippingPurpose) {
+    // Also exempt admin prepay-for-cohost (bismarck-92103): the admin disburses
+    // after their own review (caps + fake-detection + SWC-hub acks) and is not
+    // the host attesting receipts — consistent with the payout-method and
+    // tax-form gates.
+    if (!isShippingPurpose && !adminPrepayingForCohost) {
       if (receiptAttested !== true) {
         throw new AppError(
           'Confirm your receipts are submitted and itemized before submitting.',


### PR DESCRIPTION
## Problem
`porchetta-58296` (#893) added a gate to `POST /:partyId/payouts` requiring `receiptAttested===true` + at least one receipt + group/box_stack/pizza photos for all non-shipping payouts. The admin /payments **Send payment** flow (`SendPaymentModal` → `createPayout` with a `recipientHostUserId` override) creates a payout without a `receiptAttested` flag — so every admin USDC/wire/Mercury send now 400s with `RECEIPT_ATTESTATION_REQUIRED`. ("Mark city paid" / "Add external payment" use other endpoints and were unaffected.)

## Fix
Exempt `adminPrepayingForCohost` from the porchetta-58296 gate — mirroring the admin exemptions the **payout-method** gate and **tax-form** gate (`skipTaxFormGate = isShippingPurpose || adminPrepayingForCohost`) already have. The admin disburses after their own review (caps + fake-detection + SWC-hub acks) and is not the host attesting receipts.

Guard changed from `if (!isShippingPurpose) {` to `if (!isShippingPurpose && !adminPrepayingForCohost) {`.

## Scope
- One-condition change + comment in `backend/src/routes/payout.routes.ts`. No frontend change, no DB migration.
- Host submission path (non-admin) remains fully gated.

## Verification
Backend-only (frontend Vercel preview won't exercise it). tsc clean for the changed file (only the pre-existing `auth.test.ts` error remains); `npm test` shows no new failures vs master (stash-confirmed). Real verification post-merge: send a USDC payment to a city via /payments — should no longer 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
