### PR TITLE
perf(provola-58506): codify co_hosts GIN index in schema.prisma

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -312,6 +312,7 @@ model Party {
   reimbursementCapAudits  ReimbursementCapAudit[]
   surveyResponses         SurveyResponse[]
 
+  @@index([coHosts(ops: JsonbPathOps)], type: Gin, map: "idx_parties_co_hosts_gin")
   @@map("parties")
 }
 


### PR DESCRIPTION
The `idx_parties_co_hosts_gin` GIN index (`jsonb_path_ops`) was applied to prod to fix a Seq Scan on the canUserEditParty host-by-email lookup (85ms->0.04ms); this records it in schema.prisma as source of truth so it isn't dropped on a future schema sync. No DB migration run — index already exists in prod.

```prisma
@@index([coHosts(ops: JsonbPathOps)], type: Gin, map: "idx_parties_co_hosts_gin")
```

Verified with `prisma validate` (Prisma 6.19.3): schema is valid. No `db push`/`migrate` executed.