### PR TITLE
style(cavatelli P0): eslint --fix safe auto-fixables (prefer-const)

### DIFF
--- a/frontend/src/components/ShareRSVP.tsx
+++ b/frontend/src/components/ShareRSVP.tsx
@@ -30,7 +30,7 @@ export function normalizeHandle(raw: string): string {
 
 /** Build share text that fits within maxLen chars */
 function buildShareText(base: string, handles: string[], maxLen: number): string {
-  let mentions = handles.map(h => `@${h}`);
+  const mentions = handles.map(h => `@${h}`);
   let text = `${base}\n\n${mentions.join(' ')}`;
   if (text.length <= maxLen) return text;
   // Drop handles from end but always keep @Pizza_DAO (first)

--- a/frontend/src/components/sponsors/SponsorCRM.tsx
+++ b/frontend/src/components/sponsors/SponsorCRM.tsx
@@ -331,7 +331,7 @@ export function SponsorCRM({ partyId, onAddAsCoHost }: SponsorCRMProps) {
         p => p.source === 'underboss' && !p.sponsorId && p.sponsorUserId
       );
 
-      let sponsorIdMap: Record<string, string> = {};
+      const sponsorIdMap: Record<string, string> = {};
 
       if (underbossOnly.length > 0) {
         const result = await ensureUnderbossSponsors(


### PR DESCRIPTION
Phase 0 of the frontend typing-debt cleanup — see `plans/cavatelli-typing-debt.md`.

## What
`npm run lint -- --fix --report-unused-disable-directives-severity off` → 2 safe `let`→`const` fixes (`ShareRSVP.tsx`, `SponsorCRM.tsx`). Neither variable is reassigned.

## Why so small
On current master the only safe auto-fixables are these 2. A plain `--fix` wanted to do more — but the rest was **stripping `eslint-disable` directives** (ESLint 9 flat config defaults `reportUnusedDisableDirectives` to `warn`), including deliberate `react-hooks/exhaustive-deps` suppressions in payments files. Removing those is a judgment call (the `ziti-58300` refetch-loop class), so it's **excluded** here and deferred to a deliberate pass.

## Count
684 → 682 problems (544 → 542 errors). The real volume starts at Phase 1 (`no-unused-vars`, 150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)