### PR TITLE
ricotta-58512: snapshot host payout method/wallet onto rolling reimbursement rows

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -32,6 +32,10 @@ import {
   getYtdPayoutTotalUsd,
 } from './tax-form.routes.js';
 import { getPayoutCaps } from '../lib/privateConfig.js';
+import {
+  NON_TERMINAL_PAYOUT_STATUSES,
+  payoutRowSnapshotFromUser,
+} from '../services/payout-snapshot.js';
 
 const router = Router();
 
@@ -2598,7 +2602,8 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
 
 // Non-terminal statuses: a rolling record is "active" while in one of these.
 // Terminal = paid | completed | withdrawn | rejected | failed.
-const NON_TERMINAL_PAYOUT_STATUSES = ['pending', 'approved', 'queued'] as const;
+// ricotta-58512: moved to services/payout-snapshot.ts so user.routes.ts can
+// reuse it without a require cycle; re-imported above.
 
 /**
  * ziti-58300: find the caller's active rolling reimbursement record for an
@@ -2958,6 +2963,18 @@ router.post('/:partyId/reimbursement/receipts', async (req: AuthRequest, res: Re
         // Create a fresh rolling record. finalAmountUsd is set after we know
         // the eligible sum; seed FX headline from the first resolved receipt.
         const firstResolved = docsToCreate.find((d) => d.ocrAmount != null);
+        // ricotta-58512: snapshot the uploader's payout method/wallet onto the
+        // new rolling row so the execute/send path (which reads the row, not the
+        // host profile) can pay it. Covers "host set payment details first, then
+        // uploaded receipts, admin approved the rolling row without a submit."
+        const uploader = await tx.user.findUnique({
+          where: { id: uploaderUserId },
+          select: {
+            preferredPayoutMethod: true,
+            payoutWalletAddress: true,
+            payoutBankDetails: true,
+          },
+        });
         const created = await tx.payout.create({
           data: {
             partyId,
@@ -2969,6 +2986,7 @@ router.post('/:partyId/reimbursement/receipts', async (req: AuthRequest, res: Re
             extractedAmountUsd: new Decimal(0),
             finalAmountUsd: new Decimal(0),
             status: 'pending',
+            ...(uploader ? payoutRowSnapshotFromUser(uploader) : {}),
             documents: { create: stampedDocs },
           },
           include: { documents: true },
@@ -3168,9 +3186,25 @@ router.post('/:partyId/reimbursement/submit', async (req: AuthRequest, res: Resp
       );
     }
 
+    // ricotta-58512: snapshot the submitting host's payout method/wallet onto
+    // the row at submit time so the execute/send path can pay it (it reads the
+    // row, not the host profile). The host is who entered payment details, so a
+    // submit is the authoritative point to re-stamp it.
+    const submitter = await prisma.user.findUnique({
+      where: { id: req.userId },
+      select: {
+        preferredPayoutMethod: true,
+        payoutWalletAddress: true,
+        payoutBankDetails: true,
+      },
+    });
+
     const updated = await prisma.payout.update({
       where: { id: record.id },
-      data: { submittedForReviewAt: new Date() },
+      data: {
+        submittedForReviewAt: new Date(),
+        ...(submitter ? payoutRowSnapshotFromUser(submitter) : {}),
+      },
       include: {
         host: { select: { id: true, name: true, email: true } },
         documents: {

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -5,6 +5,7 @@ import { resolveWalletInput } from '../services/ens.service.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
 import { getReimbursementRules } from '../lib/privateConfig.js';
 import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
+import { payoutRowSnapshotFromUser } from '../services/payout-snapshot.js';
 
 const router = Router();
 
@@ -165,6 +166,39 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
         payoutBankDetails: true,
       },
     });
+
+    // ricotta-58512: when the host edits their payout prefs, mirror the UPDATED
+    // profile onto their non-terminal rolling event payouts. The execute/send
+    // path reads the payout ROW (no host fallback), so without this a host who
+    // fixes their wallet AFTER the rolling row exists (incl. after an admin has
+    // approved it) stays un-payable. Only re-stamp rows it's safe to touch:
+    // 'pending' and 'approved'. We deliberately EXCLUDE 'queued' (an in-flight
+    // send must not have its target wallet swapped mid-flight) even though it's
+    // in NON_TERMINAL_PAYOUT_STATUSES, and never touch terminal rows
+    // (paid/withdrawn/rejected/failed/completed). The mercury_card guard avoids
+    // clobbering an admin-issued Mercury card with the host's self-serve prefs.
+    if (
+      preferredPayoutMethod !== undefined
+      || payoutWalletAddress !== undefined
+      || payoutBankDetails !== undefined
+    ) {
+      try {
+        const snap = payoutRowSnapshotFromUser(user);
+        await prisma.payout.updateMany({
+          where: {
+            hostUserId: req.userId,
+            purpose: 'event',
+            status: { in: ['pending', 'approved'] },
+            NOT: { payoutMethod: 'mercury_card' },
+          },
+          data: snap,
+        });
+      } catch (err) {
+        // Non-fatal — the profile save itself succeeded; the row sync is a
+        // best-effort convenience so a stale rolling row doesn't strand a host.
+        console.warn('[user] failed to sync payout prefs onto rolling rows:', err);
+      }
+    }
 
     res.json({ user });
   } catch (error) {

--- a/backend/src/services/payout-snapshot.ts
+++ b/backend/src/services/payout-snapshot.ts
@@ -1,0 +1,42 @@
+/**
+ * ricotta-58512: shared payout-row snapshot helpers.
+ *
+ * The rolling-reimbursement flow (ziti-58300) never copied the host's payout
+ * method/wallet onto the `payouts` row — that data lives only on the host
+ * `User` profile (preferredPayoutMethod / payoutWalletAddress /
+ * payoutBankDetails, set via PATCH /api/user/me). The execute/send path reads
+ * the payout ROW with NO host fallback, so hosts who entered their wallet
+ * correctly were un-payable. These helpers re-introduce the snapshot the old
+ * POST /payouts create used to do, at the rolling write points.
+ *
+ * Kept in its own module (imported by both payout.routes.ts and user.routes.ts)
+ * to avoid a require cycle between those two route files.
+ */
+import { Prisma } from '@prisma/client';
+
+// Non-terminal statuses: a rolling record is "active" while in one of these.
+// Terminal = paid | completed | withdrawn | rejected | failed.
+export const NON_TERMINAL_PAYOUT_STATUSES = ['pending', 'approved', 'queued'] as const;
+
+/**
+ * method-consistent snapshot of a host's payout prefs, shaped for a payouts-row
+ * write. Mirrors the old POST /payouts rule: wallet only for usdc_base, bank
+ * only for wire. The non-matching method field is nulled so switching method
+ * leaves no stale field behind. Wallet is copied verbatim (it is already
+ * ENS-resolved to 0x at the User PATCH boundary — do NOT re-resolve here).
+ */
+export function payoutRowSnapshotFromUser(u: {
+  preferredPayoutMethod: string | null;
+  payoutWalletAddress: string | null;
+  payoutBankDetails: Prisma.JsonValue | null;
+}) {
+  const method = u.preferredPayoutMethod ?? null;
+  return {
+    payoutMethod: method,
+    payoutWalletAddress: method === 'usdc_base' ? (u.payoutWalletAddress ?? null) : null,
+    payoutBankDetails:
+      method === 'wire' && u.payoutBankDetails != null
+        ? (u.payoutBankDetails as Prisma.InputJsonValue)
+        : Prisma.JsonNull,
+  };
+}


### PR DESCRIPTION
## The bug

The rolling-reimbursement flow (ziti-58300, the `/payments` host page) never copies the host's payout method/wallet onto the `payouts` row. The wallet lives only on the host `User` profile (`preferredPayoutMethod`, `payoutWalletAddress`, `payoutBankDetails`), set via `PATCH /api/user/me` (PaymentDetailsCard).

But the admin execute/send path reads the payout **ROW** with no host fallback:
- `admin-payout.routes.ts` throws `MISSING_PAYOUT_METHOD` when `existing.payoutMethod == null`
- throws `MISSING_WALLET_ADDRESS` when a usdc_base row has no `payoutWalletAddress`
- the bulk executor silently skips such rows

Result: hosts who entered their wallet correctly were **un-payable** (San Pedro Sula + 8 others). The old `POST /payouts` create snapshotted method+wallet onto the row; the rolling rewrite dropped it. 8 of 9 stranded rows were `approved` WITHOUT a host submit (admins approve rolling rows directly), so snapshotting at submit alone is not enough.

## The fix — sync the row with the host profile at 3 write points

Shared module `backend/src/services/payout-snapshot.ts` exports `payoutRowSnapshotFromUser(user)` (method-consistent: wallet only for `usdc_base`, bank only for `wire`, the non-matching field nulled so switching method leaves no stale value) plus the `NON_TERMINAL_PAYOUT_STATUSES` constant (moved here so user.routes.ts can reuse it without a require cycle).

1. **Seed at receipt-create** — `payout.routes.ts` `POST /:partyId/reimbursement/receipts`: when creating a fresh rolling row, fetch the uploader's payout prefs and spread `payoutRowSnapshotFromUser(user)` into `tx.payout.create`. Covers "host set payment details first, then uploaded receipts, admin approved without submit."
2. **Snapshot at submit** — `payout.routes.ts` `POST /:partyId/reimbursement/submit`: fetch the submitter's prefs and include the snapshot in the `payout.update` alongside `submittedForReviewAt`.
3. **Sync on edit** — `user.routes.ts` `PATCH /me`: if any of the three payout fields was in the body, mirror the UPDATED profile (the row already selected by the existing update — not re-queried) onto the host's safe-to-touch rolling event rows via `updateMany`.

## Mercury guard

The `PATCH /me` sync excludes `payoutMethod = 'mercury_card'` (`NOT: { payoutMethod: 'mercury_card' }`) so a self-serve profile edit can't clobber an admin-issued Mercury card.

## Status set used in PATCH /me sync

`NON_TERMINAL_PAYOUT_STATUSES = ['pending', 'approved', 'queued']`. The `PATCH /me` `updateMany` deliberately uses only **`['pending', 'approved']`** — it **excludes `queued`** (an in-flight send must not have its target wallet swapped mid-flight). Terminal rows (paid/withdrawn/rejected/failed/completed) are never touched. Wallet is copied verbatim (already ENS→0x resolved at the User PATCH boundary — not re-resolved).

## Deploy / data

- **BACKEND change** — deploy backend after merge (frontend previews hit prod backend; no frontend or Prisma/schema change).
- The 9 stranded rows were already backfilled by hand; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)