### PR TITLE
feat(rigatoni-58527): hide admins & underbosses from /payments reimbursement picker

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1084,6 +1084,33 @@ router.get(
         cohostUserByEmail.set(u.email.toLowerCase(), u);
       }
 
+      const candidateEmails = Array.from(
+        new Set<string>([
+          ...Array.from(allCohostEmails),
+          ...(parties
+            .map((p) => p.user?.email?.trim().toLowerCase())
+            .filter(Boolean) as string[]),
+        ]),
+      );
+      // rigatoni-58527: admins and underbosses must never be reimbursement
+      // recipients. Batch-resolve which candidate emails are org insiders so we can
+      // drop them from every party's hostCandidates list below.
+      const [adminRows, activeUnderbossRows] = candidateEmails.length
+        ? await Promise.all([
+            prisma.admin.findMany({
+              where: { email: { in: candidateEmails } },
+              select: { email: true },
+            }),
+            prisma.underboss.findMany({
+              where: { email: { in: candidateEmails }, isActive: true },
+              select: { email: true },
+            }),
+          ])
+        : [[], []];
+      const insiderEmails = new Set<string>();
+      for (const a of adminRows) insiderEmails.add(a.email.toLowerCase());
+      for (const u of activeUnderbossRows) insiderEmails.add(u.email.toLowerCase());
+
       const results = parties
         // Skip parties with no linked main host — Payout.hostUserId is FK NOT NULL
         // and the modal needs a default selection. (Vanishingly rare in practice.)
@@ -1096,13 +1123,16 @@ router.get(
             role: 'host' | 'cohost';
           }> = [];
 
-          // Main host always first.
-          hostCandidates.push({
-            userId: p.user!.id,
-            name: p.user!.name,
-            email: p.user!.email,
-            role: 'host',
-          });
+          // Main host always first — unless they're an org insider (admin /
+          // active underboss), in which case they're dropped as a recipient.
+          if (!insiderEmails.has(p.user!.email.toLowerCase())) {
+            hostCandidates.push({
+              userId: p.user!.id,
+              name: p.user!.name,
+              email: p.user!.email,
+              role: 'host',
+            });
+          }
 
           const cohostList = Array.isArray(p.coHosts) ? (p.coHosts as any[]) : [];
           const seenUserIds = new Set<string>([p.user!.id]);
@@ -1110,6 +1140,8 @@ router.get(
             if (!ch || typeof ch !== 'object') continue;
             const email = typeof ch.email === 'string' ? ch.email.trim().toLowerCase() : '';
             if (!email) continue;
+            // Org insiders (admin / active underboss) can't be recipients.
+            if (insiderEmails.has(email)) continue;
             const u = cohostUserByEmail.get(email);
             // Cohosts without a matching User record (or no email at all) are
             // silently excluded — the modal can only set Payout.hostUserId to

--- a/plans/rigatoni-58527-hide-staff-recipients.md
+++ b/plans/rigatoni-58527-hide-staff-recipients.md
@@ -1,0 +1,91 @@
+# rigatoni-58527 — Hide admins & underbosses from /payments reimbursement recipient picker
+
+## Problem
+On `/payments`, when an admin records or sends a reimbursement, the recipient
+picker lists the event's main host plus any co-hosts that resolve to a real
+`User`. Org insiders (admins and underbosses) who are listed as a host/co-host
+on an event therefore show up as selectable reimbursement recipients. They
+should never be reimbursable — it's a conflict-of-interest / fraud surface.
+
+## Root cause (single source)
+`GET /api/admin/payouts/parties/search` in
+`backend/src/routes/admin-payout.routes.ts` (~lines 1014–1138) builds the
+`hostCandidates` array (main host first, then resolvable co-hosts). This one
+endpoint (`searchApprovedParties` in `frontend/src/lib/api.ts`) feeds BOTH
+recipient pickers:
+- `frontend/src/components/payments-admin/ExternalPaymentModal.tsx` ("Record External Payment")
+- `frontend/src/components/payments-admin/SendPaymentModal.tsx` ("Send Payment")
+
+So filtering here fixes both with no frontend change required.
+
+## Decision (confirmed with Snax)
+Exclude any candidate whose lowercased email matches:
+- **any row in the `admins` table** (every role — `admin`, `super_admin`, AND `payment_admin`), or
+- an **active** row in the `underbosses` table (`is_active = true`).
+
+This is the broadest conflict-of-interest guard: no org insider can be a
+reimbursement recipient.
+
+## Implementation
+All in `backend/src/routes/admin-payout.routes.ts`, inside the
+`/parties/search` handler:
+
+1. After resolving `parties` and `cohostUserByEmail`, collect the full set of
+   candidate emails to check = every party's main-host email (`p.user.email`)
+   UNION `allCohostEmails`. Lowercase + trim.
+
+2. Batch-look-up insiders in two queries (no per-party round-trips):
+   ```ts
+   const candidateEmails = Array.from(new Set([
+     ...Array.from(allCohostEmails),
+     ...parties.map((p) => p.user?.email?.trim().toLowerCase()).filter(Boolean) as string[],
+   ]));
+   const [adminRows, underbossRows] = candidateEmails.length
+     ? await Promise.all([
+         prisma.admin.findMany({ where: { email: { in: candidateEmails } }, select: { email: true } }),
+         prisma.underboss.findMany({ where: { email: { in: candidateEmails }, isActive: true }, select: { email: true } }),
+       ])
+     : [[], []];
+   const excludedEmails = new Set<string>();
+   for (const a of adminRows) excludedEmails.add(a.email.toLowerCase());
+   for (const u of underbossRows) excludedEmails.add(u.email.toLowerCase());
+   ```
+   (Admin/underboss emails are stored lowercased by the auth paths; lowercase
+   here defensively anyway.)
+
+3. When building `hostCandidates`:
+   - **Main host**: only push if `!excludedEmails.has(p.user.email.toLowerCase())`.
+   - **Co-hosts**: skip if `excludedEmails.has(email)` (the already-lowercased
+     `email` var in the loop).
+
+4. Leave the top-level `hostUserId: p.user!.id` field as-is — it is NOT consumed
+   for recipient selection by either modal (verified: ExternalPaymentModal and
+   SendPaymentModal both drive selection off `hostCandidates`/`recipientUserId`),
+   so changing it is unnecessary and risks interface churn.
+
+5. Do NOT drop a party from the results when its `hostCandidates` ends up empty
+   (e.g. a solo event hosted by an admin). The party should still be findable so
+   an admin can record a payment via the modal's existing **"Other"** free-form
+   email path. Both modals already handle a zero-length `hostCandidates`
+   (ExternalPaymentModal: no auto-select; SendPaymentModal: "No payable hosts
+   found for this city.").
+
+## Notes / landmines
+- **Backend-only change.** No schema/migration. Backend auto-deploys from master
+  ~1 min after merge — no DB ordering concern here.
+- Highest-churn file in the repo; keep the diff tightly scoped to the
+  `/parties/search` handler. Re-read it from `origin/master` first.
+- Keep comments full-line (no schema/migration touched, but house style).
+
+## Verification
+- Vercel preview: `https://rsvpizza-git-rigatoni-58527-hide-staff-recipients-pizza-dao.vercel.app`
+  (note: preview frontend hits the **production backend**, which won't have this
+  change until merge+deploy — so behavior verifies in prod after merge, not on
+  the preview).
+- After backend deploy: pick an event whose host/co-host is a known underboss or
+  admin in the External Payment / Send Payment modal → that person no longer
+  appears in the recipient list; non-insider hosts still appear.
+
+## Out of scope
+- The "Other" free-form email path is unchanged — an admin can still deliberately
+  type any email. This task only removes insiders from the auto-suggested options.


### PR DESCRIPTION
## What
Admins and underbosses no longer appear as selectable **reimbursement recipients** on `/payments`.

Previously, any org insider (anyone in the `admins` table — `admin`/`super_admin`/`payment_admin` — or an active underboss) who happened to be listed as a host or co-host on an event showed up as a pickable recipient in both the **Record External Payment** and **Send Payment** modals. That's a conflict-of-interest / fraud surface.

## How
Single-source fix in `GET /api/admin/payouts/parties/search` (`backend/src/routes/admin-payout.routes.ts`) — the one endpoint that builds the `hostCandidates` list feeding **both** modals:

- Batch-resolve which candidate emails (main host + resolvable co-hosts) belong to an admin-table row (any role) or an active underboss (two `findMany`s, no per-party round-trips).
- Skip those emails when building each party's `hostCandidates` (both the main-host push and the co-host loop).
- Parties whose candidate list ends up empty **still return**, so the modal's free-form **"Other"** email path keeps working — an admin can still deliberately type any address.

No frontend change, no schema/migration.

## Notes
- Backend-only. Backend tsc runs on the **master** production build (not on this frontend preview), so type-correctness verifies at merge time; the `/payments` recipient-picker behavior is observable in prod after merge + the ~1-min auto-deploy (the preview hits the production backend, which won't have this change pre-merge).

## Test plan
- Open the External Payment / Send Payment modal for an event whose host or a co-host is a known admin/active underboss → that person is gone from the recipient list; non-insider hosts still appear.
- Event hosted solely by an insider → no auto-suggested recipients, but the event is still findable and payable via "Other".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
