### PR TITLE
panzerotti-58527: host survey email

### DIFF
--- a/backend/prisma/migrations/panzerotti-58527-host-survey.sql
+++ b/backend/prisma/migrations/panzerotti-58527-host-survey.sql
@@ -1,0 +1,62 @@
+-- panzerotti-58527: post-event HOST survey.
+-- Mirrors the guest survey tables (survey_question_sets / survey_questions /
+-- survey_responses) but with a SEPARATE question set targeted at hosts.
+-- Recipients = primary host only. One response row per party (unique party_id).
+-- Idempotent so it is safe to re-run.
+
+CREATE TABLE IF NOT EXISTS host_survey_question_sets (
+  id text PRIMARY KEY,
+  version integer NOT NULL DEFAULT 1,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS host_survey_questions (
+  id text NOT NULL,
+  question_set text NOT NULL REFERENCES host_survey_question_sets(id),
+  position integer NOT NULL,
+  type text NOT NULL,
+  text text NOT NULL,
+  scale integer,
+  multi boolean NOT NULL DEFAULT false,
+  allow_other boolean NOT NULL DEFAULT false,
+  options jsonb NOT NULL DEFAULT '[]',
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (question_set, id),
+  UNIQUE (question_set, position)
+);
+
+CREATE TABLE IF NOT EXISTS host_survey_responses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  token text UNIQUE NOT NULL,
+  party_id uuid NOT NULL UNIQUE REFERENCES parties(id) ON DELETE CASCADE,
+  host_user_id text NOT NULL REFERENCES "User"(id) ON DELETE CASCADE,
+  sent_at timestamptz,
+  answers jsonb,
+  submitted_at timestamptz,
+  question_set_version integer,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz
+);
+
+ALTER TABLE parties ADD COLUMN IF NOT EXISTS host_survey_sent_at timestamptz;
+
+-- Seed the default host question set (6 questions, positions 1-6).
+INSERT INTO host_survey_question_sets (id, version)
+  VALUES ('default', 1)
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO host_survey_questions (question_set, id, position, type, text, scale)
+  VALUES
+    ('default', 'event_rating', 1, 'rating', 'How would you rate your event overall?', 5),
+    ('default', 'program_support', 4, 'rating', 'How would you rate the support you got from the PizzaDAO program?', 5)
+  ON CONFLICT (question_set, id) DO NOTHING;
+
+INSERT INTO host_survey_questions (question_set, id, position, type, text)
+  VALUES
+    ('default', 'same_pizzeria', 2, 'yesno', 'Would you use the same pizzeria again?'),
+    ('default', 'venue_ok', 3, 'yesno', 'Did the venue work out well?'),
+    ('default', 'host_again', 5, 'yesno', 'Would you host again next year?'),
+    ('default', 'improve', 6, 'text', 'What could we do to make hosting easier or better?')
+  ON CONFLICT (question_set, id) DO NOTHING;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   reimbursementCapAppealsSubmitted ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsByHost")
   reimbursementCapAppealsReviewed  ReimbursementCapAppeal[] @relation("ReimbursementCapAppealsReviewedBy")
   taxForms                         TaxForm[]
+  hostSurveyResponses              HostSurveyResponse[]
 }
 
 model Party {
@@ -235,6 +236,12 @@ model Party {
   surveyEnabled Boolean   @default(true) @map("survey_enabled")
   surveySentAt  DateTime? @map("survey_sent_at") @db.Timestamptz
 
+  // panzerotti-58527: post-event HOST survey. Distinct question set from the
+  // guest survey. host_survey_sent_at is set when the host survey email goes
+  // out (auto morning-after via cron, or manually from /underboss) so the cron
+  // won't double-send a hand-sent event.
+  hostSurveySentAt DateTime? @map("host_survey_sent_at") @db.Timestamptz
+
   // margherita-58471: T-4h reminder email opt-out at the party level.
   // Host toggles in EventDetailsTab; defaults to true for all new + existing
   // events. Cron worker skips parties where this is false.
@@ -316,6 +323,7 @@ model Party {
   reimbursementCapAppeals ReimbursementCapAppeal[]
   reimbursementCapAudits  ReimbursementCapAudit[]
   surveyResponses         SurveyResponse[]
+  hostSurveyResponse      HostSurveyResponse?
 
   @@index([coHosts(ops: JsonbPathOps)], type: Gin, map: "idx_parties_co_hosts_gin")
   @@map("parties")
@@ -1775,6 +1783,64 @@ model SurveyQuestion {
   @@id([questionSet, id])
   @@unique([questionSet, position])
   @@map("survey_questions")
+}
+
+// ============================================
+// Host survey config + responses (panzerotti-58527)
+// ============================================
+// DB-backed post-event HOST survey. Mirrors the guest survey tables but with a
+// separate question set targeted at hosts. Service-role only for config tables.
+
+model HostSurveyQuestionSet {
+  id        String   @id
+  version   Int      @default(1)
+  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz
+
+  questions HostSurveyQuestion[]
+
+  @@map("host_survey_question_sets")
+}
+
+model HostSurveyQuestion {
+  id          String
+  questionSet String                @map("question_set")
+  set         HostSurveyQuestionSet @relation(fields: [questionSet], references: [id])
+
+  position    Int
+  type        String
+  text        String
+  scale       Int?
+  multi       Boolean  @default(false)
+  allowOther  Boolean  @default(false) @map("allow_other")
+  options     Json     @default("[]")
+  active      Boolean  @default(true)
+
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime @updatedAt      @map("updated_at") @db.Timestamptz
+
+  @@id([questionSet, id])
+  @@unique([questionSet, position])
+  @@map("host_survey_questions")
+}
+
+// One post-event host survey response per party (unique party_id). Resubmit =
+// upsert. token is the public tokenized link; host_user_id snapshots the
+// primary host at send time.
+model HostSurveyResponse {
+  id                 String    @id @default(uuid()) @db.Uuid
+  token              String    @unique
+  partyId            String    @unique @map("party_id") @db.Uuid
+  party              Party     @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  hostUserId         String    @map("host_user_id")
+  host               User      @relation(fields: [hostUserId], references: [id], onDelete: Cascade)
+  sentAt             DateTime? @map("sent_at") @db.Timestamptz
+  answers            Json?
+  submittedAt        DateTime? @map("submitted_at") @db.Timestamptz
+  questionSetVersion Int?      @map("question_set_version")
+  createdAt          DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt          DateTime? @map("updated_at") @db.Timestamptz
+
+  @@map("host_survey_responses")
 }
 
 model SlugAlias {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -73,6 +73,7 @@ import configRoutes from './routes/config.routes.js'; // marinara-71630 P5: admi
 import resendWebhookRouter from './routes/webhooks.resend.routes.js';
 import ensRoutes from './routes/ens.routes.js';
 import { surveyPublicRouter, surveyHostRouter, cronRouter } from './routes/survey.routes.js';
+import { hostSurveyPublicRouter } from './routes/hostSurvey.routes.js'; // panzerotti-58527: public host survey (no auth)
 import {
   surveyQuestionsAdminRouter,
   surveyQuestionSetsAdminRouter,
@@ -231,6 +232,7 @@ app.use('/api/ens', ensRoutes); // taleggio-30219: ENS → 0x resolution utility
 app.use('/api', reminderRoutes); // margherita-58471: T-4h reminder cron + one-click unsubscribe
 app.use('/api/checkin', checkinRoutes);
 app.use('/api/survey', surveyPublicRouter); // romana-61204: public token-based survey (no auth)
+app.use('/api/host-survey', hostSurveyPublicRouter); // panzerotti-58527: public token-based host survey (no auth)
 app.use('/api/cron', cronRouter); // romana-61204: cron-only survey auto-send (CRON_SECRET gate)
 app.use('/api/scorecard', scorecardRoutes);
 app.use('/api/bizdev', bizdevRoutes); // soppressata-72251: per-partner BizDev industry report (auth-gated per-route)

--- a/backend/src/lib/hostSurveyQuestions.ts
+++ b/backend/src/lib/hostSurveyQuestions.ts
@@ -1,0 +1,207 @@
+// panzerotti-58527: post-event HOST survey question set, loaded from the DB.
+//
+// Mirrors backend/src/lib/surveyQuestions.ts (the guest loader) but reads the
+// `host_survey_question_sets` + `host_survey_questions` tables. The frontend
+// `frontend/src/lib/surveyQuestions.ts` shared types are reused (identical
+// shapes). The /api/host-survey/:token response includes the full question set
+// so HostSurveyPage renders against the current copy.
+//
+// In ADDITION to the DB-loaded set, `buildHostSurveyQuestions(party)` prepends a
+// synthetic `guests_attended` question when the party has no estimated
+// attendance, so we can capture the headcount post-event. That synthetic
+// question is NEVER written to the host_survey_questions table.
+
+import { prisma } from '../config/database.js';
+
+export type HostSurveyQuestionType = 'rating' | 'yesno' | 'multiple' | 'text';
+
+export interface HostSurveyQuestion {
+  id: string;
+  type: HostSurveyQuestionType;
+  text: string;
+  scale?: number;
+  multi?: boolean;
+  options?: string[];
+  allowOther?: boolean;
+}
+
+export type LoadedHostSet = {
+  version: number;
+  questions: HostSurveyQuestion[];
+};
+
+// Synthetic question id captured iff the party has no estimatedAttendance. It is
+// a `text` question (there is no numeric type) validated as an integer >= 0.
+export const GUESTS_ATTENDED_ID = 'guests_attended';
+
+// ---------------------------------------------------------------------------
+// In-memory cache: 60s TTL, keyed by question-set id. `refresh: true` bypasses.
+// ---------------------------------------------------------------------------
+const CACHE_TTL_MS = 60_000;
+const cache: Map<string, { value: LoadedHostSet; expiresAt: number }> = new Map();
+
+export async function loadHostQuestionSet(
+  setId: string = 'default',
+  opts?: { refresh?: boolean }
+): Promise<LoadedHostSet> {
+  const now = Date.now();
+  if (!opts?.refresh) {
+    const hit = cache.get(setId);
+    if (hit && hit.expiresAt > now) return hit.value;
+  }
+
+  const set = await prisma.hostSurveyQuestionSet.findUnique({
+    where: { id: setId },
+    include: {
+      questions: {
+        where: { active: true },
+        orderBy: { position: 'asc' },
+      },
+    },
+  });
+
+  if (!set) {
+    throw new Error(`Host survey question set "${setId}" not found`);
+  }
+
+  const questions: HostSurveyQuestion[] = set.questions.map((q) => {
+    const out: HostSurveyQuestion = {
+      id: q.id,
+      type: q.type as HostSurveyQuestionType,
+      text: q.text,
+    };
+    if (q.scale !== null && q.scale !== undefined) out.scale = q.scale;
+    if (q.multi) out.multi = true;
+    if (q.allowOther) out.allowOther = true;
+    if (Array.isArray(q.options) && q.options.length > 0) {
+      out.options = (q.options as unknown[]).filter(
+        (x): x is string => typeof x === 'string'
+      );
+    }
+    return out;
+  });
+
+  const value: LoadedHostSet = { version: set.version, questions };
+  cache.set(setId, { value, expiresAt: now + CACHE_TTL_MS });
+  return value;
+}
+
+// The synthetic guests-attended question (rendered as a numeric input on the
+// frontend; stored as a stringified integer in answers).
+function guestsAttendedQuestion(): HostSurveyQuestion {
+  return {
+    id: GUESTS_ATTENDED_ID,
+    type: 'text',
+    text: 'How many guests attended?',
+  };
+}
+
+/**
+ * Build the host question list to RENDER + VALIDATE against for a given party.
+ * Loads the default DB set and prepends the synthetic `guests_attended`
+ * question (as the FIRST question) ONLY when `party.estimatedAttendance` is
+ * null. Both the public GET (render) and POST (validate) MUST call this against
+ * the SAME party so the conditional question is accepted iff it was shown.
+ */
+export async function buildHostSurveyQuestions(
+  party: { estimatedAttendance?: number | null },
+  opts?: { refresh?: boolean }
+): Promise<LoadedHostSet> {
+  const base = await loadHostQuestionSet('default', opts);
+  if (party.estimatedAttendance === null || party.estimatedAttendance === undefined) {
+    return {
+      version: base.version,
+      questions: [guestsAttendedQuestion(), ...base.questions],
+    };
+  }
+  return base;
+}
+
+/**
+ * Validate + normalize a raw answers object against a loaded host question set.
+ * Same per-type rules as the guest validator, plus a special case for the
+ * synthetic `guests_attended` question: a non-negative integer kept as a string
+ * (it is a `text`-typed question with numeric semantics).
+ * Invalid values for a known id are dropped (not stored).
+ */
+export function validateHostSurveyAnswers(
+  raw: unknown,
+  questionSet: HostSurveyQuestion[]
+): Record<string, number | boolean | string | string[]> {
+  const out: Record<string, number | boolean | string | string[]> = {};
+  if (!raw || typeof raw !== 'object') return out;
+  const input = raw as Record<string, unknown>;
+
+  for (const q of questionSet) {
+    if (!(q.id in input)) continue;
+    const v = input[q.id];
+
+    // Synthetic numeric-text question: accept a non-negative integer (stored as
+    // a string so it round-trips through the generic `text` answer shape).
+    if (q.id === GUESTS_ATTENDED_ID) {
+      const n = typeof v === 'number' ? v : Number(String(v).trim());
+      if (Number.isInteger(n) && n >= 0) {
+        out[q.id] = String(n);
+      }
+      continue;
+    }
+
+    switch (q.type) {
+      case 'rating': {
+        const scale = q.scale ?? 5;
+        const n = typeof v === 'number' ? v : Number(v);
+        if (Number.isInteger(n) && n >= 1 && n <= scale) {
+          out[q.id] = n;
+        }
+        break;
+      }
+      case 'yesno': {
+        if (typeof v === 'boolean') {
+          out[q.id] = v;
+        }
+        break;
+      }
+      case 'multiple': {
+        const options = q.options ?? [];
+        if (q.multi) {
+          if (Array.isArray(v)) {
+            const subset = v.filter(
+              (x): x is string => typeof x === 'string' && options.includes(x)
+            );
+            const seen = new Set<string>();
+            const deduped = subset.filter((x) => {
+              if (seen.has(x)) return false;
+              seen.add(x);
+              return true;
+            });
+            out[q.id] = deduped;
+          }
+        } else {
+          if (typeof v === 'string' && options.includes(v)) {
+            out[q.id] = v;
+          }
+        }
+        break;
+      }
+      case 'text': {
+        if (typeof v === 'string') {
+          out[q.id] = v.trim().slice(0, 5000);
+        }
+        break;
+      }
+    }
+
+    if (q.allowOther) {
+      const otherKey = `${q.id}_other`;
+      const rawOther = input[otherKey];
+      if (typeof rawOther === 'string' && out[q.id] === 'Other') {
+        const trimmed = rawOther.trim();
+        if (trimmed.length > 0) {
+          out[otherKey] = trimmed.slice(0, 200);
+        }
+      }
+    }
+  }
+
+  return out;
+}

--- a/backend/src/routes/hostSurvey.routes.ts
+++ b/backend/src/routes/hostSurvey.routes.ts
@@ -1,0 +1,131 @@
+// panzerotti-58527: public token-based HOST survey routes.
+//
+//   GET  /api/host-survey/:token  — render payload (event + questions + prior answers)
+//   POST /api/host-survey/:token  — submit / resubmit answers (idempotent)
+//
+// Mirrors the public guest survey router (survey.routes.ts) but for hosts. The
+// question set is built per-party via buildHostSurveyQuestions so the synthetic
+// `guests_attended` question is shown + accepted iff the party has no estimated
+// attendance. On submit, if guests_attended was asked + answered and the party
+// still has no estimatedAttendance, we write it back (never clobber a non-null
+// value); the raw answer is also stored in `answers`.
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { AppError } from '../middleware/error.js';
+import {
+  buildHostSurveyQuestions,
+  validateHostSurveyAnswers,
+  GUESTS_ATTENDED_ID,
+} from '../lib/hostSurveyQuestions.js';
+
+const router = Router();
+
+// GET /api/host-survey/:token
+router.get('/:token', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { token } = req.params;
+
+    const response = await prisma.hostSurveyResponse.findUnique({
+      where: { token },
+      select: {
+        answers: true,
+        questionSetVersion: true,
+        party: {
+          select: {
+            name: true,
+            customUrl: true,
+            inviteCode: true,
+            eventImageUrl: true,
+            estimatedAttendance: true,
+            user: { select: { name: true } },
+          },
+        },
+      },
+    });
+
+    if (!response || !response.party) {
+      throw new AppError('Host survey not found', 404, 'NOT_FOUND');
+    }
+
+    const party = response.party;
+    const set = await buildHostSurveyQuestions(party);
+    const firstName = (party.user?.name || '').trim().split(/\s+/)[0] || '';
+
+    res.json({
+      eventName: party.name,
+      eventSlug: party.customUrl || party.inviteCode,
+      firstName,
+      eventImageUrl: party.eventImageUrl,
+      questionSet: set.questions,
+      questionSetVersion: set.version,
+      alreadySubmitted: !!response.answers,
+      answers: response.answers ?? null,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/host-survey/:token
+router.post('/:token', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { token } = req.params;
+
+    const response = await prisma.hostSurveyResponse.findUnique({
+      where: { token },
+      select: {
+        id: true,
+        partyId: true,
+        party: { select: { id: true, estimatedAttendance: true } },
+      },
+    });
+
+    if (!response || !response.party) {
+      throw new AppError('Host survey not found', 404, 'NOT_FOUND');
+    }
+
+    const set = await buildHostSurveyQuestions(response.party);
+    const answers = validateHostSurveyAnswers(
+      (req.body as { answers?: unknown })?.answers,
+      set.questions
+    );
+
+    const now = new Date();
+
+    await prisma.hostSurveyResponse.update({
+      where: { id: response.id },
+      data: {
+        answers,
+        submittedAt: now,
+        questionSetVersion: set.version,
+        updatedAt: now,
+      },
+    });
+
+    // Write-back: if guests_attended was asked AND answered AND the party still
+    // has no estimatedAttendance, persist it. Never clobber a non-null value.
+    const guestsAsked = set.questions.some((q) => q.id === GUESTS_ATTENDED_ID);
+    const guestsAnswered = answers[GUESTS_ATTENDED_ID];
+    if (
+      guestsAsked &&
+      typeof guestsAnswered === 'string' &&
+      (response.party.estimatedAttendance === null ||
+        response.party.estimatedAttendance === undefined)
+    ) {
+      const n = Number(guestsAnswered);
+      if (Number.isInteger(n) && n >= 0) {
+        await prisma.party.update({
+          where: { id: response.party.id },
+          data: { estimatedAttendance: n },
+        });
+      }
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { router as hostSurveyPublicRouter };

--- a/backend/src/routes/survey.routes.ts
+++ b/backend/src/routes/survey.routes.ts
@@ -19,6 +19,7 @@ import {
   loadQuestionSet,
   validateSurveyAnswers,
 } from '../lib/surveyQuestions.js';
+import { sendHostSurveyEmail } from '../services/hostSurveyEmail.js';
 
 const SURVEY_TAB = 'survey';
 
@@ -474,6 +475,85 @@ cronRouter.post('/send-surveys', async (req: Request, res: Response, next: NextF
     }
 
     res.json({ processed: results.length, results });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// panzerotti-58527: HOST survey morning-after cron.
+//   POST /api/cron/send-host-surveys — guarded by CRON_SECRET.
+//   Mirrors send-surveys: parties whose endTime is within the last 7 days, a
+//   primary-host email present, host_survey_sent_at IS NULL, and ~09:00 local.
+//   Atomic claim via UPDATE...RETURNING so only one tick sends; rolls the claim
+//   back to NULL on send failure. The actual send/email lives in the shared
+//   sendHostSurveyEmail service.
+// ---------------------------------------------------------------------------
+cronRouter.post('/send-host-surveys', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const cronSecret = process.env.CRON_SECRET;
+    const authHeader = req.headers.authorization || '';
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+      throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+    }
+
+    const now = new Date();
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    const candidates = await prisma.party.findMany({
+      where: {
+        hostSurveySentAt: null,
+        endTime: { not: null, gte: sevenDaysAgo, lte: now },
+        // Party must have a linked host (the primary-host email lives on the
+        // User row; email is a required column so presence of the relation is
+        // the gate). sendHostSurveyEmail re-checks the email and no-ops if absent.
+        user: { is: {} },
+      },
+      select: { id: true, endTime: true, timezone: true },
+    });
+
+    let sent = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const party of candidates) {
+      if (!party.endTime) continue;
+      if (!isMorningAfterInTimezone(party.endTime, now, party.timezone)) continue;
+
+      // Atomic claim: only the winning row (host_survey_sent_at flipped NULL ->
+      // NOW) proceeds to send.
+      const claimed = await prisma.$queryRaw<Array<{ id: string }>>`
+        UPDATE "parties"
+        SET host_survey_sent_at = NOW()
+        WHERE id = ${party.id}::uuid AND host_survey_sent_at IS NULL
+        RETURNING id
+      `;
+      if (claimed.length === 0) {
+        skipped += 1;
+        continue;
+      }
+
+      try {
+        const ok = await sendHostSurveyEmail(party.id);
+        if (ok) {
+          sent += 1;
+        } else {
+          // Roll back the claim so a later tick can retry.
+          await prisma.party.update({
+            where: { id: party.id },
+            data: { hostSurveySentAt: null },
+          });
+          failed += 1;
+        }
+      } catch {
+        await prisma.party
+          .update({ where: { id: party.id }, data: { hostSurveySentAt: null } })
+          .catch(() => {});
+        failed += 1;
+      }
+    }
+
+    res.json({ processed: candidates.length, sent, failed, skipped });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/underboss.routes.ts
+++ b/backend/src/routes/underboss.routes.ts
@@ -10,6 +10,8 @@ import { buildScopedWhereClause, partyMatchesScope, UnderbossScope } from '../he
 import { writeStatusAudit, ActorKind } from '../helpers/statusAudit.js';
 import { scorePartiesByIds, buildSybilWalletSetFromDb } from '../lib/fakeDetectionScan.js';
 import { emailHostOfStatusChange } from '../services/partyStatusEmailNotify.js';
+import { sendHostSurveyEmail } from '../services/hostSurveyEmail.js';
+import { loadHostQuestionSet } from '../lib/hostSurveyQuestions.js';
 
 // Re-export the request type under the local name used throughout this file
 type UnderbossRequest = UnderbossAuthRequest;
@@ -2218,5 +2220,242 @@ router.get('/funnel-stats', requireAuth, requireUnderbossAuth, async (req: Under
     next(error);
   }
 });
+
+// ============================================
+// panzerotti-58527: HOST survey — send + responses (city-scoped)
+// ============================================
+
+// Concurrency pool (mirrors reminder.routes.ts runWithConcurrency).
+async function runHostSurveyConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<Array<{ ok: true; value: R } | { ok: false; error: unknown }>> {
+  const results: Array<{ ok: true; value: R } | { ok: false; error: unknown }> = new Array(
+    items.length,
+  );
+  let next = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers: Array<Promise<void>> = [];
+  for (let w = 0; w < workerCount; w++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const i = next++;
+          if (i >= items.length) return;
+          try {
+            results[i] = { ok: true, value: await fn(items[i]) };
+          } catch (error) {
+            results[i] = { ok: false, error };
+          }
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return results;
+}
+
+// POST /api/underboss/host-survey/send
+//   Body: { scope: 'all' | 'city' | 'status', cityIds?: string[], statuses?: string[] }
+//   Sends the host survey email to the primary host of each target party
+//   (city-scoped for non-admins). Stamps host_survey_sent_at on success so the
+//   cron won't double-send. Returns { sent, skipped, failed }.
+router.post(
+  '/host-survey/send',
+  requireAuth,
+  requireUnderbossAuth,
+  async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+    try {
+      const scope = scopeFromReq(req);
+      const body = (req.body ?? {}) as {
+        scope?: unknown;
+        cityIds?: unknown;
+        statuses?: unknown;
+      };
+
+      const sendScope =
+        body.scope === 'city' || body.scope === 'status' ? body.scope : 'all';
+
+      // Base where: constrain to the UB's region/city scope (null for admins).
+      const scopedWhere = buildScopedWhereClause(scope);
+      const where: any = scopedWhere ? { ...scopedWhere } : {};
+      where.cancelledAt = null;
+
+      if (sendScope === 'city') {
+        const cityIds = Array.isArray(body.cityIds)
+          ? body.cityIds.filter((c): c is string => typeof c === 'string' && c.trim() !== '')
+          : [];
+        if (cityIds.length === 0) {
+          throw new AppError('No cities selected', 400, 'VALIDATION_ERROR');
+        }
+        where.OR = cityIds.map((c) => ({
+          city: { equals: c.trim(), mode: 'insensitive' as const },
+        }));
+      } else if (sendScope === 'status') {
+        const valid = ['pending', 'approved', 'rejected', 'listed', 'hidden'];
+        const statuses = Array.isArray(body.statuses)
+          ? body.statuses.filter((s): s is string => typeof s === 'string' && valid.includes(s))
+          : [];
+        if (statuses.length === 0) {
+          throw new AppError('No statuses selected', 400, 'VALIDATION_ERROR');
+        }
+        where.underbossStatus = { in: statuses };
+      }
+
+      const parties = await prisma.party.findMany({
+        where,
+        select: { id: true, user: { select: { email: true } } },
+        take: 2000,
+      });
+
+      // No host email = skipped (counts as skipped, never sent).
+      let skipped = 0;
+      const sendable = parties.filter((p) => {
+        if (p.user?.email) return true;
+        skipped += 1;
+        return false;
+      });
+
+      const results = await runHostSurveyConcurrency(sendable, 5, async (p) => {
+        const ok = await sendHostSurveyEmail(p.id);
+        if (ok) {
+          // Stamp so the morning-after cron won't double-send a hand-sent event.
+          await prisma.party.update({
+            where: { id: p.id },
+            data: { hostSurveySentAt: new Date() },
+          });
+        }
+        return ok;
+      });
+
+      let sent = 0;
+      let failed = 0;
+      for (const r of results) {
+        if (r.ok && r.value) sent += 1;
+        else failed += 1;
+      }
+
+      res.json({ sent, skipped, failed });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// GET /api/underboss/host-survey/responses[?format=csv]
+//   City-scoped per-respondent host survey responses (one row per party).
+router.get(
+  '/host-survey/responses',
+  requireAuth,
+  requireUnderbossAuth,
+  async (req: UnderbossRequest, res: Response, next: NextFunction) => {
+    try {
+      const scope = scopeFromReq(req);
+      const scopedWhere = buildScopedWhereClause(scope);
+
+      const rows = await prisma.hostSurveyResponse.findMany({
+        where: {
+          submittedAt: { not: null },
+          ...(scopedWhere ? { party: scopedWhere } : {}),
+        },
+        orderBy: { submittedAt: 'desc' },
+        take: 5001,
+        select: {
+          id: true,
+          submittedAt: true,
+          questionSetVersion: true,
+          answers: true,
+          host: { select: { name: true, email: true } },
+          party: {
+            select: {
+              name: true,
+              customUrl: true,
+              inviteCode: true,
+              region: true,
+              city: true,
+            },
+          },
+        },
+      });
+
+      const truncated = rows.length > 5000;
+      const page = rows.slice(0, 5000);
+
+      const set = await loadHostQuestionSet().catch(() => ({ version: 1, questions: [] as any[] }));
+
+      const mapped = page.map((r) => ({
+        id: r.id,
+        submittedAt: r.submittedAt,
+        questionSetVersion: r.questionSetVersion,
+        hostName: r.host?.name ?? '',
+        email: r.host?.email ?? '',
+        event: {
+          name: r.party?.name ?? '',
+          slug: r.party?.customUrl || r.party?.inviteCode || '',
+          region: r.party?.region ?? null,
+          city: r.party?.city ?? null,
+        },
+        answers: (r.answers ?? {}) as Record<string, unknown>,
+      }));
+
+      if ((req.query.format as string) === 'csv') {
+        const questions = set.questions;
+        const csvCell = (v: string) => `"${String(v).replace(/"/g, '""')}"`;
+        const answerToCsv = (value: unknown): string => {
+          if (value === undefined || value === null) return '';
+          if (Array.isArray(value)) return value.join('; ');
+          if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+          return String(value);
+        };
+        const header = [
+          'event_name',
+          'event_slug',
+          'region',
+          'city',
+          'host_name',
+          'email',
+          'submitted_at',
+          'question_set_version',
+        ];
+        for (const q of questions) {
+          header.push(q.id);
+          if (q.allowOther) header.push(`${q.id}_other`);
+        }
+        const lines = [header.map(csvCell).join(',')];
+        for (const r of mapped) {
+          const cells = [
+            r.event.name,
+            r.event.slug,
+            r.event.region ?? '',
+            r.event.city ?? '',
+            r.hostName,
+            r.email,
+            r.submittedAt ? new Date(r.submittedAt).toISOString() : '',
+            String(r.questionSetVersion ?? ''),
+          ];
+          for (const q of questions) {
+            cells.push(answerToCsv(r.answers[q.id]));
+            if (q.allowOther) cells.push(answerToCsv(r.answers[`${q.id}_other`]));
+          }
+          lines.push(cells.map(csvCell).join(','));
+        }
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+        res.setHeader('Content-Disposition', 'attachment; filename="host-survey-responses.csv"');
+        res.send(lines.join('\r\n'));
+        return;
+      }
+
+      res.json({
+        questionSet: set.questions,
+        questionSetVersion: set.version,
+        truncated,
+        responses: mapped,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
 
 export default router;

--- a/backend/src/services/hostSurveyEmail.ts
+++ b/backend/src/services/hostSurveyEmail.ts
@@ -1,0 +1,154 @@
+// panzerotti-58527: per-party HOST survey send. This is the SHARED send path
+// for both the manual /underboss send and the morning-after cron.
+//
+// - Recipients = PRIMARY host only (party.user.email). Co-hosts are out of scope.
+// - Upserts the one host_survey_responses row for the party (unique party_id),
+//   generating a token on first send and REUSING it on resend (manual re-send).
+// - Mirrors buildSurveyEmail (guest survey) for the email body.
+// - Never throws; returns a boolean (sent / not-sent). A Resend outage or a
+//   missing host email must not break the send loop.
+
+import crypto from 'crypto';
+import { prisma } from '../config/database.js';
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const FROM = 'RSV.Pizza <noreply@rsv.pizza>';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Strip the canonical "Global Pizza Party " prefix to get a clean city label.
+function cityLabel(name: string): string {
+  return name.replace(/^Global Pizza Party\s+/i, '').trim() || name;
+}
+
+function buildHostSurveyEmail(
+  party: { name: string; eventImageUrl?: string | null },
+  hostName: string | null | undefined,
+  token: string
+): { subject: string; html: string } {
+  const baseUrl = 'https://rsv.pizza';
+  const surveyUrl = `${baseUrl}/host-survey/${token}`;
+
+  const greeting = hostName ? escapeHtml(hostName.trim().split(/\s+/)[0]) : 'there';
+  const city = cityLabel(party.name);
+
+  const flyerBlock = party.eventImageUrl
+    ? `
+          <div style="text-align: center; margin-bottom: 20px;">
+            <img src="${party.eventImageUrl}" alt="${escapeHtml(party.name)}" style="max-width: 100%; border-radius: 12px;" />
+          </div>`
+    : '';
+
+  const subject = `How did hosting ${city} go? Tell us 🍕`;
+
+  const html = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>How did hosting go?</title>
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          ${flyerBlock}
+          <div style="background: #f9f9f9; padding: 30px; border-radius: 12px; margin-bottom: 20px;">
+            <h2 style="color: #1a1a2e; margin-top: 0;">Thanks for hosting, ${greeting}!</h2>
+            <p style="margin: 0; color: #333; font-size: 15px;">We'd love to hear how hosting <strong>${escapeHtml(city)}</strong> went. It takes less than a minute and helps us support hosts better next time.</p>
+          </div>
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${surveyUrl}" style="display: inline-block; background: #ff393a; color: white; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600;">Take the host survey</a>
+          </div>
+          <p style="color: #555; font-size: 14px;">Best,<br>Dread Pizza Roberts<br>PizzaDAO</p>
+        </body>
+      </html>
+    `;
+
+  return { subject, html };
+}
+
+/**
+ * Send (or resend) the host survey email for a single party. Returns true iff
+ * the email was accepted by Resend. Skips silently (returns false) when there
+ * is no primary-host email or RESEND_API_KEY is unset.
+ */
+export async function sendHostSurveyEmail(partyId: string): Promise<boolean> {
+  if (!process.env.RESEND_API_KEY) return false;
+
+  try {
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: {
+        id: true,
+        name: true,
+        customUrl: true,
+        inviteCode: true,
+        eventImageUrl: true,
+        estimatedAttendance: true,
+        userId: true,
+        user: { select: { id: true, email: true, name: true } },
+      },
+    });
+
+    if (!party?.user?.email || !party.user.id) return false;
+
+    // Upsert the response row (unique party_id). Reuse the existing token on
+    // resend; generate one on first send.
+    const existing = await prisma.hostSurveyResponse.findUnique({
+      where: { partyId: party.id },
+      select: { token: true },
+    });
+    const token = existing?.token ?? crypto.randomUUID();
+    const now = new Date();
+
+    await prisma.hostSurveyResponse.upsert({
+      where: { partyId: party.id },
+      create: {
+        token,
+        partyId: party.id,
+        hostUserId: party.user.id,
+        sentAt: now,
+      },
+      update: {
+        sentAt: now,
+        hostUserId: party.user.id,
+        updatedAt: now,
+      },
+    });
+
+    const { subject, html } = buildHostSurveyEmail(
+      { name: party.name, eventImageUrl: party.eventImageUrl },
+      party.user.name,
+      token
+    );
+
+    const resp = await fetch(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      },
+      body: JSON.stringify({
+        from: FROM,
+        to: [party.user.email],
+        subject,
+        html,
+      }),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      console.warn(`[hostSurveyEmail] Resend ${resp.status}: ${body.slice(0, 200)}`);
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    console.warn('[hostSurveyEmail] send failed:', err?.message || err);
+    return false;
+  }
+}

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -25,10 +25,6 @@
       "path": "/api/cron/send-surveys",
       "schedule": "0 * * * *"
     },
-    {
-      "path": "/api/cron/send-host-surveys",
-      "schedule": "0 * * * *"
-    },
     { "path": "/api/cron/event-reminders", "schedule": "*/15 * * * *" }
   ]
 }

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -25,6 +25,10 @@
       "path": "/api/cron/send-surveys",
       "schedule": "0 * * * *"
     },
+    {
+      "path": "/api/cron/send-host-surveys",
+      "schedule": "0 * * * *"
+    },
     { "path": "/api/cron/event-reminders", "schedule": "*/15 * * * *" }
   ]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import { PartnersPage } from './pages/PartnersPage';
 import { LeaderboardPage } from './pages/LeaderboardPage';
 import { PhotosFeedPage } from './pages/PhotosFeedPage';
 import { SurveyPage } from './pages/SurveyPage';
+import { HostSurveyPage } from './pages/HostSurveyPage';
 
 // Legacy redirect: /sponsor-intake/:token → /partner-intake/:token
 // <Navigate> doesn't forward path params, so we wrap useParams().
@@ -148,6 +149,8 @@ function App() {
             <Route path="/cmohhr0640003jp047krjarz0" element={<Navigate to="/nashville" replace />} />
             {/* romana-61204: post-event survey — must come before /:slug catch-all */}
             <Route path="/survey/:token" element={<SurveyPage />} />
+            {/* panzerotti-58527: post-event host survey — before /:slug catch-all */}
+            <Route path="/host-survey/:token" element={<HostSurveyPage />} />
             {/* Catch-all route for custom URLs - must be last */}
             <Route path="/:slug" element={<EventPage />} />
           </Routes>

--- a/frontend/src/components/underboss/HostSurveyResponsesTab.tsx
+++ b/frontend/src/components/underboss/HostSurveyResponsesTab.tsx
@@ -1,0 +1,400 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, Download, Send } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import {
+  HostSurveyResponseRow,
+  HostSurveyResponsesResponse,
+  HostSurveySendScope,
+  getHostSurveyResponses,
+  exportHostSurveyResponsesCsv,
+  sendHostSurvey,
+} from '../../lib/api';
+import type { SurveyQuestion } from '../../lib/surveyQuestions';
+
+/**
+ * panzerotti-58527: "Host Survey Responses" tab on /underboss.
+ *
+ * City-scoped per-respondent host survey responses (one row per party) with a
+ * region filter + text search + a server-rendered CSV export, plus a "Send host
+ * survey" control with an audience picker (all / by city / by status) POSTing to
+ * /api/underboss/host-survey/send.
+ *
+ * Clone of SurveyResponsesTab (guest), adapted to the host shape.
+ */
+
+const SEND_STATUSES = ['pending', 'approved', 'rejected', 'listed', 'hidden'];
+
+function formatAnswer(q: SurveyQuestion, value: unknown): string {
+  if (value === undefined || value === null) return '—';
+  switch (q.type) {
+    case 'yesno':
+      return value === true ? 'Yes' : value === false ? 'No' : String(value);
+    case 'rating':
+      return typeof value === 'number' ? `${value} / ${q.scale ?? 5}` : String(value);
+    case 'multiple':
+      return Array.isArray(value) ? value.join(', ') : String(value);
+    case 'text':
+    default:
+      return String(value);
+  }
+}
+
+export function HostSurveyResponsesTab() {
+  // ---- Hooks (all above any early return — feedback_hooks_above_early_returns)
+  const [data, setData] = useState<HostSurveyResponsesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [regionFilter, setRegionFilter] = useState<string>('');
+  const [search, setSearch] = useState('');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Send control state.
+  const [sendScope, setSendScope] = useState<HostSurveySendScope>('all');
+  const [sendCities, setSendCities] = useState('');
+  const [sendStatuses, setSendStatuses] = useState<string[]>(['approved']);
+  const [sending, setSending] = useState(false);
+  const [sendResult, setSendResult] = useState<string | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await getHostSurveyResponses();
+      setData(res);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load host survey responses');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await getHostSurveyResponses();
+        if (!cancelled) {
+          setData(res);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load host survey responses');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const questions = data?.questionSet ?? [];
+  const ratingQuestions = useMemo(
+    () => questions.filter((q) => q.type === 'rating'),
+    [questions]
+  );
+
+  const regions = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of data?.responses ?? []) {
+      if (r.event.region) set.add(r.event.region);
+    }
+    return Array.from(set).sort();
+  }, [data]);
+
+  const filtered = useMemo(() => {
+    const rows = data?.responses ?? [];
+    const term = search.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (regionFilter && r.event.region !== regionFilter) return false;
+      if (term) {
+        const haystack = `${r.event.name} ${r.hostName} ${r.email}`.toLowerCase();
+        if (!haystack.includes(term)) return false;
+      }
+      return true;
+    });
+  }, [data, regionFilter, search]);
+
+  const handleSend = async () => {
+    setSending(true);
+    setSendResult(null);
+    setSendError(null);
+    try {
+      const body: { scope: HostSurveySendScope; cityIds?: string[]; statuses?: string[] } = {
+        scope: sendScope,
+      };
+      if (sendScope === 'city') {
+        body.cityIds = sendCities
+          .split(',')
+          .map((c) => c.trim())
+          .filter(Boolean);
+      } else if (sendScope === 'status') {
+        body.statuses = sendStatuses;
+      }
+      const res = await sendHostSurvey(body);
+      setSendResult(`Sent ${res.sent}, skipped ${res.skipped}, failed ${res.failed}.`);
+      // Refresh responses so newly-stamped rows can show up over time.
+      load();
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : 'Send failed');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleExport = async () => {
+    try {
+      await exportHostSurveyResponsesCsv();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'CSV export failed');
+    }
+  };
+
+  // ---- Render (all hooks declared above)
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 size={28} className="animate-spin text-theme-text-muted" />
+      </div>
+    );
+  }
+
+  const colCount = 5 + ratingQuestions.length + 1;
+
+  return (
+    <div className="space-y-6">
+      {/* Send host survey */}
+      <div className="border border-theme-stroke rounded-xl p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-theme-text">Send host survey</h3>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={sendScope}
+            onChange={(e) => setSendScope(e.target.value as HostSurveySendScope)}
+            className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none"
+          >
+            <option value="all">All events in scope</option>
+            <option value="city">By city</option>
+            <option value="status">By status</option>
+          </select>
+
+          {sendScope === 'city' && (
+            <div className="flex-1 min-w-[14rem]">
+              <IconInput
+                placeholder="City names, comma-separated (e.g. Lagos, Manila)"
+                value={sendCities}
+                onChange={(e) => setSendCities(e.target.value)}
+                className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none"
+              />
+            </div>
+          )}
+
+          {sendScope === 'status' && (
+            <div className="flex flex-wrap gap-2">
+              {SEND_STATUSES.map((s) => {
+                const on = sendStatuses.includes(s);
+                return (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() =>
+                      setSendStatuses((prev) =>
+                        prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]
+                      )
+                    }
+                    className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                      on
+                        ? 'bg-[#ff393a] text-white border-[#ff393a]'
+                        : 'border-theme-stroke text-theme-text-muted hover:text-theme-text'
+                    }`}
+                  >
+                    {s}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <button
+            onClick={handleSend}
+            disabled={sending}
+            className="px-3 py-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1"
+          >
+            {sending ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />} Send
+          </button>
+        </div>
+        <p className="text-xs text-theme-text-faint">
+          Emails the primary host of each matching event. Events with no host email are skipped.
+          Already-sent events are re-sent (one response row, no duplicates).
+        </p>
+        {sendResult && <p className="text-xs text-green-400">{sendResult}</p>}
+        {sendError && <p className="text-xs text-red-400">{sendError}</p>}
+      </div>
+
+      {error && <div className="text-red-400 text-sm">{error}</div>}
+
+      {/* Responses */}
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={regionFilter}
+            onChange={(e) => setRegionFilter(e.target.value)}
+            className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text focus:outline-none"
+          >
+            <option value="">All regions</option>
+            {regions.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+          <div className="flex-1 min-w-[12rem]">
+            <IconInput
+              placeholder="Search event, host, or email"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="bg-theme-surface border border-theme-stroke rounded-lg px-3 py-2 text-sm text-theme-text placeholder:text-theme-text-faint focus:outline-none focus:border-theme-stroke-hover"
+            />
+          </div>
+          <button
+            onClick={handleExport}
+            disabled={(data?.responses ?? []).length === 0}
+            className="px-3 py-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1"
+          >
+            <Download size={14} /> Export CSV
+          </button>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="text-theme-text-muted text-sm py-6">No responses yet.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-left text-theme-text-muted border-b border-theme-stroke">
+                <tr>
+                  <th className="py-2 pr-3">Event</th>
+                  <th className="py-2 pr-3">Region</th>
+                  <th className="py-2 pr-3">Host</th>
+                  <th className="py-2 pr-3">Email</th>
+                  <th className="py-2 pr-3">Submitted</th>
+                  {ratingQuestions.map((q) => (
+                    <th key={q.id} className="py-2 pr-3" title={q.text}>
+                      {q.text.length > 24 ? `${q.text.slice(0, 24)}…` : q.text}
+                    </th>
+                  ))}
+                  <th className="py-2 pr-3 w-20"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((r) => (
+                  <ResponseRow
+                    key={r.id}
+                    row={r}
+                    questions={questions}
+                    ratingQuestions={ratingQuestions}
+                    expanded={expandedId === r.id}
+                    colCount={colCount}
+                    onToggle={() => setExpandedId((prev) => (prev === r.id ? null : r.id))}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ResponseRowProps {
+  row: HostSurveyResponseRow;
+  questions: SurveyQuestion[];
+  ratingQuestions: SurveyQuestion[];
+  expanded: boolean;
+  colCount: number;
+  onToggle: () => void;
+}
+
+function ResponseRow({
+  row,
+  questions,
+  ratingQuestions,
+  expanded,
+  colCount,
+  onToggle,
+}: ResponseRowProps) {
+  const submitted = (() => {
+    if (!row.submittedAt) return '—';
+    const d = new Date(row.submittedAt);
+    return Number.isNaN(d.getTime()) ? row.submittedAt : d.toLocaleDateString();
+  })();
+
+  return (
+    <>
+      <tr className="border-b border-theme-stroke/60">
+        <td className="py-2 pr-3 align-top">
+          {row.event.slug ? (
+            <a
+              href={`/${row.event.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-theme-text hover:text-theme-text-secondary underline"
+            >
+              {row.event.name || row.event.slug}
+            </a>
+          ) : (
+            <span className="text-theme-text">{row.event.name || '—'}</span>
+          )}
+        </td>
+        <td className="py-2 pr-3 align-top text-theme-text-muted text-xs">
+          {row.event.region ?? '—'}
+        </td>
+        <td className="py-2 pr-3 align-top text-theme-text">{row.hostName || '—'}</td>
+        <td className="py-2 pr-3 align-top text-theme-text-muted text-xs">{row.email || '—'}</td>
+        <td className="py-2 pr-3 align-top text-theme-text-muted text-xs">{submitted}</td>
+        {ratingQuestions.map((q) => {
+          const v = row.answers[q.id];
+          return (
+            <td key={q.id} className="py-2 pr-3 align-top text-theme-text-muted text-xs">
+              {typeof v === 'number' ? `${v}★` : '—'}
+            </td>
+          );
+        })}
+        <td className="py-2 pr-3 align-top">
+          <button
+            onClick={onToggle}
+            className="text-xs text-theme-text hover:text-theme-text-secondary underline"
+          >
+            {expanded ? 'Close' : 'View'}
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={colCount} className="bg-theme-surface/40 px-3 py-4 border-b border-theme-stroke">
+            <div className="space-y-2 max-w-2xl">
+              {questions.map((q) => {
+                const main = formatAnswer(q, row.answers[q.id]);
+                const other = q.allowOther ? row.answers[`${q.id}_other`] : undefined;
+                return (
+                  <div key={q.id}>
+                    <p className="text-xs text-theme-text-muted">{q.text}</p>
+                    <p className="text-sm text-theme-text">
+                      {main}
+                      {typeof other === 'string' && other.trim().length > 0 && (
+                        <span className="text-theme-text-muted"> — “{other}”</span>
+                      )}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/underboss/index.ts
+++ b/frontend/src/components/underboss/index.ts
@@ -12,6 +12,7 @@ export { FakeDetectionTable } from './FakeDetectionTable';
 export { SuperlativesTab } from './SuperlativesTab';
 export { SurveyQuestionsTab } from './SurveyQuestionsTab';
 export { SurveyResponsesTab } from './SurveyResponsesTab';
+export { HostSurveyResponsesTab } from './HostSurveyResponsesTab';
 export { OutreachTab } from './OutreachTab';
 export { TelegramGroupsTab } from './TelegramGroupsTab';
 export { ReimbursementCapCell } from './ReimbursementCapCell';

--- a/frontend/src/components/underboss/underbossTableUrlState.ts
+++ b/frontend/src/components/underboss/underbossTableUrlState.ts
@@ -19,6 +19,7 @@ export type UnderbossTab =
   | 'superlatives'
   | 'survey'
   | 'survey-responses'
+  | 'host-survey-responses'
   | 'outreach'
   | 'telegram-groups';
 
@@ -30,6 +31,7 @@ const UNDERBOSS_TABS: UnderbossTab[] = [
   'superlatives',
   'survey',
   'survey-responses',
+  'host-survey-responses',
   'outreach',
   'telegram-groups',
 ];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7369,6 +7369,105 @@ export async function getAdminSurveyResponses(): Promise<AdminSurveyResponsesRes
   return apiRequest<AdminSurveyResponsesResponse>('/api/admin/survey-responses', { requireAuth: true });
 }
 
+// ===========================================================================
+// panzerotti-58527: post-event HOST survey
+// ===========================================================================
+
+export interface HostSurveyFetchResponse {
+  eventName: string;
+  eventSlug: string;
+  firstName: string;
+  eventImageUrl: string | null;
+  questionSet: SurveyQuestion[];
+  questionSetVersion: number;
+  alreadySubmitted: boolean;
+  answers: SurveyAnswers | null;
+}
+
+// Public (token-based) — fetch the host survey for a /host-survey/:token link.
+export async function fetchHostSurvey(token: string): Promise<HostSurveyFetchResponse> {
+  return apiRequest<HostSurveyFetchResponse>(`/api/host-survey/${token}`, {
+    method: 'GET',
+    requireAuth: false,
+  });
+}
+
+// Public (token-based) — submit (or resubmit) host survey answers.
+export async function submitHostSurvey(
+  token: string,
+  answers: SurveyAnswers
+): Promise<{ success: boolean }> {
+  return apiRequest<{ success: boolean }>(`/api/host-survey/${token}`, {
+    method: 'POST',
+    body: { answers },
+    requireAuth: false,
+  });
+}
+
+// Underboss — send the host survey to the primary host of each target party.
+export type HostSurveySendScope = 'all' | 'city' | 'status';
+export interface HostSurveySendResult {
+  sent: number;
+  skipped: number;
+  failed: number;
+}
+export async function sendHostSurvey(body: {
+  scope: HostSurveySendScope;
+  cityIds?: string[];
+  statuses?: string[];
+}): Promise<HostSurveySendResult> {
+  return apiRequest<HostSurveySendResult>('/api/underboss/host-survey/send', {
+    method: 'POST',
+    body,
+    requireAuth: true,
+  });
+}
+
+// Underboss — per-respondent host survey responses (city-scoped).
+export interface HostSurveyResponseRow {
+  id: string;
+  submittedAt: string | null;
+  questionSetVersion: number | null;
+  hostName: string;
+  email: string;
+  event: {
+    name: string;
+    slug: string;
+    region: string | null;
+    city: string | null;
+  };
+  answers: SurveyAnswers;
+}
+export interface HostSurveyResponsesResponse {
+  questionSet: SurveyQuestion[];
+  questionSetVersion: number;
+  truncated: boolean;
+  responses: HostSurveyResponseRow[];
+}
+export async function getHostSurveyResponses(): Promise<HostSurveyResponsesResponse> {
+  return apiRequest<HostSurveyResponsesResponse>('/api/underboss/host-survey/responses', {
+    requireAuth: true,
+  });
+}
+
+// Underboss — download the host survey responses CSV (server-rendered via
+// ?format=csv). Fires a browser download via a temporary <a> element.
+export async function exportHostSurveyResponsesCsv(): Promise<void> {
+  const token = getAuthToken();
+  if (!token) throw new Error('Not authenticated');
+  const res = await fetch(`${API_URL}/api/underboss/host-survey/responses?format=csv`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`CSV export failed: ${res.status}`);
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = `host-survey-responses-${new Date().toISOString().split('T')[0]}.csv`;
+  a.click();
+  URL.revokeObjectURL(objectUrl);
+}
+
 // ============================================
 // Tax forms (salame-92110)
 // ============================================

--- a/frontend/src/pages/HostSurveyPage.tsx
+++ b/frontend/src/pages/HostSurveyPage.tsx
@@ -1,0 +1,356 @@
+import { useState, useEffect, useCallback } from 'react';
+import type React from 'react';
+import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { Loader2, AlertCircle, CheckCircle2, Star, MessageSquare, Users } from 'lucide-react';
+import { Layout } from '../components/Layout';
+import { IconInput } from '../components/IconInput';
+import { Checkbox } from '../components/Checkbox';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import { fetchHostSurvey, submitHostSurvey, type HostSurveyFetchResponse } from '../lib/api';
+import type { SurveyQuestion, SurveyAnswers, SurveyAnswerValue } from '../lib/surveyQuestions';
+
+// panzerotti-58527: host survey-taking page. Clone of SurveyPage, but rendered
+// against the HOST question set, and the synthetic `guests_attended` text
+// question is shown as a numeric input.
+const GUESTS_ATTENDED_ID = 'guests_attended';
+
+export function HostSurveyPage() {
+  return (
+    <ThemeProvider theme="gpp">
+      <HostSurveyPageInner />
+    </ThemeProvider>
+  );
+}
+
+function HostSurveyPageInner() {
+  const { token } = useParams<{ token: string }>();
+
+  // All hooks declared above any early return (rules-of-hooks).
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<HostSurveyFetchResponse | null>(null);
+  const [answers, setAnswers] = useState<SurveyAnswers>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!token) {
+      setError('Invalid survey link.');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetchHostSurvey(token);
+      setData(r);
+      if (r.answers) setAnswers(r.answers);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Survey not found.');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const setAnswer = (id: string, value: SurveyAnswerValue) => {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const toggleMulti = (id: string, option: string) => {
+    setAnswers((prev) => {
+      const current = Array.isArray(prev[id]) ? (prev[id] as string[]) : [];
+      const next = current.includes(option)
+        ? current.filter((o) => o !== option)
+        : [...current, option];
+      return { ...prev, [id]: next };
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitHostSurvey(token, answers);
+      setSubmitted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to submit survey.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // ---- Renders below (all hooks already declared) ----
+
+  if (loading) {
+    return (
+      <Layout>
+        <div className="min-h-[60vh] flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-[#ff393a]" />
+        </div>
+      </Layout>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <Layout>
+        <div className="min-h-[60vh] flex items-center justify-center p-4">
+          <div className="card p-8 max-w-md text-center">
+            <AlertCircle className="w-16 h-16 text-[#ff393a] mx-auto mb-4" />
+            <h1 className="text-2xl font-bold text-theme-text mb-2">Survey not found</h1>
+            <p className="text-theme-text-muted">{error}</p>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <Layout>
+        <div className="min-h-[60vh] flex items-center justify-center p-4">
+          <div className="card p-8 max-w-md text-center">
+            <CheckCircle2 className="w-16 h-16 text-[#2E7D32] mx-auto mb-4" />
+            <h1 className="text-2xl font-bold text-theme-text mb-2">Thank you! 🍕</h1>
+            <p className="text-theme-text-muted">
+              Your feedback helps us support PizzaDAO hosts better.
+            </p>
+            <button
+              type="button"
+              onClick={() => setSubmitted(false)}
+              className="mt-4 text-sm text-theme-text-muted hover:text-theme-text underline"
+            >
+              Edit my answers
+            </button>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  const questions = data?.questionSet ?? [];
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>{data ? `Host survey · ${data.eventName}` : 'Host survey'} | RSV.Pizza</title>
+      </Helmet>
+      <div className="max-w-2xl mx-auto px-4 py-10">
+        <div className="card p-5 mb-6 text-center">
+          <h1 className="text-3xl font-bold text-theme-text mb-1">
+            How did hosting {data?.eventName} go?
+          </h1>
+          <p className="text-theme-text-muted">
+            {data?.firstName ? `Thanks for hosting, ${data.firstName}! ` : ''}
+            Tell us how it went — it takes less than a minute.
+          </p>
+          {data?.alreadySubmitted && (
+            <p className="text-xs text-theme-text-muted mt-2">
+              You've already responded. You can update your answers below.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-6">
+          {questions.map((q) => {
+            const otherKey = `${q.id}_other`;
+            const otherRaw = answers[otherKey];
+            const otherValue = typeof otherRaw === 'string' ? otherRaw : '';
+            return (
+              <div key={q.id} className="card p-5">
+                <p className="text-sm font-medium text-theme-text mb-3">{q.text}</p>
+                <HostSurveyQuestionField
+                  question={q}
+                  value={answers[q.id]}
+                  otherValue={otherValue}
+                  onRating={(n) => setAnswer(q.id, n)}
+                  onYesNo={(b) => setAnswer(q.id, b)}
+                  onSingle={(opt) => setAnswer(q.id, opt)}
+                  onToggleMulti={(opt) => toggleMulti(q.id, opt)}
+                  onText={(s) => setAnswer(q.id, s)}
+                  onOther={(s) => setAnswer(otherKey, s)}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {error && <p className="mt-4 text-sm text-[#ff393a] text-center">{error}</p>}
+
+        <div className="mt-8 flex justify-center">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="btn-primary inline-flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+            {submitting ? 'Submitting…' : data?.alreadySubmitted ? 'Update answers' : 'Submit'}
+          </button>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+interface FieldProps {
+  question: SurveyQuestion;
+  value: SurveyAnswerValue | undefined;
+  otherValue: string;
+  onRating: (n: number) => void;
+  onYesNo: (b: boolean) => void;
+  onSingle: (opt: string) => void;
+  onToggleMulti: (opt: string) => void;
+  onText: (s: string) => void;
+  onOther: (s: string) => void;
+}
+
+const HostSurveyQuestionField: React.FC<FieldProps> = ({
+  question,
+  value,
+  otherValue,
+  onRating,
+  onYesNo,
+  onSingle,
+  onToggleMulti,
+  onText,
+  onOther,
+}) => {
+  // Synthetic numeric headcount question (a `text` question rendered numeric).
+  if (question.id === GUESTS_ATTENDED_ID) {
+    return (
+      <IconInput
+        icon={Users}
+        type="number"
+        min={0}
+        step={1}
+        placeholder="Number of guests"
+        value={typeof value === 'string' ? value : ''}
+        onChange={(e) => {
+          const raw = (e.target as HTMLInputElement).value;
+          // Keep only digits so the stored answer is a clean integer string.
+          onText(raw.replace(/[^0-9]/g, ''));
+        }}
+      />
+    );
+  }
+
+  if (question.type === 'rating') {
+    const scale = question.scale ?? 5;
+    const current = typeof value === 'number' ? value : 0;
+    return (
+      <div className="flex items-center gap-2">
+        {Array.from({ length: scale }, (_, i) => i + 1).map((n) => (
+          <button
+            key={n}
+            type="button"
+            aria-label={`Rate ${n}`}
+            onClick={() => onRating(n)}
+            className="p-1 hover:scale-110 transition-transform"
+          >
+            <Star
+              className={n <= current ? 'text-[#ff393a] fill-[#ff393a]' : 'text-theme-text-muted'}
+              size={28}
+            />
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  if (question.type === 'yesno') {
+    return (
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => onYesNo(true)}
+          className={`px-5 py-2 rounded-lg text-sm font-medium border transition-colors ${
+            value === true
+              ? 'bg-[#ff393a] text-white border-[#ff393a]'
+              : 'border-white/20 text-theme-text hover:border-white/40'
+          }`}
+        >
+          Yes
+        </button>
+        <button
+          type="button"
+          onClick={() => onYesNo(false)}
+          className={`px-5 py-2 rounded-lg text-sm font-medium border transition-colors ${
+            value === false
+              ? 'bg-[#ff393a] text-white border-[#ff393a]'
+              : 'border-white/20 text-theme-text hover:border-white/40'
+          }`}
+        >
+          No
+        </button>
+      </div>
+    );
+  }
+
+  if (question.type === 'multiple') {
+    const options = question.options ?? [];
+    if (question.multi) {
+      const selected = Array.isArray(value) ? value : [];
+      return (
+        <div className="space-y-2">
+          {options.map((opt) => (
+            <Checkbox
+              key={opt}
+              checked={selected.includes(opt)}
+              onChange={() => onToggleMulti(opt)}
+              label={opt}
+            />
+          ))}
+        </div>
+      );
+    }
+    return (
+      <div>
+        <div className="flex flex-wrap gap-2">
+          {options.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onSingle(opt)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                value === opt
+                  ? 'bg-[#ff393a] text-white border-[#ff393a]'
+                  : 'border-white/20 text-theme-text hover:border-white/40'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+        {question.allowOther && value === 'Other' && (
+          <div className="mt-3">
+            <IconInput
+              icon={MessageSquare}
+              placeholder="Please tell us more"
+              value={otherValue}
+              onChange={(e) => onOther((e.target as HTMLInputElement).value)}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // text
+  return (
+    <IconInput
+      icon={MessageSquare}
+      multiline
+      rows={4}
+      placeholder="Share your thoughts (optional)"
+      value={typeof value === 'string' ? value : ''}
+      onChange={(e) => onText((e.target as HTMLInputElement | HTMLTextAreaElement).value)}
+    />
+  );
+};

--- a/frontend/src/pages/UnderbossDashboard.tsx
+++ b/frontend/src/pages/UnderbossDashboard.tsx
@@ -7,7 +7,7 @@ import { Loader2, Shield, AlertCircle, Globe, ChevronDown, LogIn, UserPlus, X, C
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { LoginModal } from '../components/LoginModal';
-import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, SuperlativesTab, SurveyQuestionsTab, SurveyResponsesTab, OutreachTab, TelegramGroupsTab } from '../components/underboss';
+import { RegionStats, RegionBreakdown, EventTable, TelegramBroadcast, CitiesTable, PartnerManager, CityScopePicker, FakeDetectionTable, SuperlativesTab, SurveyQuestionsTab, SurveyResponsesTab, HostSurveyResponsesTab, OutreachTab, TelegramGroupsTab } from '../components/underboss';
 import { SavedViewsMenu } from '../components/SavedViewsMenu';
 // montanara-58497: URL <-> EventTable filters + active tab (de)serializer so a
 // refresh / shared link restores the exact filtered view.
@@ -751,6 +751,19 @@ export function UnderbossDashboard() {
               </button>
             )}
             <button
+              onClick={() => setActiveTab('host-survey-responses')}
+              className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
+                activeTab === 'host-survey-responses'
+                  ? 'text-theme-text'
+                  : 'text-theme-text-muted hover:text-theme-text-secondary'
+              }`}
+            >
+              {t('underbossDashboard.tabs.hostSurveyResponses', 'Host Survey Responses')}
+              {activeTab === 'host-survey-responses' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-500" />
+              )}
+            </button>
+            <button
               onClick={() => setActiveTab('outreach')}
               className={`pb-3 text-lg font-semibold transition-all whitespace-nowrap relative ${
                 activeTab === 'outreach'
@@ -828,6 +841,10 @@ export function UnderbossDashboard() {
 
           {isAdmin && activeTab === 'survey-responses' && (
             <SurveyResponsesTab />
+          )}
+
+          {activeTab === 'host-survey-responses' && (
+            <HostSurveyResponsesTab />
           )}
 
           {activeTab === 'outreach' && (


### PR DESCRIPTION
## Host survey email (panzerotti-58527)

Clones the existing post-event **guest** survey system but targets **hosts**, with a **separate question set**. Recipients are the **primary host only** (`party.user.email`); co-hosts are out of scope.

### Question set (`default`, 6 questions)
1. `event_rating` — rating /5: How would you rate your event overall?
2. `same_pizzeria` — yes/no: Would you use the same pizzeria again?
3. `venue_ok` — yes/no: Did the venue work out well?
4. `program_support` — rating /5: How would you rate the support you got from the PizzaDAO program?
5. `host_again` — yes/no: Would you host again next year?
6. `improve` — text: What could we do to make hosting easier or better?

### Conditional `guests_attended` write-back
When a party has **no `estimatedAttendance`**, a synthetic `guests_attended` question is **prepended** as the first question (rendered as a numeric input). It is never stored in the `host_survey_questions` table. The public GET (render) and POST (validate) both build the question list from the **same party**, so the conditional question is accepted iff it was shown. On submit, if it was asked + answered and the party still has no `estimatedAttendance`, the integer is written back to `parties.estimated_attendance` (never clobbering a non-null value); the raw answer is still stored in `answers`.

### Backend
- `backend/src/lib/hostSurveyQuestions.ts` — DB loader (60s cache) + `validateHostSurveyAnswers` + `buildHostSurveyQuestions(party)`.
- `backend/src/services/hostSurveyEmail.ts` — shared `sendHostSurveyEmail(partyId)` (manual + cron). Upserts the one `host_survey_responses` row (unique `party_id`), reusing the token on resend; Resend via fetch; never throws; returns boolean. Sign-off "Dread Pizza Roberts / PizzaDAO".
- `backend/src/routes/hostSurvey.routes.ts` — public `GET`/`POST /api/host-survey/:token` (mounted in `index.ts`).
- `backend/src/routes/underboss.routes.ts` — `POST /api/underboss/host-survey/send` (audience `all`/`city`/`status`, 5-worker concurrent pool, stamps `host_survey_sent_at` on success so the cron won't double-send) and `GET /api/underboss/host-survey/responses[?format=csv]` (city-scoped per-respondent rows).
- `backend/src/routes/survey.routes.ts` — `POST /api/cron/send-host-surveys` (CRON_SECRET-gated): parties whose `endTime` is within the last 7 days, host email present, `host_survey_sent_at IS NULL`, ~09:00 local (Intl.DateTimeFormat). Atomic claim via `UPDATE ... RETURNING`; rolls the claim back to NULL on send failure.
- `backend/vercel.json` — hourly cron schedule for `/api/cron/send-host-surveys`.

### Frontend
- `frontend/src/pages/HostSurveyPage.tsx` + route `/host-survey/:token` — survey-taking page (clone of the guest page); `guests_attended` rendered as a numeric input.
- `/underboss` "Host Survey Responses" tab — per-respondent table + server CSV export (`?format=csv`) + a "Send host survey" control with an audience picker (all / by city / by status) showing the sent/skipped/failed summary. Wired through the tab enum + `underbossTableUrlState`.

### Prisma / DB
- Added `HostSurveyQuestionSet` / `HostSurveyQuestion` / `HostSurveyResponse` models + `Party.hostSurveySentAt` to `schema.prisma`, mapped to the live snake_case tables.
- Loose migration `backend/prisma/migrations/panzerotti-58527-host-survey.sql` (full-line comments only).

> **The prod migration is ALREADY APPLIED.** This PR only syncs the code (Prisma models + loose migration file) to the live schema; no migration needs to be run.

### Typecheck
- Backend `tsc --noEmit`: clean in all new/changed files (remaining errors are pre-existing in `auth.test.ts`, `admin-payout.routes.ts`, `payout.routes.ts`).
- Frontend `tsc -p tsconfig.app.json --noEmit`: clean in all new/changed files (frontend baseline is not tsc-clean; `vite build` is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)