### PR TITLE
feat(stracciatella-58504): default-open additional-photos uploader + preview gallery on /payments

### DIFF
--- a/frontend/src/components/payouts/EventPhotosCard.tsx
+++ b/frontend/src/components/payouts/EventPhotosCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ImagePlus, Camera } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
@@ -7,6 +7,7 @@ import { Photo } from '../../types';
 import { designatePhotoRole, getPartyPhotos } from '../../lib/api';
 import { RolePhotoPicker, PayoutPhotoRole } from './RolePhotoPicker';
 import { PhotoUpload } from '../photos/PhotoUpload';
+import { PhotoModal } from '../photos/PhotoModal';
 
 const PAYOUT_ROLES: PayoutPhotoRole[] = ['group', 'box_stack', 'pizza'];
 
@@ -50,32 +51,42 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
   });
   const [pickerRole, setPickerRole] = useState<PayoutPhotoRole | null>(null);
   const [designating, setDesignating] = useState(false);
-  const [showAdditionalUpload, setShowAdditionalUpload] = useState(false);
+  // stracciatella-58504: default the additional-photos uploader OPEN.
+  const [showAdditionalUpload, setShowAdditionalUpload] = useState(true);
+  // stracciatella-58504: full gallery list (seeds role slots + drives the
+  // additional-photos preview below the uploader).
+  const [galleryPhotos, setGalleryPhotos] = useState<Photo[]>([]);
+  const [lightboxPhoto, setLightboxPhoto] = useState<Photo | null>(null);
 
-  // porchetta-58296: seed the role slots on mount. Pull the gallery (host view)
-  // and match the photos already carrying each payoutRole.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const photosRes = await getPartyPhotos(partyId, { status: 'all', limit: 100 });
-      if (cancelled) return;
-      const photos = photosRes?.photos ?? [];
-      const next: Record<PayoutPhotoRole, Photo | undefined> = {
-        group: undefined,
-        box_stack: undefined,
-        pizza: undefined,
-      };
-      for (const p of photos) {
-        if (p.payoutRole && PAYOUT_ROLES.includes(p.payoutRole as PayoutPhotoRole)) {
-          next[p.payoutRole as PayoutPhotoRole] = p;
-        }
-      }
-      setRoles(next);
-    })();
-    return () => {
-      cancelled = true;
+  // porchetta-58296 / stracciatella-58504: pull the gallery (host view), seed
+  // the role slots from photos already carrying each payoutRole, AND keep the
+  // full list for the additional-photos preview.
+  const loadPhotos = useCallback(async () => {
+    const photosRes = await getPartyPhotos(partyId, { status: 'all', limit: 100 });
+    const photos = photosRes?.photos ?? [];
+    const next: Record<PayoutPhotoRole, Photo | undefined> = {
+      group: undefined,
+      box_stack: undefined,
+      pizza: undefined,
     };
+    for (const p of photos) {
+      if (p.payoutRole && PAYOUT_ROLES.includes(p.payoutRole as PayoutPhotoRole)) {
+        next[p.payoutRole as PayoutPhotoRole] = p;
+      }
+    }
+    setRoles(next);
+    setGalleryPhotos(photos);
   }, [partyId]);
+
+  useEffect(() => {
+    loadPhotos();
+  }, [loadPhotos]);
+
+  // stracciatella-58504: additional photos = gallery photos NOT designated as
+  // one of the three payout roles.
+  const additionalPhotos = galleryPhotos.filter(
+    p => !p.payoutRole || !PAYOUT_ROLES.includes(p.payoutRole as PayoutPhotoRole)
+  );
 
   // calzone-58297: report all-designated state to the parent whenever roles
   // change so PaymentDetailsCard can unlock.
@@ -149,12 +160,50 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
 
       {/* Optional additional photos — gallery upload, no role. */}
       <div className="mt-4">
+        {/* stracciatella-58504: preview of already-uploaded additional photos. */}
+        {additionalPhotos.length > 0 && (
+          <div className="mb-3">
+            <div className="grid grid-cols-4 sm:grid-cols-6 gap-2">
+              {additionalPhotos.slice(0, 6).map(p => {
+                const isVideo = p.mimeType?.startsWith('video/');
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => setLightboxPhoto(p)}
+                    className="aspect-square rounded-lg overflow-hidden bg-theme-surface border border-theme-stroke hover:border-[#ff393a]/50 transition-colors"
+                  >
+                    {isVideo ? (
+                      <video src={p.url} className="w-full h-full object-cover" muted playsInline preload="metadata" />
+                    ) : (
+                      <img
+                        src={p.thumbnailUrl || p.url}
+                        alt={p.caption || 'Event photo'}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                      />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={() => setLightboxPhoto(additionalPhotos[0])}
+              className="mt-2 text-sm text-theme-text-secondary hover:text-[#ff393a] transition-colors"
+            >
+              {t('payouts.viewAllPhotos', { count: additionalPhotos.length })}
+            </button>
+          </div>
+        )}
+
         {showAdditionalUpload ? (
           <PhotoUpload
             partyId={partyId}
             isHost
             uploaderName={user?.name ?? undefined}
             uploaderEmail={user?.email ?? undefined}
+            onUploadComplete={() => loadPhotos()}
             onClose={() => setShowAdditionalUpload(false)}
           />
         ) : (
@@ -179,6 +228,17 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
           selectedPhotoId={roles[pickerRole]?.id ?? null}
           onSelect={designating ? () => {} : handleRoleSelect}
           onClose={() => setPickerRole(null)}
+        />
+      )}
+
+      {/* stracciatella-58504: read-only lightbox for additional photos. */}
+      {lightboxPhoto && (
+        <PhotoModal
+          photo={lightboxPhoto}
+          photos={additionalPhotos}
+          isHost
+          onClose={() => setLightboxPhoto(null)}
+          onNavigate={setLightboxPhoto}
         />
       )}
     </div>

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -835,6 +835,7 @@
     "eventPhotosSubtitle": "Lege ein Gruppenfoto, ein Foto des Boxstapels und ein Pizza-Foto von deinem Event fest. Wähle sie aus deiner Galerie oder lade neue hoch.",
     "selectOrUpload": "Auswählen oder hochladen",
     "additionalPhotos": "Weitere Fotos hinzufügen (optional)",
+    "viewAllPhotos": "Alle anzeigen ({{count}})",
     "roles": {
       "group": "Gruppenfoto",
       "boxStack": "Foto des Boxstapels",

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -954,6 +954,7 @@
     "eventPhotosSubtitle": "Designate a group photo, a box stack photo, and a pizza photo from your event. Select from your gallery or upload new ones.",
     "selectOrUpload": "Select or upload",
     "additionalPhotos": "Add more photos (optional)",
+    "viewAllPhotos": "View all ({{count}})",
     "roles": {
       "group": "Group photo",
       "boxStack": "Box stack photo",

--- a/plans/stracciatella-58504-payout-additional-photos.md
+++ b/plans/stracciatella-58504-payout-additional-photos.md
@@ -1,0 +1,64 @@
+# stracciatella-58504 — Default-open additional-photos uploader + preview gallery on /payments
+
+## Context
+In the payments/payout submission flow, `EventPhotosCard` shows the three required role
+photos (group / box stack / pizza) and, below them, an **"Add more photos (optional)"**
+button. Today that button is collapsed by default and reveals only the `PhotoUpload`
+dropzone — the host gets no sense of what extra photos already exist for the event.
+
+Snax wants this section to (1) **default to open** and (2) include a **small preview
+gallery of the already-uploaded additional photos** with a **"View all" button** that
+opens the existing `PhotoModal` lightbox.
+
+## Decisions (from Snax)
+- **View all** → opens the existing `PhotoModal` lightbox (self-contained, no navigation away).
+- **Scope** → preview shows **additional photos only** = gallery photos NOT designated as one
+  of the three payout roles (`payoutRole` null or not in `['group','box_stack','pizza']`).
+
+## Files to change
+- `frontend/src/components/payouts/EventPhotosCard.tsx` (primary)
+- `frontend/src/i18n/locales/en/host.json` and `de/host.json` (new `payouts.viewAllPhotos` key)
+
+## Implementation — `EventPhotosCard.tsx`
+1. **Default the uploader open**: `useState(true)` for `showAdditionalUpload` (was `false`).
+   Keep the collapse/expand toggle — `PhotoUpload`'s `onClose` still collapses it, and the
+   button still re-opens it.
+2. **Reuse the existing fetch**: the mount `useEffect` already calls
+   `getPartyPhotos(partyId, { status: 'all', limit: 100 })` to seed role slots but discards
+   the list. Lift that into a `loadPhotos` `useCallback`, store the full list in a new
+   `galleryPhotos` state (in addition to seeding `roles`), and call it on mount.
+3. **Derive additional photos**:
+   `const additionalPhotos = galleryPhotos.filter(p => !p.payoutRole || !PAYOUT_ROLES.includes(p.payoutRole as PayoutPhotoRole));`
+4. **Preview gallery UI** (render above or just under the uploader, only when
+   `additionalPhotos.length > 0`): a row of the first ~4–6 thumbnails (reuse the existing
+   thumbnail markup pattern from this file / `RolePhotoPicker` — `img thumbnailUrl||url`,
+   `video` for `mimeType` starting `video/`, `aspect-square rounded`). Add a **"View all
+   (N)"** button using `t('payouts.viewAllPhotos', { count: additionalPhotos.length })`.
+   Clicking a thumbnail OR "View all" sets a `lightboxPhoto` state (thumbnail → that photo;
+   View all → `additionalPhotos[0]`).
+5. **Lightbox**: render `<PhotoModal photo={lightboxPhoto} photos={additionalPhotos} isHost
+   onClose={() => setLightboxPhoto(null)} onNavigate={setLightboxPhoto} />` when
+   `lightboxPhoto` is set. (`PhotoModal` already `createPortal`s to body and supports
+   prev/next; its mutation callbacks are all optional — omit them for read-only viewing.)
+6. **Refresh after upload**: pass `onUploadComplete={() => loadPhotos()}` to `PhotoUpload`
+   so newly uploaded additional photos appear in the preview without a page reload.
+
+## i18n
+Add to `payouts` in `en/host.json`: `"viewAllPhotos": "View all ({{count}})"` and a German
+equivalent in `de/host.json` (`"Alle anzeigen ({{count}})"`). Other locales fall back to en.
+
+## Constraints / gotchas
+- Hooks must stay above any early return (this component has none today — keep it that way).
+- Don't add a realtime subscription; just refetch on `onUploadComplete`.
+- Match existing Tailwind theme tokens (`theme-surface`, `theme-stroke`, `#ff393a`) — no new
+  raw colors. Reuse thumbnail markup already in the file rather than inventing new styling.
+
+## Verification
+- `cd frontend && npm run build` (tsc + vite) is green.
+- On a Vercel preview, open an event's /payments payout flow as host:
+  - The additional-photos uploader is expanded by default.
+  - If the event has non-role gallery photos, a preview row + "View all (N)" shows.
+  - Clicking a thumbnail or "View all" opens the lightbox with prev/next across the
+    additional photos.
+  - Upload a new photo → it appears in the preview row without reload.
+  - Role-designated photos do NOT appear in the additional preview.


### PR DESCRIPTION
## What
In the /payments payout flow (`EventPhotosCard`), the **"Add more photos (optional)"** section now:
1. **Defaults to open** (uploader visible without clicking the toggle; still collapsible).
2. Shows a **preview gallery of already-uploaded _additional_ photos** (gallery photos not designated as one of the 3 payout roles) — up to 6 thumbnails + a **"View all (N)"** button.
3. Clicking a thumbnail or "View all" opens the existing **`PhotoModal` lightbox** (read-only, with prev/next across the additional photos).
4. Newly uploaded photos refresh the preview in-place via `onUploadComplete` (no page reload, no realtime subscription).

## Scope decisions (confirmed with Snax)
- **View all** → opens the existing `PhotoModal` lightbox (no navigation away).
- **Preview scope** → additional photos only (role-designated group/box-stack/pizza photos are excluded).

## Files
- `frontend/src/components/payouts/EventPhotosCard.tsx` — default-open; reuse the mount fetch into a `loadPhotos` callback that also stores the full gallery list; derive `additionalPhotos`; preview grid + lightbox.
- `frontend/src/i18n/locales/{en,de}/host.json` — new `payouts.viewAllPhotos` key (other locales fall back to en).

## Verify on preview
Open an event's /payments payout flow as host:
- Additional-photos uploader is expanded by default.
- Events with non-role gallery photos show the preview row + "View all (N)".
- Thumbnail / "View all" opens the lightbox with prev/next.
- Uploading a new photo updates the preview without reload.
- Role photos do NOT appear in the additional preview.

Plan: `plans/stracciatella-58504-payout-additional-photos.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
