### PR TITLE
feat(guanciale-43592): canonical country-name backfill + create-path hook

### DIFF
--- a/backend/src/lib/canonicalCountryName.test.ts
+++ b/backend/src/lib/canonicalCountryName.test.ts
@@ -21,10 +21,11 @@ describe('canonicalizeCountryName', () => {
     expect(canonicalizeCountryName('Italia')).toBe('Italy');
     expect(canonicalizeCountryName('Perú')).toBe('Peru');
     expect(canonicalizeCountryName('Österreich')).toBe('Austria');
-    // Note: Intl.DisplayNames in Node 22+ uses modern CLDR which returns
-    // "Türkiye" (not "Turkey") for TR; this matches official ISO usage.
-    expect(canonicalizeCountryName('Turkey')).toBe('Türkiye');
-    expect(canonicalizeCountryName('Türkiye')).toBe('Türkiye');
+    // Snax-decision (2026-06-06): override Intl's modern CLDR "Türkiye" back
+    // to American "Turkey" via the OVERRIDES map. Both input spellings now
+    // canonicalize to "Turkey".
+    expect(canonicalizeCountryName('Turkey')).toBe('Turkey');
+    expect(canonicalizeCountryName('Türkiye')).toBe('Turkey');
   });
 
   it('applies overrides for codes where Intl is non-American', () => {
@@ -50,6 +51,9 @@ describe('canonicalizeCountryName', () => {
     expect(canonicalizeCountryName('São Tomé and Príncipe')).toBe(
       'São Tomé and Príncipe',
     );
+    // TR -> Intl uses modern CLDR "Türkiye"; override to American "Turkey"
+    expect(canonicalizeCountryName('Turkey')).toBe('Turkey');
+    expect(canonicalizeCountryName('Türkiye')).toBe('Turkey');
   });
 
   it("normalizes Intl's curly apostrophe in Côte d'Ivoire", () => {

--- a/backend/src/lib/canonicalCountryName.test.ts
+++ b/backend/src/lib/canonicalCountryName.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizeCountryName } from './canonicalCountryName.js';
+
+describe('canonicalizeCountryName', () => {
+  it('returns canonical English for canonical English inputs', () => {
+    expect(canonicalizeCountryName('Spain')).toBe('Spain');
+    expect(canonicalizeCountryName('Germany')).toBe('Germany');
+    expect(canonicalizeCountryName('Mexico')).toBe('Mexico');
+    expect(canonicalizeCountryName('Japan')).toBe('Japan');
+    expect(canonicalizeCountryName('United States')).toBe('United States');
+    expect(canonicalizeCountryName('Brazil')).toBe('Brazil');
+  });
+
+  it('canonicalizes localized aliases', () => {
+    expect(canonicalizeCountryName('España')).toBe('Spain');
+    expect(canonicalizeCountryName('Deutschland')).toBe('Germany');
+    expect(canonicalizeCountryName('México')).toBe('Mexico');
+    expect(canonicalizeCountryName('日本')).toBe('Japan');
+    expect(canonicalizeCountryName('中国')).toBe('China');
+    expect(canonicalizeCountryName('Brasil')).toBe('Brazil');
+    expect(canonicalizeCountryName('Italia')).toBe('Italy');
+    expect(canonicalizeCountryName('Perú')).toBe('Peru');
+    expect(canonicalizeCountryName('Österreich')).toBe('Austria');
+    // Note: Intl.DisplayNames in Node 22+ uses modern CLDR which returns
+    // "Türkiye" (not "Turkey") for TR; this matches official ISO usage.
+    expect(canonicalizeCountryName('Turkey')).toBe('Türkiye');
+    expect(canonicalizeCountryName('Türkiye')).toBe('Türkiye');
+  });
+
+  it('applies overrides for codes where Intl is non-American', () => {
+    // HK -> Intl "Hong Kong SAR China"
+    expect(canonicalizeCountryName('Hong Kong')).toBe('Hong Kong');
+    // MO -> Intl "Macao SAR China", existing table has "Macau"
+    expect(canonicalizeCountryName('Macau')).toBe('Macao');
+    // MM -> Intl "Myanmar (Burma)"
+    expect(canonicalizeCountryName('Myanmar')).toBe('Myanmar');
+    // CD -> Intl "Congo - Kinshasa"
+    expect(canonicalizeCountryName('Democratic Republic of the Congo')).toBe(
+      'DR Congo',
+    );
+    expect(canonicalizeCountryName('DR Congo')).toBe('DR Congo');
+    // CG -> Intl "Congo - Brazzaville"
+    expect(canonicalizeCountryName('Congo')).toBe('Congo');
+    // PS -> Intl "Palestinian Territories"
+    expect(canonicalizeCountryName('Palestine')).toBe('Palestine');
+    expect(canonicalizeCountryName('Palestinian Territories')).toBe(
+      'Palestine',
+    );
+    // ST -> Intl uses "&" + curly apostrophe
+    expect(canonicalizeCountryName('São Tomé and Príncipe')).toBe(
+      'São Tomé and Príncipe',
+    );
+  });
+
+  it("normalizes Intl's curly apostrophe in Côte d'Ivoire", () => {
+    // Construct curly-apostrophe string explicitly so this test is robust to
+    // editor auto-replacement. ’ is RIGHT SINGLE QUOTATION MARK.
+    const curly = 'Côte d’Ivoire';
+    expect(curly).toBe('Côte d’Ivoire');
+    expect(canonicalizeCountryName(curly)).toBe("Côte d'Ivoire");
+    // Sanity: the result uses a straight apostrophe, not the curly one.
+    expect(canonicalizeCountryName(curly)).not.toContain('’');
+    expect(canonicalizeCountryName(curly)).toContain("'");
+    // Also accept the ASCII-apostrophe variant on input.
+    expect(canonicalizeCountryName("Côte d'Ivoire")).toBe("Côte d'Ivoire");
+    // And the existing-table alias "Ivory Coast" should canonicalize to CI.
+    expect(canonicalizeCountryName('Ivory Coast')).toBe("Côte d'Ivoire");
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(canonicalizeCountryName('  Spain  ')).toBe('Spain');
+    expect(canonicalizeCountryName('\tGermany\n')).toBe('Germany');
+  });
+
+  it('is case-insensitive on the input side (via getCountryCode)', () => {
+    expect(canonicalizeCountryName('spain')).toBe('Spain');
+    expect(canonicalizeCountryName('SPAIN')).toBe('Spain');
+    expect(canonicalizeCountryName('united kingdom')).toBe('United Kingdom');
+  });
+
+  it('returns null for null / undefined / empty / whitespace', () => {
+    expect(canonicalizeCountryName(null)).toBeNull();
+    expect(canonicalizeCountryName(undefined)).toBeNull();
+    expect(canonicalizeCountryName('')).toBeNull();
+    expect(canonicalizeCountryName('   ')).toBeNull();
+  });
+
+  it('returns null for unrecognized strings', () => {
+    expect(canonicalizeCountryName('Atlantis')).toBeNull();
+    expect(canonicalizeCountryName('xyzzy')).toBeNull();
+  });
+});

--- a/backend/src/lib/canonicalCountryName.ts
+++ b/backend/src/lib/canonicalCountryName.ts
@@ -1,0 +1,72 @@
+/**
+ * Canonicalize a free-text country name (English, localized, or with any
+ * Google-Places spelling quirk) to canonical American English.
+ *
+ * Uses `getCountryCode` (see ./countryCode.ts) to map the input to an
+ * ISO-3166-1 alpha-2, then `Intl.DisplayNames(['en'])` to render that code
+ * back to an English name. An OVERRIDES map handles the codes whose Intl
+ * output is non-American or has a formatting quirk Snax wants normalized.
+ *
+ * Used by:
+ *   - POST /api/parties + PATCH /api/parties/:id (defense-in-depth on create).
+ *   - scripts/backfill-canonical-country-names.cjs (one-shot DB cleanup).
+ *
+ * Returns null for null/empty input and for unrecognized strings. Callers
+ * that want "preserve raw" semantics should fall back to the input themselves
+ * (see `canonicalizeCountryName(country) ?? country ?? null` pattern in
+ * party.routes.ts).
+ */
+
+import { getCountryCode } from './countryCode.js';
+
+const ENGLISH_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });
+
+/**
+ * Codes where Intl's English name disagrees with Snax-preferred American
+ * English. Confirmed against Node 22 output 2026-06-05.
+ *
+ *   HK -> Intl says "Hong Kong SAR China" -> "Hong Kong"
+ *   MO -> Intl says "Macao SAR China"     -> "Macao"
+ *   MM -> Intl says "Myanmar (Burma)"     -> "Myanmar"
+ *   CD -> Intl says "Congo - Kinshasa"    -> "DR Congo"
+ *   CG -> Intl says "Congo - Brazzaville" -> "Congo"
+ *   PS -> Intl says "Palestinian Territories" -> "Palestine"
+ *   ST -> Intl says "São Tomé & Príncipe" -> "São Tomé and Príncipe"
+ *
+ * CI is NOT in this map: Intl returns "Côte d’Ivoire" (curly apostrophe);
+ * we normalize the apostrophe to ASCII below.
+ */
+const OVERRIDES: Record<string, string> = {
+  HK: 'Hong Kong',
+  MO: 'Macao',
+  MM: 'Myanmar',
+  CD: 'DR Congo',
+  CG: 'Congo',
+  PS: 'Palestine',
+  ST: 'São Tomé and Príncipe',
+};
+
+export function canonicalizeCountryName(
+  input: string | null | undefined,
+): string | null {
+  if (!input || typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Normalize the curly RIGHT SINGLE QUOTATION MARK (U+2019) — which both
+  // Intl.DisplayNames AND some Google-Places localized labels emit — to a
+  // straight ASCII apostrophe so getCountryCode's alias table ("côte
+  // d'ivoire") still matches.
+  const normalizedInput = trimmed.replace(/’/g, "'");
+
+  const code = getCountryCode(normalizedInput);
+  if (!code) return null;
+
+  if (code in OVERRIDES) return OVERRIDES[code];
+
+  const name = ENGLISH_NAMES.of(code);
+  if (!name) return null;
+  // Apply the same curly->straight normalization on the Intl output so
+  // "Côte d'Ivoire" is always stored with an ASCII apostrophe.
+  return name.replace(/’/g, "'");
+}

--- a/backend/src/lib/canonicalCountryName.ts
+++ b/backend/src/lib/canonicalCountryName.ts
@@ -32,6 +32,7 @@ const ENGLISH_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });
  *   CG -> Intl says "Congo - Brazzaville" -> "Congo"
  *   PS -> Intl says "Palestinian Territories" -> "Palestine"
  *   ST -> Intl says "São Tomé & Príncipe" -> "São Tomé and Príncipe"
+ *   TR -> Intl says "Türkiye" (modern CLDR) -> "Turkey" (American English)
  *
  * CI is NOT in this map: Intl returns "Côte d’Ivoire" (curly apostrophe);
  * we normalize the apostrophe to ASCII below.
@@ -44,6 +45,7 @@ const OVERRIDES: Record<string, string> = {
   CG: 'Congo',
   PS: 'Palestine',
   ST: 'São Tomé and Príncipe',
+  TR: 'Turkey',
 };
 
 export function canonicalizeCountryName(

--- a/backend/src/lib/countryCode.ts
+++ b/backend/src/lib/countryCode.ts
@@ -20,13 +20,15 @@ const COUNTRY_NAME_TO_CODE: Record<string, string> = {
   'angola': 'AO', 'antigua and barbuda': 'AG', 'argentina': 'AR',
   'armenia': 'AM', 'australia': 'AU', 'austria': 'AT', 'azerbaijan': 'AZ',
   // B
-  'bahamas': 'BS', 'bahrain': 'BH', 'bangladesh': 'BD', 'barbados': 'BB',
+  'bahamas': 'BS', 'the bahamas': 'BS',
+  'bahrain': 'BH', 'bangladesh': 'BD', 'barbados': 'BB',
   'belarus': 'BY', 'belgium': 'BE', 'belize': 'BZ', 'benin': 'BJ',
   'bhutan': 'BT', 'bolivia': 'BO', 'bosnia and herzegovina': 'BA',
   'botswana': 'BW', 'brazil': 'BR', 'brunei': 'BN', 'bulgaria': 'BG',
   'burkina faso': 'BF', 'burundi': 'BI',
   // C
   'cambodia': 'KH', 'cameroon': 'CM', 'canada': 'CA', 'cape verde': 'CV',
+  'cayman islands': 'KY',
   'central african republic': 'CF', 'chad': 'TD', 'chile': 'CL',
   'china': 'CN', 'colombia': 'CO', 'comoros': 'KM',
   'congo': 'CG',
@@ -105,6 +107,7 @@ const COUNTRY_NAME_TO_CODE: Record<string, string> = {
   'united kingdom': 'GB', 'uk': 'GB', 'great britain': 'GB',
   'united states': 'US', 'usa': 'US', 'united states of america': 'US',
   'u.s. virgin islands': 'VI', 'us virgin islands': 'VI',
+  'united states virgin islands': 'VI',
   'uruguay': 'UY', 'uzbekistan': 'UZ',
   // V
   'vanuatu': 'VU', 'vatican city': 'VA', 'venezuela': 'VE', 'vietnam': 'VN',
@@ -115,29 +118,35 @@ const COUNTRY_NAME_TO_CODE: Record<string, string> = {
 };
 
 const COUNTRY_ALIASES: Record<string, string> = {
-  // German
+  // German / Dutch / Danish (shared spelling)
   'deutschland': 'DE', 'österreich': 'AT', 'schweiz': 'CH',
+  'polen': 'PL',
   // Spanish
   'españa': 'ES', 'méxico': 'MX', 'perú': 'PE', 'alemania': 'DE',
   'francia': 'FR', 'suiza': 'CH', 'república dominicana': 'DO',
   // Portuguese
-  'brasil': 'BR',
+  'brasil': 'BR', 'índia': 'IN',
   // Italian
   'italia': 'IT',
   // French
   'algérie': 'DZ', 'maroc': 'MA',
   'république démocratique du congo': 'CD',
   'république du congo': 'CG',
+  'malaisie': 'MY',
   // Dutch
   'nederland': 'NL',
   // Danish
   'danmark': 'DK',
+  // Swedish
+  'sverige': 'SE',
   // Polish
   'polska': 'PL', 'wielka brytania': 'GB',
   // Hungarian
-  'szlovákia': 'SK',
+  'szlovákia': 'SK', 'magyarország': 'HU',
   // Romanian
   'románia': 'RO',
+  // Bosnian
+  'bosna i hercegovina': 'BA',
   // Turkish
   'türkiye': 'TR',
   // Vietnamese
@@ -145,12 +154,14 @@ const COUNTRY_ALIASES: Record<string, string> = {
   // Bulgarian
   'българия': 'BG',
   // Russian
-  'грузия': 'GE',
+  'грузия': 'GE', 'турция': 'TR',
   // Arabic
   'الجزائر': 'DZ',
   'السعودية': 'SA',
   'العراق': 'IQ',
   'مصر': 'EG',
+  // Hebrew
+  'ישראל': 'IL',
   // CJK
   '中国': 'CN',
   '日本': 'JP',

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -19,6 +19,7 @@ import { autoPopulatePizzerias } from '../lib/autoPopulatePizzerias.js';
 import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
 import { getReimbursementRules, getGppGlobalEditors, getOperationalLimits } from '../lib/privateConfig.js';
 import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
+import { canonicalizeCountryName } from '../lib/canonicalCountryName.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -320,7 +321,7 @@ router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => 
         address: address || null,
         latitude: latitude !== null && latitude !== undefined ? Number(latitude) : null,
         longitude: longitude !== null && longitude !== undefined ? Number(longitude) : null,
-        country: country || null,
+        country: canonicalizeCountryName(country) ?? country ?? null,
         placeId: placeId || null,
         venueName: venueName || null,
         city: city || null,
@@ -726,7 +727,9 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(address !== undefined && { address, addressIsCityDefault: false }),
         ...(latitude !== undefined && { latitude: latitude !== null ? Number(latitude) : null }),
         ...(longitude !== undefined && { longitude: longitude !== null ? Number(longitude) : null }),
-        ...(country !== undefined && { country: country || null }),
+        ...(country !== undefined && {
+          country: canonicalizeCountryName(country) ?? country ?? null,
+        }),
         ...(city !== undefined && { city: city || null }),
         ...(placeId !== undefined && { placeId: placeId || null }),
         ...(venueName !== undefined && { venueName: venueName || null }),

--- a/scripts/backfill-canonical-country-names.cjs
+++ b/scripts/backfill-canonical-country-names.cjs
@@ -53,13 +53,15 @@ const COUNTRY_NAME_TO_CODE = {
   angola: 'AO', 'antigua and barbuda': 'AG', argentina: 'AR',
   armenia: 'AM', australia: 'AU', austria: 'AT', azerbaijan: 'AZ',
   // B
-  bahamas: 'BS', bahrain: 'BH', bangladesh: 'BD', barbados: 'BB',
+  bahamas: 'BS', 'the bahamas': 'BS',
+  bahrain: 'BH', bangladesh: 'BD', barbados: 'BB',
   belarus: 'BY', belgium: 'BE', belize: 'BZ', benin: 'BJ',
   bhutan: 'BT', bolivia: 'BO', 'bosnia and herzegovina': 'BA',
   botswana: 'BW', brazil: 'BR', brunei: 'BN', bulgaria: 'BG',
   'burkina faso': 'BF', burundi: 'BI',
   // C
   cambodia: 'KH', cameroon: 'CM', canada: 'CA', 'cape verde': 'CV',
+  'cayman islands': 'KY',
   'central african republic': 'CF', chad: 'TD', chile: 'CL',
   china: 'CN', colombia: 'CO', comoros: 'KM',
   congo: 'CG',
@@ -138,6 +140,7 @@ const COUNTRY_NAME_TO_CODE = {
   'united kingdom': 'GB', uk: 'GB', 'great britain': 'GB',
   'united states': 'US', usa: 'US', 'united states of america': 'US',
   'u.s. virgin islands': 'VI', 'us virgin islands': 'VI',
+  'united states virgin islands': 'VI',
   uruguay: 'UY', uzbekistan: 'UZ',
   // V
   vanuatu: 'VU', 'vatican city': 'VA', venezuela: 'VE', vietnam: 'VN',
@@ -148,29 +151,35 @@ const COUNTRY_NAME_TO_CODE = {
 };
 
 const COUNTRY_ALIASES = {
-  // German
+  // German / Dutch / Danish (shared spelling)
   deutschland: 'DE', österreich: 'AT', schweiz: 'CH',
+  polen: 'PL',
   // Spanish
   españa: 'ES', méxico: 'MX', perú: 'PE', alemania: 'DE',
   francia: 'FR', suiza: 'CH', 'república dominicana': 'DO',
   // Portuguese
-  brasil: 'BR',
+  brasil: 'BR', índia: 'IN',
   // Italian
   italia: 'IT',
   // French
   algérie: 'DZ', maroc: 'MA',
   'république démocratique du congo': 'CD',
   'république du congo': 'CG',
+  malaisie: 'MY',
   // Dutch
   nederland: 'NL',
   // Danish
   danmark: 'DK',
+  // Swedish
+  sverige: 'SE',
   // Polish
   polska: 'PL', 'wielka brytania': 'GB',
   // Hungarian
-  szlovákia: 'SK',
+  szlovákia: 'SK', magyarország: 'HU',
   // Romanian
   románia: 'RO',
+  // Bosnian
+  'bosna i hercegovina': 'BA',
   // Turkish
   türkiye: 'TR',
   // Vietnamese
@@ -178,12 +187,14 @@ const COUNTRY_ALIASES = {
   // Bulgarian
   българия: 'BG',
   // Russian
-  грузия: 'GE',
+  грузия: 'GE', турция: 'TR',
   // Arabic
   الجزائر: 'DZ',
   السعودية: 'SA',
   العراق: 'IQ',
   مصر: 'EG',
+  // Hebrew
+  ישראל: 'IL',
   // CJK
   中国: 'CN',
   日本: 'JP',
@@ -210,6 +221,7 @@ const OVERRIDES = {
   CG: 'Congo',
   PS: 'Palestine',
   ST: 'São Tomé and Príncipe',
+  TR: 'Turkey',
 };
 
 const ENGLISH_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });

--- a/scripts/backfill-canonical-country-names.cjs
+++ b/scripts/backfill-canonical-country-names.cjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * scripts/backfill-canonical-country-names.cjs
+ *
+ * One-shot backfill of `parties.country` to canonical American English.
+ *
+ * Dry-run by default: prints a histogram of (before -> after) changes plus a
+ * list of unrecognized country strings (so Snax can decide whether to extend
+ * the override map / countryCode table before applying).
+ *
+ * Pass `--apply` to write to the DB. Each UPDATE includes a race-guard
+ * `WHERE country = $before` so concurrent writes from the API can't be
+ * silently overwritten.
+ *
+ * Loads backend/.env via DOTENV_PATH or the conventional path so this works
+ * from a worktree (no .env copy in the worktree dir).
+ *
+ * Notes:
+ *   - The override map and the name->ISO2 table are INLINED here because this
+ *     is a one-shot CJS script and TS sources can't be `require`'d. Keep this
+ *     in sync with backend/src/lib/canonicalCountryName.ts +
+ *     backend/src/lib/countryCode.ts. The trade-off is intentional.
+ *   - This script is read-only against `parties.country IS NOT NULL`. Rows
+ *     with country IS NULL are skipped entirely.
+ *   - The script never deletes rows; `--apply` only issues UPDATEs.
+ *
+ * Usage:
+ *   node scripts/backfill-canonical-country-names.cjs          # dry run
+ *   node scripts/backfill-canonical-country-names.cjs --apply  # write to DB
+ *
+ * Plan: plans/guanciale-43592.md
+ */
+
+const path = require('path');
+
+// Load backend/.env (worktrees don't have their own .env copy).
+const envPath =
+  process.env.DOTENV_PATH || path.resolve(__dirname, '..', 'backend', '.env');
+require('dotenv').config({ path: envPath });
+
+const { Client } = require('pg');
+
+const APPLY = process.argv.includes('--apply');
+
+// ---------------------------------------------------------------------------
+// INLINE COPY of backend/src/lib/countryCode.ts (name -> ISO2 alpha-2).
+// Keep in sync. Source of truth is the TS file; this is the script's snapshot.
+// ---------------------------------------------------------------------------
+
+const COUNTRY_NAME_TO_CODE = {
+  // A
+  afghanistan: 'AF', albania: 'AL', algeria: 'DZ', andorra: 'AD',
+  angola: 'AO', 'antigua and barbuda': 'AG', argentina: 'AR',
+  armenia: 'AM', australia: 'AU', austria: 'AT', azerbaijan: 'AZ',
+  // B
+  bahamas: 'BS', bahrain: 'BH', bangladesh: 'BD', barbados: 'BB',
+  belarus: 'BY', belgium: 'BE', belize: 'BZ', benin: 'BJ',
+  bhutan: 'BT', bolivia: 'BO', 'bosnia and herzegovina': 'BA',
+  botswana: 'BW', brazil: 'BR', brunei: 'BN', bulgaria: 'BG',
+  'burkina faso': 'BF', burundi: 'BI',
+  // C
+  cambodia: 'KH', cameroon: 'CM', canada: 'CA', 'cape verde': 'CV',
+  'central african republic': 'CF', chad: 'TD', chile: 'CL',
+  china: 'CN', colombia: 'CO', comoros: 'KM',
+  congo: 'CG',
+  'democratic republic of the congo': 'CD', 'dr congo': 'CD',
+  'costa rica': 'CR', "côte d'ivoire": 'CI', 'ivory coast': 'CI',
+  croatia: 'HR', cuba: 'CU', cyprus: 'CY', czechia: 'CZ',
+  'czech republic': 'CZ',
+  // D
+  denmark: 'DK', djibouti: 'DJ', dominica: 'DM',
+  'dominican republic': 'DO',
+  // E
+  ecuador: 'EC', egypt: 'EG', 'el salvador': 'SV',
+  'equatorial guinea': 'GQ', eritrea: 'ER', estonia: 'EE',
+  eswatini: 'SZ', ethiopia: 'ET',
+  // F
+  'faroe islands': 'FO', fiji: 'FJ', finland: 'FI', france: 'FR',
+  'french polynesia': 'PF',
+  // G
+  gabon: 'GA', gambia: 'GM', georgia: 'GE', germany: 'DE',
+  ghana: 'GH', greece: 'GR', grenada: 'GD', guadeloupe: 'GP',
+  guatemala: 'GT', guernsey: 'GG', guinea: 'GN', 'guinea-bissau': 'GW',
+  guyana: 'GY',
+  // H
+  haiti: 'HT', honduras: 'HN', 'hong kong': 'HK', hungary: 'HU',
+  // I
+  iceland: 'IS', india: 'IN', indonesia: 'ID', iran: 'IR',
+  iraq: 'IQ', ireland: 'IE', 'isle of man': 'IM', israel: 'IL',
+  italy: 'IT',
+  // J
+  jamaica: 'JM', japan: 'JP', jersey: 'JE', jordan: 'JO',
+  // K
+  kazakhstan: 'KZ', kenya: 'KE', kiribati: 'KI', kosovo: 'XK',
+  kuwait: 'KW', kyrgyzstan: 'KG',
+  // L
+  laos: 'LA', latvia: 'LV', lebanon: 'LB', lesotho: 'LS',
+  liberia: 'LR', libya: 'LY', liechtenstein: 'LI', lithuania: 'LT',
+  luxembourg: 'LU',
+  // M
+  macau: 'MO', madagascar: 'MG', malawi: 'MW', malaysia: 'MY',
+  maldives: 'MV', mali: 'ML', malta: 'MT', 'marshall islands': 'MH',
+  mauritania: 'MR', mauritius: 'MU', mexico: 'MX',
+  moldova: 'MD', monaco: 'MC', mongolia: 'MN', montenegro: 'ME',
+  morocco: 'MA', mozambique: 'MZ', myanmar: 'MM',
+  // N
+  namibia: 'NA', nauru: 'NR', nepal: 'NP', netherlands: 'NL',
+  'new zealand': 'NZ', nicaragua: 'NI', niger: 'NE', nigeria: 'NG',
+  'north korea': 'KP', 'north macedonia': 'MK', norway: 'NO',
+  // O
+  oman: 'OM',
+  // P
+  pakistan: 'PK', palau: 'PW',
+  palestine: 'PS', 'palestinian territories': 'PS',
+  panama: 'PA', 'papua new guinea': 'PG', paraguay: 'PY', peru: 'PE',
+  philippines: 'PH', poland: 'PL', portugal: 'PT', 'puerto rico': 'PR',
+  // Q
+  qatar: 'QA',
+  // R
+  romania: 'RO', russia: 'RU', rwanda: 'RW',
+  // S
+  'saint kitts and nevis': 'KN', 'saint lucia': 'LC',
+  'saint vincent and the grenadines': 'VC', samoa: 'WS',
+  'san marino': 'SM', 'são tomé and príncipe': 'ST',
+  'saudi arabia': 'SA', senegal: 'SN', serbia: 'RS',
+  seychelles: 'SC', 'sierra leone': 'SL', singapore: 'SG',
+  slovakia: 'SK', slovenia: 'SI', 'solomon islands': 'SB',
+  somalia: 'SO', 'south africa': 'ZA', 'south korea': 'KR',
+  'south sudan': 'SS', spain: 'ES', 'sri lanka': 'LK', sudan: 'SD',
+  suriname: 'SR', sweden: 'SE', switzerland: 'CH', syria: 'SY',
+  // T
+  taiwan: 'TW', tajikistan: 'TJ', tanzania: 'TZ', thailand: 'TH',
+  'timor-leste': 'TL', 'east timor': 'TL', togo: 'TG', tonga: 'TO',
+  'trinidad and tobago': 'TT', tunisia: 'TN', turkey: 'TR',
+  turkmenistan: 'TM', tuvalu: 'TV',
+  // U
+  uganda: 'UG', ukraine: 'UA', 'united arab emirates': 'AE',
+  'united kingdom': 'GB', uk: 'GB', 'great britain': 'GB',
+  'united states': 'US', usa: 'US', 'united states of america': 'US',
+  'u.s. virgin islands': 'VI', 'us virgin islands': 'VI',
+  uruguay: 'UY', uzbekistan: 'UZ',
+  // V
+  vanuatu: 'VU', 'vatican city': 'VA', venezuela: 'VE', vietnam: 'VN',
+  // Y
+  yemen: 'YE',
+  // Z
+  zambia: 'ZM', zimbabwe: 'ZW',
+};
+
+const COUNTRY_ALIASES = {
+  // German
+  deutschland: 'DE', österreich: 'AT', schweiz: 'CH',
+  // Spanish
+  españa: 'ES', méxico: 'MX', perú: 'PE', alemania: 'DE',
+  francia: 'FR', suiza: 'CH', 'república dominicana': 'DO',
+  // Portuguese
+  brasil: 'BR',
+  // Italian
+  italia: 'IT',
+  // French
+  algérie: 'DZ', maroc: 'MA',
+  'république démocratique du congo': 'CD',
+  'république du congo': 'CG',
+  // Dutch
+  nederland: 'NL',
+  // Danish
+  danmark: 'DK',
+  // Polish
+  polska: 'PL', 'wielka brytania': 'GB',
+  // Hungarian
+  szlovákia: 'SK',
+  // Romanian
+  románia: 'RO',
+  // Turkish
+  türkiye: 'TR',
+  // Vietnamese
+  'việt nam': 'VN',
+  // Bulgarian
+  българия: 'BG',
+  // Russian
+  грузия: 'GE',
+  // Arabic
+  الجزائر: 'DZ',
+  السعودية: 'SA',
+  العراق: 'IQ',
+  مصر: 'EG',
+  // CJK
+  中国: 'CN',
+  日本: 'JP',
+};
+
+function getCountryCode(country) {
+  if (!country || typeof country !== 'string') return null;
+  const trimmed = country.trim();
+  if (!trimmed) return null;
+  const key = trimmed.toLowerCase();
+  return COUNTRY_NAME_TO_CODE[key] || COUNTRY_ALIASES[key] || null;
+}
+
+// ---------------------------------------------------------------------------
+// INLINE COPY of backend/src/lib/canonicalCountryName.ts overrides.
+// Keep in sync with the TS file.
+// ---------------------------------------------------------------------------
+
+const OVERRIDES = {
+  HK: 'Hong Kong',
+  MO: 'Macao',
+  MM: 'Myanmar',
+  CD: 'DR Congo',
+  CG: 'Congo',
+  PS: 'Palestine',
+  ST: 'São Tomé and Príncipe',
+};
+
+const ENGLISH_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });
+
+function canonicalizeCountryName(input) {
+  if (!input || typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Normalize curly RIGHT SINGLE QUOTATION MARK (U+2019) on input so the
+  // straight-apostrophe alias ("côte d'ivoire") still matches.
+  const normalizedInput = trimmed.replace(/’/g, "'");
+
+  const code = getCountryCode(normalizedInput);
+  if (!code) return null;
+
+  if (OVERRIDES[code]) return OVERRIDES[code];
+
+  const name = ENGLISH_NAMES.of(code);
+  if (!name) return null;
+  // Intl emits U+2019 in "Côte d'Ivoire"; normalize to ASCII on output too.
+  return name.replace(/’/g, "'");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      `[backfill] DATABASE_URL not set. Tried loading from ${envPath}.`,
+    );
+    console.error(
+      '[backfill] Set DOTENV_PATH to the correct backend/.env path, or set DATABASE_URL directly.',
+    );
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  console.log(
+    `[backfill] Mode: ${APPLY ? 'APPLY (writes!)' : 'DRY-RUN (no writes)'}`,
+  );
+  console.log('[backfill] Reading parties.country values...');
+
+  const { rows } = await client.query(
+    'SELECT id, country FROM parties WHERE country IS NOT NULL',
+  );
+
+  console.log(`[backfill] ${rows.length} rows with non-null country.\n`);
+
+  // Bucket each row.
+  // - noop: canonical == current
+  // - change: canonical != current (recognized)
+  // - unrecognized: canonicalize returned null
+  const changes = []; // { id, before, after }
+  const unrecognized = []; // { id, before }
+  let noop = 0;
+
+  // Histogram of before->after counts.
+  const histogram = new Map(); // key = `${before} -> ${after}`, val = count
+
+  for (const row of rows) {
+    const before = row.country;
+    const after = canonicalizeCountryName(before);
+
+    if (after === null) {
+      unrecognized.push({ id: row.id, before });
+      continue;
+    }
+
+    if (after === before) {
+      noop += 1;
+      continue;
+    }
+
+    changes.push({ id: row.id, before, after });
+    const key = `${JSON.stringify(before)} -> ${JSON.stringify(after)}`;
+    histogram.set(key, (histogram.get(key) || 0) + 1);
+  }
+
+  // ---- Report ----
+  console.log('=== Histogram (changes, sorted by count desc) ===');
+  if (histogram.size === 0) {
+    console.log('  (no changes)');
+  } else {
+    const sorted = Array.from(histogram.entries()).sort(
+      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+    );
+    for (const [key, count] of sorted) {
+      console.log(`  ${String(count).padStart(5)}  ${key}`);
+    }
+  }
+  console.log('');
+
+  console.log('=== Unrecognized country strings (preserved verbatim) ===');
+  if (unrecognized.length === 0) {
+    console.log('  (none)');
+  } else {
+    // Group by raw string so the operator sees the distinct unrecognized set.
+    const grouped = new Map(); // string -> ids[]
+    for (const r of unrecognized) {
+      if (!grouped.has(r.before)) grouped.set(r.before, []);
+      grouped.get(r.before).push(r.id);
+    }
+    const sorted = Array.from(grouped.entries()).sort(
+      (a, b) => b[1].length - a[1].length,
+    );
+    for (const [raw, ids] of sorted) {
+      console.log(`  ${String(ids.length).padStart(5)}  ${JSON.stringify(raw)}`);
+      for (const id of ids) {
+        console.log(`         row id: ${id}`);
+      }
+    }
+  }
+  console.log('');
+
+  console.log('=== Totals ===');
+  console.log(`  Total rows with country     : ${rows.length}`);
+  console.log(`  No-op (already canonical)   : ${noop}`);
+  console.log(`  Will change                 : ${changes.length}`);
+  console.log(`  Unrecognized (will skip)    : ${unrecognized.length}`);
+  console.log('');
+
+  if (!APPLY) {
+    console.log('[backfill] DRY-RUN complete. No writes. Re-run with --apply to write.');
+    await client.end();
+    return;
+  }
+
+  if (changes.length === 0) {
+    console.log('[backfill] Nothing to write.');
+    await client.end();
+    return;
+  }
+
+  console.log(`[backfill] APPLY: writing ${changes.length} updates...`);
+  let updated = 0;
+  let raceSkipped = 0;
+  let failed = 0;
+
+  for (const c of changes) {
+    try {
+      // Race guard: only update if the current value is still what we read.
+      const res = await client.query(
+        'UPDATE parties SET country = $1 WHERE id = $2 AND country = $3',
+        [c.after, c.id, c.before],
+      );
+      if (res.rowCount === 1) {
+        updated += 1;
+        console.log(
+          `  ok    ${c.id}  ${JSON.stringify(c.before)} -> ${JSON.stringify(c.after)}`,
+        );
+      } else {
+        raceSkipped += 1;
+        console.log(
+          `  race  ${c.id}  ${JSON.stringify(c.before)} -> ${JSON.stringify(c.after)} (value changed between read and write)`,
+        );
+      }
+    } catch (err) {
+      failed += 1;
+      console.error(`  ERR   ${c.id}  ${err && err.message ? err.message : err}`);
+    }
+  }
+
+  console.log('');
+  console.log('=== Apply summary ===');
+  console.log(`  updated    : ${updated}`);
+  console.log(`  race-skipped: ${raceSkipped}`);
+  console.log(`  failed     : ${failed}`);
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error('[backfill] Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `canonicalizeCountryName()` helper using Intl.DisplayNames + override map for non-American Intl outputs (HK, MO, MM, CD, CG, PS, ST). Normalizes curly RIGHT SINGLE QUOTATION MARK on input AND output so "Côte d'Ivoire" round-trips with an ASCII apostrophe.
- One-shot script `scripts/backfill-canonical-country-names.cjs` (dry-run by default; `--apply` to write). Loops one UPDATE per row with a `WHERE country = $before` race guard.
- Defense-in-depth on the create path: POST + PATCH `/api/parties` canonicalize incoming `country` before write. Falls back to raw value when unrecognized (same "log + preserve" guarantee as the backfill).

Plan: `plans/guanciale-43592.md`

## Dry-run findings (1207 rows scanned)
- 1097 rows already canonical (no-op)
- 98 rows will change (most common: Brasil->Brazil ×19, México->Mexico ×19, Deutschland->Germany ×7, Italia->Italy ×6, Turkey->Türkiye ×5, España->Spain ×4)
- 12 unrecognized rows preserved verbatim (Sverige, Polen, Magyarország, Malaisie, Bosna i Hercegovina, Cayman Islands, The Bahamas, Índia, Турция, ישראל, United States Virgin Islands) — Snax may want to extend the alias map before applying.

A few rewrites use Intl's ampersand spelling ("Bosnia & Herzegovina", "Trinidad & Tobago", "Antigua & Barbuda") instead of "and". Snax can add overrides to `canonicalCountryName.ts` if "and" is preferred. Per modern CLDR, TR returns "Türkiye" — five rows currently spelled "Turkey" will be rewritten.

## Test plan
- [ ] Dry-run histogram reviewed by Snax
- [ ] Snax runs `--apply` from the master-deploy worktree once histogram is approved
- [ ] /leaderboard?nocache=1 shows no duplicate countries (España/Spain, Deutschland/Germany, México/Mexico, 日本/Japan, 中国/China, Italia/Italy, Perú/Peru, Österreich/Austria all collapsed)
- [ ] EventPage for a previously-Spanish-locale event renders "Spain" not "España"
- [ ] After PR merge, a freshly created event with `country: "Deutschland"` lands in DB as `"Germany"`
- [ ] `git diff frontend/` empty
- [ ] `git diff backend/prisma/` empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)