### PR TITLE
feat(tigella-58512): show TBD events with no payment submission on /payments (hidden by default)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2207,6 +2207,130 @@ router.get(
         };
       });
 
+      // tigella-58512: optional `?showTbdUnsubmitted=1` injects synthetic
+      // by-party rows for approved events tagged `tbd` that have submitted
+      // NOTHING yet (zero payouts AND zero payout documents of any kind).
+      // Because these parties have zero payouts they produce zero grouped
+      // `rows` above, so they're invisible on /payments without this. OFF by
+      // default — when the param is absent the response is byte-identical to
+      // before. Scoped to the by-city view (this endpoint) only.
+      const showTbdUnsubmitted =
+        req.query.showTbdUnsubmitted === '1' || req.query.showTbdUnsubmitted === 'true';
+      if (showTbdUnsubmitted) {
+        // Reuse the SAME party-level scope this handler already computed in
+        // `buildPayoutWhere` (underbossStatus 'approved' + optional
+        // country/tag/region/closed clauses live on `where.party`; the search
+        // partyId set lives on `where.OR` / `where.partyId`). We do NOT apply
+        // any payout-level filters (status/method/purpose/currency/date) —
+        // these rows have no payouts. The tbd + zero-submission predicates are
+        // AND'd on top via an explicit AND array so a `tag` filter on
+        // `where.party.eventTags` is preserved rather than clobbered.
+        const partyScope: any = { ...(where.party ?? {}) };
+        const andParts: any[] = [
+          { eventTags: { hasSome: ['tbd', 'TBD'] } },
+          { payouts: { none: {} } },
+          { payoutDocuments: { none: {} } },
+        ];
+        // Respect the unified search scope (salame-83472 / diavola-83147):
+        // `where.OR` restricts to a partyId set; only the partyId arm applies
+        // at the party level (hostUserId is a payout column).
+        if (Array.isArray(where.OR)) {
+          const searchPartyIds = where.OR
+            .map((o: any) => o?.partyId?.in)
+            .find((v: any) => Array.isArray(v));
+          if (Array.isArray(searchPartyIds)) {
+            andParts.push({ id: { in: searchPartyIds } });
+          }
+        }
+        // Single-partyId filter (where.partyId is a payout column, but the
+        // same id is the party id we want to scope to).
+        if (typeof where.partyId === 'string' && where.partyId.length > 0) {
+          andParts.push({ id: where.partyId });
+        }
+        // Defensively exclude any party already present in `rows`.
+        const existingPartyIds = new Set(rows.map((r) => r.party.id));
+        if (existingPartyIds.size > 0) {
+          andParts.push({ id: { notIn: Array.from(existingPartyIds) } });
+        }
+        partyScope.AND = [...(Array.isArray(partyScope.AND) ? partyScope.AND : []), ...andParts];
+
+        const tbdParties = await prisma.party.findMany({
+          where: partyScope,
+          select: PAYOUT_PARTY_SELECT,
+        });
+
+        for (const partyMeta of tbdParties as any[]) {
+          const partyId = partyMeta.id;
+          // Synthetic by-party row in the EXACT shape the real rows use, with
+          // every count/usd aggregate = 0 and no payouts/photos. Keys mirror
+          // the serializer above field-for-field so the frontend renders these
+          // with NO special-casing. Cast to the row element type because the
+          // real rows infer `lastActivityAt: string` whereas these are null.
+          rows.push({
+            party: {
+              id: partyId,
+              name: partyMeta.name,
+              customUrl: partyMeta.customUrl ?? null,
+              inviteCode: partyMeta.inviteCode ?? null,
+              country: partyMeta.country ?? null,
+              region: (partyMeta.region as string | null) ?? null,
+              effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+                reimbursementCapUsd: partyMeta.reimbursementCapUsd,
+                eventTags: partyMeta.eventTags,
+              }),
+              eventTags: Array.isArray(partyMeta.eventTags) ? partyMeta.eventTags : [],
+              primaryHostInCohosts: isPrimaryHostInCohosts(partyMeta),
+              userId: partyMeta.userId ?? null,
+              paymentsClosedAt: partyMeta.paymentsClosedAt
+                ? partyMeta.paymentsClosedAt.toISOString()
+                : null,
+              taxFormRequired: partyMeta.taxFormRequired === true,
+              adminNotes:
+                req.viewerRole === 'admin'
+                  ? (partyMeta.adminNotes ?? null)
+                  : null,
+              receiptsReminderSentAt: partyMeta.receiptsReminderSentAt
+                ? partyMeta.receiptsReminderSentAt.toISOString()
+                : null,
+              walletReminderSentAt: partyMeta.walletReminderSentAt
+                ? partyMeta.walletReminderSentAt.toISOString()
+                : null,
+              paymentsApprovedUsd: partyMeta.paymentsApprovedUsd
+                ? Number(partyMeta.paymentsApprovedUsd)
+                : null,
+              paymentsApprovedAt: partyMeta.paymentsApprovedAt
+                ? partyMeta.paymentsApprovedAt.toISOString()
+                : null,
+            },
+            aggregates: {
+              pendingCount: 0,
+              pendingUsd: 0,
+              approvedCount: 0,
+              approvedUsd: 0,
+              paidCount: 0,
+              paidUsd: 0,
+              paidNoProofCount: 0,
+              paidNoProofUsd: 0,
+              rejectedCount: 0,
+              rejectedUsd: 0,
+              failedCount: 0,
+              failedUsd: 0,
+              withdrawnCount: 0,
+              withdrawnUsd: 0,
+              completedCount: 0,
+              completedUsd: 0,
+              completedNoProofCount: 0,
+              completedNoProofUsd: 0,
+              totalReceiptCount: 0,
+              lastActivityAt: null,
+              flaggedReadyCount: 0,
+            },
+            payouts: [],
+            eventPhotos: [],
+          } as (typeof rows)[number]);
+        }
+      }
+
       // pinsa-92103: optional `?hideClosed=true` filters out rows the admin
       // has explicitly closed out (Ekiti, Tangier). Doing this server-side
       // (vs. in the table component) keeps row counts honest and is cheap —

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -3512,9 +3512,16 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                     </td>
                     <td className="px-3 py-3 text-sm text-theme-text-secondary">
                       <div className="flex items-center justify-between gap-2">
-                        <div title={new Date(row.aggregates.lastActivityAt).toLocaleString()}>
-                          {relativeTime(new Date(row.aggregates.lastActivityAt))}
-                        </div>
+                        {/* tigella-58512: synthetic TBD rows have no payout
+                            activity (lastActivityAt=null) → show an em dash
+                            instead of a 1969 epoch date. */}
+                        {row.aggregates.lastActivityAt ? (
+                          <div title={new Date(row.aggregates.lastActivityAt).toLocaleString()}>
+                            {relativeTime(new Date(row.aggregates.lastActivityAt))}
+                          </div>
+                        ) : (
+                          <div className="text-theme-text-faint">—</div>
+                        )}
                         <CityActionsMenu
                           canMarkPaid={showMarkPartyPaid}
                           canAddExternal={canAddExternal}

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -54,6 +54,14 @@ interface PayoutsFilterBarProps {
    */
   showHideUsToggle?: boolean;
   /**
+   * tigella-58512: when true, render the "Show TBD (no submission)" checkbox.
+   * By-city view only (the synthetic rows it reveals only exist on the
+   * by-party endpoint). OFF by default — turning it on asks the backend to
+   * inject approved `tbd`-tagged events that have submitted nothing yet.
+   * Defaults to false.
+   */
+  showTbdToggle?: boolean;
+  /**
    * pancetta-92103: when true, render the Regions multi-select dropdown
    * (admin /payments). Hidden on regional sub-portals (which are already
    * hard-scoped by their `regionFilter` prop). Defaults to false.
@@ -174,6 +182,8 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.hideScams) n += 1;
   // provatura-92107: count Hide US cities alongside the other hide toggles.
   if (filters.hideUsCities) n += 1;
+  // tigella-58512: count Show TBD (no submission) when the admin turns it on.
+  if (filters.showTbdUnsubmitted) n += 1;
   return n;
 }
 
@@ -199,6 +209,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   showHideClosedToggle,
   showHideScamsToggle,
   showHideUsToggle,
+  showTbdToggle,
   showRegionsFilter,
   showStatusTabs = true,
 }) => {
@@ -533,6 +544,19 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
                 checked={!!filters.hideUsCities}
                 onChange={() => update({ hideUsCities: !filters.hideUsCities })}
                 label="Hide US cities"
+                labelClassName="text-xs text-theme-text-secondary"
+                size={14}
+              />
+            )}
+            {/* tigella-58512: Show approved `tbd` events that have submitted
+                nothing yet (zero payouts + zero documents). By-city view only;
+                OFF by default. The backend injects synthetic rows on /by-party
+                when `showTbdUnsubmitted` is set. */}
+            {showTbdToggle && (
+              <Checkbox
+                checked={!!filters.showTbdUnsubmitted}
+                onChange={() => update({ showTbdUnsubmitted: !filters.showTbdUnsubmitted })}
+                label="Show TBD (no submission)"
                 labelClassName="text-xs text-theme-text-secondary"
                 size={14}
               />

--- a/frontend/src/components/payments-admin/paymentsUrlState.test.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.test.ts
@@ -70,6 +70,21 @@ describe('filtersToSearchParams', () => {
     expect(off.get('hideClosed')).toBe('0');
     expect(off.get('hideScams')).toBe('0');
   });
+
+  // tigella-58512: default-FALSE toggle — emit `tbd=1` only when ON.
+  it('showTbdUnsubmitted: emits tbd=1 only when ON, nothing by default', () => {
+    // default (false / undefined) -> no key
+    expect(
+      filtersToSearchParams(DEFAULT_FILTERS, 'by-city').get('tbd'),
+    ).toBeNull();
+    expect(
+      filtersToSearchParams({ ...DEFAULT_FILTERS, showTbdUnsubmitted: false }, 'by-city').get('tbd'),
+    ).toBeNull();
+    // turned on -> tbd=1
+    expect(
+      filtersToSearchParams({ ...DEFAULT_FILTERS, showTbdUnsubmitted: true }, 'by-city').get('tbd'),
+    ).toBe('1');
+  });
 });
 
 describe('searchParamsToFilters', () => {
@@ -125,6 +140,21 @@ describe('searchParamsToFilters', () => {
     );
     expect(filters.hideClosed).toBe(false);
     expect(filters.hideScams).toBe(false);
+  });
+
+  // tigella-58512: default-FALSE toggle round-trip.
+  it('showTbdUnsubmitted: tbd=1 parses to true; absent stays false', () => {
+    const on = searchParamsToFilters(new URLSearchParams('tbd=1'), undefined);
+    expect(on.filters.showTbdUnsubmitted).toBe(true);
+    // absent -> default false
+    const off = searchParamsToFilters(new URLSearchParams(), undefined);
+    expect(off.filters.showTbdUnsubmitted).toBe(false);
+    // round-trip: ON serializes and parses back to ON
+    const params = filtersToSearchParams(
+      { ...DEFAULT_FILTERS, showTbdUnsubmitted: true },
+      'by-city',
+    );
+    expect(searchParamsToFilters(params, undefined).filters.showTbdUnsubmitted).toBe(true);
   });
 
   it('unknown enum values silently fall back to defaults', () => {

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -34,6 +34,8 @@ const DEFAULTS = {
   hideClosed: true,
   hideScams: true,
   hideUsCities: true,
+  // tigella-58512: default-FALSE — only emitted (as `tbd=1`) when turned ON.
+  showTbdUnsubmitted: false,
 };
 const DEFAULT_VIEW: ViewMode = 'by-city';
 
@@ -94,6 +96,9 @@ export function filtersToSearchParams(
   if (filters.hideScams === false) params.set('hideScams', '0');
   if (filters.hideUsCities === false) params.set('hideUsCities', '0');
 
+  // tigella-58512: default-FALSE toggle — only emit when turned ON.
+  if (filters.showTbdUnsubmitted === true) params.set('tbd', '1');
+
   if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
 
   return params;
@@ -131,6 +136,7 @@ export function searchParamsToFilters(
     hideClosed: DEFAULTS.hideClosed,
     hideScams: DEFAULTS.hideScams,
     hideUsCities: DEFAULTS.hideUsCities,
+    showTbdUnsubmitted: DEFAULTS.showTbdUnsubmitted,
     sort: DEFAULTS.sort,
     ...(regions ? { regions } : {}),
   };
@@ -199,6 +205,10 @@ export function searchParamsToFilters(
   if (params.has('hideClosed')) filters.hideClosed = params.get('hideClosed') !== '0';
   if (params.has('hideScams')) filters.hideScams = params.get('hideScams') !== '0';
   if (params.has('hideUsCities')) filters.hideUsCities = params.get('hideUsCities') !== '0';
+
+  // tigella-58512: default-FALSE toggle — present `tbd=1` => true; absent =>
+  // leave the default (false). Any non-`1` value is treated as false.
+  if (params.has('tbd')) filters.showTbdUnsubmitted = params.get('tbd') === '1';
 
   const viewRaw = params.get('view');
   const viewMode: ViewMode | null =

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4929,6 +4929,11 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.provenOnly) {
     params.set('provenOnly', 'true');
   }
+  // tigella-58512: surface approved `tbd` events with zero submissions on the
+  // by-city view. Only set when ON so the default request is byte-identical.
+  if (filters.showTbdUnsubmitted) {
+    params.set('showTbdUnsubmitted', '1');
+  }
   const qs = params.toString();
   return qs ? `?${qs}` : '';
 }

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -121,6 +121,9 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   // provatura-92107: hide US cities (party.region === 'usa') by default on the
   // admin /payments by-city dashboard.
   hideUsCities: true,
+  // tigella-58512: surface approved `tbd` events with zero submissions —
+  // OFF by default so the default request is byte-identical to before.
+  showTbdUnsubmitted: false,
   // arancino-92103: sort order default — newest submitted first. Matches the
   // prior implicit backend ordering, so non-sorting callers see no change.
   sort: 'created_desc',
@@ -721,7 +724,11 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     // work and stay in lockstep with the lastActivityAt the column renders.
     if (sort === 'activity_asc' || sort === 'activity_desc') {
       const activity = (r: PartyPayoutsRow) =>
-        new Date(r.aggregates.lastActivityAt).getTime();
+        // tigella-58512: synthetic TBD rows have lastActivityAt=null → sort to
+        // the bottom (0 = epoch) the same way the backend orders them.
+        r.aggregates.lastActivityAt
+          ? new Date(r.aggregates.lastActivityAt).getTime()
+          : 0;
       return [...rows].sort((a, b) =>
         sort === 'activity_asc' ? activity(a) - activity(b) : activity(b) - activity(a),
       );
@@ -1251,6 +1258,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           showHideClosedToggle={viewMode === 'by-city'}
           // stracchino-92108: Hide possible scams, by-city view only (same as above).
           showHideScamsToggle={viewMode === 'by-city'}
+          // tigella-58512: Show TBD (no submission) — by-city view only. These
+          // synthetic rows come from the by-party endpoint, which is the only
+          // place a zero-payout party can surface.
+          showTbdToggle={viewMode === 'by-city'}
           // provatura-92107: Hide US cities — by-city view + admin dashboard
           // only (regional portals are already region-scoped).
           showHideUsToggle={viewMode === 'by-city' && !isRegionalPortal}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2252,6 +2252,15 @@ export interface AdminPayoutFilters {
    * regional portals). Default true.
    */
   hideUsCities?: boolean;
+  /**
+   * tigella-58512: surface approved events tagged `tbd` that have submitted
+   * NOTHING yet (zero payouts + zero payout documents). These produce no
+   * grouped rows normally, so the backend injects synthetic by-party rows
+   * when this is set. By-city endpoint only; OFF by default — when false the
+   * `showTbdUnsubmitted` query param is omitted entirely (byte-identical to
+   * prior behavior).
+   */
+  showTbdUnsubmitted?: boolean;
 }
 
 export interface AdminPayoutTotals {
@@ -2512,8 +2521,14 @@ export interface PartyPayoutsRow {
     completedNoProofUsd?: number;
     /** payout_documents rows where kind='receipt' for this party. */
     totalReceiptCount: number;
-    /** ISO timestamp — max(updated_at) across this party's payouts. */
-    lastActivityAt: string;
+    /**
+     * ISO timestamp — max(updated_at) across this party's payouts.
+     * tigella-58512: null on synthetic "TBD / no submission" rows (events
+     * tagged `tbd` with zero payouts + zero documents) injected by the
+     * by-party endpoint when `showTbdUnsubmitted` is on — they have no
+     * payout activity to derive a timestamp from.
+     */
+    lastActivityAt: string | null;
     /** Count of payouts whose sticky `flaggedReady` is currently true (argentina-92103). */
     flaggedReadyCount: number;
   };


### PR DESCRIPTION
## What
Surfaces every **approved** event tagged `tbd` that **hasn't submitted any payment receipts or info yet** (zero payout rows **and** zero payout documents) in the `/payments` **by-city** view — **hidden by default**, revealed by a new off-by-default toggle.

## Why it needed a backend change
`/payments` is payout-based: the by-city endpoint groups rows from the `payouts` table, so a party with **zero payouts produces zero rows** regardless of filters. That's why these events are invisible today. When the toggle is on, the `by-party` handler injects **synthetic zero-dollar city rows** for the qualifying parties.

## Definition of "no submission" (locked with Snax)
`underbossStatus = 'approved'` AND `event_tags` contains `tbd`/`TBD` AND `payouts: none` AND `payoutDocuments: none` (any kind).

## UX
- New filter-bar toggle **"Show TBD (no submission)"**, **OFF by default**, by-city view only (mirrors the existing Hide-closed / Hide-scams toggles).
- Toggle OFF ⇒ request sends no new param ⇒ default `/payments` behavior is **byte-identical** to before.

## Changes
- **Backend** `admin-payout.routes.ts` `/by-party`: parse `?showTbdUnsubmitted=1`; when set, query qualifying parties (reusing the handler's party-level scope: approved + country/tag/region/closed + search; **no** payout-level filters), dedupe against existing rows, append synthetic rows matching the real serializer field-for-field (all aggregates 0, `lastActivityAt: null`). Totals unaffected.
- **Frontend**: new `showTbdUnsubmitted` flag threaded through `AdminPayoutFilters` → `buildPayoutQuery` (`showTbdUnsubmitted=1`) → URL state (`tbd=1`, diff-against-defaults) → `PayoutsFilterBar` toggle (`Checkbox`). Null-guard for `lastActivityAt` in the by-party table cell + activity-sort comparator (em-dash instead of a 1969 date).
- Test: round-trip cases in `paymentsUrlState.test.ts` (15/15 pass).

## Verify
- Toggle OFF: by-city list unchanged.
- Toggle ON: approved `tbd` cities with nothing submitted appear as $0 rows; URL round-trips `?tbd=1`.

## Notes / deploy
- **No migration** (no schema change), but the **backend must deploy to master/prod before the preview toggle returns rows** (previews hit the prod backend).
- Full `tsc`/build couldn't run locally (node_modules OneDrive-offloaded) — verified via per-file typecheck, esbuild syntax, passing vitest, and serializer parity review. **Vercel build is the authoritative gate.**
- Overlaps the same by-city filter-bar files as in-flight **cornetto-58510 (#945)**; additive, second-to-merge resolves the trivial conflict.
- Tag casing: no `tbd` tag exists in code; used casing-safe `hasSome: ['tbd','TBD']`. Confirm live DB casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)