### PR TITLE
fix(grana-58505): unresolvable receipt currency → flag for manual pick, not silent 1:1 USD

### DIFF
--- a/backend/src/services/fx.service.ts
+++ b/backend/src/services/fx.service.ts
@@ -193,14 +193,18 @@ export async function convertToUSD(
     };
   }
 
-  // 4. Last resort: rate=1 passthrough. Caller should flag this.
-  console.warn(`[fx] Could not convert ${normalizedCurrency} to USD; no rate available, returning passthrough`);
+  // 4. Could not resolve via any source. Do NOT silently stamp the foreign
+  // amount as 1:1 USD (mortadella-92103: never auto-convert when unsure) —
+  // flag UNRESOLVED so the row surfaces a manual currency picker instead of a
+  // wrong USD total.
+  console.warn(`[fx] Could not convert ${normalizedCurrency} to USD; no rate available — flagging CURRENCY_UNRESOLVED`);
   return {
-    usdAmount: round2(amount),
-    exchangeRate: 1,
+    usdAmount: null,
+    exchangeRate: null,
     originalAmount: amount,
-    originalCurrency: normalizedCurrency,
-    source: 'unknown',
+    originalCurrency: null,
+    source: 'unresolved',
+    error: 'CURRENCY_UNRESOLVED',
   };
 }
 


### PR DESCRIPTION
convertToUSD's last-resort branch silently stamped any unresolvable currency as 1:1 USD (`source:'unknown'`, `exchangeRate:1`), so the wrong foreign amount was counted as real USD instead of being flagged for manual selection. Callers in `payout.routes.ts` only treat a result as unresolved when `source==='unresolved' || usdAmount==null`, so this branch slipped through.

Now the final fallback returns the **same `CURRENCY_UNRESOLVED` shape** as the existing empty/UNKNOWN early-return in the same function (`usdAmount:null`, `exchangeRate:null`, `originalCurrency:null`, `source:'unresolved'`, `error:'CURRENCY_UNRESOLVED'`), so the row surfaces the manual currency picker instead of a wrong USD total.

Found while investigating /sanpedrosula (Honduras HNL actually resolves fine via the providers; this is the latent same-class bug for garbled/non-fiat codes like a model emitting 'USDC' or an OCR typo).

Backend-only, no migration. Only the final fallback branch of `convertToUSD` changed; provider branches, USD passthrough, and CURRENCY_MAP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)