### PR TITLE
fix(views): make saved-views dropdown opaque

### DIFF
--- a/frontend/src/components/SavedViewsMenu.tsx
+++ b/frontend/src/components/SavedViewsMenu.tsx
@@ -92,7 +92,7 @@ export function SavedViewsMenu({ scope, currentParams, onApply }: SavedViewsMenu
       {open && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <div className="absolute top-full right-0 z-50 mt-1 w-72 rounded-lg border border-theme-stroke bg-theme-card py-1 shadow-xl">
+          <div className="absolute top-full right-0 z-50 mt-1 w-72 rounded-lg border border-theme-stroke bg-theme-header py-1 shadow-xl">
             {/* List */}
             <div className="max-h-72 overflow-y-auto">
               {loading ? (


### PR DESCRIPTION
The Views dropdown panel used `bg-theme-card` (`rgba(255,255,255,0.07)` in the dark theme), so page content showed through it. Switched the panel to the opaque `bg-theme-header` (`#1a1a2e`), matching other dropdowns like `TimePickerInput`/`CryptoDonationWidget`.

Frontend-only, one-class change. No backend/DB impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)