### PR TITLE
fix(fontina-58504): sanitize OCR boundingHint + host fileName before payout-doc insert

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -52,6 +52,7 @@ import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
 import { withPaidTag, withoutPaidTag } from '../lib/eventTags.js';
 import { sendToCityGroup } from '../services/cityTelegramGroup.js';
 import { cityKeyFromPartyName } from '../helpers/underbossScope.js';
+import { sanitizePgString } from '../lib/sanitizePg.js';
 
 const router = Router();
 
@@ -5125,7 +5126,9 @@ router.patch(
           );
         }
         const e = raw as Record<string, unknown>;
-        const name = typeof e.name === 'string' ? e.name.trim() : '';
+        // fontina-58504: admin-supplied free-form name → ocrLineItems JSONB;
+        // strip NUL / unpaired surrogates first (mirrors stracchino-49640).
+        const name = typeof e.name === 'string' ? sanitizePgString(e.name.trim()) : '';
 
         const qtyNum = Number(e.qty);
         if (!Number.isFinite(qtyNum) || qtyNum < 0) {
@@ -5213,7 +5216,9 @@ router.patch(
         if (body.ocrCurrency === null) {
           data.ocrCurrency = null;
         } else {
-          const c = String(body.ocrCurrency).trim();
+          // fontina-58504: strip NUL / unpaired surrogates from the admin-
+          // supplied currency before it's persisted (mirrors stracchino-49640).
+          const c = sanitizePgString(String(body.ocrCurrency).trim());
           if (c.length === 0 || c.length > 8) {
             throw new AppError(
               'ocrCurrency must be a non-empty string of 1-8 characters or null',
@@ -5409,7 +5414,8 @@ router.patch(
         }
         data.ocrAmount = fx.usdAmount;
         data.originalAmount = originalAmount;
-        data.originalCurrency = fx.originalCurrency;
+        // fontina-58504: defensively sanitize the model/FX-derived currency code.
+        data.originalCurrency = fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency;
         data.exchangeRate = fx.exchangeRate;
       } else if (
         body.originalAmount !== undefined
@@ -5458,7 +5464,8 @@ router.patch(
         }
         data.ocrAmount = fx.usdAmount;
         data.originalAmount = n;
-        data.originalCurrency = fx.originalCurrency;
+        // fontina-58504: defensively sanitize the model/FX-derived currency code.
+        data.originalCurrency = fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency;
         data.exchangeRate = fx.exchangeRate;
       }
 
@@ -5946,7 +5953,8 @@ router.post(
               // see what the receipt said so they can pick the right currency.
               originalAmount: new Decimal(fx.originalAmount),
               ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
-              ocrCurrency: unresolved ? null : fx.originalCurrency,
+              // fontina-58504: currency codes are model-derived; sanitize defensively.
+              ocrCurrency: unresolved ? null : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency),
               exchangeRate: unresolved
                 ? null
                 : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
@@ -6127,8 +6135,11 @@ router.post(
       }
       const docKind = kind as AdminDocKind;
 
+      // fontina-58504: sanitize host/admin-supplied fileName (NUL / unpaired
+      // surrogates) before it's persisted to payout_documents + photos
+      // (mirrors stracchino-49640).
       const fileName = typeof body.fileName === 'string' && body.fileName.length > 0
-        ? body.fileName
+        ? sanitizePgString(body.fileName)
         : 'upload';
       const fileSize = typeof body.fileSize === 'number' && Number.isFinite(body.fileSize)
         ? body.fileSize
@@ -6200,7 +6211,8 @@ router.post(
           // receipt said and can pick the right currency in the edit modal.
           originalAmount = new Decimal(fx.originalAmount);
           ocrAmount = unresolved ? null : new Decimal(fx.usdAmount!);
-          ocrCurrency = unresolved ? null : fx.originalCurrency;
+          // fontina-58504: currency codes are model-derived; sanitize defensively.
+          ocrCurrency = unresolved ? null : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency);
           exchangeRate = unresolved
             ? null
             : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null);

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -52,7 +52,7 @@ import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
 import { withPaidTag, withoutPaidTag } from '../lib/eventTags.js';
 import { sendToCityGroup } from '../services/cityTelegramGroup.js';
 import { cityKeyFromPartyName } from '../helpers/underbossScope.js';
-import { sanitizePgString } from '../lib/sanitizePg.js';
+import { sanitizePgString, sanitizeForPg } from '../lib/sanitizePg.js';
 
 const router = Router();
 
@@ -5946,9 +5946,9 @@ router.post(
           await prisma.payoutDocument.update({
             where: { id: docId },
             data: {
-              ocrLineItems: (result.lineItems ?? []) as unknown as Prisma.InputJsonValue,
+              ocrLineItems: sanitizeForPg((result.lineItems ?? []) as unknown as Prisma.InputJsonValue),
               ocrConfidence: new Decimal(result.confidence),
-              ocrRaw: { ocr: result.raw, fx: { source: fx.source, rate: fx.exchangeRate } } as Prisma.InputJsonValue,
+              ocrRaw: sanitizeForPg({ ocr: result.raw, fx: { source: fx.source, rate: fx.exchangeRate } } as Prisma.InputJsonValue),
               // Even unresolved rows keep originalAmount — the admin needs to
               // see what the receipt said so they can pick the right currency.
               originalAmount: new Decimal(fx.originalAmount),
@@ -6201,12 +6201,12 @@ router.post(
           });
           const fx = await convertToUSD(result.amount, result.currency);
           const unresolved = fx.source === 'unresolved' || fx.usdAmount == null;
-          ocrLineItems = (result.lineItems ?? []) as unknown as Prisma.InputJsonValue;
+          ocrLineItems = sanitizeForPg((result.lineItems ?? []) as unknown as Prisma.InputJsonValue);
           ocrConfidence = new Decimal(result.confidence);
-          ocrRaw = {
+          ocrRaw = sanitizeForPg({
             ocr: result.raw,
             fx: { source: fx.source, rate: fx.exchangeRate },
-          } as Prisma.InputJsonValue;
+          } as Prisma.InputJsonValue);
           // Keep originalAmount even when unresolved so the admin sees what the
           // receipt said and can pick the right currency in the edit modal.
           originalAmount = new Decimal(fx.originalAmount);

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -1338,17 +1338,20 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           docsToCreate.push({
             kind: 'receipt',
             url: doc.url,
-            fileName: doc.fileName || extractFileName(doc.url),
+            // fontina-58504: host-supplied fileName can carry NUL/surrogate
+            // bytes; sanitize before it hits the text column (stracchino-49640).
+            fileName: sanitizePgString(doc.fileName || extractFileName(doc.url)),
             fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
             mimeType: doc.mimeType || 'image/jpeg',
             ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
-            ocrCurrency: unresolved ? null : fx.originalCurrency,
+            // fontina-58504: currency codes are model-derived; sanitize defensively.
+            ocrCurrency: unresolved ? null : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency),
             ocrConfidence: new Decimal(ocr.confidence),
             // mortadella-92103: persist the raw foreign-currency amount + ISO
             // code + locked rate per receipt. Even unresolved rows carry
             // originalAmount (the host needs to see what the receipt said).
             originalAmount: new Decimal(fx.originalAmount),
-            originalCurrency: unresolved ? null : (fx.originalCurrency ?? null),
+            originalCurrency: unresolved ? null : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : null),
             exchangeRate: unresolved ? null : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
             ocrRaw: sanitizeForPg({ ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } }),
             // formaggi-89172: structured per-line items for pizza-price analytics.
@@ -1373,7 +1376,8 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
         docsToCreate.push({
           kind: 'receipt',
           url: doc.url,
-          fileName: doc.fileName || extractFileName(doc.url),
+          // fontina-58504: sanitize host-supplied fileName before the text insert.
+          fileName: sanitizePgString(doc.fileName || extractFileName(doc.url)),
           fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
           mimeType: doc.mimeType || 'image/jpeg',
           ocrAmount: null,
@@ -2163,14 +2167,16 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         newReceiptDocs.push({
           kind: 'receipt',
           url: doc.url,
-          fileName: doc.fileName || extractFileName(doc.url),
+          // fontina-58504: sanitize host-supplied fileName before the text insert.
+          fileName: sanitizePgString(doc.fileName || extractFileName(doc.url)),
           fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
           mimeType: doc.mimeType || 'image/jpeg',
           ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
-          ocrCurrency: unresolved ? null : fx.originalCurrency,
+          // fontina-58504: currency codes are model-derived; sanitize defensively.
+          ocrCurrency: unresolved ? null : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency),
           ocrConfidence: new Decimal(ocr.confidence),
           originalAmount: new Decimal(fx.originalAmount),
-          originalCurrency: unresolved ? null : (fx.originalCurrency ?? null),
+          originalCurrency: unresolved ? null : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : null),
           exchangeRate: unresolved ? null : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
           ocrRaw: sanitizeForPg({ ocr: ocr.raw, fx: { source: fx.source, rate: fx.exchangeRate } }),
           // formaggi-89172: structured per-line items for pizza-price analytics.
@@ -2184,7 +2190,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
         newReceiptDocs.push({
           kind: 'receipt',
           url: doc.url,
-          fileName: doc.fileName || extractFileName(doc.url),
+          // fontina-58504: sanitize host-supplied fileName before the text insert.
+          fileName: sanitizePgString(doc.fileName || extractFileName(doc.url)),
           fileSize: typeof doc.fileSize === 'number' ? doc.fileSize : 0,
           mimeType: doc.mimeType || 'image/jpeg',
           ocrAmount: null,
@@ -2205,7 +2212,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     const newPizzaDocs = newPizza.map((p, i) => ({
       kind: 'pizza',
       url: p.url,
-      fileName: p.fileName || extractFileName(p.url),
+      // fontina-58504: sanitize host-supplied fileName before the text insert.
+      fileName: sanitizePgString(p.fileName || extractFileName(p.url)),
       fileSize: typeof p.fileSize === 'number' ? p.fileSize : 0,
       mimeType: p.mimeType || 'image/jpeg',
       ocrAmount: null,
@@ -2229,7 +2237,8 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
     const newEventDocs = newEvent.map((p, i) => ({
       kind: 'event',
       url: p.url,
-      fileName: p.fileName || extractFileName(p.url),
+      // fontina-58504: sanitize host-supplied fileName before the text insert.
+      fileName: sanitizePgString(p.fileName || extractFileName(p.url)),
       fileSize: typeof p.fileSize === 'number' ? p.fileSize : 0,
       mimeType: p.mimeType || 'image/jpeg',
       ocrAmount: null,

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -17,6 +17,7 @@
 import { getOpenAI } from '../lib/openai.js';
 import { getCountryCode } from '../lib/countryCode.js';
 import { getLlmModels } from '../lib/privateConfig.js';
+import { sanitizePgString } from '../lib/sanitizePg.js';
 
 // formaggi-89172: allowed categories. Keep in sync with the system prompt
 // and the sanitizer below. `other` is the safe fallback for anything else.
@@ -218,9 +219,11 @@ function sanitizeLineItems(raw: unknown): OcrLineItem[] {
     const e = entry as Record<string, unknown>;
 
     // Name is required; coerce non-strings, fall back to placeholder.
+    // fontina-58504: sanitize NUL / unpaired surrogates so the line-item name
+    // can't 500 the payout_documents JSONB insert (mirrors stracchino-49640).
     const rawName = e.name;
     const name = typeof rawName === 'string' && rawName.trim().length > 0
-      ? rawName.trim()
+      ? sanitizePgString(rawName.trim())
       : '[illegible]';
 
     const qtyNum = Number(e.qty);
@@ -297,15 +300,18 @@ export function parseSingleReceipt(parsed: any): OcrResult {
 
   // formaggi-89172: merchant + receiptDate are best-effort. Coerce missing/
   // empty strings to null so the JSONB row has consistent shape.
+  // fontina-58504: run free-form model strings through sanitizePgString at the
+  // source so every consumer that persists ocr.merchant / ocr.boundingHint to
+  // payout_documents gets NUL/surrogate-free values (mirrors stracchino-49640).
   const merchant = typeof parsed?.merchant === 'string' && parsed.merchant.trim().length > 0
-    ? parsed.merchant.trim()
+    ? sanitizePgString(parsed.merchant.trim())
     : null;
   const receiptDate = typeof parsed?.receiptDate === 'string' && parsed.receiptDate.trim().length > 0
     ? parsed.receiptDate.trim()
     : null;
   // stracciatella-92114: optional locator for multi-receipt photos.
   const boundingHint = typeof parsed?.boundingHint === 'string' && parsed.boundingHint.trim().length > 0
-    ? parsed.boundingHint.trim().slice(0, 120)
+    ? sanitizePgString(parsed.boundingHint.trim().slice(0, 120))
     : null;
 
   // stracciatella-92114: truncate per-receipt line items to keep token + DB
@@ -316,7 +322,9 @@ export function parseSingleReceipt(parsed: any): OcrResult {
     amount,
     currency,
     confidence,
-    items: Array.isArray(parsed?.items) ? parsed.items.filter((s: unknown) => typeof s === 'string') : undefined,
+    items: Array.isArray(parsed?.items)
+      ? parsed.items.filter((s: unknown): s is string => typeof s === 'string').map((s: string) => sanitizePgString(s))
+      : undefined,
     lineItems,
     merchant,
     receiptDate,


### PR DESCRIPTION
Closes a residual NUL/unpaired-surrogate → JSONB/text-column 500 gap left by stracchino-49640 (which only sanitized `ocrRaw` + `ocrLineItems`).

## What
Runs every free-form OCR-derived / host-supplied string through `sanitizePgString` before it is persisted to `payout_documents` (and the mirrored `photos` rows):

- **DRY at the source** (`backend/src/services/ocr.service.ts`, `parseSingleReceipt` + `sanitizeLineItems`): `merchant`, `boundingHint`, legacy `items[]`, and line-item `name` are now sanitized once, so every consumer of `ocr.*` gets clean values everywhere they're persisted.
- **Per-site for host/admin-supplied `fileName`** (not OCR-derived) in both `payout.routes.ts` (host submit + second receipt-doc build path + pizza/event doc builds) and `admin-payout.routes.ts` (add-documents create, which also mirrors to the gallery).
- **Defensive currency sanitize** on persisted `ocrCurrency` / `originalCurrency` (model/FX-derived codes) at every insert/update site, plus the admin edit-PATCH `ocrCurrency` parse and admin-edited line-item `name`.

Prisma `select { ... }` blocks (`boundingHint: true`, `fileName: true`, …) and response serializers were left untouched.

## Scope
Backend-only. No schema/migration. No frontend change.

## Verify
`npx tsc --noEmit` is clean for all touched files (the only error is a pre-existing `@types/jsonwebtoken` overload mismatch in `src/middleware/auth.test.ts`, present on master and unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)