### PR TITLE
provolone-58531: unify admin "Add photo" into one button + host-style modal

### DIFF
--- a/backend/src/routes/photo.routes.ts
+++ b/backend/src/routes/photo.routes.ts
@@ -1,13 +1,25 @@
 import { Router, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../config/database.js';
-import { requireAuth, optionalAuth, isSuperAdmin, AuthRequest } from '../middleware/auth.js';
+import { requireAuth, optionalAuth, isSuperAdmin, isPaymentAdmin, isUnderboss, AuthRequest } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { canUserEditParty, canUserAccessTab } from '../helpers/partyAccess.js';
+import { getUnderbossScope, partyMatchesScope } from '../helpers/underbossScope.js';
 import { autoCompleteScorecardItem } from './scorecard.routes.js';
 import { getOperationalLimits } from '../lib/privateConfig.js';
 
 const router = Router();
+
+// provolone-58531: payment admins + region/city-scoped underbosses may manage a
+// party's payout photos (designate roles + auto-approved uploads) even though
+// they aren't hosts/cohosts. Mirrors the /payments edit scope.
+async function canAdminManagePartyPhotos(partyId: string, email?: string): Promise<boolean> {
+  if (await isPaymentAdmin(email)) return true;
+  if (!(await isUnderboss(email))) return false;
+  const party = await prisma.party.findUnique({ where: { id: partyId }, select: { region: true, city: true } });
+  if (!party) return false;
+  return partyMatchesScope(party, await getUnderbossScope(email));
+}
 
 // GET /api/parties/:partyId/photos - List all photos for a party (public if photosPublic is true)
 //
@@ -613,7 +625,11 @@ router.post('/:partyId/photos', optionalAuth, async (req: AuthRequest, res: Resp
     // margherita-43821: host uploads (owner / co-host w/ canEdit / super-admin /
     // GPP editor) are auto-approved + auto-starred so they appear in /photos
     // immediately. Guest uploads still go through pending moderation.
-    const isHostUpload = await canUserEditParty(partyId, req.userId, req.userEmail);
+    // provolone-58531: payment admins + scoped underbosses managing payout
+    // photos are treated as host uploads too (auto-approve + auto-star).
+    const isHostUpload =
+      (await canUserEditParty(partyId, req.userId, req.userEmail)) ||
+      (await canAdminManagePartyPhotos(partyId, req.userEmail));
     const initialStatus = isHostUpload ? 'approved' : 'pending';
     const initialStarred = isHostUpload ? true : false;
     const now = new Date();
@@ -726,16 +742,23 @@ router.patch('/:partyId/photos/:photoId', requireAuth, async (req: AuthRequest, 
     const { partyId, photoId } = req.params;
     const { caption, tags, starred, status, photoYear, payoutRole } = req.body;
 
-    // Verify ownership or super admin
+    // Verify ownership or super admin.
+    // provolone-58531: payment admins + region/city-scoped underbosses can also
+    // manage a party's payout photos (designate roles) even though they aren't
+    // hosts/cohosts. When they qualify this way, skip the host-tab gate.
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
-    if (!canEdit) {
+    const isAdminManager = canEdit ? false : await canAdminManagePartyPhotos(partyId, req.userEmail);
+    if (!canEdit && !isAdminManager) {
       throw new AppError('Unauthorized', 403, 'UNAUTHORIZED');
     }
 
-    // Verify co-host has access to photos tab
-    const canAccessPhotosTab = await canUserAccessTab(partyId, req.userEmail, req.userId, 'photos');
-    if (!canAccessPhotosTab) {
-      throw new AppError('You do not have access to the photos tab', 403, 'TAB_ACCESS_DENIED');
+    // Verify co-host has access to photos tab (host/cohost path only — admins/
+    // underbosses managing payout photos bypass the tab-access requirement).
+    if (canEdit) {
+      const canAccessPhotosTab = await canUserAccessTab(partyId, req.userEmail, req.userId, 'photos');
+      if (!canAccessPhotosTab) {
+        throw new AppError('You do not have access to the photos tab', 403, 'TAB_ACCESS_DENIED');
+      }
     }
 
     // Check if photo exists. provolone-58931: soft-deleted photos can't be

--- a/frontend/src/components/payments-admin/AdminAddAttachment.tsx
+++ b/frontend/src/components/payments-admin/AdminAddAttachment.tsx
@@ -5,13 +5,16 @@ import { addAdminPayoutDocument } from '../../lib/api';
 
 /**
  * sfincione-58500: a small self-contained uploader that lets a full payment
- * admin attach a receipt / pizza-proof / event-proof to an existing payout
- * straight from the /payments review modal.
+ * admin attach a receipt to an existing payout straight from the /payments
+ * review modal.
  *
- * Upload flow: `uploadPayoutPhoto(file, partyId, payoutId, kind)` (the real
+ * Upload flow: `uploadPayoutPhoto(file, partyId, payoutId, 'receipt')` (the real
  * payoutId is fine as the storage path segment) → `addAdminPayoutDocument(...)`
- * → `onAdded()`. The backend OCRs receipts inline and mirrors pizza/event docs
- * into the gallery, so callers just re-fetch the payout detail in `onAdded`.
+ * → `onAdded()`. The backend OCRs receipts inline, so callers just re-fetch the
+ * payout detail in `onAdded`.
+ *
+ * provolone-58531: this control is now RECEIPT-ONLY. Admin photo attachment
+ * moved onto the host role model via AdminAddPhotosModal (EventPhotosCard).
  *
  * Rendered only for full payment admins — the parent hides it for regional
  * underbosses.
@@ -19,32 +22,29 @@ import { addAdminPayoutDocument } from '../../lib/api';
 
 const RECEIPT_ACCEPT =
   'image/jpeg,image/png,image/webp,image/heic,image/heif,application/pdf';
-const PHOTO_ACCEPT = 'image/jpeg,image/png,image/webp,image/heic,image/heif';
 
 interface AdminAddAttachmentProps {
   payoutId: string;
   partyId: string;
-  mode: 'receipt' | 'photo';
+  // provolone-58531: kept for call-site compatibility, but only 'receipt' is
+  // used now (the 'photo' branch was removed).
+  mode?: 'receipt';
   onAdded: () => void;
 }
 
 export const AdminAddAttachment: React.FC<AdminAddAttachmentProps> = ({
   payoutId,
   partyId,
-  mode,
   onAdded,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  // photo mode picks between pizza / event proof; receipt mode is fixed.
-  const [photoKind, setPhotoKind] = useState<'pizza' | 'event'>('pizza');
   const [status, setStatus] = useState<'idle' | 'uploading' | 'reading'>('idle');
   const [error, setError] = useState<string | null>(null);
   // focaccia-58519: keep the last picked file so a transient failure can be
   // retried without re-selecting it.
   const lastFileRef = useRef<File | null>(null);
 
-  const kind: 'receipt' | 'pizza' | 'event' =
-    mode === 'receipt' ? 'receipt' : photoKind;
+  const kind = 'receipt' as const;
   const busy = status !== 'idle';
 
   // focaccia-58519: deterministic local-validation rejections aren't retryable.
@@ -61,7 +61,7 @@ export const AdminAddAttachment: React.FC<AdminAddAttachmentProps> = ({
       const uploaded = await uploadPayoutPhoto(file, partyId, payoutId, kind);
       // Receipts get OCR'd server-side — surface a "reading" state so the
       // admin knows the request is still in flight after the upload finishes.
-      if (kind === 'receipt') setStatus('reading');
+      setStatus('reading');
       await addAdminPayoutDocument(payoutId, {
         kind,
         url: uploaded.url,
@@ -77,43 +77,12 @@ export const AdminAddAttachment: React.FC<AdminAddAttachmentProps> = ({
     }
   };
 
-  const accept = mode === 'receipt' ? RECEIPT_ACCEPT : PHOTO_ACCEPT;
-  const buttonLabel =
-    mode === 'receipt' ? 'Add receipt' : 'Add photo';
+  const accept = RECEIPT_ACCEPT;
+  const buttonLabel = 'Add receipt';
 
   return (
     <div className="flex flex-col items-end gap-1.5">
       <div className="flex items-center gap-2">
-        {/* photo mode: two-way kind picker (Pizza proof | Event proof). */}
-        {mode === 'photo' && (
-          <div className="inline-flex rounded-lg border border-theme-stroke overflow-hidden text-xs">
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => setPhotoKind('pizza')}
-              className={`px-2.5 py-1.5 transition-colors ${
-                photoKind === 'pizza'
-                  ? 'bg-[#ff393a] text-white'
-                  : 'bg-theme-surface text-theme-text-muted hover:text-theme-text'
-              }`}
-            >
-              Pizza proof
-            </button>
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => setPhotoKind('event')}
-              className={`px-2.5 py-1.5 transition-colors ${
-                photoKind === 'event'
-                  ? 'bg-[#ff393a] text-white'
-                  : 'bg-theme-surface text-theme-text-muted hover:text-theme-text'
-              }`}
-            >
-              Event proof
-            </button>
-          </div>
-        )}
-
         <input
           ref={inputRef}
           type="file"

--- a/frontend/src/components/payments-admin/AdminAddPhotosModal.tsx
+++ b/frontend/src/components/payments-admin/AdminAddPhotosModal.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { EventPhotosCard } from '../payouts/EventPhotosCard';
+
+/**
+ * provolone-58531: admin/underboss "Add photo" modal for /payments.
+ *
+ * Replaces the old pizza/event document-kind AdminAddAttachment photo control
+ * with a modal that mirrors the HOST "submit photos" UI — the 3 role slots
+ * (group / box_stack / pizza) + the generic additional-photos uploader — by
+ * reusing the host `EventPhotosCard` component for an ARBITRARY party (the party
+ * being reviewed, which is NOT the PizzaContext party). Uploads route through
+ * the existing photo endpoints which now auto-approve for admins/underbosses.
+ *
+ * Follows the repo modal pattern: fixed inset backdrop + z-50 +
+ * click-outside-to-close + a close (X) button. Body scrolls if tall.
+ */
+
+interface AdminAddPhotosModalProps {
+  partyId: string;
+  /** Reviewed party's start date (ISO) or null (null ⇒ no event-start cutoff). */
+  eventStart: string | null;
+  partyName?: string;
+  onClose: () => void;
+  /** Fires whenever the gallery reloads (a photo was added / role designated). */
+  onAdded: () => void;
+}
+
+export const AdminAddPhotosModal: React.FC<AdminAddPhotosModalProps> = ({
+  partyId,
+  eventStart,
+  partyName,
+  onClose,
+  onAdded,
+}) => {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="card w-full max-w-2xl max-h-[85vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-theme-stroke">
+          <div>
+            <h3 className="text-base font-semibold text-theme-text">
+              {partyName || 'Add event photos'}
+            </h3>
+            <p className="text-xs text-theme-text-muted mt-0.5">Add event photos</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-theme-text-secondary hover:text-theme-text transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Body (scrolls if tall) */}
+        <div className="flex-1 overflow-y-auto p-5">
+          <EventPhotosCard
+            partyId={partyId}
+            eventStartDate={eventStart}
+            onPhotosChange={onAdded}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end p-4 border-t border-theme-stroke">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-sm font-medium bg-[#ff393a] text-white hover:bg-[#ff393a]/90 transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -24,6 +24,7 @@ import {
 import { ReceiptEditor, computeLineSubtotal } from './ReceiptEditor';
 import { TaxFormReviewPanel } from './TaxFormReviewPanel';
 import { AdminAddAttachment } from './AdminAddAttachment';
+import { AdminAddPhotosModal } from './AdminAddPhotosModal';
 
 /**
  * parmigiana-58291: strip the "Global Pizza Party " prefix from event names so
@@ -307,6 +308,16 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // argentina-92103: underbosses lose Execute/Mark-paid affordances. The
   // green Flag-ready button replaces them in the footer slot.
   const isAdminViewer = viewerRole === 'admin';
+  // provolone-58531: the "+ Add photo" button (host-style role modal) is open to
+  // admins AND underbosses — unlike receipt attachment, which stays admin-only.
+  const canManagePhotos = viewerRole === 'admin' || viewerRole === 'underboss';
+  // provolone-58531: open/close state for the admin/underboss Add-photos modal.
+  const [showAddPhotos, setShowAddPhotos] = useState(false);
+  // provolone-58531: stable refetch callback (same one the old photo control
+  // used) so EventPhotosCard's onPhotosChange doesn't churn its load effect.
+  const handlePhotosAdded = useCallback(() => {
+    onDocumentsChanged?.();
+  }, [onDocumentsChanged]);
   // marinara-71630 P6: per-submission soft cap fetched from app_config (not
   // hardcoded). High neutral sentinel while unknown → the amber warning below
   // is inert until the real cap loads.
@@ -2033,17 +2044,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 <h3 className="text-sm font-semibold text-theme-text">
                   Pizza photos ({pizzaPhotos.length})
                 </h3>
-                {/* sfincione-58500: full payment admins can attach a pizza- or
-                    event-proof photo (kind picker on the control). The backend
-                    mirrors it into the gallery. Hidden for underbosses. */}
-                {isAdminViewer && (
-                  <AdminAddAttachment
-                    payoutId={payout.id}
-                    partyId={payout.partyId}
-                    mode="photo"
-                    onAdded={() => onDocumentsChanged?.()}
-                  />
-                )}
+                {/* provolone-58531: the old pizza/event-kind "+ Add photo"
+                    control was removed. Admins/underbosses now add photos via
+                    the single "+ Add photo" button next to Add receipt below
+                    (opens the host-style role modal). */}
               </div>
               {pizzaPhotos.length === 0 ? (
                 <p className="text-sm text-theme-text-faint">No pizza photos yet.</p>
@@ -2114,16 +2118,29 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                 <h3 className="text-sm font-semibold text-theme-text">
                   Receipts ({receipts.length})
                 </h3>
-                {/* sfincione-58500: full payment admins can attach a receipt
-                    here — OCR'd inline server-side. Hidden for underbosses. */}
-                {isAdminViewer && (
-                  <AdminAddAttachment
-                    payoutId={payout.id}
-                    partyId={payout.partyId}
-                    mode="receipt"
-                    onAdded={() => onDocumentsChanged?.()}
-                  />
-                )}
+                <div className="flex items-center gap-2">
+                  {/* provolone-58531: admin/underboss "+ Add photo" → host-style
+                      role modal (3 role slots + additional photos). */}
+                  {canManagePhotos && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAddPhotos(true)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-theme-surface border border-theme-stroke text-theme-text hover:border-[#ff393a]/40 transition-colors"
+                    >
+                      <Plus size={13} /> Add photo
+                    </button>
+                  )}
+                  {/* sfincione-58500: full payment admins can attach a receipt
+                      here — OCR'd inline server-side. Hidden for underbosses. */}
+                  {isAdminViewer && (
+                    <AdminAddAttachment
+                      payoutId={payout.id}
+                      partyId={payout.partyId}
+                      mode="receipt"
+                      onAdded={() => onDocumentsChanged?.()}
+                    />
+                  )}
+                </div>
               </div>
               {receipts.length === 0 ? (
                 <p className="text-sm text-theme-text-faint">No receipts attached.</p>
@@ -4301,6 +4318,19 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
           lightboxReceipt ? (authChecks[lightboxReceipt.url]?.verdict ?? null) : null
         }
       />
+
+      {/* provolone-58531: admin/underboss Add-photos modal (host-style role
+          slots + additional photos). AdminPayout.party carries no date field,
+          so the event-start cutoff is disabled (eventStart={null}). */}
+      {showAddPhotos && (
+        <AdminAddPhotosModal
+          partyId={payout.partyId}
+          eventStart={null}
+          partyName={payout.party.name}
+          onClose={() => setShowAddPhotos(false)}
+          onAdded={handlePhotosAdded}
+        />
+      )}
     </div>,
     document.body,
   );

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -51,6 +51,7 @@ import {
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
 import { AdminAddAttachment } from './AdminAddAttachment';
+import { AdminAddPhotosModal } from './AdminAddPhotosModal';
 import { isSwcHubParty } from '../../utils/swcHub';
 import { isVideoFile } from '../../lib/mediaUtils';
 import {
@@ -1182,6 +1183,7 @@ function CityExpansion({
   onRowClick,
   busyRowId,
   canEditReceipts,
+  canManagePhotos,
   canEditAdminNotes,
   onApprove,
   onExecute,
@@ -1200,6 +1202,11 @@ function CityExpansion({
    * the plain photo-only lightbox.
    */
   canEditReceipts: boolean;
+  /**
+   * provolone-58531: gates the "+ Add photo" button (admin OR underboss).
+   * Unlike `canEditReceipts` (admin-only), underbosses can add event photos.
+   */
+  canManagePhotos: boolean;
   /**
    * mortadella-92106: gates the city-level admin notes textarea (read AND
    * write). True for admin / super_admin / payment_admin. Underbosses don't
@@ -1237,6 +1244,13 @@ function CityExpansion({
     index: number;
   } | null>(null);
   const [showPendingClaims, setShowPendingClaims] = useState(false);
+  // provolone-58531: admin/underboss "Add photo" modal (host-style role slots).
+  const [showAddPhotos, setShowAddPhotos] = useState(false);
+  // provolone-58531: stable refetch callback for the photos modal so passing it
+  // into EventPhotosCard's onPhotosChange doesn't churn its load effect.
+  const handlePhotosAdded = useCallback(() => {
+    onDocumentsChanged?.(row.party.id);
+  }, [onDocumentsChanged, row.party.id]);
 
   // pesto-92105: per-receipt edit state. Mirrors the agnolotti-58291 /
   // taralli-92104 / culatello-92104 state on PayoutReviewModal but local to
@@ -2461,20 +2475,34 @@ function CityExpansion({
           "Add receipt" control) renders whenever the viewer can edit receipts
           and there's a target payout — even on an empty city, so the FIRST
           receipt can be added. Only the thumbnail grid stays gated on count. */}
-      {(receiptEntries.length > 0 || (canEditReceipts && primaryPayout)) && (
+      {(receiptEntries.length > 0 || (canEditReceipts && primaryPayout) || canManagePhotos) && (
         <div>
           <div className="flex items-center justify-between gap-2 mb-2">
             <div className="text-xs uppercase tracking-wide text-theme-text-muted">
               Receipts ({receiptEntries.length})
             </div>
-            {canEditReceipts && primaryPayout && (
-              <AdminAddAttachment
-                payoutId={primaryPayout.id}
-                partyId={row.party.id}
-                mode="receipt"
-                onAdded={() => onDocumentsChanged?.(row.party.id)}
-              />
-            )}
+            <div className="flex items-center gap-2">
+              {/* provolone-58531: admin/underboss "Add photo" → host-style modal
+                  (3 role slots + additional photos). Available even with no
+                  payout, since it operates on the party gallery. */}
+              {canManagePhotos && (
+                <button
+                  type="button"
+                  onClick={() => setShowAddPhotos(true)}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-theme-surface border border-theme-stroke text-theme-text hover:border-[#ff393a]/40 transition-colors"
+                >
+                  <Plus size={13} /> Add photo
+                </button>
+              )}
+              {canEditReceipts && primaryPayout && (
+                <AdminAddAttachment
+                  payoutId={primaryPayout.id}
+                  partyId={row.party.id}
+                  mode="receipt"
+                  onAdded={() => onDocumentsChanged?.(row.party.id)}
+                />
+              )}
+            </div>
           </div>
           {receiptEntries.length === 0 ? (
             <div className="text-sm text-theme-text-faint">
@@ -2693,31 +2721,19 @@ function CityExpansion({
           read; photos give visual context when drilling in. Empty buckets
           hide entirely via PhotoPreviewSection. Mirrors the focaccia-92104
           split in PayoutReviewModal. */}
+      {/* provolone-58531: the old per-section "+ Add photo" (pizza/event kind)
+          controls were removed. Admins/underbosses now add photos via the
+          single "+ Add photo" button next to Add receipt, which opens the
+          host-style role modal (AdminAddPhotosModal). */}
       <PhotoPreviewSection
         label="Event photos"
         photos={eventPhotos}
         onThumbClick={(idx) => setLightbox({ bucket: 'event', index: idx })}
-        headerAction={canEditReceipts && primaryPayout ? (
-          <AdminAddAttachment
-            payoutId={primaryPayout.id}
-            partyId={row.party.id}
-            mode="photo"
-            onAdded={() => onDocumentsChanged?.(row.party.id)}
-          />
-        ) : undefined}
       />
       <PhotoPreviewSection
         label="Pizza photos"
         photos={pizzaPhotos}
         onThumbClick={(idx) => setLightbox({ bucket: 'pizza', index: idx })}
-        headerAction={canEditReceipts && primaryPayout ? (
-          <AdminAddAttachment
-            payoutId={primaryPayout.id}
-            partyId={row.party.id}
-            mode="photo"
-            onAdded={() => onDocumentsChanged?.(row.party.id)}
-          />
-        ) : undefined}
       />
 
       {receiptEntries.length === 0
@@ -2769,6 +2785,19 @@ function CityExpansion({
           && lightboxReceipt?.isDuplicate !== true
         }
       />
+
+      {/* provolone-58531: admin/underboss "Add photo" modal (host-style role
+          slots + additional photos). row.party has no date field, so the
+          event-start cutoff is disabled (eventStart={null}). */}
+      {showAddPhotos && (
+        <AdminAddPhotosModal
+          partyId={row.party.id}
+          eventStart={null}
+          partyName={row.party.name}
+          onClose={() => setShowAddPhotos(false)}
+          onAdded={handlePhotosAdded}
+        />
+      )}
     </div>
   );
 }
@@ -3921,6 +3950,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                             onRowClick={onRowClick}
                             busyRowId={busyRowId}
                             canEditReceipts={canEditReceipts}
+                            canManagePhotos={viewerRole === 'admin' || viewerRole === 'underboss'}
                             canEditAdminNotes={canEditAdminNotes}
                             onDocumentsChanged={onDocumentsChanged}
                             onApprove={viewerRole === 'admin' ? onApprove : undefined}

--- a/frontend/src/components/payouts/EventPhotosCard.tsx
+++ b/frontend/src/components/payouts/EventPhotosCard.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ImagePlus, Camera } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
-import { usePizza } from '../../contexts/PizzaContext';
+import { PizzaContext } from '../../contexts/PizzaContext';
 import { Photo } from '../../types';
 import { designatePhotoRole, getPartyPhotos } from '../../lib/api';
 import { RolePhotoPicker, PayoutPhotoRole } from './RolePhotoPicker';
@@ -25,6 +25,20 @@ interface EventPhotosCardProps {
    * now requires >=5 additional event photos beyond the 3 role photos.
    */
   onPhotosChange?: () => void;
+  /**
+   * provolone-58531: when this card is rendered in an admin context (the party
+   * being reviewed is NOT the PizzaContext party), pass the reviewed party's
+   * start date so the role-picker cutoff + additional-photo eligibility use it
+   * instead of `party?.date`. Omitted on the host call site → falls back to the
+   * PizzaContext party's date.
+   */
+  eventStartDate?: string | null;
+  /**
+   * provolone-58531: admin-context uploader identity. When provided, photos are
+   * attributed to this name/email instead of the logged-in `useAuth()` user.
+   */
+  uploaderName?: string;
+  uploaderEmail?: string;
 }
 
 /**
@@ -42,10 +56,27 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
   partyId,
   onRolesChange,
   onPhotosChange,
+  eventStartDate,
+  uploaderName,
+  uploaderEmail,
 }) => {
   const { t } = useTranslation('host');
   const { user } = useAuth();
-  const { party } = usePizza();
+  // provolone-58531: read PizzaContext OPTIONALLY (not via usePizza(), which
+  // throws outside a PizzaProvider). The /payments admin pages mount this card
+  // inside AdminAddPhotosModal WITHOUT a PizzaProvider, so the hard hook would
+  // crash there. In admin context the reviewed party's start date arrives via
+  // `eventStartDate` instead.
+  const pizza = useContext(PizzaContext);
+  const party = pizza?.party;
+
+  // provolone-58531: prefer the explicit admin-context start date; fall back to
+  // the PizzaContext party's date for the host call site.
+  const effectiveEventStart = eventStartDate ?? party?.date ?? null;
+  // provolone-58531: uploader identity — explicit admin props win over the
+  // logged-in user.
+  const effectiveUploaderName = uploaderName ?? user?.name ?? undefined;
+  const effectiveUploaderEmail = uploaderEmail ?? user?.email ?? undefined;
 
   // porchetta-58296: the three host-designated event role photos. Each slot
   // holds the designated Photo (or undefined). Seeded on mount from the
@@ -103,7 +134,7 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
   // gate (getPayoutSubmissionReadiness) and the RolePhotoPicker cutoff. The
   // preview grid above still shows ALL additional photos; only this count drives
   // the progress line so it never reads "5 of 5" while the server still blocks.
-  const cutoff = party?.date ? new Date(party.date).getTime() : null;
+  const cutoff = effectiveEventStart ? new Date(effectiveEventStart).getTime() : null;
   const eligibleAdditionalCount = additionalPhotos.filter(
     p => cutoff == null || new Date(p.createdAt).getTime() >= cutoff
   ).length;
@@ -229,8 +260,8 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
           <PhotoUpload
             partyId={partyId}
             isHost
-            uploaderName={user?.name ?? undefined}
-            uploaderEmail={user?.email ?? undefined}
+            uploaderName={effectiveUploaderName}
+            uploaderEmail={effectiveUploaderEmail}
             onUploadComplete={() => loadPhotos()}
             onClose={() => setShowAdditionalUpload(false)}
           />
@@ -252,7 +283,7 @@ export const EventPhotosCard: React.FC<EventPhotosCardProps> = ({
           partyId={partyId}
           role={pickerRole}
           roleLabel={roleLabels[pickerRole]}
-          eventStart={party?.date ?? null}
+          eventStart={effectiveEventStart}
           selectedPhotoId={roles[pickerRole]?.id ?? null}
           onSelect={designating ? () => {} : handleRoleSelect}
           onClose={() => setPickerRole(null)}


### PR DESCRIPTION
## What
Replaces the admin/underboss inline **Pizza proof / Event proof** kind toggle + the two per-section **+ Add photo** controls with a **single "+ Add photo" button** (next to **+ Add receipt**) that opens a modal mirroring the host submit-photos UI: 3 role slots (group / box_stack / pizza) + a generic additional-photos uploader. Moves the admin side onto the host **role model** (`photos.payout_role` + gallery), retiring the `pizza`/`event` document-kind scheme in the UI.

Per Snax: available to payment **admins AND regional underbosses** (scoped); **receipts stay admin-only**.

### Before
Two rows of `Pizza proof | Event proof | + Add photo` (one per photo section). The toggle tagged the upload as a `pizza`/`event` proof doc.

## Changes
**Backend — `photo.routes.ts`** (no migration)
- New `canAdminManagePartyPhotos(partyId, email)` = `isPaymentAdmin` OR region/city-scoped `isUnderboss` (`partyMatchesScope`/`getUnderbossScope`).
- `PATCH /:partyId/photos/:photoId` (role designate) and `POST /:partyId/photos` (gallery upload auto-approve) now also pass for it. Admins/underbosses **bypass the host photos-tab gate** (they have no tabs). Host/cohost path, event-start cutoff, one-role-per-party clear, and tag mirroring all unchanged. `/admin/payouts/:id/documents` untouched (receipts).

**Frontend**
- `EventPhotosCard`: additive optional props `eventStartDate` / `uploaderName` / `uploaderEmail`; now reads `PizzaContext` via `useContext` (optional) instead of `usePizza()` so it doesn't crash when mounted outside a `PizzaProvider` (the /payments admin pages). **Host call site unchanged.**
- New `AdminAddPhotosModal` (repo-standard backdrop + `z-50` + click-outside-close) wraps `EventPhotosCard`.
- `AdminAddAttachment` is now **receipt-only** (toggle + `photoKind` removed).
- `PayoutsByPartyTable` + `PayoutReviewModal`: removed the `mode="photo"` controls; added one **"+ Add photo"** button (gated `viewerRole === 'admin' || 'underboss'`) next to Add receipt, opening the modal with `onAdded` wired to the existing refetch.

## ⚠️ Known limitation
The admin by-party row and `AdminPayoutDetail.party` projections carry **no `party.date`**, so the modal passes `eventStart={null}` → the *client-side* role-picker cutoff is disabled. The **backend PATCH still enforces** the cutoff from the DB when designating a pre-event photo, so the server gate is intact; only the in-modal preview is looser. Surfacing `party.date` in those projections would re-enable the client cutoff (follow-up if wanted).

## Deploy / preview
Backend permission widening auto-deploys from master on merge. Previews share the prod backend, so the new admin/underboss upload+designate permissions won't take effect on the preview branch until merge + backend redeploy — the modal renders on preview but server calls 403 for non-host admins until then.

## Test checklist
- [ ] Vercel preview builds green (no local node_modules → gated on Vercel).
- [ ] By-party panel: ONE "+ Add photo" next to "+ Add receipt"; the two old toggle rows are gone.
- [ ] Admin uploads group/box_stack/pizza + a generic photo via the modal → auto-approved, role slots fill after refetch.
- [ ] Underboss in-scope: sees + can use Add photo; out-of-scope underboss → backend 403.
- [ ] Underboss does NOT see Add receipt (unchanged).
- [ ] PayoutReviewModal: same single Add photo next to Add receipt; works.
- [ ] No `kind:'pizza'|'event'` calls fire from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)