### PR TITLE
fix(bresaola-58502): Risk pill opens flag popover instead of expanding the row

### DIFF
--- a/frontend/src/components/payments-admin/FakeDetectionBadge.tsx
+++ b/frontend/src/components/payments-admin/FakeDetectionBadge.tsx
@@ -103,7 +103,13 @@ export function FakeDetectionBadge({
         ref={buttonRef}
         type="button"
         className={className}
-        onClick={() => setOpen(o => !o)}
+        onClick={e => {
+          // Stop the click from bubbling to the by-city row's onClick (which
+          // toggles row expansion in PayoutsByPartyTable) — otherwise the row
+          // expands instead of (just) opening the flag popover.
+          e.stopPropagation();
+          setOpen(o => !o);
+        }}
         aria-expanded={open}
       >
         <AlertTriangle size={11} />


### PR DESCRIPTION
## Problem
On `/payments`, clicking the **Risk pill** (`FakeDetectionBadge`) on a by-city row was expanding the event row instead of opening the fired-flags popover that shipped in PR #914.

## Root cause
The pill button is rendered inside the by-city row in `PayoutsByPartyTable.tsx`, whose `onClick` toggles row expansion. The pill's own `onClick` (`setOpen(o => !o)`) never called `e.stopPropagation()`, so the click bubbled up to the row handler. Every other interactive control in that row already guards with `stopPropagation()`; the badge was the one that was missed.

## Fix
One line — `e.stopPropagation()` in the pill button's `onClick` before toggling the popover. Frontend-only, no DB migration, no backend change.

## Verify
On a preview build, open `/payments` (by-city view), find a city with an amber/red Risk pill, and click it — the flag popover should open and the row should **not** expand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)