### PR TITLE
feat(panino-58508): receipt uploader + upload date on /payments

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -862,6 +862,9 @@ function serializePayout(row: any): any {
       uploadedByUserId: d.uploadedByUserId ?? null,
       uploadedByName: d.uploadedBy?.name ?? null,
       uploadedByEmail: d.uploadedByEmail ?? d.uploadedBy?.email ?? null,
+      // panino-58508: per-doc upload timestamp so admin /payments can show
+      // "Uploaded {date} by {name}".
+      createdAt: d.createdAt ? d.createdAt.toISOString() : null,
     })),
     party: row.party
       ? {

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -34,6 +34,14 @@ function stripGppPrefix(name: string): string {
   return name.replace(/^Global Pizza Party\s+/i, '');
 }
 
+// panino-58508: shared short-date formatter for receipt upload attribution.
+// Matches ReceiptsLibrary's "MMM D, YYYY" format.
+function formatUploadedAt(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  });
+}
+
 /**
  * taleggio-58499: IconInput defaults to the global dark-theme input styling
  * (near-white text on translucent dark bg from index.css). Inside the
@@ -2017,6 +2025,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     // DUPLICATE pill) so the grid stays scannable. Admin
                     // can still un-toggle either flag from the editor.
                     const isIne = doc.ineligible === true && !isDup;
+                    // panino-58508: second tooltip line — "Uploaded {date} by {name}".
+                    const uploadedLine = (doc.createdAt || doc.uploadedByName || doc.uploadedByEmail)
+                      ? `\nUploaded ${doc.createdAt ? formatUploadedAt(doc.createdAt) : ''}${
+                          (doc.uploadedByName || doc.uploadedByEmail)
+                            ? `${doc.createdAt ? ' by ' : 'by '}${doc.uploadedByName || doc.uploadedByEmail}` : ''}`
+                      : '';
                     return (
                       <button
                         key={doc.id}
@@ -2048,10 +2062,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         }`}
                         title={
                           isDup
-                            ? `[DUPLICATE — excluded from totals] ${doc.fileName}`
+                            ? `[DUPLICATE — excluded from totals] ${doc.fileName}${uploadedLine}`
                             : isIne
-                              ? `[INELIGIBLE — excluded from totals] ${doc.fileName}`
-                              : doc.fileName
+                              ? `[INELIGIBLE — excluded from totals] ${doc.fileName}${uploadedLine}`
+                              : `${doc.fileName}${uploadedLine}`
                         }
                       >
                         {isVideoFile(doc) ? (
@@ -2557,7 +2571,20 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                               'bg-gray-400'
                             }`}
                           />
-                          <span className="text-theme-text-muted flex-1 truncate">{r.fileName}</span>
+                          {/* panino-58508: filename + upload attribution stacked
+                              so "Uploaded {date} by {name}" sits under the name
+                              without breaking the inline-edit flex row. */}
+                          <span className="flex-1 min-w-0 flex flex-col">
+                            <span className="text-theme-text-muted truncate">{r.fileName}</span>
+                            {(r.createdAt || r.uploadedByName || r.uploadedByEmail) && (
+                              <span className="text-[10px] text-white/40 truncate">
+                                {r.createdAt && <>Uploaded {formatUploadedAt(r.createdAt)}</>}
+                                {(r.uploadedByName || r.uploadedByEmail) && (
+                                  <>{r.createdAt ? ' by ' : 'Uploaded by '}{r.uploadedByName || r.uploadedByEmail}</>
+                                )}
+                              </span>
+                            )}
+                          </span>
                           {canEditReceipts ? (
                             <>
                               {/*

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -150,6 +150,14 @@ function draftSubtotalSum(drafts: LineItemDraft[] | undefined): number {
   return sum;
 }
 
+// panino-58508: shared short-date formatter for receipt upload attribution.
+// Matches ReceiptsLibrary's "MMM D, YYYY" format.
+function formatUploadedAt(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  });
+}
+
 export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   doc,
   draft,
@@ -190,6 +198,8 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
     authenticityVerdict === 'suspicious' || authenticityVerdict === 'likely_fake';
   const conf = doc.ocrConfidence ?? 0;
   const lowConf = conf > 0 && conf < 0.8;
+  // panino-58508: per-doc uploader attribution for the receipt header.
+  const uploader = doc.uploadedByName || doc.uploadedByEmail || null;
   const lineSum = draftSubtotalSum(lineItemDrafts);
   // The "Sum" label uses the receipt's original currency if known so it
   // matches what admins are typing into the per-line subtotals.
@@ -296,6 +306,13 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
           <p className="text-xs text-theme-text-muted truncate" title={doc.fileName}>
             {doc.fileName}
           </p>
+          {/* panino-58508: receipt upload attribution — "Uploaded {date} by {name}". */}
+          {(doc.createdAt || uploader) && (
+            <p className="text-xs text-white/40 mt-0.5">
+              {doc.createdAt && <>Uploaded {formatUploadedAt(doc.createdAt)}</>}
+              {uploader && <>{doc.createdAt ? ' by ' : 'Uploaded by '}{uploader}</>}
+            </p>
+          )}
           {/* stracciatella-92114: multi-receipt-per-photo label. Only when a
               single photo resolved to >1 detected receipts. */}
           {doc.sourceReceiptCount != null && doc.sourceReceiptCount > 1 && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1741,6 +1741,8 @@ export interface PayoutDocument {
   uploadedByUserId?: string | null;
   uploadedByName?: string | null;
   uploadedByEmail?: string | null;
+  // panino-58508: per-doc upload timestamp (ISO). Null/omitted on older payloads.
+  createdAt?: string | null;
 }
 
 /**


### PR DESCRIPTION
## What
Surface **"Uploaded {date} by {name}"** on the admin `/payments` receipt surfaces. The uploader name/email was already on the wire (`PayoutDocument.uploadedByName` / `uploadedByEmail`); this adds the missing per-doc upload **timestamp** and renders the attribution in three places.

## Changes
- **Backend** (`admin-payout.routes.ts`): `serializePayout` now emits `createdAt` (ISO) for each document. The scalar is already loaded by the existing `include`, so no query/select change — and every payout endpoint reuses `serializePayout`, so all callsites are covered.
- **Type** (`types.ts`): `PayoutDocument.createdAt?: string | null` (null/omitted on older payloads).
- **ReceiptEditor.tsx**: attribution line under the filename in the receipt header.
- **PayoutReviewModal.tsx**: (a) thumbnail tooltip gets a second line; (b) compact right-pane row stacks filename + attribution without breaking the inline-edit flex layout.
- Shared `formatUploadedAt` helper (`MMM D, YYYY`) mirroring `ReceiptsLibrary`.

## Deploy ordering
The new `createdAt` wire field requires the **backend on master** before preview frontends render the **date** (preview frontends talk to the prod backend). The uploader **name** works immediately since it was already on the wire. Graceful: if `createdAt` is absent, only the name shows.

## Verification note
`node_modules` was unavailable in the worktree (and the main repo's copy is OneDrive-offloaded), so `tsc --noEmit` could not be run here. Edits were verified by reading: `r`/`doc` are `PayoutDocument` (derived from `payout.documents`), all new field accesses resolve to `string | null | undefined`, JSX is balanced, and `PayoutDocument.createdAt` is a non-null Prisma `DateTime`. A CI/preview typecheck should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)