### PR TITLE
feat(farinata-58532): drop purpose dropdown + add receipts filter on /payments

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -3,7 +3,7 @@ import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-rea
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { TriStateFilterDropdown } from '../TriStateFilterDropdown';
-import type { AdminPayoutFilters, PayoutMethod, PayoutPurpose, PayoutStatus } from '../../types';
+import type { AdminPayoutFilters, PayoutMethod, PayoutStatus } from '../../types';
 import { PAYOUT_METHOD_LABELS } from '../payments-shared';
 import {
   PAYMENTS_REGION_DISPLAY_ORDER,
@@ -74,6 +74,13 @@ interface PayoutsFilterBarProps {
    * true (existing behavior).
    */
   showStatusTabs?: boolean;
+  /**
+   * farinata-58532: when true, render the "Has submitted receipts" checkbox.
+   * By-city view only (keys off `aggregates.totalReceiptCount` on by-party
+   * rows). OFF by default — turning it on narrows the list to cities with at
+   * least one submitted receipt. Defaults to false.
+   */
+  showReceiptsToggle?: boolean;
 }
 
 // ciabatta-92110: `'closed'` is a party-level pseudo-status (filters on
@@ -109,13 +116,6 @@ const METHOD_OPTIONS: Array<{ value: PayoutMethod | 'all'; label: string }> = [
   { value: 'usdc_base', label: PAYOUT_METHOD_LABELS.usdc_base },
   { value: 'mercury_card', label: PAYOUT_METHOD_LABELS.mercury_card },
   { value: 'wire', label: PAYOUT_METHOD_LABELS.wire },
-];
-
-// salumi-89172: Purpose filter — event reimbursements vs shipping receipts.
-const PURPOSE_OPTIONS: Array<{ value: PayoutPurpose | 'all'; label: string }> = [
-  { value: 'all', label: 'All purposes' },
-  { value: 'event', label: 'Event' },
-  { value: 'shipping', label: 'Shipping' },
 ];
 
 // arancino-92103: sort order for the payouts list. `created_desc` is the
@@ -170,7 +170,6 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   // active filter when any include/exclude is selected.
   if ((filters.tagIncludes?.length ?? 0) + (filters.tagExcludes?.length ?? 0) > 0) n += 1;
   if ((filters.countryIncludes?.length ?? 0) + (filters.countryExcludes?.length ?? 0) > 0) n += 1;
-  if (filters.purpose && filters.purpose !== 'all') n += 1;
   if (filters.dateFrom) n += 1;
   if (filters.dateTo) n += 1;
   // arancino-92103: count sort as an active filter when it differs from
@@ -184,6 +183,8 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
   if (filters.hideUsCities) n += 1;
   // tigella-58512: count Show TBD (no submission) when the admin turns it on.
   if (filters.showTbdUnsubmitted) n += 1;
+  // farinata-58532: count Has submitted receipts when the admin turns it on.
+  if (filters.hasReceipts) n += 1;
   return n;
 }
 
@@ -210,6 +211,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   showHideScamsToggle,
   showHideUsToggle,
   showTbdToggle,
+  showReceiptsToggle,
   showRegionsFilter,
   showStatusTabs = true,
 }) => {
@@ -455,21 +457,6 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
             </div>
           )}
 
-          {/* salumi-89172: Purpose dropdown — Event reimbursements vs
-              Shipping coordinator receipts. Default 'all' shows both. */}
-          <div>
-            <select
-              value={filters.purpose ?? 'all'}
-              onChange={(e) => update({ purpose: e.target.value as PayoutPurpose | 'all' })}
-              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Filter by purpose"
-            >
-              {PURPOSE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </div>
-
           {/* arancino-92103: Sort dropdown — controls the row order of the
               payouts table. Default is `created_desc` (newest submitted
               first), matching the prior implicit backend ordering. */}
@@ -557,6 +544,17 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
                 checked={!!filters.showTbdUnsubmitted}
                 onChange={() => update({ showTbdUnsubmitted: !filters.showTbdUnsubmitted })}
                 label="Show unsubmitted cities"
+                labelClassName="text-xs text-theme-text-secondary"
+                size={14}
+              />
+            )}
+            {/* farinata-58532: show only cities with ≥1 submitted receipt
+                (aggregates.totalReceiptCount > 0). By-city view only; OFF by default. */}
+            {showReceiptsToggle && (
+              <Checkbox
+                checked={!!filters.hasReceipts}
+                onChange={() => update({ hasReceipts: !filters.hasReceipts })}
+                label="Has submitted receipts"
                 labelClassName="text-xs text-theme-text-secondary"
                 size={14}
               />

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -36,6 +36,8 @@ const DEFAULTS = {
   hideUsCities: true,
   // tigella-58512: default-FALSE — only emitted (as `tbd=1`) when turned ON.
   showTbdUnsubmitted: false,
+  // farinata-58532: default-FALSE — only emitted (as `receipts=1`) when turned ON.
+  hasReceipts: false,
 };
 const DEFAULT_VIEW: ViewMode = 'by-city';
 
@@ -99,6 +101,9 @@ export function filtersToSearchParams(
   // tigella-58512: default-FALSE toggle — only emit when turned ON.
   if (filters.showTbdUnsubmitted === true) params.set('tbd', '1');
 
+  // farinata-58532: default-FALSE toggle — only emit when turned ON.
+  if (filters.hasReceipts === true) params.set('receipts', '1');
+
   if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
 
   return params;
@@ -137,6 +142,7 @@ export function searchParamsToFilters(
     hideScams: DEFAULTS.hideScams,
     hideUsCities: DEFAULTS.hideUsCities,
     showTbdUnsubmitted: DEFAULTS.showTbdUnsubmitted,
+    hasReceipts: DEFAULTS.hasReceipts,
     sort: DEFAULTS.sort,
     ...(regions ? { regions } : {}),
   };
@@ -209,6 +215,10 @@ export function searchParamsToFilters(
   // tigella-58512: default-FALSE toggle — present `tbd=1` => true; absent =>
   // leave the default (false). Any non-`1` value is treated as false.
   if (params.has('tbd')) filters.showTbdUnsubmitted = params.get('tbd') === '1';
+
+  // farinata-58532: default-FALSE toggle — present `receipts=1` => true; absent
+  // => leave the default (false). Any non-`1` value is treated as false.
+  if (params.has('receipts')) filters.hasReceipts = params.get('receipts') === '1';
 
   const viewRaw = params.get('view');
   const viewMode: ViewMode | null =

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -687,6 +687,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
     if (ctryInc.length) rows = rows.filter((r) => !!r.party.country && ctryInc.includes(r.party.country));
     if (ctryExc.length) rows = rows.filter((r) => !r.party.country || !ctryExc.includes(r.party.country));
 
+    // farinata-58532: keep only cities with at least one submitted receipt.
+    if (filters.hasReceipts) rows = rows.filter((r) => r.aggregates.totalReceiptCount > 0);
+
     // "Oldest/Newest first" in the by-city view should order cities by their
     // host UPLOAD time, not lastActivityAt. The /by-party endpoint doesn't
     // implement created_asc/created_desc — they fall through to its activity
@@ -758,7 +761,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
       return [...rows].sort((a, b) => (asc ? pick(a) - pick(b) : pick(b) - pick(a)));
     }
     return rows;
-  }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal, filters.tagIncludes, filters.tagExcludes, filters.countryIncludes, filters.countryExcludes]);
+  }, [byPartyRows, filters.status, filters.sort, filters.hideUsCities, isRegionalPortal, filters.tagIncludes, filters.tagExcludes, filters.countryIncludes, filters.countryExcludes, filters.hasReceipts]);
 
   // salsiccia-49102: count of selected payouts eligible for bulk USDC send.
   // Mirrors the backend filter (usdc_base + approved/failed + valid 0x
@@ -1266,6 +1269,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           // synthetic rows come from the by-party endpoint, which is the only
           // place a zero-payout party can surface.
           showTbdToggle={viewMode === 'by-city'}
+          // farinata-58532: Has submitted receipts — by-city view only.
+          showReceiptsToggle={viewMode === 'by-city'}
           // provatura-92107: Hide US cities — by-city view + admin dashboard
           // only (regional portals are already region-scoped).
           showHideUsToggle={viewMode === 'by-city' && !isRegionalPortal}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2431,6 +2431,12 @@ export interface AdminPayoutFilters {
    * prior behavior).
    */
   showTbdUnsubmitted?: boolean;
+  /**
+   * farinata-58532: by-city toggle — when true, show only parties with at least
+   * one submitted receipt (aggregates.totalReceiptCount > 0). Client-side filter
+   * over byPartyRows; OFF/undefined = show all. By-city view only.
+   */
+  hasReceipts?: boolean;
 }
 
 export interface AdminPayoutTotals {


### PR DESCRIPTION
## What
Two changes to the `/payments` admin filter bar (frontend-only — no backend, no migration):

1. **Removed the Purpose dropdown** ("All purposes / Event / Shipping", `salumi-89172`). Only the filter-bar UI control is removed — the `purpose` field stays in the filter type, URL serializer, `api.ts` query, and the Shipping dashboard (which still depend on it).
2. **Added a by-city "Has submitted receipts" toggle** — filters to cities with at least one submitted receipt (`aggregates.totalReceiptCount > 0`). Client-side over `byPartyRows`, OFF by default, by-city view only, persisted in the URL as `receipts=1` (mirrors the `tbd` toggle).

## Files
- `frontend/src/types.ts` — `hasReceipts?: boolean` on `AdminPayoutFilters`
- `frontend/src/components/payments-admin/PayoutsFilterBar.tsx` — drop Purpose dropdown + add receipts toggle
- `frontend/src/pages/PaymentsAdminPage.tsx` — client-side filter + pass `showReceiptsToggle`
- `frontend/src/components/payments-admin/paymentsUrlState.ts` — persist `receipts=1`

## Verify
Preview: https://rsvpizza-git-farinata-58532-receipts-filter-pizza-dao.vercel.app/payments
- Purpose dropdown gone from the filter bar
- "Has submitted receipts" checkbox on the by-city view (not on by-payment/payments); toggling narrows the list + adds `receipts=1` to the URL

Plan: `plans/farinata-58532-payments-receipts-filter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)