### PR TITLE
feat(tortellini-58520): structured error log on POST /payouts submit failure

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -1713,6 +1713,21 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
 
     res.status(201).json({ payout: serializePayout(payout) });
   } catch (error) {
+    // tortellini-58520: structured capture so the next prod 500 on payout
+    // submit is diagnosable from Vercel logs (cause was opaque before).
+    const e = error as any;
+    const b = (req.body || {}) as any;
+    console.error('[payouts] POST submit failed', {
+      partyId: req.params.partyId,
+      userId: req.userId,
+      code: e?.code,
+      statusCode: e?.statusCode,
+      message: e?.message,
+      pizzaPhotos: Array.isArray(b.pizzaPhotos) ? b.pizzaPhotos.length : undefined,
+      eventPhotos: Array.isArray(b.eventPhotos) ? b.eventPhotos.length : undefined,
+      receiptPhotos: Array.isArray(b.receiptPhotos) ? b.receiptPhotos.length : undefined,
+      stack: e?.stack,
+    });
     next(error);
   }
 });


### PR DESCRIPTION
Diagnostic-only follow-up to #966 / the Cordoba payout-upload incident.

The `POST /:partyId/payouts` submit handler was returning opaque 500s (seen in the Cordoba console) that couldn't be traced — `vercel logs` only streams live, and the catch block delegated straight to `next(error)` with no context.

## Change
Single edit in `backend/src/routes/payout.routes.ts` — the handler's final `catch` now logs one structured `console.error('[payouts] POST submit failed', {...})` line before `next(error)`, capturing:
- `partyId`, `userId`
- error `code` / `statusCode` / `message` / `stack`
- guarded `pizzaPhotos` / `eventPhotos` / `receiptPhotos` counts

No response change, no behavior change, no new imports (1 file, +15 lines). The next prod 500 on this endpoint will be fully diagnosable from Vercel logs.

## Deploy
Backend-only — **auto-deploys from master on merge** (~1 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
