### PR TITLE
fix(tortano-58516): include queued payouts in profile→row wallet re-stamp

### DIFF
--- a/backend/src/routes/user.routes.test.ts
+++ b/backend/src/routes/user.routes.test.ts
@@ -17,6 +17,9 @@ const mockPrisma = vi.hoisted(() => ({
   admin: {
     findUnique: vi.fn(),
   },
+  payout: {
+    updateMany: vi.fn(),
+  },
 }));
 
 vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
@@ -112,6 +115,7 @@ describe('PATCH /api/user/me — payout-method gating (marinara-71630 P7b)', () 
     vi.clearAllMocks();
     mockCanUserEditParty.mockResolvedValue(true);
     mockPrisma.user.update.mockResolvedValue(UPDATED_USER);
+    mockPrisma.payout.updateMany.mockResolvedValue({ count: 0 });
   });
 
   function patch(body: any) {
@@ -182,6 +186,27 @@ describe('PATCH /api/user/me — payout-method gating (marinara-71630 P7b)', () 
     expect(mockGetReimbursementRules).not.toHaveBeenCalled();
     expect(mockPrisma.party.findUnique).not.toHaveBeenCalled();
     expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-stamps non-terminal payouts INCLUDING queued, excluding mercury_card (tortano-58516)', async () => {
+    // A profile save that touches a payout pref triggers the ricotta-58512
+    // re-stamp. tortano-58516 widened it from ['pending','approved'] to the
+    // shared NON_TERMINAL_PAYOUT_STATUSES (which adds 'queued'), so an admin who
+    // queues a payout before the host finalizes their wallet no longer strands
+    // it un-payable.
+    const res = await patch({
+      payoutWalletAddress: '0x2222222222222222222222222222222222222222',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.payout.updateMany).toHaveBeenCalledTimes(1);
+
+    const where = mockPrisma.payout.updateMany.mock.calls[0][0].where;
+    expect(where.status.in).toContain('queued');
+    expect(where.status.in).toContain('pending');
+    expect(where.status.in).toContain('approved');
+    // Mercury-card rows stay excluded so an admin-issued card isn't clobbered.
+    expect(where.NOT.payoutMethod).toBe('mercury_card');
   });
 
   it('fails OPEN when the config is unseeded — even mercury_card in a blocked country (200)', async () => {

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -5,7 +5,7 @@ import { resolveWalletInput } from '../services/ens.service.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
 import { getReimbursementRules } from '../lib/privateConfig.js';
 import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
-import { payoutRowSnapshotFromUser } from '../services/payout-snapshot.js';
+import { payoutRowSnapshotFromUser, NON_TERMINAL_PAYOUT_STATUSES } from '../services/payout-snapshot.js';
 
 const router = Router();
 
@@ -171,12 +171,17 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
     // profile onto their non-terminal rolling event payouts. The execute/send
     // path reads the payout ROW (no host fallback), so without this a host who
     // fixes their wallet AFTER the rolling row exists (incl. after an admin has
-    // approved it) stays un-payable. Only re-stamp rows it's safe to touch:
-    // 'pending' and 'approved'. We deliberately EXCLUDE 'queued' (an in-flight
-    // send must not have its target wallet swapped mid-flight) even though it's
-    // in NON_TERMINAL_PAYOUT_STATUSES, and never touch terminal rows
-    // (paid/withdrawn/rejected/failed/completed). The mercury_card guard avoids
-    // clobbering an admin-issued Mercury card with the host's self-serve prefs.
+    // approved it) stays un-payable.
+    // tortano-58516: re-stamp across ALL non-terminal statuses
+    // (NON_TERMINAL_PAYOUT_STATUSES = pending/approved/queued), now INCLUDING
+    // 'queued'. This matches the receipt-upload snapshot path in
+    // payout.routes.ts (which already uses NON_TERMINAL_PAYOUT_STATUSES), so an
+    // admin who marks a payout 'queued' before the host has finalized their
+    // wallet/method no longer strands it un-payable when the host later fixes
+    // their profile. Terminal rows (paid/completed/withdrawn/rejected/failed)
+    // stay excluded because NON_TERMINAL_PAYOUT_STATUSES lists only the three
+    // non-terminal statuses. The mercury_card guard avoids clobbering an
+    // admin-issued Mercury card with the host's self-serve prefs.
     if (
       preferredPayoutMethod !== undefined
       || payoutWalletAddress !== undefined
@@ -188,7 +193,7 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
           where: {
             hostUserId: req.userId,
             purpose: 'event',
-            status: { in: ['pending', 'approved'] },
+            status: { in: [...NON_TERMINAL_PAYOUT_STATUSES] },
             NOT: { payoutMethod: 'mercury_card' },
           },
           data: snap,


### PR DESCRIPTION
## Problem
ricotta-58512's profile→row payout snapshot (PATCH /api/user/me) re-stamps the host's wallet/method onto non-terminal rolling payouts, but hard-coded `status in (pending, approved)` and **excluded `queued`**. So if an admin marks a payout `queued` before the host finalizes their wallet, a later profile fix never reaches the row → permanently un-payable (execute/send reads the ROW, no host fallback).

Real incident: Warsaw payout `6514b4dc-...` (queued 2026-06-03 with wire/null wallet while the host's profile had a usdc_base wallet). Row manually backfilled; this fixes the class.

## Fix
Use the shared `NON_TERMINAL_PAYOUT_STATUSES` (`pending,approved,queued`) in the profile re-stamp `updateMany`, matching the receipt-upload snapshot path in `payout.routes.ts` which already includes `queued`. Mercury-card and terminal rows remain excluded.

## Test
`user.routes.test.ts` asserts the re-stamp now targets `queued` rows (and still excludes mercury_card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)