### PR TITLE
fix(mortadella-58517): surface real photo per-user-limit error on upload

### DIFF
--- a/frontend/src/components/PreviousYearPhotos.tsx
+++ b/frontend/src/components/PreviousYearPhotos.tsx
@@ -238,15 +238,21 @@ export function PreviousYearPhotos() {
 
         const result = await uploadEventPhoto(file, party.id);
         if (result) {
-          await uploadPhoto(party.id, {
-            url: result.url,
-            fileName: result.fileName,
-            fileSize: result.fileSize,
-            mimeType: result.mimeType,
-            width: result.width,
-            height: result.height,
-            photoYear: eventYear,
-          });
+          try {
+            await uploadPhoto(party.id, {
+              url: result.url,
+              fileName: result.fileName,
+              fileSize: result.fileSize,
+              mimeType: result.mimeType,
+              width: result.width,
+              height: result.height,
+              photoYear: eventYear,
+            });
+          } catch (err) {
+            // mortadella-58517: uploadPhoto now throws (e.g. per-user photo cap).
+            // Skip the failed file and keep going so the batch + spinner don't hang.
+            console.error('Previous-year photo upload failed:', err);
+          }
         }
       }
 

--- a/frontend/src/components/photos/PhotoUpload.tsx
+++ b/frontend/src/components/photos/PhotoUpload.tsx
@@ -218,19 +218,24 @@ export const PhotoUpload: React.FC<PhotoUploadProps> = ({
         onUploadComplete?.(result.photo);
       } catch (error) {
         console.error('Upload error:', error);
-        // Surface the 30-photo limit message verbatim (snax requested exact copy)
+        // mortadella-58517: surface the backend's real message verbatim. The
+        // per-user photo cap is config-driven, so detect it via the structured
+        // error code (PHOTO_LIMIT_REACHED) rather than a hardcoded "30" string;
+        // keep a message-substring fallback for resilience.
         const message = error instanceof Error ? error.message : String(error);
+        const code = (error as { code?: string } | null)?.code;
+        const isLimitError = code === 'PHOTO_LIMIT_REACHED' || /photo limit per user/i.test(message);
         setFiles(prev => {
           const newFiles = [...prev];
           newFiles[fileIndex] = {
             ...newFiles[fileIndex],
             status: 'error',
-            error: message.includes('30 photo limit') ? message : (message || 'Upload failed'),
+            error: message || 'Upload failed',
           };
           return newFiles;
         });
         // If hit the per-user limit, stop trying further files (they'd all fail)
-        if (message.includes('30 photo limit')) break;
+        if (isLimitError) break;
       }
     }
   };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1267,16 +1267,16 @@ export async function uploadPhoto(
   partyId: string,
   data: PhotoUploadData
 ): Promise<{ photo: Photo } | null> {
-  try {
-    return await apiRequest<{ photo: Photo }>(`/api/parties/${partyId}/photos`, {
-      method: 'POST',
-      body: data,
-      requireAuth: false,
-    });
-  } catch (error) {
-    console.error('Error uploading photo:', error);
-    return null;
-  }
+  // mortadella-58517: do NOT swallow errors here. apiRequest throws an Error
+  // carrying the backend message + structured `.code` (e.g. PHOTO_LIMIT_REACHED).
+  // Callers wrap this in try/catch and surface err.message, so re-throw to let
+  // the real reason (per-user photo cap, etc.) reach the user instead of a
+  // generic "upload failed". (Previously this returned null on any error.)
+  return await apiRequest<{ photo: Photo }>(`/api/parties/${partyId}/photos`, {
+    method: 'POST',
+    body: data,
+    requireAuth: false,
+  });
 }
 
 // Get single photo details


### PR DESCRIPTION
## Problem
When a user hits their per-event photo cap, the backend correctly returns `400 PHOTO_LIMIT_REACHED` with a message like *"30 photo limit per user. Remove photos to make room"*. But the frontend `uploadPhoto()` helper caught **every** error and returned `null`, discarding both the message and the structured `.code`. `PhotoUpload` then fell into `if (!result) throw new Error('Failed to create photo record')`, so the user (e.g. **quetzaltenango**) saw a meaningless generic error instead of the real reason.

## Fix (frontend-only — no migration, no backend deploy)
- **`api.ts`** — `uploadPhoto` re-throws the `apiRequest` error (preserving `message` + `.code`) instead of swallowing it to `null`. The 7 other callers already `catch (err) { setError(err.message) }`, so they now surface the real reason too.
- **`PhotoUpload.tsx`** — detect the cap via `code === 'PHOTO_LIMIT_REACHED'` (the cap is config-driven now per marinara-71630, so the old hardcoded `'30 photo limit'` substring was brittle) and surface the backend message verbatim.
- **`PreviousYearPhotos.tsx`** — the one caller not already in a try/catch (fire-and-forget batch loop); wrapped each upload so a thrown error skips that file instead of breaking the batch and hanging the "uploading" spinner.

## Test plan
- Upload past the per-user cap → error tile now reads *"N photo limit per user. Remove photos to make room"* and the batch stops.
- Normal uploads still succeed; day-of cards / RolePhotoPicker now show real failure reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
