### PR TITLE
fix(stromboli-58518): readable amber warning text on gpp-theme + ESLint contrast guard

### DIFF
--- a/frontend/eslint-rules/gpp-theme-text-contrast.js
+++ b/frontend/eslint-rules/gpp-theme-text-contrast.js
@@ -1,0 +1,45 @@
+/**
+ * gpp/text-contrast
+ * Flags warm light text utility classes (text-amber|yellow|orange-100|200) that lack a
+ * [.gpp-theme_&]:text-* dark override. On the light "gpp-theme", `.gpp-theme .card` repaints
+ * the panel white, so these near-white classes wash out to invisible.
+ * Incidents: ricotta-92103, stromboli-58518.
+ */
+const WASHOUT = /\btext-(amber|yellow|orange)-(100|200)(?:\/\d{1,3})?\b/;
+const HAS_OVERRIDE = /\[\.gpp-theme_&\]:text-/;
+
+function check(context, node, raw) {
+  if (typeof raw !== 'string') return;
+  if (WASHOUT.test(raw) && !HAS_OVERRIDE.test(raw)) {
+    context.report({
+      node,
+      messageId: 'washout',
+      data: { cls: raw.match(WASHOUT)[0] },
+    });
+  }
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Warm light text classes need a [.gpp-theme_&]:text-* dark override or they vanish on the light gpp-theme card.',
+    },
+    schema: [],
+    messages: {
+      washout:
+        '"{{cls}}" has no [.gpp-theme_&]:text-* override and washes out to invisible on the light gpp-theme. Add a dark override, e.g. [.gpp-theme_&]:text-amber-900.',
+    },
+  },
+  create(context) {
+    return {
+      Literal(node) {
+        check(context, node, node.value);
+      },
+      TemplateElement(node) {
+        check(context, node, node.value && node.value.raw);
+      },
+    };
+  },
+};

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
+import gppTextContrast from './eslint-rules/gpp-theme-text-contrast.js';
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -24,5 +25,20 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
     },
+  },
+  {
+    // gpp-theme surfaces only: these render under the light .gpp-theme where
+    // near-white amber text washes out. Keep this scope tight to avoid noise.
+    files: [
+      'src/components/payouts/**/*.{ts,tsx}',
+      'src/components/payments-admin/**/*.{ts,tsx}',
+      'src/components/payments-shared/**/*.{ts,tsx}',
+      'src/pages/GPP27CreatePage.tsx',
+      'src/pages/ConsolidatedReportPage.tsx',
+      'src/pages/AdminPage.tsx',
+      'src/pages/DJPage.tsx',
+    ],
+    plugins: { gpp: { rules: { 'text-contrast': gppTextContrast } } },
+    rules: { 'gpp/text-contrast': 'error' },
   }
 );

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -505,7 +505,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                         className="flex items-baseline gap-2 px-2 py-1 rounded bg-amber-500/5 border border-amber-500/20"
                       >
                         <AlertTriangle size={10} className="text-amber-400 shrink-0 self-center" />
-                        <span className="font-mono text-[11px] text-amber-100">{shortAddr}</span>
+                        <span className="font-mono text-[11px] text-amber-100 [.gpp-theme_&]:text-amber-900">{shortAddr}</span>
                         <span className="text-theme-text-muted">
                           ${Number(p.finalAmountUsd).toFixed(2)}
                         </span>

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -580,7 +580,7 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
                 <div className="flex items-start gap-3">
                   <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={18} />
                   <div className="flex-1 text-sm">
-                    <div className="font-medium text-amber-200 mb-1">
+                    <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
                       Heads-up: over per-submission soft cap
                     </div>
                     <div className="text-theme-text-secondary">

--- a/frontend/src/components/payments-admin/HotWalletCard.tsx
+++ b/frontend/src/components/payments-admin/HotWalletCard.tsx
@@ -124,11 +124,11 @@ export const HotWalletCard: React.FC<HotWalletCardProps> = ({ readOnly = false }
       {errorMsg ? (
         <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 flex items-start gap-2">
           <AlertTriangle size={16} className="text-amber-500 shrink-0 mt-0.5" />
-          <div className="text-sm text-amber-200">
+          <div className="text-sm text-amber-200 [.gpp-theme_&]:text-amber-900">
             <div className="font-medium">Hot wallet unavailable</div>
-            <div className="text-amber-200/80 mt-0.5 break-words">{errorMsg}</div>
+            <div className="text-amber-200/80 [.gpp-theme_&]:text-amber-900/80 mt-0.5 break-words">{errorMsg}</div>
             {isUnconfigured && (
-              <div className="text-xs text-amber-200/70 mt-1">
+              <div className="text-xs text-amber-200/70 [.gpp-theme_&]:text-amber-900/70 mt-1">
                 Set <span className="font-mono">USDC_PAYOUT_WALLET_PRIVATE_KEY</span> on backend Vercel
                 and redeploy.
               </div>

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -2323,7 +2323,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                           <div className="flex items-start gap-2.5">
                             <AlertTriangle className="text-amber-300 mt-0.5 flex-shrink-0" size={16} />
                             <div className="flex-1 text-sm">
-                              <div className="font-medium text-amber-200 mb-1">
+                              <div className="font-medium text-amber-200 [.gpp-theme_&]:text-amber-900 mb-1">
                                 Heads-up: over per-submission soft cap
                               </div>
                               <div className="text-theme-text-secondary text-xs">

--- a/frontend/src/components/payments-admin/TaxFormReviewPanel.tsx
+++ b/frontend/src/components/payments-admin/TaxFormReviewPanel.tsx
@@ -87,7 +87,7 @@ export const TaxFormReviewPanel: React.FC<TaxFormReviewPanelProps> = ({ taxFormI
   if (!taxFormId) {
     return (
       <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-3">
-        <div className="flex items-start gap-2 text-xs text-amber-100">
+        <div className="flex items-start gap-2 text-xs text-amber-100 [.gpp-theme_&]:text-amber-900">
           <AlertTriangle size={14} className="mt-0.5 flex-shrink-0 text-amber-300" />
           <div>
             <span className="font-semibold">Tax form</span> — host has not submitted a tax form for this payment.

--- a/frontend/src/components/payouts/tax/W8BENEForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENEForm.tsx
@@ -350,7 +350,7 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
         <div className="card p-3 border-l-4 border-l-amber-500 bg-amber-500/10">
           <div className="flex items-start gap-2.5">
             <AlertTriangle size={16} className="text-amber-300 mt-0.5 flex-shrink-0" />
-            <div className="text-xs text-amber-100">
+            <div className="text-xs text-amber-100 [.gpp-theme_&]:text-amber-900">
               FFIs need to submit a paper form via our admin team; the auto-generated PDF won't satisfy reporting requirements.
             </div>
           </div>
@@ -672,7 +672,7 @@ export const W8BENEForm: React.FC<W8BENEFormProps> = ({ value, onChange, disable
         )}
         {treatyKey && treatyEntry && !treatyEntry.hasTreaty && (
           <div className="card p-2.5 border-l-4 border-l-amber-500 bg-amber-500/10">
-            <div className="flex items-start gap-2 text-[11px] text-amber-100">
+            <div className="flex items-start gap-2 text-[11px] text-amber-100 [.gpp-theme_&]:text-amber-900">
               <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
               <span>
                 No US tax treaty in force with {treatyKey} — leave the treaty fields blank; default

--- a/frontend/src/components/payouts/tax/W8BENForm.tsx
+++ b/frontend/src/components/payouts/tax/W8BENForm.tsx
@@ -428,7 +428,7 @@ export const W8BENForm: React.FC<W8BENFormProps> = ({ value, onChange, disabled,
         )}
         {treatyKey && treatyEntry && !treatyEntry.hasTreaty && (
           <div className="card p-2.5 border-l-4 border-l-amber-500 bg-amber-500/10">
-            <div className="flex items-start gap-2 text-[11px] text-amber-100">
+            <div className="flex items-start gap-2 text-[11px] text-amber-100 [.gpp-theme_&]:text-amber-900">
               <AlertTriangle size={12} className="mt-0.5 flex-shrink-0" />
               <span>
                 No US tax treaty in force with {treatyKey} — leave the treaty fields blank; default


### PR DESCRIPTION
@
## Problem
On the light **gpp-theme** (tax-form creator, payments admin), `.gpp-theme .card` repaints panels white. Amber warning text using `text-amber-100/200` (near-white) with **no** `[.gpp-theme_&]:` override becomes invisible — e.g. the "No US tax treaty in force with {country}" notice. Same class of bug as `ricotta-92103`.

## Fix (2 parts)
**1. 10 washout offenders** — added the established `[.gpp-theme_&]:text-amber-900` dark override (opacity preserved) to each warm-light amber text class. All 10 sit on `bg-amber-500/10|/5|/20` tint surfaces, so the dark override is correct everywhere; the light class is kept for dark theme.
- `payouts/tax/W8BENForm.tsx`, `W8BENEForm.tsx` (×2) — the reported treaty notice + FFI notice
- `payments-admin/`: TaxFormReviewPanel, BulkSendModal, ExternalPaymentModal, PayoutReviewModal, HotWalletCard (×3)

**2. ESLint guard** — new local rule `gpp/text-contrast` (`frontend/eslint-rules/gpp-theme-text-contrast.js`) that **errors** on `text-(amber|yellow|orange)-(100|200)` in a className lacking a `[.gpp-theme_&]:text-*` override. Scoped tightly to gpp-theme surface dirs (payouts, payments-admin, payments-shared, GPP/Admin/DJ/ConsolidatedReport pages) to keep noise ~0. After part 1, 0 violations remain.

## Verify
- Regex logic unit-checked: all 10 fixed classNames pass; `text-white`/`text-amber-300`/`text-amber-500/90`/theme tokens correctly NOT flagged; bare `text-amber-100/200` flagged.
- Manual: open the tax form on gpp-theme → warning text now dark/readable.
- Frontend-only; no backend deploy, no migration.

Plan: `plans/stromboli-58518-gpp-text-contrast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@