### PR TITLE
bombolone-58515: receipts filter (has/missing) on /payments by-city

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../utils/regions';
 // panuozzo-92114: canonical filter VALUE lists live in the React-free options
 // module so PayoutsFilterBar and the URL (de)serializer can't drift.
-import type { SortValue, StatusTabValue } from './paymentsFilterOptions';
+import type { SortValue, StatusTabValue, ReceiptsValue } from './paymentsFilterOptions';
 
 interface PayoutsFilterBarProps {
   filters: AdminPayoutFilters;
@@ -61,6 +61,13 @@ interface PayoutsFilterBarProps {
    * Defaults to false.
    */
   showTbdToggle?: boolean;
+  /**
+   * bombolone-58515: when true, render the receipt-presence filter dropdown
+   * (All / Has receipts / Missing receipts). By-city view only — the filter is
+   * client-side over `aggregates.totalReceiptCount`, which only exists on the
+   * by-city rows. Defaults to false.
+   */
+  showReceiptsFilter?: boolean;
   /**
    * pancetta-92103: when true, render the Regions multi-select dropdown
    * (admin /payments). Hidden on regional sub-portals (which are already
@@ -116,6 +123,16 @@ const PURPOSE_OPTIONS: Array<{ value: PayoutPurpose | 'all'; label: string }> = 
   { value: 'all', label: 'All purposes' },
   { value: 'event', label: 'Event' },
   { value: 'shipping', label: 'Shipping' },
+];
+
+// bombolone-58515: receipt-presence filter — by-city view only. Filters cities
+// client-side on `aggregates.totalReceiptCount`. Values validated against
+// RECEIPTS_VALUES in paymentsFilterOptions.ts (the URL serializer's source of
+// truth) — keep this list and that one in sync.
+const RECEIPTS_OPTIONS: Array<{ value: ReceiptsValue; label: string }> = [
+  { value: 'all', label: 'All receipts' },
+  { value: 'has', label: 'Has receipts' },
+  { value: 'missing', label: 'Missing receipts' },
 ];
 
 // arancino-92103: sort order for the payouts list. `created_desc` is the
@@ -184,6 +201,8 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.hideUsCities) n += 1;
   // tigella-58512: count Show TBD (no submission) when the admin turns it on.
   if (filters.showTbdUnsubmitted) n += 1;
+  // bombolone-58515: count the receipt-presence filter when it's not 'all'.
+  if (filters.receipts && filters.receipts !== 'all') n += 1;
   return n;
 }
 
@@ -210,6 +229,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   showHideScamsToggle,
   showHideUsToggle,
   showTbdToggle,
+  showReceiptsFilter,
   showRegionsFilter,
   showStatusTabs = true,
 }) => {
@@ -469,6 +489,24 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               ))}
             </select>
           </div>
+
+          {/* bombolone-58515: Receipts dropdown — filter the by-city view by
+              receipt presence (All / Has receipts / Missing receipts). Gated to
+              the by-city view, where `aggregates.totalReceiptCount` exists. */}
+          {showReceiptsFilter && (
+            <div>
+              <select
+                value={filters.receipts ?? 'all'}
+                onChange={(e) => update({ receipts: e.target.value as ReceiptsValue })}
+                className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+                aria-label="Filter by receipts"
+              >
+                {RECEIPTS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* arancino-92103: Sort dropdown — controls the row order of the
               payouts table. Default is `created_desc` (newest submitted

--- a/frontend/src/components/payments-admin/paymentsFilterOptions.ts
+++ b/frontend/src/components/payments-admin/paymentsFilterOptions.ts
@@ -35,6 +35,12 @@ export const METHOD_VALUES: Array<PayoutMethod | 'all'> = [
 
 export const PURPOSE_VALUES: Array<PayoutPurpose | 'all'> = ['all', 'event', 'shipping'];
 
+// bombolone-58515: by-city receipt-presence filter values. Client-side over
+// aggregates.totalReceiptCount; labels live in PayoutsFilterBar at render time.
+export type ReceiptsValue = NonNullable<AdminPayoutFilters['receipts']>;
+
+export const RECEIPTS_VALUES: ReceiptsValue[] = ['all', 'has', 'missing'];
+
 export type SortValue = NonNullable<AdminPayoutFilters['sort']>;
 
 export const SORT_VALUES: SortValue[] = [

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -14,6 +14,7 @@ import {
   METHOD_VALUES as METHOD_OPTION_VALUES,
   PURPOSE_VALUES as PURPOSE_OPTION_VALUES,
   SORT_VALUES as SORT_OPTION_VALUES,
+  RECEIPTS_VALUES as RECEIPTS_OPTION_VALUES,
   type SortValue,
 } from './paymentsFilterOptions';
 
@@ -36,6 +37,8 @@ const DEFAULTS = {
   hideUsCities: true,
   // tigella-58512: default-FALSE — only emitted (as `tbd=1`) when turned ON.
   showTbdUnsubmitted: false,
+  // bombolone-58515: by-city receipt-presence filter — 'all' = no filter.
+  receipts: 'all' as NonNullable<AdminPayoutFilters['receipts']>,
 };
 const DEFAULT_VIEW: ViewMode = 'by-city';
 
@@ -45,6 +48,7 @@ const STATUS_VALUES = new Set<string>(STATUS_TAB_VALUES.map(String));
 const METHOD_VALUES = new Set<string>(METHOD_OPTION_VALUES.map(String));
 const PURPOSE_VALUES = new Set<string>(PURPOSE_OPTION_VALUES.map(String));
 const SORT_VALUES = new Set<string>(SORT_OPTION_VALUES.map(String));
+const RECEIPTS_VALUES = new Set<string>(RECEIPTS_OPTION_VALUES.map(String));
 
 /**
  * Serialize the active filters + view mode to a URLSearchParams. A key is
@@ -90,6 +94,10 @@ export function filtersToSearchParams(
 
   const sort = filters.sort ?? DEFAULTS.sort;
   if (sort !== DEFAULTS.sort) params.set('sort', String(sort));
+
+  // bombolone-58515: receipt-presence filter — only emit when not the default.
+  const receipts = filters.receipts ?? DEFAULTS.receipts;
+  if (receipts !== DEFAULTS.receipts) params.set('receipts', String(receipts));
 
   // Default-TRUE booleans: only emit when the user turned them OFF.
   if (filters.hideClosed === false) params.set('hideClosed', '0');
@@ -138,6 +146,8 @@ export function searchParamsToFilters(
     hideUsCities: DEFAULTS.hideUsCities,
     showTbdUnsubmitted: DEFAULTS.showTbdUnsubmitted,
     sort: DEFAULTS.sort,
+    // bombolone-58515: receipt-presence filter seeds to its default.
+    receipts: DEFAULTS.receipts,
     ...(regions ? { regions } : {}),
   };
 
@@ -198,6 +208,13 @@ export function searchParamsToFilters(
   const sortRaw = params.get('sort');
   if (sortRaw && SORT_VALUES.has(sortRaw)) {
     filters.sort = sortRaw as SortValue;
+  }
+
+  // bombolone-58515: receipt-presence filter — validate against RECEIPTS_VALUES
+  // so a hand-mangled URL falls back to the default ('all').
+  const receiptsRaw = params.get('receipts');
+  if (receiptsRaw && RECEIPTS_VALUES.has(receiptsRaw)) {
+    filters.receipts = receiptsRaw as AdminPayoutFilters['receipts'];
   }
 
   // Default-TRUE booleans: when the param is present, `0` => false, anything

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -124,6 +124,8 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   // tigella-58512: surface approved `tbd` events with zero submissions —
   // OFF by default so the default request is byte-identical to before.
   showTbdUnsubmitted: false,
+  // bombolone-58515: by-city receipt-presence filter — 'all' = no filter.
+  receipts: 'all',
   // arancino-92103: sort order default — newest submitted first. Matches the
   // prior implicit backend ordering, so non-sorting callers see no change.
   sort: 'created_desc',
@@ -671,6 +673,14 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         ? filtered.filter((row) => row.party.region !== 'usa')
         : filtered;
 
+    // bombolone-58515: filter by receipt presence (by-city only).
+    const receipts = filters.receipts ?? 'all';
+    if (receipts === 'has') {
+      rows = rows.filter((row) => row.aggregates.totalReceiptCount > 0);
+    } else if (receipts === 'missing') {
+      rows = rows.filter((row) => row.aggregates.totalReceiptCount === 0);
+    }
+
     // cornetto-58510: client-side tri-state tag/country filter (by-city view).
     // Tags: include = must have ALL; exclude = must have NONE. Country (single-
     // valued per party): include = OR (any selected); exclude = NONE.
@@ -754,7 +764,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
       return [...rows].sort((a, b) => (asc ? pick(a) - pick(b) : pick(b) - pick(a)));
     }
     return rows;
-  }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal, filters.tagIncludes, filters.tagExcludes, filters.countryIncludes, filters.countryExcludes]);
+  }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, filters.receipts, isRegionalPortal, filters.tagIncludes, filters.tagExcludes, filters.countryIncludes, filters.countryExcludes]);
 
   // salsiccia-49102: count of selected payouts eligible for bulk USDC send.
   // Mirrors the backend filter (usdc_base + approved/failed + valid 0x
@@ -1262,6 +1272,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           // synthetic rows come from the by-party endpoint, which is the only
           // place a zero-payout party can surface.
           showTbdToggle={viewMode === 'by-city'}
+          // bombolone-58515: Receipt-presence filter — by-city view only
+          // (client-side over aggregates.totalReceiptCount). Applies on
+          // regional portals too, like showHideClosedToggle.
+          showReceiptsFilter={viewMode === 'by-city'}
           // provatura-92107: Hide US cities — by-city view + admin dashboard
           // only (regional portals are already region-scoped).
           showHideUsToggle={viewMode === 'by-city' && !isRegionalPortal}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2261,6 +2261,13 @@ export interface AdminPayoutFilters {
    * prior behavior).
    */
   showTbdUnsubmitted?: boolean;
+  /**
+   * bombolone-58515: filter the by-city /payments view by receipt presence.
+   * 'all' = no filter, 'has' = cities with >=1 receipt document,
+   * 'missing' = cities with zero receipt documents. Client-side over
+   * aggregates.totalReceiptCount. By-city view only. Default 'all'.
+   */
+  receipts?: 'all' | 'has' | 'missing';
 }
 
 export interface AdminPayoutTotals {


### PR DESCRIPTION
## What
Adds a **Receipts** filter dropdown to the `/payments` **by-city** view: **All / Has receipts / Missing receipts**. Lets admins quickly isolate cities that still owe receipts (or that have submitted some).

## How
Frontend-only — the by-city row already carries `aggregates.totalReceiptCount` (backend-computed count of `payout_documents` with `kind='receipt'` per party), so this is a pure client-side predicate over `byPartyRows`:
- `has` -> `totalReceiptCount > 0`
- `missing` -> `totalReceiptCount === 0`

Wired through the same plumbing as the other by-city filters: `AdminPayoutFilters.receipts` (default `'all'`), `RECEIPTS_VALUES` source-of-truth in `paymentsFilterOptions.ts`, a dropdown in `PayoutsFilterBar` (new `showReceiptsFilter` prop, by-city only), applied in the `displayedByPartyRows` memo, counted in `countActiveFilters`, and serialized to/from the URL (`?receipts=has|missing`) so it persists across reload + saved views.

By-city view only — the per-payment / payments-ledger views have no party-level receipt rollup.

## Notes
- `totalReceiptCount` is the raw count (includes duplicate/ineligible docs) — correct for *presence*. Distinct from `computeReceiptsTotalUsd` (eligible $ sum used for the amount column).
- Composes with the default-on hide toggles.

## Verification
- `npx tsc --noEmit` green.
- Manual (by-city): All = unchanged; Has/Missing filter correctly; non-All bumps the Filters (N) count + writes `?receipts=`; reload restores; Reset clears; dropdown absent on By-payment/Payments views.

Plan: `plans/bombolone-58515-payments-receipts-filter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)