### PR TITLE
feat(soppressata-72251): /partner/bizdev partner industry report

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -79,6 +79,7 @@ import reminderRoutes from './routes/reminder.routes.js';
 import { taxFormRouter, adminTaxFormRouter } from './routes/tax-form.routes.js';
 import suggestionsRoutes from './routes/suggestions.routes.js'; // scarpetta-58472: admin/underboss-only suggestions list
 import savedViewsRoutes from './routes/saved-views.routes.js'; // montanara-58497: per-account saved filter views (/payments + /underboss)
+import bizdevRoutes from './routes/bizdev.routes.js'; // soppressata-72251: per-partner BizDev industry report (companies-only, no PII)
 
 const app = express();
 const PORT = process.env.PORT || 3006;
@@ -222,6 +223,7 @@ app.use('/api/checkin', checkinRoutes);
 app.use('/api/survey', surveyPublicRouter); // romana-61204: public token-based survey (no auth)
 app.use('/api/cron', cronRouter); // romana-61204: cron-only survey auto-send (CRON_SECRET gate)
 app.use('/api/scorecard', scorecardRoutes);
+app.use('/api/bizdev', bizdevRoutes); // soppressata-72251: per-partner BizDev industry report (auth-gated per-route)
 app.use('/api/display', displayRoutes); // Public display viewer routes
 app.use('/api/reports', reportRoutes); // Public report viewing via slug
 app.use('/api/reports', venueReportRoutes); // Public venue report viewing via slug

--- a/backend/src/lib/bizdevPartners.ts
+++ b/backend/src/lib/bizdevPartners.ts
@@ -1,0 +1,85 @@
+// soppressata-72251: per-partner BizDev report lenses (TS port of the
+// stracciatella-72140 partner config). Each partner FEATURES the taxonomy
+// buckets most relevant to it; every other bucket with matches still shows
+// under "Other industries". `lensBuckets` order = display order.
+//
+// Scope for ALL partners is identical: approved GPP events
+// (event_type='gpp' AND underboss_status='approved'). The partner only changes
+// which buckets are FEATURED, NOT the event universe.
+//
+// `id` is the public-facing `?partner=` slug. `tag` is the REAL value to compare
+// against `SponsorUser.tag` for access control (it usually equals `id`, but
+// e.g. Stand With Crypto's sponsor/event tag is `swc`, not `stand-with-crypto`).
+
+export interface BizdevPartner {
+  id: string;
+  /** Real SponsorUser.tag / event-tag value used for access control. */
+  tag: string;
+  label: string;
+  blurb: string;
+  lensBuckets: string[];
+}
+
+export const BIZDEV_PARTNERS: BizdevPartner[] = [
+  {
+    id: 'ens',
+    tag: 'ens',
+    label: 'ENS',
+    blurb: 'Ethereum Name Service — umbrella GPP sponsor. Lens: the Ethereum ecosystem.',
+    lensBuckets: ['identity-naming', 'chains-l2-infra', 'wallets-custody', 'defi',
+      'developer-tooling', 'daos-communities'],
+  },
+  {
+    id: 'stand-with-crypto',
+    // SponsorUser.tag / event-tag is `swc` (confirmed across the codebase:
+    // admin.routes.ts opt-in column map, StandWithCryptoCard, PrintTab requireTag).
+    tag: 'swc',
+    label: 'Stand With Crypto',
+    blurb: 'Crypto policy & advocacy. Lens: the whole industry that mobilizes / advocates.',
+    lensBuckets: ['advocacy-policy', 'exchanges', 'funds-and-vc', 'stablecoins-payments',
+      'chains-l2-infra', 'wallets-custody', 'defi'],
+  },
+  {
+    id: 'brave',
+    tag: 'brave',
+    label: 'Brave',
+    blurb: 'Browser, privacy & BAT. Lens: ad-tech, publishers, privacy, creators.',
+    lensBuckets: ['adtech-publishers-privacy', 'wallets-custody', 'media', 'gaming-nft', 'defi'],
+  },
+  {
+    id: 'tangem',
+    tag: 'tangem',
+    label: 'Tangem',
+    blurb: 'Hardware wallet. Lens: self-custody, exchanges, security, Bitcoin.',
+    lensBuckets: ['wallets-custody', 'bitcoin-native', 'exchanges', 'security-audit'],
+  },
+  {
+    id: 'bitvavo',
+    tag: 'bitvavo',
+    label: 'Bitvavo',
+    blurb: 'EU exchange. Lens: exchanges, institutional & asset management.',
+    lensBuckets: ['exchanges', 'funds-and-vc', 'asset-managers', 'stablecoins-payments'],
+  },
+  {
+    id: 'octant',
+    tag: 'octant',
+    label: 'Octant',
+    blurb: 'Public-goods funding (Golem). Lens: regen, DAOs, grant funds, Ethereum infra.',
+    lensBuckets: ['public-goods-regen', 'daos-communities', 'funds-and-vc', 'chains-l2-infra',
+      'developer-tooling'],
+  },
+];
+
+/**
+ * Resolve a `?partner=` value (case-insensitive) to a partner config. Matches
+ * either the public `id` slug OR the real `tag` so both `stand-with-crypto`
+ * and `swc` resolve to the same partner. Returns null for an unknown partner.
+ */
+export function resolveBizdevPartner(raw: string | null | undefined): BizdevPartner | null {
+  if (!raw) return null;
+  const q = String(raw).trim().toLowerCase();
+  if (!q) return null;
+  return (
+    BIZDEV_PARTNERS.find((p) => p.id.toLowerCase() === q || p.tag.toLowerCase() === q) || null
+  );
+}

--- a/backend/src/lib/industryTaxonomy.ts
+++ b/backend/src/lib/industryTaxonomy.ts
@@ -1,0 +1,423 @@
+// soppressata-72251: master crypto-industry taxonomy (TS port of the curated
+// stracciatella-72140 dictionary). Maps an email domain -> { company, bucket }
+// so one classifier powers per-partner BizDev report lenses at /api/bizdev.
+// Local-only, curated, no network. Counts are a FLOOR — most guests use freemail.
+// `(inferred)` = keyword match on an unknown domain (confidence: 'medium').
+//
+// NOTE: this is intentionally separate from `emailDomains.ts` (which only
+// derives org domains for the consolidated report). They MUST NOT diverge on
+// the personal-email exclusion semantics — see FREEMAIL/INTERNAL below, which
+// is the superset of `emailDomains.PERSONAL_EMAIL_PROVIDERS`. If you add a
+// freemail provider in one place, mirror it here (and vice-versa).
+
+export const TAXONOMY_VERSION = 1;
+
+export type IndustryConfidence = 'high' | 'medium';
+
+export interface DomainClassification {
+  company: string;
+  bucket: string;
+  confidence: IndustryConfidence;
+}
+
+// id -> label
+export const BUCKETS: Record<string, string> = {
+  'exchanges': 'Exchanges',
+  'chains-l2-infra': 'Chains, L2s & infrastructure',
+  'wallets-custody': 'Wallets & custody',
+  'defi': 'DeFi protocols',
+  'stablecoins-payments': 'Stablecoins & payments',
+  'funds-and-vc': 'Funds & VC',
+  'asset-managers': 'Asset managers / ETF issuers',
+  'mining': 'Bitcoin mining',
+  'dats': 'Digital Asset Treasuries',
+  'bitcoin-native': 'Bitcoin-native protocols & companies',
+  'identity-naming': 'Identity & naming',
+  'developer-tooling': 'Developer tooling & data',
+  'security-audit': 'Security & audit',
+  'advocacy-policy': 'Advocacy & policy',
+  'adtech-publishers-privacy': 'Ad-tech, publishers & privacy',
+  'public-goods-regen': 'Public goods & regen',
+  'media': 'Media',
+  'gaming-nft': 'Gaming & NFT',
+  'daos-communities': 'DAOs & communities',
+};
+
+// Exact registrable-domain -> { company, bucket }. HIGH confidence.
+export const DOMAIN_MAP: Record<string, { company: string; bucket: string }> = {
+  // ===== exchanges =====
+  'coinbase.com': { company: 'Coinbase', bucket: 'exchanges' },
+  'binance.com': { company: 'Binance', bucket: 'exchanges' },
+  'kraken.com': { company: 'Kraken', bucket: 'exchanges' },
+  'bybit.com': { company: 'Bybit', bucket: 'exchanges' },
+  'bitvavo.com': { company: 'Bitvavo', bucket: 'exchanges' },
+  'okx.com': { company: 'OKX', bucket: 'exchanges' },
+  'gemini.com': { company: 'Gemini', bucket: 'exchanges' },
+  'crypto.com': { company: 'Crypto.com', bucket: 'exchanges' },
+  'kucoin.com': { company: 'KuCoin', bucket: 'exchanges' },
+  'bitstamp.net': { company: 'Bitstamp', bucket: 'exchanges' },
+  'bitfinex.com': { company: 'Bitfinex', bucket: 'exchanges' },
+  'gate.io': { company: 'Gate.io', bucket: 'exchanges' },
+  'mexc.com': { company: 'MEXC', bucket: 'exchanges' },
+  'bitget.com': { company: 'Bitget', bucket: 'exchanges' },
+  'luno.com': { company: 'Luno', bucket: 'exchanges' },
+  'bitso.com': { company: 'Bitso', bucket: 'exchanges' },
+  'ripio.com': { company: 'Ripio', bucket: 'exchanges' },
+  'buenbit.com': { company: 'Buenbit', bucket: 'exchanges' },
+  'mercadobitcoin.com.br': { company: 'Mercado Bitcoin', bucket: 'exchanges' },
+
+  // ===== chains, L2s & infra =====
+  'ethereum.org': { company: 'Ethereum Foundation', bucket: 'chains-l2-infra' },
+  'optimism.io': { company: 'Optimism', bucket: 'chains-l2-infra' },
+  'arbitrum.foundation': { company: 'Arbitrum', bucket: 'chains-l2-infra' },
+  'offchainlabs.com': { company: 'Offchain Labs (Arbitrum)', bucket: 'chains-l2-infra' },
+  'polygon.technology': { company: 'Polygon', bucket: 'chains-l2-infra' },
+  'matterlabs.dev': { company: 'Matter Labs (zkSync)', bucket: 'chains-l2-infra' },
+  'base.org': { company: 'Base', bucket: 'chains-l2-infra' },
+  'consensys.net': { company: 'Consensys', bucket: 'chains-l2-infra' },
+  'consensys.io': { company: 'Consensys', bucket: 'chains-l2-infra' },
+  'infura.io': { company: 'Infura', bucket: 'chains-l2-infra' },
+  'alchemy.com': { company: 'Alchemy', bucket: 'chains-l2-infra' },
+  'quicknode.com': { company: 'QuickNode', bucket: 'chains-l2-infra' },
+  'chainlinklabs.com': { company: 'Chainlink Labs', bucket: 'chains-l2-infra' },
+  'thegraph.com': { company: 'The Graph', bucket: 'chains-l2-infra' },
+  'avalabs.org': { company: 'Ava Labs (Avalanche)', bucket: 'chains-l2-infra' },
+  'solana.org': { company: 'Solana Foundation', bucket: 'chains-l2-infra' },
+  'solana.com': { company: 'Solana', bucket: 'chains-l2-infra' },
+  'near.org': { company: 'NEAR', bucket: 'chains-l2-infra' },
+  'aptoslabs.com': { company: 'Aptos', bucket: 'chains-l2-infra' },
+  'mystenlabs.com': { company: 'Mysten Labs (Sui)', bucket: 'chains-l2-infra' },
+  'celo.org': { company: 'Celo', bucket: 'chains-l2-infra' },
+  'confluxnetwork.org': { company: 'Conflux', bucket: 'chains-l2-infra' },
+  'scroll.io': { company: 'Scroll', bucket: 'chains-l2-infra' },
+  'starkware.co': { company: 'StarkWare', bucket: 'chains-l2-infra' },
+
+  // ===== wallets & custody =====
+  'metamask.io': { company: 'MetaMask', bucket: 'wallets-custody' },
+  'ledger.com': { company: 'Ledger', bucket: 'wallets-custody' },
+  'ledger.fr': { company: 'Ledger', bucket: 'wallets-custody' },
+  'tangem.com': { company: 'Tangem', bucket: 'wallets-custody' },
+  'trezor.io': { company: 'Trezor', bucket: 'wallets-custody' },
+  'safe.global': { company: 'Safe', bucket: 'wallets-custody' },
+  'fireblocks.com': { company: 'Fireblocks', bucket: 'wallets-custody' },
+  'rainbow.me': { company: 'Rainbow', bucket: 'wallets-custody' },
+  'argent.xyz': { company: 'Argent', bucket: 'wallets-custody' },
+  'zerion.io': { company: 'Zerion', bucket: 'wallets-custody' },
+  'phantom.app': { company: 'Phantom', bucket: 'wallets-custody' },
+  'trustwallet.com': { company: 'Trust Wallet', bucket: 'wallets-custody' },
+  'bitgo.com': { company: 'BitGo', bucket: 'wallets-custody' },
+  'copper.co': { company: 'Copper', bucket: 'wallets-custody' },
+  'anchorage.com': { company: 'Anchorage Digital', bucket: 'wallets-custody' },
+  'reown.com': { company: 'Reown (WalletConnect)', bucket: 'wallets-custody' },
+
+  // ===== DeFi =====
+  'uniswap.org': { company: 'Uniswap', bucket: 'defi' },
+  'aave.com': { company: 'Aave', bucket: 'defi' },
+  'makerdao.com': { company: 'MakerDAO / Sky', bucket: 'defi' },
+  'sky.money': { company: 'Sky (MakerDAO)', bucket: 'defi' },
+  'compound.finance': { company: 'Compound', bucket: 'defi' },
+  'curve.fi': { company: 'Curve', bucket: 'defi' },
+  'lido.fi': { company: 'Lido', bucket: 'defi' },
+  'rocketpool.net': { company: 'Rocket Pool', bucket: 'defi' },
+  '1inch.io': { company: '1inch', bucket: 'defi' },
+  'gmx.io': { company: 'GMX', bucket: 'defi' },
+  'synthetix.io': { company: 'Synthetix', bucket: 'defi' },
+  'dydx.exchange': { company: 'dYdX', bucket: 'defi' },
+  'ondo.finance': { company: 'Ondo Finance', bucket: 'defi' },
+  'pendle.finance': { company: 'Pendle', bucket: 'defi' },
+
+  // ===== stablecoins & payments =====
+  'tether.to': { company: 'Tether', bucket: 'stablecoins-payments' },
+  'circle.com': { company: 'Circle (USDC)', bucket: 'stablecoins-payments' },
+  'paxos.com': { company: 'Paxos', bucket: 'stablecoins-payments' },
+  'moonpay.com': { company: 'MoonPay', bucket: 'stablecoins-payments' },
+  'ramp.network': { company: 'Ramp', bucket: 'stablecoins-payments' },
+  'transak.com': { company: 'Transak', bucket: 'stablecoins-payments' },
+  'stripe.com': { company: 'Stripe', bucket: 'stablecoins-payments' },
+  'bridge.xyz': { company: 'Bridge', bucket: 'stablecoins-payments' },
+  'request.finance': { company: 'Request Finance', bucket: 'stablecoins-payments' },
+  'takenos.com': { company: 'Takenos', bucket: 'stablecoins-payments' },
+  'lemon.me': { company: 'Lemon', bucket: 'stablecoins-payments' },
+
+  // ===== identity & naming =====
+  'ens.domains': { company: 'ENS', bucket: 'identity-naming' },
+  'unstoppabledomains.com': { company: 'Unstoppable Domains', bucket: 'identity-naming' },
+  'lens.xyz': { company: 'Lens', bucket: 'identity-naming' },
+  'farcaster.xyz': { company: 'Farcaster', bucket: 'identity-naming' },
+  'merklemanufactory.com': { company: 'Farcaster (Merkle Manufactory)', bucket: 'identity-naming' },
+  'spruceid.com': { company: 'SpruceID', bucket: 'identity-naming' },
+
+  // ===== developer tooling & data =====
+  'tenderly.co': { company: 'Tenderly', bucket: 'developer-tooling' },
+  'openzeppelin.com': { company: 'OpenZeppelin', bucket: 'developer-tooling' },
+  'thirdweb.com': { company: 'thirdweb', bucket: 'developer-tooling' },
+  'moralis.io': { company: 'Moralis', bucket: 'developer-tooling' },
+  'dune.com': { company: 'Dune', bucket: 'developer-tooling' },
+  'flipsidecrypto.xyz': { company: 'Flipside Crypto', bucket: 'developer-tooling' },
+  'etherscan.io': { company: 'Etherscan', bucket: 'developer-tooling' },
+  'blockscout.com': { company: 'Blockscout', bucket: 'developer-tooling' },
+  'nomicfoundation.org': { company: 'Nomic Foundation (Hardhat)', bucket: 'developer-tooling' },
+
+  // ===== security & audit =====
+  'trailofbits.com': { company: 'Trail of Bits', bucket: 'security-audit' },
+  'certik.com': { company: 'CertiK', bucket: 'security-audit' },
+  'quantstamp.com': { company: 'Quantstamp', bucket: 'security-audit' },
+  'halborn.com': { company: 'Halborn', bucket: 'security-audit' },
+  'hacken.io': { company: 'Hacken', bucket: 'security-audit' },
+  'slowmist.com': { company: 'SlowMist', bucket: 'security-audit' },
+
+  // ===== advocacy & policy =====
+  'standwithcrypto.org': { company: 'Stand With Crypto', bucket: 'advocacy-policy' },
+  'coincenter.org': { company: 'Coin Center', bucket: 'advocacy-policy' },
+  'theblockchainassociation.org': { company: 'Blockchain Association', bucket: 'advocacy-policy' },
+  'digitalchamber.org': { company: 'Digital Chamber', bucket: 'advocacy-policy' },
+  'defieducationfund.org': { company: 'DeFi Education Fund', bucket: 'advocacy-policy' },
+
+  // ===== ad-tech, publishers & privacy =====
+  'brave.com': { company: 'Brave', bucket: 'adtech-publishers-privacy' },
+  'basicattentiontoken.org': { company: 'Basic Attention Token', bucket: 'adtech-publishers-privacy' },
+
+  // ===== public goods & regen =====
+  'octant.build': { company: 'Octant', bucket: 'public-goods-regen' },
+  'golem.network': { company: 'Golem Foundation', bucket: 'public-goods-regen' },
+  'gitcoin.co': { company: 'Gitcoin', bucket: 'public-goods-regen' },
+  'giveth.io': { company: 'Giveth', bucket: 'public-goods-regen' },
+
+  // ===== media =====
+  'coindesk.com': { company: 'CoinDesk', bucket: 'media' },
+  'cointelegraph.com': { company: 'Cointelegraph', bucket: 'media' },
+  'theblock.co': { company: 'The Block', bucket: 'media' },
+  'decrypt.co': { company: 'Decrypt', bucket: 'media' },
+  'bankless.com': { company: 'Bankless', bucket: 'media' },
+
+  // ===== gaming & NFT =====
+  'opensea.io': { company: 'OpenSea', bucket: 'gaming-nft' },
+  'dapperlabs.com': { company: 'Dapper Labs', bucket: 'gaming-nft' },
+  'immutable.com': { company: 'Immutable', bucket: 'gaming-nft' },
+  'yuga.com': { company: 'Yuga Labs', bucket: 'gaming-nft' },
+  'animocabrands.com': { company: 'Animoca Brands', bucket: 'gaming-nft' },
+  'skymavis.com': { company: 'Sky Mavis (Axie)', bucket: 'gaming-nft' },
+  'magiceden.io': { company: 'Magic Eden', bucket: 'gaming-nft' },
+
+  // ===== DAOs & communities =====
+  'ownthedoge.com': { company: 'Own The Doge', bucket: 'daos-communities' },
+  'aragon.org': { company: 'Aragon', bucket: 'daos-communities' },
+
+  // ===== funds & VC (carried from Rootstock + promotions) =====
+  'a16z.com': { company: 'a16z', bucket: 'funds-and-vc' },
+  'a16zcrypto.com': { company: 'a16z crypto', bucket: 'funds-and-vc' },
+  'paradigm.xyz': { company: 'Paradigm', bucket: 'funds-and-vc' },
+  'panteracapital.com': { company: 'Pantera Capital', bucket: 'funds-and-vc' },
+  'polychain.capital': { company: 'Polychain Capital', bucket: 'funds-and-vc' },
+  'multicoin.capital': { company: 'Multicoin Capital', bucket: 'funds-and-vc' },
+  'electriccapital.com': { company: 'Electric Capital', bucket: 'funds-and-vc' },
+  'dragonfly.xyz': { company: 'Dragonfly', bucket: 'funds-and-vc' },
+  'variant.fund': { company: 'Variant', bucket: 'funds-and-vc' },
+  'framework.ventures': { company: 'Framework Ventures', bucket: 'funds-and-vc' },
+  'galaxy.com': { company: 'Galaxy', bucket: 'funds-and-vc' },
+  'castleisland.vc': { company: 'Castle Island Ventures', bucket: 'funds-and-vc' },
+  'stillmark.com': { company: 'Stillmark', bucket: 'funds-and-vc' },
+  'ten31.vc': { company: 'Ten31', bucket: 'funds-and-vc' },
+  'trammellvp.com': { company: 'Trammell Venture Partners', bucket: 'funds-and-vc' },
+  'fulgur.ventures': { company: 'Fulgur Ventures', bucket: 'funds-and-vc' },
+  'brevanhoward.com': { company: 'Brevan Howard', bucket: 'funds-and-vc' },
+  'thielcapital.com': { company: 'Thiel Capital', bucket: 'funds-and-vc' },
+  'iconiqcapital.com': { company: 'Iconiq Capital', bucket: 'funds-and-vc' },
+  'outlierventures.io': { company: 'Outlier Ventures', bucket: 'funds-and-vc' },
+  'arringtoncapital.com': { company: 'Arrington Capital', bucket: 'funds-and-vc' },
+  'defiance.capital': { company: 'DeFiance Capital', bucket: 'funds-and-vc' },
+  'shima.capital': { company: 'Shima Capital', bucket: 'funds-and-vc' },
+  'whitestarcapital.com': { company: 'White Star Capital', bucket: 'funds-and-vc' },
+  'targetglobal.vc': { company: 'Target Global', bucket: 'funds-and-vc' },
+  'draper.vc': { company: 'Draper', bucket: 'funds-and-vc' },
+  'bloccelerate.vc': { company: 'Bloccelerate VC', bucket: 'funds-and-vc' },
+  'fracton.ventures': { company: 'Fracton Ventures', bucket: 'funds-and-vc' },
+  'redbeard.ventures': { company: 'Redbeard Ventures', bucket: 'funds-and-vc' },
+  'blockchange.vc': { company: 'Blockchange Ventures', bucket: 'funds-and-vc' },
+  'cmcc.vc': { company: 'CMCC Global', bucket: 'funds-and-vc' },
+  'ngc.fund': { company: 'NGC Ventures', bucket: 'funds-and-vc' },
+  'cyphercapital.com': { company: 'Cypher Capital', bucket: 'funds-and-vc' },
+  'cosimo.fund': { company: 'Cosimo Ventures', bucket: 'funds-and-vc' },
+  'whitelioncapital.com': { company: 'Whitelion Capital', bucket: 'funds-and-vc' },
+  'polymorphic.capital': { company: 'Polymorphic Capital', bucket: 'funds-and-vc' },
+  'blockonventures.com': { company: 'BlockOn Ventures', bucket: 'funds-and-vc' },
+  'kosmos.vc': { company: 'Kosmos Ventures', bucket: 'funds-and-vc' },
+  'gft.vc': { company: 'GFT Ventures', bucket: 'funds-and-vc' },
+  'matchstick.vc': { company: 'Matchstick Ventures', bucket: 'funds-and-vc' },
+  'onebit.ventures': { company: 'OneBit Ventures', bucket: 'funds-and-vc' },
+  'onigiri.vc': { company: 'Onigiri Capital', bucket: 'funds-and-vc' },
+  'trive.vc': { company: 'Trive Ventures', bucket: 'funds-and-vc' },
+
+  // ===== asset managers (carried) =====
+  'blackrock.com': { company: 'BlackRock', bucket: 'asset-managers' },
+  'fidelity.com': { company: 'Fidelity', bucket: 'asset-managers' },
+  'fidelitydigitalassets.com': { company: 'Fidelity Digital Assets', bucket: 'asset-managers' },
+  'vaneck.com': { company: 'VanEck', bucket: 'asset-managers' },
+  'grayscale.com': { company: 'Grayscale', bucket: 'asset-managers' },
+  'bitwiseinvestments.com': { company: 'Bitwise', bucket: 'asset-managers' },
+  'bitwise.com': { company: 'Bitwise', bucket: 'asset-managers' },
+  'ark-invest.com': { company: 'ARK Invest', bucket: 'asset-managers' },
+  'franklintempleton.com': { company: 'Franklin Templeton', bucket: 'asset-managers' },
+  'invesco.com': { company: 'Invesco', bucket: 'asset-managers' },
+  'wisdomtree.com': { company: 'WisdomTree', bucket: 'asset-managers' },
+  '21shares.com': { company: '21Shares', bucket: 'asset-managers' },
+  'coinshares.com': { company: 'CoinShares', bucket: 'asset-managers' },
+  'hashdex.com': { company: 'Hashdex', bucket: 'asset-managers' },
+  'nydig.com': { company: 'NYDIG', bucket: 'asset-managers' },
+
+  // ===== mining (carried) =====
+  'mara.com': { company: 'Marathon Digital (MARA)', bucket: 'mining' },
+  'marathondh.com': { company: 'Marathon Digital (MARA)', bucket: 'mining' },
+  'riotplatforms.com': { company: 'Riot Platforms', bucket: 'mining' },
+  'corescientific.com': { company: 'Core Scientific', bucket: 'mining' },
+  'cleanspark.com': { company: 'CleanSpark', bucket: 'mining' },
+  'terawulf.com': { company: 'TeraWulf', bucket: 'mining' },
+  'ciphermining.com': { company: 'Cipher Mining', bucket: 'mining' },
+  'bitfarms.com': { company: 'Bitfarms', bucket: 'mining' },
+  'hut8.com': { company: 'Hut 8', bucket: 'mining' },
+  'iren.com': { company: 'IREN (Iris Energy)', bucket: 'mining' },
+  'irisenergy.co': { company: 'IREN (Iris Energy)', bucket: 'mining' },
+  'bitdeer.com': { company: 'Bitdeer', bucket: 'mining' },
+  'foundrydigital.com': { company: 'Foundry', bucket: 'mining' },
+  'luxor.tech': { company: 'Luxor Technology', bucket: 'mining' },
+  'braiins.com': { company: 'Braiins / Slush Pool', bucket: 'mining' },
+  'compassmining.io': { company: 'Compass Mining', bucket: 'mining' },
+
+  // ===== DATs (carried) =====
+  'strategy.com': { company: 'Strategy (MicroStrategy)', bucket: 'dats' },
+  'microstrategy.com': { company: 'Strategy (MicroStrategy)', bucket: 'dats' },
+  'metaplanet.jp': { company: 'Metaplanet', bucket: 'dats' },
+  'semlerscientific.com': { company: 'Semler Scientific', bucket: 'dats' },
+  'block.xyz': { company: 'Block, Inc.', bucket: 'dats' },
+
+  // ===== bitcoin-native (carried) =====
+  'rootstock.io': { company: 'Rootstock', bucket: 'bitcoin-native' },
+  'rsk.co': { company: 'Rootstock (RSK)', bucket: 'bitcoin-native' },
+  'iovlabs.org': { company: 'IOV Labs / RIF', bucket: 'bitcoin-native' },
+  'blockstream.com': { company: 'Blockstream', bucket: 'bitcoin-native' },
+  'lightning.engineering': { company: 'Lightning Labs', bucket: 'bitcoin-native' },
+  'spiral.xyz': { company: 'Spiral', bucket: 'bitcoin-native' },
+  'chaincode.com': { company: 'Chaincode Labs', bucket: 'bitcoin-native' },
+  'brink.dev': { company: 'Brink', bucket: 'bitcoin-native' },
+  'strike.me': { company: 'Strike', bucket: 'bitcoin-native' },
+  'river.com': { company: 'River', bucket: 'bitcoin-native' },
+  'swanbitcoin.com': { company: 'Swan Bitcoin', bucket: 'bitcoin-native' },
+  'unchained.com': { company: 'Unchained', bucket: 'bitcoin-native' },
+  'casa.io': { company: 'Casa', bucket: 'bitcoin-native' },
+  'voltage.cloud': { company: 'Voltage', bucket: 'bitcoin-native' },
+  'hiro.so': { company: 'Hiro / Stacks', bucket: 'bitcoin-native' },
+  'babylonlabs.io': { company: 'Babylon', bucket: 'bitcoin-native' },
+  'hrf.org': { company: 'Human Rights Foundation', bucket: 'bitcoin-native' },
+  'opensats.org': { company: 'OpenSats', bucket: 'bitcoin-native' },
+  'bitcoinmagazine.com': { company: 'Bitcoin Magazine', bucket: 'bitcoin-native' },
+  'mimo.capital': { company: 'Mimo (Rootstock)', bucket: 'bitcoin-native' },
+};
+
+// Substring/regex fallback for UNKNOWN domains. MEDIUM confidence. First match
+// wins, so order most-specific first. Negative lookarounds kill known false
+// positives.
+export const KEYWORD_RULES: { pattern: RegExp; bucket: string }[] = [
+  { pattern: /mining|miner(?!va)|hashrate|hashpower/i, bucket: 'mining' },
+  { pattern: /asset[\s._-]?(management|mgmt)|advisors/i, bucket: 'asset-managers' },
+  { pattern: /treasury/i, bucket: 'dats' },
+  { pattern: /\bwallet/i, bucket: 'wallets-custody' },
+  { pattern: /bitcoin|lightning|\bbtc\b|\bsats\b/i, bucket: 'bitcoin-native' },
+  { pattern: /(?<!ad)ventures?|capital|partners(?!hip)|family[\s._-]?office|endowment|\.vc$|\.fund$/i,
+    bucket: 'funds-and-vc' },
+];
+
+// Personal / free webmail — names no company. Never classify.
+export const FREEMAIL: Set<string> = new Set([
+  'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com', 'msn.com',
+  'yahoo.com', 'ymail.com', 'icloud.com', 'me.com', 'mac.com', 'proton.me', 'protonmail.com',
+  'pm.me', 'aol.com', 'gmx.com', 'gmx.de', 'mail.com', 'zoho.com', 'yandex.com', 'fastmail.com',
+  'hey.com', 'duck.com', 'tutanota.com', 'qq.com', '163.com', '126.com', 'foxmail.com',
+  'naver.com', 'hotmail.co.uk', 'yahoo.co.uk', 'yahoo.co.jp', 'web.de', 't-online.de',
+  'orange.fr', 'free.fr', 'hotmail.fr', 'yahoo.fr', 'gmail.con', 'outlook.es', 'hotmail.es',
+  'seznam.cz', 'mail.ru', 'list.ru', 'bk.ru', 'inbox.ru', 'rambler.ru', 'ya.ru',
+  'privaterelay.appleid.com', 'passmail.net', 'passinbox.com', 'simplelogin.com', 'relay.firefox.com',
+  'comcast.net', 'verizon.net', 'att.net', 'sbcglobal.net', 'cox.net', 'bellsouth.net',
+  'charter.net', 'earthlink.net', 'roadrunner.com', 'optonline.net', 'frontier.com',
+  'gmx.net', 'freenet.de', 'arcor.de', 'laposte.net', 'sfr.fr', 'wanadoo.fr', 'bbox.fr',
+  'wp.pl', 'o2.pl', 'interia.pl', 'onet.pl', 'abv.bg', 'libero.it', 'virgilio.it', 'tin.it',
+  'alice.it', 'terra.com.br', 'uol.com.br', 'bol.com.br', 'hotmail.com.br', 'yahoo.com.br',
+  'yahoo.com.ar', 'yahoo.com.mx', 'yahoo.es', 'yahoo.de', 'yahoo.it', 'yahoo.ca', 'yahoo.in',
+  'yahoo.com.ph', 'yahoo.gr', 'rediffmail.com', 'sina.com', 'sohu.com', 'aliyun.com',
+  'outlook.fr', 'outlook.de', 'outlook.com.br', 'outlook.it', 'hotmail.de', 'hotmail.it',
+  'hotmail.com.ar', 'hotmail.com.mx', 'live.fr', 'live.com.mx', 'live.com.ar', 'live.co.uk',
+]);
+
+// Non-company junk (test fixtures + PizzaDAO's own).
+export const INTERNAL: Set<string> = new Set([
+  'test.com', 'test.test', 'example.com', 'example.org', 'rarepizzas.com', 'pizzadao.com',
+]);
+
+// Readable names for keyword-inferred domains we couldn't verify (stay MEDIUM /
+// `(inferred)`). Carried from the Rootstock report; extend freely.
+export const DISPLAY_NAMES: Record<string, string> = {
+  'elkcapitalmarkets.com': 'Elk Capital Markets', 'penrosepartners.com': 'Penrose Partners',
+  'silverminecapital.com': 'Silvermine Capital', 'allo.capital': 'Allo Capital',
+  'arcanum.capital': 'Arcanum Capital', 'brd.capital': 'BRD Capital',
+  'digitalfamilyoffice.io': 'Digital Family Office', 'funders.vc': 'Funders VC',
+  'iftcfamilyoffice.com': 'IFTC Family Office', 'lightnodeventures.com': 'Lightnode Ventures',
+  'newchiccapital.com': 'Newchic Capital', 'smartpay.com.vc': 'SmartPay',
+  '2punkscapital.com': '2Punks Capital', '5dcapital.org': '5D Capital', 'alchemist.fund': 'Alchemist',
+  'allenfamilyoffice.com': 'Allen Family Office', 'arbalestpartners.com': 'Arbalest Partners',
+  'armanhammercapital.com': 'Arman Hammer Capital', 'basalcapital.xyz': 'Basal Capital',
+  'baytechcapital.com': 'Baytech Capital', 'beyondventures.hk': 'Beyond Ventures',
+  'quantixcapital.xyz': 'Quantix Capital', 'blockcrestcapital.com': 'Blockcrest Capital',
+  'blockstreet.capital': 'Blockstreet Capital', 'boltscapital.com': 'Bolts Capital',
+  'brownricecapital.com': 'Brown Rice Capital', 'btcfrontier.fund': 'BTC Frontier Fund',
+  'buzzbridge.capital': 'Buzzbridge Capital', 'calocapital.io': 'Calo Capital',
+  'capitaltao.com': 'Capital Tao', 'cmventure.net': 'CM Venture', 'cofounder.fund': 'Cofounder Fund',
+  'cryptobytecapital.com': 'CryptoByte Capital', 'dhvp.vc': 'DHVP', 'dira.capital': 'Dira Capital',
+  'dmtech.vc': 'DM Tech Ventures', 'dwfventuresllc.com': 'DWF Ventures', 'edge-capital-fund.com': 'Edge Capital',
+  'eh.capital': 'EH Capital', 'exitliquiditycapital.com': 'Exit Liquidity Capital',
+  'forasventures.com': 'Foras Ventures', 'gain.ventures': 'Gain Ventures',
+  'haliburtoncapitalgroup.com': 'Haliburton Capital Group', 'inception.capital': 'Inception Capital',
+  'izwanpartners.com': 'Izwan Partners', 'keyplayercapital.com': 'Key Player Capital',
+  'kitpartners.asia': 'KIT Partners', 'lecrypcapital.com': 'Lecryp Capital',
+  'montoyacapital.org': 'Montoya Capital', 'morgancapital.org': 'Morgan Capital',
+  'mossyventures.com': 'Mossy Ventures', 'mpipartners.com': 'MPI Partners', 'nakama.fund': 'Nakama Fund',
+  'neotechcapital.com': 'Neotech Capital', 'odysseyventures.llc': 'Odyssey Ventures',
+  'omair.vc': 'Omair Ventures', 'orbitventures.com': 'Orbit Ventures', 'palcapital.com': 'PAL Capital',
+  'pentathlon.vc': 'Pentathlon Ventures', 'protaventures.com': 'Prota Ventures', 'rayo.capital': 'Rayo Capital',
+  'rivendell.capital': 'Rivendell Capital', 'rspartners.my': 'RS Partners', 'sdv.vc': 'SDV Ventures',
+  'sigone.capital': 'SigOne Capital', 'silvercircle.vc': 'Silver Circle Ventures',
+  'solanuscapital.com': 'Solanus Capital', 'specialist.vc': 'Specialist VC', 'strt.vc': 'STRT Ventures',
+  'tanzent.capital': 'Tanzent Capital', 'topmarketcapital.co.bw': 'Top Market Capital',
+  'truescopeventures.com': 'Truescope Ventures', 'tulipa.capital': 'Tulipa Capital',
+  'vacacapital.com': 'Vaca Capital', 'vcventures.co.in': 'VC Ventures', 'veloqpartners.com': 'Veloq Partners',
+  'x10xcapital.com': 'X10X Capital', 'xgcapitalstrategies.com': 'XG Capital Strategies',
+  'y10k.capital': 'Y10K Capital', 'yellowumbrellaventures.com': 'Yellow Umbrella Ventures',
+  'zerogcapital.com': 'ZeroG Capital',
+  'alchemistminers.com': 'Alchemist Miners', 'ordinalminers.com': 'Ordinal Miners',
+  'solminer.io': 'SolMiner', 'wildrosemining.com': 'Wild Rose Mining',
+  'avataradvisors.com': 'Avatar Advisors', 'futuretechadvisors.com': 'FutureTech Advisors',
+  'matrix-advisors.com': 'Matrix Advisors', 'northsoundadvisors.com': 'Northsound Advisors',
+  'redpointadvisors.com': 'Redpoint Advisors', 'americabitcoinatm.com': 'America Bitcoin ATM',
+  'aureobitcoin.com': 'Aureo Bitcoin', 'bigbackbitcoin.com': 'Big Back Bitcoin',
+  'bitcoin.ar': 'Bitcoin Argentina', 'bitcoinbay.ca': 'Bitcoin Bay', 'bitcoinbrisbane.com.au': 'Bitcoin Brisbane',
+  'bitcoinbuilders.xyz': 'Bitcoin Builders', 'bitcoindominicana.com': 'Bitcoin Dominicana',
+  'bitcoinertalent.com': 'Bitcoiner Talent', 'bitcoinindiatour.com': 'Bitcoin India Tour',
+  'lightning.news': 'Lightning News', 'mandebitcoin.com': 'Mande Bitcoin', 'thebitcoinmint.com': 'The Bitcoin Mint',
+};
+
+/** Classify an email domain. Returns { company, bucket, confidence } or null. */
+export function classifyDomain(rawDomain: string | null | undefined): DomainClassification | null {
+  if (!rawDomain) return null;
+  const domain = String(rawDomain).trim().toLowerCase().replace(/\.$/, '');
+  if (!domain || !domain.includes('.')) return null;
+  if (FREEMAIL.has(domain) || INTERNAL.has(domain)) return null;
+
+  if (DOMAIN_MAP[domain]) return { ...DOMAIN_MAP[domain], confidence: 'high' };
+  for (const mapped of Object.keys(DOMAIN_MAP)) {
+    if (domain.endsWith('.' + mapped)) return { ...DOMAIN_MAP[mapped], confidence: 'high' };
+  }
+  for (const rule of KEYWORD_RULES) {
+    if (rule.pattern.test(domain)) {
+      return { company: DISPLAY_NAMES[domain] || domain, bucket: rule.bucket, confidence: 'medium' };
+    }
+  }
+  return null;
+}

--- a/backend/src/routes/bizdev.routes.ts
+++ b/backend/src/routes/bizdev.routes.ts
@@ -1,0 +1,251 @@
+// soppressata-72251: per-partner BizDev industry report at GET /api/bizdev?partner={tag}.
+//
+// Serves a companies-only (NO PII — no guest names/emails) breakdown of which
+// COMPANIES (inferred from email domain) RSVP'd across APPROVED GPP events,
+// bucketed by industry and shown through each partner's lens.
+//
+// Scope (same for every partner): event_type='gpp' AND underboss_status='approved'.
+// The partner only changes which buckets are FEATURED, not the event universe.
+//
+// Access control (authoritative = server-side, per-route — NEVER a path-less
+// router.use gate, which would leak to sibling /api routers):
+//   requireAuth, then allow if isAdmin || isUnderboss || (caller's active
+//   SponsorUser.tag === requested partner's tag). Other partner's tag -> 403.
+//   Unknown partner -> 404. Logged-out -> 401 (via requireAuth).
+
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { requireAuth, AuthRequest, isAdmin, isUnderboss } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { BUCKETS, classifyDomain } from '../lib/industryTaxonomy.js';
+import { BIZDEV_PARTNERS, resolveBizdevPartner } from '../lib/bizdevPartners.js';
+
+const router = Router();
+
+type Confidence = 'high' | 'medium';
+
+interface CompanyAccumulator {
+  company: string;
+  bucket: string;
+  confidence: Confidence;
+  rsvpCount: number;
+  eventIds: Set<string>;
+}
+
+interface CompanyOut {
+  company: string;
+  rsvpCount: number;
+  eventCount: number;
+  confidence: Confidence;
+}
+
+interface BucketOut {
+  bucketId: string;
+  label: string;
+  companies: CompanyOut[];
+}
+
+interface BizdevCache {
+  buckets: Map<string, BucketOut>; // bucketId -> bucket with companies
+  coverage: {
+    events: number;
+    totalEmails: number;
+    matched: number;
+    personal: number;
+    internal: number;
+    distinctCompanies: number;
+  };
+  computedAt: number;
+}
+
+const CACHE_TTL_MS = 45 * 60 * 1000; // ~45 min
+let cache: BizdevCache | null = null;
+let inFlight: Promise<BizdevCache> | null = null;
+
+// Classification is partner-independent: compute the full bucketed result ONCE
+// (deduped to distinct companies per bucket with rsvpCount + distinct
+// eventCount), cache it, and filter cached buckets per partner on each request.
+async function buildBizdevCache(): Promise<BizdevCache> {
+  // Pull every approved-GPP guest email + its party id. The filter lives in
+  // `where` (NOT a take-then-filter) so rare matches are never dropped.
+  const guests = await prisma.guest.findMany({
+    where: {
+      email: { not: null },
+      party: { eventType: 'gpp', underbossStatus: 'approved' },
+    },
+    select: { email: true, partyId: true },
+  });
+
+  // company key (lowercased company name within a bucket) -> accumulator
+  const byCompany = new Map<string, CompanyAccumulator>();
+  const eventIds = new Set<string>();
+
+  let totalEmails = 0;
+  let matched = 0;
+  let personalOrUnmatched = 0;
+
+  for (const g of guests) {
+    const email = g.email;
+    if (!email) continue;
+    const at = email.lastIndexOf('@');
+    if (at < 0) continue;
+    const domain = email.slice(at + 1).trim().toLowerCase();
+    if (!domain) continue;
+
+    totalEmails += 1;
+    eventIds.add(g.partyId);
+
+    const cls = classifyDomain(domain);
+    if (!cls) {
+      // Personal/freemail/internal OR unknown domain with no keyword match.
+      personalOrUnmatched += 1;
+      continue;
+    }
+    matched += 1;
+
+    const key = `${cls.bucket}::${cls.company.toLowerCase()}`;
+    const existing = byCompany.get(key);
+    if (existing) {
+      existing.rsvpCount += 1;
+      existing.eventIds.add(g.partyId);
+      // Prefer the higher-confidence label if any row was 'high'.
+      if (cls.confidence === 'high') existing.confidence = 'high';
+    } else {
+      byCompany.set(key, {
+        company: cls.company,
+        bucket: cls.bucket,
+        confidence: cls.confidence,
+        rsvpCount: 1,
+        eventIds: new Set([g.partyId]),
+      });
+    }
+  }
+
+  // Group companies into buckets, sorted by rsvpCount desc then name asc.
+  const buckets = new Map<string, BucketOut>();
+  for (const acc of byCompany.values()) {
+    let bucket = buckets.get(acc.bucket);
+    if (!bucket) {
+      bucket = {
+        bucketId: acc.bucket,
+        label: BUCKETS[acc.bucket] || acc.bucket,
+        companies: [],
+      };
+      buckets.set(acc.bucket, bucket);
+    }
+    bucket.companies.push({
+      company: acc.company,
+      rsvpCount: acc.rsvpCount,
+      eventCount: acc.eventIds.size,
+      confidence: acc.confidence,
+    });
+  }
+  for (const bucket of buckets.values()) {
+    bucket.companies.sort(
+      (a, b) => b.rsvpCount - a.rsvpCount || a.company.localeCompare(b.company)
+    );
+  }
+
+  // `personal` and `internal` are reported together in `personal` for the
+  // coverage banner caveat ("counts are a floor"); classifyDomain doesn't
+  // distinguish them in its null return, so personal here = freemail + internal
+  // + unknown-unmatched. Keep `internal` as 0 to avoid implying a precision we
+  // don't have; the banner copy explains the floor.
+  return {
+    buckets,
+    coverage: {
+      events: eventIds.size,
+      totalEmails,
+      matched,
+      personal: personalOrUnmatched,
+      internal: 0,
+      distinctCompanies: byCompany.size,
+    },
+    computedAt: Date.now(),
+  };
+}
+
+async function getBizdevCache(): Promise<BizdevCache> {
+  if (cache && Date.now() - cache.computedAt < CACHE_TTL_MS) return cache;
+  if (inFlight) return inFlight;
+  inFlight = buildBizdevCache()
+    .then((c) => {
+      cache = c;
+      return c;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+/**
+ * GET /api/bizdev?partner={tag}
+ * Auth: requireAuth, then admin OR underboss OR own-tag sponsor.
+ */
+router.get('/', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const email = req.userEmail; // requireAuth guarantees this (else 401)
+
+    const partner = resolveBizdevPartner(req.query?.partner as string | undefined);
+    if (!partner) {
+      throw new AppError('Unknown partner', 404, 'PARTNER_NOT_FOUND');
+    }
+
+    // OR gate — DO NOT use a sponsor middleware that hard-403s underbosses.
+    const [admin, underboss] = await Promise.all([
+      isAdmin(email),
+      isUnderboss(email),
+    ]);
+
+    let authorized = admin || underboss;
+    if (!authorized && email) {
+      // Caller must have an ACTIVE SponsorUser row whose tag matches THIS
+      // partner's real tag. Any other tag -> 403.
+      const sponsor = await prisma.sponsorUser.findFirst({
+        where: { email: email.toLowerCase(), tag: partner.tag, isActive: true },
+        select: { id: true },
+      });
+      authorized = !!sponsor;
+    }
+
+    if (!authorized) {
+      throw new AppError('Not authorized for this partner', 403, 'FORBIDDEN');
+    }
+
+    const data = await getBizdevCache();
+
+    // Filter cached buckets through this partner's lens.
+    const lensSet = new Set(partner.lensBuckets);
+    const featured: BucketOut[] = [];
+    for (const bucketId of partner.lensBuckets) {
+      const bucket = data.buckets.get(bucketId);
+      if (bucket && bucket.companies.length > 0) featured.push(bucket);
+    }
+    // `other` = buckets with matches NOT in the lens, in canonical BUCKETS order.
+    const other: BucketOut[] = [];
+    for (const bucketId of Object.keys(BUCKETS)) {
+      if (lensSet.has(bucketId)) continue;
+      const bucket = data.buckets.get(bucketId);
+      if (bucket && bucket.companies.length > 0) other.push(bucket);
+    }
+
+    res.set('Cache-Control', 'private, max-age=300');
+    res.json({
+      tag: partner.id,
+      label: partner.label,
+      blurb: partner.blurb,
+      scope: 'approved-gpp',
+      coverage: data.coverage,
+      featured,
+      other,
+    });
+  } catch (e) {
+    next(e);
+  }
+});
+
+// Exported for tests / introspection.
+export const BIZDEV_PARTNER_IDS = BIZDEV_PARTNERS.map((p) => p.id);
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { AsiaPaymentsPage } from './pages/AsiaPaymentsPage';
 import { PartnerIntakePage } from './pages/PartnerIntakePage';
 import { PartnerDashboardPage } from './pages/PartnerDashboardPage';
 import { ConsolidatedReportPage } from './pages/ConsolidatedReportPage';
+import { PartnerBizdevPage } from './pages/PartnerBizdevPage';
 import { PostComposerPage } from './pages/PostComposerPage';
 import { OneSheetPage } from './pages/OneSheetPage';
 import { GPPPizzeriasPage } from './pages/GPPPizzeriasPage';
@@ -125,6 +126,8 @@ function App() {
             <Route path="/admin/logo-cleanup" element={<AdminLogoCleanup />} />
             <Route path="/partner" element={<PartnerDashboardPage />} />
             <Route path="/partner/report" element={<ConsolidatedReportPage />} />
+            {/* soppressata-72251: per-partner BizDev industry report — before /:slug catch-all */}
+            <Route path="/partner/bizdev" element={<PartnerBizdevPage />} />
             <Route path="/partner-dashboard" element={<Navigate to="/partner" replace />} />
             <Route path="/sponsor-dashboard" element={<Navigate to="/partner" replace />} />
             <Route path="/partner-intake/:token" element={<PartnerIntakePage />} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3922,6 +3922,67 @@ export async function revokePartnerAiShareToken(
   });
 }
 
+// soppressata-72251: per-partner BizDev industry report (companies-only, no PII).
+// Lives behind GET /api/bizdev?partner={tag}. Auth: admin / underboss / own-tag
+// sponsor (server-authoritative). Uses a bespoke fetch (not apiRequest) so the
+// page can branch on the HTTP status — 401/403/404 each render a distinct state,
+// and a 401 here must NOT clear the auth token (apiRequest does that on 401).
+export interface BizdevCompany {
+  company: string;
+  rsvpCount: number;
+  eventCount: number;
+  confidence: 'high' | 'medium';
+}
+
+export interface BizdevBucket {
+  bucketId: string;
+  label: string;
+  companies: BizdevCompany[];
+}
+
+export interface BizdevReport {
+  tag: string;
+  label: string;
+  blurb: string;
+  scope: 'approved-gpp';
+  coverage: {
+    events: number;
+    totalEmails: number;
+    matched: number;
+    personal: number;
+    internal: number;
+    distinctCompanies: number;
+  };
+  featured: BizdevBucket[];
+  other: BizdevBucket[];
+}
+
+export class BizdevReportError extends Error {
+  status: number;
+  code?: string;
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.name = 'BizdevReportError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export async function fetchBizdevReport(partner: string): Promise<BizdevReport> {
+  const token = getAuthToken();
+  const res = await fetch(
+    `${API_URL}/api/bizdev?partner=${encodeURIComponent(partner)}`,
+    { headers: token ? { Authorization: `Bearer ${token}` } : {} }
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body?.error?.message || body?.message || `Request failed (${res.status})`;
+    const code = body?.error?.code || body?.code;
+    throw new BizdevReportError(res.status, message, code);
+  }
+  return res.json();
+}
+
 // pecorino-64118 follow-up: download list of guest emails opted into a partner's
 // newsletter (ethconf + SWC family). Errors with 400 NO_NEWSLETTER for tags
 // without a newsletter (e.g. pizzadao).

--- a/frontend/src/pages/PartnerBizdevPage.tsx
+++ b/frontend/src/pages/PartnerBizdevPage.tsx
@@ -1,0 +1,282 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useSearchParams } from 'react-router-dom';
+import { Loader2, Shield, Building2, Info } from 'lucide-react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+import { LoginModal } from '../components/LoginModal';
+import { useAuth } from '../contexts/AuthContext';
+import { fetchBizdevReport, BizdevReportError } from '../lib/api';
+import type { BizdevReport, BizdevBucket } from '../lib/api';
+
+const themeClass = 'gpp-theme';
+const backgroundStyle = {
+  background: 'linear-gradient(180deg, #7EC8E3 0%, #B6E4F7 100%)',
+} as React.CSSProperties;
+
+// soppressata-72251: per-partner BizDev industry report at /partner/bizdev?partner={tag}.
+// Companies-only (NO PII — domains never tied to a guest name/email). Scope is
+// approved GPP events; the partner only changes which buckets are FEATURED.
+//
+// NOTE: the data comes from the backend /api/bizdev endpoint, which only ships
+// from master. On Vercel preview branches the page renders but the fetch 404s
+// (preview frontend → prod backend that doesn't yet have the route), so the
+// "report not available yet" state is expected until backend deploys.
+export function PartnerBizdevPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [searchParams] = useSearchParams();
+  const partnerParam = (searchParams.get('partner') || '').trim();
+
+  const [loading, setLoading] = useState(true);
+  const [report, setReport] = useState<BizdevReport | null>(null);
+  const [errStatus, setErrStatus] = useState<number | null>(null);
+  const [errMessage, setErrMessage] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  // Set body class for elements outside the React tree (matches ConsolidatedReportPage).
+  useEffect(() => {
+    document.body.classList.add('gpp-theme-active');
+    return () => { document.body.classList.remove('gpp-theme-active'); };
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!user) {
+      setErrStatus(401);
+      setLoading(false);
+      return;
+    }
+
+    if (!partnerParam) {
+      setErrStatus(404);
+      setErrMessage('No partner specified.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setErrStatus(null);
+    setErrMessage(null);
+
+    fetchBizdevReport(partnerParam)
+      .then((data) => { if (!cancelled) setReport(data); })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof BizdevReportError) {
+          setErrStatus(err.status);
+          setErrMessage(err.message);
+        } else {
+          setErrStatus(500);
+          setErrMessage(err instanceof Error ? err.message : 'Failed to load report');
+        }
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [user, authLoading, partnerParam]);
+
+  const shell = (children: React.ReactNode) => (
+    <div className={`min-h-screen ${themeClass} relative overflow-hidden`} style={backgroundStyle}>
+      <Helmet>
+        <title>Partner BizDev Report | RSV.Pizza</title>
+      </Helmet>
+      <Header />
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-8 relative z-10">{children}</main>
+      <Footer />
+    </div>
+  );
+
+  // Loading
+  if (authLoading || loading) {
+    return shell(
+      <div className="flex items-center justify-center py-32">
+        <Loader2 size={32} className="animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+
+  // 401 — logged out
+  if (errStatus === 401) {
+    return shell(
+      <div className="flex flex-col items-center justify-center px-4 py-32 text-center">
+        <Shield size={48} className="text-theme-text-faint mb-4" />
+        <h1 className="text-2xl font-bold text-theme-text mb-2">Partner BizDev Report</h1>
+        <p className="text-theme-text-muted max-w-md mb-6">
+          Log in with your partner account to view your industry RSVP report.
+        </p>
+        <button
+          onClick={() => setShowLoginModal(true)}
+          className="px-6 py-2 bg-[#E52828] text-[#ffffff] rounded-xl text-sm font-medium hover:bg-[#CC2020] transition-colors"
+        >
+          Log in
+        </button>
+        <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      </div>
+    );
+  }
+
+  // 403 — not authorized for this partner
+  if (errStatus === 403) {
+    return shell(
+      <div className="flex flex-col items-center justify-center px-4 py-32 text-center">
+        <Shield size={48} className="text-red-400/60 mb-4" />
+        <h1 className="text-2xl font-bold text-theme-text mb-2">Not authorized</h1>
+        <p className="text-theme-text-muted max-w-md">
+          You’re signed in, but your account isn’t authorized to view this partner’s report.
+        </p>
+      </div>
+    );
+  }
+
+  // 404 — unknown partner / no partner
+  if (errStatus === 404) {
+    return shell(
+      <div className="flex flex-col items-center justify-center px-4 py-32 text-center">
+        <Building2 size={48} className="text-theme-text-faint mb-4" />
+        <h1 className="text-2xl font-bold text-theme-text mb-2">Unknown partner</h1>
+        <p className="text-theme-text-muted max-w-md">
+          {errMessage || `No BizDev report exists for “${partnerParam}”.`}
+        </p>
+      </div>
+    );
+  }
+
+  // Other errors (incl. backend not yet deployed on preview → typically a
+  // network/parse failure rather than a clean status).
+  if (errStatus || !report) {
+    return shell(
+      <div className="flex flex-col items-center justify-center px-4 py-32 text-center">
+        <Info size={48} className="text-theme-text-faint mb-4" />
+        <h1 className="text-xl font-semibold text-theme-text mb-2">Report not available</h1>
+        <p className="text-theme-text-muted max-w-md">
+          {errMessage || 'This report could not be loaded right now. If you’re on a preview deploy, the BizDev endpoint only ships from the production backend.'}
+        </p>
+      </div>
+    );
+  }
+
+  const { coverage } = report;
+  const hasFeatured = report.featured.some((b) => b.companies.length > 0);
+  const hasOther = report.other.some((b) => b.companies.length > 0);
+
+  return shell(
+    <div
+      className="rounded-2xl p-6 sm:p-8"
+      style={{ background: 'rgba(240, 240, 240, 0.95)' }}
+    >
+      {/* Header */}
+      <div className="mb-6">
+        <p className="text-xs uppercase tracking-wide text-theme-text-faint mb-1">
+          BizDev report · approved GPP events
+        </p>
+        <h1 className="text-2xl sm:text-3xl font-bold text-theme-text">{report.label}</h1>
+        {report.blurb && (
+          <p className="text-sm text-theme-text-muted mt-1">{report.blurb}</p>
+        )}
+      </div>
+
+      {/* Coverage banner */}
+      <div className="rounded-xl border border-black/10 bg-white/70 p-4 mb-8">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-3">
+          <Stat label="Approved events" value={coverage.events} />
+          <Stat label="Companies" value={coverage.distinctCompanies} />
+          <Stat label="Matched RSVPs" value={coverage.matched} />
+          <Stat label="Total RSVPs" value={coverage.totalEmails} />
+        </div>
+        <p className="flex items-start gap-2 text-xs text-theme-text-muted">
+          <Info size={14} className="mt-0.5 shrink-0" />
+          <span>
+            These counts are a <strong>floor, not a census</strong>. Most guests RSVP with a
+            personal email, so company affiliation is only visible for the{' '}
+            {coverage.matched.toLocaleString()} of {coverage.totalEmails.toLocaleString()} RSVPs on a
+            recognizable work domain. No personal data (names or emails) is shown — only companies
+            inferred from email domains. <em>(inferred)</em> marks a keyword-matched domain we
+            couldn’t verify.
+          </span>
+        </p>
+      </div>
+
+      {/* Featured (lens) buckets */}
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-theme-text mb-1">Featured for {report.label}</h2>
+        <p className="text-xs text-theme-text-muted mb-4">
+          Industries most relevant to your lens.
+        </p>
+        {hasFeatured ? (
+          <div className="space-y-6">
+            {report.featured
+              .filter((b) => b.companies.length > 0)
+              .map((bucket) => (
+                <BucketBlock key={bucket.bucketId} bucket={bucket} />
+              ))}
+          </div>
+        ) : (
+          <p className="text-sm text-theme-text-muted py-4">
+            No companies matched your featured industries yet.
+          </p>
+        )}
+      </section>
+
+      {/* Other industries */}
+      {hasOther && (
+        <section>
+          <h2 className="text-lg font-semibold text-theme-text mb-1">Other industries</h2>
+          <p className="text-xs text-theme-text-muted mb-4">
+            Companies that RSVP’d outside your lens.
+          </p>
+          <div className="space-y-6">
+            {report.other
+              .filter((b) => b.companies.length > 0)
+              .map((bucket) => (
+                <BucketBlock key={bucket.bucketId} bucket={bucket} />
+              ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="text-2xl font-bold text-theme-text">{value.toLocaleString()}</div>
+      <div className="text-xs text-theme-text-muted">{label}</div>
+    </div>
+  );
+}
+
+function BucketBlock({ bucket }: { bucket: BizdevBucket }) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-2">
+        <h3 className="text-sm font-semibold text-theme-text">{bucket.label}</h3>
+        <span className="text-xs text-theme-text-faint">
+          {bucket.companies.length} {bucket.companies.length === 1 ? 'company' : 'companies'}
+        </span>
+      </div>
+      <div className="rounded-xl border border-black/10 bg-white/70 divide-y divide-black/5">
+        {bucket.companies.map((c) => (
+          <div
+            key={`${bucket.bucketId}::${c.company}`}
+            className="flex items-center justify-between gap-3 px-3 py-2"
+          >
+            <div className="min-w-0 flex items-center gap-2">
+              <span className="truncate text-sm text-theme-text">{c.company}</span>
+              {c.confidence === 'medium' && (
+                <span className="shrink-0 text-[11px] text-theme-text-faint italic">(inferred)</span>
+              )}
+            </div>
+            <div className="shrink-0 text-xs text-theme-text-muted tabular-nums">
+              {c.rsvpCount.toLocaleString()} RSVP{c.rsvpCount === 1 ? '' : 's'}
+              {' · '}
+              {c.eventCount} {c.eventCount === 1 ? 'event' : 'events'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
A live per-partner **BizDev report** at `/partner/bizdev?partner={tag}`. It shows which **companies** (inferred from email domain) RSVP'd across **approved GPP events**, bucketed by industry and shown through each partner's lens. `?partner={tag}` selects the partner and only changes which buckets are **featured** — never the event universe.

6 partners: `ens`, `stand-with-crypto` (real tag `swc`), `brave`, `tangem`, `bitvavo`, `octant`.

## Companies-only (no PII)
The report returns **only companies** (e.g. "Coinbase — 12 RSVPs across 4 events"). No guest names, no emails, no raw domains tied to a person. Email domains are classified to a company via a curated map + keyword fallback; personal/freemail/internal domains are dropped entirely. Counts are surfaced as a **floor, not a census** (most guests use personal email), and `(inferred)` marks medium-confidence keyword matches.

## Auth model (server-authoritative)
`requireAuth`, then an **OR gate**: `isAdmin(email) || isUnderboss(email) || (caller has an active SponsorUser whose tag === the requested partner's tag)`.
- Logged out → **401**
- A partner requesting a different partner's tag → **403**
- Unknown partner (not in config) → **404**

Deliberately does **not** reuse `requireSponsorAuth` (that gate would hard-403 underbosses). The route is mounted **path-scoped** at `/api/bizdev` with the gate applied **per-route** (no path-less `router.use`, which would leak to sibling `/api` routers).

## Scope
Approved GPP events only: `event_type='gpp' AND underboss_status='approved'`, applied in the Prisma `where` (no take-then-filter). Classification is partner-independent, computed once and cached in-module (~45-min TTL); each request filters the cached buckets by the partner lens.

## Files changed
- `backend/src/lib/industryTaxonomy.ts` (new) — TS port of the curated domain map / keyword rules / freemail+internal sets / `classifyDomain`.
- `backend/src/lib/bizdevPartners.ts` (new) — 6 partner lenses; SWC keyed on `swc`.
- `backend/src/routes/bizdev.routes.ts` (new) — endpoint + cache + auth gate.
- `backend/src/index.ts` — mount `/api/bizdev`.
- `frontend/src/pages/PartnerBizdevPage.tsx` (new) — page (coverage banner, Featured + Other sections, loading/401/403/404/empty).
- `frontend/src/lib/api.ts` — `fetchBizdevReport()` + typed `BizdevReportError`.
- `frontend/src/App.tsx` — route after `/partner/report`, before `/:slug`.

## NOTE — preview won't serve live data
`/api/bizdev` is **backend** code, and the backend only deploys from `master`. On the Vercel preview branch the **frontend page renders** but the fetch will fail (preview talks to the prod backend, which won't have the route until this merges and backend ships from `master`). The page degrades to a friendly "report not available" state until then.

## Verification
- Backend `tsc --noEmit`: clean (0 errors).
- Frontend `vite build`: succeeds with the new page included.
- **Not verified:** live DB execution — the worktree has no `backend/.env`, so the actual query + classification against ~38k guest rows hasn't been run. The query uses Prisma (type-checked) with the filter in `where`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)