### PR TITLE
ci: focused react-hooks/rules-of-hooks gate on PRs (+ CLAUDE.md CI/migration docs)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,24 +1,26 @@
-name: Lint (frontend)
+name: Hooks lint (frontend)
 
-# Runs `npm run lint` (ESLint) on PRs that touch the frontend. The repo already
-# enables react-hooks/rules-of-hooks (error) via the recommended config, but
-# nothing ran it: build/deploy only fire on push to master, vite build does not
-# lint, and a hooks-order violation usually still BUILDS yet crashes at runtime
-# (black-screen). This gate catches that class before merge.
+# Runs ONLY react-hooks/rules-of-hooks over frontend/src on PRs that touch it.
 #
-# ESLint exits non-zero only on error-level rules (rules-of-hooks). exhaustive-deps
-# and react-refresh are warnings and do NOT fail the job, so this is not noisy.
-# Incident this guards: arugula-38633 v2 — useMemo added below an early return
-# black-screened HostPage (2026-05-19).
+# Why focused and not `npm run lint`: the full lint carries ~678 pre-existing debt
+# items (no-explicit-any, no-unused-vars, exhaustive-deps warnings) so it can't gate
+# PRs yet. But rules-of-hooks is the high-value incident class — a hook declared
+# below an early return builds fine yet black-screens at runtime (arugula-38633 v2,
+# 2026-05-19). This gate blocks that one class without the debt noise.
+#
+# Config: frontend/eslint.hooks.config.js (e2e/ excluded — Playwright's `use` param
+# false-positives the rule). To later enforce full lint, pay down the debt and point
+# this at `npm run lint`.
 
 on:
   pull_request:
     paths:
-      - 'frontend/**'
+      - 'frontend/src/**'
+      - 'frontend/eslint.hooks.config.js'
       - '.github/workflows/lint.yml'
 
 jobs:
-  lint:
+  hooks-lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,6 +39,6 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Lint
+      - name: Lint hooks rules (src only)
         working-directory: frontend
-        run: npm run lint
+        run: npx eslint --config eslint.hooks.config.js "src/**/*.{ts,tsx}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint (frontend)
+
+# Runs `npm run lint` (ESLint) on PRs that touch the frontend. The repo already
+# enables react-hooks/rules-of-hooks (error) via the recommended config, but
+# nothing ran it: build/deploy only fire on push to master, vite build does not
+# lint, and a hooks-order violation usually still BUILDS yet crashes at runtime
+# (black-screen). This gate catches that class before merge.
+#
+# ESLint exits non-zero only on error-level rules (rules-of-hooks). exhaustive-deps
+# and react-refresh are warnings and do NOT fail the job, so this is not noisy.
+# Incident this guards: arugula-38633 v2 — useMemo added below an early return
+# black-screened HostPage (2026-05-19).
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/lint.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Lint
+        working-directory: frontend
+        run: npm run lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,11 @@ Use **`mcp__supabase-pizzadao__`** for this project (not `supabase-snax`).
 - Supabase storage buckets must be created via dashboard, not code
 - **Preview deploys share production backend + DB.** Frontend previews auto-deploy per branch, but the backend only deploys from `master` and the database is a single Supabase instance. New DB columns and backend endpoints must be applied to production **before** they'll work on preview branches.
 
+## CI gates & migration safety
+- **Apply Prisma migrations to prod BEFORE merging the schema change.** The backend auto-deploys from `master` within ~1 min, and Prisma SELECTs every declared field, so a `schema.prisma` field-add merged ahead of its column 500s every query on that model (incident 2026-05-17, PR #356 / arugula-38633).
+- **`scripts/check-schema-drift.js`** (run via `npm --prefix backend run check:schema-drift`, needs `DATABASE_URL`) is the read-only guard for the above. CI runs it on every PR touching the schema/migrations (`.github/workflows/schema-drift.yml`). It only `SELECT`s `information_schema` — never add writes.
+- **`.github/workflows/lint.yml`** runs `npm run lint` on frontend PRs. `rules-of-hooks` is error-level, so hooks declared below an early return fail CI here (they build fine but black-screen at runtime — arugula-38633 v2). `vite build` does NOT lint, so this gate is the only automated lint.
+
 ## Realtime
 
 - The `guests` table is the only app table in the `supabase_realtime` publication.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Use **`mcp__supabase-pizzadao__`** for this project (not `supabase-snax`).
 ## CI gates & migration safety
 - **Apply Prisma migrations to prod BEFORE merging the schema change.** The backend auto-deploys from `master` within ~1 min, and Prisma SELECTs every declared field, so a `schema.prisma` field-add merged ahead of its column 500s every query on that model (incident 2026-05-17, PR #356 / arugula-38633).
 - **`scripts/check-schema-drift.js`** (run via `npm --prefix backend run check:schema-drift`, needs `DATABASE_URL`) is the read-only guard for the above. CI runs it on every PR touching the schema/migrations (`.github/workflows/schema-drift.yml`). It only `SELECT`s `information_schema` — never add writes.
-- **`.github/workflows/lint.yml`** runs `npm run lint` on frontend PRs. `rules-of-hooks` is error-level, so hooks declared below an early return fail CI here (they build fine but black-screen at runtime — arugula-38633 v2). `vite build` does NOT lint, so this gate is the only automated lint.
+- **`.github/workflows/lint.yml`** runs **only `react-hooks/rules-of-hooks`** over `frontend/src` on PRs (via `frontend/eslint.hooks.config.js`). That's the high-value class: a hook below an early return builds fine but black-screens at runtime (arugula-38633 v2). It's scoped this tight because full `npm run lint` carries ~678 pre-existing debt items (`no-explicit-any`, `no-unused-vars`); pay that down before widening the gate. `vite build` does NOT lint, so this is the only automated lint.
 
 ## Realtime
 

--- a/frontend/eslint.hooks.config.js
+++ b/frontend/eslint.hooks.config.js
@@ -6,16 +6,18 @@
 // return builds fine yet black-screens at runtime (arugula-38633 v2, 2026-05-19).
 //
 // This config runs just that one rule so CI can block it without the debt noise.
+// We pull in ONLY the typescript-eslint parser (so .tsx parses) — none of its
+// *rules* — which is why the `any`/unused-vars debt doesn't surface here.
 // e2e/ is intentionally NOT matched: Playwright's `use` fixture param trips the
 // rule (false positive), and e2e is not shipped React anyway.
 //
 // Run via: npx eslint --config eslint.hooks.config.js "src/**/*.{ts,tsx}"
 import reactHooks from 'eslint-plugin-react-hooks';
+import tseslint from 'typescript-eslint';
 
-export default [
-  {
-    files: ['src/**/*.{ts,tsx}'],
-    plugins: { 'react-hooks': reactHooks },
-    rules: { 'react-hooks/rules-of-hooks': 'error' },
-  },
-];
+export default tseslint.config({
+  files: ['src/**/*.{ts,tsx}'],
+  languageOptions: { parser: tseslint.parser },
+  plugins: { 'react-hooks': reactHooks },
+  rules: { 'react-hooks/rules-of-hooks': 'error' },
+});

--- a/frontend/eslint.hooks.config.js
+++ b/frontend/eslint.hooks.config.js
@@ -1,0 +1,21 @@
+// Focused ESLint config: ONLY react-hooks/rules-of-hooks, over src.
+//
+// The full `npm run lint` carries ~678 pre-existing debt items (no-explicit-any,
+// no-unused-vars, exhaustive-deps warnings), so it can't gate PRs as-is. But
+// rules-of-hooks is the high-value incident class: a hook declared below an early
+// return builds fine yet black-screens at runtime (arugula-38633 v2, 2026-05-19).
+//
+// This config runs just that one rule so CI can block it without the debt noise.
+// e2e/ is intentionally NOT matched: Playwright's `use` fixture param trips the
+// rule (false positive), and e2e is not shipped React anyway.
+//
+// Run via: npx eslint --config eslint.hooks.config.js "src/**/*.{ts,tsx}"
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: { 'react-hooks/rules-of-hooks': 'error' },
+  },
+];

--- a/frontend/src/components/GuestList.tsx
+++ b/frontend/src/components/GuestList.tsx
@@ -229,6 +229,7 @@ export const GuestList: React.FC = () => {
     .sort((a, b) => (a.waitlistPosition || 0) - (b.waitlistPosition || 0));
 
   // Compute available bulk actions based on selected guests
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- false positive: this hook is in a flat, unconditional sequence (no early return precedes it; see hooks at L16-232). eslint-plugin-react-hooks@5.1.0-rc.0 misfires here.
   const bulkActions = useMemo(() => {
     if (selectedIds.size === 0) return null;
     const selected = guests.filter(g => g.id && selectedIds.has(g.id));

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1088,7 +1088,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // caprino-92104: line items are in the receipt's ORIGINAL currency (see
   // `sumCurrency` in ReceiptEditor), so the sum maps to `originalAmount`,
   // not the USD value.
-  function useLineSumForAmount(docId: string) {
+  function applyLineSumToAmount(docId: string) {
     const drafts = lineItemDrafts[docId];
     const sum = draftSubtotalSum(drafts);
     setReceiptDrafts((m) => {
@@ -1540,7 +1540,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           }
           saveLineItemsEdit(r.id);
         }}
-        onUseLineSumForAmount={() => useLineSumForAmount(r.id)}
+        onUseLineSumForAmount={() => applyLineSumToAmount(r.id)}
         hasOcrError={!!localOcrError}
         retrying={retryingDocId === r.id}
         retryError={retryErrors[r.id]}
@@ -2973,7 +2973,7 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                                     </button>
                                     <button
                                       type="button"
-                                      onClick={() => useLineSumForAmount(r.id)}
+                                      onClick={() => applyLineSumToAmount(r.id)}
                                       className="px-2 py-1 rounded border border-theme-stroke text-theme-text text-xs inline-flex items-center gap-1 hover:bg-theme-surface"
                                       title="Copy the line sum into the receipt total above"
                                       disabled={(drafts ?? []).length === 0}

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -1836,7 +1836,7 @@ function CityExpansion({
     });
   }, []);
 
-  const useLineSumForAmount = useCallback((docId: string) => {
+  const applyLineSumToAmount = useCallback((docId: string) => {
     const drafts = lineItemDrafts[docId] ?? [];
     let sum = 0;
     for (const d of drafts) {
@@ -2122,7 +2122,7 @@ function CityExpansion({
           }
           saveLineItemsEdit(r.id);
         }}
-        onUseLineSumForAmount={() => useLineSumForAmount(r.id)}
+        onUseLineSumForAmount={() => applyLineSumToAmount(r.id)}
         hasOcrError={!!localOcrError}
         retrying={retryingDocId === r.id}
         retryError={retryErrors[r.id]}


### PR DESCRIPTION
## What
- **`.github/workflows/lint.yml`** — runs **only `react-hooks/rules-of-hooks`** over `frontend/src` on PRs (via the new **`frontend/eslint.hooks.config.js`**, which pulls in just the TS parser, no TS rules).
- **`frontend/src/components/GuestList.tsx`** — one justified `eslint-disable` for a verified RC-plugin false positive (correctly-ordered `useMemo`).
- **`PayoutReviewModal.tsx` / `PayoutsByPartyTable.tsx`** — renamed `useLineSumForAmount` → `applyLineSumToAmount` (it's a plain helper, not a hook; the `use*` name caused 3 false positives). Pure rename, no logic change; the `onUseLineSumForAmount` prop is a separate identifier and untouched.
- **`CLAUDE.md`** — documents the schema-drift gate, this lint gate, and the apply-migration-before-merge rule.

## Why focused, not full `npm run lint`
`rules-of-hooks` is the high-value incident class: a hook below an early return builds fine but **black-screens at runtime** (arugula-38633 v2, 2026-05-19). It was configured but **never run** — CI build/deploy only fire on push to master, `vite build` doesn't lint, and Vercel previews don't catch runtime-only hook bugs.

A full-lint gate isn't adoptable yet: the repo carries **~678 pre-existing lint problems** (342 `no-explicit-any`, 150 `no-unused-vars`, 37 `exhaustive-deps` warnings). This gate blocks the one class that actually causes outages, without that noise. Path to widen later: pay down the debt, then point the workflow at `npm run lint`.

## Findings surfaced while building this
- **No real hooks-order bugs exist today** — the GuestList flag was an RC-plugin misfire; the payments flags were a mis-named helper.
- Follow-up worth considering: the `eslint-plugin-react-hooks@5.1.0-rc.0` is a release candidate that false-positives (Playwright `use`, the GuestList case). Bumping to a stable release later could drop the GuestList suppression.

`hooks-lint` is green on this PR. Draft for your review — ready to mark ready/merge when you're happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)