### PR TITLE
fix: multi-receipt upload race (sfogliatella-58523)

### DIFF
--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Loader2,
@@ -117,6 +117,19 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   const [failedSaveIds, setFailedSaveIds] = useState<Set<string>>(new Set());
   const [retryNonce, setRetryNonce] = useState(0);
 
+  // sfogliatella-58523: ref-based in-flight guard for the auto-save effect. The
+  // previous `addingReceipts`-state + `cancelled`-cleanup guard leaked: during a
+  // multi-file upload every finished file mutated `uploadItems`, the effect
+  // cleanup flipped `cancelled = true` on the in-flight save, the POST still
+  // persisted server-side, but the continuation bailed BEFORE removing the saved
+  // rows / refetching AND left `addingReceipts === true` forever → permanent
+  // deadlock until reload. `savingRef` is the re-entrancy guard now and ALWAYS
+  // releases in `finally`; `addingReceipts` state only drives the "Saving…" UI.
+  // `inFlightIdsRef` excludes ids already mid-POST from the next `ready` filter
+  // so a re-run mid-save can't double-write payout_documents (no backend dedup).
+  const savingRef = useRef(false);
+  const inFlightIdsRef = useRef<Set<string>>(new Set());
+
   // porchetta-58296: receipts-itemized attestation (re-used key).
   const [attested, setAttested] = useState(false);
 
@@ -220,26 +233,32 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   }, []);
 
   useEffect(() => {
-    // Automatic pass: exclude items whose previous save attempt failed so we
-    // don't loop. The Retry button bumps `retryNonce` to bypass the flag.
+    // sfogliatella-58523: re-entrancy guard is `savingRef` (NOT `addingReceipts`
+    // state) so it can never get stuck true. Automatic pass: exclude items whose
+    // previous save attempt failed (so we don't loop — Retry bumps `retryNonce`
+    // to bypass the flag) and items already mid-POST (`inFlightIdsRef`).
+    if (savingRef.current) return;
     const ready = uploadItems.filter(
-      (r) => isReadyItem(r) && !failedSaveIds.has(r.id)
+      (r) => isReadyItem(r) && !failedSaveIds.has(r.id) && !inFlightIdsRef.current.has(r.id)
     );
-    if (ready.length === 0 || addingReceipts) return;
+    if (ready.length === 0) return;
 
-    let cancelled = false;
+    savingRef.current = true;
+    const attemptedIds = ready.map((r) => r.id);
+    attemptedIds.forEach((id) => inFlightIdsRef.current.add(id));
+    setAddingReceipts(true);
+    setReceiptError(null);
+
     (async () => {
-      setAddingReceipts(true);
-      setReceiptError(null);
-      const attemptedIds = ready.map((r) => r.id);
       try {
         const docs = ready.flatMap(buildDocsFromItem);
         const res = await addReimbursementReceipts(partyId, docs);
-        if (cancelled) return;
+        // The POST persisted server-side, so ALWAYS reconcile (no cancellation
+        // bail-out) — that bail-out is what lost the UI before.
         setCapWarning(res.capWarning ?? null);
         // Remove the appended rows from the live buffer.
-        const appendedIds = new Set(attemptedIds);
-        setUploadItems((prev) => prev.filter((r) => !appendedIds.has(r.id)));
+        const appended = new Set(attemptedIds);
+        setUploadItems((prev) => prev.filter((r) => !appended.has(r.id)));
         // Refresh the rolling record + event roll-up from the server.
         setData((prev) =>
           prev
@@ -252,10 +271,11 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
               }
             : prev
         );
-        loadMine();
+        // ziti-58300: silent refresh — the loud `loading` spinner remounts the
+        // body (and EventPhotosCard), tripping the onRolesChange refetch loop.
+        loadMine(true);
         loadEvent();
       } catch (err: any) {
-        if (cancelled) return;
         // grissini-58511: keep the failed items in the buffer (don't drop them)
         // and flag them so the automatic pass stops retrying. The Retry button
         // clears these flags for one pass.
@@ -266,14 +286,13 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           return next;
         });
       } finally {
-        if (!cancelled) setAddingReceipts(false);
+        attemptedIds.forEach((id) => inFlightIdsRef.current.delete(id));
+        savingRef.current = false;
+        setAddingReceipts(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uploadItems, addingReceipts, partyId, buildDocsFromItem, isReadyItem, failedSaveIds, retryNonce]);
+  }, [uploadItems, partyId, buildDocsFromItem, isReadyItem, failedSaveIds, retryNonce, loadMine, loadEvent]);
 
   // grissini-58511: explicit Retry — clear the failed flags so the auto-save
   // effect re-attempts the now-unblocked items on its next run, and bump the

--- a/frontend/src/components/payouts/ReceiptUpload.tsx
+++ b/frontend/src/components/payouts/ReceiptUpload.tsx
@@ -97,7 +97,7 @@ interface ReceiptUploadProps {
   partyId: string;
   payoutTempId: string;
   items: ReceiptItem[];
-  onChange: (items: ReceiptItem[]) => void;
+  onChange: React.Dispatch<React.SetStateAction<ReceiptItem[]>>;
   maxItems?: number;
 }
 
@@ -125,15 +125,13 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
    */
   const filesRef = useRef<Map<string, File>>(new Map());
 
-  // Read freshest items via a ref so async upload/OCR work that resolves out of
-  // order doesn't clobber sibling updates with a stale list snapshot.
-  const itemsRef = useRef<ReceiptItem[]>(items);
-  itemsRef.current = items;
-
+  // sfogliatella-58523: patch a single item via a FUNCTIONAL updater so async
+  // upload/OCR work that resolves out of order always reads the freshest list
+  // (including concurrent parent removals of saved rows) instead of a stale
+  // snapshot. The old itemsRef-snapshot approach re-inserted rows the parent had
+  // already removed, churning uploadItems and tripping the auto-save guard.
   const patchItem = (itemId: string, patch: Partial<ReceiptItem>) => {
-    const next = updateItem(itemsRef.current, itemId, patch);
-    itemsRef.current = next;
-    onChange(next);
+    onChange((prev) => updateItem(prev, itemId, patch));
   };
 
   // Upload a single file then run OCR. Reused for the initial parallel pass and
@@ -193,9 +191,9 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({
       mimeType: f.type,
     }));
     fileArr.forEach((f, i) => filesRef.current.set(newItems[i].id, f));
-    const nextItems = [...itemsRef.current, ...newItems];
-    itemsRef.current = nextItems;
-    onChange(nextItems);
+    // sfogliatella-58523: functional updater — append placeholders to the
+    // freshest list instead of a captured snapshot.
+    onChange((prev) => [...prev, ...newItems]);
 
     // Upload each file in parallel, then run OCR.
     await Promise.all(fileArr.map((file, i) => uploadOne(file, newItems[i].id)));


### PR DESCRIPTION
## Problem

On the host Payments tab, dropping/selecting **multiple receipts at once** caused only the first to persist and the UI to never update — the auto-save deadlocked until a full page reload. Two interacting frontend bugs.

### Bug A (primary) — auto-save lock leaked → permanent deadlock
`PayoutsTab.tsx` guarded the auto-save `useEffect` with `addingReceipts` state + a `cancelled` cleanup flag. During a multi-file upload, every file finishing OCR mutated `uploadItems`, the effect cleanup flipped `cancelled = true` on the in-flight save. The POST still completed server-side, but the continuation bailed **before** removing the saved rows / refetching, and `if (!cancelled)` left `addingReceipts === true` forever. Every later effect run then early-returned on the stuck lock — only a reload cleared it.

**Fix:** ref-based in-flight guard that always releases.
- `savingRef` is the re-entrancy guard (always reset in `finally`); `addingReceipts` state now only drives the "Saving…" indicator.
- `inFlightIdsRef` excludes ids already mid-POST from the `ready` filter, preventing duplicate `payout_documents` on a re-run mid-save (no backend URL dedup).
- Removed the `cancelled` flag, the cleanup `return`, and all `if (cancelled) return;` bail-outs — the POST persists server-side, so the batch must always reconcile (remove attempted ids + refetch).
- Success uses `loadMine(true)` (silent) to avoid the ziti-58300 spinner remount loop.

### Bug B (trigger) — stale snapshot in `ReceiptUpload.handleFiles`
The per-file write-backs wrote whole-array snapshots (`itemsRef.current`) that re-inserted rows the parent had concurrently removed, churning `uploadItems` and tripping Bug A's cancellation.

**Fix:** functional state updates.
- `onChange` prop type → `React.Dispatch<React.SetStateAction<ReceiptItem[]>>` (both call sites already pass a `useState` setter).
- `patchItem` and `handleFiles` now use functional updaters (`onChange((prev) => …)`) and drop the `itemsRef` snapshot. Discrete click handlers (remove / per-receipt edits) read current-render `items` and are unchanged.

## Scope
Frontend-only. No migration, no backend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)