### PR TITLE
feat(focaccia-58519): payout photo 25MB cap + upload retry & clear failure UX

### DIFF
--- a/frontend/src/components/payments-admin/AdminAddAttachment.tsx
+++ b/frontend/src/components/payments-admin/AdminAddAttachment.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Loader2, Plus, AlertCircle } from 'lucide-react';
+import { Loader2, Plus, AlertCircle, RotateCw } from 'lucide-react';
 import { uploadPayoutPhoto } from '../../lib/supabase';
 import { addAdminPayoutDocument } from '../../lib/api';
 
@@ -39,12 +39,22 @@ export const AdminAddAttachment: React.FC<AdminAddAttachmentProps> = ({
   const [photoKind, setPhotoKind] = useState<'pizza' | 'event'>('pizza');
   const [status, setStatus] = useState<'idle' | 'uploading' | 'reading'>('idle');
   const [error, setError] = useState<string | null>(null);
+  // focaccia-58519: keep the last picked file so a transient failure can be
+  // retried without re-selecting it.
+  const lastFileRef = useRef<File | null>(null);
 
   const kind: 'receipt' | 'pizza' | 'event' =
     mode === 'receipt' ? 'receipt' : photoKind;
   const busy = status !== 'idle';
 
+  // focaccia-58519: deterministic local-validation rejections aren't retryable.
+  const retryable =
+    !!error &&
+    !error.startsWith('File is too large') &&
+    !error.startsWith('Unsupported file type');
+
   const handleFile = async (file: File) => {
+    lastFileRef.current = file;
     setError(null);
     setStatus('uploading');
     try {
@@ -138,9 +148,23 @@ export const AdminAddAttachment: React.FC<AdminAddAttachmentProps> = ({
       </div>
 
       {error && (
-        <span className="inline-flex items-center gap-1 text-xs text-red-400">
-          <AlertCircle size={12} /> {error}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1 text-xs text-red-400 max-w-[16rem] truncate" title={error}>
+            <AlertCircle size={12} className="flex-shrink-0" /> {error}
+          </span>
+          {retryable && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => {
+                if (lastFileRef.current) handleFile(lastFileRef.current);
+              }}
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-[#ff393a]/15 text-[#ff393a] hover:bg-[#ff393a]/25 disabled:opacity-50 transition-colors"
+            >
+              <RotateCw size={11} /> Retry
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/ExternalPaymentModal.tsx
@@ -18,6 +18,7 @@ import {
   Check,
   AlertTriangle,
   Star,
+  RotateCw,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { SwcHubWarning } from './SwcHubWarning';
@@ -110,6 +111,9 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
   const [uploadedProofUrl, setUploadedProofUrl] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  // focaccia-58519: keep the last picked file so a transient upload failure can
+  // be retried without re-selecting it.
+  const lastUploadFileRef = useRef<File | null>(null);
 
   const [adminNotes, setAdminNotes] = useState('');
 
@@ -257,14 +261,12 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
     setSwcAck(false);
   }
 
-  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  async function uploadProofFile(file: File) {
     if (!partyId.trim()) {
       setUploadError('Pick a party first so we can group the upload correctly.');
-      e.target.value = '';
       return;
     }
+    lastUploadFileRef.current = file;
     setUploadError(null);
     setUploading(true);
     try {
@@ -277,9 +279,22 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
       setUploadError(err?.message || 'Upload failed');
     } finally {
       setUploading(false);
-      e.target.value = '';
     }
   }
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    await uploadProofFile(file);
+  }
+
+  // focaccia-58519: deterministic local-validation rejections aren't retryable.
+  const uploadRetryable =
+    !!uploadError &&
+    !uploadError.startsWith('File is too large') &&
+    !uploadError.startsWith('Unsupported file type') &&
+    !uploadError.startsWith('Pick a party first');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -709,7 +724,21 @@ export const ExternalPaymentModal: React.FC<ExternalPaymentModalProps> = ({
               />
             </label>
             {uploadError && (
-              <p className="text-xs text-red-400">{uploadError}</p>
+              <div className="flex items-center gap-2">
+                <p className="text-xs text-red-400" title={uploadError}>{uploadError}</p>
+                {uploadRetryable && (
+                  <button
+                    type="button"
+                    disabled={uploading}
+                    onClick={() => {
+                      if (lastUploadFileRef.current) uploadProofFile(lastUploadFileRef.current);
+                    }}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-[#ff393a]/15 text-[#ff393a] hover:bg-[#ff393a]/25 disabled:opacity-50 transition-colors"
+                  >
+                    <RotateCw size={11} /> Retry
+                  </button>
+                )}
+              </div>
             )}
             {uploadedProofUrl && (
               <p className="text-xs text-emerald-500 break-all">

--- a/frontend/src/components/payouts/PizzaPhotoUpload.tsx
+++ b/frontend/src/components/payouts/PizzaPhotoUpload.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Loader2, X, Upload, AlertCircle } from 'lucide-react';
+import { Loader2, X, Upload, AlertCircle, RotateCw } from 'lucide-react';
 import { uploadPayoutPhoto } from '../../lib/supabase';
 
 export interface PizzaPhotoItem {
@@ -10,6 +10,25 @@ export interface PizzaPhotoItem {
   fileSize: number;
   mimeType: string;
   error?: string;
+  /**
+   * focaccia-58519: the original File, kept in memory so a failed tile can be
+   * retried without re-picking. Not serialized anywhere (lives only on the
+   * in-flight client item).
+   */
+  file?: File;
+}
+
+/**
+ * focaccia-58519: a failure is retryable unless it's a deterministic
+ * local-validation rejection (too large / unsupported type). Those carry a
+ * known prefix from `uploadPayoutPhoto`'s pre-upload checks.
+ */
+function isRetryableError(error?: string): boolean {
+  if (!error) return true;
+  return !(
+    error.startsWith('File is too large') ||
+    error.startsWith('Unsupported file type')
+  );
 }
 
 interface PizzaPhotoUploadProps {
@@ -51,6 +70,43 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
   const noun = kind === 'event' ? 'event' : 'pizza';
   const remaining = Math.max(0, maxItems - existingCount - items.length);
 
+  /**
+   * focaccia-58519: keep the original File objects reachable for retry, keyed
+   * by item id. Lives in a ref (not serialized into the item list that flows to
+   * the parent). Populated on add; read on retry.
+   */
+  const filesRef = useRef<Map<string, File>>(new Map());
+
+  // Always read the freshest items via a ref so async work that resolves after
+  // multiple onChange calls doesn't clobber sibling updates with a stale list.
+  const itemsRef = useRef<PizzaPhotoItem[]>(items);
+  itemsRef.current = items;
+
+  const patchItem = (itemId: string, patch: Partial<PizzaPhotoItem>) => {
+    const next = itemsRef.current.map(it => (it.id === itemId ? { ...it, ...patch } : it));
+    itemsRef.current = next;
+    onChange(next);
+  };
+
+  const uploadOne = async (file: File, itemId: string) => {
+    try {
+      const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, kind);
+      patchItem(itemId, {
+        status: 'done',
+        url: uploaded.url,
+        fileName: uploaded.fileName,
+        fileSize: uploaded.fileSize,
+        mimeType: uploaded.mimeType,
+        error: undefined,
+      });
+    } catch (err) {
+      patchItem(itemId, {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Upload failed',
+      });
+    }
+  };
+
   const handleFiles = async (files: FileList | File[]) => {
     const fileArr = Array.from(files).slice(0, remaining);
     if (fileArr.length === 0) return;
@@ -62,26 +118,23 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
       fileSize: f.size,
       mimeType: f.type,
     }));
-    let nextItems = [...items, ...newItems];
+    fileArr.forEach((f, i) => filesRef.current.set(newItems[i].id, f));
+    const nextItems = [...itemsRef.current, ...newItems];
+    itemsRef.current = nextItems;
     onChange(nextItems);
 
-    await Promise.all(fileArr.map(async (file, i) => {
-      const itemId = newItems[i].id;
-      try {
-        const uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, kind);
-        nextItems = nextItems.map(it => it.id === itemId
-          ? { ...it, status: 'done' as const, url: uploaded.url,
-              fileName: uploaded.fileName, fileSize: uploaded.fileSize, mimeType: uploaded.mimeType }
-          : it);
-      } catch (err) {
-        nextItems = nextItems.map(it => it.id === itemId
-          ? { ...it, status: 'error' as const, error: err instanceof Error ? err.message : 'Upload failed' } : it);
-      }
-      onChange(nextItems);
-    }));
+    await Promise.all(fileArr.map((file, i) => uploadOne(file, newItems[i].id)));
+  };
+
+  const handleRetry = (itemId: string) => {
+    const file = filesRef.current.get(itemId);
+    if (!file) return;
+    patchItem(itemId, { status: 'uploading', error: undefined });
+    void uploadOne(file, itemId);
   };
 
   const handleRemove = (id: string) => {
+    filesRef.current.delete(id);
     onChange(items.filter(i => i.id !== id));
   };
 
@@ -141,8 +194,25 @@ export const PizzaPhotoUpload: React.FC<PizzaPhotoUploadProps> = ({
               {item.url ? (
                 <img src={item.url} alt="" className="w-full h-full object-cover" />
               ) : item.status === 'error' ? (
-                <div className="w-full h-full flex items-center justify-center text-red-400">
-                  <AlertCircle size={20} />
+                <div className="w-full h-full flex flex-col items-center justify-center gap-1 p-1 text-red-400 text-center">
+                  <AlertCircle size={18} className="flex-shrink-0" />
+                  {item.error && (
+                    <span
+                      className="text-[10px] leading-tight text-red-400 line-clamp-2 w-full"
+                      title={item.error}
+                    >
+                      {item.error}
+                    </span>
+                  )}
+                  {isRetryableError(item.error) && (
+                    <button
+                      type="button"
+                      onClick={() => handleRetry(item.id)}
+                      className="inline-flex items-center gap-1 mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#ff393a]/15 text-[#ff393a] hover:bg-[#ff393a]/25 transition-colors"
+                    >
+                      <RotateCw size={10} /> Retry
+                    </button>
+                  )}
                 </div>
               ) : (
                 <div className="w-full h-full flex items-center justify-center text-theme-text-muted">

--- a/frontend/src/components/payouts/ReceiptUpload.tsx
+++ b/frontend/src/components/payouts/ReceiptUpload.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Loader2, X, Upload, Receipt as ReceiptIcon, AlertCircle, CheckCircle2, FileText, DollarSign, GitMerge, Layers } from 'lucide-react';
+import { Loader2, X, Upload, Receipt as ReceiptIcon, AlertCircle, CheckCircle2, FileText, DollarSign, GitMerge, Layers, RotateCw } from 'lucide-react';
 import { uploadPayoutPhoto } from '../../lib/supabase';
 import { previewReceiptOCR } from '../../lib/api';
 import { OcrPreviewResult, OcrReceiptPreview } from '../../types';
@@ -80,6 +80,19 @@ function toReceiptArray(ocr: OcrPreviewResult): OcrReceiptPreview[] {
   ];
 }
 
+/**
+ * focaccia-58519: a failure is retryable unless it's a deterministic
+ * local-validation rejection (too large / unsupported type) from
+ * `uploadPayoutPhoto`'s pre-upload checks.
+ */
+function isRetryableError(error?: string): boolean {
+  if (!error) return true;
+  return !(
+    error.startsWith('File is too large') ||
+    error.startsWith('Unsupported file type')
+  );
+}
+
 interface ReceiptUploadProps {
   partyId: string;
   payoutTempId: string;
@@ -105,6 +118,68 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
 
   const remaining = maxItems - items.length;
 
+  /**
+   * focaccia-58519: keep the original File objects reachable for per-tile
+   * retry, keyed by item id. Lives in a ref (never serialized into the item
+   * list that flows to the parent).
+   */
+  const filesRef = useRef<Map<string, File>>(new Map());
+
+  // Read freshest items via a ref so async upload/OCR work that resolves out of
+  // order doesn't clobber sibling updates with a stale list snapshot.
+  const itemsRef = useRef<ReceiptItem[]>(items);
+  itemsRef.current = items;
+
+  const patchItem = (itemId: string, patch: Partial<ReceiptItem>) => {
+    const next = updateItem(itemsRef.current, itemId, patch);
+    itemsRef.current = next;
+    onChange(next);
+  };
+
+  // Upload a single file then run OCR. Reused for the initial parallel pass and
+  // for retrying one failed tile.
+  const uploadOne = async (file: File, itemId: string) => {
+    let uploaded: Awaited<ReturnType<typeof uploadPayoutPhoto>>;
+    try {
+      uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, 'receipt');
+    } catch (err) {
+      patchItem(itemId, {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Upload failed',
+      });
+      return;
+    }
+    patchItem(itemId, {
+      status: 'ocring',
+      url: uploaded.url,
+      fileName: uploaded.fileName,
+      fileSize: uploaded.fileSize,
+      mimeType: uploaded.mimeType,
+      error: undefined,
+    });
+
+    try {
+      // bocconcino-92104: PDFs can't be OCR'd directly by gpt-4o vision
+      // (image-only). Hand the OCR pipeline the convention-derived
+      // `.thumb.png` rendered at upload time instead. The backend uses the
+      // same derivation in its ocr-preview / POST /payouts handlers.
+      const ocrUrl = uploaded.mimeType === 'application/pdf'
+        ? derivePdfThumbnailUrl(uploaded.url)
+        : uploaded.url;
+      const ocr = await previewReceiptOCR(partyId, ocrUrl);
+      patchItem(itemId, {
+        status: 'done',
+        receipts: toReceiptArray(ocr),
+        error: undefined,
+      });
+    } catch (err: any) {
+      patchItem(itemId, {
+        status: 'error',
+        error: err?.message || 'OCR failed',
+      });
+    }
+  };
+
   const handleFiles = async (files: FileList | File[]) => {
     const fileArr = Array.from(files).slice(0, remaining);
     if (fileArr.length === 0) return;
@@ -117,57 +192,24 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
       fileSize: f.size,
       mimeType: f.type,
     }));
-    let nextItems = [...items, ...newItems];
+    fileArr.forEach((f, i) => filesRef.current.set(newItems[i].id, f));
+    const nextItems = [...itemsRef.current, ...newItems];
+    itemsRef.current = nextItems;
     onChange(nextItems);
 
     // Upload each file in parallel, then run OCR.
-    await Promise.all(fileArr.map(async (file, i) => {
-      const itemId = newItems[i].id;
-      let uploaded: Awaited<ReturnType<typeof uploadPayoutPhoto>>;
-      try {
-        uploaded = await uploadPayoutPhoto(file, partyId, payoutTempId, 'receipt');
-      } catch (err) {
-        nextItems = updateItem(nextItems, itemId, {
-          status: 'error',
-          error: err instanceof Error ? err.message : 'Upload failed',
-        });
-        onChange(nextItems);
-        return;
-      }
-      nextItems = updateItem(nextItems, itemId, {
-        status: 'ocring',
-        url: uploaded.url,
-        fileName: uploaded.fileName,
-        fileSize: uploaded.fileSize,
-        mimeType: uploaded.mimeType,
-      });
-      onChange(nextItems);
+    await Promise.all(fileArr.map((file, i) => uploadOne(file, newItems[i].id)));
+  };
 
-      try {
-        // bocconcino-92104: PDFs can't be OCR'd directly by gpt-4o vision
-        // (image-only). Hand the OCR pipeline the convention-derived
-        // `.thumb.png` rendered at upload time instead. The backend uses the
-        // same derivation in its ocr-preview / POST /payouts handlers.
-        const ocrUrl = uploaded.mimeType === 'application/pdf'
-          ? derivePdfThumbnailUrl(uploaded.url)
-          : uploaded.url;
-        const ocr = await previewReceiptOCR(partyId, ocrUrl);
-        nextItems = updateItem(nextItems, itemId, {
-          status: 'done',
-          receipts: toReceiptArray(ocr),
-        });
-        onChange(nextItems);
-      } catch (err: any) {
-        nextItems = updateItem(nextItems, itemId, {
-          status: 'error',
-          error: err?.message || 'OCR failed',
-        });
-        onChange(nextItems);
-      }
-    }));
+  const handleRetry = (itemId: string) => {
+    const file = filesRef.current.get(itemId);
+    if (!file) return;
+    patchItem(itemId, { status: 'uploading', error: undefined });
+    void uploadOne(file, itemId);
   };
 
   const handleRemove = (id: string) => {
+    filesRef.current.delete(id);
     onChange(items.filter(i => i.id !== id));
   };
 
@@ -309,12 +351,25 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
                         and is NOT submitted — make that unambiguous so the host
                         removes + re-uploads instead of assuming it counted. */}
                     {item.status === 'error' && (
-                      <span className="inline-flex items-start gap-1 text-red-400">
-                        <AlertCircle size={12} className="mt-0.5 flex-shrink-0" />
-                        <span>
-                          This receipt didn't save — remove it and re-upload.
-                          {item.error ? ` (${item.error})` : ''}
+                      <span className="flex flex-col items-start gap-1 text-red-400">
+                        <span className="inline-flex items-start gap-1">
+                          <AlertCircle size={12} className="mt-0.5 flex-shrink-0" />
+                          <span className="truncate" title={item.error || undefined}>
+                            {isRetryableError(item.error)
+                              ? "This receipt didn't save — retry or remove it."
+                              : "This receipt didn't save — remove it and re-upload."}
+                            {item.error ? ` (${item.error})` : ''}
+                          </span>
                         </span>
+                        {isRetryableError(item.error) && (
+                          <button
+                            type="button"
+                            onClick={() => handleRetry(item.id)}
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-[#ff393a]/15 text-[#ff393a] hover:bg-[#ff393a]/25 transition-colors"
+                          >
+                            <RotateCw size={11} /> Retry
+                          </button>
+                        )}
                       </span>
                     )}
                   </div>

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -298,7 +298,7 @@ export async function uploadReceipt(file: File, partyId: string): Promise<string
     return null;
   }
 
-  const maxSize = 10 * 1024 * 1024; // 10MB
+  const maxSize = 25 * 1024 * 1024; // 25MB
   if (file.size > maxSize) {
     console.error('Receipt file too large:', file.size);
     return null;
@@ -386,10 +386,10 @@ export async function uploadPayoutPhoto(
     console.error('Invalid file type for payout photo:', file.type);
     throw new Error(`Unsupported file type: ${file.type || 'unknown'}. Accepted: JPEG, PNG, WebP, HEIC, PDF.`);
   }
-  const maxSize = 10 * 1024 * 1024; // 10MB
+  const maxSize = 25 * 1024 * 1024; // 25MB
   if (file.size > maxSize) {
     console.error('Payout photo too large:', file.size);
-    throw new Error(`File is too large (${(file.size / 1048576).toFixed(1)}MB). Max 10MB.`);
+    throw new Error(`File is too large (${(file.size / 1048576).toFixed(1)}MB). Max 25MB.`);
   }
 
   // schiacciata-71042: convert HEIC->JPEG client-side before upload. iPhone
@@ -421,14 +421,64 @@ export async function uploadPayoutPhoto(
     const rand = Math.random().toString(36).substring(7);
     const path = `payouts/${partyId}/${payoutTempId}/${kind}/${timestamp}-${rand}.${fileExt}`;
 
-    const { error } = await supabase.storage
-      .from('event-images')
-      .upload(path, uploadBlob, { cacheControl: '3600', upsert: false, contentType: uploadMime });
+    // focaccia-58519: transient Supabase Storage blips (HTTP 520, network
+    // hiccups) were surfacing to the host as a bare red error icon with no
+    // retry. Wrap the upload in a small retry loop that ONLY re-attempts
+    // transient failures (5xx / network / timeout). Deterministic failures
+    // (413 too-large, 415 unsupported-type) throw immediately.
+    async function uploadWithRetry(): Promise<void> {
+      const maxAttempts = 3; // initial + 2 retries
+      const backoffs = [600, 1800]; // ms before retry 1 and retry 2
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        let uploadError: any = null;
+        try {
+          const { error } = await supabase.storage
+            .from('event-images')
+            .upload(path, uploadBlob, { cacheControl: '3600', upsert: false, contentType: uploadMime });
+          uploadError = error;
+        } catch (netErr) {
+          // A thrown error (network/fetch failure) is treated like a transient
+          // upload error so the same classification + retry logic applies.
+          uploadError = netErr;
+        }
 
-    if (error) {
-      console.error('Error uploading payout photo:', error);
-      throw new Error(error.message);
+        if (!uploadError) return; // success
+
+        // Classify. statusCode may be a string ("520") or number; message may
+        // hint at a transient failure even when the status is unknown.
+        const rawStatus = (uploadError as any)?.statusCode ?? (uploadError as any)?.status;
+        const status = rawStatus != null ? parseInt(String(rawStatus), 10) : NaN;
+        const message = String((uploadError as any)?.message ?? '');
+        const lowerMsg = message.toLowerCase();
+
+        // Deterministic — never retry.
+        if (status === 413 || status === 415) {
+          console.error('Error uploading payout photo (non-retryable):', uploadError);
+          throw new Error(message || 'Upload failed');
+        }
+
+        const transientByStatus = status >= 500 && status <= 599; // includes 520
+        const transientByMessage =
+          /520|fetch|network|timeout/.test(lowerMsg) ||
+          (Number.isNaN(status) && lowerMsg !== '');
+        const isTransient = transientByStatus || transientByMessage;
+
+        const isLastAttempt = attempt === maxAttempts;
+        if (!isTransient || isLastAttempt) {
+          console.error('Error uploading payout photo:', uploadError);
+          throw new Error(message || 'Upload failed');
+        }
+
+        // Transient + attempts remaining — back off and retry.
+        console.warn(
+          `Transient payout photo upload error (attempt ${attempt}/${maxAttempts}), retrying:`,
+          message || uploadError,
+        );
+        await new Promise(r => setTimeout(r, backoffs[attempt - 1] ?? 1800));
+      }
     }
+
+    await uploadWithRetry();
 
     const { data: urlData } = supabase.storage
       .from('event-images')

--- a/supabase/migrations/20260609000000_focaccia_58519_bump_event_images_25mb.sql
+++ b/supabase/migrations/20260609000000_focaccia_58519_bump_event_images_25mb.sql
@@ -1,0 +1,3 @@
+-- focaccia-58519: bump event-images bucket file_size_limit from 10MB to 25MB
+-- (already applied to prod manually; this is the tracked record). Mirrors nduja-58296.
+UPDATE storage.buckets SET file_size_limit = 26214400 WHERE id = 'event-images';


### PR DESCRIPTION
Fixes Cordoba (and the broad class of) payout-photo upload failures on `/payments`.

## What broke
1. **10MB cap** rejected 11MB phone photos (`Payout photo too large` in console). Modern phones routinely shoot 10-12MB.
2. **Transient Supabase Storage HTTP 520** blips showed only a bare red icon — no message, no retry — so the host had no idea what happened.

## Changes (frontend-only + record-only migration)
- **Cap 10MB -> 25MB** in `uploadPayoutPhoto` + `uploadReceipt` (matches the `event-photos` bucket). Left `uploadVenuePhoto` untouched (different bucket).
- **Silent auto-retry** centralized in `uploadPayoutPhoto`: 3 attempts, 600ms/1800ms backoff, **transient-only** (5xx/520/network). Never retries 413/415.
- **Tile failure UX + per-file retry** in host components (`PizzaPhotoUpload`, `ReceiptUpload`) and admin (`AdminAddAttachment`, `ExternalPaymentModal`): show the failure reason + a **Retry** button that re-uploads just that file (ReceiptUpload re-runs OCR). Retry hidden for deterministic errors (too large / wrong type).
- **Migration** `..._focaccia_58519_bump_event_images_25mb.sql` — record-only; the prod `event-images` bucket limit was already raised to 25MB out-of-band.

## Prod state
- ✅ `event-images` bucket `file_size_limit` already `26214400` (25MB) in prod.
- Frontend-only — **no backend deploy needed**. Preview fully exercises it.

## Verify on preview
Upload a ~15MB JPEG on a test event's Fotos / receipts tab -> succeeds (previously rejected at 10MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
