### PR TITLE
stromboli-58523: email hosts on party approve/reject + cap change

### DIFF
--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -20,6 +20,7 @@ import { renderAnnouncementBodyHtml } from '../lib/markdownLinks.js';
 import { getReimbursementRules, getGppGlobalEditors, getOperationalLimits } from '../lib/privateConfig.js';
 import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
 import { canonicalizeCountryName } from '../lib/canonicalCountryName.js';
+import { emailHostOfCapChange } from '../services/partyStatusEmailNotify.js';
 
 // Helper function to get party with ownership check
 async function getPartyWithOwnershipCheck(partyId: string, userId?: string, userEmail?: string) {
@@ -864,6 +865,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         actorKind,
         note: 'PATCH /api/parties/:id',
       });
+      // stromboli-58523: notify host of reimbursement-cap change (fire-and-forget)
+      void emailHostOfCapChange(id, priorCapUsd, reimbursementCapUsdToWrite);
     }
 
     // Trigger webhook for party update

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -9,6 +9,7 @@ import { addPartnerToParty, removePartnerFromParty, getAutoCoHostPartners } from
 import { buildScopedWhereClause, partyMatchesScope, UnderbossScope } from '../helpers/underbossScope.js';
 import { writeStatusAudit, ActorKind } from '../helpers/statusAudit.js';
 import { scorePartiesByIds, buildSybilWalletSetFromDb } from '../lib/fakeDetectionScan.js';
+import { emailHostOfStatusChange } from '../services/partyStatusEmailNotify.js';
 
 // Re-export the request type under the local name used throughout this file
 type UnderbossRequest = UnderbossAuthRequest;
@@ -1166,7 +1167,7 @@ router.patch('/events/bulk-status', requireAuth, requireUnderbossAuth, async (re
     const isAdminUser = await isAdmin(email);
     const actorKind: ActorKind = isAdminUser ? 'admin' : 'underboss';
 
-    const updatedCount = await prisma.$transaction(async (tx) => {
+    const { count: updatedCount, ids: changedIds } = await prisma.$transaction(async (tx) => {
       const before = await tx.party.findMany({
         where: { id: { in: partyIds } },
         select: { id: true, underbossStatus: true },
@@ -1183,8 +1184,13 @@ router.patch('/events/bulk-status', requireAuth, requireUnderbossAuth, async (re
       for (const p of changing) {
         await writeStatusAudit(tx, p.id, p.underbossStatus, status, email, actorKind);
       }
-      return changing.length;
+      return { count: changing.length, ids: changing.map(p => p.id) };
     });
+
+    // stromboli-58523: notify each host of approve/reject (fire-and-forget)
+    if (status === 'approved' || status === 'rejected') {
+      for (const cid of changedIds) void emailHostOfStatusChange(cid, status);
+    }
 
     res.json({ updated: updatedCount });
   } catch (error) {
@@ -1463,12 +1469,14 @@ router.patch('/event/:partyId/status', requireAuth, async (req: AuthRequest, res
       }
       // Underboss/admin: allow all statuses
       const actorKind: ActorKind = isAdminUser ? 'admin' : 'underboss';
+      let priorStatus: string | null = null;
       const party = await prisma.$transaction(async (tx) => {
         const before = await tx.party.findUnique({
           where: { id: partyId },
           select: { underbossStatus: true },
         });
         if (!before) throw new AppError('Party not found', 404, 'NOT_FOUND');
+        priorStatus = before.underbossStatus;
 
         const updated = await tx.party.update({
           where: { id: partyId },
@@ -1479,6 +1487,10 @@ router.patch('/event/:partyId/status', requireAuth, async (req: AuthRequest, res
         await writeStatusAudit(tx, partyId, before.underbossStatus, status, email, actorKind);
         return updated;
       });
+      // stromboli-58523: notify host of approve/reject (fire-and-forget, only on real change)
+      if ((status === 'approved' || status === 'rejected') && priorStatus !== status) {
+        void emailHostOfStatusChange(partyId, status);
+      }
       return res.json({ party });
     }
 

--- a/backend/src/services/partyStatusEmailNotify.ts
+++ b/backend/src/services/partyStatusEmailNotify.ts
@@ -1,0 +1,122 @@
+/**
+ * stromboli-58523: Email notifications for party status + reimbursement-cap changes.
+ *
+ * Mirrors payoutEmailNotify's Resend path (RESEND_API_KEY, from `noreply@rsv.pizza`).
+ * Fires whenever an admin/underboss approves or rejects a party, or changes its
+ * reimbursement cap.
+ *
+ * Fire-and-forget: callers should NOT await these functions. Every failure mode
+ * is caught internally so a Resend outage never blocks the underlying mutation.
+ * Hosts without a `User.email` are silently skipped (also filters seed rows).
+ */
+import { prisma } from '../config/database.js';
+
+function esc(s: string): string {
+  return s.replace(/[<>&]/g, (c) => (c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;'));
+}
+
+async function loadHostCtx(partyId: string) {
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: {
+      name: true,
+      customUrl: true,
+      inviteCode: true,
+      user: { select: { email: true, name: true } },
+    },
+  });
+  if (!party?.user?.email) return null; // no host email -> silent skip (also filters seed rows)
+  const cityName =
+    party.name.replace(/^Global Pizza Party\s+/i, '').trim() || party.name;
+  const slug = party.customUrl ?? party.inviteCode;
+  return {
+    toEmail: party.user.email,
+    hostName: party.user.name ?? 'there',
+    cityName: esc(cityName),
+    slug,
+  };
+}
+
+async function sendResend(
+  apiKey: string,
+  to: string,
+  subject: string,
+  html: string,
+  tag: string,
+) {
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: 'RSV.Pizza <noreply@rsv.pizza>',
+      to,
+      subject,
+      html,
+    }),
+  }).catch((err) => console.warn(`[${tag}] Resend send failed:`, err?.message || err));
+}
+
+/** Fire-and-forget. Email host that an admin/UB approved or rejected their party. */
+export async function emailHostOfStatusChange(
+  partyId: string,
+  newStatus: 'approved' | 'rejected',
+): Promise<void> {
+  try {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) return;
+    const ctx = await loadHostCtx(partyId);
+    if (!ctx) return;
+    const eventUrl = `https://rsv.pizza/host/${ctx.slug}`;
+    let subject: string;
+    let html: string;
+    if (newStatus === 'approved') {
+      subject = `🍕 Your Global Pizza Party in ${ctx.cityName} is approved!`;
+      html = `<p>Hey ${esc(ctx.hostName)},</p>
+<p>Great news — your event for <b>${ctx.cityName}</b> has been approved.</p>
+<p>View and manage it on your <a href="${eventUrl}">event page</a>.</p>
+<p>Best,<br>Dread Pizza Roberts<br>PizzaDAO</p>`;
+    } else {
+      subject = `Update on your Global Pizza Party in ${ctx.cityName}`;
+      html = `<p>Hey ${esc(ctx.hostName)},</p>
+<p>Your event for <b>${ctx.cityName}</b> wasn't approved. If you'd like to discuss or resubmit, reach out to your underboss.</p>
+<p>Best,<br>Dread Pizza Roberts<br>PizzaDAO</p>`;
+    }
+    await sendResend(apiKey, ctx.toEmail, subject, html, 'emailHostOfStatusChange');
+  } catch (err: any) {
+    console.warn('[emailHostOfStatusChange] error:', err?.message || err);
+  }
+}
+
+/** Fire-and-forget. Email host that their reimbursement cap changed. */
+export async function emailHostOfCapChange(
+  partyId: string,
+  oldCapUsd: number | null,
+  newCapUsd: number | null,
+): Promise<void> {
+  try {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) return;
+    const ctx = await loadHostCtx(partyId);
+    if (!ctx) return;
+    const paymentsUrl = `https://rsv.pizza/host/${ctx.slug}/payments`;
+    const subject = `🍕 Reimbursement cap updated for ${ctx.cityName}`;
+    let line: string;
+    if (newCapUsd == null) {
+      line = `Your reimbursement cap for <b>${ctx.cityName}</b> was cleared — it now uses the default.`;
+    } else {
+      const was =
+        oldCapUsd != null ? ` (was $${Number(oldCapUsd).toFixed(2)})` : '';
+      line = `Your reimbursement cap for <b>${ctx.cityName}</b> is now <b>$${Number(newCapUsd).toFixed(2)}</b>${was}.`;
+    }
+    const html = `<p>Hey ${esc(ctx.hostName)},</p>
+<p>${line}</p>
+<p>View details on your <a href="${paymentsUrl}">Payments tab</a>.</p>
+<p>Best,<br>Dread Pizza Roberts<br>PizzaDAO</p>`;
+    await sendResend(apiKey, ctx.toEmail, subject, html, 'emailHostOfCapChange');
+  } catch (err: any) {
+    console.warn('[emailHostOfCapChange] error:', err?.message || err);
+  }
+}


### PR DESCRIPTION
## What
Sends the **primary host** a transactional email whenever an admin/underboss:
- **approves** their party
- **rejects** their party
- changes their **reimbursement cap**

## How
New fire-and-forget Resend service `backend/src/services/partyStatusEmailNotify.ts` (`emailHostOfStatusChange`, `emailHostOfCapChange`), structurally cloned from the existing `payoutEmailNotify.ts` (same `RESEND_API_KEY` early-return, `from: noreply@rsv.pizza`, try/catch + `.catch()`, never throws). Wired into three existing mutation sites:
- `PATCH /api/underboss/event/:partyId/status` (single) — approved/rejected only, guarded on real status change
- `PATCH /api/underboss/events/bulk-status` (bulk) — one email per *changed* party
- `PATCH /api/parties/:id` cap-audit block — fires on the same `capValuesDiffer` guard as the audit

## Guards
- No-op writes never email (reuses existing change-detection at each site)
- Host with no email → silent skip (also filters seed rows)
- Resend down / no key → caught internally, mutation still 200
- Owner self-serve listed/hidden toggles → not emailed

## Notes
- **Backend-only, no migration.** Frontend Vercel check is a no-op here; backend goes live on merge→master (auto-deploy).
- `tsc --noEmit` clean for all three touched files.
- Plan: `plans/stromboli-58523-status-change-host-emails.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)