### PR TITLE
fix(bombolone-58533): no-op amount save no longer errors

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -3356,6 +3356,13 @@ router.patch(
         payoutBankDetails,
       } = req.body || {};
 
+      const anyFieldSupplied =
+        finalAmountUsd !== undefined ||
+        adminNotes !== undefined ||
+        payoutMethod !== undefined ||
+        payoutWalletAddress !== undefined ||
+        payoutBankDetails !== undefined;
+
       let amountChanged = false;
       let oldAmount: number | null = null;
       let newAmount: number | null = null;
@@ -3452,6 +3459,24 @@ router.patch(
       }
 
       if (Object.keys(data).length === 0) {
+        if (anyFieldSupplied) {
+          // No-op edit (e.g. re-saved the same amount). Nothing to persist; return
+          // the current payout unchanged rather than 400ing the caller.
+          const current = await prisma.payout.findUnique({
+            where: { id: existing.id },
+            include: {
+              party: { select: PAYOUT_PARTY_SELECT },
+              host: { select: { id: true, name: true, email: true } },
+              documents: {
+                orderBy: { sortOrder: 'asc' },
+                include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+              },
+              audits: { orderBy: { createdAt: 'desc' } },
+            },
+          });
+          res.json({ payout: serializePayout(current) });
+          return;
+        }
         throw new AppError('No editable fields supplied', 400, 'VALIDATION_ERROR');
       }
 

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -2358,6 +2358,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
                           type="button"
                           onClick={async () => {
                             if (!draftIsValid) return;
+                            // No-op: re-saving the unchanged amount would 400 "No editable fields supplied".
+                            if (draftNum === Number(payout.finalAmountUsd)) {
+                              setEditingAmount(false);
+                              setSaveAmountError(null);
+                              return;
+                            }
                             setSaveAmountError(null);
                             try {
                               // lasagna-92103: no longer forward


### PR DESCRIPTION
Saving the Amount in PayoutReviewModal without changing it returned a confusing 400 'No editable fields supplied'. Frontend now short-circuits an unchanged amount to a silent close; backend PATCH returns the current payout 200 (no audit row) when a recognized field was supplied but unchanged. No migration. Plan: plans/bombolone-58533-amount-noop-save.md

Repro: payout finalAmountUsd already 250; Edit Amount -> Save without change -> error.

Backend change needs a master deploy after merge (backend auto-deploys on master push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)