### PR TITLE
feat(bombolone-58509): last-sent date on Send wallet reminder

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -172,6 +172,7 @@ model Party {
   hostTelegramChatId      BigInt?   @map("host_telegram_chat_id") // Host's private Telegram chat_id (set via /start <token> webhook)
   hostTelegramLinkToken   String?   @unique @map("host_telegram_link_token") @db.VarChar // nanoid(10) token for host /start deeplink
   receiptsReminderSentAt  DateTime? @map("receipts_reminder_sent_at") @db.Timestamptz // When admin sent TG receipts reminder
+  walletReminderSentAt    DateTime? @map("wallet_reminder_sent_at") @db.Timestamptz // When admin sent TG wallet reminder
   poapEventId             String?   @map("poap_event_id") // POAP event ID
   poapMints             Int?    @map("poap_mints") // POAP mint count
   poapMoments           Int?    @map("poap_moments") // POAP moments count

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -290,6 +290,8 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   adminNotes: true,
   // Track when the TG receipts reminder was last sent for this city.
   receiptsReminderSentAt: true,
+  // Track when the TG wallet reminder was last sent for this city.
+  walletReminderSentAt: true,
   // City-level payment approval fields.
   paymentsApprovedUsd: true,
   paymentsApprovedAt: true,
@@ -2149,6 +2151,10 @@ router.get(
             // When the TG receipts reminder was last sent.
             receiptsReminderSentAt: b.partyMeta.receiptsReminderSentAt
               ? b.partyMeta.receiptsReminderSentAt.toISOString()
+              : null,
+            // When the TG wallet reminder was last sent.
+            walletReminderSentAt: b.partyMeta.walletReminderSentAt
+              ? b.partyMeta.walletReminderSentAt.toISOString()
               : null,
             // City-level payment approval.
             paymentsApprovedUsd: b.partyMeta.paymentsApprovedUsd
@@ -6540,8 +6546,9 @@ router.post(
 // is linked) and posts to the city's GPP group chat, telling the host to
 // submit their payout wallet address on the host page's Payments tab. Same
 // per-channel send + skip-reason contract; the only differences are the
-// message text + target URL. We don't persist a "sent at" timestamp for this
-// one (no DB column), so unlike receipts there's no last-sent sub-label.
+// message text + target URL. Persists `parties.wallet_reminder_sent_at` on
+// success, mirroring the receipts reminder, so the menu can show a last-sent
+// sub-label.
 router.post(
   '/:partyId/tg-wallet-reminder',
   requireAuth,
@@ -6588,6 +6595,14 @@ router.post(
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
       const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+
+      // Record when the reminder was sent (if at least one message succeeded).
+      if (hostDmSent || groupSent) {
+        await prisma.party.update({
+          where: { id: partyId },
+          data: { walletReminderSentAt: new Date() },
+        });
+      }
 
       console.log(
         `[tg-wallet-reminder] party=${party.id} slug=${slug} host_dm=${

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -456,6 +456,7 @@ function CityActionsMenu({
   customTags,
   tagBusy,
   receiptsReminderSentAt,
+  walletReminderSentAt,
   paymentsApprovedUsd,
   receiptsTotalUsd,
 }: {
@@ -504,6 +505,7 @@ function CityActionsMenu({
   /** panuozzo-58217: an add/remove is in flight for this party. */
   tagBusy: boolean;
   receiptsReminderSentAt?: string | null;
+  walletReminderSentAt?: string | null;
   paymentsApprovedUsd?: number | null;
   paymentsApprovedAt?: string | null;
   /** Receipts total for default approval amount. */
@@ -826,8 +828,8 @@ function CityActionsMenu({
                 {/* Send wallet reminder — sibling of the receipts reminder.
                     DMs the host + posts to the city group telling them to
                     submit their payout wallet address. Same two-click confirm
-                    (DMs can't be unsent). No last-sent sub-label (not
-                    persisted). */}
+                    (DMs can't be unsent). Shows a last-sent sub-label from
+                    `walletReminderSentAt`, mirroring the receipts reminder. */}
                 {canSendWalletReminder && (
                   <button
                     type="button"
@@ -857,9 +859,18 @@ function CityActionsMenu({
                         }
                       />
                     )}
-                    {confirmWalletReminder
-                      ? 'Click again to confirm'
-                      : 'Send wallet reminder'}
+                    <span className="flex flex-col items-start">
+                      <span>
+                        {confirmWalletReminder
+                          ? 'Click again to confirm'
+                          : 'Send wallet reminder'}
+                      </span>
+                      {walletReminderSentAt && !confirmWalletReminder && (
+                        <span className="text-xs text-theme-text-muted">
+                          Sent {new Date(walletReminderSentAt).toLocaleDateString()}
+                        </span>
+                      )}
+                    </span>
                   </button>
                 )}
                 {/* panuozzo-58217: free-text custom tags. Admins + underbosses
@@ -3524,6 +3535,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           reopenBusy={reopenBusyPartyId === row.party.id}
                           approveBusy={approveBusyPartyId === row.party.id}
                           receiptsReminderSentAt={row.party.receiptsReminderSentAt}
+                          walletReminderSentAt={row.party.walletReminderSentAt}
                           paymentsApprovedUsd={row.party.paymentsApprovedUsd}
                           paymentsApprovedAt={row.party.paymentsApprovedAt}
                           receiptsTotalUsd={receiptUsdTotal}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -340,6 +340,7 @@ export interface Party {
   hostTelegramChatId?: string | null;
   hostTelegramLinkToken?: string | null;
   receiptsReminderSentAt?: string | null;
+  walletReminderSentAt?: string | null;
   underbossStatus?: UnderbossStatus | null;
   turtleRolesEnabled?: boolean;
   // romana-61204: post-event survey toggle
@@ -2457,6 +2458,8 @@ export interface PartyPayoutsRow {
     adminNotes?: string | null;
     /** ISO timestamp of when the TG receipts reminder was last sent. */
     receiptsReminderSentAt?: string | null;
+    /** ISO timestamp of when the TG wallet reminder was last sent. */
+    walletReminderSentAt?: string | null;
     /** City-level approved payment amount. */
     paymentsApprovedUsd?: number | null;
     /** ISO timestamp of when the city payment was approved. */

--- a/supabase/migrations/20260607_wallet_reminder_sent_at.sql
+++ b/supabase/migrations/20260607_wallet_reminder_sent_at.sql
@@ -1,0 +1,4 @@
+-- Track when wallet reminders are sent for a party/city.
+-- Recorded when the TG wallet-reminder endpoint successfully sends at least one message.
+
+ALTER TABLE parties ADD COLUMN IF NOT EXISTS wallet_reminder_sent_at timestamptz;


### PR DESCRIPTION
## Problem
On `/payments`, **Send receipts reminder** shows a "Sent M/D/YYYY" sub-label but **Send wallet reminder** does not — even when both were sent the same day. The receipts route persisted `parties.receipts_reminder_sent_at`; the wallet route deliberately persisted nothing (no column), so there was no date to render.

## Fix
Symmetric treatment via a new nullable `parties.wallet_reminder_sent_at` column:
- **schema.prisma**: `walletReminderSentAt` on `Party`.
- **admin-payout.routes.ts**: select it, return it on the payouts row, and write `walletReminderSentAt: new Date()` in the `tg-wallet-reminder` route on a successful send (same `hostDmSent || groupSent` guard as receipts).
- **types.ts**: add to `Party` + `PartyPayoutsRow.party`.
- **PayoutsByPartyTable.tsx**: thread the prop and render the "Sent …" sub-label, mirroring the receipts item.

## DB
`ALTER TABLE parties ADD COLUMN IF NOT EXISTS wallet_reminder_sent_at timestamptz;` — applied to prod **before** merge (this repo has no auto-migrate).

## Notes
Nullable, no backfill — existing rows show no sub-label until the next send (same as receipts at launch). Prior sends won't retro-populate.

Plan: `plans/bombolone-58509-wallet-reminder-sentat.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)