### PR TITLE
feat(ravioli-58517): split receipts reminder into receipts + photo reminders

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -173,6 +173,7 @@ model Party {
   hostTelegramLinkToken   String?   @unique @map("host_telegram_link_token") @db.VarChar // nanoid(10) token for host /start deeplink
   receiptsReminderSentAt  DateTime? @map("receipts_reminder_sent_at") @db.Timestamptz // When admin sent TG receipts reminder
   walletReminderSentAt    DateTime? @map("wallet_reminder_sent_at") @db.Timestamptz // When admin sent TG wallet reminder
+  photoReminderSentAt     DateTime? @map("photo_reminder_sent_at") @db.Timestamptz // When admin sent TG photo reminder
   poapEventId             String?   @map("poap_event_id") // POAP event ID
   poapMints             Int?    @map("poap_mints") // POAP mint count
   poapMoments           Int?    @map("poap_moments") // POAP moments count

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -294,6 +294,8 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   receiptsReminderSentAt: true,
   // Track when the TG wallet reminder was last sent for this city.
   walletReminderSentAt: true,
+  // Track when the TG photo reminder was last sent for this city.
+  photoReminderSentAt: true,
   // City-level payment approval fields.
   paymentsApprovedUsd: true,
   paymentsApprovedAt: true,
@@ -2163,6 +2165,10 @@ router.get(
             walletReminderSentAt: b.partyMeta.walletReminderSentAt
               ? b.partyMeta.walletReminderSentAt.toISOString()
               : null,
+            // When the TG photo reminder was last sent.
+            photoReminderSentAt: b.partyMeta.photoReminderSentAt
+              ? b.partyMeta.photoReminderSentAt.toISOString()
+              : null,
             // City-level payment approval.
             paymentsApprovedUsd: b.partyMeta.paymentsApprovedUsd
               ? Number(b.partyMeta.paymentsApprovedUsd)
@@ -2297,6 +2303,9 @@ router.get(
                 : null,
               walletReminderSentAt: partyMeta.walletReminderSentAt
                 ? partyMeta.walletReminderSentAt.toISOString()
+                : null,
+              photoReminderSentAt: partyMeta.photoReminderSentAt
+                ? partyMeta.photoReminderSentAt.toISOString()
                 : null,
               paymentsApprovedUsd: partyMeta.paymentsApprovedUsd
                 ? Number(partyMeta.paymentsApprovedUsd)
@@ -6707,7 +6716,7 @@ router.post(
       // Prefer custom_url for the public link; fall back to invite_code so
       // the URL always resolves even on parties without a custom slug.
       const slug = party.customUrl || party.inviteCode;
-      const text = `Make sure you've uploaded receipts and photos to rsv.pizza/${slug}`;
+      const text = `Make sure you've uploaded your receipts to rsv.pizza/${slug}`;
 
       // Host DM — only when the party has a linked Telegram chat id.
       let hostDmSent = false;
@@ -6826,6 +6835,87 @@ router.post(
 
       console.log(
         `[tg-wallet-reminder] party=${party.id} slug=${slug} host_dm=${
+          hostDmSent ? 'ok' : `skipped:${hostDmReason ?? 'unknown'}`
+        } group=${groupSent ? 'ok' : `skipped:${groupReason ?? 'unknown'}`}`,
+      );
+
+      res.json({
+        hostDmSent,
+        ...(hostDmReason ? { hostDmReason } : {}),
+        groupSent,
+        ...(groupReason ? { groupReason } : {}),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// POST /:partyId/tg-photo-reminder
+//
+// Sibling of tg-receipts-reminder: DMs the primary host (when their Telegram
+// is linked) and posts to the city's GPP group chat, telling the host to
+// upload their event photos to the public event page. Same per-channel send +
+// skip-reason contract; the only differences are the message text + target
+// URL. Persists `parties.photo_reminder_sent_at` on success, mirroring the
+// receipts reminder, so the menu can show a last-sent sub-label.
+router.post(
+  '/:partyId/tg-photo-reminder',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: {
+          id: true,
+          customUrl: true,
+          inviteCode: true,
+          name: true,
+          hostTelegramChatId: true,
+        },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      const slug = party.customUrl || party.inviteCode;
+      const text = `Make sure you've uploaded your event photos to rsv.pizza/${slug}`;
+
+      let hostDmSent = false;
+      let hostDmReason: string | undefined;
+      if (party.hostTelegramChatId) {
+        const result = await sendTelegramMessage(
+          party.hostTelegramChatId.toString(),
+          text,
+        );
+        if (result.ok) {
+          hostDmSent = true;
+        } else {
+          hostDmReason = result.reason;
+        }
+      } else {
+        hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
+      }
+
+      // Group chat — tonda-58293: resolved server-side from
+      // `city_telegram_groups` via `sendToCityGroup` (adds the migration
+      // retry+persist this endpoint previously lacked). FIX #4: shared helper
+      // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+
+      // Record when the reminder was sent (if at least one message succeeded).
+      if (hostDmSent || groupSent) {
+        await prisma.party.update({
+          where: { id: partyId },
+          data: { photoReminderSentAt: new Date() },
+        });
+      }
+
+      console.log(
+        `[tg-photo-reminder] party=${party.id} slug=${slug} host_dm=${
           hostDmSent ? 'ok' : `skipped:${hostDmReason ?? 'unknown'}`
         } group=${groupSent ? 'ok' : `skipped:${groupReason ?? 'unknown'}`}`,
       );

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -26,6 +26,7 @@ import {
   ThumbsUp,
   RotateCcw,
   Wallet,
+  Camera,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type {
@@ -65,6 +66,7 @@ import {
   CUSTOM_TAG_PREFIX,
   sendTgReceiptsReminder,
   sendTgWalletReminder,
+  sendTgPhotoReminder,
   setCityAdminNotes,
   approveCity,
   reopenParty,
@@ -287,6 +289,19 @@ interface PayoutsByPartyTableProps {
     } | { error: string },
   ) => void;
   /**
+   * Toast callback for the Send photo reminder action — same per-channel
+   * success/skip shape as `onTgReminderResult`. The menu owns the API call.
+   */
+  onTgPhotoReminderResult?: (
+    partyId: string,
+    result: {
+      hostDmSent: boolean;
+      hostDmReason?: string;
+      groupSent: boolean;
+      groupReason?: string;
+    } | { error: string },
+  ) => void;
+  /**
    * bufalina-60733: fake-detection risk scores keyed by party id. Only
    * medium/high (≥30) parties are present; an absent key means "no badge".
    * Rendered as a caution pill in the city header strip.
@@ -482,6 +497,7 @@ function CityActionsMenu({
   onToggleScamFlag,
   onSendTgReminder,
   onSendWalletReminder,
+  onSendPhotoReminder,
   onApproveCity,
   onReopen,
   onAddCustomTag,
@@ -492,6 +508,7 @@ function CityActionsMenu({
   canToggleScamFlag,
   canSendTgReminder,
   canSendWalletReminder,
+  canSendPhotoReminder,
   canApproveCity,
   canReopen,
   canManageTags,
@@ -500,12 +517,14 @@ function CityActionsMenu({
   scamFlagBusy,
   tgReminderBusy,
   walletReminderBusy,
+  photoReminderBusy,
   reopenBusy,
   approveBusy,
   customTags,
   tagBusy,
   receiptsReminderSentAt,
   walletReminderSentAt,
+  photoReminderSentAt,
   paymentsApprovedUsd,
   receiptsTotalUsd,
 }: {
@@ -524,6 +543,11 @@ function CityActionsMenu({
    * two-click confirm pattern as the receipts reminder).
    */
   onSendWalletReminder?: () => void;
+  /**
+   * Fires after the second click on the Send photo reminder menu item (same
+   * two-click confirm pattern as the receipts reminder).
+   */
+  onSendPhotoReminder?: () => void;
   /** Approve city payment amount. Called with the amount to approve. */
   onApproveCity?: (amountUsd: number | null) => void;
   /** Reopen a closed city (undo the close). */
@@ -538,6 +562,7 @@ function CityActionsMenu({
   canToggleScamFlag: boolean;
   canSendTgReminder: boolean;
   canSendWalletReminder: boolean;
+  canSendPhotoReminder: boolean;
   canApproveCity: boolean;
   canReopen: boolean;
   /** panuozzo-58217: admins + underbosses may add/view/remove custom tags. */
@@ -547,6 +572,7 @@ function CityActionsMenu({
   scamFlagBusy: boolean;
   tgReminderBusy: boolean;
   walletReminderBusy: boolean;
+  photoReminderBusy: boolean;
   reopenBusy: boolean;
   approveBusy: boolean;
   /** panuozzo-58217: current custom-tag display labels (no `custom:` prefix). */
@@ -555,6 +581,7 @@ function CityActionsMenu({
   tagBusy: boolean;
   receiptsReminderSentAt?: string | null;
   walletReminderSentAt?: string | null;
+  photoReminderSentAt?: string | null;
   paymentsApprovedUsd?: number | null;
   paymentsApprovedAt?: string | null;
   /** Receipts total for default approval amount. */
@@ -572,6 +599,9 @@ function CityActionsMenu({
   // Same two-click confirm, separate state so the wallet + receipts items
   // don't share a confirm flag.
   const [confirmWalletReminder, setConfirmWalletReminder] = useState(false);
+  // Same two-click confirm, separate state so the photo + wallet + receipts
+  // items don't share a confirm flag.
+  const [confirmPhotoReminder, setConfirmPhotoReminder] = useState(false);
   // panuozzo-58217: the custom-tag add field. Declared above the no-actions
   // early return so the conditional return can't reorder hooks.
   const [tagDraft, setTagDraft] = useState('');
@@ -618,6 +648,7 @@ function CityActionsMenu({
     canToggleScamFlag ||
     canSendTgReminder ||
     canSendWalletReminder ||
+    canSendPhotoReminder ||
     canReopen ||
     canManageTags;
   // Nothing to show at all — render nothing.
@@ -719,6 +750,7 @@ function CityActionsMenu({
                 } else {
                   setConfirmTgReminder(false);
                   setConfirmWalletReminder(false);
+                  setConfirmPhotoReminder(false);
                   setMenuPos(null);
                 }
                 return next;
@@ -741,6 +773,7 @@ function CityActionsMenu({
                   setMenuOpen(false);
                   setConfirmTgReminder(false);
                   setConfirmWalletReminder(false);
+                  setConfirmPhotoReminder(false);
                   setMenuPos(null);
                 }}
               />
@@ -917,6 +950,54 @@ function CityActionsMenu({
                       {walletReminderSentAt && !confirmWalletReminder && (
                         <span className="text-xs text-theme-text-muted">
                           Sent {new Date(walletReminderSentAt).toLocaleDateString()}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                )}
+                {/* Send photo reminder — sibling of the receipts reminder.
+                    DMs the host + posts to the city group telling them to
+                    upload their event photos. Same two-click confirm
+                    (DMs can't be unsent). Shows a last-sent sub-label from
+                    `photoReminderSentAt`, mirroring the receipts reminder. */}
+                {canSendPhotoReminder && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={photoReminderBusy}
+                    onClick={() => {
+                      if (!confirmPhotoReminder) {
+                        setConfirmPhotoReminder(true);
+                        return;
+                      }
+                      setMenuOpen(false);
+                      setConfirmPhotoReminder(false);
+                      onSendPhotoReminder?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
+                  >
+                    {photoReminderBusy ? (
+                      <Loader2
+                        size={14}
+                        className="animate-spin text-theme-text-muted"
+                      />
+                    ) : (
+                      <Camera
+                        size={14}
+                        className={
+                          confirmPhotoReminder ? 'text-amber-400' : 'text-sky-400'
+                        }
+                      />
+                    )}
+                    <span className="flex flex-col items-start">
+                      <span>
+                        {confirmPhotoReminder
+                          ? 'Click again to confirm'
+                          : 'Send photo reminder'}
+                      </span>
+                      {photoReminderSentAt && !confirmPhotoReminder && (
+                        <span className="text-xs text-theme-text-muted">
+                          Sent {new Date(photoReminderSentAt).toLocaleDateString()}
                         </span>
                       )}
                     </span>
@@ -2824,6 +2905,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onTagsChanged,
   onTgReminderResult,
   onTgWalletReminderResult,
+  onTgPhotoReminderResult,
   fakeScores,
   viewerRole = 'admin',
   busyRowId,
@@ -2866,6 +2948,10 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   const [walletReminderBusyPartyId, setWalletReminderBusyPartyId] = useState<
     string | null
   >(null);
+  // Per-row busy spinner for the Send photo reminder action.
+  const [photoReminderBusyPartyId, setPhotoReminderBusyPartyId] = useState<
+    string | null
+  >(null);
   // City-level approval busy spinner.
   const [approveBusyPartyId, setApproveBusyPartyId] = useState<string | null>(null);
   // Per-row busy spinner for the Reopen city action.
@@ -2893,6 +2979,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   const canToggleTaxFormRequired = viewerRole === 'admin';
   // Wallet reminder shares the same admin-only gate as the receipts reminder.
   const canSendWalletReminder = viewerRole === 'admin';
+  // Photo reminder shares the same admin-only gate as the receipts reminder.
+  const canSendPhotoReminder = viewerRole === 'admin';
   // City-level approval is admin-only.
   const canApproveCity = viewerRole === 'admin';
   // Reopen (undo a close) is admin-only — the endpoint enforces
@@ -3138,6 +3226,26 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   }
 
   /**
+   * Sibling of {@link handleSendTgReminder}: dispatch the photo reminder POST
+   * and forward the per-channel outcome via `onTgPhotoReminderResult`. Group
+   * chat_id resolved server-side (tonda-58293) — no client groupChatId.
+   */
+  async function handleSendPhotoReminder(row: PartyPayoutsRow) {
+    const partyId = row.party.id;
+    setPhotoReminderBusyPartyId(partyId);
+    try {
+      const result = await sendTgPhotoReminder(partyId);
+      onTgPhotoReminderResult?.(partyId, result);
+    } catch (err) {
+      onTgPhotoReminderResult?.(partyId, {
+        error: (err as Error)?.message ?? 'Could not send reminder',
+      });
+    } finally {
+      setPhotoReminderBusyPartyId((id) => (id === partyId ? null : id));
+    }
+  }
+
+  /**
    * City-level payment approval. Approves the receipts total as the payment
    * amount (or clears approval when amountUsd is null).
    */
@@ -3269,6 +3377,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
               const tgReminderBusy = tgReminderBusyPartyId === row.party.id;
               const walletReminderBusy =
                 walletReminderBusyPartyId === row.party.id;
+              const photoReminderBusy =
+                photoReminderBusyPartyId === row.party.id;
               const hasInFlight =
                 row.aggregates.pendingCount + row.aggregates.approvedCount > 0;
               // pinsa-92103: ALSO show the button when the city has paid
@@ -3582,6 +3692,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           canToggleScamFlag={canToggleScamFlag}
                           canSendTgReminder={canSendTgReminder}
                           canSendWalletReminder={canSendWalletReminder}
+                          canSendPhotoReminder={canSendPhotoReminder}
                           canApproveCity={canApproveCity}
                           canReopen={isClosed && canReopenCap}
                           canManageTags={canManageTags}
@@ -3592,10 +3703,12 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           scamFlagBusy={scamFlagBusy}
                           tgReminderBusy={tgReminderBusy}
                           walletReminderBusy={walletReminderBusy}
+                          photoReminderBusy={photoReminderBusy}
                           reopenBusy={reopenBusyPartyId === row.party.id}
                           approveBusy={approveBusyPartyId === row.party.id}
                           receiptsReminderSentAt={row.party.receiptsReminderSentAt}
                           walletReminderSentAt={row.party.walletReminderSentAt}
+                          photoReminderSentAt={row.party.photoReminderSentAt}
                           paymentsApprovedUsd={row.party.paymentsApprovedUsd}
                           paymentsApprovedAt={row.party.paymentsApprovedAt}
                           receiptsTotalUsd={receiptUsdTotal}
@@ -3642,6 +3755,11 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           onSendWalletReminder={
                             canSendWalletReminder
                               ? () => handleSendWalletReminder(row)
+                              : undefined
+                          }
+                          onSendPhotoReminder={
+                            canSendPhotoReminder
+                              ? () => handleSendPhotoReminder(row)
                               : undefined
                           }
                           onReopen={

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -608,6 +608,25 @@ export async function sendTgWalletReminder(
 }
 
 /**
+ * Sibling of {@link sendTgReceiptsReminder}: sends an "upload your event photos
+ * to rsv.pizza/<slug>" reminder via the Molto Benny Telegram bot — DM to the
+ * primary host + post to the city's group chat. Same per-channel success +
+ * skip-reason contract. Persists a sent-at timestamp on success. tonda-58293:
+ * group chat_id resolved server-side; no `groupChatId` arg.
+ */
+export async function sendTgPhotoReminder(
+  partyId: string,
+): Promise<SendTgReceiptsReminderResponse> {
+  return apiRequest<SendTgReceiptsReminderResponse>(
+    `/api/admin/payouts/${partyId}/tg-photo-reminder`,
+    {
+      method: 'POST',
+      requireAuth: true,
+    },
+  );
+}
+
+/**
  * tonda-58293: DB-first read of the city → Telegram group mapping. Replaces
  * the client-side Google Sheet fetch (`fetchTelegramGroups()`) for sends.
  * Returns rows from `city_telegram_groups` scoped to the caller's cities

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1593,6 +1593,30 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 result.hostDmSent || result.groupSent ? 'success' : 'error';
               pushToast(`Wallet reminder: ${hostLabel} | ${groupLabel}`, tone);
             }}
+            // Photo reminder — same per-channel success/skip toast as the
+            // receipts reminder.
+            onTgPhotoReminderResult={(_partyId, result) => {
+              if ('error' in result) {
+                pushToast(
+                  `Could not send photo reminder: ${result.error}`,
+                  'error',
+                );
+                return;
+              }
+              const hostLabel = result.hostDmSent
+                ? 'DM ✓'
+                : `DM skipped${
+                    result.hostDmReason ? ` (${result.hostDmReason})` : ''
+                  }`;
+              const groupLabel = result.groupSent
+                ? 'Group ✓'
+                : `Group skipped${
+                    result.groupReason ? ` (${result.groupReason})` : ''
+                  }`;
+              const tone =
+                result.hostDmSent || result.groupSent ? 'success' : 'error';
+              pushToast(`Photo reminder: ${hostLabel} | ${groupLabel}`, tone);
+            }}
             viewerRole={viewerKind}
             busyRowId={rowBusyId}
             loading={loading}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -341,6 +341,7 @@ export interface Party {
   hostTelegramLinkToken?: string | null;
   receiptsReminderSentAt?: string | null;
   walletReminderSentAt?: string | null;
+  photoReminderSentAt?: string | null;
   underbossStatus?: UnderbossStatus | null;
   turtleRolesEnabled?: boolean;
   // romana-61204: post-event survey toggle
@@ -2478,6 +2479,8 @@ export interface PartyPayoutsRow {
     receiptsReminderSentAt?: string | null;
     /** ISO timestamp of when the TG wallet reminder was last sent. */
     walletReminderSentAt?: string | null;
+    /** ISO timestamp of when the TG photo reminder was last sent. */
+    photoReminderSentAt?: string | null;
     /** City-level approved payment amount. */
     paymentsApprovedUsd?: number | null;
     /** ISO timestamp of when the city payment was approved. */

--- a/plans/ravioli-58517-split-photo-reminder.md
+++ b/plans/ravioli-58517-split-photo-reminder.md
@@ -1,0 +1,108 @@
+# ravioli-58517 — Split the receipts reminder into a receipts reminder + a photo reminder
+
+## Goal
+The `/payments` by-city ⋮ menu currently has a single **"Send receipts reminder"** action
+(`crocchetta-92106/92107`) whose Telegram message says *"Make sure you've uploaded receipts
+**and photos** to rsv.pizza/<slug>"* and which persists `parties.receipts_reminder_sent_at`
+(shown as a "Sent {date}" sub-label).
+
+Split this into **two** independent menu actions, each with its own send-history timestamp
+(mirroring the existing **wallet reminder** sibling, which already has this exact shape):
+
+| Action | Telegram message | sent-at column |
+|---|---|---|
+| Send receipts reminder | `Make sure you've uploaded your receipts to rsv.pizza/<slug>` | `receipts_reminder_sent_at` (existing) |
+| **Send photo reminder** (new) | `Make sure you've uploaded your event photos to rsv.pizza/<slug>` | `photo_reminder_sent_at` (new) |
+
+"With the same send history as the others" = the new photo reminder gets a
+`photo_reminder_sent_at` timestamptz column + "Sent {date}" sub-label, identical to receipts
++ wallet.
+
+## Architecture (existing pattern to clone)
+The wallet reminder is the precise template — it is already a sibling clone of the receipts
+reminder. Everywhere `walletReminder` / `wallet_reminder_sent_at` / `tg-wallet-reminder`
+appears, add a parallel `photoReminder` / `photo_reminder_sent_at` / `tg-photo-reminder`.
+
+Both reminders share the `sendTelegramMessage` + `sendCityGroupReminder` helpers and the
+host-DM + city-group two-channel send. No new helpers needed.
+
+## Changes
+
+### DB / Prisma (apply to PROD before merge — preview shares prod backend+DB)
+1. **New migration** `supabase/migrations/20260608_photo_reminder_sent_at.sql`:
+   ```sql
+   -- Track when photo reminders are sent for a party/city.
+   -- Recorded when the TG photo-reminder endpoint successfully sends at least one message.
+   ALTER TABLE parties ADD COLUMN IF NOT EXISTS photo_reminder_sent_at timestamptz;
+   ```
+2. **`backend/prisma/schema.prisma`** (after line 175, next to `walletReminderSentAt`):
+   ```prisma
+   photoReminderSentAt     DateTime? @map("photo_reminder_sent_at") @db.Timestamptz // When admin sent TG photo reminder
+   ```
+
+### Backend — `backend/src/routes/admin-payout.routes.ts`
+3. `partyMetaSelect` (~line 295): add `photoReminderSentAt: true,`.
+4. Both by-party projection sites (~2158-2164 and ~2295-2299): emit
+   `photoReminderSentAt: <...>?.toISOString() ?? null` alongside the wallet one.
+5. **Change the existing receipts message** (~line 6710) from
+   `Make sure you've uploaded receipts and photos to rsv.pizza/${slug}` to
+   `Make sure you've uploaded your receipts to rsv.pizza/${slug}`.
+6. **New endpoint** `POST /:partyId/tg-photo-reminder` — clone of `tg-wallet-reminder`
+   (~line 6772). Identical structure (`requireAuth` + `requireAnyAdminOrPaymentAdmin`,
+   host DM + `sendCityGroupReminder`, per-channel success/skip response), with:
+   - `text = \`Make sure you've uploaded your event photos to rsv.pizza/${slug}\``
+   - persists `data: { photoReminderSentAt: new Date() }` on `hostDmSent || groupSent`
+   - console marker `[tg-photo-reminder] party=... slug=... host_dm=... group=...`
+
+### Frontend — types
+7. **`frontend/src/types.ts`**: add `photoReminderSentAt?: string | null;` in BOTH places
+   next to `walletReminderSentAt` (~line 343 Party type, ~line 2480 by-party projection type).
+
+### Frontend — api
+8. **`frontend/src/lib/api.ts`**: add `sendTgPhotoReminder(partyId)` — clone of
+   `sendTgWalletReminder` (~line 598), POSTing `/api/admin/payouts/${partyId}/tg-photo-reminder`,
+   returns `SendTgReceiptsReminderResponse` (reuse the existing response interface).
+
+### Frontend — `frontend/src/components/payments-admin/PayoutsByPartyTable.tsx`
+Clone every `walletReminder` touchpoint into a `photoReminder` sibling:
+9. Import `sendTgPhotoReminder` (~line 67) and a `Camera` icon from lucide-react (~line 22-29).
+10. `PayoutsByPartyTableProps`: add `onTgPhotoReminderResult?` (clone of `onTgWalletReminderResult`, ~line 280).
+11. `CityActionsMenu`:
+    - props: `onSendPhotoReminder`, `canSendPhotoReminder`, `photoReminderBusy`, `photoReminderSentAt`
+      (clone wallet equivalents in destructure + type block).
+    - state: `const [confirmPhotoReminder, setConfirmPhotoReminder] = useState(false);`
+    - reset `setConfirmPhotoReminder(false)` everywhere `setConfirmWalletReminder(false)` is called
+      (menu open/close + click-out overlay).
+    - `hasMenuItems`: add `|| canSendPhotoReminder`.
+    - new menu `<button>` after the wallet-reminder item (~line 924): two-click confirm, `Camera`
+      icon, label "Send photo reminder" / "Click again to confirm", "Sent {date}" sub-label from
+      `photoReminderSentAt`.
+12. Parent `PayoutsByPartyTable`:
+    - destructure `onTgPhotoReminderResult` (~2826).
+    - state `const [photoReminderBusyPartyId, setPhotoReminderBusyPartyId] = useState<string|null>(null);`
+    - `const canSendPhotoReminder = viewerRole === 'admin';`
+    - `handleSendPhotoReminder(row)` — clone of `handleSendWalletReminder` calling `sendTgPhotoReminder`.
+    - in the render loop: `const photoReminderBusy = photoReminderBusyPartyId === row.party.id;`
+    - `<CityActionsMenu>`: pass `canSendPhotoReminder`, `photoReminderBusy`,
+      `photoReminderSentAt={row.party.photoReminderSentAt}`, and
+      `onSendPhotoReminder={canSendPhotoReminder ? () => handleSendPhotoReminder(row) : undefined}`.
+
+### Frontend — `frontend/src/pages/PaymentsAdminPage.tsx`
+13. Add an `onTgPhotoReminderResult={(_partyId, result) => {...}}` toast handler (~line 1574),
+    cloned from `onTgWalletReminderResult`, toast prefix `Photo reminder:`.
+
+## Out of scope
+- No cron/automation — both reminders stay manual admin actions.
+- No reminders log table — the single sent-at timestamp is the audit trail (matches existing).
+- Underbosses don't see either action (admin-only gate, unchanged).
+
+## Verification
+- `cd frontend && npx tsc --noEmit` and `cd backend && npx tsc --noEmit` clean.
+- Preview: on `/payments` by-city ⋮ menu, two distinct items ("Send receipts reminder",
+  "Send photo reminder"), each two-click-confirm, each showing its own "Sent {date}" after firing.
+- Receipts message no longer mentions photos; photo message mentions only photos.
+
+## Deploy ordering (memory: apply migration before merging Prisma change)
+1. Create `photo_reminder_sent_at` column in PROD (migration SQL).
+2. Merge PR → backend auto-deploys from master.
+3. No backfill needed (new column defaults NULL = "never sent", correct).

--- a/supabase/migrations/20260608_photo_reminder_sent_at.sql
+++ b/supabase/migrations/20260608_photo_reminder_sent_at.sql
@@ -1,0 +1,4 @@
+-- Track when photo reminders are sent for a party/city.
+-- Recorded when the TG photo-reminder endpoint successfully sends at least one message.
+
+ALTER TABLE parties ADD COLUMN IF NOT EXISTS photo_reminder_sent_at timestamptz;


### PR DESCRIPTION
## What
Splits the single **Send receipts reminder** action on the `/payments` by-city ⋮ menu into **two** independent admin actions, each with its own send-history timestamp — mirroring the existing **wallet reminder** sibling.

| Action | Telegram message | sent-at column |
|---|---|---|
| Send receipts reminder | `Make sure you've uploaded your receipts to rsv.pizza/<slug>` | `receipts_reminder_sent_at` (existing) |
| **Send photo reminder** (new) | `Make sure you've uploaded your event photos to rsv.pizza/<slug>` | `photo_reminder_sent_at` (new) |

The old receipts message said *"receipts **and photos**"*; it's now receipts-only, and photos get their own reminder.

## Changes
- **DB**: `supabase/migrations/20260608_photo_reminder_sent_at.sql` — `ALTER TABLE parties ADD COLUMN IF NOT EXISTS photo_reminder_sent_at timestamptz`.
- **Prisma**: `photoReminderSentAt` field on `Party`.
- **Backend** (`admin-payout.routes.ts`): new `POST /:partyId/tg-photo-reminder` (clone of `tg-wallet-reminder`), added to `PartySelect` + both by-party projections; receipts message reworded.
- **Frontend**: `sendTgPhotoReminder` api fn; `Camera`-icon menu item with two-click confirm + "Sent {date}" sub-label; page-level toast handler; `photoReminderSentAt` types.

## Verification
- ✅ **Frontend** `tsc --noEmit` — clean (0 errors).
- ✅ **Backend** `tsc --noEmit` (after `prisma generate`) — clean except 2 **pre-existing, unrelated** errors, both confirmed by reproducing them on unmodified `origin/master`: `auth.test.ts` JWT `expiresIn` overload (untouched test file) and the synthetic-row `as (typeof rows)[number]` TS2352 cast in `admin-payout.routes.ts` (unrelated to the new field — it appears symmetrically on both sides of the cast).
- Underbosses don't see either action (admin-only gate, unchanged).

## ⚠️ Deploy ordering (preview shares prod DB+backend)
1. Create `photo_reminder_sent_at` column in **prod** before merge.
2. Merge → backend auto-deploys from master.
3. No backfill (NULL = "never sent", correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)