### PR TITLE
tiramisu-58530: require 5 additional event photos beyond the 3 role photos

### DIFF
--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -77,6 +77,12 @@ type PayoutMethod = (typeof PAYOUT_METHODS)[number];
 // `paid`, `rejected`, and `failed` remain terminal from the host side.
 const WITHDRAWABLE_STATUSES = ['pending', 'approved'] as const;
 
+// tiramisu-58530: in addition to the 3 designated role photos (group/box_stack/
+// pizza), hosts must upload at least this many ADDITIONAL event photos (gallery
+// photos not carrying one of those 3 payout roles, dated after the event start)
+// before they can submit a reimbursement.
+const REQUIRED_ADDITIONAL_PHOTOS = 5;
+
 // ---------- helpers ----------
 
 /**
@@ -92,6 +98,7 @@ export async function getPayoutSubmissionReadiness(partyId: string) {
     has_box: boolean;
     has_pizza: boolean;
     has_receipt: boolean;
+    additional_count: number;
   }[]>(Prisma.sql`
     WITH pa AS (SELECT date FROM parties WHERE id = ${partyId}::uuid)
     SELECT
@@ -101,7 +108,11 @@ export async function getPayoutSubmissionReadiness(partyId: string) {
                 AND p.payout_role = 'box_stack' AND (pa.date IS NULL OR p.created_at >= pa.date)) AS has_box,
       EXISTS (SELECT 1 FROM photos p, pa WHERE p.party_id = ${partyId}::uuid AND p.deleted_at IS NULL
                 AND p.payout_role = 'pizza'     AND (pa.date IS NULL OR p.created_at >= pa.date)) AS has_pizza,
-      EXISTS (SELECT 1 FROM payout_documents pd WHERE pd.party_id = ${partyId}::uuid AND pd.kind = 'receipt') AS has_receipt
+      EXISTS (SELECT 1 FROM payout_documents pd WHERE pd.party_id = ${partyId}::uuid AND pd.kind = 'receipt') AS has_receipt,
+      (SELECT COUNT(*)::int FROM photos p, pa
+         WHERE p.party_id = ${partyId}::uuid AND p.deleted_at IS NULL
+           AND (p.payout_role IS NULL OR p.payout_role NOT IN ('group','box_stack','pizza'))
+           AND (pa.date IS NULL OR p.created_at >= pa.date)) AS additional_count
   `);
   const row = rows[0];
   return {
@@ -109,6 +120,8 @@ export async function getPayoutSubmissionReadiness(partyId: string) {
     hasBoxStackPhoto: !!row?.has_box,
     hasPizzaPhoto: !!row?.has_pizza,
     hasReceipt: !!row?.has_receipt,
+    // tiramisu-58530: count of non-role gallery photos dated after event start.
+    additionalPhotoCount: Number(row?.additional_count ?? 0),
   };
 }
 
@@ -1031,6 +1044,14 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           'Designate a pizza photo before submitting.',
           400,
           'PIZZA_PHOTO_REQUIRED',
+        );
+      }
+      // tiramisu-58530: beyond the 3 role photos, require >=5 additional event photos.
+      if (submissionReadiness.additionalPhotoCount < REQUIRED_ADDITIONAL_PHOTOS) {
+        throw new AppError(
+          `Upload at least ${REQUIRED_ADDITIONAL_PHOTOS} additional event photos before submitting.`,
+          400,
+          'ADDITIONAL_PHOTOS_REQUIRED',
         );
       }
     }
@@ -2772,6 +2793,7 @@ async function getReimbursementReadiness(partyId: string, userId: string) {
     photoReadiness.hasBoxStackPhoto &&
     photoReadiness.hasPizzaPhoto &&
     photoReadiness.hasReceipt &&
+    photoReadiness.additionalPhotoCount >= REQUIRED_ADDITIONAL_PHOTOS &&
     paymentMethodValid;
 
   return {
@@ -2780,6 +2802,8 @@ async function getReimbursementReadiness(partyId: string, userId: string) {
     hasBoxStackPhoto: photoReadiness.hasBoxStackPhoto,
     hasPizzaPhoto: photoReadiness.hasPizzaPhoto,
     hasReceipt: photoReadiness.hasReceipt,
+    // tiramisu-58530: count of non-role gallery photos dated after event start.
+    additionalPhotoCount: photoReadiness.additionalPhotoCount,
     paymentMethodValid,
     readyToSubmit,
   };

--- a/frontend/src/components/payouts/EventPhotosCard.tsx
+++ b/frontend/src/components/payouts/EventPhotosCard.tsx
@@ -19,6 +19,12 @@ interface EventPhotosCardProps {
    * unlock the PaymentDetailsCard.
    */
   onRolesChange?: (allDesignated: boolean) => void;
+  /**
+   * tiramisu-58530: fires whenever the gallery reloads (e.g. an additional
+   * photo was uploaded) so the parent can refresh server readiness — which
+   * now requires >=5 additional event photos beyond the 3 role photos.
+   */
+  onPhotosChange?: () => void;
 }
 
 /**
@@ -35,6 +41,7 @@ interface EventPhotosCardProps {
 export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
   partyId,
   onRolesChange,
+  onPhotosChange,
 }) => {
   const { t } = useTranslation('host');
   const { user } = useAuth();
@@ -76,7 +83,10 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
     }
     setRoles(next);
     setGalleryPhotos(photos);
-  }, [partyId]);
+    // tiramisu-58530: tell the parent to refresh readiness whenever the gallery
+    // reloads (covers additional-photo uploads, not just role designations).
+    onPhotosChange?.();
+  }, [partyId, onPhotosChange]);
 
   useEffect(() => {
     loadPhotos();
@@ -87,6 +97,16 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
   const additionalPhotos = galleryPhotos.filter(
     p => !p.payoutRole || !PAYOUT_ROLES.includes(p.payoutRole as PayoutPhotoRole)
   );
+
+  // tiramisu-58530: the 5-additional-photo requirement only counts photos dated
+  // after the event start (party.date NULL ⇒ no cutoff), mirroring the backend
+  // gate (getPayoutSubmissionReadiness) and the RolePhotoPicker cutoff. The
+  // preview grid above still shows ALL additional photos; only this count drives
+  // the progress line so it never reads "5 of 5" while the server still blocks.
+  const cutoff = party?.date ? new Date(party.date).getTime() : null;
+  const eligibleAdditionalCount = additionalPhotos.filter(
+    p => cutoff == null || new Date(p.createdAt).getTime() >= cutoff
+  ).length;
 
   // calzone-58297: report all-designated state to the parent whenever roles
   // change so PaymentDetailsCard can unlock.
@@ -160,6 +180,14 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
 
       {/* Optional additional photos — gallery upload, no role. */}
       <div className="mt-4">
+        {/* tiramisu-58530: progress toward the 5 required additional photos. */}
+        <div
+          className={`text-xs mb-2 ${
+            eligibleAdditionalCount >= 5 ? 'text-emerald-500' : 'text-theme-text-muted'
+          }`}
+        >
+          {t('payouts.additionalPhotosProgress', { count: eligibleAdditionalCount, required: 5 })}
+        </div>
         {/* stracciatella-58504: preview of already-uploaded additional photos. */}
         {additionalPhotos.length > 0 && (
           <div className="mb-3">

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -56,6 +56,10 @@ interface PayoutsTabProps {
   expectedGuests?: number | null;
 }
 
+// tiramisu-58530: hosts must upload at least this many ADDITIONAL event photos
+// (gallery photos beyond the 3 designated role photos) before submitting.
+const REQUIRED_ADDITIONAL_PHOTOS = 5;
+
 /**
  * ziti-58300 Phase 3: the host Payments tab is now ONE rolling
  * "Your reimbursement" page for the signed-in co-host. There is no list / new
@@ -407,6 +411,10 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
     if (!readiness.hasGroupPhoto) list.push(t('payouts.missingGroupPhoto'));
     if (!readiness.hasBoxStackPhoto) list.push(t('payouts.missingBoxStackPhoto'));
     if (!readiness.hasPizzaPhoto) list.push(t('payouts.missingPizzaPhoto'));
+    // tiramisu-58530: require >=5 additional event photos beyond the 3 roles.
+    const addl = readiness.additionalPhotoCount ?? 0;
+    if (addl < REQUIRED_ADDITIONAL_PHOTOS)
+      list.push(t('payouts.missingAdditionalPhotos', { count: addl, required: REQUIRED_ADDITIONAL_PHOTOS }));
     if (!readiness.hasReceipt) list.push(t('payouts.missingReceipt'));
     if (!readiness.paymentMethodValid) list.push(t('payouts.missingPaymentMethod'));
     return list;
@@ -437,7 +445,9 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   }
 
   const photosAllDesignated =
-    !!readiness?.hasGroupPhoto && !!readiness?.hasBoxStackPhoto && !!readiness?.hasPizzaPhoto;
+    !!readiness?.hasGroupPhoto && !!readiness?.hasBoxStackPhoto &&
+    !!readiness?.hasPizzaPhoto &&
+    (readiness?.additionalPhotoCount ?? 0) >= REQUIRED_ADDITIONAL_PHOTOS;
 
   return (
     <div className="space-y-4">
@@ -579,7 +589,11 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
             {t('payouts.eventPhotosDone')}
           </div>
         )}
-        <EventPhotosCard partyId={partyId} onRolesChange={handleRolesChange} />
+        <EventPhotosCard
+          partyId={partyId}
+          onRolesChange={handleRolesChange}
+          onPhotosChange={handleRolesChange}
+        />
       </div>
 
       {/* ===== 4. Receipts (rolling, auto-saved) ===== */}

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -886,6 +886,8 @@
     "missingGroupPhoto": "Gruppenfoto",
     "missingBoxStackPhoto": "Foto vom Kartonstapel",
     "missingPizzaPhoto": "Pizzafoto",
+    "missingAdditionalPhotos": "{{count}}/{{required}} zusätzliche Fotos",
+    "additionalPhotosProgress": "Zusätzliche Fotos: {{count}} von {{required}}",
     "missingReceipt": "Mindestens ein Beleg",
     "missingPaymentMethod": "Zahlungsmethode",
     "submitForReview": "Zur Prüfung einreichen",

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -1008,6 +1008,8 @@
     "missingGroupPhoto": "Group photo",
     "missingBoxStackPhoto": "Box stack photo",
     "missingPizzaPhoto": "Pizza photo",
+    "missingAdditionalPhotos": "{{count}}/{{required}} additional photos",
+    "additionalPhotosProgress": "Additional photos: {{count}} of {{required}}",
     "missingReceipt": "At least one receipt",
     "missingPaymentMethod": "Payment method",
     "submitForReview": "Submit for review",

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -885,6 +885,8 @@
     "missingGroupPhoto": "Foto grupal",
     "missingBoxStackPhoto": "Foto de la pila de cajas",
     "missingPizzaPhoto": "Foto de la pizza",
+    "missingAdditionalPhotos": "{{count}}/{{required}} fotos adicionales",
+    "additionalPhotosProgress": "Fotos adicionales: {{count}} de {{required}}",
     "missingReceipt": "Al menos un recibo",
     "missingPaymentMethod": "Método de pago",
     "submitForReview": "Enviar para revisión",

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -885,6 +885,8 @@
     "missingGroupPhoto": "Photo de groupe",
     "missingBoxStackPhoto": "Photo de la pile de boîtes",
     "missingPizzaPhoto": "Photo de la pizza",
+    "missingAdditionalPhotos": "{{count}}/{{required}} photos supplémentaires",
+    "additionalPhotosProgress": "Photos supplémentaires : {{count}} sur {{required}}",
     "missingReceipt": "Au moins un reçu",
     "missingPaymentMethod": "Mode de paiement",
     "submitForReview": "Soumettre pour examen",

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -885,6 +885,8 @@
     "missingGroupPhoto": "集合写真",
     "missingBoxStackPhoto": "箱を積んだ写真",
     "missingPizzaPhoto": "ピザの写真",
+    "missingAdditionalPhotos": "追加写真 {{count}}/{{required}} 枚",
+    "additionalPhotosProgress": "追加写真：{{count}}/{{required}} 枚",
     "missingReceipt": "領収書を1枚以上",
     "missingPaymentMethod": "支払い方法",
     "submitForReview": "審査のため提出",

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -841,6 +841,8 @@
     "missingGroupPhoto": "단체 사진",
     "missingBoxStackPhoto": "박스 더미 사진",
     "missingPizzaPhoto": "피자 사진",
+    "missingAdditionalPhotos": "추가 사진 {{count}}/{{required}}장",
+    "additionalPhotosProgress": "추가 사진: {{count}}/{{required}}장",
     "missingReceipt": "영수증 1장 이상",
     "missingPaymentMethod": "결제 수단",
     "submitForReview": "검토를 위해 제출",

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -885,6 +885,8 @@
     "missingGroupPhoto": "Foto em grupo",
     "missingBoxStackPhoto": "Foto da pilha de caixas",
     "missingPizzaPhoto": "Foto da pizza",
+    "missingAdditionalPhotos": "{{count}}/{{required}} fotos adicionais",
+    "additionalPhotosProgress": "Fotos adicionais: {{count}} de {{required}}",
     "missingReceipt": "Pelo menos um recibo",
     "missingPaymentMethod": "Forma de pagamento",
     "submitForReview": "Enviar para revisão",

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -885,6 +885,8 @@
     "missingGroupPhoto": "合影",
     "missingBoxStackPhoto": "披萨盒堆叠照片",
     "missingPizzaPhoto": "披萨照片",
+    "missingAdditionalPhotos": "{{count}}/{{required}} 张额外照片",
+    "additionalPhotosProgress": "额外照片：{{count}}/{{required}} 张",
     "missingReceipt": "至少一张收据",
     "missingPaymentMethod": "付款方式",
     "submitForReview": "提交审核",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6524,6 +6524,8 @@ export interface ReimbursementReadiness {
   hasPizzaPhoto: boolean;
   /** This co-host has at least one receipt on the event. */
   hasReceipt: boolean;
+  /** Count of non-role gallery photos dated after event start (tiramisu-58530). */
+  additionalPhotoCount: number;
   /** The caller's saved payment method is valid (mirrors PaymentDetailsCard). */
   paymentMethodValid: boolean;
   /** All of the above — the "Submit for review" toggle is enabled when true. */


### PR DESCRIPTION
## What
Hosts must now upload **5 additional event photos** in addition to the existing 3 designated role photos (group / box_stack / pizza) before they can submit a reimbursement. "Additional" = any gallery photo on the party **not** carrying one of those 3 payout roles, **dated after the event start** (same cutoff as the role photos; `party.date` NULL ⇒ no cutoff). Total required = 8 photos + ≥1 receipt.

Confirmed with Snax: 5 *generic* extras (not new named slots), same post-event-start cutoff as the role photos.

## Changes
**Backend — `backend/src/routes/payout.routes.ts`**
- `getPayoutSubmissionReadiness` counts non-role photos after the cutoff → `additionalPhotoCount`.
- `POST /:partyId/payouts` submit gate throws `400 ADDITIONAL_PHOTOS_REQUIRED` when `< 5`.
- `getReimbursementReadiness` folds `>= 5` into `readyToSubmit` and surfaces the count.
- Shipping-purpose payouts + admin prepay-for-cohost stay exempt (same guard block as the existing photo gates).

**Frontend**
- `ReimbursementReadiness.additionalPhotoCount` (read as `?? 0` so old responses fail safe = locked).
- `PayoutsTab`: missing-requirements entry + `photosAllDesignated`/done-banner now require the 5.
- `EventPhotosCard`: "Additional photos: N of 5" progress line (emerald when met) + `onPhotosChange` so the parent refreshes readiness after an additional-photo upload. The counter applies the **same event-start cutoff** as the backend, so it never reads "5 of 5" while the server still blocks.
- i18n: `missingAdditionalPhotos` + `additionalPhotosProgress` across all 8 locales.

No DB migration (uses existing `photos.payout_role`).

## ⚠️ Deploy ordering / preview caveat
Previews share the **prod backend**, which won't return `additionalPhotoCount` until this merges and the backend redeploys from `master`. Until then the preview frontend reads it as `0` → the gate shows "0/5" and submit stays locked (fail-safe direction). Full green-path verification happens **after merge**.

## Test checklist
- [ ] Vercel preview builds green (no local node_modules → tsc gated on Vercel).
- [ ] 3 roles + 4 post-start extras → submit blocked (`ADDITIONAL_PHOTOS_REQUIRED`), missing list shows "4/5 additional photos".
- [ ] Add a 5th post-start extra → counter emerald, submit unlocks after readiness refetch.
- [ ] Photos dated before event start don't count.
- [ ] Designating an extra as a role decrements the additional count.
- [ ] Shipping-purpose payout still submits with 0 additional photos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)