### PR TITLE
margherita-58526: live-refresh hot wallet balance on /payments after a USDC send

### DIFF
--- a/frontend/src/components/payments-admin/HotWalletCard.tsx
+++ b/frontend/src/components/payments-admin/HotWalletCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Wallet, RefreshCcw, Copy, Check, AlertTriangle, Loader2 } from 'lucide-react';
 import { fetchPayoutWalletInfo, type PayoutWalletInfo } from '../../lib/api';
 
@@ -47,9 +47,14 @@ interface HotWalletCardProps {
    * two balance tiles still render.
    */
   readOnly?: boolean;
+  /**
+   * margherita-58526: parent bumps this to a new truthy value after a USDC
+   * send so the card re-fetches its balances in place (no manual refresh).
+   */
+  refreshSignal?: number;
 }
 
-export const HotWalletCard: React.FC<HotWalletCardProps> = ({ readOnly = false }) => {
+export const HotWalletCard: React.FC<HotWalletCardProps> = ({ readOnly = false, refreshSignal }) => {
   const [info, setInfo] = useState<PayoutWalletInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -72,6 +77,16 @@ export const HotWalletCard: React.FC<HotWalletCardProps> = ({ readOnly = false }
   useEffect(() => {
     load();
   }, [load]);
+
+  const prevSignalRef = useRef<number | undefined>(refreshSignal);
+  useEffect(() => {
+    // margherita-58526: parent bumps refreshSignal after a USDC send so the
+    // balance updates in place without a manual refresh. Skip the initial
+    // value — the mount effect above already does the first fetch.
+    if (prevSignalRef.current === refreshSignal) return;
+    prevSignalRef.current = refreshSignal;
+    if (refreshSignal) load();
+  }, [refreshSignal, load]);
 
   const handleCopy = useCallback(async () => {
     if (!info?.address) return;

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -349,6 +349,10 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     | null
   >(null);
 
+  // margherita-58526: bumped after a USDC-on-Base send to drive HotWalletCard's
+  // re-fetch so the live balance updates in place (no manual refresh / reload).
+  const [walletRefreshKey, setWalletRefreshKey] = useState(0);
+
   // lardo-58294: local-only substring filter for the prepay queue. Cleared
   // on tab refresh — no persistence.
   const [prepaySearch, setPrepaySearch] = useState('');
@@ -1158,7 +1162,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             argentina-92103: read-only for regional underbosses — they can
             see balances but the refresh button + low-gas warning + "Base
             only" caption are hidden. */}
-        <HotWalletCard readOnly={isUnderboss} />
+        <HotWalletCard readOnly={isUnderboss} refreshSignal={walletRefreshKey} />
 
         <PaymentsStatsCards totals={totals} loading={loading && !totals} />
 
@@ -2105,6 +2109,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
                 'success',
               );
               await Promise.all([refresh(), loadPrepayQueue()]);
+              // margherita-58526: only USDC-on-Base sends move the hot wallet; wire /
+              // mercury_card don't, so don't refetch the balance for them.
+              if (method === 'usdc_base') setWalletRefreshKey((k) => k + 1);
             }}
           />
         )}
@@ -2226,6 +2233,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             );
             clearSelection();
             await Promise.all([refresh(), loadPrepayQueue()]);
+            // margherita-58526: bulk send is USDC-on-Base — refresh the hot wallet balance.
+            if (paid > 0) setWalletRefreshKey((k) => k + 1);
           }}
         />
 


### PR DESCRIPTION
## Problem
The **Hot wallet (Base)** card on `/payments` self-fetches its ETH/USDC balance only on mount (and on the manual refresh button). After an admin sends a USDC payout, the on-chain balance drops but the card keeps showing the stale balance until a manual refresh or page reload.

## Fix (frontend-only — no backend / no migration)
- `HotWalletCard.tsx` — new optional `refreshSignal?: number` prop; a guarded `useEffect` re-runs the existing `load()` when the signal changes to a truthy value (skips the mount fetch via a `prevSignalRef`).
- `PaymentsAdminPage.tsx` — new `walletRefreshKey` counter passed to the card; bumped after a successful **USDC** send in `SendPaymentModal.onSent` (only when `method === 'usdc_base'`) and `BulkSendModal.onComplete` (when `paid > 0`). Wire / Mercury-card sends don't move the on-chain wallet, so they don't trigger a refetch.

No visual change — `load()` already spins the refresh icon and updates the tiles in place.

## Verify
Preview: https://rsvpizza-git-margherita-58526-hotwallet-live-refresh-pizza-dao.vercel.app/payments
Note the USDC balance → send a USDC payout → balance updates within a second or two without touching refresh. Send a wire/Mercury payment → wallet does not refetch.

Plan: `plans/margherita-58526-hotwallet-live-refresh.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)