### PR TITLE
fix(panzerotti-58519): readable colored text on gpp-theme + broaden contrast guard + checkbox

### DIFF
--- a/frontend/eslint-rules/gpp-theme-text-contrast.js
+++ b/frontend/eslint-rules/gpp-theme-text-contrast.js
@@ -1,45 +1,52 @@
 /**
- * gpp/text-contrast
- * Flags warm light text utility classes (text-amber|yellow|orange-100|200) that lack a
- * [.gpp-theme_&]:text-* dark override. On the light "gpp-theme", `.gpp-theme .card` repaints
- * the panel white, so these near-white classes wash out to invisible.
- * Incidents: ricotta-92103, stromboli-58518.
+ * gpp/text-contrast       (config: error) — all hues at shade 100|200
+ * gpp/text-contrast-300   (config: warn)  — all hues at shade 300
+ * Flags light colored text classes lacking a [.gpp-theme_&]:text-* dark override.
+ * On the light gpp-theme, `.gpp-theme .card` is white, so these wash out.
+ * Incidents: ricotta-92103, stromboli-58518, panzerotti-58519.
  */
-const WASHOUT = /\btext-(amber|yellow|orange)-(100|200)(?:\/\d{1,3})?\b/;
+const HUES =
+  'amber|yellow|orange|red|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|lime';
 const HAS_OVERRIDE = /\[\.gpp-theme_&\]:text-/;
 
-function check(context, node, raw) {
-  if (typeof raw !== 'string') return;
-  if (WASHOUT.test(raw) && !HAS_OVERRIDE.test(raw)) {
-    context.report({
-      node,
-      messageId: 'washout',
-      data: { cls: raw.match(WASHOUT)[0] },
-    });
-  }
+function makeRule(shadeAlt) {
+  const re = new RegExp(`\\btext-(?:${HUES})-(?:${shadeAlt})(?:\\/\\d{1,3})?\\b`);
+  return {
+    meta: {
+      type: 'problem',
+      docs: {
+        description:
+          'Light colored text needs a [.gpp-theme_&]:text-* dark override or it washes out on the light gpp-theme card.',
+      },
+      schema: [],
+      messages: {
+        washout:
+          '"{{cls}}" has no [.gpp-theme_&]:text-* override and is low-contrast/invisible on the light gpp-theme card. Add a dark override, e.g. [.gpp-theme_&]:text-<hue>-800.',
+      },
+    },
+    create(context) {
+      function check(node, raw) {
+        if (typeof raw !== 'string') return;
+        const m = raw.match(re);
+        if (m && !HAS_OVERRIDE.test(raw)) {
+          context.report({ node, messageId: 'washout', data: { cls: m[0] } });
+        }
+      }
+      return {
+        Literal(node) {
+          check(node, node.value);
+        },
+        TemplateElement(node) {
+          check(node, node.value && node.value.raw);
+        },
+      };
+    },
+  };
 }
 
-export default {
-  meta: {
-    type: 'problem',
-    docs: {
-      description:
-        'Warm light text classes need a [.gpp-theme_&]:text-* dark override or they vanish on the light gpp-theme card.',
-    },
-    schema: [],
-    messages: {
-      washout:
-        '"{{cls}}" has no [.gpp-theme_&]:text-* override and washes out to invisible on the light gpp-theme. Add a dark override, e.g. [.gpp-theme_&]:text-amber-900.',
-    },
-  },
-  create(context) {
-    return {
-      Literal(node) {
-        check(context, node, node.value);
-      },
-      TemplateElement(node) {
-        check(context, node, node.value && node.value.raw);
-      },
-    };
-  },
+export const rules = {
+  'text-contrast': makeRule('100|200'),
+  'text-contrast-300': makeRule('300'),
 };
+
+export default { rules };

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -38,7 +38,10 @@ export default tseslint.config(
       'src/pages/AdminPage.tsx',
       'src/pages/DJPage.tsx',
     ],
-    plugins: { gpp: { rules: { 'text-contrast': gppTextContrast } } },
-    rules: { 'gpp/text-contrast': 'error' },
+    plugins: { gpp: { rules: gppTextContrast.rules } },
+    rules: {
+      'gpp/text-contrast': 'error',
+      'gpp/text-contrast-300': 'warn',
+    },
   }
 );

--- a/frontend/src/components/Checkbox.tsx
+++ b/frontend/src/components/Checkbox.tsx
@@ -29,7 +29,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       {checked ? (
         <CheckSquare2 size={size} className="text-[#ff393a] flex-shrink-0" />
       ) : (
-        <SquareIcon size={size} className="text-theme-text-muted flex-shrink-0" />
+        <SquareIcon size={size} className="text-theme-text-secondary flex-shrink-0" />
       )}
       <span className={labelClassName}>{label}</span>
       {children}

--- a/frontend/src/components/payments-admin/BulkSendModal.tsx
+++ b/frontend/src/components/payments-admin/BulkSendModal.tsx
@@ -626,8 +626,8 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                     key={r.id}
                     className={`flex items-start gap-2 px-3 py-2 rounded-lg text-sm border ${
                       isPaid
-                        ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-100'
-                        : 'bg-red-500/10 border-red-500/30 text-red-100'
+                        ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-100 [.gpp-theme_&]:text-emerald-800'
+                        : 'bg-red-500/10 border-red-500/30 text-red-100 [.gpp-theme_&]:text-red-800'
                     }`}
                   >
                     {isPaid ? (
@@ -651,7 +651,7 @@ export const BulkSendModal: React.FC<BulkSendModalProps> = ({
                         )}
                       </div>
                       {!isPaid && r.error && (
-                        <p className="text-xs mt-1 break-words text-red-200/90">{r.error}</p>
+                        <p className="text-xs mt-1 break-words text-red-200/90 [.gpp-theme_&]:text-red-800/90">{r.error}</p>
                       )}
                     </div>
                   </li>

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -2345,7 +2345,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                         <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10">
                           <div className="flex items-start gap-2.5">
                             <AlertTriangle className="text-red-300 mt-0.5 flex-shrink-0" size={16} />
-                            <div className="flex-1 text-sm text-red-100">
+                            <div className="flex-1 text-sm text-red-100 [.gpp-theme_&]:text-red-800">
                               {saveAmountError}
                             </div>
                           </div>
@@ -3667,7 +3667,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               // LIGHT_PANEL_INPUT on the inputs here — they use the native dark
               // styling.
               <div className="rounded-xl border border-blue-500/30 p-3 bg-blue-500/10 text-sm space-y-2">
-                <h3 className="font-semibold text-blue-200 mb-1">Mark as paid (manual)</h3>
+                <h3 className="font-semibold text-blue-200 [.gpp-theme_&]:text-blue-800 mb-1">Mark as paid (manual)</h3>
                 {payout.payoutMethod === 'wire' && (
                   <IconInput
                     icon={Pencil}

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -1033,7 +1033,7 @@ function CityActionsMenu({
                               aria-label={`Remove tag ${label}`}
                               disabled={tagBusy}
                               onClick={() => onRemoveCustomTag?.(label)}
-                              className="text-indigo-300/70 hover:text-indigo-200 disabled:opacity-50"
+                              className="text-indigo-300/70 hover:text-indigo-200 [.gpp-theme_&]:text-indigo-700 [.gpp-theme_&]:hover:text-indigo-900 disabled:opacity-50"
                             >
                               <XCircle size={12} />
                             </button>

--- a/frontend/src/components/payments-admin/TaxFormReviewPanel.tsx
+++ b/frontend/src/components/payments-admin/TaxFormReviewPanel.tsx
@@ -152,7 +152,7 @@ export const TaxFormReviewPanel: React.FC<TaxFormReviewPanelProps> = ({ taxFormI
             <div className="text-xs text-theme-text-muted">No PDF available.</div>
           )}
           {form.status === 'rejected' && form.rejectedReason && (
-            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200">
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200 [.gpp-theme_&]:text-red-800">
               Rejection reason: {form.rejectedReason}
             </div>
           )}
@@ -229,9 +229,9 @@ export const TaxFormReviewPanel: React.FC<TaxFormReviewPanelProps> = ({ taxFormI
 const StatusPill: React.FC<{ status: TaxForm['status'] }> = ({ status }) => {
   const styles: Record<TaxForm['status'], string> = {
     draft: 'bg-theme-surface-hover text-theme-text-muted',
-    submitted: 'bg-blue-500/15 text-blue-200',
-    verified: 'bg-emerald-500/15 text-emerald-200',
-    rejected: 'bg-red-500/15 text-red-200',
+    submitted: 'bg-blue-500/15 text-blue-200 [.gpp-theme_&]:text-blue-800',
+    verified: 'bg-emerald-500/15 text-emerald-200 [.gpp-theme_&]:text-emerald-800',
+    rejected: 'bg-red-500/15 text-red-200 [.gpp-theme_&]:text-red-800',
   };
   return (
     <span

--- a/frontend/src/components/payments-shared/AuthenticityPanel.tsx
+++ b/frontend/src/components/payments-shared/AuthenticityPanel.tsx
@@ -37,19 +37,19 @@ const VERDICT_META: Record<
   authentic: {
     label: 'Likely authentic',
     Icon: ShieldCheck,
-    classes: 'bg-emerald-500/15 border-emerald-500/40 text-emerald-300',
+    classes: 'bg-emerald-500/15 border-emerald-500/40 text-emerald-300 [.gpp-theme_&]:text-emerald-800',
     dot: 'bg-emerald-500',
   },
   suspicious: {
     label: 'Suspicious — needs review',
     Icon: ShieldAlert,
-    classes: 'bg-purple-500/15 border-purple-500/40 text-purple-200',
+    classes: 'bg-purple-500/15 border-purple-500/40 text-purple-200 [.gpp-theme_&]:text-purple-800',
     dot: 'bg-purple-500',
   },
   likely_fake: {
     label: 'Likely AI-generated / doctored',
     Icon: ShieldX,
-    classes: 'bg-fuchsia-600/20 border-fuchsia-500/50 text-fuchsia-200',
+    classes: 'bg-fuchsia-600/20 border-fuchsia-500/50 text-fuchsia-200 [.gpp-theme_&]:text-fuchsia-800',
     dot: 'bg-fuchsia-500',
   },
 };
@@ -125,14 +125,14 @@ export const AuthenticityPanel: React.FC<AuthenticityPanelProps> = ({
     return (
       <div className={`rounded-lg border border-purple-500/30 bg-purple-500/5 ${pad} space-y-1.5`}>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs font-semibold text-purple-200 inline-flex items-center gap-1.5">
+          <span className="text-xs font-semibold text-purple-200 [.gpp-theme_&]:text-purple-800 inline-flex items-center gap-1.5">
             <Sparkles size={12} /> Image authenticity
           </span>
           <button
             type="button"
             onClick={() => run(false)}
             disabled={loading}
-            className="px-2.5 py-1 rounded border border-purple-500/40 text-purple-200 text-xs disabled:opacity-40 inline-flex items-center gap-1.5 hover:bg-purple-500/10"
+            className="px-2.5 py-1 rounded border border-purple-500/40 text-purple-200 [.gpp-theme_&]:text-purple-800 text-xs disabled:opacity-40 inline-flex items-center gap-1.5 hover:bg-purple-500/10"
             title="Run an AI-generated / doctored check on this image"
           >
             {loading ? <Loader2 size={12} className="animate-spin" /> : <ShieldCheck size={12} />}

--- a/frontend/src/components/payouts/TaxFormSection.tsx
+++ b/frontend/src/components/payouts/TaxFormSection.tsx
@@ -214,7 +214,7 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
         </div>
         {editorBody}
         {error && (
-          <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10 text-xs text-red-200">
+          <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10 text-xs text-red-200 [.gpp-theme_&]:text-red-800">
             {error}
           </div>
         )}
@@ -324,7 +324,7 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
               </div>
             )}
             {rejected && currentForm.rejectedReason && (
-              <div className="text-xs text-red-200 mt-1">
+              <div className="text-xs text-red-200 [.gpp-theme_&]:text-red-800 mt-1">
                 Reason: {currentForm.rejectedReason}
               </div>
             )}
@@ -375,7 +375,7 @@ export const TaxFormSection: React.FC<TaxFormSectionProps> = ({ autoOpenFormType
       </div>
       {error && !editingType && (
         <div className="card p-3 border-l-4 border-l-red-500 bg-red-500/10">
-          <div className="flex items-start gap-2 text-xs text-red-200">
+          <div className="flex items-start gap-2 text-xs text-red-200 [.gpp-theme_&]:text-red-800">
             <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
             <div>{error}</div>
           </div>

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -2153,8 +2153,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 key={t.id}
                 className={`pointer-events-auto rounded-lg px-4 py-3 text-sm shadow-lg border-l-4 ${
                   t.kind === 'success'
-                    ? 'bg-emerald-500/15 border-emerald-500 text-emerald-100'
-                    : 'bg-red-500/15 border-red-500 text-red-100'
+                    ? 'bg-emerald-500/15 border-emerald-500 text-emerald-100 [.gpp-theme_&]:text-emerald-800'
+                    : 'bg-red-500/15 border-red-500 text-red-100 [.gpp-theme_&]:text-red-800'
                 }`}
               >
                 {t.message}


### PR DESCRIPTION
@
Follow-on to #965 (stromboli-58518). That fixed amber/yellow/orange washouts; an audit found the **same class of bug in other hues** (red/emerald/purple/blue/fuchsia/indigo) that the amber-only rule didnt catch — plus an invisible checkbox.

## Fixes
**1. 19 colored-text washouts** — error/status text + verdict badges using `text-{hue}-100|200` (e.g. `text-red-100` #fecaca ≈1.9:1, `text-emerald-300` ≈1.4:1 on the white gpp card) now carry a `[.gpp-theme_&]:text-{hue}-800` dark override (opacity preserved; hover states handled). Files: BulkSendModal, PayoutReviewModal, PayoutsByPartyTable, TaxFormReviewPanel, AuthenticityPanel, TaxFormSection, PaymentsAdminPage.

**2. Shared `Checkbox`** — the unchecked `Square` used `text-theme-text-muted` (#777 on gpp, near-invisible next to the bright-red checked state). Bumped to `text-theme-text-secondary` (#444 gpp / white@0.68 dark). Fixes the reported invisible "Pay without a receipt" checkbox on SendPaymentModal; improves every checkbox app-wide.

**3. Broadened the ESLint guard** — `gpp/text-contrast` now covers **all 17 hues**, split by severity:
- **error** on shade 100/200 (true invisibles) — 0 violations after the fixes above.
- **warn** on shade 300 (borderline, ~64 spots, mostly icons) — surfaced in lint for opportunistic cleanup, does not fail `eslint .` (no `--max-warnings`).

## Not touched (deliberately)
`text-white/X`, `border-white/X`, `bg-white/X` are globally remapped under gpp (`index.css:469-490`) to the correct grays — they are NOT washouts. The original audit over-flagged them; verified and excluded.

## Verify
- Error-tier grep on the branch = 0; warn-tier = 64; rule file syntax-checked.
- Manual: SendPaymentModal checkbox + AuthenticityPanel verdict badges readable on gpp-theme.
- Frontend-only; no backend deploy / migration.

Plan: `plans/panzerotti-58519-gpp-colored-text-contrast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@