### PR TITLE
Show est. attendance, RSVPs & check-ins on /payments by-city lines (cappelletti-58525)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -266,6 +266,9 @@ const PAYOUT_PARTY_SELECT: Prisma.PartySelect = {
   // toggle can filter rows where party.region === 'usa'.
   region: true,
   expectedGuests: true,
+  // cappelletti-58525: host-submitted estimated attendance, surfaced on the
+  // /payments by-city line (distinct from expectedGuests).
+  estimatedAttendance: true,
   // arugula-38633 v2 follow-up: surface the effective reimbursement cap on
   // the /payments admin dashboard. Raw `reimbursementCapUsd` + `eventTags`
   // are selected here so `serializePayout` can resolve them via the shared
@@ -1937,6 +1940,33 @@ router.get(
         }
       }
 
+      // cappelletti-58525: per-party RSVP + check-in counts for the by-city
+      // line. RSVPs = all non-invited guests (matches /underboss guestCount);
+      // check-ins = guests with a check-in timestamp. Two batched groupBys
+      // over the same party id set, mirroring the receiptCounts pattern.
+      const rsvpCounts = new Map<string, number>();
+      const checkInCounts = new Map<string, number>();
+      if (uniquePartyIds.length > 0) {
+        const [rsvpRows, checkInRows] = await Promise.all([
+          prisma.guest.groupBy({
+            by: ['partyId'],
+            where: { partyId: { in: uniquePartyIds }, status: { not: 'INVITED' } },
+            _count: { id: true },
+          }),
+          prisma.guest.groupBy({
+            by: ['partyId'],
+            where: { partyId: { in: uniquePartyIds }, checkedInAt: { not: null } },
+            _count: { id: true },
+          }),
+        ]);
+        for (const r of rsvpRows) {
+          rsvpCounts.set(r.partyId, r._count.id);
+        }
+        for (const r of checkInRows) {
+          checkInCounts.set(r.partyId, r._count.id);
+        }
+      }
+
       // ricotta-92104: per-party event photos for the by-city expansion's
       // Event/Pizza preview sections. Mirrors the same select shape as the
       // per-payout serializer (admin-payout.routes.ts ~line 2189) so the
@@ -2185,6 +2215,11 @@ router.get(
             paymentsApprovedAt: b.partyMeta.paymentsApprovedAt
               ? b.partyMeta.paymentsApprovedAt.toISOString()
               : null,
+            // cappelletti-58525: est. attendance + RSVP + check-in counts for
+            // the by-city line.
+            estimatedAttendance: b.partyMeta.estimatedAttendance ?? null,
+            rsvpCount: rsvpCounts.get(partyId) ?? 0,
+            checkInCount: checkInCounts.get(partyId) ?? 0,
           },
           aggregates: {
             pendingCount: b.pendingCount,
@@ -2325,6 +2360,13 @@ router.get(
               paymentsApprovedAt: partyMeta.paymentsApprovedAt
                 ? partyMeta.paymentsApprovedAt.toISOString()
                 : null,
+              // cappelletti-58525: keep the shape consistent with real rows.
+              // tbd/unsubmitted events surface their real est. attendance (if
+              // any); RSVP/check-in counts default to 0 (these are
+              // zero-submission events and not in the groupBy id set).
+              estimatedAttendance: partyMeta.estimatedAttendance ?? null,
+              rsvpCount: 0,
+              checkInCount: 0,
             },
             aggregates: {
               pendingCount: 0,

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -3581,6 +3581,15 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                           {row.party.country}
                         </div>
                       )}
+                      {/* cappelletti-58525: est. attendance + RSVP + check-in
+                          counts as a compact sub-line on each city row. */}
+                      <div className="text-xs text-theme-text-muted mt-0.5 flex flex-wrap items-center gap-x-2">
+                        <span title="Host-estimated attendance">Est. {row.party.estimatedAttendance ?? '—'}</span>
+                        <span aria-hidden>·</span>
+                        <span title="RSVPs (non-invited guests)">{row.party.rsvpCount ?? 0} RSVP{(row.party.rsvpCount ?? 0) === 1 ? '' : 's'}</span>
+                        <span aria-hidden>·</span>
+                        <span title="Checked-in guests">{row.party.checkInCount ?? 0} check-in{(row.party.checkInCount ?? 0) === 1 ? '' : 's'}</span>
+                      </div>
                       <div className="flex flex-wrap items-center gap-2 mt-1">
                         {/* parmigiana-92104: tiny SWC Hub pill so admins notice
                             before they expand the row + click into a modal. The

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2655,6 +2655,12 @@ export interface PartyPayoutsRow {
     paymentsApprovedUsd?: number | null;
     /** ISO timestamp of when the city payment was approved. */
     paymentsApprovedAt?: string | null;
+    /** cappelletti-58525: host-submitted estimated attendance (null when unsubmitted). */
+    estimatedAttendance?: number | null;
+    /** cappelletti-58525: count of non-invited guests (status != INVITED). */
+    rsvpCount?: number;
+    /** cappelletti-58525: count of guests with a check-in timestamp. */
+    checkInCount?: number;
   };
   aggregates: {
     pendingCount: number;


### PR DESCRIPTION
Adds three numbers to each event/city line on the **/payments by-city view**:

- **Estimated attendance** — `parties.estimated_attendance` only (shows `—` when the host hasn't submitted it)
- **RSVPs** — count of all non-invited guests (`status != INVITED`), matching the `/underboss` definition
- **Check-ins** — count of guests with a check-in timestamp

## Changes
- `admin-payout.routes.ts` — `by-party` returns `estimatedAttendance` + two batched `groupBy` counts (non-invited RSVPs, check-ins) per party; synthetic TBD-unsubmitted rows default counts to 0.
- `types.ts` — optional fields on `PartyPayoutsRow.party`.
- `PayoutsByPartyTable.tsx` — compact muted sub-line on the collapsed city row.

## Notes
- **No DB migration** — all source fields pre-exist.
- New **backend response fields**, so real numbers only appear after merge (preview uses the prod/master backend). Preview renders the sub-line with placeholder values (`Est. — · 0 RSVPs · 0 check-ins`) so layout/styling is verifiable there.
- Backend typecheck errors are all pre-existing on master (verified via stash); this PR adds none.

Plan: `plans/cappelletti-58525-payments-attendance-line.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
