### PR TITLE
fix(polpetta): remove single_checker_dominance from fraud risk flags

### DIFF
--- a/backend/src/lib/fakeDetection.test.ts
+++ b/backend/src/lib/fakeDetection.test.ts
@@ -33,7 +33,6 @@ import {
   checkHighBounceRate,
   checkCheckinVelocitySuperhuman,
   checkCheckinTimestampCollapse,
-  checkSingleCheckerDominance,
   checkCheckinRatioExtreme,
   scoreEvent,
   buildSybilWalletSet,
@@ -93,7 +92,6 @@ const TEST_WEIGHTS: Record<keyof typeof WEIGHTS, number> = {
   high_bounce_rate: SYNTH_W,
   checkin_velocity_superhuman: SYNTH_CHECKIN_W,
   checkin_timestamp_collapse: SYNTH_CHECKIN_W,
-  single_checker_dominance: SYNTH_CHECKIN_W,
   checkin_ratio_extreme: SYNTH_CHECKIN_W,
 };
 
@@ -1449,32 +1447,6 @@ describe('checkCheckinTimestampCollapse', () => {
   });
 });
 
-describe('checkSingleCheckerDominance', () => {
-  it('fires when one checker performed ≥95% of check-ins', () => {
-    const guests = fraudCheckinRoster(40, 3600, 'host-1');
-    const r = checkSingleCheckerDominance(guests);
-    expect(r.fired).toBe(true);
-    expect((r.evidence as { distinctCheckers: number }).distinctCheckers).toBe(1);
-  });
-
-  it('treats null checker as a single dominant bucket', () => {
-    const guests = fraudCheckinRoster(40, 3600, null);
-    const r = checkSingleCheckerDominance(guests);
-    expect(r.fired).toBe(true);
-    expect((r.evidence as { dominantIsNull: boolean }).dominantIsNull).toBe(true);
-  });
-
-  it('collapses (not fired) below n=20', () => {
-    const guests = fraudCheckinRoster(19, 3600, 'host-1');
-    expect(checkSingleCheckerDominance(guests).fired).toBe(false);
-  });
-
-  it('does not fire with multiple distinct checkers', () => {
-    const guests = healthyCheckinRoster(40, 40); // 4 rotating checkers → topShare 25%
-    expect(checkSingleCheckerDominance(guests).fired).toBe(false);
-  });
-});
-
 describe('checkCheckinRatioExtreme', () => {
   it('fires when ≥95% of the roster is checked in', () => {
     // 78 checked in + 3 not = 81 total → 96%.
@@ -1507,7 +1479,6 @@ describe('scoreEvent — check-in heuristics integration', () => {
     const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
     expect(firedIds).toContain('checkin_velocity_superhuman');
     expect(firedIds).toContain('checkin_timestamp_collapse');
-    expect(firedIds).toContain('single_checker_dominance');
     expect(firedIds).toContain('checkin_ratio_extreme');
     expect(row.score).toBeGreaterThanOrEqual(
       TEST_WEIGHTS.checkin_velocity_superhuman + TEST_WEIGHTS.checkin_ratio_extreme,
@@ -1521,7 +1492,6 @@ describe('scoreEvent — check-in heuristics integration', () => {
     const firedIds = row.flags.filter(f => f.fired).map(f => f.id);
     expect(firedIds).not.toContain('checkin_velocity_superhuman');
     expect(firedIds).not.toContain('checkin_timestamp_collapse');
-    expect(firedIds).not.toContain('single_checker_dominance');
     expect(firedIds).not.toContain('checkin_ratio_extreme');
   });
 });

--- a/backend/src/lib/fakeDetection.ts
+++ b/backend/src/lib/fakeDetection.ts
@@ -153,7 +153,6 @@ export const WEIGHTS = {
   // guests.checked_in_at / checked_in_by.
   checkin_velocity_superhuman: 0,
   checkin_timestamp_collapse: 0,
-  single_checker_dominance: 0,
   checkin_ratio_extreme: 0,
 } as const;
 
@@ -1166,40 +1165,6 @@ export function checkCheckinTimestampCollapse(guests: FakeDetectionGuest[]): Fla
 }
 
 /**
- * single_checker_dominance — one account (`checked_in_by`) performed ≥95% of
- * all check-ins. Null/undefined checkers bucket under the literal "__null__".
- */
-export function checkSingleCheckerDominance(guests: FakeDetectionGuest[]): FlagResult {
-  const id = 'single_checker_dominance';
-  const checkedIn = checkedInGuests(guests);
-  const n = checkedIn.length;
-  if (n < 20) return flag(id, false, `n=${n} below 20`);
-  const counts = new Map<string, number>();
-  for (const g of checkedIn) {
-    const key = g.checkedInBy ?? '__null__';
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  let maxCount = 0;
-  let topKey = '';
-  for (const [key, c] of counts) {
-    if (c > maxCount) {
-      maxCount = c;
-      topKey = key;
-    }
-  }
-  const topShare = maxCount / n;
-  const distinctCheckers = counts.size;
-  const dominantIsNull = topKey === '__null__';
-  const fired = topShare >= 0.95;
-  return flag(
-    id,
-    fired,
-    `topShare=${(topShare * 100).toFixed(1)}%, distinctCheckers=${distinctCheckers}, dominantIsNull=${dominantIsNull}`,
-    { n, topShare, distinctCheckers, dominantIsNull },
-  );
-}
-
-/**
  * checkin_ratio_extreme — ≥95% of the entire RSVP roster is marked checked-in.
  * Real events have no-shows; a near-100% attendance rate is a fraud tell.
  */
@@ -1281,7 +1246,6 @@ export function scoreEvent(
     // check-ins can land on invite/host rows, not just direct RSVPs.
     checkCheckinVelocitySuperhuman(allGuests),
     checkCheckinTimestampCollapse(allGuests),
-    checkSingleCheckerDominance(allGuests),
     checkCheckinRatioExtreme(allGuests),
   ];
 

--- a/plans/polpetta-drop-single-checker.md
+++ b/plans/polpetta-drop-single-checker.md
@@ -1,0 +1,42 @@
+# polpetta — remove `single_checker_dominance` from fraud risk flags
+
+## Problem
+The `single_checker_dominance` heuristic fires when one account performed ≥95% of
+an event's door check-ins. On this platform a single host checking everyone in is
+the **norm**, not a fraud signal — most events are run by one person with one phone.
+It produced a false-positive +10 on Bhubaneswar while its sibling check-in
+heuristics (`checkin_velocity_superhuman`, `checkin_timestamp_collapse`,
+`checkin_ratio_extreme`) — the ones that actually indicate roster-blasting fraud —
+did **not** fire. We're retiring it.
+
+## Scope
+Backend-only. No DB migration. No frontend change (the Risk pill renders whatever
+flags the backend returns, so dropping the flag from `row.flags` removes it from the
+UI automatically). Once the key leaves `WEIGHTS`, `resolveWeights` no longer reads
+it from `private.fraud_weights`, so any production weight for it goes dead — no
+config edit required.
+
+## Changes
+### `backend/src/lib/fakeDetection.ts`
+1. Remove the `single_checker_dominance: 0,` entry from the `WEIGHTS` map.
+2. Delete the `checkSingleCheckerDominance` function and its doc-comment block.
+3. Remove the `checkSingleCheckerDominance(allGuests),` call from `scoreEvent`'s
+   `rawFlags` array.
+
+### `backend/src/lib/fakeDetection.test.ts`
+1. Remove `checkSingleCheckerDominance` from the import list.
+2. Remove the `single_checker_dominance: SYNTH_CHECKIN_W,` entry from `TEST_WEIGHTS`.
+3. Delete the `describe('checkSingleCheckerDominance', ...)` block.
+4. In `scoreEvent — check-in heuristics integration`, remove the two assertions
+   referencing `single_checker_dominance` (the `toContain` in the fraud-roster test
+   and the `not.toContain` in the healthy-roster test).
+
+## Verification
+- `npm run build` (tsc) green in `backend/`.
+- `npm test -- fakeDetection` green — the three remaining check-in heuristics still
+  fire on the fraud roster and stay quiet on the healthy roster.
+
+## Follow-up (Snax)
+- Backfill the project-sheet row with the real pizza id/number for this task.
+- Optional housekeeping: drop the `single_checker_dominance` key from the
+  `private.fraud_weights` app_config row (harmless if left — it's now ignored).


### PR DESCRIPTION
@
## What
Removes the `single_checker_dominance` fraud-detection heuristic entirely.

## Why
It fires when one account performed ≥95% of an events door check-ins. On this
platform a single host checking everyone in with one phone is the **norm**, not a
fraud signal — so it produced a false-positive **+10** on legitimate events (e.g.
Bhubaneswar). Tellingly, its sibling check-in heuristics that *do* indicate
roster-blasting fraud — `checkin_velocity_superhuman`, `checkin_timestamp_collapse`,
`checkin_ratio_extreme` — did **not** fire on those same events. The signal only
ever added noise in isolation.

## Scope
- Backend-only. **No DB migration.**
- **No frontend change**: the Risk pill renders whatever flags the backend returns,
  so dropping it from `row.flags` removes it from the UI automatically.
- **No config change required**: once the key leaves `WEIGHTS`, `resolveWeights`
  stops reading it from `private.fraud_weights`, so any prod weight goes dead.
  (Optional housekeeping: delete the now-ignored key from that app_config row.)

## Changes
- `backend/src/lib/fakeDetection.ts` — drop the `WEIGHTS` entry, the
  `checkSingleCheckerDominance` function, and its call in `scoreEvent`.
- `backend/src/lib/fakeDetection.test.ts` — drop the import, the `TEST_WEIGHTS`
  entry, the heuristics `describe` block, and two integration assertions.
- `plans/polpetta-drop-single-checker.md` — plan.

## Verification
Pure deletion; grep confirms zero remaining references to `single_checker_dominance`
/ `checkSingleCheckerDominance`. The three other check-in heuristics are untouched
and their tests remain. Not built/tested locally (backend `node_modules` not
installed in this env) — relying on the merge/CI build.

> ⚠️ Backend logic change: takes effect only after merge to `master` (backend
> auto-deploys from master); the Vercel **frontend** preview does not exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@