### PR TITLE
fix(agnolotti-58521): show reminder Sent date immediately on /payments

### DIFF
--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1547,13 +1547,28 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             // each channel as a "✓"/"–" so the admin can see at a glance
             // whether both messages went out, or just the group post when
             // the host hasn't linked TG yet.
-            onTgReminderResult={(_partyId, result) => {
+            onTgReminderResult={(partyId, result) => {
               if ('error' in result) {
                 pushToast(
                   `Could not send reminder: ${result.error}`,
                   'error',
                 );
                 return;
+              }
+              if (result.hostDmSent || result.groupSent) {
+                setByPartyRows((prev) =>
+                  prev.map((r) =>
+                    r.party.id === partyId
+                      ? {
+                          ...r,
+                          party: {
+                            ...r.party,
+                            receiptsReminderSentAt: new Date().toISOString(),
+                          },
+                        }
+                      : r,
+                  ),
+                );
               }
               const hostLabel = result.hostDmSent
                 ? 'DM ✓'
@@ -1571,13 +1586,28 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             }}
             // Wallet reminder — same per-channel success/skip toast as the
             // receipts reminder.
-            onTgWalletReminderResult={(_partyId, result) => {
+            onTgWalletReminderResult={(partyId, result) => {
               if ('error' in result) {
                 pushToast(
                   `Could not send wallet reminder: ${result.error}`,
                   'error',
                 );
                 return;
+              }
+              if (result.hostDmSent || result.groupSent) {
+                setByPartyRows((prev) =>
+                  prev.map((r) =>
+                    r.party.id === partyId
+                      ? {
+                          ...r,
+                          party: {
+                            ...r.party,
+                            walletReminderSentAt: new Date().toISOString(),
+                          },
+                        }
+                      : r,
+                  ),
+                );
               }
               const hostLabel = result.hostDmSent
                 ? 'DM ✓'
@@ -1595,13 +1625,28 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             }}
             // Photo reminder — same per-channel success/skip toast as the
             // receipts reminder.
-            onTgPhotoReminderResult={(_partyId, result) => {
+            onTgPhotoReminderResult={(partyId, result) => {
               if ('error' in result) {
                 pushToast(
                   `Could not send photo reminder: ${result.error}`,
                   'error',
                 );
                 return;
+              }
+              if (result.hostDmSent || result.groupSent) {
+                setByPartyRows((prev) =>
+                  prev.map((r) =>
+                    r.party.id === partyId
+                      ? {
+                          ...r,
+                          party: {
+                            ...r.party,
+                            photoReminderSentAt: new Date().toISOString(),
+                          },
+                        }
+                      : r,
+                  ),
+                );
               }
               const hostLabel = result.hostDmSent
                 ? 'DM ✓'


### PR DESCRIPTION
@
## Problem
On `/payments` (by-city view), after sending a Telegram reminder (receipts, wallet, or photo), the green **"Sent {date}"** label under the button didnt appear until a page refresh. Reported for the photo reminder (Da Nang).

## Root cause
The backend persists `*ReminderSentAt = now()` on success but does **not** return the timestamp, and the three result handlers in `PaymentsAdminPage.tsx` (`onTgReminderResult` / `onTgWalletReminderResult` / `onTgPhotoReminderResult`) only `pushToast` — they never patch `byPartyRows`. So the label only updated on the next full refresh.

## Fix (frontend-only — no backend, no DB)
In each of the three handlers, after the existing `error` guard, optimistically patch `byPartyRows` when `result.hostDmSent || result.groupSent` (mirrors the backends persist-on-success condition), setting the matching `*ReminderSentAt` to `new Date().toISOString()`. Mirrors the existing `onScamFlagChanged` / `onTagsChanged` optimistic patches in the same file.

- Only `frontend/src/pages/PaymentsAdminPage.tsx` changed
- `npx tsc --noEmit` passes clean

## Verify
On the preview by-city view, send a reminder to a test city → "Sent {today}" appears immediately, no refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@