### PR TITLE
ziti-58300 Phase 4: admin by-city primary + submitted-for-review

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -788,6 +788,13 @@ function serializePayout(row: any): any {
     extractedAmountUsd: Number(row.extractedAmountUsd),
     finalAmountUsd: Number(row.finalAmountUsd),
     status: row.status,
+    // ziti-58300: host-signaled "ready for review" timestamp on the rolling
+    // per-(party,host) reimbursement record. Status stays 'pending' while
+    // this is set; admin /payments surfaces it as a "Submitted" badge so
+    // host-ready reimbursements can be prioritized. Null = still rolling.
+    submittedForReviewAt: row.submittedForReviewAt
+      ? row.submittedForReviewAt.toISOString()
+      : null,
     payoutMethod: row.payoutMethod,
     payoutWalletAddress: row.payoutWalletAddress,
     // caciotta-92104: original ENS input (e.g. `puebla.eth`) when the

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -19,6 +19,7 @@ import {
   formatOriginalCurrency,
   ReceiptLightbox,
   AuthenticityPanel,
+  SubmittedForReviewBadge,
 } from '../payments-shared';
 import { ReceiptEditor, computeLineSubtotal } from './ReceiptEditor';
 import { TaxFormReviewPanel } from './TaxFormReviewPanel';
@@ -1766,6 +1767,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 Payment {payout.id.slice(0, 8)}
               </h2>
               <PayoutStatusPill status={payout.status} size="md" />
+              {/* ziti-58300: amber "Submitted {date}" pill in the review header
+                  so the reviewer sees the co-host explicitly marked their
+                  rolling reimbursement ready for review. */}
+              <SubmittedForReviewBadge submittedForReviewAt={payout.submittedForReviewAt} />
               <PayoutMethodIcon method={payout.payoutMethod} showLabel />
             </div>
             <div className="text-xs text-theme-text-muted mt-0.5">

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -45,6 +45,7 @@ import {
   formatUsd,
   computePartyTotals,
   CapInlineEditor,
+  SubmittedForReviewBadge,
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
 import { AdminAddAttachment } from './AdminAddAttachment';
@@ -1241,13 +1242,37 @@ function CityExpansion({
 
   // Hosts — derived from the underlying payouts. Multi-host parties merge
   // into a deduplicated list keyed on the host user-id.
+  // ziti-58300: also capture the most-recent `submittedForReviewAt` across the
+  // host's active (non-terminal) rolling records so the chip can show which
+  // co-hosts have signalled "ready for review" vs still rolling.
+  const TERMINAL_STATUSES = ['paid', 'completed', 'withdrawn', 'rejected'];
   const hosts = useMemo(() => {
-    const seen = new Map<string, { id: string; name: string | null; email: string | null }>();
+    const seen = new Map<
+      string,
+      { id: string; name: string | null; email: string | null; submittedForReviewAt: string | null }
+    >();
     for (const p of row.payouts) {
       const h = p.host;
       if (!h?.id) continue;
-      if (seen.has(h.id)) continue;
-      seen.set(h.id, { id: h.id, name: h.name, email: h.email });
+      // Only an active (non-terminal) rolling record counts as host-ready.
+      const submitted =
+        !TERMINAL_STATUSES.includes(p.status) && p.submittedForReviewAt
+          ? p.submittedForReviewAt
+          : null;
+      const existing = seen.get(h.id);
+      if (existing) {
+        // Keep the latest submitted timestamp if more than one active record.
+        if (submitted && (!existing.submittedForReviewAt || submitted > existing.submittedForReviewAt)) {
+          existing.submittedForReviewAt = submitted;
+        }
+        continue;
+      }
+      seen.set(h.id, {
+        id: h.id,
+        name: h.name,
+        email: h.email,
+        submittedForReviewAt: submitted,
+      });
     }
     return Array.from(seen.values());
   }, [row.payouts]);
@@ -1924,6 +1949,11 @@ function CityExpansion({
                       <ClickableEmail email={h.email} />
                     </span>
                   )}
+                  {/* ziti-58300: amber pill on the co-host chip when they've
+                      flipped their rolling reimbursement's "Submit for review"
+                      toggle — distinguishes host-ready co-hosts from those
+                      still rolling. */}
+                  <SubmittedForReviewBadge submittedForReviewAt={h.submittedForReviewAt} compact />
                 </span>
               ))}
             </div>
@@ -2116,6 +2146,12 @@ function CityExpansion({
                       className="flex-1 flex items-center gap-3 text-left min-w-0"
                     >
                       <PayoutStatusPill status={p.status} />
+                      {/* ziti-58300: host-signaled "ready for review" pill on
+                          the per-payout ledger row inside the expansion. */}
+                      <SubmittedForReviewBadge
+                        submittedForReviewAt={p.submittedForReviewAt}
+                        compact
+                      />
                       <span className="text-theme-text-secondary text-xs min-w-[5.5rem] shrink-0">
                         {formatLedgerDate(p.createdAt)}
                       </span>

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Flag } from 'lucide-react';
 import type { AdminPayout, Payout } from '../../types';
 import { ClickableEmail } from '../ClickableEmail';
 import { PayoutStatusPill } from './PayoutStatusPill';
+import { SubmittedForReviewBadge } from './SubmittedForReviewBadge';
 import { PayoutMethodIcon } from './PayoutMethodIcon';
 import { formatPayoutAmount, formatOriginalCurrency } from './formatPayoutAmount';
 import { CapInlineEditor } from './CapInlineEditor';
@@ -284,8 +285,12 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
       </td>
 
       <td className="px-3 py-3">
-        <div className="inline-flex items-center gap-1.5">
+        <div className="inline-flex items-center gap-1.5 flex-wrap">
           <PayoutStatusPill status={payout.status} />
+          {/* ziti-58300: amber "Submitted" pill when the co-host has flipped
+              their rolling reimbursement's "Submit for review" toggle. Helps
+              admins prioritise host-ready records over still-rolling ones. */}
+          <SubmittedForReviewBadge submittedForReviewAt={payout.submittedForReviewAt} compact />
           {/* argentina-92103: green Flag icon when a regional underboss (or
               admin) has marked the row "ready for payment". Tooltip carries
               the actor email + timestamp. Sticky until the row is paid /

--- a/frontend/src/components/payments-shared/SubmittedForReviewBadge.tsx
+++ b/frontend/src/components/payments-shared/SubmittedForReviewBadge.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { CheckCircle2 } from 'lucide-react';
+
+interface SubmittedForReviewBadgeProps {
+  /**
+   * ziti-58300: the rolling reimbursement's `submittedForReviewAt` timestamp
+   * (ISO string) or null. When null the badge renders nothing — the host
+   * hasn't signalled their reimbursement is ready for review yet.
+   */
+  submittedForReviewAt?: string | null;
+  /** Compact variant drops the date text and shows just the check + label. */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * ziti-58300: amber "Submitted {date}" pill surfaced wherever a payout / host
+ * reimbursement row is shown on the admin /payments app. Signals that a co-host
+ * has explicitly marked their rolling reimbursement ready for review (the
+ * `submitted_for_review_at` flag) so admins can prioritise host-ready records.
+ *
+ * Mirrors PayoutStatusPill's pill aesthetic so it sits cleanly alongside the
+ * status pill. Amber matches the "pending but actionable" convention used for
+ * the unapprove / cap-warning affordances across the admin tables.
+ */
+export const SubmittedForReviewBadge: React.FC<SubmittedForReviewBadgeProps> = ({
+  submittedForReviewAt,
+  compact = false,
+  className = '',
+}) => {
+  if (!submittedForReviewAt) return null;
+  const abs = new Date(submittedForReviewAt).toLocaleString();
+  const label = compact
+    ? 'Submitted'
+    : `Submitted ${new Date(submittedForReviewAt).toLocaleDateString()}`;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full font-medium border px-2 py-0.5 text-xs bg-amber-100 text-amber-800 border-amber-300 ${className}`}
+      title={`Host marked this reimbursement ready for review on ${abs}`}
+    >
+      <CheckCircle2 size={12} className="shrink-0" />
+      {label}
+    </span>
+  );
+};

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -1,4 +1,5 @@
 export { PayoutStatusPill } from './PayoutStatusPill';
+export { SubmittedForReviewBadge } from './SubmittedForReviewBadge';
 export { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from './PayoutMethodIcon';
 export { PayoutRow } from './PayoutRow';
 export { CapInlineEditor } from './CapInlineEditor';


### PR DESCRIPTION
## ziti-58300 Phase 4 — admin /payments by-city primary + submitted-for-review signal

Phase 4 of the event-level reimbursements work. Phase 1 backend (rolling per-(party,host) reimbursements + the `payouts.submitted_for_review_at` column, already in prod) is merged. This PR is **display + default-view only** plus a small additive serialization add — no migration, no money-movement changes.

### Backend (additive, no migration)
- `admin-payout.routes.ts` `serializePayout` now emits `submittedForReviewAt` (ISO string | null). It flows through the single payout GET, the list endpoint, and the `/by-party` rollup's embedded payouts (all three serialize via this one helper).
- The host-side `serializePayout` in `payout.routes.ts` is **separate** and already emits the field (Phase 1/3) — it was **not** touched, so the host endpoints are unaffected.
- TS types: the base `Payout` interface (extended by `AdminPayout`) already carries `submittedForReviewAt?: string | null` from Phase 3 — no new frontend type needed.

### Frontend
- New shared `SubmittedForReviewBadge` (amber "Submitted {date}" pill, matching `PayoutStatusPill` aesthetic).
- `PayoutRow` (per-payment power table) — badge in the status cell next to the flagged-ready icon.
- `PayoutsByPartyTable` (by-city) — per-co-host chip shows the badge when that host has an active (non-terminal) submitted record, distinguishing host-ready co-hosts from still-rolling; per-payout ledger rows inside the expansion also show it.
- `PayoutReviewModal` header — badge next to the status pill.
- **by-city is already the default** `viewMode` (sticky in localStorage, falls back to `by-city`); the `by-payment` and `payments` tabs are unchanged.

### Not changed
Payment execution, caps, lifecycle endpoints, prepay queue, money movement.

### Skipped (noted in plan as optional)
A sort/filter to float host-submitted-but-pending records to the top — left out as not low-risk enough for this display-only PR.

### Verification
- `backend npx tsc --noEmit`: clean except the pre-existing `auth.test.ts` jsonwebtoken overload error (unrelated, not touched).
- `frontend npx tsc --noEmit`: clean.

Plan: `plans/ziti-58300-event-level-reimbursements.md` (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
