### PR TITLE
provola-58508: strip 'pizzadao'/'pizza dao' in city-name normalizer (captured groups are titled '{City} PizzaDAO')

### DIFF
--- a/backend/src/helpers/underbossScope.ts
+++ b/backend/src/helpers/underbossScope.ts
@@ -62,9 +62,10 @@ export function cityKeyFromPartyName(name: string | null | undefined): string | 
  *      durham" stays "raleigh durham" (a real two-name metro) — splitting it
  *      would silently truncate a legitimate hyphenated city.
  *   4. (per segment) remove noise phrases: "global pizza party", "bitcoin
- *      pizza", "pizza party", "gpp", "telegram", "group", "official", "no kids
- *      allowed"; remove 4-digit years; strip non-alphanumeric/space (emoji,
- *      symbols, leftover punctuation/separators); collapse whitespace.
+ *      pizza", "pizza party", "pizza dao", "pizzadao", "gpp", "telegram",
+ *      "group", "official", "no kids allowed"; remove 4-digit years; strip
+ *      non-alphanumeric/space (emoji, symbols, leftover punctuation/separators);
+ *      collapse whitespace.
  *
  * Returns '' when nothing recognizable remains — callers MUST treat '' as a
  * non-match (never index the missing-cities map by an empty key).
@@ -79,11 +80,13 @@ function cleanCityCore(segment: string): string {
     'global pizza party',
     'bitcoin pizza',
     'pizza party',
+    'pizza dao',
     'no kids allowed',
     'official',
     'telegram',
     'group',
     'gpp',
+    'pizzadao',
   ];
   for (const phrase of noisePhrases) {
     const re = new RegExp(`\\b${phrase.replace(/\s+/g, '\\s+')}\\b`, 'g');


### PR DESCRIPTION
## Why
Every captured Telegram group is titled **\"{City} PizzaDAO\"** (e.g. `Goshen PizzaDAO`, `Dar es Salaam PizzaDAO`). The city-name normalizer used for moltobene matching (`cleanCityCore` in `backend/src/helpers/underbossScope.ts`) strips `global pizza party`/`gpp` but **not** `pizzadao`/`pizza dao`. So `normalizeCityName("Goshen PizzaDAO")` returned `"goshen pizzadao"` and failed the `===` comparison against the approved city `"goshen"` — captured groups never linked to their cities.

## Change (one spot)
Added two word-bounded noise tokens to `cleanCityCore`'s `noisePhrases` array:
- `'pizza dao'` (near the other pizza phrases)
- `'pizzadao'` (single token)

Both are matched word-bounded (`\b...\b`), so:
- `"Goshen PizzaDAO"` → `"goshen"`
- `"Dar es Salaam PizzaDAO"` → `"dar es salaam"`
- `"Goshen Pizza DAO"` → `"goshen"`

(Doc comment enumerating the phrases updated to stay accurate. Nothing else changed.)

## Impact
Lets the deployed on-demand / admin-sync matcher link captured `{City} PizzaDAO` Telegram groups to their approved cities, instead of silently missing the match and leaving the city without a `chat_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)