### PR TITLE
OCR cost/accuracy upgrade + non-English receipt summary (bruschetta-58519)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2062,6 +2062,13 @@ model PayoutDocument {
   sourceReceiptIndex Int?    @map("source_receipt_index")
   sourceReceiptCount Int?    @map("source_receipt_count")
   boundingHint       String? @map("bounding_hint")
+  // bruschetta-58519: OCR-supplied ISO-639-1 language of the receipt's PRINTED
+  // text ("en","es","ja","uk"...) and a short ≤140-char ENGLISH summary of what
+  // the receipt is for. Both nullable; populated at OCR time + on-demand via the
+  // admin "Summarize" backfill endpoint. Non-English receipts surface the
+  // language tag + English summary on /payments so admins can review at a glance.
+  ocrLanguage        String? @map("ocr_language")
+  ocrSummary         String? @map("ocr_summary")
   createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   // napoletana-58210: thumbs-up voting on payout pizza photos surfaced in

--- a/backend/src/lib/privateConfig.test.ts
+++ b/backend/src/lib/privateConfig.test.ts
@@ -284,6 +284,8 @@ describe('getLlmModels', () => {
     mockPrisma.appConfig.findUnique.mockResolvedValue(null);
     expect(await getLlmModels()).toEqual({
       ocr: 'gpt-4o',
+      // bruschetta-58519: cheap first-pass OCR model (cost routing).
+      ocrCheap: 'gpt-4o-mini',
       visionPrimary: 'gpt-4o',
       assistant: 'gpt-4o-mini',
       visionSecondOpinion: 'claude-3-5-sonnet-latest',

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -465,6 +465,15 @@ export function getOperationalLimits(): Promise<OperationalLimits> {
 export interface LlmModels {
   /** Receipt OCR (OpenAI chat-completions vision, json_object). */
   ocr: string;
+  /**
+   * bruschetta-58519: cheaper first-pass receipt OCR model (cost routing). The
+   * OCR service runs this first and ESCALATES to `ocr` only when the cheap pass
+   * looks weak (null/≤0 amount, null currency, confidence<0.6, sum(lineItems)
+   * vs amount mismatch, or zero receipts parsed). KILL SWITCH: set this equal to
+   * `ocr` ("gpt-4o") in app_config and the first pass is already strong, so
+   * nothing escalates — model routing is effectively disabled with no deploy.
+   */
+  ocrCheap: string;
   /** Primary receipt-image authenticity vision verdict (OpenAI). */
   visionPrimary: string;
   /** Event-edit assistant (OpenAI tool-calling). Intentionally the cheaper tier. */
@@ -490,6 +499,9 @@ export interface LlmModels {
 export function getLlmModels(): Promise<LlmModels> {
   return getConfig<LlmModels>(KEYS.llmModels, {
     ocr: 'gpt-4o',
+    // bruschetta-58519: cheap first-pass OCR (cost routing). Set equal to `ocr`
+    // in app_config to disable routing (no escalation) without a deploy.
+    ocrCheap: 'gpt-4o-mini',
     visionPrimary: 'gpt-4o',
     assistant: 'gpt-4o-mini',
     visionSecondOpinion: 'claude-3-5-sonnet-latest',

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -854,6 +854,9 @@ function serializePayout(row: any): any {
       sourceReceiptIndex: d.sourceReceiptIndex ?? null,
       sourceReceiptCount: d.sourceReceiptCount ?? null,
       boundingHint: d.boundingHint ?? null,
+      // bruschetta-58519: OCR language (ISO-639-1) + English summary.
+      ocrLanguage: d.ocrLanguage ?? null,
+      ocrSummary: d.ocrSummary ?? null,
       // culatello-92104: admin-flagged duplicate receipts. Reviewer modal
       // dims these rows + excludes them from the OCR sum + the host PATCH
       // finalAmountUsd recompute path.
@@ -5917,6 +5920,9 @@ router.patch(
           sourceReceiptIndex: updated.sourceReceiptIndex ?? null,
           sourceReceiptCount: updated.sourceReceiptCount ?? null,
           boundingHint: updated.boundingHint ?? null,
+          // bruschetta-58519: echo OCR language + English summary.
+          ocrLanguage: updated.ocrLanguage ?? null,
+          ocrSummary: updated.ocrSummary ?? null,
           uploadedByUserId: updated.uploadedByUserId ?? null,
         },
       });
@@ -6038,6 +6044,10 @@ router.post(
             where: { id: doc.id },
             data: {
               ocrLineItems: (result.lineItems ?? []) as unknown as Prisma.InputJsonValue,
+              // bruschetta-58519: additive — populate language + English summary
+              // alongside line items (new columns, no prior admin value to clobber).
+              ocrLanguage: result.language ? sanitizePgString(result.language) : null,
+              ocrSummary: result.summary ? sanitizePgString(result.summary) : null,
               ocrAttemptedAt: new Date(),
               ocrAttemptCount: { increment: 1 },
               ocrError: null,
@@ -6188,6 +6198,10 @@ router.post(
               exchangeRate: unresolved
                 ? null
                 : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
+              // bruschetta-58519: refresh OCR language + English summary on a
+              // full re-read (sanitized).
+              ocrLanguage: result.language ? sanitizePgString(result.language) : null,
+              ocrSummary: result.summary ? sanitizePgString(result.summary) : null,
               ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
               ocrAttemptedAt: new Date(),
               ocrAttemptCount: { increment: 1 },
@@ -6231,6 +6245,9 @@ router.post(
           sourceReceiptIndex: true,
           sourceReceiptCount: true,
           boundingHint: true,
+          // bruschetta-58519: surface OCR language + English summary.
+          ocrLanguage: true,
+          ocrSummary: true,
         },
       });
 
@@ -6262,10 +6279,69 @@ router.post(
           sourceReceiptIndex: updated.sourceReceiptIndex ?? null,
           sourceReceiptCount: updated.sourceReceiptCount ?? null,
           boundingHint: updated.boundingHint ?? null,
+          // bruschetta-58519
+          ocrLanguage: updated.ocrLanguage ?? null,
+          ocrSummary: updated.ocrSummary ?? null,
         },
         ranInline,
         inlineError,
       });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ============================================
+// bruschetta-58519: POST /api/admin/payouts/documents/:docId/summarize
+//
+// Admin-only on-demand backfill: re-run OCR on a single receipt and write ONLY
+// the `ocrLanguage` + `ocrSummary` columns. Mirrors the auth of
+// /documents/:docId/retry-ocr (requireAuth + requireAnyAdminOrPaymentAdmin).
+//
+// Crucially this does NOT touch ocr_amount / ocr_currency / ocr_line_items /
+// ocr_confidence / FX — preserving any admin corrections. It's for populating
+// the new language/summary on historical rows (which predate this feature) so
+// /payments can show a one-line English description + a non-English tag.
+//
+// Returns: { ocrLanguage, ocrSummary }
+// ============================================
+router.post(
+  '/documents/:docId/summarize',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { docId } = req.params;
+
+      const existing = await prisma.payoutDocument.findUnique({
+        where: { id: docId },
+        select: { id: true, url: true, party: { select: { country: true } } },
+      });
+      if (!existing) {
+        throw new AppError('Document not found', 404, 'NOT_FOUND');
+      }
+      if (!existing.url) {
+        throw new AppError('Document has no image URL to summarize', 400, 'NO_URL');
+      }
+
+      const { analyzeReceipt } = await import('../services/ocr.service.js');
+      const result = await analyzeReceipt({
+        imageUrl: existing.url,
+        partyCountry: existing.party?.country ?? null,
+      });
+
+      // bruschetta-58519: write ONLY language + summary (sanitized). Do not
+      // touch amount/currency/lineItems — those may carry admin edits.
+      const ocrLanguage = result.language ? sanitizePgString(result.language) : null;
+      const ocrSummary = result.summary ? sanitizePgString(result.summary) : null;
+
+      await prisma.payoutDocument.update({
+        where: { id: docId },
+        data: { ocrLanguage, ocrSummary },
+      });
+
+      res.json({ ocrLanguage, ocrSummary });
     } catch (err) {
       next(err);
     }
@@ -6417,6 +6493,9 @@ router.post(
       let ocrError: string | null = null;
       let ocrAttemptedAt: Date | null = null;
       let ocrAttemptCount = 0;
+      // bruschetta-58519: OCR language + English summary.
+      let ocrLanguage: string | null = null;
+      let ocrSummary: string | null = null;
 
       if (docKind === 'receipt') {
         const { analyzeReceipt } = await import('../services/ocr.service.js');
@@ -6446,6 +6525,9 @@ router.post(
           exchangeRate = unresolved
             ? null
             : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null);
+          // bruschetta-58519: capture language + English summary (sanitized).
+          ocrLanguage = result.language ? sanitizePgString(result.language) : null;
+          ocrSummary = result.summary ? sanitizePgString(result.summary) : null;
           ocrError = unresolved ? 'CURRENCY_UNRESOLVED' : null;
         } catch (err: any) {
           // Don't fail the request — persist the doc with the error so the
@@ -6515,6 +6597,9 @@ router.post(
             ocrError,
             ocrAttemptedAt,
             ocrAttemptCount,
+            // bruschetta-58519: persist OCR language + English summary.
+            ocrLanguage,
+            ocrSummary,
           },
           select: {
             id: true,
@@ -6537,6 +6622,9 @@ router.post(
             sourceReceiptIndex: true,
             sourceReceiptCount: true,
             boundingHint: true,
+            // bruschetta-58519
+            ocrLanguage: true,
+            ocrSummary: true,
             uploadedByUserId: true,
           },
         });
@@ -6585,6 +6673,9 @@ router.post(
           sourceReceiptIndex: created.sourceReceiptIndex ?? null,
           sourceReceiptCount: created.sourceReceiptCount ?? null,
           boundingHint: created.boundingHint ?? null,
+          // bruschetta-58519
+          ocrLanguage: created.ocrLanguage ?? null,
+          ocrSummary: created.ocrSummary ?? null,
           uploadedByUserId: created.uploadedByUserId ?? null,
         },
       });

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -189,6 +189,9 @@ function serializeDocument(d: any) {
     sourceReceiptIndex: d.sourceReceiptIndex ?? null,
     sourceReceiptCount: d.sourceReceiptCount ?? null,
     boundingHint: d.boundingHint ?? null,
+    // bruschetta-58519: OCR language (ISO-639-1) + English summary.
+    ocrLanguage: d.ocrLanguage ?? null,
+    ocrSummary: d.ocrSummary ?? null,
     // soppressata-92110: surface admin exclusion flags read-only so hosts can
     // see which receipts / OCR line items were excluded from their total.
     isDuplicate: d.isDuplicate ?? false,
@@ -657,6 +660,9 @@ router.post(
             ocrRaw: ocr.raw ?? null,
             merchant: ocr.merchant ?? null,
             boundingHint: ocr.boundingHint ?? null,
+            // bruschetta-58519: surface OCR language + English summary in preview.
+            ocrLanguage: ocr.language ?? null,
+            ocrSummary: ocr.summary ?? null,
             fxSource: fx.source,
             conversionNote: unresolved
               ? `Currency could not be determined automatically — please pick the correct currency to convert ${fx.originalAmount.toLocaleString()} to USD.`
@@ -1301,6 +1307,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       sourceReceiptIndex: number | null;
       sourceReceiptCount: number | null;
       boundingHint: string | null;
+      // bruschetta-58519: OCR language + English summary.
+      ocrLanguage: string | null;
+      ocrSummary: string | null;
       // napoletana-58211: filled in below for kind='pizza' docs after we
       // insert the canonical photos row. Receipts keep this null.
       photoId: string | null;
@@ -1379,6 +1388,10 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
                 : null,
             sourceReceiptCount: sourceReceiptCount > 1 ? sourceReceiptCount : null,
             boundingHint: typeof ocr.boundingHint === 'string' ? ocr.boundingHint : null,
+            // bruschetta-58519: persist OCR language + English summary (sanitized
+            // at the OCR source; defensively re-sanitize here before the insert).
+            ocrLanguage: ocr.language ? sanitizePgString(ocr.language) : null,
+            ocrSummary: ocr.summary ? sanitizePgString(ocr.summary) : null,
             photoId: null,
           });
         });
@@ -1404,6 +1417,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           sourceReceiptIndex: typeof doc.sourceReceiptIndex === 'number' ? doc.sourceReceiptIndex : null,
           sourceReceiptCount: null,
           boundingHint: null,
+          // bruschetta-58519: OCR errored — no language/summary available.
+          ocrLanguage: null,
+          ocrSummary: null,
           photoId: null,
         });
       }
@@ -2162,6 +2178,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrLineItems: any;
       ocrError: string | null;
       sortOrder: number;
+      // bruschetta-58519: OCR language + English summary.
+      ocrLanguage: string | null;
+      ocrSummary: string | null;
       // napoletana-58211: kept here for shape parity with newPizzaDocs so the
       // combined createMany call below has a uniform input type. Receipts
       // always carry null.
@@ -2214,6 +2233,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrLineItems: ocr.lineItems && ocr.lineItems.length > 0 ? sanitizeForPg(ocr.lineItems) : null,
           ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
           sortOrder: i,
+          // bruschetta-58519: persist OCR language + English summary (sanitized).
+          ocrLanguage: ocr.language ? sanitizePgString(ocr.language) : null,
+          ocrSummary: ocr.summary ? sanitizePgString(ocr.summary) : null,
           photoId: null,
         });
       } else {
@@ -2235,6 +2257,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
           ocrLineItems: null,
           ocrError: err,
           sortOrder: i,
+          // bruschetta-58519: OCR errored — no language/summary.
+          ocrLanguage: null,
+          ocrSummary: null,
           photoId: null,
         });
       }
@@ -2258,6 +2283,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrLineItems: null,
       ocrError: null,
       sortOrder: i,
+      // bruschetta-58519: pizza photos have no OCR language/summary.
+      ocrLanguage: null as string | null,
+      ocrSummary: null as string | null,
       // napoletana-58211: filled in inside the transaction below — we
       // insert the canonical photos row first, then attach its id.
       photoId: null as string | null,
@@ -2282,6 +2310,9 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       ocrLineItems: null,
       ocrError: null,
       sortOrder: i,
+      // bruschetta-58519: event photos have no OCR language/summary.
+      ocrLanguage: null as string | null,
+      ocrSummary: null as string | null,
       photoId: null as string | null,
     }));
 
@@ -2887,6 +2918,9 @@ router.post('/:partyId/reimbursement/receipts', async (req: AuthRequest, res: Re
       sourceReceiptIndex: number | null;
       sourceReceiptCount: number | null;
       boundingHint: string | null;
+      // bruschetta-58519: OCR language + English summary.
+      ocrLanguage: string | null;
+      ocrSummary: string | null;
     }> = [];
 
     let idx = 0;
@@ -2925,6 +2959,9 @@ router.post('/:partyId/reimbursement/receipts', async (req: AuthRequest, res: Re
                 : null,
             sourceReceiptCount: sourceReceiptCount > 1 ? sourceReceiptCount : null,
             boundingHint: typeof ocr.boundingHint === 'string' ? ocr.boundingHint : null,
+            // bruschetta-58519: persist OCR language + English summary (sanitized).
+            ocrLanguage: ocr.language ? sanitizePgString(ocr.language) : null,
+            ocrSummary: ocr.summary ? sanitizePgString(ocr.summary) : null,
           });
         });
       } else {
@@ -2948,6 +2985,9 @@ router.post('/:partyId/reimbursement/receipts', async (req: AuthRequest, res: Re
           sourceReceiptIndex: typeof doc.sourceReceiptIndex === 'number' ? doc.sourceReceiptIndex : null,
           sourceReceiptCount: null,
           boundingHint: null,
+          // bruschetta-58519: OCR errored — no language/summary.
+          ocrLanguage: null,
+          ocrSummary: null,
         });
       }
       idx++;

--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -14,6 +14,7 @@
  * prices by country/city. Stored on `payout_documents.ocr_line_items` JSONB.
  */
 
+import sharp from 'sharp';
 import { getOpenAI } from '../lib/openai.js';
 import { getCountryCode } from '../lib/countryCode.js';
 import { getLlmModels } from '../lib/privateConfig.js';
@@ -58,6 +59,13 @@ export interface OcrResult {
   // so the host can map each detected receipt back to its position in a
   // multi-receipt photo. Null for single-receipt images / older callers.
   boundingHint?: string | null;
+  // bruschetta-58519: ISO-639-1 code of the receipt's PRINTED language
+  // ("en","es","ja","uk"...); null if undeterminable. Lowercased.
+  language?: string | null;
+  // bruschetta-58519: ONE short ENGLISH sentence (≤140 chars from the model,
+  // hard-capped 280) describing what the receipt is for, regardless of the
+  // receipt's printed language. Null if undeterminable.
+  summary?: string | null;
   raw: unknown;
 }
 
@@ -66,6 +74,21 @@ export interface OcrResult {
 // receipts; cap defensively and truncate per-receipt line items.
 const MAX_DETECTED_RECEIPTS = 10;
 const MAX_LINE_ITEMS_PER_RECEIPT = 60;
+
+// bruschetta-58519 (Part A): downscale + auto-rotate target for the vision call.
+// gpt-4o's high-detail tiling tops out well below this; 1568px on the long edge
+// is OpenAI's recommended max useful dimension and shrinks tokens/cost without
+// losing legibility. JPEG q85 is a good size/quality tradeoff for receipts.
+const OCR_MAX_DIMENSION = 1568;
+const OCR_JPEG_QUALITY = 85;
+
+// bruschetta-58519 (Part C): sum(lineItems) vs reported amount cross-check.
+// If the summed subtotals diverge from the grand total by more than this
+// fraction, the extraction is suspect → clamp confidence so the row routes to
+// low-confidence review AND triggers the cheap→strong model escalation.
+const LINE_ITEM_SUM_TOLERANCE = 0.2;
+// Confidence ceiling applied when the sum/total cross-check fails.
+const LINE_ITEM_MISMATCH_CONFIDENCE_CAP = 0.49;
 
 // mortadella-92103: ISO-2 country → primary ISO-4217 currency. Used as a
 // strong currency prior when the receipt symbol is ambiguous (most LATAM
@@ -114,6 +137,8 @@ Return ONLY a JSON object with these fields:
 - confidence: number (0-1, your confidence in the total extraction)
 - merchant: string (restaurant/store name if visible, else null)
 - receiptDate: string (YYYY-MM-DD if visible, else null)
+- language: string (ISO-639-1 code of the receipt's PRINTED language, e.g. "en", "es", "ja", "uk"; null if you cannot determine it)
+- summary: string (ONE short sentence IN ENGLISH, at most 140 characters, describing what was purchased / what this receipt is for — ALWAYS in English regardless of the receipt's printed language; null if undeterminable)
 - lineItems: Array<{
     name: string,            // the item as printed on the receipt
     qty: number,             // quantity (default 1 if not visible)
@@ -172,7 +197,7 @@ export function buildMultiSystemPrompt(partyCountry?: string | null): string {
 Return ONLY a JSON object of the form:
 { "receipts": Receipt[] }
 
-Each Receipt object has EXACTLY the fields described below (amount, currency, confidence, merchant, receiptDate, lineItems, items), PLUS one optional field:
+Each Receipt object has EXACTLY the fields described below (amount, currency, confidence, merchant, receiptDate, language, summary, lineItems, items), PLUS one optional field:
 - boundingHint: string | null (a short human locator for where this receipt sits in the image, e.g. "left half", "top", "right receipt". Null if there is only one receipt or you can't tell.)
 
 CRITICAL splitting rules (UNDER-SPLIT — when unsure, MERGE):
@@ -201,9 +226,37 @@ async function imageUrlToBase64DataUrl(imageUrl: string): Promise<string> {
     throw new Error(`Failed to fetch image (HTTP ${response.status}) from ${imageUrl}`);
   }
   const arrayBuf = await response.arrayBuffer();
-  const base64 = Buffer.from(arrayBuf).toString('base64');
-  const contentType = response.headers.get('content-type') || 'image/jpeg';
-  return `data:${contentType};base64,${base64}`;
+  const originalContentType = response.headers.get('content-type') || 'image/jpeg';
+  const originalBuf = Buffer.from(arrayBuf);
+
+  // bruschetta-58519 (Part A): downscale + auto-rotate before sending to the
+  // vision model. `.rotate()` (no arg) applies the EXIF orientation so sideways
+  // phone photos read upright; resize-inside caps the long edge at 1568px; jpeg
+  // q85 shrinks the payload. Cheaper tokens + more reliable extraction.
+  //
+  // LANDMINE: sharp CANNOT decode HEIC on Vercel (libheif not bundled). ANY
+  // failure here MUST fall back to the ORIGINAL bytes + content-type so OCR
+  // still runs — preprocessing must never break extraction.
+  try {
+    const processed = await sharp(originalBuf)
+      .rotate()
+      .resize({
+        width: OCR_MAX_DIMENSION,
+        height: OCR_MAX_DIMENSION,
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .jpeg({ quality: OCR_JPEG_QUALITY })
+      .toBuffer();
+    return `data:image/jpeg;base64,${processed.toString('base64')}`;
+  } catch (err) {
+    // sharp couldn't decode (HEIC/HDR/corrupt) — send the original untouched.
+    console.warn(
+      `[ocr] sharp preprocess failed for ${imageUrl}; falling back to original bytes (${originalContentType}):`,
+      err instanceof Error ? err.message : err,
+    );
+    return `data:${originalContentType};base64,${originalBuf.toString('base64')}`;
+  }
 }
 
 /**
@@ -291,8 +344,10 @@ export function parseSingleReceipt(parsed: any): OcrResult {
     ? Math.max(0, Math.min(1, parsed.confidence))
     : 0;
   // Clamp confidence to 0.49 when currency is unresolved so the UI consistently
-  // surfaces it as "low" and asks for review.
-  const confidence = currency === null ? Math.min(modelConfidence, 0.49) : modelConfidence;
+  // surfaces it as "low" and asks for review. bruschetta-58519: this is the
+  // pre-sum-check confidence; the Part-C line-item cross-check may clamp it
+  // further below (after lineItems are computed).
+  const confidenceBeforeSumCheck = currency === null ? Math.min(modelConfidence, 0.49) : modelConfidence;
 
   if (!Number.isFinite(amount)) {
     throw new Error(`OpenAI returned non-numeric amount: ${JSON.stringify(parsed)}`);
@@ -314,9 +369,35 @@ export function parseSingleReceipt(parsed: any): OcrResult {
     ? sanitizePgString(parsed.boundingHint.trim().slice(0, 120))
     : null;
 
+  // bruschetta-58519 (Part B): receipt language (ISO-639-1) + English summary.
+  // Sanitize free-form model strings (NUL/surrogate JSONB-500 guard), lowercase
+  // the language code, and hard-cap the summary at 280 chars (the model is asked
+  // for ≤140 but we defend against runaway output before it hits ocr_summary).
+  const rawLanguage = typeof parsed?.language === 'string' ? parsed.language.trim() : '';
+  const language: string | null =
+    rawLanguage.length > 0 ? sanitizePgString(rawLanguage.toLowerCase()) : null;
+  const rawSummary = typeof parsed?.summary === 'string' ? parsed.summary.trim() : '';
+  const summary: string | null =
+    rawSummary.length > 0 ? sanitizePgString(rawSummary.slice(0, 280)) : null;
+
   // stracciatella-92114: truncate per-receipt line items to keep token + DB
   // sizes bounded when several receipts share one image.
   const lineItems = sanitizeLineItems(parsed?.lineItems).slice(0, MAX_LINE_ITEMS_PER_RECEIPT);
+
+  // bruschetta-58519 (Part C): sum(lineItems) ≈ amount cross-check. When we have
+  // both line items and a positive total, a large divergence between the summed
+  // subtotals and the reported grand total signals a misread total (or missed
+  // lines). Clamp confidence so the row routes to low-confidence review and the
+  // cheap→strong model escalation fires. We deliberately do NOT mutate `amount`
+  // — the model's grand total is usually the most reliable single number, and we
+  // never want a silent money change.
+  let confidence = confidenceBeforeSumCheck;
+  if (lineItems.length > 0 && amount > 0) {
+    const sum = lineItems.reduce((acc, li) => acc + (Number.isFinite(li.subtotal) ? li.subtotal : 0), 0);
+    if (Math.abs(sum - amount) / amount > LINE_ITEM_SUM_TOLERANCE) {
+      confidence = Math.min(confidence, LINE_ITEM_MISMATCH_CONFIDENCE_CAP);
+    }
+  }
 
   return {
     amount,
@@ -329,6 +410,8 @@ export function parseSingleReceipt(parsed: any): OcrResult {
     merchant,
     receiptDate,
     boundingHint,
+    language,
+    summary,
     raw: parsed,
   };
 }
@@ -350,16 +433,95 @@ export function parseSingleReceipt(parsed: any): OcrResult {
  * Does NOT do currency conversion — call `convertToUSD` per element.
  * Throws only on network/auth/non-JSON errors (parity with `analyzeReceipt`).
  */
-export async function analyzeReceiptMulti(
-  arg: string | { imageUrl: string; partyCountry?: string | null },
-): Promise<OcrResult[]> {
-  const imageUrl = typeof arg === 'string' ? arg : arg.imageUrl;
-  const partyCountry = typeof arg === 'string' ? null : (arg.partyCountry ?? null);
-  const base64Image = await imageUrlToBase64DataUrl(imageUrl);
-  const ocrModel = (await getLlmModels()).ocr;
+/**
+ * bruschetta-58519 (Part D): strict Structured-Outputs JSON schema for the
+ * multi-receipt envelope `{ receipts: Receipt[] }`. Strict mode requires:
+ *   - `additionalProperties: false` on EVERY object,
+ *   - EVERY property listed in `required`,
+ *   - nullable fields typed as `["string","null"]` / `["number","null"]`.
+ * The model is forced to emit exactly this shape; our bare-object/bare-array
+ * fallback in the parser stays as insurance against provider drift.
+ */
+const RECEIPTS_JSON_SCHEMA: {
+  name: string;
+  strict: boolean;
+  schema: Record<string, unknown>;
+} = {
+  name: 'receipts_envelope',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['receipts'],
+    properties: {
+      receipts: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: [
+            'amount',
+            'currency',
+            'confidence',
+            'merchant',
+            'receiptDate',
+            'boundingHint',
+            'language',
+            'summary',
+            'lineItems',
+            'items',
+          ],
+          properties: {
+            amount: { type: 'number' },
+            currency: { type: ['string', 'null'] },
+            confidence: { type: 'number' },
+            merchant: { type: ['string', 'null'] },
+            receiptDate: { type: ['string', 'null'] },
+            boundingHint: { type: ['string', 'null'] },
+            language: { type: ['string', 'null'] },
+            summary: { type: ['string', 'null'] },
+            lineItems: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['name', 'qty', 'unitPrice', 'subtotal', 'category'],
+                properties: {
+                  name: { type: 'string' },
+                  qty: { type: 'number' },
+                  unitPrice: { type: 'number' },
+                  subtotal: { type: 'number' },
+                  category: {
+                    type: 'string',
+                    enum: [...ALLOWED_CATEGORIES],
+                  },
+                },
+              },
+            },
+            items: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+  },
+};
 
+/**
+ * bruschetta-58519 (Part E): run ONE vision pass with a specific model and
+ * return the parsed `OcrResult[]`. Shared by the cheap first pass and the
+ * strong escalation pass so both use the identical prompt + strict schema +
+ * normalization/fallback logic.
+ */
+async function runOcrPass(
+  model: string,
+  base64Image: string,
+  partyCountry: string | null,
+): Promise<OcrResult[]> {
   const response = await getOpenAI().chat.completions.create({
-    model: ocrModel,
+    model,
     messages: [
       { role: 'system', content: buildMultiSystemPrompt(partyCountry) },
       {
@@ -376,7 +538,12 @@ export async function analyzeReceiptMulti(
     // stracciatella-92114: bumped 1500 → 4000 to fit multiple receipts each
     // with their own per-line items array without mid-JSON truncation.
     max_tokens: 4000,
-    response_format: { type: 'json_object' },
+    // bruschetta-58519 (Part D): strict Structured Outputs. The bare-object /
+    // bare-array parse fallback below remains as insurance.
+    response_format: {
+      type: 'json_schema',
+      json_schema: RECEIPTS_JSON_SCHEMA,
+    },
   });
 
   const content = response.choices[0]?.message?.content;
@@ -420,6 +587,55 @@ export async function analyzeReceiptMulti(
 }
 
 /**
+ * bruschetta-58519 (Part E): decide whether the cheap first pass is weak enough
+ * to justify re-running on the stronger model. ESCALATE when ANY parsed receipt
+ * has a missing/non-positive amount, null currency, sub-0.6 confidence (which
+ * also captures the Part-C sum/total mismatch, since that clamps confidence to
+ * 0.49), OR when zero receipts were parsed at all.
+ */
+function shouldEscalateOcr(results: OcrResult[]): boolean {
+  if (results.length === 0) return true;
+  return results.some(
+    (r) =>
+      !(typeof r.amount === 'number' && r.amount > 0) ||
+      r.currency === null ||
+      r.confidence < 0.6,
+  );
+}
+
+export async function analyzeReceiptMulti(
+  arg: string | { imageUrl: string; partyCountry?: string | null },
+): Promise<OcrResult[]> {
+  const imageUrl = typeof arg === 'string' ? arg : arg.imageUrl;
+  const partyCountry = typeof arg === 'string' ? null : (arg.partyCountry ?? null);
+  const base64Image = await imageUrlToBase64DataUrl(imageUrl);
+  const models = await getLlmModels();
+
+  // bruschetta-58519 (Part E): cost routing. First pass on the cheap model;
+  // escalate to the strong `ocr` model only when the cheap result looks weak.
+  // KILL SWITCH: when app_config sets `llm.models.ocrCheap` == `ocr` ("gpt-4o"),
+  // the first pass is already strong, so nothing escalates — routing is
+  // effectively disabled with no deploy.
+  const firstPass = await runOcrPass(models.ocrCheap, base64Image, partyCountry);
+
+  if (models.ocrCheap !== models.ocr && shouldEscalateOcr(firstPass)) {
+    try {
+      return await runOcrPass(models.ocr, base64Image, partyCountry);
+    } catch (err) {
+      // Escalation failed (network/auth/parse) — keep the cheap result rather
+      // than failing the whole image.
+      console.warn(
+        `[ocr] escalation to ${models.ocr} failed for ${imageUrl}; keeping cheap (${models.ocrCheap}) result:`,
+        err instanceof Error ? err.message : err,
+      );
+      return firstPass;
+    }
+  }
+
+  return firstPass;
+}
+
+/**
  * Send a single receipt image to gpt-4o and return ONE `OcrResult`.
  *
  * stracciatella-92114: now a thin wrapper over `analyzeReceiptMulti` that
@@ -445,6 +661,8 @@ export async function analyzeReceipt(
       merchant: null,
       receiptDate: null,
       boundingHint: null,
+      language: null,
+      summary: null,
       raw: { receipts: [] },
     };
   }

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
 import { SwcHubWarning } from './SwcHubWarning';
 import { isSwcHubParty } from '../../utils/swcHub';
-import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, markReceiptDuplicate, markReceiptIneligible, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
+import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, summarizePayoutDocument, markReceiptDuplicate, markReceiptIneligible, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { usePayoutCaps } from '../../hooks/usePayoutCaps';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
@@ -552,6 +552,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     originalAmount?: number | null;
     originalCurrency?: string | null;
     exchangeRate?: number | null;
+    // bruschetta-58519: post-Summarize fields so the editor + lightbox footer
+    // show the new summary/language immediately without a parent refetch.
+    ocrLanguage?: string | null;
+    ocrSummary?: string | null;
   };
   const [receiptOverrides, setReceiptOverrides] = useState<Record<string, ReceiptOverride>>({});
   // Per-row save state.
@@ -586,6 +590,13 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // ocrError from `payout.documents` once retry succeeds. We only set true
   // on success; failures still surface a per-row error chip.
   const [retryClearedErrors, setRetryClearedErrors] = useState<Record<string, boolean>>({});
+
+  // bruschetta-58519: per-row "Summarize" backfill state (language + English
+  // summary). Mirrors the retry-OCR state shape — one in-flight docId + a
+  // per-doc error map. Result is merged into receiptOverrides so the editor +
+  // lightbox footer reflect the new summary without a parent refetch.
+  const [summarizingDocId, setSummarizingDocId] = useState<string | null>(null);
+  const [summarizeErrors, setSummarizeErrors] = useState<Record<string, string>>({});
 
   // taralli-92104: per-receipt line-item editor state.
   //
@@ -680,6 +691,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               ov.originalCurrency !== undefined ? ov.originalCurrency : d.originalCurrency,
             exchangeRate:
               ov.exchangeRate !== undefined ? ov.exchangeRate : d.exchangeRate,
+            // bruschetta-58519: layer the Summarize backfill result.
+            ocrLanguage:
+              ov.ocrLanguage !== undefined ? ov.ocrLanguage : d.ocrLanguage,
+            ocrSummary:
+              ov.ocrSummary !== undefined ? ov.ocrSummary : d.ocrSummary,
           };
         }),
     [payout.documents, receiptOverrides],
@@ -760,6 +776,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         url: d.url,
         fileName: d.fileName,
         mimeType: d.mimeType,
+        // bruschetta-58519: surface OCR English summary + language tag.
+        ocrSummary: d.ocrSummary ?? null,
+        ocrLanguage: d.ocrLanguage ?? null,
       })),
       ...pizzaPhotos.map((p) => ({
         url: p.url,
@@ -949,6 +968,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
             originalAmount: fresh.originalAmount,
             originalCurrency: fresh.originalCurrency,
             exchangeRate: fresh.exchangeRate,
+            // bruschetta-58519: the full re-read also refreshes language + summary.
+            ocrLanguage: fresh.ocrLanguage,
+            ocrSummary: fresh.ocrSummary,
           },
         }));
         // Re-seed line item drafts from the fresh array.
@@ -977,6 +999,43 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       }));
     } finally {
       setRetryingDocId(null);
+    }
+  }
+
+  // bruschetta-58519: on-demand Summarize backfill. Re-runs OCR and writes ONLY
+  // language + English summary (amount/currency/lineItems preserved). Merge the
+  // result into receiptOverrides so the editor + lightbox footer update in place.
+  async function summarizeDoc(docId: string) {
+    setSummarizingDocId(docId);
+    setSummarizeErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    const prior = receipts.find((r) => r.id === docId);
+    try {
+      const res = await summarizePayoutDocument(docId);
+      setReceiptOverrides((m) => {
+        const cur = m[docId] ?? {
+          ocrAmount: prior?.ocrAmount ?? null,
+          ocrCurrency: prior?.ocrCurrency ?? null,
+        };
+        return {
+          ...m,
+          [docId]: {
+            ...cur,
+            ocrLanguage: res.ocrLanguage,
+            ocrSummary: res.ocrSummary,
+          },
+        };
+      });
+    } catch (err: any) {
+      setSummarizeErrors((m) => ({
+        ...m,
+        [docId]: err?.message || 'Summarize failed',
+      }));
+    } finally {
+      setSummarizingDocId(null);
     }
   }
 
@@ -1545,6 +1604,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         retrying={retryingDocId === r.id}
         retryError={retryErrors[r.id]}
         onRetryOcr={() => retryOcr(r.id)}
+        onSummarize={() => summarizeDoc(r.id)}
+        summarizing={summarizingDocId === r.id}
+        summarizeError={summarizeErrors[r.id]}
         authenticityVerdict={authChecks[r.url]?.verdict ?? null}
         authenticityPanel={
           <AuthenticityPanel
@@ -1581,6 +1643,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     retryingDocId,
     retryErrors,
     retryClearedErrors,
+    summarizingDocId,
+    summarizeErrors,
     authChecks,
   ]);
 

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw, Receipt } from 'lucide-react';
+import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw, Receipt, Languages, Sparkles } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { CurrencyPicker } from './CurrencyPicker';
@@ -107,6 +107,18 @@ interface ReceiptEditorProps {
   retryError?: string;
   onRetryOcr?: () => void;
 
+  /**
+   * bruschetta-58519: on-demand "Summarize" backfill. When the receipt has no
+   * `ocrSummary` yet (historical rows predating the feature), the editor shows
+   * a Summarize button wired to this callback. The parent calls
+   * summarizePayoutDocument(doc.id) and merges {ocrLanguage,ocrSummary} into its
+   * local doc state (no reload). Optional so non-receipt / non-admin callsites
+   * can omit it.
+   */
+  onSummarize?: () => void;
+  summarizing?: boolean;
+  summarizeError?: string;
+
   /** Whether the draft differs from persisted values (drives Save button). */
   isDirty: boolean;
 
@@ -186,6 +198,9 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   retrying,
   retryError,
   onRetryOcr,
+  onSummarize,
+  summarizing,
+  summarizeError,
   isDirty,
   authenticityPanel,
   authenticityVerdict,
@@ -331,6 +346,55 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
           >
             {(conf * 100).toFixed(0)}% confidence
           </span>
+        )}
+      </div>
+
+      {/* bruschetta-58519: compact Summary block. Shows the OCR English summary
+          (with a 🌐 language tag when the receipt isn't in English) so admins can
+          tell at a glance what a non-English receipt is for. When there's no
+          summary yet (historical rows), a Summarize button backfills it via
+          analyzeReceipt — language/summary only, never amount/currency. */}
+      <div className="relative z-10 rounded-lg border border-theme-stroke bg-theme-bg p-3 space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-theme-text-faint flex items-center gap-1.5">
+            <Sparkles size={12} /> Summary
+          </h4>
+          {doc.ocrLanguage && doc.ocrLanguage !== 'en' && (
+            <span
+              className="text-[10px] text-theme-text-muted inline-flex items-center gap-1"
+              title="Receipt printed language (ISO-639-1)"
+            >
+              <Languages size={11} /> {doc.ocrLanguage.toUpperCase()}
+            </span>
+          )}
+        </div>
+        {doc.ocrSummary ? (
+          <p className="text-xs text-theme-text">{doc.ocrSummary}</p>
+        ) : (
+          <div className="space-y-1">
+            <p className="text-xs text-theme-text-faint">
+              No summary yet.
+            </p>
+            {onSummarize && (
+              <button
+                type="button"
+                onClick={onSummarize}
+                disabled={summarizing}
+                className="px-2.5 py-1 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center gap-1.5"
+                title="Re-run OCR to extract a one-line English summary + language (does not change amount/currency)"
+              >
+                {summarizing ? (
+                  <Loader2 size={12} className="animate-spin" />
+                ) : (
+                  <Sparkles size={12} />
+                )}
+                Summarize
+              </button>
+            )}
+            {summarizeError && (
+              <div className="text-xs text-red-300">{summarizeError}</div>
+            )}
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/payments-shared/ReceiptLightbox.tsx
+++ b/frontend/src/components/payments-shared/ReceiptLightbox.tsx
@@ -40,6 +40,14 @@ export interface ReceiptLightboxImage {
    * without a caption render exactly as before.
    */
   caption?: string;
+  /**
+   * bruschetta-58519: OCR English summary (≤140 chars) + ISO-639-1 language of
+   * the receipt's printed text. Shown as a muted line under the file name; when
+   * the language is non-English a 🌐 tag is prefixed. Both optional — images
+   * without them render exactly as before.
+   */
+  ocrSummary?: string | null;
+  ocrLanguage?: string | null;
 }
 
 interface ReceiptLightboxProps {
@@ -541,6 +549,15 @@ export const ReceiptLightbox: React.FC<ReceiptLightboxProps> = ({
             photos. Receipts pass no caption and render unchanged. */}
         {current.caption && (
           <span className="truncate text-white/60">· {current.caption}</span>
+        )}
+        {/* bruschetta-58519: OCR English summary + non-English language tag. */}
+        {current.ocrSummary && (
+          <span className="truncate text-white/60">
+            {current.ocrLanguage && current.ocrLanguage !== 'en' && (
+              <span className="mr-1">🌐 {current.ocrLanguage.toUpperCase()}</span>
+            )}
+            {current.ocrSummary}
+          </span>
         )}
       </div>
     </div>,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5214,6 +5214,9 @@ export async function retryPayoutDocumentOcr(
     ocrAttemptCount: number;
     ocrLineItems: ReceiptLineItem[] | null;
     sortOrder: number;
+    // bruschetta-58519: the inline re-read also refreshes language + summary.
+    ocrLanguage?: string | null;
+    ocrSummary?: string | null;
   } | null;
   ranInline: boolean;
   inlineError: string | null;
@@ -5221,6 +5224,21 @@ export async function retryPayoutDocumentOcr(
   return apiRequest(
     `/api/admin/payouts/documents/${docId}/retry-ocr`,
     { method: 'POST', body: { runNow: opts?.runNow ?? true } },
+  );
+}
+
+/**
+ * bruschetta-58519: admin on-demand "Summarize" backfill. Re-runs OCR on a
+ * single receipt and updates ONLY `ocrLanguage` + `ocrSummary` (preserving any
+ * admin-edited amount/currency/lineItems). Used to populate the new language +
+ * English-summary fields on historical rows that predate the feature.
+ */
+export async function summarizePayoutDocument(
+  docId: string,
+): Promise<{ ocrLanguage: string | null; ocrSummary: string | null }> {
+  return apiRequest(
+    `/api/admin/payouts/documents/${docId}/summarize`,
+    { method: 'POST' },
   );
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1738,6 +1738,13 @@ export interface PayoutDocument {
   sourceReceiptIndex?: number | null;
   sourceReceiptCount?: number | null;
   boundingHint?: string | null;
+  // bruschetta-58519: OCR-supplied ISO-639-1 language of the receipt's PRINTED
+  // text ("en","es","ja","uk"...) and a short ≤140-char ENGLISH summary of what
+  // the receipt is for. Both null on historical rows until backfilled via the
+  // admin "Summarize" control. Surfaced on every receipt in the lightbox +
+  // admin editor; non-English receipts show a 🌐 language tag.
+  ocrLanguage?: string | null;
+  ocrSummary?: string | null;
   // pancetta-37195: per-doc uploader attribution. Null on historical rows
   // created before this feature shipped.
   uploadedByUserId?: string | null;


### PR DESCRIPTION
## Summary
Five OCR improvements centered on the single gpt-4o vision call in `ocr.service.ts`, plus a non-English receipt summary on /payments. One cohesive PR.

1. **Downscale + auto-rotate** images before the call (1568px via sharp, HEIC-safe fallback) — cheaper input tokens + fixes sideways photos.
2. **`sum(lineItems) ≈ amount` cross-check** — clamps confidence to ≤0.49 on >20% mismatch (free accuracy; no amount mutation).
3. **Structured Outputs** (strict `json_schema`) — removes the parse-failure/retry path.
4. **Model routing** — `ocrCheap` (gpt-4o-mini) first pass, escalates to `ocr` (gpt-4o) on low confidence / missing amount/currency / sum-mismatch / zero receipts. **Kill-switch:** set `app_config llm.models.ocrCheap = "gpt-4o"` to disable, no deploy.
5. **Language detection + one-line English summary** on every receipt — shown in `ReceiptLightbox` (footer + 🌐 tag) and `ReceiptEditor`, with an on-demand **Summarize** button (`POST /admin/payouts/documents/:id/summarize`) to backfill older receipts.

## DB migration (apply to PROD before merge)
Adds two **nullable** columns — additive/safe:
```sql
ALTER TABLE payout_documents ADD COLUMN ocr_language text, ADD COLUMN ocr_summary text;
```

## Verification notes
- Agent had no local `node_modules`; relying on this Vercel preview build for tsc. Backend tsc needs `prisma generate` (new columns) — N/A for preview since backend deploys only from master.
- Backend behavior (routing, /summarize, new OCR call) is only live post-merge (backend auto-deploys from master). Will confirm cost/accuracy on real uploads right after merge.

Plan: `plans/bruschetta-58519-ocr-upgrade.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)