### PR TITLE
provola-58509: city exonym alias map (Göteborg→Gothenburg etc.) for moltobene matching

### DIFF
--- a/backend/src/helpers/underbossScope.ts
+++ b/backend/src/helpers/underbossScope.ts
@@ -123,6 +123,107 @@ export function normalizeCityName(input: string | null | undefined): string {
 }
 
 /**
+ * provola-58509: curated city EXONYM alias map for the moltobene matcher.
+ *
+ * The bot's captured-group titles use LOCAL city names ("Göteborg",
+ * "München"), but approved GPP cities are stored with ENGLISH names
+ * ("Gothenburg", "Munich"). After `normalizeCityName` lowercases and strips
+ * accents, the two forms still differ (`goteborg` ≠ `gothenburg`), so the
+ * exact-equality matcher misses. This map collapses each well-established 1:1
+ * exonym↔English pair to ONE canonical normalized form.
+ *
+ * CONTRACT (must be upheld so `canonicalCityName` stays correct):
+ *   - Both KEYS and VALUES are in the SAME normalized form `normalizeCityName`
+ *     produces: lowercased + de-accented + de-noised. (e.g. "goteborg", never
+ *     "Göteborg".) Verify any new entry by running it through
+ *     `normalizeCityName` first.
+ *   - Every entry maps the NON-canonical form → the canonical form. The
+ *     canonical form itself is NOT a key (it already canonicalizes to itself
+ *     via the `?? normalizeCityName(input)` fallback in `canonicalCityName`),
+ *     EXCEPT when we deliberately collapse a pair where BOTH names are still in
+ *     active use (e.g. bengaluru↔bangalore) — then we add BOTH directions
+ *     pointing at the chosen canonical so the comparison is symmetric no matter
+ *     which side the data uses.
+ *
+ * CONSERVATIVE by design: ONLY true same-city aliases of long standing. Never
+ * add near-homonyms of DIFFERENT cities — a wrong entry would silently route a
+ * Telegram group to the wrong city. When in doubt, leave it out.
+ *
+ * Notes on the curated set below:
+ *   - German: München→Munich, Köln→Cologne, Nürnberg→Nuremberg.
+ *   - Iberian: Lisboa→Lisbon, Sevilla→Seville. (Porto, Madrid, Barcelona
+ *     unchanged — same in both languages.)
+ *   - Italian: Napoli→Naples, Roma→Rome, Milano→Milan, Torino→Turin,
+ *     Venezia→Venice, Firenze→Florence, Genova→Genoa.
+ *   - Central/Eastern Europe: Praha→Prague, Warszawa→Warsaw, Wien→Vienna.
+ *     (Kraków normalizes to "krakow" and is the same in English — no entry.)
+ *   - Low Countries: Bruxelles→Brussels, Antwerpen→Antwerp, Gent→Ghent,
+ *     Den Haag→The Hague.
+ *   - Swiss/Nordic: Genève→Geneva, Göteborg→Gothenburg. (Zürich normalizes to
+ *     "zurich" and is the same in English — no entry.)
+ *   - Russian (Latin transliteration): Moskva→Moscow,
+ *     Sankt Peterburg→Saint Petersburg.
+ *   - Indian renamings (BOTH directions → single canonical, since the GPP data
+ *     may use either): Bengaluru/Bangalore → "bangalore"; Mumbai/Bombay →
+ *     "mumbai"; Kolkata/Calcutta → "kolkata"; Chennai/Madras → "chennai".
+ *     Canonical chosen as the form most likely present in current GPP city
+ *     data (modern official name, except Bangalore where the English-common
+ *     form is retained).
+ */
+export const CITY_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  // German
+  munchen: 'munich',
+  koln: 'cologne',
+  nurnberg: 'nuremberg',
+  // Iberian
+  lisboa: 'lisbon',
+  sevilla: 'seville',
+  // Italian
+  napoli: 'naples',
+  roma: 'rome',
+  milano: 'milan',
+  torino: 'turin',
+  venezia: 'venice',
+  firenze: 'florence',
+  genova: 'genoa',
+  // Central/Eastern Europe
+  praha: 'prague',
+  warszawa: 'warsaw',
+  wien: 'vienna',
+  // Low Countries
+  bruxelles: 'brussels',
+  antwerpen: 'antwerp',
+  gent: 'ghent',
+  'den haag': 'the hague',
+  // Swiss / Nordic
+  geneve: 'geneva',
+  goteborg: 'gothenburg',
+  // Russian (Latin transliteration)
+  moskva: 'moscow',
+  'sankt peterburg': 'saint petersburg',
+  // Indian renamings — BOTH directions collapse to one canonical.
+  bengaluru: 'bangalore',
+  bombay: 'mumbai',
+  calcutta: 'kolkata',
+  madras: 'chennai',
+});
+
+/**
+ * provola-58509: normalize an input, then map it through `CITY_ALIASES` to its
+ * canonical city form. This is the function the moltobene matcher should use on
+ * BOTH sides of an equality comparison (the approved-city index keys AND the
+ * captured-title/cityName lookups) so local↔English exonyms resolve to one
+ * canonical string.
+ *
+ * Returns '' for empty/unrecognizable input (same as `normalizeCityName`) —
+ * callers MUST treat '' as a non-match.
+ */
+export function canonicalCityName(input: string | null | undefined): string {
+  const normalized = normalizeCityName(input);
+  return CITY_ALIASES[normalized] ?? normalized;
+}
+
+/**
  * tonda-58293 FIX #1: build a map of GPP cityKey → region (GPP slug).
  *
  * `city_telegram_groups.region`, `parties.region`, and `underbosses.regions`

--- a/backend/src/services/moltobeneSync.ts
+++ b/backend/src/services/moltobeneSync.ts
@@ -30,7 +30,7 @@ import { prisma } from '../config/database.js';
 import {
   getGppRegionByCityKey,
   cityKeyFromPartyName,
-  normalizeCityName,
+  canonicalCityName,
 } from '../helpers/underbossScope.js';
 
 interface MoltobeneCity {
@@ -96,7 +96,7 @@ function canonicalCityKey(name: string | null | undefined): string {
  */
 export interface MissingApprovedCity {
   cityKey: string;
-  /** normalizeCityName(cityKey) — the comparable core used for matching. */
+  /** canonicalCityName(cityKey) — the comparable core used for matching. */
   normalized: string;
 }
 
@@ -155,7 +155,10 @@ export async function buildMissingApprovedCityIndex(): Promise<{
   const coreToKeys = new Map<string, Set<string>>();
   for (const cityKey of approvedKeys) {
     if (resolved.has(cityKey)) continue;
-    const normalized = normalizeCityName(cityKey);
+    // provola-58509: canonicalize through the exonym alias map so a captured
+    // group's LOCAL name ("Göteborg") resolves to the same core as the approved
+    // ENGLISH city ("Gothenburg").
+    const normalized = canonicalCityName(cityKey);
     missing.push({ cityKey, normalized });
     if (!normalized) continue; // empty core is never indexable.
     const set = coreToKeys.get(normalized) ?? new Set<string>();
@@ -248,7 +251,9 @@ export async function syncCityGroupsFromMoltobene(): Promise<MoltobeneSyncResult
     //   - that core hasn't already been claimed this run.
     // This NEVER clobbers — the downstream chat_id/cityKey collision guards
     // still apply.
-    const normalizedIncoming = normalizeCityName(cityName);
+    // provola-58509: canonicalize through the exonym alias map (same as the
+    // index keys) so LOCAL incoming names match ENGLISH approved cities.
+    const normalizedIncoming = canonicalCityName(cityName);
     if (normalizedIncoming) {
       const target = missingByNormalized.get(normalizedIncoming);
       if (
@@ -412,7 +417,10 @@ export async function refreshCityGroupFromMoltobene(
   // Find the city whose normalized name matches the requested key. First try
   // the exact raw key (preserves existing behavior), then fall back to exact
   // normalized-core equality so a messy cityKey can still recover its group.
-  const wantNorm = normalizeCityName(key);
+  // provola-58509: canonicalize through the exonym alias map on both sides so a
+  // LOCAL cityKey ("goteborg") matches an ENGLISH /city/groups name
+  // ("Gothenburg") and vice-versa.
+  const wantNorm = canonicalCityName(key);
   let match = cities.find((c) => {
     const name = typeof c.cityName === 'string' ? c.cityName : '';
     return name.toLowerCase().trim() === key;
@@ -420,7 +428,7 @@ export async function refreshCityGroupFromMoltobene(
   if (!match && wantNorm) {
     const normMatches = cities.filter((c) => {
       const name = typeof c.cityName === 'string' ? c.cityName : '';
-      return normalizeCityName(name) === wantNorm;
+      return canonicalCityName(name) === wantNorm;
     });
     // Conservative: only accept a UNIQUE normalized match.
     if (normMatches.length === 1) match = normMatches[0];
@@ -432,7 +440,7 @@ export async function refreshCityGroupFromMoltobene(
     if (captures && wantNorm) {
       const capMatches = captures.filter(
         (g) =>
-          normalizeCityName(typeof g.title === 'string' ? g.title : '') ===
+          canonicalCityName(typeof g.title === 'string' ? g.title : '') ===
           wantNorm,
       );
       if (capMatches.length === 1) {
@@ -649,7 +657,9 @@ export async function syncFromCapturedGroups(): Promise<CapturedGroupsSyncResult
     const chatId = parseGroupId(g.chatId);
     if (chatId === null) continue;
     const title = typeof g.title === 'string' ? g.title : '';
-    const normalized = normalizeCityName(title);
+    // provola-58509: canonicalize captured titles through the exonym alias map
+    // so LOCAL group names match the canonical core of ENGLISH approved cities.
+    const normalized = canonicalCityName(title);
     if (!normalized) continue;
     captures.push({
       chatId,


### PR DESCRIPTION
## What

Adds a curated city **exonym alias map** so local-vs-English city names resolve to one canonical form during moltobene Telegram-group matching. The bot's captured-group titles use LOCAL names (`Göteborg`, `München`) but approved GPP cities are stored with ENGLISH names (`Gothenburg`, `Munich`); after `normalizeCityName` de-accents, `goteborg ≠ gothenburg` so the exact-equality matcher missed. This collapses each well-established 1:1 pair to one canonical normalized string.

## `CITY_ALIASES` (in `backend/src/helpers/underbossScope.ts`)

Both keys and values are in the normalized form `normalizeCityName` produces (lowercased, de-accented):

| local → canonical | local → canonical |
|---|---|
| munchen → munich | bruxelles → brussels |
| koln → cologne | antwerpen → antwerp |
| nurnberg → nuremberg | gent → ghent |
| lisboa → lisbon | den haag → the hague |
| sevilla → seville | geneve → geneva |
| napoli → naples | goteborg → gothenburg |
| roma → rome | moskva → moscow |
| milano → milan | sankt peterburg → saint petersburg |
| torino → turin | bengaluru → bangalore |
| venezia → venice | bombay → mumbai |
| firenze → florence | calcutta → kolkata |
| genova → genoa | madras → chennai |
| praha → prague | warszawa → warsaw |
| wien → vienna | |

Indian renamings collapse BOTH directions to a single canonical (canonical = bangalore / mumbai / kolkata / chennai). **Deliberately left as self (no alias):** porto, madrid, barcelona, zurich, krakow — same in both languages.

## `canonicalCityName(input)`

```ts
export function canonicalCityName(input) {
  const normalized = normalizeCityName(input);
  return CITY_ALIASES[normalized] ?? normalized;
}
```
Normalize, then map through the alias map to canonical. Returns '' for unrecognizable input (callers treat '' as a non-match).

## Where it's wired (`backend/src/services/moltobeneSync.ts`)

`normalizeCityName` → `canonicalCityName` on BOTH sides of every match:
- `buildMissingApprovedCityIndex` — the approved-city `normalizedCore → cityKey` index keys.
- `syncCityGroupsFromMoltobene` — the normalized fallback lookup (incoming `cityName`).
- `syncFromCapturedGroups` — captured-group `title` normalization.
- `refreshCityGroupFromMoltobene` — `wantNorm` + both /city/groups and /captured-groups title matches.

## Conservative-match note

No matching logic was loosened: still **exact equality** on the canonical form, ambiguity exclusion (a canonical shared by >1 missing approved city → skip + report), fill-if-empty, per-run consumed set. Only true same-city aliases of long standing were added; near-homonyms of different cities are excluded. Verified by node check: all 27 pairs canonicalize equal; non-collisions (Munich/Naples, Porto/Lisbon, Zürich/Geneva, Genoa/Geneva, Madrid/Milan) stay distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)