### PR TITLE
margherita-58526: let underbosses override per-party cap up to $675

### DIFF
--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -168,6 +168,7 @@ export interface PayoutCaps {
   dailyCapUsd: number;
   w9ThresholdUsd: number;
   hardPerTxCeilingUsd: number;
+  underbossOverPartyCapMaxUsd: number;
 }
 
 /**
@@ -191,6 +192,7 @@ export function getPayoutCaps(): Promise<PayoutCaps> {
     dailyCapUsd: 100,
     w9ThresholdUsd: 100,
     hardPerTxCeilingUsd: 100,
+    underbossOverPartyCapMaxUsd: 675,
   });
 }
 

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -491,6 +491,7 @@ async function assertWithinPartyCap(
   partyId: string,
   proposedUsd: number,
   ignorePayoutId?: string,
+  ceilingOverrideUsd?: number,
 ): Promise<void> {
   const party = await prisma.party.findUnique({
     where: { id: partyId },
@@ -503,7 +504,15 @@ async function assertWithinPartyCap(
     reimbursementCapUsd: party.reimbursementCapUsd,
     eventTags: party.eventTags,
   });
-  if (effectiveCap == null) return;
+  // margherita-58526: an underboss bounded override (ceilingOverrideUsd set)
+  // ignores the event cap and enforces a config-driven per-party-TOTAL ceiling
+  // instead — never MORE restrictive than the plain event-cap path, and it
+  // bounds an otherwise-uncapped party. The no-override path is unchanged.
+  const ceiling =
+    ceilingOverrideUsd != null
+      ? Math.max(effectiveCap ?? 0, ceilingOverrideUsd)
+      : effectiveCap;
+  if (ceiling == null) return;
 
   // prosciutto-92106: cap math splits paid rows into proven vs zombie. Zombie
   // status='paid' rows (no transaction_hash / wire_reference / mercury card /
@@ -541,13 +550,15 @@ async function assertWithinPartyCap(
     (provenPaidAgg._sum.finalAmountUsd
       ? Number(provenPaidAgg._sum.finalAmountUsd.toString())
       : 0);
-  const remainingUsd = Math.max(0, effectiveCap - usedUsd);
+  const remainingUsd = Math.max(0, ceiling - usedUsd);
 
-  if (usedUsd + proposedUsd > effectiveCap + 1e-9) {
+  if (usedUsd + proposedUsd > ceiling + 1e-9) {
     throw new AppError(
-      `This payment would exceed the party's $${effectiveCap.toFixed(2)} cap. $${remainingUsd.toFixed(2)} remaining.`,
+      ceilingOverrideUsd != null
+        ? `This would exceed the $${ceiling.toFixed(2)} underboss limit. $${remainingUsd.toFixed(2)} remaining — ask an admin to approve a higher amount.`
+        : `This payment would exceed the party's $${ceiling.toFixed(2)} cap. $${remainingUsd.toFixed(2)} remaining.`,
       409,
-      'PARTY_CAP_EXCEEDED',
+      ceilingOverrideUsd != null ? 'UNDERBOSS_CAP_EXCEEDED' : 'PARTY_CAP_EXCEEDED',
     );
   }
 }
@@ -3501,13 +3512,20 @@ router.post(
 
       // nduja-92106: admin-class can opt to bypass the per-party cap at
       // approve time via `allowOverPartyCap` (mirrors salame-92103's existing
-      // override on /execute). Underbosses can NEVER skip the cap — only the
-      // four admin-class roles (admin / super_admin / payment_admin) get the
-      // ack pathway. The per-submission ceiling, per-address cap, and daily
-      // cap are unchanged.
-      const allowOverPartyCap =
-        actor.actorKind !== 'underboss' &&
-        !!(req.body && req.body.allowOverPartyCap);
+      // override on /execute). The four admin-class roles
+      // (admin / super_admin / payment_admin) get an UNBOUNDED bypass.
+      //
+      // margherita-58526: underbosses can now ALSO tick the over-cap ack, but
+      // their override is BOUNDED to a config-driven per-party-TOTAL ceiling
+      // (underbossOverPartyCapMaxUsd, default $675). Above the ceiling the
+      // override stays admin-only (UNDERBOSS_CAP_EXCEEDED). The per-submission
+      // ceiling, per-address cap, and daily cap are unchanged.
+      const wantsOverride = !!(req.body && req.body.allowOverPartyCap);
+      const isAdminClass = actor.actorKind !== 'underboss';
+      // `allowOverPartyCap` keeps its original meaning here — admin-class
+      // FULL bypass — so the autoExecute forward into executePayout below and
+      // the audit-note suffix preserve current behavior for admins.
+      const allowOverPartyCap = wantsOverride && isAdminClass;
 
       // guanciale-49340: admin-class can also opt to bypass the per-address
       // hard cap in the inline autoExecute usdc_base branch via
@@ -3533,9 +3551,24 @@ router.post(
       // nduja-92106: skip the per-party throw when the admin has ticked the
       // override checkbox in PayoutReviewModal. Per-submission ceiling stays.
       // marinara-71630 P2: per-submission cap from app_config (env-free).
-      const { perSubmissionMaxUsd: approvePerSubmissionMaxUsd } = await getPayoutCaps();
-      assertWithinPerSubmissionCap(Number(existing.finalAmountUsd), approvePerSubmissionMaxUsd);
-      if (!allowOverPartyCap) {
+      // margherita-58526: one getPayoutCaps() call, reused for both the
+      // per-submission ceiling and the underboss bounded-override ceiling.
+      const caps = await getPayoutCaps();
+      const underbossCeiling = caps.underbossOverPartyCapMaxUsd ?? 675; // ?? guards an unseeded prod blob
+      assertWithinPerSubmissionCap(Number(existing.finalAmountUsd), caps.perSubmissionMaxUsd);
+
+      if (wantsOverride && isAdminClass) {
+        // admin-class full bypass of the per-party cap — unchanged behavior
+      } else if (wantsOverride && !isAdminClass) {
+        // underboss bounded override: ignore the event cap, enforce the
+        // config-driven $675 party-total ceiling instead.
+        await assertWithinPartyCap(
+          existing.partyId,
+          Number(existing.finalAmountUsd),
+          existing.id,
+          underbossCeiling,
+        );
+      } else {
         await assertWithinPartyCap(
           existing.partyId,
           Number(existing.finalAmountUsd),
@@ -3582,9 +3615,17 @@ router.post(
         // nduja-92106: append `[override: party cap]` so the audit row
         // captures that the per-party cap was bypassed at approve time. Mirrors
         // salame-92103's mark_paid suffix on /execute.
+        // margherita-58526: distinguish the admin FULL bypass from the underboss
+        // BOUNDED (≤$675) override. The marker is null when no override applied.
+        const overrideMarker =
+          wantsOverride && isAdminClass
+            ? '[override: party cap]'
+            : wantsOverride && !isAdminClass
+              ? `[override: party cap ≤$${underbossCeiling} underboss]`
+              : null;
         const baseNote = typeof note === 'string' && note ? note : null;
-        const auditNote = allowOverPartyCap
-          ? (baseNote ? `${baseNote} [override: party cap]` : '[override: party cap]')
+        const auditNote = overrideMarker
+          ? (baseNote ? `${baseNote} ${overrideMarker}` : overrideMarker)
           : baseNote;
         await tx.payoutAudit.create({
           data: {

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -3830,7 +3830,11 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                     <Checkbox
                       checked={approveOverridePartyCap}
                       onChange={() => setApproveOverridePartyCap((v) => !v)}
-                      label="I acknowledge — proceed anyway"
+                      label={
+                        isAdminViewer
+                          ? 'I acknowledge — proceed anyway'
+                          : 'I acknowledge — approve over the event cap (underboss limit $675)'
+                      }
                       labelClassName="text-sm text-amber-100 [.gpp-theme_&]:text-amber-900"
                     />
                   </div>


### PR DESCRIPTION
## What
Lets regional underbosses tick the over-cap acknowledgement at payout **approve** time, bounded to a config-driven **per-party-total** ceiling (`underbossOverPartyCapMaxUsd`, default **\$675**). Above the ceiling, the override stays admin-only.

Previously underbosses were hard-blocked (`allowOverPartyCap = actor.actorKind !== 'underboss' && …`) — they could approve up to the event's reimbursement cap but never beyond it.

## How
- **`privateConfig.ts`** — new `underbossOverPartyCapMaxUsd` field on `PayoutCaps` (fallback 675). Read with `?? 675` so it's correct even before the prod `private.payout_caps` blob is re-seeded (`getConfig` returns the blob wholesale, no merge).
- **`admin-payout.routes.ts`**
  - `assertWithinPartyCap` gains an optional `ceilingOverrideUsd`. When set, it enforces `max(eventCap ?? 0, ceiling)` instead of the event cap — never more restrictive than the plain path, and it bounds an otherwise-uncapped party. New `409 UNDERBOSS_CAP_EXCEEDED` for the override branch; existing `PARTY_CAP_EXCEEDED` path untouched.
  - Approve handler: three-branch gate — admin full bypass (unchanged) / underboss bounded override (new) / no override (unchanged). `allowOverPartyCap` keeps its original admin-only meaning for the autoExecute forward + audit semantics.
  - Audit note distinguishes admin `[override: party cap]` from underboss `[override: party cap ≤\$675 underboss]`.
- **`PayoutReviewModal.tsx`** — underboss-facing ack copy now reads "approve over the event cap (underboss limit \$675)". The checkbox already rendered for underbosses; backend just honors it now.

## Guardrails preserved
Per-submission cap (already \$675 in prod), per-address / per-tx / daily caps, and the receipt gate all still fire for everyone. Single payouts >\$675 are still blocked by the per-submission cap.

## Deploy notes
- No schema/Prisma migration.
- Backend auto-deploys from master on merge.
- Optional: re-seed `private.payout_caps` to add `underbossOverPartyCapMaxUsd: 675` so it's editable without a deploy — feature is already correct without it via the `?? 675` guard.

## Verify on preview
As an in-region underboss, approve a payout that exceeds the event cap but keeps the party total ≤ \$675 → succeeds (audit shows the underboss override marker). Push the total > \$675 → 409 "ask an admin". Admin full bypass and no-override paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)