### PR TITLE
feat(tigella-58513): cap GPP events at 3 hours

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -715,6 +715,47 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
     }
 
+    // tigella-58513: authoritative guard — GPP events are capped at 3 hours.
+    // The frontend block is UX only; this also covers the NL Event Assistant
+    // path (arancini-58492), which writes through this same PATCH endpoint.
+    // We only enforce when the editor is a plain host — admins and underbosses
+    // can grant the "ask your underboss for an exception" override. eventType is
+    // read from the PRE-update party in the DB, never trusted from req.body.
+    {
+      const isGppEdit =
+        (duration !== undefined && duration != null) ||
+        (date && endTime);
+      if (isGppEdit) {
+        const existing = await prisma.party.findUnique({
+          where: { id },
+          select: { eventType: true },
+        });
+        if (existing?.eventType === 'gpp') {
+          const privileged = (await isSuperAdmin(req.userEmail))
+            || (await isAdmin(req.userEmail))
+            || (await isUnderboss(req.userEmail));
+          if (!privileged) {
+            // Effective new duration: explicit `duration` wins; otherwise derive
+            // from date+endTime when both are present. (3_600_000 ms = 1 hour.)
+            let effectiveDuration: number | null = null;
+            if (duration !== undefined && duration != null) {
+              effectiveDuration = Number(duration);
+            } else if (date && endTime) {
+              effectiveDuration =
+                (new Date(endTime).getTime() - new Date(date).getTime()) / 3_600_000;
+            }
+            // epsilon so an exactly-3h block isn't falsely rejected.
+            if (effectiveDuration != null && effectiveDuration > 3 + 1e-6) {
+              return res.status(400).json({
+                error: 'GPP_DURATION_EXCEEDED',
+                message: 'GPP events are limited to 3 hours.',
+              });
+            }
+          }
+        }
+      }
+    }
+
     const party = await prisma.party.update({
       where: { id },
       data: {

--- a/frontend/src/components/EventDetailsTab.tsx
+++ b/frontend/src/components/EventDetailsTab.tsx
@@ -17,7 +17,12 @@ import { DonationSettings } from './DonationSettings';
 import { HostsManager } from './HostsManager';
 import { DescriptionEditor } from './DescriptionEditor';
 import { triggerFlyerRegen } from './flyer/autoRegenFlyer';
+import { getUnderbossContact } from '../utils/underbossContacts';
 import type { Party } from '../types';
+
+// tigella-58513: GPP events may not exceed 3 hours. Compared with a tiny
+// epsilon so an exactly-3h block (from floating-point ms math) isn't rejected.
+const GPP_MAX_DURATION_HOURS = 3;
 
 export const EventDetailsTab: React.FC = () => {
   const { t } = useTranslation('host');
@@ -106,6 +111,8 @@ export const EventDetailsTab: React.FC = () => {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [toast, setToast] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
+  // tigella-58513: error shown in the Event Time modal when a GPP edit exceeds 3h.
+  const [dateTimeError, setDateTimeError] = useState<string | null>(null);
 
   // Pending lat/lng from LocationAutocomplete (fires before onPlaceSelected)
   const pendingCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
@@ -590,8 +597,8 @@ export const EventDetailsTab: React.FC = () => {
     }
   };
 
-  // Save date/time
-  const saveDateTime = async () => {
+  // Save date/time. Returns true on a successful save, false when blocked or failed.
+  const saveDateTime = async (): Promise<boolean> => {
     let calculatedDuration: number | null = null;
     let startDateTime: string | null = null;
 
@@ -606,6 +613,22 @@ export const EventDetailsTab: React.FC = () => {
       startDateTime = start.toISOString();
     } else if (startDate && startTime) {
       startDateTime = parseDateTimeInTimezone(startDate, startTime, tz).toISOString();
+    }
+
+    // tigella-58513: GPP events are capped at 3h. Reject (don't clamp) and tell
+    // the host to ask their regional underboss for an exception.
+    if (
+      party?.eventType === 'gpp' &&
+      calculatedDuration != null &&
+      calculatedDuration > GPP_MAX_DURATION_HOURS + 1e-6
+    ) {
+      const handle = getUnderbossContact(party.country)?.handle;
+      setDateTimeError(
+        handle
+          ? `GPP events are limited to 3 hours. Ask your underboss ${handle} if you want an exception.`
+          : `GPP events are limited to 3 hours. Ask your underboss if you want an exception.`,
+      );
+      return false;
     }
 
     const success = await saveField(
@@ -642,6 +665,7 @@ export const EventDetailsTab: React.FC = () => {
         );
       }
     }
+    return success;
   };
 
   // Save description
@@ -834,7 +858,7 @@ export const EventDetailsTab: React.FC = () => {
         {/* Change Date Button */}
         <button
           type="button"
-          onClick={() => setShowDateTimeModal(true)}
+          onClick={() => { setDateTimeError(null); setShowDateTimeModal(true); }}
           className="w-full bg-theme-surface border border-theme-stroke rounded-xl p-4 text-left hover:bg-theme-surface-hover transition-colors"
         >
           <div className="flex items-center justify-between">
@@ -1326,16 +1350,19 @@ export const EventDetailsTab: React.FC = () => {
       {/* Mobile Date/Time Modal */}
       {showDateTimeModal && createPortal(
         <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 p-4 bg-black/70" onClick={async () => {
-          if (
+          const changed =
             originalValues && (
               startDate !== originalValues.startDate ||
               startTime !== originalValues.startTime ||
               endDate !== originalValues.endDate ||
               endTime !== originalValues.endTime ||
               timezone !== originalValues.timezone
-            )
-          ) {
-            await saveDateTime();
+            );
+          if (changed) {
+            // tigella-58513: keep the modal open on a rejected/failed save so the
+            // host sees the underboss-exception message instead of auto-dismissing.
+            const ok = await saveDateTime();
+            if (!ok) return;
           }
           setShowDateTimeModal(false);
         }}>
@@ -1353,6 +1380,7 @@ export const EventDetailsTab: React.FC = () => {
                   type="date"
                   value={startDate}
                   onChange={(e) => {
+                    setDateTimeError(null);
                     setStartDate(e.target.value);
                     if (!endDate) setEndDate(e.target.value);
                   }}
@@ -1368,7 +1396,7 @@ export const EventDetailsTab: React.FC = () => {
                 <span className="text-xs text-theme-text-muted mb-1 block ml-0.5">Start Time</span>
                 <TimePickerInput
                   value={startTime}
-                  onChange={setStartTime}
+                  onChange={(v) => { setDateTimeError(null); setStartTime(v); }}
                   placeholder="12:00 PM"
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
@@ -1383,7 +1411,7 @@ export const EventDetailsTab: React.FC = () => {
                 <input
                   type="date"
                   value={endDate}
-                  onChange={(e) => setEndDate(e.target.value)}
+                  onChange={(e) => { setDateTimeError(null); setEndDate(e.target.value); }}
                   min={startDate || undefined}
                   max={party?.eventType === 'gpp' ? '2026-05-23' : undefined}
                   onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
@@ -1397,7 +1425,7 @@ export const EventDetailsTab: React.FC = () => {
                 <span className="text-xs text-theme-text-muted mb-1 block ml-0.5">End Time</span>
                 <TimePickerInput
                   value={endTime}
-                  onChange={setEndTime}
+                  onChange={(v) => { setDateTimeError(null); setEndTime(v); }}
                   placeholder="1:00 PM"
                   className="w-full bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-theme-text text-sm focus:outline-none focus:ring-1 focus:ring-[#ff393a] focus:border-[#ff393a]"
                 />
@@ -1410,14 +1438,24 @@ export const EventDetailsTab: React.FC = () => {
                   onChange={setTimezone}
                 />
               </div>
+
+              {/* tigella-58513: always-on GPP 3h cap reminder */}
+              {party?.eventType === 'gpp' && (
+                <p className="text-xs text-white/40">GPP events are limited to 3 hours.</p>
+              )}
             </div>
+
+            {/* tigella-58513: GPP 3h cap rejection message */}
+            {dateTimeError && (
+              <p className="text-xs text-red-400 mt-3">{dateTimeError}</p>
+            )}
 
             {/* Done Button */}
             <button
               type="button"
               onClick={async () => {
-                await saveDateTime();
-                setShowDateTimeModal(false);
+                const ok = await saveDateTime();
+                if (ok) setShowDateTimeModal(false);
               }}
               disabled={savingField === 'dateTime'}
               className="w-full mt-4 bg-[#ff393a] hover:bg-[#ff5a5b] disabled:opacity-50 text-white font-medium py-2.5 rounded-lg transition-colors text-sm flex items-center justify-center gap-2"

--- a/plans/tigella-58513-gpp-3h-cap.md
+++ b/plans/tigella-58513-gpp-3h-cap.md
@@ -1,0 +1,121 @@
+# tigella-58513 — GPP events capped at 3 hours
+
+**Priority:** Medium
+**Branch:** `tigella-58513-gpp-3h-cap`
+
+## Feature
+GPP events (`eventType === 'gpp'`) may not be longer than **3 hours**. GPP creation already
+defaults to a 3h block (start 6pm / end 9pm / `duration: 3`), but a host can currently stretch
+the end time in the Event Time editor to make a 5h+ GPP event — nothing validates duration.
+
+When a host tries to save a GPP event longer than 3h, **block the save** and show:
+
+> Ask your underboss @{handle} if you want an exception.
+
+…where `@{handle}` is the regional underboss Telegram handle resolved from the event's country.
+
+### Decisions (Snax)
+- **Reject, don't clamp.** Show the "ask your underboss for an exception" message instead of
+  silently snapping the end time back.
+- **No backfill.** Existing GPP events already > 3h are left as-is; enforcement is on new edits only.
+
+## How event time is stored / edited (architecture findings)
+- `Party.date` = start (timestamptz), `Party.endTime` (timestamptz), `Party.duration` = **Float hours**
+  (`backend/prisma/schema.prisma`). The duration column is the source of truth the UI displays from.
+- **Frontend editor:** `frontend/src/components/EventDetailsTab.tsx`
+  - `saveDateTime()` (`:594`) parses the start/end date+time pickers in the event timezone, computes
+    `calculatedDuration = (end - start) / 3600_000`, then `saveField('dateTime', { date, duration, timezone })`.
+  - The same Event Time modal already has **GPP-specific locks**: start *date* input `disabled` for gpp
+    (`:1359`), end-date `max` (`:1388`). So gpp start is pinned; the 3h rule effectively caps the **end time**.
+  - `saveDateTime()` is called from BOTH the Done button (`:1419`) and the click-outside backdrop
+    handler (`:1338`) — both currently close the modal unconditionally afterward.
+- **Backend save:** `PATCH /api/parties/:id` in `backend/src/routes/party.routes.ts` persists
+  `date` / `endTime` / `duration` (`:722-724`) with **no duration validation**. This same endpoint is
+  what the **NL Event Assistant** (arancini-58492) writes through, so a backend guard covers that path too.
+- **Underboss handle resolver already exists:** `getUnderbossContact(country)` in
+  `frontend/src/utils/underbossContacts.ts:101` returns `{ handle: '@username', url: 't.me/...' }` from a
+  hardcoded country→Telegram map (already used on `PayoutsTab.tsx`). Reuse it — do NOT build a new lookup.
+  The `Underboss` DB model has **no** username/telegram field, so this country map is the canonical handle source.
+
+> Re-verify against origin/master before building (parent branch may be behind):
+> (a) `saveDateTime()` still computes `calculatedDuration` the same way; (b) the gpp start-date lock /
+> end-date `max` are still the only gpp time constraints; (c) `getUnderbossContact` signature unchanged;
+> (d) the PATCH handler still has no duration guard.
+
+## Constant
+Define one shared limit so frontend + backend agree:
+`GPP_MAX_DURATION_HOURS = 3` (use a tiny epsilon when comparing: `dur > GPP_MAX_DURATION_HOURS + 1e-6`,
+so an exactly-3.0h block from floating-point ms math is never falsely rejected).
+
+## Frontend (`EventDetailsTab.tsx`)
+1. Add a `dateTimeError: string | null` state, rendered inside the Event Time modal (above the Done
+   button, red text — clone the existing `imageError` styling). Clear it whenever the pickers change.
+2. **Make `saveDateTime()` return a boolean** (`true` on success, `false` when blocked/failed).
+   After computing `calculatedDuration`, before calling `saveField`:
+   ```ts
+   if (party?.eventType === 'gpp' && calculatedDuration != null
+       && calculatedDuration > GPP_MAX_DURATION_HOURS + 1e-6) {
+     const handle = getUnderbossContact(party.country)?.handle;
+     setDateTimeError(
+       handle
+         ? `GPP events are limited to 3 hours. Ask your underboss ${handle} if you want an exception.`
+         : `GPP events are limited to 3 hours. Ask your underboss if you want an exception.`
+     );
+     return false;
+   }
+   ```
+   (`handle` already includes the leading `@`.)
+3. **Gate modal-close on success** in both callers:
+   - Done button (`:1419`): `const ok = await saveDateTime(); if (ok) setShowDateTimeModal(false);`
+   - Backdrop click-out (`:1328`): only `saveDateTime()` when values changed, and **keep the modal open
+     if it returns false** so the host sees the message (don't auto-dismiss a rejected save).
+4. Add a small always-on helper note in the modal for gpp events ("GPP events are limited to 3 hours.",
+   `text-xs text-white/40`) so the rule is visible before they hit it.
+5. **Reuse, don't reimplement:** import `getUnderbossContact` (already in the utils file). Put
+   `GPP_MAX_DURATION_HOURS` in a shared spot (e.g. `frontend/src/utils/dateUtils.ts` or a small consts file)
+   if the backend can't share it.
+
+## Backend (`party.routes.ts`, `PATCH /api/parties/:id`) — authoritative guard
+The frontend block is UX only; the backend is the real enforcement (and covers the NL Assistant path).
+
+1. The handler already fetches prior party state for the cap audit — ensure the **`eventType`** (and
+   existing `date`) are available; select them if not already loaded.
+2. Compute the **effective new duration** from the incoming payload:
+   - if `duration` is provided → use it;
+   - else if both `date` and `endTime` are provided → `(new Date(endTime) - new Date(date)) / 3600_000`;
+   - else (time not being changed) → skip the check.
+3. If the event is gpp and the effective duration `> 3 + 1e-6`, **return 400** with a machine code, e.g.
+   `{ error: 'GPP_DURATION_EXCEEDED', message: 'GPP events are limited to 3 hours.' }`, before `prisma.party.update`.
+
+### Privileged override (so the "exception" is actually grantable)
+The message tells hosts to ask their underboss for an exception — so **admins and scoped underbosses must
+be able to bypass** the cap. The route already has `req.userEmail`, `resolveCapActorKind(...)`, and
+`underbossScope` helpers. Apply the guard only when the editor is a plain host; skip it when
+`actorKind === 'admin'` or the requester is an underboss whose scope covers this party.
+> Confirm during build exactly how actor kind is resolved in this handler and that scoped-underboss
+> identity is cheaply available; if it isn't, fall back to **admin-only bypass** for v1 and note it.
+
+- **DB: NONE.** Pure validation. Per `CLAUDE.md`, the backend guard must be on **master** before it
+  takes effect on preview branches (previews share the prod backend).
+
+## Out of scope / notes
+- **No backfill** (Snax decision). Existing > 3h gpp events keep their length until edited.
+- The end-date `max` in the modal is a **stale hardcode** (`'2026-05-23'`, but GPP27 is 2027) — not this
+  task's concern, but worth a separate cleanup ticket.
+- GPP27 create defaults (`gpp27.routes.ts`: 6pm/9pm/duration 3) already satisfy the rule — no change.
+
+## Test plan
+- Host edits a gpp event end time to 5h → save blocked, message shows correct `@handle` for the country
+  (and the generic fallback when the country isn't in the map). Modal stays open.
+- Host sets exactly 3h → saves fine (epsilon).
+- Non-gpp event set to 5h → saves fine (rule is gpp-only).
+- API/curl `PATCH` a gpp party with `duration: 5` as a plain host → 400 `GPP_DURATION_EXCEEDED`;
+  as admin/scoped-underboss → 200.
+- NL Assistant instruction "make the party 5 hours" on a gpp event → backend rejects.
+
+## Ship checklist
+- [ ] Branch `tigella-58513-gpp-3h-cap` off `origin/master`, draft PR for Vercel preview.
+- [ ] Re-verify the four origin/master assumptions above before coding.
+- [ ] Merge to master so the backend guard is live (frontend preview alone can't enforce it).
+- [ ] **Sheet row needs creating/backfill** — `tigella-58513` is a locally-picked id (sheets-claude
+      create currently 403s); ask Snax to add the row.


### PR DESCRIPTION
## Feature
GPP events (`eventType === 'gpp'`) are capped at **3 hours**. Creation already defaults to a 3h block; this closes the **editing** gap where a host could stretch the end time.

When a host edits a GPP event past 3h, the save is **rejected** (not clamped) with:
> GPP events are limited to 3 hours. Ask your underboss @{handle} if you want an exception.

`@{handle}` is the regional underboss Telegram handle from the existing `getUnderbossContact(party.country)` util. **Admins / underbosses bypass** the cap, so the exception is grantable.

### Decisions (Snax)
- **Reject, not clamp.**
- **No backfill** — existing >3h GPP events are left as-is; enforcement is new-edits-only.

## Changes
- **Frontend** (`EventDetailsTab.tsx`): `saveDateTime()` returns success/failure; a >3h gpp edit sets the underboss-exception message and keeps the Event Time modal open. Always-on "limited to 3 hours" helper note for gpp events. Error clears on picker change / modal open.
- **Backend** (`party.routes.ts` PATCH `/api/parties/:id`): authoritative `400 GPP_DURATION_EXCEEDED` guard — also covers the NL Event Assistant path. eventType read from the pre-update DB row (never trusted from the body); privileged bypass via `isSuperAdmin || isAdmin || isUnderboss`.
- **No DB migration.** Per repo norms the backend guard must reach **master** before it enforces on preview branches (previews share the prod backend).

## Test plan
- Host sets a gpp event to 5h → blocked, correct `@handle` shown, modal stays open.
- Exactly 3h → saves (epsilon).
- Non-gpp event 5h → saves (gpp-only).
- `PATCH` gpp party `duration: 5` as plain host → 400; as admin/underboss → 200.
- NL Assistant "make it 5 hours" on a gpp event → backend rejects.

> Note: `tigella-58513` is a locally-picked task id — project-sheet row needs backfilling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)