### PR TITLE
feat(tortellini-58525): global per-year invoice numbering

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2366,6 +2366,15 @@ model Invoice {
   @@map("invoices")
 }
 
+model InvoiceCounter {
+  scope   String  @db.Text
+  year    Int
+  nextVal Int     @default(0) @map("next_val")
+
+  @@id([scope, year])
+  @@map("invoice_counters")
+}
+
 model Mou {
   id             String    @id @default(uuid()) @db.Uuid
   partyId        String    @map("party_id") @db.Uuid

--- a/backend/src/routes/invoice.routes.test.ts
+++ b/backend/src/routes/invoice.routes.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = 'test-secret';
+
+// ─── Prisma mock ────────────────────────────────────────────────────────────
+const mockPrisma = vi.hoisted(() => ({
+  invoice: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  party: {
+    findUnique: vi.fn(),
+  },
+  sponsor: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+  },
+  $queryRaw: vi.fn(),
+  $transaction: vi.fn(async (ops: any) => {
+    if (Array.isArray(ops)) return Promise.all(ops);
+    return ops(mockPrisma);
+  }),
+}));
+
+vi.mock('../config/database.js', () => ({ prisma: mockPrisma }));
+
+// ─── Auth / access helpers ──────────────────────────────────────────────────
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    const authHeader = req.headers.authorization || '';
+    const token = authHeader.replace('Bearer ', '');
+    try {
+      const payload = jwt.verify(token, JWT_SECRET) as any;
+      req.userId = payload.sub;
+      req.userEmail = payload.email;
+    } catch {
+      req.userId = 'test-user-id';
+      req.userEmail = 'host@test.com';
+    }
+    next();
+  },
+  AuthRequest: {},
+}));
+
+vi.mock('../helpers/partyAccess.js', () => ({
+  canUserEditParty: vi.fn().mockResolvedValue(true),
+  canUserAccessTab: vi.fn().mockResolvedValue(true),
+}));
+
+// ─── App setup ──────────────────────────────────────────────────────────────
+async function buildApp() {
+  const { invoiceHostRoutes } = await import('./invoice.routes.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/parties', invoiceHostRoutes);
+  return app;
+}
+
+function makeToken(sub = 'test-user-id', email = 'host@test.com') {
+  return jwt.sign({ sub, email }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+// ─── Shared test data ────────────────────────────────────────────────────────
+const PARTY_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const SPONSOR_ID = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+const baseSponsor = {
+  id: SPONSOR_ID,
+  partyId: PARTY_ID,
+  name: 'Acme Corp',
+  contactEmail: 'billing@acme.com',
+  contactName: 'Jane Doe',
+  amount: 500,
+  sponsorshipType: 'gold',
+  logoUrl: null,
+};
+
+const baseInvoice = {
+  id: 'cccccccc-0000-0000-0000-000000000003',
+  partyId: PARTY_ID,
+  sponsorId: SPONSOR_ID,
+  invoiceNumber: '2026-00001',
+  viewToken: 'abc123token',
+  billToCompany: 'Acme Corp',
+  billToContact: 'Jane Doe',
+  billToAddress: null,
+  billToEmail: 'billing@acme.com',
+  ccEmails: [],
+  lineItems: [{ description: 'Gold Sponsorship', amount: 50000 }],
+  total: 50000,
+  currency: 'usd',
+  paymentTerms: null,
+  paymentInstructions: null,
+  dueDate: null,
+  memo: null,
+  status: 'draft',
+  paidAt: null,
+  paidAmount: null,
+  paymentMethod: null,
+  paymentRef: null,
+  sentAt: null,
+  viewedAt: null,
+  attachments: [],
+  createdAt: new Date('2026-06-10T12:00:00Z'),
+  updatedAt: new Date('2026-06-10T12:00:00Z'),
+  sponsor: { id: SPONSOR_ID, name: 'Acme Corp', contactEmail: 'billing@acme.com', logoUrl: null },
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+describe('POST /api/parties/:partyId/invoices — invoice numbering', () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+
+    // Default sponsor stub
+    mockPrisma.sponsor.findFirst.mockResolvedValue(baseSponsor);
+    // Default invoice create stub
+    mockPrisma.invoice.create.mockResolvedValue(baseInvoice);
+  });
+
+  // ── Non-GPP event: year-prefixed number, no GPP- prefix ──────────────────
+  it('generates a non-GPP number (year-NNNNN) for a non-gpp event', async () => {
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'standard',
+      date: new Date('2026-07-15T18:00:00Z'),
+      timezone: 'America/New_York',
+    });
+    // Allocation returns next_val = 1
+    mockPrisma.$queryRaw.mockResolvedValue([{ next_val: 1 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    // Verify the invoice was created with a non-GPP number
+    const createCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(createCall.data.invoiceNumber).toBe('2026-00001');
+    expect(createCall.data.invoiceNumber).not.toMatch(/^GPP-/);
+  });
+
+  // ── GPP event: GPP-year-NNNNN format ─────────────────────────────────────
+  it('generates a GPP-prefixed number for a gpp event', async () => {
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'gpp',
+      date: new Date('2026-07-15T18:00:00Z'),
+      timezone: 'America/New_York',
+    });
+    mockPrisma.$queryRaw.mockResolvedValue([{ next_val: 1 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const createCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(createCall.data.invoiceNumber).toBe('GPP-2026-00001');
+  });
+
+  // ── 5-digit zero-padding ──────────────────────────────────────────────────
+  it('zero-pads to 5 digits', async () => {
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'standard',
+      date: new Date('2026-07-15T18:00:00Z'),
+      timezone: 'UTC',
+    });
+    mockPrisma.$queryRaw.mockResolvedValue([{ next_val: 42 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const createCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(createCall.data.invoiceNumber).toBe('2026-00042');
+  });
+
+  // ── Two creates in same scope+year increment correctly ────────────────────
+  it('increments counter: first create returns 00001, second returns 00002', async () => {
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'standard',
+      date: new Date('2026-07-15T18:00:00Z'),
+      timezone: 'UTC',
+    });
+
+    // First call: next_val = 1
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ next_val: 1 }]);
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const firstCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(firstCall.data.invoiceNumber).toBe('2026-00001');
+
+    // Reset create mock for second call
+    mockPrisma.invoice.create.mockResolvedValue({ ...baseInvoice, invoiceNumber: '2026-00002' });
+
+    // Second call: next_val = 2
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ next_val: 2 }]);
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const secondCall = mockPrisma.invoice.create.mock.calls[1][0];
+    expect(secondCall.data.invoiceNumber).toBe('2026-00002');
+  });
+
+  // ── Different year resets counter to 00001 ────────────────────────────────
+  it('resets to 00001 for a different year', async () => {
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'standard',
+      date: new Date('2027-01-20T18:00:00Z'),
+      timezone: 'UTC',
+    });
+    // Allocation for 2027 scope returns 1 (independent counter)
+    mockPrisma.$queryRaw.mockResolvedValue([{ next_val: 1 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const createCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(createCall.data.invoiceNumber).toBe('2027-00001');
+  });
+
+  // ── GPP and non-GPP are independent sequences ─────────────────────────────
+  it('GPP and non-GPP use independent sequences (scope passed to $queryRaw)', async () => {
+    // GPP event
+    mockPrisma.party.findUnique.mockResolvedValueOnce({
+      eventType: 'gpp',
+      date: new Date('2026-07-15T18:00:00Z'),
+      timezone: 'UTC',
+    });
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ next_val: 5 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const gppCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(gppCall.data.invoiceNumber).toBe('GPP-2026-00005');
+
+    // Non-GPP event for same year: its own counter
+    mockPrisma.party.findUnique.mockResolvedValueOnce({
+      eventType: 'standard',
+      date: new Date('2026-08-10T18:00:00Z'),
+      timezone: 'UTC',
+    });
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ next_val: 3 }]);
+    mockPrisma.invoice.create.mockResolvedValueOnce({ ...baseInvoice, invoiceNumber: '2026-00003' });
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const nonGppCall = mockPrisma.invoice.create.mock.calls[1][0];
+    expect(nonGppCall.data.invoiceNumber).toBe('2026-00003');
+  });
+
+  // ── Null start_time falls back to current year ────────────────────────────
+  it('falls back to current year when party date is null', async () => {
+    const currentYear = new Date().getUTCFullYear();
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'standard',
+      date: null,
+      timezone: null,
+    });
+    mockPrisma.$queryRaw.mockResolvedValue([{ next_val: 1 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const createCall = mockPrisma.invoice.create.mock.calls[0][0];
+    expect(createCall.data.invoiceNumber).toBe(`${currentYear}-00001`);
+  });
+
+  // ── Timezone-local year is used for event spanning year boundary ──────────
+  it('uses timezone-local year (e.g. Jan 1 UTC is still Dec 31 in US/Pacific)', async () => {
+    // 2027-01-01T05:00:00Z = 2026-12-31 in America/Los_Angeles (UTC-8)
+    mockPrisma.party.findUnique.mockResolvedValue({
+      eventType: 'standard',
+      date: new Date('2027-01-01T05:00:00Z'),
+      timezone: 'America/Los_Angeles',
+    });
+    mockPrisma.$queryRaw.mockResolvedValue([{ next_val: 1 }]);
+
+    await request(app)
+      .post(`/api/parties/${PARTY_ID}/invoices`)
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ sponsorId: SPONSOR_ID });
+
+    const createCall = mockPrisma.invoice.create.mock.calls[0][0];
+    // Should be 2026 since the event is Dec 31 local time
+    expect(createCall.data.invoiceNumber).toBe('2026-00001');
+  });
+});

--- a/backend/src/routes/invoice.routes.ts
+++ b/backend/src/routes/invoice.routes.ts
@@ -5,6 +5,46 @@ import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
 
+/**
+ * Compute the calendar year for the given date in the specified timezone.
+ * Falls back to the UTC year if timezone is null/undefined/invalid.
+ */
+function getEventYear(date: Date | null | undefined, timezone: string | null | undefined): number {
+  const now = new Date();
+  const effective = date ?? now;
+  if (timezone) {
+    try {
+      const year = new Intl.DateTimeFormat('en-US', { timeZone: timezone, year: 'numeric' }).format(effective);
+      const parsed = parseInt(year, 10);
+      if (!isNaN(parsed)) return parsed;
+    } catch {
+      // fall through to UTC
+    }
+  }
+  return effective.getUTCFullYear();
+}
+
+/**
+ * Atomically allocate the next invoice number for the given (scope, year).
+ * Returns a formatted invoice number string like "GPP-2026-00001" or "2026-00001".
+ */
+async function allocateInvoiceNumber(
+  isGpp: boolean,
+  year: number,
+): Promise<string> {
+  const scope = isGpp ? 'gpp' : 'nongpp';
+  const rows = await prisma.$queryRaw<Array<{ next_val: number }>>`
+    INSERT INTO invoice_counters (scope, year, next_val)
+    VALUES (${scope}, ${year}, 1)
+    ON CONFLICT (scope, year)
+    DO UPDATE SET next_val = invoice_counters.next_val + 1
+    RETURNING next_val
+  `;
+  const nextVal = rows[0].next_val;
+  const padded = String(nextVal).padStart(5, '0');
+  return isGpp ? `GPP-${year}-${padded}` : `${year}-${padded}`;
+}
+
 // ============================================
 // Host routes (mounted at /api/parties)
 // ============================================
@@ -122,11 +162,18 @@ hostRouter.post('/:partyId/invoices', requireAuth, async (req: AuthRequest, res:
       throw new AppError('Sponsor not found', 404, 'NOT_FOUND');
     }
 
-    // Auto-generate invoice number (count existing + 1, zero-padded to 3 digits)
-    const existingCount = await prisma.invoice.count({
-      where: { partyId },
+    // Load party metadata needed for invoice numbering
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { eventType: true, date: true, timezone: true },
     });
-    const invoiceNumber = String(existingCount + 1).padStart(3, '0');
+
+    // Compute scope (gpp vs nongpp) and calendar year of the event
+    const isGpp = party?.eventType === 'gpp';
+    const eventYear = getEventYear(party?.date, party?.timezone);
+
+    // Atomically allocate a globally-unique, per-year invoice number
+    const invoiceNumber = await allocateInvoiceNumber(isGpp, eventYear);
 
     // Generate view token
     const viewToken = crypto.randomBytes(32).toString('hex');

--- a/supabase/migrations/20260610_create_invoice_counters.sql
+++ b/supabase/migrations/20260610_create_invoice_counters.sql
@@ -1,0 +1,7 @@
+-- counter table for per-year, per-scope invoice numbering (tortellini-58525)
+CREATE TABLE invoice_counters (
+  scope    TEXT    NOT NULL,
+  year     INTEGER NOT NULL,
+  next_val INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (scope, year)
+);


### PR DESCRIPTION
## Summary

- Replaces per-event 3-digit invoice numbering (`001`, `002`, ...) with a globally unique, year-scoped scheme
- **GPP events**: `GPP-{year}-{NNNNN}` (e.g. `GPP-2026-00001`)
- **Non-GPP events**: `{year}-{NNNNN}` (e.g. `2026-00001`)
- Counter resets each calendar year; GPP and non-GPP are independent sequences
- Year is computed from the event's `date` field in the event's `timezone` (Intl.DateTimeFormat); falls back to current UTC year if date/timezone is null or invalid
- Allocation is atomic via `INSERT ... ON CONFLICT DO UPDATE ... RETURNING next_val` — no double-counting under concurrent requests

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260610_create_invoice_counters.sql` | New migration — creates `invoice_counters (scope TEXT, year INT, next_val INT, PK(scope,year))` |
| `backend/prisma/schema.prisma` | Adds `InvoiceCounter` model mapped to `invoice_counters` |
| `backend/src/routes/invoice.routes.ts` | Replaces `count+1` with `allocateInvoiceNumber()` + `getEventYear()` helpers |
| `backend/src/routes/invoice.routes.test.ts` | New test file — 7 test cases covering all numbering scenarios |

## Prod prereq (MUST apply before merging)

Apply the migration in Supabase before merging — the backend auto-deploys from master and will 500 on invoice create if the table doesn't exist.

```sql
-- supabase/migrations/20260610_create_invoice_counters.sql
CREATE TABLE invoice_counters (
  scope    TEXT    NOT NULL,
  year     INTEGER NOT NULL,
  next_val INTEGER NOT NULL DEFAULT 0,
  PRIMARY KEY (scope, year)
);
```

## Legacy invoices

Existing `001`-format invoice numbers are untouched. No unique index on `invoice_number` globally, so there's no collision risk.

## Test plan

- [ ] Apply migration to prod Supabase
- [ ] Merge PR (backend auto-deploys from master)
- [ ] Create a new invoice on a standard event → number should be `2026-00001` (or increment)
- [ ] Create a new invoice on a GPP event → number should be `GPP-2026-00001` (or increment, independent counter)
- [ ] Verify old invoices still show their original `001`-format numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)