### PR TITLE
feat(cornetto-58510): tri-state tag+country filter on /payments

### DIFF
--- a/frontend/src/components/TriStateFilterDropdown.tsx
+++ b/frontend/src/components/TriStateFilterDropdown.tsx
@@ -1,0 +1,163 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronDown, ThumbsUp, ThumbsDown } from 'lucide-react';
+
+/**
+ * cornetto-58510: shared tri-state filter dropdown extracted from the inline
+ * /underboss EventTable tag/country dropdowns. Thumbs-up = include / thumbs-down
+ * = exclude / neutral, with an in-dropdown type-ahead search and float-active-
+ * to-top ordering. Controlled: the effective include/exclude arrays are driven
+ * by props; only cosmetic state (open / search / touch-order) lives internally.
+ */
+interface TriStateFilterDropdownProps {
+  label: string;
+  /** available values (unordered; component sorts + orders internally) */
+  items: string[];
+  includes: string[];
+  excludes: string[];
+  onChange: (next: { includes: string[]; excludes: string[] }) => void;
+  searchPlaceholder: string;
+  noMatchesLabel: string;
+  clearLabel: string;
+  includeLabel: string;
+  excludeLabel: string;
+  /** applied to the outer `relative` wrapper */
+  className?: string;
+}
+
+export function TriStateFilterDropdown({
+  label,
+  items,
+  includes,
+  excludes,
+  onChange,
+  searchPlaceholder,
+  noMatchesLabel,
+  clearLabel,
+  includeLabel,
+  excludeLabel,
+  className,
+}: TriStateFilterDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  // touchOrder floats recently-interacted items to the top of the dropdown.
+  // Purely cosmetic, owned by the component, never lifted.
+  const [touchOrder, setTouchOrder] = useState<string[]>([]); // most-recently-touched first
+
+  const availableSorted = useMemo(
+    () => [...new Set(items)].sort(),
+    [items],
+  );
+
+  // Dropdown ordering: floated active (include/exclude) items first (most-
+  // recently touched first), then the remaining available items alphabetically.
+  const orderedItems = useMemo(() => {
+    const active = touchOrder.filter((x) => includes.includes(x) || excludes.includes(x));
+    const rest = availableSorted.filter((x) => !active.includes(x));
+    return [...active, ...rest];
+  }, [availableSorted, touchOrder, includes, excludes]);
+
+  const visibleItems = search.trim()
+    ? orderedItems.filter((x) => x.toLowerCase().includes(search.trim().toLowerCase()))
+    : orderedItems;
+
+  function getState(item: string): 'neutral' | 'include' | 'exclude' {
+    if (includes.includes(item)) return 'include';
+    if (excludes.includes(item)) return 'exclude';
+    return 'neutral';
+  }
+
+  function setState(item: string, next: 'neutral' | 'include' | 'exclude') {
+    const nextInc = includes.filter((k) => k !== item);
+    const nextExc = excludes.filter((k) => k !== item);
+    if (next === 'include') nextInc.push(item);
+    else if (next === 'exclude') nextExc.push(item);
+    setTouchOrder((p) => [item, ...p.filter((k) => k !== item)]); // float to top
+    onChange({ includes: nextInc, excludes: nextExc });
+  }
+
+  function clear() {
+    setTouchOrder([]);
+    onChange({ includes: [], excludes: [] });
+  }
+
+  function closePanel() {
+    setOpen(false);
+    setSearch('');
+  }
+
+  const activeTotal = includes.length + excludes.length;
+
+  return (
+    <div className={`relative ${className ?? ''}`}>
+      <button
+        onClick={() => setOpen((v) => { if (v) setSearch(''); return !v; })}
+        className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+          activeTotal > 0
+            ? 'bg-theme-surface border-theme-stroke-hover text-theme-text'
+            : 'bg-theme-surface border-theme-stroke text-theme-text-secondary hover:border-theme-stroke-hover'
+        }`}
+      >
+        {activeTotal > 0 ? `${label} (${activeTotal})` : label}
+        <ChevronDown size={14} />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={closePanel} />
+          <div className="absolute top-full left-0 mt-1 z-50 w-64 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1">
+            {(includes.length > 0 || excludes.length > 0) && (
+              <div className="flex items-center justify-end px-3 py-1.5 border-b border-theme-stroke">
+                <button onClick={clear} className="text-xs text-red-500/70 hover:text-red-500 transition-colors">{clearLabel}</button>
+              </div>
+            )}
+            <div className="px-2 py-1.5 border-b border-theme-stroke">
+              <input
+                type="text"
+                autoFocus
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={searchPlaceholder}
+                className="w-full bg-theme-surface border border-theme-stroke rounded-md px-2 py-1 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+              />
+            </div>
+            <div className="max-h-80 overflow-y-auto py-1">
+              {visibleItems.length === 0 && (
+                <div className="px-3 py-2 text-sm text-theme-text-faint">{noMatchesLabel}</div>
+              )}
+              {visibleItems.map((item, i) => {
+                const state = getState(item);
+                const activeCount = orderedItems.filter((x) => includes.includes(x) || excludes.includes(x)).length;
+                const showDivider = !search.trim() && activeCount > 0 && i === activeCount && activeCount < orderedItems.length;
+                return (
+                  <React.Fragment key={item}>
+                    {showDivider && <div className="border-t border-theme-stroke my-1" />}
+                    <div className="flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-theme-surface transition-colors">
+                      <span className="text-sm text-theme-text truncate">{item}</span>
+                      <div className="flex items-center gap-1 shrink-0">
+                        <button
+                          onClick={() => setState(item, state === 'include' ? 'neutral' : 'include')}
+                          className="p-1 hover:opacity-70 transition-opacity"
+                          aria-label={includeLabel}
+                          title={includeLabel}
+                        >
+                          <ThumbsUp size={13} className={`transition-all ${state === 'include' ? 'text-[#39d98a]' : 'text-theme-text-faint'}`} />
+                        </button>
+                        <button
+                          onClick={() => setState(item, state === 'exclude' ? 'neutral' : 'exclude')}
+                          className="p-1 hover:opacity-70 transition-opacity"
+                          aria-label={excludeLabel}
+                          title={excludeLabel}
+                        >
+                          <ThumbsDown size={13} className={`transition-all ${state === 'exclude' ? 'text-[#ff393a]' : 'text-theme-text-faint'}`} />
+                        </button>
+                      </div>
+                    </div>
+                  </React.Fragment>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
+import { TriStateFilterDropdown } from '../TriStateFilterDropdown';
 import type { AdminPayoutFilters, PayoutMethod, PayoutPurpose, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
 import {
@@ -24,6 +25,17 @@ interface PayoutsFilterBarProps {
    * `PaymentsAdminPage`. Sorted ascending.
    */
   availableTags: string[];
+  /**
+   * cornetto-58510: distinct `party.country` values across the loaded by-city
+   * rows. Powers the tri-state Country dropdown (by-city view only). Sorted.
+   */
+  availableCountries: string[];
+  /**
+   * cornetto-58510: when true (by-city view), replace the single-select Tag
+   * dropdown with tri-state Tag + Country dropdowns (client-side filtering).
+   * When false (by-payment / ledger), keep the legacy single-select Tag select.
+   */
+  showTriStateFilters?: boolean;
   /**
    * pinsa-92103: when true, render the "Hide closed cities" checkbox.
    * Only meaningful on the by-city view (`paymentsClosedAt` lives at the
@@ -146,6 +158,10 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   // when at least one portal is selected (regardless of how many).
   if (Array.isArray(filters.regionPortals) && filters.regionPortals.length > 0) n += 1;
   if (filters.tag && filters.tag !== 'all') n += 1;
+  // cornetto-58510: tri-state tag/country (by-city view) each count as one
+  // active filter when any include/exclude is selected.
+  if ((filters.tagIncludes?.length ?? 0) + (filters.tagExcludes?.length ?? 0) > 0) n += 1;
+  if ((filters.countryIncludes?.length ?? 0) + (filters.countryExcludes?.length ?? 0) > 0) n += 1;
   if (filters.purpose && filters.purpose !== 'all') n += 1;
   if (filters.dateFrom) n += 1;
   if (filters.dateTo) n += 1;
@@ -178,6 +194,8 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   onChange,
   onReset,
   availableTags,
+  availableCountries,
+  showTriStateFilters,
   showHideClosedToggle,
   showHideScamsToggle,
   showHideUsToggle,
@@ -373,22 +391,58 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
             </div>
           )}
 
-          {/* mascarpone-49102: Tag dropdown — populated from event_tags
-              flattened across the loaded payout set. Backend filters
-              `party.eventTags` via Prisma `{ has: tag }`. */}
-          <div>
-            <select
-              value={filters.tag ?? 'all'}
-              onChange={(e) => update({ tag: e.target.value })}
-              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Filter by tag"
-            >
-              <option value="all">All tags</option>
-              {availableTags.map((t) => (
-                <option key={t} value={t}>{t}</option>
-              ))}
-            </select>
-          </div>
+          {/* cornetto-58510: by-city view uses tri-state Tag + Country dropdowns
+              (client-side filtering). Other views keep the legacy single-select
+              Tag dropdown (mascarpone-49102), which is filtered server-side via
+              Prisma `{ has: tag }`. */}
+          {showTriStateFilters ? (
+            <>
+              <div>
+                <TriStateFilterDropdown
+                  label="Tags"
+                  className="w-full"
+                  items={availableTags}
+                  includes={filters.tagIncludes ?? []}
+                  excludes={filters.tagExcludes ?? []}
+                  onChange={({ includes, excludes }) => update({ tagIncludes: includes, tagExcludes: excludes })}
+                  searchPlaceholder="Search tags…"
+                  noMatchesLabel="No tags"
+                  clearLabel="Clear"
+                  includeLabel="Include (must have)"
+                  excludeLabel="Exclude (must not have)"
+                />
+              </div>
+              <div>
+                <TriStateFilterDropdown
+                  label="Country"
+                  className="w-full"
+                  items={availableCountries}
+                  includes={filters.countryIncludes ?? []}
+                  excludes={filters.countryExcludes ?? []}
+                  onChange={({ includes, excludes }) => update({ countryIncludes: includes, countryExcludes: excludes })}
+                  searchPlaceholder="Search countries…"
+                  noMatchesLabel="No countries"
+                  clearLabel="Clear"
+                  includeLabel="Include (must have)"
+                  excludeLabel="Exclude (must not have)"
+                />
+              </div>
+            </>
+          ) : (
+            <div>
+              <select
+                value={filters.tag ?? 'all'}
+                onChange={(e) => update({ tag: e.target.value })}
+                className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+                aria-label="Filter by tag"
+              >
+                <option value="all">All tags</option>
+                {availableTags.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* salumi-89172: Purpose dropdown — Event reimbursements vs
               Shipping coordinator receipts. Default 'all' shows both. */}

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -68,6 +68,13 @@ export function filtersToSearchParams(
   const tag = filters.tag ?? DEFAULTS.tag;
   if (tag !== DEFAULTS.tag) params.set('tag', String(tag));
 
+  // cornetto-58510: tri-state tag/country filters (by-city view, client-side).
+  // Only emitted when non-empty so the default view stays param-free.
+  if (filters.tagIncludes && filters.tagIncludes.length) params.set('tagInc', filters.tagIncludes.join(','));
+  if (filters.tagExcludes && filters.tagExcludes.length) params.set('tagExc', filters.tagExcludes.join(','));
+  if (filters.countryIncludes && filters.countryIncludes.length) params.set('countryInc', filters.countryIncludes.join(','));
+  if (filters.countryExcludes && filters.countryExcludes.length) params.set('countryExc', filters.countryExcludes.join(','));
+
   const purpose = filters.purpose ?? DEFAULTS.purpose;
   if (purpose !== DEFAULTS.purpose) params.set('purpose', String(purpose));
 
@@ -115,6 +122,11 @@ export function searchParamsToFilters(
     currency: 'all',
     country: 'all',
     tag: DEFAULTS.tag,
+    // cornetto-58510: tri-state tag/country arrays default empty (no filter).
+    tagIncludes: [],
+    tagExcludes: [],
+    countryIncludes: [],
+    countryExcludes: [],
     purpose: DEFAULTS.purpose,
     hideClosed: DEFAULTS.hideClosed,
     hideScams: DEFAULTS.hideScams,
@@ -147,6 +159,16 @@ export function searchParamsToFilters(
 
   const tag = params.get('tag');
   if (tag) filters.tag = tag;
+
+  // cornetto-58510: parse tri-state tag/country lists from the URL.
+  const parseList = (key: string) => {
+    const raw = params.get(key);
+    return raw ? raw.split(',').map((s) => s.trim()).filter(Boolean) : [];
+  };
+  filters.tagIncludes = parseList('tagInc');
+  filters.tagExcludes = parseList('tagExc');
+  filters.countryIncludes = parseList('countryInc');
+  filters.countryExcludes = parseList('countryExc');
 
   const purposeRaw = params.get('purpose');
   if (purposeRaw && PURPOSE_VALUES.has(purposeRaw)) {

--- a/frontend/src/components/underboss/EventTable.tsx
+++ b/frontend/src/components/underboss/EventTable.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Search, ArrowUpDown, ThumbsUp, ThumbsDown, ChevronDown, Check, X, DollarSign } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
+import { TriStateFilterDropdown } from '../TriStateFilterDropdown';
 import { EventRow } from './EventRow';
 import { EventCard } from './EventCard';
 import { bulkUpdateUnderbossStatus, bulkDeleteEvents, bulkUpdateEventTags } from '../../lib/api';
@@ -156,25 +157,16 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
   const [progressExcludesUncontrolled, setProgressExcludes] = useState<string[]>([]);
 
   // Tri-state per-tag filter (provola-58497): include (require) / exclude / neutral.
+  // cornetto-58510: dropdown chrome (open/search/touch-order) now lives inside
+  // the shared TriStateFilterDropdown; only the effective include/exclude arrays
+  // remain here.
   const [tagIncludesUncontrolled, setTagIncludes] = useState<string[]>([]);
   const [tagExcludesUncontrolled, setTagExcludes] = useState<string[]>([]);
-  // tagTouchOrder floats recently-interacted tags to the top of the dropdown.
-  // Purely cosmetic — internal in BOTH modes (never persisted to the URL).
-  const [tagTouchOrder, setTagTouchOrder] = useState<string[]>([]); // most-recently-touched first
-  const [showTagFilter, setShowTagFilter] = useState(false);
 
   // Tri-state per-country filter (crosta-58498): mirrors the tag filter, but
   // country is single-valued per event so includes use OR (not AND).
   const [countryIncludesUncontrolled, setCountryIncludes] = useState<string[]>([]);
   const [countryExcludesUncontrolled, setCountryExcludes] = useState<string[]>([]);
-  // countryTouchOrder floats recently-interacted countries to the top of the
-  // dropdown. Purely cosmetic — internal in BOTH modes (never persisted).
-  const [countryTouchOrder, setCountryTouchOrder] = useState<string[]>([]);
-  const [showCountryFilter, setShowCountryFilter] = useState(false);
-  // crosta-58498: in-dropdown type-ahead for the tag + country lists. Cosmetic,
-  // internal-only (never persisted), reset when the dropdown closes.
-  const [tagSearch, setTagSearch] = useState('');
-  const [countrySearch, setCountrySearch] = useState('');
 
   // montanara-58497: effective filter values — from props when controlled, else
   // from internal state. All downstream JSX/memos read these.
@@ -234,58 +226,6 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     } else {
       setProgressIncludes(nextInc);
       setProgressExcludes(nextExc);
-    }
-  }
-
-  function getTagFilterState(tag: string): 'neutral' | 'include' | 'exclude' {
-    if (tagIncludes.includes(tag)) return 'include';
-    if (tagExcludes.includes(tag)) return 'exclude';
-    return 'neutral';
-  }
-
-  function setTagFilterState(tag: string, next: 'neutral' | 'include' | 'exclude') {
-    const nextInc = tagIncludes.filter((k) => k !== tag);
-    const nextExc = tagExcludes.filter((k) => k !== tag);
-    if (next === 'include') nextInc.push(tag);
-    else if (next === 'exclude') nextExc.push(tag);
-    setTagTouchOrder((p) => [tag, ...p.filter((k) => k !== tag)]); // float to top
-    if (isControlled) {
-      emit({ tagIncludes: nextInc, tagExcludes: nextExc });
-    } else {
-      setTagIncludes(nextInc);
-      setTagExcludes(nextExc);
-    }
-  }
-
-  // Tri-state per-country filter (crosta-58498): mirrors the tag filter, but
-  // country is single-valued per event so includes use OR (not AND).
-  function getCountryFilterState(country: string): 'neutral' | 'include' | 'exclude' {
-    if (countryIncludes.includes(country)) return 'include';
-    if (countryExcludes.includes(country)) return 'exclude';
-    return 'neutral';
-  }
-
-  function setCountryFilterState(country: string, next: 'neutral' | 'include' | 'exclude') {
-    const nextInc = countryIncludes.filter((k) => k !== country);
-    const nextExc = countryExcludes.filter((k) => k !== country);
-    if (next === 'include') nextInc.push(country);
-    else if (next === 'exclude') nextExc.push(country);
-    setCountryTouchOrder((p) => [country, ...p.filter((k) => k !== country)]); // float to top
-    if (isControlled) {
-      emit({ countryIncludes: nextInc, countryExcludes: nextExc });
-    } else {
-      setCountryIncludes(nextInc);
-      setCountryExcludes(nextExc);
-    }
-  }
-
-  function clearCountryFilter() {
-    setCountryTouchOrder([]);
-    if (isControlled) {
-      emit({ countryIncludes: [], countryExcludes: [] });
-    } else {
-      setCountryIncludes([]);
-      setCountryExcludes([]);
     }
   }
 
@@ -422,26 +362,10 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
     [events]
   );
 
-  // Dropdown ordering: floated active (include/exclude) tags first (most-recently
-  // touched first), then the remaining available tags alphabetically.
-  const orderedTags = useMemo(() => {
-    const active = tagTouchOrder.filter((t) => tagIncludes.includes(t) || tagExcludes.includes(t));
-    const rest = availableTags.filter((t) => !active.includes(t));
-    return [...active, ...rest];
-  }, [availableTags, tagTouchOrder, tagIncludes, tagExcludes]);
-
   const availableCountries = useMemo(
     () => Array.from(new Set(events.map((e) => e.country).filter((c): c is string => Boolean(c)))).sort(),
     [events]
   );
-
-  // Dropdown ordering: floated active (include/exclude) countries first
-  // (most-recently touched first), then the remaining available alphabetically.
-  const orderedCountries = useMemo(() => {
-    const active = countryTouchOrder.filter((c) => countryIncludes.includes(c) || countryExcludes.includes(c));
-    const rest = availableCountries.filter((c) => !active.includes(c));
-    return [...active, ...rest];
-  }, [availableCountries, countryTouchOrder, countryIncludes, countryExcludes]);
 
   // Sponsorship suggestion banner: shown when exactly one tag is required
   // (single-tag include is the analog of the old single-select tag filter).
@@ -494,16 +418,6 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
       </th>
     );
   }
-
-  // crosta-58498: type-ahead-filtered views of the dropdown lists. When a search
-  // term is present we hide the active/inactive divider (indices no longer line
-  // up with the full ordered list).
-  const visibleTags = tagSearch.trim()
-    ? orderedTags.filter((tg) => tg.toLowerCase().includes(tagSearch.trim().toLowerCase()))
-    : orderedTags;
-  const visibleCountries = countrySearch.trim()
-    ? orderedCountries.filter((c) => c.toLowerCase().includes(countrySearch.trim().toLowerCase()))
-    : orderedCountries;
 
   const hasActiveFilters =
     progressIncludes.length > 0 ||
@@ -576,192 +490,40 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
 
         {/* Tri-state country filter dropdown (crosta-58498) -- only when showRegion */}
         {showRegion && availableCountries.length > 0 && (
-          <div className="relative">
-            <button
-              onClick={() => setShowCountryFilter((v) => { if (v) setCountrySearch(''); return !v; })}
-              className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
-                countryIncludes.length + countryExcludes.length > 0
-                  ? 'bg-theme-surface border-theme-stroke-hover text-theme-text'
-                  : 'bg-theme-surface border-theme-stroke text-theme-text-secondary hover:border-theme-stroke-hover'
-              }`}
-            >
-              {countryIncludes.length + countryExcludes.length > 0
-                ? `${t('eventTable.countryFilterLabel')} (${countryIncludes.length + countryExcludes.length})`
-                : t('eventTable.countryFilterLabel')}
-              <ChevronDown size={14} />
-            </button>
-            {showCountryFilter && (
-              <>
-                <div className="fixed inset-0 z-40" onClick={() => { setShowCountryFilter(false); setCountrySearch(''); }} />
-                <div className="absolute top-full left-0 mt-1 z-50 w-64 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1">
-                  {(countryIncludes.length > 0 || countryExcludes.length > 0) && (
-                    <div className="flex items-center justify-end px-3 py-1.5 border-b border-theme-stroke">
-                      <button
-                        onClick={clearCountryFilter}
-                        className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
-                      >
-                        {t('eventTable.countryFilterClear')}
-                      </button>
-                    </div>
-                  )}
-                  <div className="px-2 py-1.5 border-b border-theme-stroke">
-                    <input
-                      type="text"
-                      autoFocus
-                      value={countrySearch}
-                      onChange={(e) => setCountrySearch(e.target.value)}
-                      placeholder={t('eventTable.countryFilterSearch')}
-                      className="w-full bg-theme-surface border border-theme-stroke rounded-md px-2 py-1 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
-                    />
-                  </div>
-                  <div className="max-h-80 overflow-y-auto py-1">
-                    {visibleCountries.length === 0 && (
-                      <div className="px-3 py-2 text-sm text-theme-text-faint">{t('eventTable.countryFilterNoMatches')}</div>
-                    )}
-                    {visibleCountries.map((country, i) => {
-                      const state = getCountryFilterState(country);
-                      // Divider after the last floated active country (only if there are inactive countries below). Hidden while searching.
-                      const activeCount = orderedCountries.filter(
-                        (cc) => countryIncludes.includes(cc) || countryExcludes.includes(cc)
-                      ).length;
-                      const showDivider = !countrySearch.trim() && activeCount > 0 && i === activeCount && activeCount < orderedCountries.length;
-                      return (
-                        <React.Fragment key={country}>
-                          {showDivider && <div className="border-t border-theme-stroke my-1" />}
-                          <div className="flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-theme-surface transition-colors">
-                            <span className="text-sm text-theme-text truncate">{country}</span>
-                            <div className="flex items-center gap-1 shrink-0">
-                              <button
-                                onClick={() => setCountryFilterState(country, state === 'include' ? 'neutral' : 'include')}
-                                className="p-1 hover:opacity-70 transition-opacity"
-                                aria-label={t('eventTable.countryFilterInclude')}
-                                title={t('eventTable.countryFilterInclude')}
-                              >
-                                <ThumbsUp
-                                  size={13}
-                                  className={`transition-all ${state === 'include' ? 'text-[#39d98a]' : 'text-theme-text-faint'}`}
-                                />
-                              </button>
-                              <button
-                                onClick={() => setCountryFilterState(country, state === 'exclude' ? 'neutral' : 'exclude')}
-                                className="p-1 hover:opacity-70 transition-opacity"
-                                aria-label={t('eventTable.countryFilterExclude')}
-                                title={t('eventTable.countryFilterExclude')}
-                              >
-                                <ThumbsDown
-                                  size={13}
-                                  className={`transition-all ${state === 'exclude' ? 'text-[#ff393a]' : 'text-theme-text-faint'}`}
-                                />
-                              </button>
-                            </div>
-                          </div>
-                        </React.Fragment>
-                      );
-                    })}
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
+          <TriStateFilterDropdown
+            label={t('eventTable.countryFilterLabel')}
+            items={availableCountries}
+            includes={countryIncludes}
+            excludes={countryExcludes}
+            onChange={({ includes, excludes }) => {
+              if (isControlled) emit({ countryIncludes: includes, countryExcludes: excludes });
+              else { setCountryIncludes(includes); setCountryExcludes(excludes); }
+            }}
+            searchPlaceholder={t('eventTable.countryFilterSearch')}
+            noMatchesLabel={t('eventTable.countryFilterNoMatches')}
+            clearLabel={t('eventTable.countryFilterClear')}
+            includeLabel={t('eventTable.countryFilterInclude')}
+            excludeLabel={t('eventTable.countryFilterExclude')}
+          />
         )}
 
         {/* Tri-state tag filter dropdown (provola-58497) */}
         {availableTags.length > 0 && (
-          <div className="relative">
-            <button
-              onClick={() => setShowTagFilter((v) => { if (v) setTagSearch(''); return !v; })}
-              className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
-                tagIncludes.length + tagExcludes.length > 0
-                  ? 'bg-theme-surface border-theme-stroke-hover text-theme-text'
-                  : 'bg-theme-surface border-theme-stroke text-theme-text-secondary hover:border-theme-stroke-hover'
-              }`}
-            >
-              {tagIncludes.length + tagExcludes.length > 0
-                ? `${t('eventTable.tagsFilterLabel')} (${tagIncludes.length + tagExcludes.length})`
-                : t('eventTable.tagsFilterLabel')}
-              <ChevronDown size={14} />
-            </button>
-            {showTagFilter && (
-              <>
-                <div className="fixed inset-0 z-40" onClick={() => { setShowTagFilter(false); setTagSearch(''); }} />
-                <div className="absolute top-full left-0 mt-1 z-50 w-64 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1">
-                  {(tagIncludes.length > 0 || tagExcludes.length > 0) && (
-                    <div className="flex items-center justify-end px-3 py-1.5 border-b border-theme-stroke">
-                      <button
-                        onClick={() => {
-                          setTagTouchOrder([]);
-                          if (isControlled) {
-                            emit({ tagIncludes: [], tagExcludes: [] });
-                          } else {
-                            setTagIncludes([]);
-                            setTagExcludes([]);
-                          }
-                        }}
-                        className="text-xs text-red-500/70 hover:text-red-500 transition-colors"
-                      >
-                        {t('eventTable.tagsFilterClear')}
-                      </button>
-                    </div>
-                  )}
-                  <div className="px-2 py-1.5 border-b border-theme-stroke">
-                    <input
-                      type="text"
-                      autoFocus
-                      value={tagSearch}
-                      onChange={(e) => setTagSearch(e.target.value)}
-                      placeholder={t('eventTable.tagsFilterSearch')}
-                      className="w-full bg-theme-surface border border-theme-stroke rounded-md px-2 py-1 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
-                    />
-                  </div>
-                  <div className="max-h-80 overflow-y-auto py-1">
-                    {visibleTags.length === 0 && (
-                      <div className="px-3 py-2 text-sm text-theme-text-faint">{t('eventTable.tagsFilterNoMatches')}</div>
-                    )}
-                    {visibleTags.map((tag, i) => {
-                      const state = getTagFilterState(tag);
-                      // Divider after the last floated active tag (only if there are inactive tags below). Hidden while searching.
-                      const activeCount = orderedTags.filter(
-                        (tt) => tagIncludes.includes(tt) || tagExcludes.includes(tt)
-                      ).length;
-                      const showDivider = !tagSearch.trim() && activeCount > 0 && i === activeCount && activeCount < orderedTags.length;
-                      return (
-                        <React.Fragment key={tag}>
-                          {showDivider && <div className="border-t border-theme-stroke my-1" />}
-                          <div className="flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-theme-surface transition-colors">
-                            <span className="text-sm text-theme-text truncate">{tag}</span>
-                            <div className="flex items-center gap-1 shrink-0">
-                              <button
-                                onClick={() => setTagFilterState(tag, state === 'include' ? 'neutral' : 'include')}
-                                className="p-1 hover:opacity-70 transition-opacity"
-                                aria-label={t('eventTable.tagsFilterInclude')}
-                                title={t('eventTable.tagsFilterInclude')}
-                              >
-                                <ThumbsUp
-                                  size={13}
-                                  className={`transition-all ${state === 'include' ? 'text-[#39d98a]' : 'text-theme-text-faint'}`}
-                                />
-                              </button>
-                              <button
-                                onClick={() => setTagFilterState(tag, state === 'exclude' ? 'neutral' : 'exclude')}
-                                className="p-1 hover:opacity-70 transition-opacity"
-                                aria-label={t('eventTable.tagsFilterExclude')}
-                                title={t('eventTable.tagsFilterExclude')}
-                              >
-                                <ThumbsDown
-                                  size={13}
-                                  className={`transition-all ${state === 'exclude' ? 'text-[#ff393a]' : 'text-theme-text-faint'}`}
-                                />
-                              </button>
-                            </div>
-                          </div>
-                        </React.Fragment>
-                      );
-                    })}
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
+          <TriStateFilterDropdown
+            label={t('eventTable.tagsFilterLabel')}
+            items={availableTags}
+            includes={tagIncludes}
+            excludes={tagExcludes}
+            onChange={({ includes, excludes }) => {
+              if (isControlled) emit({ tagIncludes: includes, tagExcludes: excludes });
+              else { setTagIncludes(includes); setTagExcludes(excludes); }
+            }}
+            searchPlaceholder={t('eventTable.tagsFilterSearch')}
+            noMatchesLabel={t('eventTable.tagsFilterNoMatches')}
+            clearLabel={t('eventTable.tagsFilterClear')}
+            includeLabel={t('eventTable.tagsFilterInclude')}
+            excludeLabel={t('eventTable.tagsFilterExclude')}
+          />
         )}
 
         {/* RSVP count filter */}
@@ -817,8 +579,6 @@ export function EventTable({ events, showRegion, onEventUpdate, onBulkAction, on
         {hasActiveFilters && (
           <button
             onClick={() => {
-              setTagTouchOrder([]);
-              setCountryTouchOrder([]);
               if (isControlled) {
                 // Reset to the canonical defaults, preserving current semantics.
                 onFiltersChange!({ ...DEFAULT_EVENT_TABLE_FILTERS });

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -106,6 +106,11 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   country: 'all',
   // mascarpone-49102: tag filter default — 'all' means no filter.
   tag: 'all',
+  // cornetto-58510: tri-state tag/country filters (by-city view, client-side).
+  tagIncludes: [],
+  tagExcludes: [],
+  countryIncludes: [],
+  countryExcludes: [],
   // salumi-89172: purpose filter default — 'all' shows both event and
   // shipping payouts so the existing admin queue is unchanged out of box.
   purpose: 'all',
@@ -592,6 +597,34 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     return Array.from(set).sort();
   }, [payouts]);
 
+  // cornetto-58510: distinct `party.country` values across the by-city rows.
+  // Powers the tri-state Country dropdown (by-city view only). Derived from the
+  // COMPLETE per-city rollup so the dropdown lists every loaded city's country.
+  const availableCountries = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of byPartyRows) {
+      if (p.party.country) set.add(p.party.country);
+    }
+    return Array.from(set).sort();
+  }, [byPartyRows]);
+
+  // cornetto-58510: tag list for the by-city tri-state Tag dropdown. Derived
+  // from `byPartyRows` (the COMPLETE per-city rollup) rather than `payouts` —
+  // in by-city view `payouts` holds only the first per-payment page (no
+  // load-more), so it would miss tags. The legacy by-payment single-select
+  // keeps using `availableTags` (sourced from the paginated `payouts`).
+  const availableTagsByParty = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of byPartyRows) {
+      if (Array.isArray(p.party.eventTags)) {
+        for (const t of p.party.eventTags) {
+          if (t && typeof t === 'string') set.add(t);
+        }
+      }
+    }
+    return Array.from(set).sort();
+  }, [byPartyRows]);
+
   // siciliana-69183: derive the AdminPayout objects matching `selectedIds` for
   // the Safe-export modal. The modal itself filters non-USDC / missing-wallet
   // rows; we just hand it the full selection.
@@ -630,10 +663,22 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     // provatura-92107: hide US cities (region 'usa') when the toggle is on.
     // Admin dashboard only — regional portals are already region-scoped and
     // never apply this.
-    const rows =
+    let rows =
       !isRegionalPortal && filters.hideUsCities
         ? filtered.filter((row) => row.party.region !== 'usa')
         : filtered;
+
+    // cornetto-58510: client-side tri-state tag/country filter (by-city view).
+    // Tags: include = must have ALL; exclude = must have NONE. Country (single-
+    // valued per party): include = OR (any selected); exclude = NONE.
+    const tagInc = filters.tagIncludes ?? [];
+    const tagExc = filters.tagExcludes ?? [];
+    const ctryInc = filters.countryIncludes ?? [];
+    const ctryExc = filters.countryExcludes ?? [];
+    if (tagInc.length) rows = rows.filter((r) => tagInc.every((tg) => r.party.eventTags?.includes(tg)));
+    if (tagExc.length) rows = rows.filter((r) => tagExc.every((tg) => !r.party.eventTags?.includes(tg)));
+    if (ctryInc.length) rows = rows.filter((r) => !!r.party.country && ctryInc.includes(r.party.country));
+    if (ctryExc.length) rows = rows.filter((r) => !r.party.country || !ctryExc.includes(r.party.country));
 
     // "Oldest/Newest first" in the by-city view should order cities by their
     // host UPLOAD time, not lastActivityAt. The /by-party endpoint doesn't
@@ -702,7 +747,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
       return [...rows].sort((a, b) => (asc ? pick(a) - pick(b) : pick(b) - pick(a)));
     }
     return rows;
-  }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal]);
+  }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal, filters.tagIncludes, filters.tagExcludes, filters.countryIncludes, filters.countryExcludes]);
 
   // salsiccia-49102: count of selected payouts eligible for bulk USDC send.
   // Mirrors the backend filter (usdc_base + approved/failed + valid 0x
@@ -1191,7 +1236,15 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           // portals so Reset can't silently widen a regional underboss's view.
           // The URL sync effect then clears the query string automatically.
           onReset={() => setFilters(regions ? { ...DEFAULT_FILTERS, regions } : DEFAULT_FILTERS)}
-          availableTags={availableTags}
+          // cornetto-58510: in by-city the tri-state Tag dropdown needs the
+          // COMPLETE tag set (byPartyRows); by-payment's single-select keeps
+          // the paginated `payouts`-derived list.
+          availableTags={viewMode === 'by-city' ? availableTagsByParty : availableTags}
+          // cornetto-58510: by-city tri-state Tag + Country dropdowns. Country
+          // list + the tri-state UI render only on the by-city view (the
+          // filtering is client-side over byPartyRows).
+          availableCountries={availableCountries}
+          showTriStateFilters={viewMode === 'by-city'}
           // pinsa-92103: Hide closed cities only makes sense on the by-city
           // view (paymentsClosedAt is a party-level signal). The per-payment
           // view has no party-row, so the toggle would be confusing there.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2157,6 +2157,12 @@ export interface AdminPayoutFilters {
   country?: string;
   /** mascarpone-49102: event-tag filter — single tag "has" match on `parties.event_tags`. `'all'` / undefined = no filter. */
   tag?: string;
+  /** cornetto-58510: tri-state event-tag filter (by-city view, client-side). include = has ALL; exclude = has NONE. */
+  tagIncludes?: string[];
+  tagExcludes?: string[];
+  /** cornetto-58510: tri-state country filter (by-city view, client-side). include = OR (any); exclude = NONE. */
+  countryIncludes?: string[];
+  countryExcludes?: string[];
   /**
    * argentina-92103: regional scope for regional /payments portals (e.g.
    * `/payments/latam` -> `['central-america','south-america']`). When set,


### PR DESCRIPTION
Brings the `/underboss` tri-state filter dropdown (👍 include / 👎 exclude / neutral, in-dropdown type-ahead search, float-active-to-top) to `/payments`.

## What
- **New `TriStateFilterDropdown`** — extracted from the inline `/underboss` `EventTable` tag/country dropdowns into a shared controlled component. `EventTable` now consumes it (behavior unchanged on `/underboss`).
- **`/payments` by-city view** — the single-select **Tag** dropdown is replaced with the tri-state version, and a new tri-state **Country** dropdown is added. Full parity with `/underboss`.

## How
- Filtering is **client-side** over the complete `byPartyRows` per-city rollup (the by-city endpoint returns all matching parties), so this is **frontend-only — no backend change/deploy**.
- Tag list for the tri-state dropdown is derived from `byPartyRows` (complete), not the paginated `payouts` page.
- State persists to the URL: `tagInc` / `tagExc` / `countryInc` / `countryExc`.
- The paginated **by-payment** + **ledger** views keep their existing single-select tag (their rows don't carry `eventTags`); the tri-state UI renders only on by-city.

## Verify on preview
- `/underboss`: tag + country tri-state filter behaves exactly as before (include = AND tags / OR country, exclude = NONE, search, float-to-top, divider-hidden-while-searching, clear, URL round-trip). **Main regression surface.**
- `/payments` (by-city, admin): tri-state Tag + new Country dropdowns; `(N)` badges + reset + URL persistence work.
- `/payments` by-payment / Payments views: unchanged.
- Regional portal (e.g. `/payments/na`): Country dropdown lists only that region's countries.

`tsc --noEmit` passes locally. Plan: `plans/cornetto-58510-payments-tristate-filter.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
