### PR TITLE
polpetta-58528: show all unsubmitted approved cities on /payments by-city

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -2261,8 +2261,12 @@ router.get(
       });
 
       // tigella-58512: optional `?showTbdUnsubmitted=1` injects synthetic
-      // by-party rows for approved events tagged `tbd` that have submitted
-      // NOTHING yet (zero payouts AND zero payout documents of any kind).
+      // by-party rows for approved events that have submitted NOTHING yet
+      // (zero payouts AND zero payout documents of any kind).
+      // polpetta-58528: the `tbd`-tag scope was REMOVED — the injection now
+      // covers ANY approved city with no submission, regardless of tag, so
+      // already-settled GPP hubs (e.g. tagged `paid` but with no payout row)
+      // also surface instead of being silently hidden.
       // Because these parties have zero payouts they produce zero grouped
       // `rows` above, so they're invisible on /payments without this. OFF by
       // default — when the param is absent the response is byte-identical to
@@ -2275,12 +2279,11 @@ router.get(
         // country/tag/region/closed clauses live on `where.party`; the search
         // partyId set lives on `where.OR` / `where.partyId`). We do NOT apply
         // any payout-level filters (status/method/purpose/currency/date) —
-        // these rows have no payouts. The tbd + zero-submission predicates are
+        // these rows have no payouts. The zero-submission predicates are
         // AND'd on top via an explicit AND array so a `tag` filter on
         // `where.party.eventTags` is preserved rather than clobbered.
         const partyScope: any = { ...(where.party ?? {}) };
         const andParts: any[] = [
-          { eventTags: { hasSome: ['tbd', 'TBD'] } },
           { payouts: { none: {} } },
           { payoutDocuments: { none: {} } },
         ];

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -556,7 +556,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               <Checkbox
                 checked={!!filters.showTbdUnsubmitted}
                 onChange={() => update({ showTbdUnsubmitted: !filters.showTbdUnsubmitted })}
-                label="Show TBD (no submission)"
+                label="Show unsubmitted cities"
                 labelClassName="text-xs text-theme-text-secondary"
                 size={14}
               />


### PR DESCRIPTION
@
## Problem
`/payments?...&tbd=1` by-city showed **342** cities, but there are **374** approved parties. The by-party view is payout-gated (only cities with ≥1 payout render), and the `tbd=1` injection that patches in zero-payout cities was hard-scoped to the `tbd` tag — so 32 approved GPP hub cities (Vegas, Nashville, Boston, LA, NYC, London…) tagged `paid` but with no payout row stayed invisible.

DB breakdown (2026-06-10): 374 approved = 297 with a payout + 45 tbd-tagged zero-submission (injected) + **32 non-tbd zero-submission (hidden)**. All 32 have zero payout_documents too.

## Change
- **Backend** (`admin-payout.routes.ts`): removed the `{ eventTags: { hasSome: [tbd,TBD] } }` predicate from the `showTbdUnsubmitted` injection. The `payouts: none` + `payoutDocuments: none` guards stay, so it now injects **any** approved city with no submission, not just tbd-tagged ones.
- **Frontend** (`PayoutsFilterBar.tsx`): relabeled the toggle "Show TBD (no submission)" → "Show unsubmitted cities". Internal param `tbd`/`showTbdUnsubmitted` unchanged.

No migration. Plan: `plans/polpetta-58528-show-all-unsubmitted-cities.md`.

## Verify
- Backend auto-deploys from master; the preview shares the prod backend, so the **count** wont change on the preview URL until merge — only the label will.
- Post-merge expected: `/payments?...&tbd=1` by-city count = **374** (was 342); the 32 hidden hubs appear as `$0` synthetic rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@