### PR TITLE
nduja-58514: show uploader + timestamp on /payments photos

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1961,6 +1961,7 @@ router.get(
             starred: true,
             tags: true,
             uploaderName: true,
+            uploaderEmail: true,
             createdAt: true,
           },
         });
@@ -1981,6 +1982,7 @@ router.get(
             starred: p.starred,
             tags: p.tags,
             uploaderName: p.uploaderName,
+            uploaderEmail: p.uploaderEmail,
             createdAt: p.createdAt.toISOString(),
           });
           eventPhotosByParty.set(p.partyId, list);
@@ -3146,6 +3148,7 @@ router.get(
           starred: true,
           tags: true,
           uploaderName: true,
+          uploaderEmail: true,
           createdAt: true,
         },
       });
@@ -3160,6 +3163,7 @@ router.get(
         starred: p.starred,
         tags: p.tags,
         uploaderName: p.uploaderName,
+        uploaderEmail: p.uploaderEmail,
         createdAt: p.createdAt.toISOString(),
       }));
 

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -42,6 +42,31 @@ function formatUploadedAt(iso: string): string {
   });
 }
 
+// nduja-58514: photo uploader attribution helpers, mirroring receipts. Guards
+// missing / invalid createdAt so we never render "Invalid Date" or
+// "by undefined". Works off either a PayoutDocument (uploadedByName/Email) or
+// an AdminPayoutEventPhoto (uploaderName/Email) — pass the resolved values.
+function safePhotoDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  });
+}
+function photoTooltipSuffix(who: string | null | undefined, iso: string | null | undefined): string {
+  const date = safePhotoDate(iso);
+  if (!date) return '';
+  const name = (who || '').trim();
+  return name ? ` — uploaded by ${name} · ${date}` : ` · ${date}`;
+}
+function photoCaption(who: string | null | undefined, iso: string | null | undefined): string {
+  const date = safePhotoDate(iso);
+  if (!date) return '';
+  const name = (who || '').trim();
+  return name ? `Uploaded ${date} by ${name}` : `Uploaded ${date}`;
+}
+
 /**
  * taleggio-58499: IconInput defaults to the global dark-theme input styling
  * (near-white text on translucent dark bg from index.css). Inside the
@@ -700,12 +725,17 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         url: d.url,
         fileName: d.fileName,
         mimeType: d.mimeType,
+        // nduja-58514: uploader + timestamp caption in the lightbox footer.
+        caption: photoCaption(d.uploadedByName || d.uploadedByEmail, d.createdAt),
       })),
       ...eventDocs.map((d) => ({
         url: d.url,
         fileName: d.fileName,
         mimeType: d.mimeType,
+        caption: photoCaption(d.uploadedByName || d.uploadedByEmail, d.createdAt),
       })),
+      // Receipts intentionally render without a caption — they already surface
+      // uploader attribution elsewhere in the modal.
       ...receipts.map((d) => ({
         url: d.url,
         fileName: d.fileName,
@@ -715,11 +745,13 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         url: p.url,
         fileName: p.fileName,
         mimeType: p.mimeType,
+        caption: photoCaption(p.uploaderName || p.uploaderEmail, p.createdAt),
       })),
       ...eventPhotos.map((p) => ({
         url: p.url,
         fileName: p.fileName,
         mimeType: p.mimeType,
+        caption: photoCaption(p.uploaderName || p.uploaderEmail, p.createdAt),
       })),
     ],
     [pizzas, eventDocs, receipts, pizzaPhotos, eventPhotos],
@@ -1861,7 +1893,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         type="button"
                         onClick={() => setLightboxIndex(carouselIdx)}
                         className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
-                        title={p.caption || p.fileName}
+                        title={`${p.caption || p.fileName}${photoTooltipSuffix(p.uploaderName || p.uploaderEmail, p.createdAt)}`}
                       >
                         {/* melanzane-92103: video event-photos render as
                             <video preload=metadata> so the browser pulls the
@@ -1945,7 +1977,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         type="button"
                         onClick={() => setLightboxIndex(carouselIdx)}
                         className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
-                        title={p.caption || p.fileName}
+                        title={`${p.caption || p.fileName}${photoTooltipSuffix(p.uploaderName || p.uploaderEmail, p.createdAt)}`}
                       >
                         {isVideoFile(p) ? (
                           <>
@@ -3051,7 +3083,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       type="button"
                       onClick={() => setLightboxIndex(idx)}
                       className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
-                      title={doc.fileName}
+                      title={`${doc.fileName}${photoTooltipSuffix(doc.uploadedByName || doc.uploadedByEmail, doc.createdAt)}`}
                     >
                       {isVideoFile(doc) ? (
                         <>
@@ -3096,7 +3128,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                       type="button"
                       onClick={() => setLightboxIndex(pizzas.length + idx)}
                       className="relative aspect-square rounded-lg overflow-hidden border border-theme-stroke group"
-                      title={doc.fileName}
+                      title={`${doc.fileName}${photoTooltipSuffix(doc.uploadedByName || doc.uploadedByEmail, doc.createdAt)}`}
                     >
                       {isVideoFile(doc) ? (
                         <>

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -99,6 +99,55 @@ function isPizzaPhoto(p: AdminPayoutEventPhoto): boolean {
 const PHOTO_PREVIEW_LIMIT = 4;
 
 /**
+ * nduja-58514: mirror the receipt "uploaded by {name|email} · {date}" surfacing
+ * for event/pizza photos on /payments. Receipts already show uploader + date in
+ * their thumbnail tooltip + lightbox; photos didn't. These two helpers produce
+ * the tooltip suffix (appended to the thumbnail title) and the lightbox caption
+ * line from a photo's uploader fields. Same date format as ReceiptsLibrary
+ * (toLocaleDateString { year, month: 'short', day }). Guards invalid/missing
+ * createdAt so we never render "Invalid Date" or "by undefined".
+ */
+function formatPhotoDate(createdAt: string | null | undefined): string | null {
+  if (!createdAt) return null;
+  const d = new Date(createdAt);
+  if (isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+interface PhotoUploaderMeta {
+  uploaderName?: string | null;
+  uploaderEmail?: string | null;
+  createdAt?: string | null;
+}
+
+/**
+ * Tooltip suffix appended to a thumbnail `title`. Always includes the date when
+ * present; prepends " — uploaded by {name|email}" only when a name or email
+ * exists. Returns '' when there's no usable date (nothing to append).
+ */
+function photoUploaderTooltipSuffix(p: PhotoUploaderMeta): string {
+  const date = formatPhotoDate(p.createdAt);
+  if (!date) return '';
+  const who = (p.uploaderName || p.uploaderEmail || '').trim();
+  return who ? ` — uploaded by ${who} · ${date}` : ` · ${date}`;
+}
+
+/**
+ * Lightbox caption line: "Uploaded {date}" plus " by {name|email}" when known.
+ * Returns '' when there's no usable date (caption omitted).
+ */
+function photoUploaderCaption(p: PhotoUploaderMeta): string {
+  const date = formatPhotoDate(p.createdAt);
+  if (!date) return '';
+  const who = (p.uploaderName || p.uploaderEmail || '').trim();
+  return who ? `Uploaded ${date} by ${who}` : `Uploaded ${date}`;
+}
+
+/**
  * mostarda-92103: rework of the /payments by-city expanded row. Each city
  * (party) now renders as a single rolled-up panel — Receipt total + Approved
  * + Paid + Outstanding — instead of enumerating per-host claim splits. The
@@ -1306,6 +1355,8 @@ function CityExpansion({
         url: p.url,
         fileName: p.fileName,
         mimeType: p.mimeType,
+        // nduja-58514: surface uploader + timestamp in the lightbox footer.
+        caption: photoUploaderCaption(p),
       })),
     [eventPhotos],
   );
@@ -1315,6 +1366,8 @@ function CityExpansion({
         url: p.url,
         fileName: p.fileName,
         mimeType: p.mimeType,
+        // nduja-58514: surface uploader + timestamp in the lightbox footer.
+        caption: photoUploaderCaption(p),
       })),
     [pizzaPhotos],
   );
@@ -2621,7 +2674,7 @@ function PhotoPreviewSection({
               type="button"
               onClick={() => onThumbClick(idx)}
               className="relative w-16 h-16 rounded-md overflow-hidden border border-theme-stroke hover:border-theme-stroke-hover group"
-              title={p.caption || p.fileName}
+              title={`${p.caption || p.fileName}${photoUploaderTooltipSuffix(p)}`}
             >
               {/* melanzane-92103 / focaccia-92104: video photos render as
                   <video preload=metadata> so the browser pulls the first

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -32,6 +32,14 @@ export interface ReceiptLightboxImage {
   url: string;
   fileName: string;
   mimeType?: string;
+  /**
+   * nduja-58514: optional muted caption line shown in the footer under the
+   * file name (e.g. "Uploaded Jun 7, 2026 by Jane"). Receipts pass none;
+   * event/pizza photos pass an uploader+timestamp string so the /payments
+   * photo lightbox mirrors what receipts already surface. Additive — images
+   * without a caption render exactly as before.
+   */
+  caption?: string;
 }
 
 interface ReceiptLightboxProps {
@@ -529,6 +537,11 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
           </span>
         )}
         <span className="truncate">{current.fileName}</span>
+        {/* nduja-58514: muted uploader + timestamp caption for event/pizza
+            photos. Receipts pass no caption and render unchanged. */}
+        {current.caption && (
+          <span className="truncate text-white/60">· {current.caption}</span>
+        )}
       </div>
     </div>,
     document.body,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2114,6 +2114,7 @@ export interface AdminPayoutEventPhoto {
    */
   tags?: string[];
   uploaderName: string | null;
+  uploaderEmail: string | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
## What
Photos on /payments now show **who uploaded them and when**, mirroring what receipts already surface. Covers three surfaces:
1. **By-city grid** photo-thumbnail tooltip (`PhotoPreviewSection`)
2. **Photo lightbox** — new muted caption line in the footer (`ReceiptLightbox`)
3. **PayoutReviewModal** pizza/event photo grids — tooltip + lightbox caption

## Why
Receipts show `uploaded by X · {date}` (by-city tooltip) and `Uploaded {date} by {uploader}` (host ReceiptsLibrary). Photos showed neither. Snax asked for parity.

## How
- Data was mostly already present: `AdminPayoutEventPhoto` carries `uploaderName` + `createdAt`; modal grids render `PayoutDocument`s with `uploadedByName/Email/createdAt`.
- **Data gap fixed:** admin-*added* photos store `uploaderEmail` but `uploaderName: null`, and the projection only exposed `uploaderName`. Added `uploaderEmail` to both `AdminPayoutEventPhoto` backend projections + the frontend type, with a name → email fallback (same as receipts).
- New shared formatters (`photoUploaderTooltipSuffix` / `photoUploaderCaption`) reuse the exact `ReceiptsLibrary` date format and guard missing/invalid dates (no "Invalid Date" / "by undefined").
- `ReceiptLightbox` gains an additive optional `caption?` — receipts pass none and are unchanged.

## Deploy note
The `uploaderName` + date path is frontend-only. The `uploaderEmail` fallback needs the **backend deployed from master** (previews share prod backend) before admin-added photos show their uploader.

## Test
- Vercel preview /payments → hover a by-city photo thumb (tooltip), open the photo lightbox (caption line), open a payout in PayoutReviewModal (pizza/event tooltip + lightbox caption).
- Historical photo with no uploader → still shows the date, no dangling "by".

Plan: `plans/nduja-58514-photo-uploader-metadata.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)