### PR TITLE
feat(tigella-58512): separate /payments/eastafrica + /payments/westafrica portals

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,8 @@ import { PaymentsAdminPage } from './pages/PaymentsAdminPage';
 import { LatamPaymentsPage } from './pages/LatamPaymentsPage';
 import { SouthAfricaPaymentsPage } from './pages/SouthAfricaPaymentsPage';
 import { AfricaPaymentsPage } from './pages/AfricaPaymentsPage';
+import { WestAfricaPaymentsPage } from './pages/WestAfricaPaymentsPage';
+import { EastAfricaPaymentsPage } from './pages/EastAfricaPaymentsPage';
 import { NaPaymentsPage } from './pages/NaPaymentsPage';
 import { EuropePaymentsPage } from './pages/EuropePaymentsPage';
 import { IndiaPaymentsPage } from './pages/IndiaPaymentsPage';
@@ -97,6 +99,8 @@ function App() {
                 with a fixed regionFilter + portalSlug. Must come before /:slug. */}
             <Route path="/payments/southafrica" element={<SouthAfricaPaymentsPage />} />
             <Route path="/payments/africa" element={<AfricaPaymentsPage />} />
+            <Route path="/payments/westafrica" element={<WestAfricaPaymentsPage />} />
+            <Route path="/payments/eastafrica" element={<EastAfricaPaymentsPage />} />
             <Route path="/payments/na" element={<NaPaymentsPage />} />
             <Route path="/payments/europe" element={<EuropePaymentsPage />} />
             <Route path="/payments/india" element={<IndiaPaymentsPage />} />

--- a/frontend/src/pages/EastAfricaPaymentsPage.tsx
+++ b/frontend/src/pages/EastAfricaPaymentsPage.tsx
@@ -1,0 +1,15 @@
+/**
+ * tigella-58512: East/West Africa regional payments portal.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function EastAfricaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.eastafrica)}
+      portalSlug="eastafrica"
+    />
+  );
+}

--- a/frontend/src/pages/WestAfricaPaymentsPage.tsx
+++ b/frontend/src/pages/WestAfricaPaymentsPage.tsx
@@ -1,0 +1,15 @@
+/**
+ * tigella-58512: East/West Africa regional payments portal.
+ */
+import React from 'react';
+import { PAYMENTS_REGION_SCOPES } from '../utils/regions';
+import { PaymentsAdminPage } from './PaymentsAdminPage';
+
+export function WestAfricaPaymentsPage() {
+  return (
+    <PaymentsAdminPage
+      regionFilter={Array.from(PAYMENTS_REGION_SCOPES.westafrica)}
+      portalSlug="westafrica"
+    />
+  );
+}

--- a/frontend/src/utils/regions.ts
+++ b/frontend/src/utils/regions.ts
@@ -12,6 +12,8 @@
  *   /payments/southafrica  → @pnsibanda (South Africa country)
  *   /payments/africa       → @BuildwithMc + @PeriPeriPacino (West / East /
  *                            South Africa region slugs)
+ *   /payments/westafrica   → West Africa region slug only (tigella-58512)
+ *   /payments/eastafrica   → East Africa region slug only (tigella-58512)
  *   /payments/na           → @cauleneamagi (USA + Canada)
  *   /payments/europe       → @APlazzi (Western + Eastern Europe)
  *   /payments/india        → @simarpreet_019 (India)
@@ -28,6 +30,8 @@
 
 export const LATAM_REGIONS = ['central-america', 'south-america'] as const;
 export const SOUTHAFRICA_REGIONS = ['south-africa'] as const;
+export const EASTAFRICA_REGIONS = ['east-africa'] as const;
+export const WESTAFRICA_REGIONS = ['west-africa'] as const;
 export const AFRICA_REGIONS = ['west-africa', 'east-africa', 'south-africa'] as const;
 export const NA_REGIONS = ['usa', 'canada'] as const;
 export const EUROPE_REGIONS = ['western-europe', 'eastern-europe'] as const;
@@ -38,6 +42,8 @@ export type PaymentsRegionPortal =
   | 'latam'
   | 'southafrica'
   | 'africa'
+  | 'eastafrica'
+  | 'westafrica'
   | 'na'
   | 'europe'
   | 'india'
@@ -47,6 +53,8 @@ export const PAYMENTS_REGION_LABELS: Record<PaymentsRegionPortal, string> = {
   latam: 'LATAM',
   southafrica: 'South Africa',
   africa: 'Africa',
+  eastafrica: 'East Africa',
+  westafrica: 'West Africa',
   na: 'North America',
   europe: 'Europe',
   india: 'India',
@@ -57,6 +65,8 @@ export const PAYMENTS_REGION_SCOPES: Record<PaymentsRegionPortal, readonly strin
   latam: LATAM_REGIONS,
   southafrica: SOUTHAFRICA_REGIONS,
   africa: AFRICA_REGIONS,
+  eastafrica: EASTAFRICA_REGIONS,
+  westafrica: WESTAFRICA_REGIONS,
   na: NA_REGIONS,
   europe: EUROPE_REGIONS,
   india: INDIA_REGIONS,
@@ -73,6 +83,8 @@ export const PAYMENTS_REGION_DISPLAY_ORDER: PaymentsRegionPortal[] = [
   'na',
   'europe',
   'africa',
+  'westafrica',
+  'eastafrica',
   'southafrica',
   'india',
   'asia',


### PR DESCRIPTION
## What
Splits the combined Africa payments portal into region-scoped dashboards. Adds /payments/westafrica (west-africa) and /payments/eastafrica (east-africa) alongside the existing /payments/southafrica. The combined /payments/africa is kept.

Each is a thin PaymentsAdminPage wrapper hard-scoped to one parties.region slug (tortelli-92103 pattern). Frontend-only — no backend or migration.

## Files
- utils/regions.ts: EASTAFRICA_REGIONS / WESTAFRICA_REGIONS scopes, new portal keys in the label/scope/display-order maps
- pages/WestAfricaPaymentsPage.tsx, pages/EastAfricaPaymentsPage.tsx (new wrappers)
- App.tsx: imports + routes

## Note
Who can OPEN each portal is gated by the underbosses.regions array (regionalUnderboss.ts), handled separately. The view itself is always hard-scoped to its region.

Plan: plans/tigella-58512-africa-portals.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)