### PR TITLE
feat(zeppole-58522): add submit-estimated-attendance TG reminder on /payments

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -174,6 +174,7 @@ model Party {
   receiptsReminderSentAt  DateTime? @map("receipts_reminder_sent_at") @db.Timestamptz // When admin sent TG receipts reminder
   walletReminderSentAt    DateTime? @map("wallet_reminder_sent_at") @db.Timestamptz // When admin sent TG wallet reminder
   photoReminderSentAt     DateTime? @map("photo_reminder_sent_at") @db.Timestamptz // When admin sent TG photo reminder
+  attendanceReminderSentAt DateTime? @map("attendance_reminder_sent_at") @db.Timestamptz // When admin sent TG attendance reminder
   poapEventId             String?   @map("poap_event_id") // POAP event ID
   poapMints             Int?    @map("poap_mints") // POAP mint count
   poapMoments           Int?    @map("poap_moments") // POAP moments count

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -296,6 +296,8 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   walletReminderSentAt: true,
   // Track when the TG photo reminder was last sent for this city.
   photoReminderSentAt: true,
+  // Track when the TG attendance reminder was last sent for this city.
+  attendanceReminderSentAt: true,
   // City-level payment approval fields.
   paymentsApprovedUsd: true,
   paymentsApprovedAt: true,
@@ -2169,6 +2171,10 @@ router.get(
             photoReminderSentAt: b.partyMeta.photoReminderSentAt
               ? b.partyMeta.photoReminderSentAt.toISOString()
               : null,
+            // When the TG attendance reminder was last sent.
+            attendanceReminderSentAt: b.partyMeta.attendanceReminderSentAt
+              ? b.partyMeta.attendanceReminderSentAt.toISOString()
+              : null,
             // City-level payment approval.
             paymentsApprovedUsd: b.partyMeta.paymentsApprovedUsd
               ? Number(b.partyMeta.paymentsApprovedUsd)
@@ -2306,6 +2312,9 @@ router.get(
                 : null,
               photoReminderSentAt: partyMeta.photoReminderSentAt
                 ? partyMeta.photoReminderSentAt.toISOString()
+                : null,
+              attendanceReminderSentAt: partyMeta.attendanceReminderSentAt
+                ? partyMeta.attendanceReminderSentAt.toISOString()
                 : null,
               paymentsApprovedUsd: partyMeta.paymentsApprovedUsd
                 ? Number(partyMeta.paymentsApprovedUsd)
@@ -6916,6 +6925,87 @@ router.post(
 
       console.log(
         `[tg-photo-reminder] party=${party.id} slug=${slug} host_dm=${
+          hostDmSent ? 'ok' : `skipped:${hostDmReason ?? 'unknown'}`
+        } group=${groupSent ? 'ok' : `skipped:${groupReason ?? 'unknown'}`}`,
+      );
+
+      res.json({
+        hostDmSent,
+        ...(hostDmReason ? { hostDmReason } : {}),
+        groupSent,
+        ...(groupReason ? { groupReason } : {}),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// POST /:partyId/tg-attendance-reminder
+//
+// Sibling of tg-photo-reminder: DMs the primary host (when their Telegram
+// is linked) and posts to the city's GPP group chat, telling the host to
+// submit their event's estimated attendance. Same per-channel send +
+// skip-reason contract; the only differences are the message text + target
+// URL. Persists `parties.attendance_reminder_sent_at` on success, mirroring the
+// photo reminder, so the menu can show a last-sent sub-label.
+router.post(
+  '/:partyId/tg-attendance-reminder',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { partyId } = req.params;
+
+      const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: {
+          id: true,
+          customUrl: true,
+          inviteCode: true,
+          name: true,
+          hostTelegramChatId: true,
+        },
+      });
+      if (!party) {
+        throw new AppError('Party not found', 404, 'PARTY_NOT_FOUND');
+      }
+
+      const slug = party.customUrl || party.inviteCode;
+      const text = `Please submit your event's estimated attendance at rsv.pizza/${slug}`;
+
+      let hostDmSent = false;
+      let hostDmReason: string | undefined;
+      if (party.hostTelegramChatId) {
+        const result = await sendTelegramMessage(
+          party.hostTelegramChatId.toString(),
+          text,
+        );
+        if (result.ok) {
+          hostDmSent = true;
+        } else {
+          hostDmReason = result.reason;
+        }
+      } else {
+        hostDmReason = 'Host has not linked Telegram (no host_telegram_chat_id on file)';
+      }
+
+      // Group chat — tonda-58293: resolved server-side from
+      // `city_telegram_groups` via `sendToCityGroup` (adds the migration
+      // retry+persist this endpoint previously lacked). FIX #4: shared helper
+      // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+
+      // Record when the reminder was sent (if at least one message succeeded).
+      if (hostDmSent || groupSent) {
+        await prisma.party.update({
+          where: { id: partyId },
+          data: { attendanceReminderSentAt: new Date() },
+        });
+      }
+
+      console.log(
+        `[tg-attendance-reminder] party=${party.id} slug=${slug} host_dm=${
           hostDmSent ? 'ok' : `skipped:${hostDmReason ?? 'unknown'}`
         } group=${groupSent ? 'ok' : `skipped:${groupReason ?? 'unknown'}`}`,
       );

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -27,6 +27,7 @@ import {
   RotateCcw,
   Wallet,
   Camera,
+  Users,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type {
@@ -67,6 +68,7 @@ import {
   sendTgReceiptsReminder,
   sendTgWalletReminder,
   sendTgPhotoReminder,
+  sendTgAttendanceReminder,
   setCityAdminNotes,
   approveCity,
   reopenParty,
@@ -302,6 +304,19 @@ interface PayoutsByPartyTableProps {
     } | { error: string },
   ) => void;
   /**
+   * Toast callback for the Send attendance reminder action — same per-channel
+   * success/skip shape as `onTgReminderResult`. The menu owns the API call.
+   */
+  onTgAttendanceReminderResult?: (
+    partyId: string,
+    result: {
+      hostDmSent: boolean;
+      hostDmReason?: string;
+      groupSent: boolean;
+      groupReason?: string;
+    } | { error: string },
+  ) => void;
+  /**
    * bufalina-60733: fake-detection risk scores keyed by party id. Only
    * medium/high (≥30) parties are present; an absent key means "no badge".
    * Rendered as a caution pill in the city header strip.
@@ -498,6 +513,7 @@ function CityActionsMenu({
   onSendTgReminder,
   onSendWalletReminder,
   onSendPhotoReminder,
+  onSendAttendanceReminder,
   onApproveCity,
   onReopen,
   onAddCustomTag,
@@ -509,6 +525,7 @@ function CityActionsMenu({
   canSendTgReminder,
   canSendWalletReminder,
   canSendPhotoReminder,
+  canSendAttendanceReminder,
   canApproveCity,
   canReopen,
   canManageTags,
@@ -518,6 +535,7 @@ function CityActionsMenu({
   tgReminderBusy,
   walletReminderBusy,
   photoReminderBusy,
+  attendanceReminderBusy,
   reopenBusy,
   approveBusy,
   customTags,
@@ -525,6 +543,7 @@ function CityActionsMenu({
   receiptsReminderSentAt,
   walletReminderSentAt,
   photoReminderSentAt,
+  attendanceReminderSentAt,
   paymentsApprovedUsd,
   receiptsTotalUsd,
 }: {
@@ -548,6 +567,11 @@ function CityActionsMenu({
    * two-click confirm pattern as the receipts reminder).
    */
   onSendPhotoReminder?: () => void;
+  /**
+   * Fires after the second click on the Send attendance reminder menu item (same
+   * two-click confirm pattern as the receipts reminder).
+   */
+  onSendAttendanceReminder?: () => void;
   /** Approve city payment amount. Called with the amount to approve. */
   onApproveCity?: (amountUsd: number | null) => void;
   /** Reopen a closed city (undo the close). */
@@ -563,6 +587,7 @@ function CityActionsMenu({
   canSendTgReminder: boolean;
   canSendWalletReminder: boolean;
   canSendPhotoReminder: boolean;
+  canSendAttendanceReminder: boolean;
   canApproveCity: boolean;
   canReopen: boolean;
   /** panuozzo-58217: admins + underbosses may add/view/remove custom tags. */
@@ -573,6 +598,7 @@ function CityActionsMenu({
   tgReminderBusy: boolean;
   walletReminderBusy: boolean;
   photoReminderBusy: boolean;
+  attendanceReminderBusy: boolean;
   reopenBusy: boolean;
   approveBusy: boolean;
   /** panuozzo-58217: current custom-tag display labels (no `custom:` prefix). */
@@ -582,6 +608,7 @@ function CityActionsMenu({
   receiptsReminderSentAt?: string | null;
   walletReminderSentAt?: string | null;
   photoReminderSentAt?: string | null;
+  attendanceReminderSentAt?: string | null;
   paymentsApprovedUsd?: number | null;
   paymentsApprovedAt?: string | null;
   /** Receipts total for default approval amount. */
@@ -602,6 +629,9 @@ function CityActionsMenu({
   // Same two-click confirm, separate state so the photo + wallet + receipts
   // items don't share a confirm flag.
   const [confirmPhotoReminder, setConfirmPhotoReminder] = useState(false);
+  // Same two-click confirm, separate state so the attendance + photo + wallet +
+  // receipts items don't share a confirm flag.
+  const [confirmAttendanceReminder, setConfirmAttendanceReminder] = useState(false);
   // panuozzo-58217: the custom-tag add field. Declared above the no-actions
   // early return so the conditional return can't reorder hooks.
   const [tagDraft, setTagDraft] = useState('');
@@ -649,6 +679,7 @@ function CityActionsMenu({
     canSendTgReminder ||
     canSendWalletReminder ||
     canSendPhotoReminder ||
+    canSendAttendanceReminder ||
     canReopen ||
     canManageTags;
   // Nothing to show at all — render nothing.
@@ -751,6 +782,7 @@ function CityActionsMenu({
                   setConfirmTgReminder(false);
                   setConfirmWalletReminder(false);
                   setConfirmPhotoReminder(false);
+                  setConfirmAttendanceReminder(false);
                   setMenuPos(null);
                 }
                 return next;
@@ -774,6 +806,7 @@ function CityActionsMenu({
                   setConfirmTgReminder(false);
                   setConfirmWalletReminder(false);
                   setConfirmPhotoReminder(false);
+                  setConfirmAttendanceReminder(false);
                   setMenuPos(null);
                 }}
               />
@@ -998,6 +1031,54 @@ function CityActionsMenu({
                       {photoReminderSentAt && !confirmPhotoReminder && (
                         <span className="text-xs text-theme-text-muted">
                           Sent {new Date(photoReminderSentAt).toLocaleDateString()}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                )}
+                {/* Send attendance reminder — sibling of the photo reminder.
+                    DMs the host + posts to the city group telling them to
+                    submit their event's estimated attendance. Same two-click
+                    confirm (DMs can't be unsent). Shows a last-sent sub-label
+                    from `attendanceReminderSentAt`, mirroring the photo reminder. */}
+                {canSendAttendanceReminder && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={attendanceReminderBusy}
+                    onClick={() => {
+                      if (!confirmAttendanceReminder) {
+                        setConfirmAttendanceReminder(true);
+                        return;
+                      }
+                      setMenuOpen(false);
+                      setConfirmAttendanceReminder(false);
+                      onSendAttendanceReminder?.();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-center gap-2 disabled:opacity-50"
+                  >
+                    {attendanceReminderBusy ? (
+                      <Loader2
+                        size={14}
+                        className="animate-spin text-theme-text-muted"
+                      />
+                    ) : (
+                      <Users
+                        size={14}
+                        className={
+                          confirmAttendanceReminder ? 'text-amber-400' : 'text-sky-400'
+                        }
+                      />
+                    )}
+                    <span className="flex flex-col items-start">
+                      <span>
+                        {confirmAttendanceReminder
+                          ? 'Click again to confirm'
+                          : 'Send attendance reminder'}
+                      </span>
+                      {attendanceReminderSentAt && !confirmAttendanceReminder && (
+                        <span className="text-xs text-theme-text-muted">
+                          Sent {new Date(attendanceReminderSentAt).toLocaleDateString()}
                         </span>
                       )}
                     </span>
@@ -2906,6 +2987,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onTgReminderResult,
   onTgWalletReminderResult,
   onTgPhotoReminderResult,
+  onTgAttendanceReminderResult,
   fakeScores,
   viewerRole = 'admin',
   busyRowId,
@@ -2952,6 +3034,9 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   const [photoReminderBusyPartyId, setPhotoReminderBusyPartyId] = useState<
     string | null
   >(null);
+  const [attendanceReminderBusyPartyId, setAttendanceReminderBusyPartyId] = useState<
+    string | null
+  >(null);
   // City-level approval busy spinner.
   const [approveBusyPartyId, setApproveBusyPartyId] = useState<string | null>(null);
   // Per-row busy spinner for the Reopen city action.
@@ -2981,6 +3066,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   const canSendWalletReminder = viewerRole === 'admin';
   // Photo reminder shares the same admin-only gate as the receipts reminder.
   const canSendPhotoReminder = viewerRole === 'admin';
+  // Attendance reminder shares the same admin-only gate as the photo reminder.
+  const canSendAttendanceReminder = viewerRole === 'admin';
   // City-level approval is admin-only.
   const canApproveCity = viewerRole === 'admin';
   // Reopen (undo a close) is admin-only — the endpoint enforces
@@ -3246,6 +3333,26 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   }
 
   /**
+   * Sibling of {@link handleSendPhotoReminder}: dispatch the attendance reminder
+   * POST and forward the per-channel outcome via `onTgAttendanceReminderResult`.
+   * Group chat_id resolved server-side (tonda-58293) — no client groupChatId.
+   */
+  async function handleSendAttendanceReminder(row: PartyPayoutsRow) {
+    const partyId = row.party.id;
+    setAttendanceReminderBusyPartyId(partyId);
+    try {
+      const result = await sendTgAttendanceReminder(partyId);
+      onTgAttendanceReminderResult?.(partyId, result);
+    } catch (err) {
+      onTgAttendanceReminderResult?.(partyId, {
+        error: (err as Error)?.message ?? 'Could not send reminder',
+      });
+    } finally {
+      setAttendanceReminderBusyPartyId((id) => (id === partyId ? null : id));
+    }
+  }
+
+  /**
    * City-level payment approval. Approves the receipts total as the payment
    * amount (or clears approval when amountUsd is null).
    */
@@ -3379,6 +3486,8 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                 walletReminderBusyPartyId === row.party.id;
               const photoReminderBusy =
                 photoReminderBusyPartyId === row.party.id;
+              const attendanceReminderBusy =
+                attendanceReminderBusyPartyId === row.party.id;
               const hasInFlight =
                 row.aggregates.pendingCount + row.aggregates.approvedCount > 0;
               // pinsa-92103: ALSO show the button when the city has paid
@@ -3693,6 +3802,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           canSendTgReminder={canSendTgReminder}
                           canSendWalletReminder={canSendWalletReminder}
                           canSendPhotoReminder={canSendPhotoReminder}
+                          canSendAttendanceReminder={canSendAttendanceReminder}
                           canApproveCity={canApproveCity}
                           canReopen={isClosed && canReopenCap}
                           canManageTags={canManageTags}
@@ -3704,11 +3814,13 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           tgReminderBusy={tgReminderBusy}
                           walletReminderBusy={walletReminderBusy}
                           photoReminderBusy={photoReminderBusy}
+                          attendanceReminderBusy={attendanceReminderBusy}
                           reopenBusy={reopenBusyPartyId === row.party.id}
                           approveBusy={approveBusyPartyId === row.party.id}
                           receiptsReminderSentAt={row.party.receiptsReminderSentAt}
                           walletReminderSentAt={row.party.walletReminderSentAt}
                           photoReminderSentAt={row.party.photoReminderSentAt}
+                          attendanceReminderSentAt={row.party.attendanceReminderSentAt}
                           paymentsApprovedUsd={row.party.paymentsApprovedUsd}
                           paymentsApprovedAt={row.party.paymentsApprovedAt}
                           receiptsTotalUsd={receiptUsdTotal}
@@ -3760,6 +3872,11 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           onSendPhotoReminder={
                             canSendPhotoReminder
                               ? () => handleSendPhotoReminder(row)
+                              : undefined
+                          }
+                          onSendAttendanceReminder={
+                            canSendAttendanceReminder
+                              ? () => handleSendAttendanceReminder(row)
                               : undefined
                           }
                           onReopen={

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -627,6 +627,25 @@ export async function sendTgPhotoReminder(
 }
 
 /**
+ * Sibling of {@link sendTgPhotoReminder}: sends a "submit your event's
+ * estimated attendance at rsv.pizza/<slug>" reminder via the Molto Benny
+ * Telegram bot — DM to the primary host + post to the city's group chat. Same
+ * per-channel success + skip-reason contract. Persists a sent-at timestamp on
+ * success. tonda-58293: group chat_id resolved server-side; no `groupChatId` arg.
+ */
+export async function sendTgAttendanceReminder(
+  partyId: string,
+): Promise<SendTgReceiptsReminderResponse> {
+  return apiRequest<SendTgReceiptsReminderResponse>(
+    `/api/admin/payouts/${partyId}/tg-attendance-reminder`,
+    {
+      method: 'POST',
+      requireAuth: true,
+    },
+  );
+}
+
+/**
  * tonda-58293: DB-first read of the city → Telegram group mapping. Replaces
  * the client-side Google Sheet fetch (`fetchTelegramGroups()`) for sends.
  * Returns rows from `city_telegram_groups` scoped to the caller's cities

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1662,6 +1662,45 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 result.hostDmSent || result.groupSent ? 'success' : 'error';
               pushToast(`Photo reminder: ${hostLabel} | ${groupLabel}`, tone);
             }}
+            // Attendance reminder — same per-channel success/skip toast as the
+            // photo reminder.
+            onTgAttendanceReminderResult={(partyId, result) => {
+              if ('error' in result) {
+                pushToast(
+                  `Could not send attendance reminder: ${result.error}`,
+                  'error',
+                );
+                return;
+              }
+              if (result.hostDmSent || result.groupSent) {
+                setByPartyRows((prev) =>
+                  prev.map((r) =>
+                    r.party.id === partyId
+                      ? {
+                          ...r,
+                          party: {
+                            ...r.party,
+                            attendanceReminderSentAt: new Date().toISOString(),
+                          },
+                        }
+                      : r,
+                  ),
+                );
+              }
+              const hostLabel = result.hostDmSent
+                ? 'DM ✓'
+                : `DM skipped${
+                    result.hostDmReason ? ` (${result.hostDmReason})` : ''
+                  }`;
+              const groupLabel = result.groupSent
+                ? 'Group ✓'
+                : `Group skipped${
+                    result.groupReason ? ` (${result.groupReason})` : ''
+                  }`;
+              const tone =
+                result.hostDmSent || result.groupSent ? 'success' : 'error';
+              pushToast(`Attendance reminder: ${hostLabel} | ${groupLabel}`, tone);
+            }}
             viewerRole={viewerKind}
             busyRowId={rowBusyId}
             loading={loading}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -342,6 +342,7 @@ export interface Party {
   receiptsReminderSentAt?: string | null;
   walletReminderSentAt?: string | null;
   photoReminderSentAt?: string | null;
+  attendanceReminderSentAt?: string | null;
   underbossStatus?: UnderbossStatus | null;
   turtleRolesEnabled?: boolean;
   // romana-61204: post-event survey toggle
@@ -2481,6 +2482,8 @@ export interface PartyPayoutsRow {
     walletReminderSentAt?: string | null;
     /** ISO timestamp of when the TG photo reminder was last sent. */
     photoReminderSentAt?: string | null;
+    /** ISO timestamp of when the TG attendance reminder was last sent. */
+    attendanceReminderSentAt?: string | null;
     /** City-level approved payment amount. */
     paymentsApprovedUsd?: number | null;
     /** ISO timestamp of when the city payment was approved. */

--- a/supabase/migrations/20260610_attendance_reminder_sent_at.sql
+++ b/supabase/migrations/20260610_attendance_reminder_sent_at.sql
@@ -1,0 +1,3 @@
+-- Track when the TG "submit estimated attendance" reminder is sent for a party/city.
+-- Recorded when the TG attendance-reminder endpoint successfully sends at least one message.
+ALTER TABLE parties ADD COLUMN IF NOT EXISTS attendance_reminder_sent_at timestamptz;


### PR DESCRIPTION
@
## What
Adds a fourth Telegram reminder on the `/payments` by-city row menu — **"Send attendance reminder"** — that DMs the host + posts to the city group asking them to submit their events **estimated attendance**. Cloned end-to-end from the photo reminder (two-click confirm, per-channel success/skip toast, persisted "Sent {date}" sub-label that updates optimistically).

## Changes (7 files)
- **DB**: new nullable column `parties.attendance_reminder_sent_at` (Prisma `attendanceReminderSentAt`) + migration file.
- **Backend** (`admin-payout.routes.ts`): projection + both by-party row mappings + new `POST /:partyId/tg-attendance-reminder` route (byte-for-byte clone of `tg-photo-reminder`; only message text / persisted field / log prefix differ).
- **Frontend**: `sendTgAttendanceReminder` (api.ts), type field (types.ts), full menu-button + handler wiring (`PayoutsByPartyTable.tsx`), and the optimistic-sent result handler (`PaymentsAdminPage.tsx`).

## Message text
`Please submit your events estimated attendance at rsv.pizza/{slug}`

## Deploy ordering (landmine)
The new `attendanceReminderSentAt` Prisma field 500s every party query if the prod column is missing. **Apply `ALTER TABLE parties ADD COLUMN IF NOT EXISTS attendance_reminder_sent_at timestamptz;` to prod BEFORE merge.** Backend auto-deploys from master after merge.

## Verify
By-city row ⋯ menu → "Send attendance reminder" → two-click confirm → toast shows per-channel result and "Sent {today}" appears immediately, no refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@