### PR TITLE
feat(pinsa-58293): show cities without submissions on /payments (opt-in)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2334,6 +2334,136 @@ router.get(
         }
       }
 
+      // pinsa-58293: optional `?includeUnsubmitted=1` injects synthetic
+      // by-party rows for EVERY approved city that has submitted no payouts at
+      // all (zero rows in the `payout` table) — e.g. Houston. Unlike the
+      // tigella-58512 `tbd` variant this is NOT tag-restricted and only checks
+      // for zero payouts (a city may have uploaded receipt documents but still
+      // never had a payout created). These parties produce zero grouped `rows`
+      // above, so they're invisible on /payments without this. OFF by default —
+      // when the param is absent the response is byte-identical to before.
+      //
+      // Gated to status unset/'all': a zero-payout city can never match a
+      // specific payout-status filter (it has no payouts), so injecting it
+      // under e.g. `status=paid` would be misleading. The `closed` pseudo-status
+      // is also a status filter and so suppresses these rows.
+      const includeUnsubmitted =
+        req.query.includeUnsubmitted === 'true' || req.query.includeUnsubmitted === '1';
+      const statusParam = typeof req.query.status === 'string' ? req.query.status.trim() : '';
+      const statusFilterActive = statusParam.length > 0 && statusParam !== 'all';
+      if (includeUnsubmitted && !statusFilterActive) {
+        // Reuse the SAME party-level scope this handler already computed in
+        // `buildPayoutWhere` (underbossStatus 'approved' + optional
+        // country/tag/region/closed clauses live on `where.party`). We do NOT
+        // apply any payout-level filters (method/purpose/currency/date) — these
+        // rows have no payouts. The zero-payout predicate is AND'd on top via an
+        // explicit AND array so a `tag` filter on `where.party.eventTags` is
+        // preserved rather than clobbered.
+        const partyScope: any = { ...(where.party ?? {}) };
+        const andParts: any[] = [{ payouts: { none: {} } }];
+
+        // Respect the unified search scope (salame-83472 / diavola-83147):
+        // `where.OR` restricts to a partyId set; only the partyId arm applies at
+        // the party level (hostUserId is a payout column). This keeps search
+        // working for the empty rows too.
+        if (Array.isArray(where.OR)) {
+          const searchPartyIds = where.OR
+            .map((o: any) => o?.partyId?.in)
+            .find((v: any) => Array.isArray(v));
+          if (Array.isArray(searchPartyIds)) {
+            andParts.push({ id: { in: searchPartyIds } });
+          }
+        }
+        // Single-partyId filter (where.partyId is a payout column, but the same
+        // id is the party id we want to scope to).
+        if (typeof where.partyId === 'string' && where.partyId.length > 0) {
+          andParts.push({ id: where.partyId });
+        }
+        // Defensively exclude any party already present in `rows` (incl. any TBD
+        // rows injected above).
+        const existingPartyIds = new Set(rows.map((r) => r.party.id));
+        if (existingPartyIds.size > 0) {
+          andParts.push({ id: { notIn: Array.from(existingPartyIds) } });
+        }
+        partyScope.AND = [...(Array.isArray(partyScope.AND) ? partyScope.AND : []), ...andParts];
+
+        const unsubmittedParties = await prisma.party.findMany({
+          where: partyScope,
+          select: PAYOUT_PARTY_SELECT,
+        });
+
+        for (const partyMeta of unsubmittedParties as any[]) {
+          const partyId = partyMeta.id;
+          // Synthetic by-party row in the EXACT shape the real rows use, with
+          // every count/usd aggregate = 0 and no payouts/photos. Keys mirror
+          // the serializer above field-for-field so the frontend renders these
+          // with NO special-casing. Cast to the row element type because the
+          // real rows infer `lastActivityAt: string` whereas these are null.
+          rows.push({
+            party: {
+              id: partyId,
+              name: partyMeta.name,
+              customUrl: partyMeta.customUrl ?? null,
+              inviteCode: partyMeta.inviteCode ?? null,
+              country: partyMeta.country ?? null,
+              region: (partyMeta.region as string | null) ?? null,
+              effectiveReimbursementCapUsd: computeEffectiveCapUsd({
+                reimbursementCapUsd: partyMeta.reimbursementCapUsd,
+                eventTags: partyMeta.eventTags,
+              }),
+              eventTags: Array.isArray(partyMeta.eventTags) ? partyMeta.eventTags : [],
+              primaryHostInCohosts: isPrimaryHostInCohosts(partyMeta),
+              userId: partyMeta.userId ?? null,
+              paymentsClosedAt: partyMeta.paymentsClosedAt
+                ? partyMeta.paymentsClosedAt.toISOString()
+                : null,
+              taxFormRequired: partyMeta.taxFormRequired === true,
+              adminNotes:
+                req.viewerRole === 'admin'
+                  ? (partyMeta.adminNotes ?? null)
+                  : null,
+              receiptsReminderSentAt: partyMeta.receiptsReminderSentAt
+                ? partyMeta.receiptsReminderSentAt.toISOString()
+                : null,
+              walletReminderSentAt: partyMeta.walletReminderSentAt
+                ? partyMeta.walletReminderSentAt.toISOString()
+                : null,
+              paymentsApprovedUsd: partyMeta.paymentsApprovedUsd
+                ? Number(partyMeta.paymentsApprovedUsd)
+                : null,
+              paymentsApprovedAt: partyMeta.paymentsApprovedAt
+                ? partyMeta.paymentsApprovedAt.toISOString()
+                : null,
+            },
+            aggregates: {
+              pendingCount: 0,
+              pendingUsd: 0,
+              approvedCount: 0,
+              approvedUsd: 0,
+              paidCount: 0,
+              paidUsd: 0,
+              paidNoProofCount: 0,
+              paidNoProofUsd: 0,
+              rejectedCount: 0,
+              rejectedUsd: 0,
+              failedCount: 0,
+              failedUsd: 0,
+              withdrawnCount: 0,
+              withdrawnUsd: 0,
+              completedCount: 0,
+              completedUsd: 0,
+              completedNoProofCount: 0,
+              completedNoProofUsd: 0,
+              totalReceiptCount: 0,
+              lastActivityAt: null,
+              flaggedReadyCount: 0,
+            },
+            payouts: [],
+            eventPhotos: [],
+          } as (typeof rows)[number]);
+        }
+      }
+
       // pinsa-92103: optional `?hideClosed=true` filters out rows the admin
       // has explicitly closed out (Ekiti, Tangier). Doing this server-side
       // (vs. in the table component) keeps row counts honest and is cheap —

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -62,6 +62,14 @@ interface PayoutsFilterBarProps {
    */
   showTbdToggle?: boolean;
   /**
+   * pinsa-58293: when true, render the "Show cities without submissions"
+   * checkbox. By-city view only (the synthetic zero-payout rows it reveals only
+   * exist on the by-party endpoint). OFF by default — turning it on asks the
+   * backend to inject every approved city that has zero payouts (e.g. Houston)
+   * so an admin can record an external payment for them. Defaults to false.
+   */
+  showUnsubmittedToggle?: boolean;
+  /**
    * pancetta-92103: when true, render the Regions multi-select dropdown
    * (admin /payments). Hidden on regional sub-portals (which are already
    * hard-scoped by their `regionFilter` prop). Defaults to false.
@@ -184,6 +192,8 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.hideUsCities) n += 1;
   // tigella-58512: count Show TBD (no submission) when the admin turns it on.
   if (filters.showTbdUnsubmitted) n += 1;
+  // pinsa-58293: count Show cities without submissions when turned on.
+  if (filters.showUnsubmitted) n += 1;
   return n;
 }
 
@@ -210,6 +220,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   showHideScamsToggle,
   showHideUsToggle,
   showTbdToggle,
+  showUnsubmittedToggle,
   showRegionsFilter,
   showStatusTabs = true,
 }) => {
@@ -557,6 +568,20 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
                 checked={!!filters.showTbdUnsubmitted}
                 onChange={() => update({ showTbdUnsubmitted: !filters.showTbdUnsubmitted })}
                 label="Show TBD (no submission)"
+                labelClassName="text-xs text-theme-text-secondary"
+                size={14}
+              />
+            )}
+            {/* pinsa-58293: Show approved cities that have submitted no payouts
+                at all (e.g. Houston). By-city view only; OFF by default. The
+                backend injects synthetic zero-payout rows on /by-party when
+                `includeUnsubmitted` is set, so an admin can record an external
+                payment for them. */}
+            {showUnsubmittedToggle && (
+              <Checkbox
+                checked={!!filters.showUnsubmitted}
+                onChange={() => update({ showUnsubmitted: !filters.showUnsubmitted })}
+                label="Show cities without submissions"
                 labelClassName="text-xs text-theme-text-secondary"
                 size={14}
               />

--- a/frontend/src/components/payments-admin/paymentsUrlState.test.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.test.ts
@@ -85,6 +85,21 @@ describe('filtersToSearchParams', () => {
       filtersToSearchParams({ ...DEFAULT_FILTERS, showTbdUnsubmitted: true }, 'by-city').get('tbd'),
     ).toBe('1');
   });
+
+  // pinsa-58293: default-FALSE toggle — emit `unsub=1` only when ON.
+  it('showUnsubmitted: emits unsub=1 only when ON, nothing by default', () => {
+    // default (false / undefined) -> no key
+    expect(
+      filtersToSearchParams(DEFAULT_FILTERS, 'by-city').get('unsub'),
+    ).toBeNull();
+    expect(
+      filtersToSearchParams({ ...DEFAULT_FILTERS, showUnsubmitted: false }, 'by-city').get('unsub'),
+    ).toBeNull();
+    // turned on -> unsub=1
+    expect(
+      filtersToSearchParams({ ...DEFAULT_FILTERS, showUnsubmitted: true }, 'by-city').get('unsub'),
+    ).toBe('1');
+  });
 });
 
 describe('searchParamsToFilters', () => {
@@ -155,6 +170,21 @@ describe('searchParamsToFilters', () => {
       'by-city',
     );
     expect(searchParamsToFilters(params, undefined).filters.showTbdUnsubmitted).toBe(true);
+  });
+
+  // pinsa-58293: default-FALSE toggle round-trip.
+  it('showUnsubmitted: unsub=1 parses to true; absent stays false', () => {
+    const on = searchParamsToFilters(new URLSearchParams('unsub=1'), undefined);
+    expect(on.filters.showUnsubmitted).toBe(true);
+    // absent -> default false
+    const off = searchParamsToFilters(new URLSearchParams(), undefined);
+    expect(off.filters.showUnsubmitted).toBe(false);
+    // round-trip: ON serializes and parses back to ON
+    const params = filtersToSearchParams(
+      { ...DEFAULT_FILTERS, showUnsubmitted: true },
+      'by-city',
+    );
+    expect(searchParamsToFilters(params, undefined).filters.showUnsubmitted).toBe(true);
   });
 
   it('unknown enum values silently fall back to defaults', () => {

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -36,6 +36,8 @@ const DEFAULTS = {
   hideUsCities: true,
   // tigella-58512: default-FALSE — only emitted (as `tbd=1`) when turned ON.
   showTbdUnsubmitted: false,
+  // pinsa-58293: default-FALSE — only emitted (as `unsub=1`) when turned ON.
+  showUnsubmitted: false,
 };
 const DEFAULT_VIEW: ViewMode = 'by-city';
 
@@ -99,6 +101,9 @@ export function filtersToSearchParams(
   // tigella-58512: default-FALSE toggle — only emit when turned ON.
   if (filters.showTbdUnsubmitted === true) params.set('tbd', '1');
 
+  // pinsa-58293: default-FALSE toggle — only emit when turned ON.
+  if (filters.showUnsubmitted === true) params.set('unsub', '1');
+
   if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
 
   return params;
@@ -137,6 +142,7 @@ export function searchParamsToFilters(
     hideScams: DEFAULTS.hideScams,
     hideUsCities: DEFAULTS.hideUsCities,
     showTbdUnsubmitted: DEFAULTS.showTbdUnsubmitted,
+    showUnsubmitted: DEFAULTS.showUnsubmitted,
     sort: DEFAULTS.sort,
     ...(regions ? { regions } : {}),
   };
@@ -209,6 +215,10 @@ export function searchParamsToFilters(
   // tigella-58512: default-FALSE toggle — present `tbd=1` => true; absent =>
   // leave the default (false). Any non-`1` value is treated as false.
   if (params.has('tbd')) filters.showTbdUnsubmitted = params.get('tbd') === '1';
+
+  // pinsa-58293: default-FALSE toggle — present `unsub=1` => true; absent =>
+  // leave the default (false). Any non-`1` value is treated as false.
+  if (params.has('unsub')) filters.showUnsubmitted = params.get('unsub') === '1';
 
   const viewRaw = params.get('view');
   const viewMode: ViewMode | null =

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4934,6 +4934,12 @@ function buildPayoutQuery(filters: AdminPayoutFilters | undefined): string {
   if (filters.showTbdUnsubmitted) {
     params.set('showTbdUnsubmitted', '1');
   }
+  // pinsa-58293: surface every approved city with zero payouts (e.g. Houston)
+  // on the by-city view so an admin can log an external payment. Only set when
+  // ON so the default request is byte-identical.
+  if (filters.showUnsubmitted) {
+    params.set('includeUnsubmitted', 'true');
+  }
   const qs = params.toString();
   return qs ? `?${qs}` : '';
 }

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -124,6 +124,9 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   // tigella-58512: surface approved `tbd` events with zero submissions —
   // OFF by default so the default request is byte-identical to before.
   showTbdUnsubmitted: false,
+  // pinsa-58293: surface approved cities with zero payouts (e.g. Houston) —
+  // OFF by default so the default request is byte-identical to before.
+  showUnsubmitted: false,
   // arancino-92103: sort order default — newest submitted first. Matches the
   // prior implicit backend ordering, so non-sorting callers see no change.
   sort: 'created_desc',
@@ -1262,6 +1265,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           // synthetic rows come from the by-party endpoint, which is the only
           // place a zero-payout party can surface.
           showTbdToggle={viewMode === 'by-city'}
+          // pinsa-58293: Show cities without submissions — by-city view only.
+          // These synthetic zero-payout rows come from the by-party endpoint.
+          showUnsubmittedToggle={viewMode === 'by-city'}
           // provatura-92107: Hide US cities — by-city view + admin dashboard
           // only (regional portals are already region-scoped).
           showHideUsToggle={viewMode === 'by-city' && !isRegionalPortal}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2262,6 +2262,17 @@ export interface AdminPayoutFilters {
    * prior behavior).
    */
   showTbdUnsubmitted?: boolean;
+  /**
+   * pinsa-58293: surface EVERY approved city that has submitted no payouts at
+   * all (zero rows in the payout table) — e.g. Houston — so an admin can record
+   * an external payment for them. Broader than `showTbdUnsubmitted` (not tag-
+   * restricted, only checks for zero payouts). Produces no grouped rows
+   * normally, so the backend injects synthetic by-party rows when this is set.
+   * By-city endpoint only; OFF by default — when false the `includeUnsubmitted`
+   * query param is omitted entirely (byte-identical to prior behavior). Only
+   * honored when no payout-status filter is active.
+   */
+  showUnsubmitted?: boolean;
 }
 
 export interface AdminPayoutTotals {


### PR DESCRIPTION
## What

Adds an opt-in **"Show cities without submissions"** toggle to the /payments by-city admin view. When turned ON, the `/api/admin/payouts/by-party` endpoint injects synthetic rows for **every approved city that has zero payouts** (e.g. Houston) so an admin can record a payment for them via the existing per-row **Add external payment** action (`ExternalPaymentModal`). No new payment logic.

## How

- **Backend** (`admin-payout.routes.ts` /by-party): reads `includeUnsubmitted=1`. When set AND no payout-status filter is active, queries `prisma.party.findMany({ where: { ...where.party, payouts: { none: {} } } })` reusing the same approved + country/tag/region (regional-UB) scope, honors search, and pushes synthetic all-zero rows in the exact shape the real rows use. Mirrors the existing `showTbdUnsubmitted` (tigella-58512) pattern but is broader (not tag-restricted, only checks zero payouts).
- **Frontend**: `showUnsubmitted` filter state (`paymentsUrlState.ts` URL param `unsub=1`, default false), `api.ts` maps it to `includeUnsubmitted=true`, a `Checkbox` toggle in `PayoutsFilterBar` (by-city view only), wired through `PaymentsAdminPage`. Zero-payout rows already render fine via `CityActionsMenu` (same path the TBD rows use), which exposes Add external payment on every row.

## Behavior when OFF

Byte-identical request + response to today — the query param is omitted entirely.

## Verification

- Frontend `tsc --noEmit`: clean.
- Backend tsc could not be fully run in the worktree (no installed node_modules / stale Prisma client); the only errors surfaced are pre-existing environmental ones (missing optional deps + stale Prisma client missing `walletReminderSentAt`/`submittedForReviewAt`), including the **identical** TS2352 cast on the unmodified tigella-58512 TBD block — which is green on Vercel today. The new block uses that same proven pattern.
- Added mirror unit tests in `paymentsUrlState.test.ts`.

## Deploy note

The new `includeUnsubmitted` backend behavior only works on the Vercel preview **after this merges to master**, because preview frontends call the production backend. Until merge, toggling on a preview will send the param but the prod backend will ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)