### PR TITLE
bottarga-58513: require a receipt to approve/pay a payout (overridable)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -43,6 +43,7 @@ import { isMercuryBlocked } from '../lib/mercuryBlockedCountries.js';
 import { notifyHostOfPaymentExecution } from '../services/payoutTelegramNotify.js';
 import { emailHostOfPaymentExecution } from '../services/payoutEmailNotify.js';
 import { notifyPaymentsTeam } from '../services/paymentsTeamNotify.js';
+import { payoutHasReceipt } from '../services/payout-receipts.js';
 import {
   requireAdminOrRegionalUnderboss,
   parseRegionsQuery,
@@ -3450,6 +3451,12 @@ router.post(
       // separate /execute call that carries its own ack).
       const allowOverPerAddressCap = !!(req.body && req.body.allowOverPerAddressCap);
 
+      // bottarga-58513: admin-class can acknowledge "pay without a receipt" via
+      // `allowMissingReceipts` (mirrors the over-cap override). The receipt gate
+      // is enforced both here (so a payout can't be approved undocumented) and
+      // inside executePayout (the money chokepoint).
+      const allowMissingReceipts = !!(req.body && req.body.allowMissingReceipts);
+
       // bocconcini-49102: re-run the per-submission + per-party cap checks at
       // approve time so rows created/edited BEFORE the cap rules landed (or
       // rows whose party's cap was tightened after creation) can't be pushed
@@ -3467,6 +3474,21 @@ router.post(
           Number(existing.finalAmountUsd),
           existing.id,
         );
+      }
+
+      // bottarga-58513: block approving a payout with no receipt unless the
+      // admin ticked the "pay without a receipt" ack. Runs before the status
+      // flip so an undocumented row never reaches `approved` (and from there to
+      // `paid`). The same gate runs again inside executePayout.
+      if (!allowMissingReceipts) {
+        const hasReceipt = await payoutHasReceipt(prisma, existing);
+        if (!hasReceipt) {
+          throw new AppError(
+            'This payout has no receipt uploaded. Upload a receipt or acknowledge to pay without one.',
+            400,
+            'MISSING_RECEIPT',
+          );
+        }
       }
 
       const { note, autoExecute } = req.body || {};
@@ -3544,6 +3566,9 @@ router.post(
               // inline USDC send can bypass the per-address hard cap when the
               // admin acked the by-city Send modal's per-address warning.
               allowOverPerAddressCap,
+              // bottarga-58513: forward the no-receipt ack so approve+autoExecute
+              // with the checkbox ticked doesn't re-block at the execute gate.
+              allowMissingReceipts,
             });
             autoExecuted = true;
           } catch (err: any) {
@@ -4486,8 +4511,22 @@ async function executePayout(params: {
    * checkbox has been ticked. Audited via the mark_paid note suffix.
    */
   allowOverPartyCap?: boolean;
+  /**
+   * bottarga-58513: when true, skip the receipt gate so an admin can pay a
+   * payout that has no receipt uploaded. The admin UI sets this only when the
+   * "Pay without a receipt" acknowledgement checkbox has been ticked. Audited
+   * via the mark_paid note suffix (mirrors the `allowOverPartyCap` pattern).
+   */
+  allowMissingReceipts?: boolean;
 }) {
-  const { payoutId, actor, body, allowOverPerAddressCap, allowOverPartyCap } = params;
+  const {
+    payoutId,
+    actor,
+    body,
+    allowOverPerAddressCap,
+    allowOverPartyCap,
+    allowMissingReceipts,
+  } = params;
 
   const existing = await prisma.payout.findUnique({
     where: { id: payoutId },
@@ -4546,6 +4585,26 @@ async function executePayout(params: {
       'MISSING_PAYOUT_METHOD',
     );
   }
+
+  // bottarga-58513: hard money stop — a payout must have a receipt before it
+  // can be paid. A receipt is either linked to the payout directly or to the
+  // same party by the same host (legacy/admin-added receipts stamp party_id,
+  // not payout_id). Admin-class can override via the acknowledgement checkbox
+  // (`allowMissingReceipts`), audited via the mark_paid note suffix below.
+  const hasReceipt = await payoutHasReceipt(prisma, existing);
+  const noReceiptOverride = !hasReceipt && !!allowMissingReceipts;
+  if (!hasReceipt && !allowMissingReceipts) {
+    throw new AppError(
+      'This payout has no receipt uploaded. Upload a receipt or acknowledge to pay without one.',
+      400,
+      'MISSING_RECEIPT',
+    );
+  }
+  // Audit suffix appended to every payout-method's mark_paid note when the
+  // receipt gate was overridden (mirrors salame-92103's `[override: party cap]`).
+  const noReceiptNote = noReceiptOverride
+    ? ` [paid without receipt — ack by ${actor.email}]`
+    : '';
 
   if (existing.payoutMethod === 'usdc_base') {
     if (!existing.payoutWalletAddress) {
@@ -4616,7 +4675,8 @@ async function executePayout(params: {
               (result.resolvedFromEns
                 ? ` [resolved ENS ${result.resolvedFromEns.input} -> ${result.resolvedFromEns.address}]`
                 : '') +
-              (allowOverPartyCap ? ' [override: party cap]' : ''),
+              (allowOverPartyCap ? ' [override: party cap]' : '') +
+              noReceiptNote,
           },
         });
         return row;
@@ -4790,7 +4850,8 @@ async function executePayout(params: {
           // salame-92103: append override marker when per-party cap was bypassed.
           note: `Wire executed out-of-band, reference: ${wireRef}` +
             (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : '') +
-            (allowOverPartyCap ? ' [override: party cap]' : ''),
+            (allowOverPartyCap ? ' [override: party cap]' : '') +
+            noReceiptNote,
         },
       });
       return row;
@@ -4845,7 +4906,8 @@ async function executePayout(params: {
           note: `Mercury card issued via dashboard, last4=${last4Raw}` +
             (cardId ? `, id=${cardId}` : '') +
             (typeof body?.note === 'string' && body.note ? ` — ${body.note}` : '') +
-            (allowOverPartyCap ? ' [override: party cap]' : ''),
+            (allowOverPartyCap ? ' [override: party cap]' : '') +
+            noReceiptNote,
         },
       });
       return row;
@@ -4993,6 +5055,8 @@ router.post(
           payoutWalletAddress: true,
           finalAmountUsd: true,
           hostUserId: true,
+          // bottarga-58513: needed for the per-row receipt gate below.
+          partyId: true,
         },
       });
 
@@ -5066,7 +5130,18 @@ router.post(
 
       // SEQUENTIAL execution — nonce safety. Do NOT switch to Promise.all.
       const results: BulkSendResult[] = [];
+      // bottarga-58513: bulk has NO per-row override. Skip any row with no
+      // receipt and report the ids back so the admin can send them
+      // individually (where the no-receipt ack is available). Don't silently
+      // drop them.
+      const skippedNoReceipt: string[] = [];
       for (const row of eligible) {
+        // bottarga-58513: receipt gate, no override in bulk.
+        const hasReceipt = await payoutHasReceipt(prisma, row);
+        if (!hasReceipt) {
+          skippedNoReceipt.push(row.id);
+          continue;
+        }
         const priorStatus = row.status; // 'approved' or 'failed' (passata-49102)
         try {
           const updated = await executePayout({
@@ -5127,7 +5202,9 @@ router.post(
         }
       }
 
-      res.json({ results });
+      // bottarga-58513: include the skipped (no-receipt) ids so the UI can tell
+      // the admin which rows were not sent and need a receipt / individual send.
+      res.json({ results, skippedNoReceipt });
     } catch (error) {
       next(error);
     }

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -1458,6 +1458,26 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
     // finalUsd as both originalAmount and extractedAmountUsd so the row reads
     // cleanly in the admin UI.)
     const noReceiptsFallback = receiptPhotos.length === 0;
+
+    // bottarga-58513: close the zero-receipt creation path. A host can no
+    // longer submit a payout with no receipt — those rows were the source of
+    // the undocumented money-path. PRESERVE the bismarck-92103 admin-on-behalf
+    // override: an admin creating a prepayment for another host
+    // (`recipientHostUserId`) may still submit with zero receipts. The
+    // `skipPartyEditCheck` admin path (shipping) is also exempt — shipping
+    // receipts are handled by their own flow.
+    if (noReceiptsFallback) {
+      const adminOnBehalf =
+        recipientOverrideRequested && (await isAnyAdmin(req.userEmail));
+      if (!adminOnBehalf && !isShippingPurpose) {
+        throw new AppError(
+          'Upload at least one receipt before submitting a payout.',
+          400,
+          'NO_RECEIPTS',
+        );
+      }
+    }
+
     const effectiveExtractedUsd = noReceiptsFallback ? finalUsd : extractedUsdSum;
     const effectiveOriginalAmount = noReceiptsFallback
       ? finalUsd

--- a/backend/src/services/payout-receipts.ts
+++ b/backend/src/services/payout-receipts.ts
@@ -1,0 +1,19 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+// bottarga-58513: a payout is documented if a receipt payout_document is linked directly (payout_id)
+// or to the same party by the same host (legacy/admin-added receipts stamp party_id, not payout_id).
+export async function payoutHasReceipt(
+  db: PrismaClient | Prisma.TransactionClient,
+  p: { id: string; partyId: string | null; hostUserId: string | null },
+): Promise<boolean> {
+  const hit = await db.payoutDocument.findFirst({
+    where: {
+      kind: 'receipt',
+      OR: [
+        { payoutId: p.id },
+        ...(p.partyId && p.hostUserId ? [{ partyId: p.partyId, uploadedByUserId: p.hostUserId }] : []),
+      ],
+    },
+    select: { id: true },
+  });
+  return !!hit;
+}

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -63,9 +63,14 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
   // Eligibility filter — keep in sync with backend bulk-execute filter
   // (USDC + approved-or-failed + valid 0x wallet). passata-49102 added
   // failed-status retry. Anything not matching is shown as "skipped".
-  const { eligible, skippedCount, totalUsd, distinctRecipients } = useMemo(() => {
+  const { eligible, skippedCount, noReceiptCount, totalUsd, distinctRecipients } = useMemo(() => {
     const e: AdminPayout[] = [];
     let skipped = 0;
+    // bottarga-58513: rows with no receipt are excluded from bulk send — bulk
+    // has NO per-row no-receipt override (the backend skips them too). The
+    // admin must send those individually where the "pay without a receipt"
+    // ack is available. Detected from the row's own `documents` (kind:'receipt').
+    let noReceipt = 0;
     const recipients = new Set<string>();
     for (const p of selectedPayouts) {
       if (
@@ -74,6 +79,11 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
         p.payoutWalletAddress &&
         WALLET_RE.test(p.payoutWalletAddress)
       ) {
+        const rowHasReceipt = (p.documents || []).some((d) => d.kind === 'receipt');
+        if (!rowHasReceipt) {
+          noReceipt += 1;
+          continue;
+        }
         e.push(p);
         recipients.add(p.payoutWalletAddress.toLowerCase());
       } else {
@@ -84,6 +94,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
     return {
       eligible: e,
       skippedCount: skipped,
+      noReceiptCount: noReceipt,
       totalUsd: sum,
       distinctRecipients: recipients.size,
     };
@@ -347,6 +358,17 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                   <span>
                     {skippedCount} selected payout{skippedCount === 1 ? '' : 's'} skipped (non-USDC,
                     wrong status, or invalid wallet).
+                  </span>
+                </div>
+              )}
+              {/* bottarga-58513: receiptless rows are hidden from bulk send —
+                  no bulk override. Direct the admin to send them individually
+                  where the "pay without a receipt" ack is available. */}
+              {noReceiptCount > 0 && (
+                <div className="flex items-start gap-1.5 mt-2 text-xs text-amber-500/90">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <span>
+                    {noReceiptCount} hidden — no receipt; send individually.
                   </span>
                 </div>
               )}

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -81,7 +81,7 @@ interface PayoutReviewModalProps {
    */
   onApprove: (
     note?: string,
-    opts?: { allowOverPartyCap?: boolean },
+    opts?: { allowOverPartyCap?: boolean; allowMissingReceipts?: boolean },
   ) => Promise<void> | void;
   /**
    * gouda-92103: optional second arg lets the admin opt into a silent
@@ -178,6 +178,12 @@ interface PayoutReviewModalProps {
      * `[override: party cap]` to the audit row's note.
      */
     allowOverPartyCap?: boolean;
+    /**
+     * bottarga-58513: forwarded when the admin has ticked the "pay without a
+     * receipt" override checkbox. Server bypasses the receipt gate and appends
+     * `[paid without receipt — ack by <email>]` to the audit row's note.
+     */
+    allowMissingReceipts?: boolean;
   }) => Promise<void> | void;
   /**
    * Optional fetcher for the USDC daily-cap-remaining hint. Only called when
@@ -456,6 +462,14 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // never share a render path, but the ack lifecycles are independent.
   const [approveOverridePartyCap, setApproveOverridePartyCap] = useState(false);
 
+  // bottarga-58513: no-receipt ack. Distinct acks for the Execute (Send) path
+  // and the Approve path — same rationale as the per-party cap acks above
+  // (the two transitions never share a render path but have independent
+  // lifecycles). Surfaces an amber warning + ack when this payout has no
+  // receipt; the Send / Approve buttons stay disabled until ticked.
+  const [overrideNoReceipt, setOverrideNoReceipt] = useState(false);
+  const [approveOverrideNoReceipt, setApproveOverrideNoReceipt] = useState(false);
+
   // parmigiana-92104: SWC Hub ack. Reimbursement for SWC Hub parties is
   // processed through SWC, not rsv.pizza — admin reimbursement actions
   // (Approve, Execute, Mark paid manual) stay disabled until the admin ticks
@@ -644,6 +658,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           };
         }),
     [payout.documents, receiptOverrides],
+  );
+  // bottarga-58513: a payout is "documented" if it has any receipt-kind
+  // document. Drives the no-receipt amber warning + ack on Approve/Send.
+  const hasReceipt = useMemo(
+    () => payout.documents.some((d) => d.kind === 'receipt'),
+    [payout.documents],
   );
   const pizzas = useMemo(
     () => payout.documents.filter((d) => d.kind === 'pizza'),
@@ -3345,6 +3365,37 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   </div>
                 )}
 
+                {/* bottarga-58513: no-receipt warning for the Execute (Send)
+                    path. Surfaces when the payout has no receipt document; the
+                    admin must explicitly take responsibility before the Send
+                    button enables. Mirrors the per-party cap amber-panel + ack
+                    pattern above (solid dark amber shades read on the light
+                    emerald execute panel in both themes). */}
+                {!hasReceipt && (
+                  <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+                    <div className="flex items-start gap-2.5">
+                      <AlertTriangle className="text-amber-600 mt-0.5 flex-shrink-0" size={16} />
+                      <div className="flex-1 text-sm">
+                        <div className="font-medium text-amber-900 mb-1">
+                          No receipt uploaded for this payout
+                        </div>
+                        <div className="text-amber-800 text-xs">
+                          This payout has no receipt. Paying without documentation
+                          should be rare — prefer asking the host to upload one.
+                        </div>
+                        <div className="mt-3">
+                          <Checkbox
+                            checked={overrideNoReceipt}
+                            onChange={() => setOverrideNoReceipt((v) => !v)}
+                            label="Pay without a receipt — I take responsibility"
+                            labelClassName="text-sm text-amber-900"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
                 {payout.payoutMethod === 'usdc_base' && (
                   <div className="space-y-2">
                     <p className="text-emerald-900">
@@ -3504,6 +3555,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       if (partyWouldExceedCap && !overridePartyCap) {
                         return;
                       }
+                      // bottarga-58513: block submit if there's no receipt and
+                      // the admin hasn't ticked the "pay without a receipt" ack.
+                      if (!hasReceipt && !overrideNoReceipt) {
+                        return;
+                      }
                       await onExecute({
                         wireReference: payout.payoutMethod === 'wire' ? execWireRef.trim() : undefined,
                         mercuryCardLast4:
@@ -3523,6 +3579,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         // the server bypasses its own per-party cap check + adds
                         // `[override: party cap]` to the audit row's note.
                         allowOverPartyCap: partyWouldExceedCap ? overridePartyCap : undefined,
+                        // bottarga-58513: forward the no-receipt ack so the
+                        // server bypasses the receipt gate + audits the override.
+                        allowMissingReceipts: !hasReceipt ? overrideNoReceipt : undefined,
                       });
                       setShowExecuteForm(false);
                     }}
@@ -3538,6 +3597,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         !overrideCap) ||
                       // salame-92103: disabled until ack when the per-party cap would exceed.
                       (partyWouldExceedCap && !overridePartyCap) ||
+                      // bottarga-58513: disabled until ack when there's no receipt.
+                      (!hasReceipt && !overrideNoReceipt) ||
                       // parmigiana-92104: disabled until ack when the party is an SWC Hub
                       // party (reimbursement should be processed via SWC, not rsv.pizza).
                       swcBlocked
@@ -3681,6 +3742,34 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               </div>
             </div>
           )}
+          {/* bottarga-58513: no-receipt warning for the Approve transition.
+              The backend now blocks approving an undocumented payout unless the
+              admin acks. Mirrors the per-party cap amber-panel + ack pattern
+              above. */}
+          {isPending && !hasReceipt && (
+            <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+              <div className="flex items-start gap-2.5">
+                <AlertTriangle className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0" size={16} />
+                <div className="flex-1 text-sm">
+                  <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
+                    No receipt uploaded for this payout
+                  </div>
+                  <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
+                    This payout has no receipt. Approving without documentation
+                    should be rare — prefer asking the host to upload one.
+                  </div>
+                  <div className="mt-3">
+                    <Checkbox
+                      checked={approveOverrideNoReceipt}
+                      onChange={() => setApproveOverrideNoReceipt((v) => !v)}
+                      label="Pay without a receipt — I take responsibility"
+                      labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
           <div className="flex items-center gap-2 flex-wrap">
           {isPending && (
             <>
@@ -3690,12 +3779,25 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   // nduja-92106: block submit if the per-party cap would
                   // exceed and the admin hasn't ticked the override.
                   if (partyWouldExceedCap && !approveOverridePartyCap) return;
-                  // nduja-92106: forward the admin's acknowledgement so the
-                  // server skips its bocconcini-49102 recheck + records
-                  // `[override: party cap]` on the audit row.
+                  // bottarga-58513: block submit if there's no receipt and the
+                  // admin hasn't ticked the no-receipt ack.
+                  if (!hasReceipt && !approveOverrideNoReceipt) return;
+                  // nduja-92106 / bottarga-58513: forward the admin's
+                  // acknowledgements so the server skips its rechecks + records
+                  // the override markers on the audit row. Both flags can be
+                  // sent together when both warnings apply.
                   onApprove(
                     undefined,
-                    partyWouldExceedCap ? { allowOverPartyCap: approveOverridePartyCap } : undefined,
+                    partyWouldExceedCap || !hasReceipt
+                      ? {
+                          ...(partyWouldExceedCap
+                            ? { allowOverPartyCap: approveOverridePartyCap }
+                            : {}),
+                          ...(!hasReceipt
+                            ? { allowMissingReceipts: approveOverrideNoReceipt }
+                            : {}),
+                        }
+                      : undefined,
                   );
                 }}
                 disabled={
@@ -3703,7 +3805,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                   selfPayoutBlocked ||
                   swcBlocked ||
                   // nduja-92106: disabled until ack when the per-party cap would exceed.
-                  (partyWouldExceedCap && !approveOverridePartyCap)
+                  (partyWouldExceedCap && !approveOverridePartyCap) ||
+                  // bottarga-58513: disabled until ack when there's no receipt.
+                  (!hasReceipt && !approveOverrideNoReceipt)
                 }
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
               >

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -265,6 +265,17 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   const [fakeAck, setFakeAck] = useState(false);
   const isFlagged = fakeTier === 'medium' || fakeTier === 'high';
 
+  // bottarga-58513: no-receipt ack. This by-city Send flow creates a fresh
+  // payout with `receiptPhotos: []`, so when the city has no receipts on file
+  // (receiptsTotalUsd <= 0) the new payout is undocumented and the backend's
+  // receipt gate (at approve + execute) would block it. Surface an amber
+  // warning + ack so the admin explicitly takes responsibility; forward
+  // `allowMissingReceipts` when ticked. When the city already has receipts
+  // (receiptsTotalUsd > 0) the gate keys on party+host and passes, so no ack
+  // is needed.
+  const [noReceiptAck, setNoReceiptAck] = useState(false);
+  const cityHasReceipts = receiptsTotalUsd > 0;
+
   // Close on Escape.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -393,6 +404,9 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
     (!swcHub || swcAck) &&
     // bufalina-60733: flagged (medium/high fake-detection) requires explicit ack.
     (!isFlagged || fakeAck) &&
+    // bottarga-58513: when the city has no receipts on file, the no-receipt
+    // ack is required (the created payout would be undocumented).
+    (cityHasReceipts || noReceiptAck) &&
     !submitting &&
     !candidatesLoading;
 
@@ -454,6 +468,11 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
       const allowOverPerAddressCap = walletPaidTotal?.wouldExceed
         ? overridePerAddressCap
         : undefined;
+      // bottarga-58513: forward the no-receipt ack to BOTH approve and execute
+      // so the new (undocumented) payout passes the receipt gate. Only sent
+      // when the city has no receipts on file AND the admin acked.
+      const allowMissingReceipts =
+        !cityHasReceipts && noReceiptAck ? true : undefined;
       if (method === 'usdc_base') {
         // guanciale-49340: the approve handler runs executePayout server-side
         // for USDC and keeps the HTTP 200 contract even when the on-chain send
@@ -468,6 +487,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
           note: note.trim() || undefined,
           allowOverPartyCap,
           allowOverPerAddressCap,
+          allowMissingReceipts,
         });
         if (res.autoExecuted !== true) {
           throw new Error(
@@ -479,6 +499,7 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
         await approveAdminPayout(payoutId, {
           note: note.trim() || undefined,
           allowOverPartyCap,
+          allowMissingReceipts,
         });
         await executeAdminPayout(payoutId, {
           wireReference:
@@ -497,6 +518,8 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
           // guanciale-49340: forward the per-address ($676) cap ack so the
           // wire/mercury execute path bypasses the per-address hard cap too.
           allowOverPerAddressCap,
+          // bottarga-58513: forward the no-receipt ack to the execute path too.
+          allowMissingReceipts,
         });
       }
 
@@ -854,6 +877,39 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
                       checked={fakeAck}
                       onChange={() => setFakeAck((v) => !v)}
                       label="I've reviewed this event's fake-detection flags"
+                      labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* bottarga-58513: no-receipt warning + ack. This by-city Send
+              creates a fresh payout with no receipt; when the city has no
+              receipts on file the row is undocumented and the backend gate
+              would block it. Mirrors the fake-detection ack card above. */}
+          {!cityHasReceipts && (
+            <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
+              <div className="flex items-start gap-2.5">
+                <AlertTriangle
+                  className="text-amber-300 [.gpp-theme_&]:text-amber-700 mt-0.5 flex-shrink-0"
+                  size={16}
+                />
+                <div className="flex-1 text-sm">
+                  <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
+                    No receipt uploaded for {cleanName}
+                  </div>
+                  <div className="text-theme-text-secondary [.gpp-theme_&]:text-amber-900 text-xs">
+                    This city has no receipts on file. Paying without
+                    documentation should be rare — prefer asking the host to
+                    upload one first.
+                  </div>
+                  <div className="mt-3">
+                    <Checkbox
+                      checked={noReceiptAck}
+                      onChange={() => setNoReceiptAck((v) => !v)}
+                      label="Pay without a receipt — I take responsibility"
                       labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                     />
                   </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5251,6 +5251,14 @@ export async function approveAdminPayout(
      * Checkbox has been ticked.
      */
     allowOverPerAddressCap?: boolean;
+    /**
+     * bottarga-58513: admin-class only. When true, the backend skips the
+     * receipt gate (added at approve + execute) so an undocumented payout can
+     * be approved/paid. The PayoutReviewModal Approve button sets this when the
+     * amber "no receipt" warning's ack Checkbox has been ticked; passes through
+     * to the autoExecute branch as well.
+     */
+    allowMissingReceipts?: boolean;
   },
 ): Promise<{
   payout: AdminPayout;
@@ -5265,6 +5273,7 @@ export async function approveAdminPayout(
       autoExecute: opts?.autoExecute,
       allowOverPartyCap: opts?.allowOverPartyCap,
       allowOverPerAddressCap: opts?.allowOverPerAddressCap,
+      allowMissingReceipts: opts?.allowMissingReceipts,
     },
   });
 }
@@ -5659,6 +5668,12 @@ export async function executeAdminPayout(
     note?: string;
     allowOverPerAddressCap?: boolean;
     allowOverPartyCap?: boolean;
+    /**
+     * bottarga-58513: forwarded to bypass the receipt gate when the admin has
+     * acknowledged the "no receipt" warning. The server appends
+     * `[paid without receipt — ack by <email>]` to the audit row's note.
+     */
+    allowMissingReceipts?: boolean;
   } = {},
 ): Promise<AdminPayout> {
   const res = await apiRequest<{ payout: AdminPayout }>(`/api/admin/payouts/${id}/execute`, {

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1650,6 +1650,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                   // backend skips its bocconcini-49102 recheck + records the
                   // override marker on the audit row.
                   ...(opts?.allowOverPartyCap ? { allowOverPartyCap: true } : {}),
+                  // bottarga-58513: forward the no-receipt override ack so the
+                  // backend skips the receipt gate + audits the override.
+                  ...(opts?.allowMissingReceipts ? { allowMissingReceipts: true } : {}),
                 });
                 const fresh = await getAdminPayout(detail.id, regions ? { regions } : undefined);
                 setDetail(fresh);


### PR DESCRIPTION
## Problem

A payout could be **approved and paid with ZERO receipts**. There was no receipt check on either `POST /:id/approve` or the `executePayout` money chokepoint, and the legacy `POST /:partyId/payouts` creation path had a `noReceiptsFallback` that happily accepted `receiptPhotos: []`. Result: ~10 live undocumented paid rows (incl. goshen).

## Fix — overridable + audited receipt gate at the money chokepoint

**New helper** `backend/src/services/payout-receipts.ts` → `payoutHasReceipt(db, {id, partyId, hostUserId})`: a payout is documented if a `receipt`-kind `payout_document` is linked directly (`payout_id`) OR to the same party by the same host (legacy/admin-added receipts stamp `party_id`, not `payout_id`).

**Backend (`admin-payout.routes.ts`)**
- `executePayout` helper: new `allowMissingReceipts?` param; gate runs after the method/wallet checks, before the `usdc_base` branch. Throws `MISSING_RECEIPT` (400) when undocumented and not overridden. When overridden, appends ` [paid without receipt — ack by <email>]` to the mark_paid audit note across all three methods (usdc/wire/mercury) — mirrors salame-92103's `[override: party cap]` suffix.
- `POST /:id/approve`: parses `allowMissingReceipts`, gates before the status flip, forwards the flag into the `autoExecute` execute call.
- `POST /bulk-execute`: no per-row override — receiptless rows are skipped and returned in a new `skippedNoReceipt: string[]` on the response (not silently dropped).

**Backend (`payout.routes.ts`)**
- `POST /:partyId/payouts`: zero-receipt submissions now throw `NO_RECEIPTS` (400). PRESERVES the bismarck-92103 admin-on-behalf path (`recipientHostUserId` + admin caller) and the shipping-receipt flow.

**Frontend** (mirrors the over-cap ack exactly)
- `api.ts`: `allowMissingReceipts?` on the approve + execute option types.
- `PayoutReviewModal.tsx`: amber "No receipt uploaded" warning + "Pay without a receipt — I take responsibility" ack on both the Execute (Send) form and the Approve footer; disables the button until ticked; forwards the flag only when ticked. Stacks with the cap-override ack (both must be ticked when both apply).
- `SendPaymentModal.tsx`: by-city Send creates a fresh receiptless payout — shows the ack when the city has no receipts on file (`receiptsTotalUsd <= 0`) and forwards `allowMissingReceipts` to approve + execute.
- `BulkSendModal.tsx`: excludes receiptless rows from the bulk selection (detected from each row's existing `documents[]`, kind=='receipt' — no new data plumbing) with a "N hidden — no receipt; send individually" note. No bulk override.
- `PaymentsAdminPage.tsx`: forwards the ack from the modal's `onApprove` opts to the API.

## Deploy
**BACKEND change** — deploy the backend after merge (receipt gate lives server-side). The frontend ack just unlocks the existing override path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)