### PR TITLE
rigatoni-58301: hide 50% prepayment checkbox after event has happened

### DIFF
--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -492,7 +492,9 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
         </div>
       )}
 
-      <PrepayCheckbox partyId={partyId} />
+      {/* rigatoni-58301: 50% prepayment only makes sense before the event —
+          hide the opt-in once the event date has passed. */}
+      {!eventHasHappened && <PrepayCheckbox partyId={partyId} />}
 
       {/* ===== 2. Estimated attendance (hard requirement) ===== */}
       <div className="relative">


### PR DESCRIPTION
Hides the "I need 50% prepayment for this event" checkbox on the host Payments tab once the event date has passed (prepayment is pre-event only). One-line guard reusing the existing `eventHasHappened`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)