### PR TITLE
feat(stracci-58506): host-selectable survey audience

### DIFF
--- a/backend/src/routes/survey.routes.ts
+++ b/backend/src/routes/survey.routes.ts
@@ -80,7 +80,10 @@ export function buildSurveyEmail(
 // Reuses the bulk-invite batching pattern (groups of 10, 500ms delay, max 500).
 // Returns { sent, failed, skipped } counts.
 // ---------------------------------------------------------------------------
-async function sendSurveyToParty(partyId: string): Promise<{
+async function sendSurveyToParty(
+  partyId: string,
+  audience: 'rsvped' | 'checkedin' | 'approved' = 'rsvped'
+): Promise<{
   sent: number;
   failed: number;
   skipped: number;
@@ -93,10 +96,31 @@ async function sendSurveyToParty(partyId: string): Promise<{
     throw new AppError('Party not found', 404, 'NOT_FOUND');
   }
 
-  // Transactional email — RSVP'd-yes guests only (status CONFIRMED) with an
-  // email. We intentionally ignore mailing_list_opt_in here.
+  // Build the recipient filter from the chosen audience. We intentionally
+  // ignore mailing_list_opt_in here.
+  //   rsvped    → everyone who RSVP'd yes, excluding rejected guests
+  //   checkedin → only guests checked in at the event, excluding rejected
+  //   approved  → only host-approved guests
+  // NOTE: `OR: [{ approved: true }, { approved: null }]` (NOT
+  // `approved: { not: false }`) excludes only rejected (approved=false) while
+  // keeping pending (null) — Prisma 3VL makes `{ not: false }` drop NULL rows.
+  const where =
+    audience === 'checkedin'
+      ? {
+          partyId,
+          checkedInAt: { not: null },
+          OR: [{ approved: true }, { approved: null }],
+        }
+      : audience === 'approved'
+        ? { partyId, status: 'CONFIRMED' as const, approved: true }
+        : {
+            partyId,
+            status: 'CONFIRMED' as const,
+            OR: [{ approved: true }, { approved: null }],
+          };
+
   const guests = await prisma.guest.findMany({
-    where: { partyId, status: 'CONFIRMED' },
+    where,
     select: { id: true, name: true, email: true, surveyToken: true },
   });
 
@@ -298,7 +322,11 @@ hostRouter.post('/:partyId/survey/send', async (req: AuthRequest, res: Response,
     const { partyId } = req.params;
     await assertSurveyTabAccess(req, partyId);
 
-    const result = await sendSurveyToParty(partyId);
+    const requested = (req.body as { audience?: unknown })?.audience;
+    const audience: 'rsvped' | 'checkedin' | 'approved' =
+      requested === 'checkedin' || requested === 'approved' ? requested : 'rsvped';
+
+    const result = await sendSurveyToParty(partyId, audience);
 
     // Manual path may re-send even if survey_sent_at is already set.
     await prisma.party.update({

--- a/frontend/src/components/SurveyTab.tsx
+++ b/frontend/src/components/SurveyTab.tsx
@@ -23,6 +23,7 @@ export const SurveyTab: React.FC<SurveyTabProps> = ({ partyId, surveyEnabled: in
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [sendResult, setSendResult] = useState<{ sent: number; failed: number; skipped: number } | null>(null);
+  const [audience, setAudience] = useState<'rsvped' | 'checkedin' | 'approved'>('rsvped');
 
   const loadResults = useCallback(async () => {
     setLoading(true);
@@ -58,7 +59,7 @@ export const SurveyTab: React.FC<SurveyTabProps> = ({ partyId, surveyEnabled: in
     setSendResult(null);
     setError(null);
     try {
-      const r = await sendSurvey(partyId);
+      const r = await sendSurvey(partyId, audience);
       setSendResult(r);
       await loadResults();
     } catch (e) {
@@ -88,7 +89,37 @@ export const SurveyTab: React.FC<SurveyTabProps> = ({ partyId, surveyEnabled: in
           label="Survey enabled for this event"
         />
 
-        <div className="mt-5 flex flex-wrap items-center gap-3">
+        <div className="mt-5">
+          <div className="inline-flex flex-wrap gap-2">
+            {([
+              ['rsvped', "RSVP'd yes"],
+              ['checkedin', 'Checked-in'],
+              ['approved', 'Approved only'],
+            ] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setAudience(value)}
+                className={
+                  audience === value
+                    ? 'btn-primary text-sm px-3 py-1.5'
+                    : 'text-sm px-3 py-1.5 rounded-lg border border-white/10 text-theme-text-muted hover:text-theme-text'
+                }
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <p className="mt-2 text-xs text-theme-text-muted">
+            {audience === 'checkedin'
+              ? 'Sends only to guests checked in at the event.'
+              : audience === 'approved'
+                ? 'Sends only to host-approved guests.'
+                : "Sends to everyone who RSVP'd yes (excludes rejected guests)."}
+          </p>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
           <button
             type="button"
             onClick={handleSend}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6736,13 +6736,14 @@ export async function submitSurvey(
   });
 }
 
-// Host — send the survey email to all CONFIRMED guests with an email.
+// Host — send the survey email to the chosen audience of guests with an email.
 export async function sendSurvey(
-  partyId: string
+  partyId: string,
+  audience: 'rsvped' | 'checkedin' | 'approved' = 'rsvped'
 ): Promise<{ sent: number; failed: number; skipped: number }> {
   return apiRequest<{ sent: number; failed: number; skipped: number }>(
     `/api/parties/${partyId}/survey/send`,
-    { method: 'POST', requireAuth: true }
+    { method: 'POST', body: { audience }, requireAuth: true }
   );
 }
 


### PR DESCRIPTION
## What
Hosts can now choose **who** the post-event survey email goes to from the Survey tab. A 3-button segmented control sits above "Send survey now".

## Options
- **RSVP'd yes** (default) — everyone who RSVP'd yes, **excluding rejected guests**.
- **Checked-in** — only guests checked in at the event (also excludes rejected).
- **Approved only** — only host-approved guests.

## Rejected-guest exclusion fix
The audience where-clauses use `OR: [{ approved: true }, { approved: null }]` to drop only `approved=false` (rejected) rows while keeping pending (`null`). We deliberately avoid `approved: { not: false }`, which Prisma's 3-valued logic would also use to exclude NULL rows. The new default (`rsvped`) therefore now excludes rejected guests, which is the desired behavior — the hourly cron keeps using this default.

## Notes
- No DB migration. Public survey read/submit endpoints and results aggregation are unchanged.
- **Audience behavior needs the backend deployed from master to take effect** — previews use the production backend, so the new `audience` body param is a no-op on preview until this merges and the backend redeploys.

## Files
- `backend/src/routes/survey.routes.ts` — `sendSurveyToParty(partyId, audience)`; host endpoint reads+validates `audience`.
- `frontend/src/lib/api.ts` — `sendSurvey(partyId, audience)` sends `{ audience }`.
- `frontend/src/components/SurveyTab.tsx` — audience selector + helper text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)