### PR TITLE
fix(stromboli): native <select> option text invisible on dark theme

### DIFF
--- a/frontend/src/components/budget/BudgetItemForm.tsx
+++ b/frontend/src/components/budget/BudgetItemForm.tsx
@@ -178,7 +178,7 @@ export const BudgetItemForm: React.FC<BudgetItemFormProps> = ({
                 className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
               >
                 {BUDGET_CATEGORIES.map((cat) => (
-                  <option key={cat.id} value={cat.id} className="bg-theme-header">
+                  <option key={cat.id} value={cat.id}>
                     {cat.label}
                   </option>
                 ))}

--- a/frontend/src/components/photos/PhotoUpload.tsx
+++ b/frontend/src/components/photos/PhotoUpload.tsx
@@ -306,9 +306,9 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
             onChange={(e) => setPhotoYear(e.target.value ? parseInt(e.target.value, 10) : null)}
             className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-4 py-2 text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
           >
-            <option value="" className="bg-theme-card text-theme-text">Year taken (optional)</option>
+            <option value="">Year taken (optional)</option>
             {yearOptions.map((year) => (
-              <option key={year} value={year} className="bg-theme-card text-theme-text">
+              <option key={year} value={year}>
                 {year}
               </option>
             ))}

--- a/frontend/src/components/raffle/RaffleForm.tsx
+++ b/frontend/src/components/raffle/RaffleForm.tsx
@@ -69,10 +69,10 @@ export function RaffleForm({ raffle, onSubmit, onClose, isLoading }: RaffleFormP
               onChange={(e) => setEntriesPerGuest(parseInt(e.target.value, 10))}
               className="w-full bg-theme-surface border border-theme-stroke rounded-xl px-4 py-3 text-theme-text text-sm focus:outline-none focus:border-[#ff393a]/50"
             >
-              <option value={1} className="bg-theme-header text-theme-text">{t('raffle.entriesPerGuest_1')}</option>
-              <option value={2} className="bg-theme-header text-theme-text">{t('raffle.entriesPerGuest_2')}</option>
-              <option value={3} className="bg-theme-header text-theme-text">{t('raffle.entriesPerGuest_3')}</option>
-              <option value={5} className="bg-theme-header text-theme-text">{t('raffle.entriesPerGuest_5')}</option>
+              <option value={1}>{t('raffle.entriesPerGuest_1')}</option>
+              <option value={2}>{t('raffle.entriesPerGuest_2')}</option>
+              <option value={3}>{t('raffle.entriesPerGuest_3')}</option>
+              <option value={5}>{t('raffle.entriesPerGuest_5')}</option>
             </select>
           </div>
 

--- a/frontend/src/components/sponsors/PartnerForm.tsx
+++ b/frontend/src/components/sponsors/PartnerForm.tsx
@@ -573,9 +573,9 @@ export function PartnerForm({
             className="w-full !pl-14 bg-theme-input border border-theme-stroke rounded-xl text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
             style={{ colorScheme: 'dark' }}
           >
-            <option value="" className="bg-theme-header text-theme-text-muted">Category</option>
+            <option value="">Category</option>
             {SPONSOR_CATEGORIES.map(opt => (
-              <option key={opt.id} value={opt.id} className="bg-theme-header text-theme-text">
+              <option key={opt.id} value={opt.id}>
                 {opt.label}
               </option>
             ))}
@@ -670,7 +670,7 @@ export function PartnerForm({
                 style={{ colorScheme: 'dark' }}
               >
                 {STATUS_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value} className="bg-theme-header text-theme-text">
+                  <option key={opt.value} value={opt.value}>
                     {t(opt.labelKey)}
                   </option>
                 ))}
@@ -684,9 +684,9 @@ export function PartnerForm({
                 className="w-full !pl-14 bg-theme-input border border-theme-stroke rounded-xl text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
                 style={{ colorScheme: 'dark' }}
               >
-                <option value="" className="bg-theme-header text-theme-text-muted">Category</option>
+                <option value="">Category</option>
                 {SPONSOR_CATEGORIES.map(opt => (
-                  <option key={opt.id} value={opt.id} className="bg-theme-header text-theme-text">
+                  <option key={opt.id} value={opt.id}>
                     {opt.label}
                   </option>
                 ))}
@@ -729,9 +729,9 @@ export function PartnerForm({
                 className="w-full !pl-14 bg-theme-input border border-theme-stroke rounded-xl text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
                 style={{ colorScheme: 'dark' }}
               >
-                <option value="" className="bg-theme-header text-theme-text-muted">{t('sponsors.contributionType')}</option>
+                <option value="">{t('sponsors.contributionType')}</option>
                 {TYPE_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value} className="bg-theme-header text-theme-text">
+                  <option key={opt.value} value={opt.value}>
                     {t(opt.labelKey)}
                   </option>
                 ))}
@@ -764,9 +764,9 @@ export function PartnerForm({
                 className="w-full !pl-14 bg-theme-input border border-theme-stroke rounded-xl text-theme-text focus:outline-none focus:ring-1 focus:ring-[#ff393a] appearance-none cursor-pointer"
                 style={{ colorScheme: 'dark' }}
               >
-                <option value="" className="bg-theme-header text-theme-text-muted">{t('sponsors.contributionType')}</option>
+                <option value="">{t('sponsors.contributionType')}</option>
                 {TYPE_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value} className="bg-theme-header text-theme-text">
+                  <option key={opt.value} value={opt.value}>
                     {t(opt.labelKey)}
                   </option>
                 ))}

--- a/frontend/src/components/sponsors/SponsorList.tsx
+++ b/frontend/src/components/sponsors/SponsorList.tsx
@@ -249,7 +249,7 @@ export function SponsorList({ sponsors, partyId, onEdit, onDelete, onSponsorUpda
                         className={`status-pill rounded-full pl-2.5 pr-6 py-0.5 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-[#ff393a] cursor-pointer ${statusConfig.bgColor} ${statusConfig.color}`}
                       >
                         {Object.entries(STATUS_CONFIG).map(([status, config]) => (
-                          <option key={status} value={status} className="bg-theme-header text-theme-text">
+                          <option key={status} value={status}>
                             {t(config.labelKey)}
                           </option>
                         ))}

--- a/frontend/src/components/staffing/StaffForm.tsx
+++ b/frontend/src/components/staffing/StaffForm.tsx
@@ -200,7 +200,7 @@ export const StaffForm: React.FC<StaffFormProps> = ({
             className="w-full bg-theme-surface border border-theme-stroke rounded-xl px-4 py-3 text-theme-text text-sm focus:outline-none focus:border-[#ff393a]/50"
           >
             {STATUS_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value} className="bg-theme-header text-theme-text">
+              <option key={option.value} value={option.value}>
                 {option.label}
               </option>
             ))}

--- a/frontend/src/components/venue/VenueForm.tsx
+++ b/frontend/src/components/venue/VenueForm.tsx
@@ -329,7 +329,7 @@ const EditVenueForm: React.FC<VenueFormProps> = ({ venue, onSave, onClose }) => 
                 style={{ colorScheme: 'dark' }}
               >
                 {venueStatusOptions.map((option) => (
-                  <option key={option.value} value={option.value} className="bg-theme-header">
+                  <option key={option.value} value={option.value}>
                     {t(option.labelKey)}
                   </option>
                 ))}

--- a/frontend/src/components/venue/VenuePhotoUpload.tsx
+++ b/frontend/src/components/venue/VenuePhotoUpload.tsx
@@ -80,7 +80,7 @@ export const VenuePhotoUpload: React.FC<VenuePhotoUploadProps> = ({ partyId, ven
           style={{ colorScheme: 'dark' }}
         >
           {CATEGORIES.map((cat) => (
-            <option key={cat.value} value={cat.value} className="bg-theme-header">
+            <option key={cat.value} value={cat.value}>
               {t(cat.labelKey)}
             </option>
           ))}


### PR DESCRIPTION
## Problem
The **Year Taken** dropdown (and several other native `<select>`s) render option text **black-on-navy** in the default dark theme, so the options are invisible (only the OS-highlighted selected row shows). Reported on the photo upload year picker.

## Root cause
`gorgonzola-92103` established that **Chrome on Windows ignores CSS-variable colors on native `<option>` elements** — only literal colors are honored. It added global theme-aware rules in `index.css`:
\`\`\`css
option            { background-color: #1a1a2e; color: rgba(255,255,255,0.92); }
.gpp-theme option { background-color: #ffffff; color: #1a1a1a; }
\`\`\`
But these `<option>`s carried inline `className="bg-theme-card text-theme-text"` (variable utilities) that out-specify the global rule. Chrome can't apply the var color → text falls back to black → invisible.

`PhotoModal`'s year picker works because it uses literal `text-white`.

## Fix
Removed the variable-based `className`s from the affected `<option>`s so the global literal, theme-aware rules apply (correct in both dark and GPP themes). Also removed dead bg-only var classes for consistency.

**Files:** PhotoUpload, RaffleForm, PartnerForm, SponsorList, StaffForm, BudgetItemForm, VenueForm, VenuePhotoUpload.

## Verify
On a dark-theme page, open each select — all options should be white-on-navy and readable. On a `.gpp-theme` page they should be dark-on-white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)