### PR TITLE
suppli-58533: host DM submissions to Molto Benny

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -51,6 +51,7 @@ import { setupSwagger } from './swagger.js';
 import aiPhoneRoutes from './routes/ai-phone.routes.js';
 import telegramRoutes from './routes/telegram.routes.js';
 import telegramLinkCallbackRoutes from './routes/telegram-link-callback.routes.js'; // provola-58505: moltobene host-link callback
+import telegramInboundRoutes from './routes/telegram-inbound.routes.js'; // suppli-58533: moltobene host DM submissions
 import hostTelegramRoutes from './routes/host-telegram.routes.js';
 import underbossRoutes from './routes/underboss.routes.js';
 import shippingRoutes from './routes/shipping.routes.js';
@@ -172,6 +173,7 @@ app.use('/api/graphics-admin', graphicsAdminRoutes); // Graphics admin managemen
 app.use('/api/suggestions', suggestionsRoutes); // scarpetta-58472: admin/underboss-only site-wide suggestions (view-only)
 app.use('/api/saved-views', savedViewsRoutes); // montanara-58497: per-account saved filter views (/payments + /underboss)
 app.use('/api/telegram', telegramLinkCallbackRoutes); // provola-58505: moltobene host-link callback (x-api-key gate)
+app.use('/api/telegram', telegramInboundRoutes); // suppli-58533: moltobene host DM submissions (x-api-key gate)
 app.use('/api/underboss/telegram', telegramRoutes); // Telegram broadcast (before underboss catch-all)
 app.use('/api/underboss', underbossRoutes); // Underboss dashboard (token auth + admin routes)
 app.use('/api/sponsor-users', sponsorUserAdminRouter); // Sponsor user admin management

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -15,11 +15,11 @@
  * wires in the actual Mercury / wire / USDC-via-Privy execution paths.
  */
 import { Router, Request, Response, NextFunction } from 'express';
+import { customAlphabet } from 'nanoid';
 import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../config/database.js';
 import { unaccentMatchIds } from '../lib/accentSearch.js';
-import { withBennySignature } from '../lib/bennySignature.js';
 import {
   requireAuth,
   AuthRequest,
@@ -52,6 +52,9 @@ import {
 import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
 import { withPaidTag, withoutPaidTag } from '../lib/eventTags.js';
 import { sendToCityGroup } from '../services/cityTelegramGroup.js';
+// suppli-58533: sendTelegramMessage moved to a shared service so the host-inbound
+// handler can reuse the exact same send path (withBennySignature + preview off).
+import { sendTelegramMessage } from '../services/telegramSend.js';
 import { cityKeyFromPartyName } from '../helpers/underbossScope.js';
 import { sanitizePgString, sanitizeForPg } from '../lib/sanitizePg.js';
 
@@ -6844,45 +6847,9 @@ router.post(
 // the menu item.
 // ============================================
 
-async function sendTelegramMessage(
-  chatId: string,
-  text: string,
-): Promise<{ ok: true } | { ok: false; reason: string }> {
-  const token = process.env.TELEGRAM_BOT_TOKEN;
-  if (!token) {
-    return { ok: false, reason: 'TELEGRAM_BOT_TOKEN not configured' };
-  }
-  try {
-    const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: chatId,
-        text: withBennySignature(text),
-        disable_web_page_preview: true,
-      }),
-    });
-    if (!resp.ok) {
-      let detail = '';
-      try {
-        const body = await resp.text();
-        detail = body.slice(0, 200);
-      } catch {
-        // ignore — surface just the status
-      }
-      return {
-        ok: false,
-        reason: `Telegram API returned ${resp.status}${detail ? `: ${detail}` : ''}`,
-      };
-    }
-    return { ok: true };
-  } catch (err: any) {
-    return {
-      ok: false,
-      reason: `Telegram fetch failed: ${err?.message || String(err)}`,
-    };
-  }
-}
+// suppli-58533: sendTelegramMessage was moved to ../services/telegramSend.ts
+// (imported above) so the host-inbound endpoint can reuse the identical send
+// path. The implementation is unchanged.
 
 /**
  * tonda-58293 FIX #4: send a reminder to a party's city Telegram GROUP.
@@ -6909,6 +6876,63 @@ async function sendCityGroupReminder(
     : { groupSent: false, groupReason: result.reason };
 }
 
+// suppli-58533: host DM submissions to Molto Benny.
+//
+// A host can now REPLY to the bot (photo or a headcount number) and we add it
+// to their event. Append a no-login CTA to BOTH the host-DM and city-group
+// reminder bodies. For the GROUP message only, also append a deeplink the host
+// can tap to open a DM with the bot (?start=submit_<token>) — moltobene routes
+// that payload back to the host-inbound flow.
+const HOST_INBOUND_CTA =
+  "📸 No need to log in — just reply with your receipt photo, an event photo, or type your headcount and I'll add it for you.";
+
+// nanoid(10) mint mirrors host-telegram.routes.ts:25-67 (same URL-safe alphabet
+// + length). Used to lazily mint a host_telegram_link_token when one is absent
+// so the group deeplink always resolves.
+const generateHostTelegramToken = customAlphabet(
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+  10,
+);
+
+/**
+ * suppli-58533: append the no-login CTA to a host-DM reminder body.
+ */
+function withHostInboundCta(text: string): string {
+  return `${text}\n\n${HOST_INBOUND_CTA}`;
+}
+
+/**
+ * suppli-58533: build the GROUP reminder body: base text + CTA + a tap-to-DM
+ * deeplink. Mints the party's host_telegram_link_token if it's missing (mirrors
+ * the host-telegram.routes.ts mint). Returns the group text; the deeplink is
+ * omitted when TELEGRAM_BOT_USERNAME is unset (no usable link to offer).
+ */
+async function buildGroupReminderText(party: {
+  id: string;
+  hostTelegramLinkToken: string | null;
+}, baseText: string): Promise<string> {
+  let body = withHostInboundCta(baseText);
+  const botUsername = process.env.TELEGRAM_BOT_USERNAME || '';
+  if (!botUsername) return body;
+
+  let token = party.hostTelegramLinkToken;
+  if (!token) {
+    token = generateHostTelegramToken();
+    try {
+      await prisma.party.update({
+        where: { id: party.id },
+        data: { hostTelegramLinkToken: token },
+      });
+    } catch (err) {
+      // Non-fatal — if the mint write fails we just skip the deeplink.
+      console.warn('[suppli-58533] failed to mint host_telegram_link_token:', err);
+      return body;
+    }
+  }
+  body += `\n\n👉 Tap to submit by DM: https://t.me/${botUsername}?start=submit_${token}`;
+  return body;
+}
+
 router.post(
   '/:partyId/tg-receipts-reminder',
   requireAuth,
@@ -6925,6 +6949,8 @@ router.post(
           inviteCode: true,
           name: true,
           hostTelegramChatId: true,
+          // suppli-58533: needed to build the group-only tap-to-DM deeplink.
+          hostTelegramLinkToken: true,
         },
       });
       if (!party) {
@@ -6942,7 +6968,8 @@ router.post(
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          text,
+          // suppli-58533: append the no-login reply CTA to the host DM.
+          withHostInboundCta(text),
         );
         if (result.ok) {
           hostDmSent = true;
@@ -6957,7 +6984,9 @@ router.post(
       // chat_id from `city_telegram_groups` via `sendToCityGroup` (which also
       // persists supergroup migrations). FIX #4: falls back to the raw party
       // name as cityKey so non-GPP-named parties aren't silently skipped.
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
+      const groupText = await buildGroupReminderText(party, text);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {
@@ -7012,6 +7041,8 @@ router.post(
           inviteCode: true,
           name: true,
           hostTelegramChatId: true,
+          // suppli-58533: needed to build the group-only tap-to-DM deeplink.
+          hostTelegramLinkToken: true,
         },
       });
       if (!party) {
@@ -7026,7 +7057,8 @@ router.post(
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          text,
+          // suppli-58533: append the no-login reply CTA to the host DM.
+          withHostInboundCta(text),
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7041,7 +7073,9 @@ router.post(
       // `city_telegram_groups` via `sendToCityGroup` (adds the migration
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
+      const groupText = await buildGroupReminderText(party, text);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {
@@ -7093,6 +7127,8 @@ router.post(
           inviteCode: true,
           name: true,
           hostTelegramChatId: true,
+          // suppli-58533: needed to build the group-only tap-to-DM deeplink.
+          hostTelegramLinkToken: true,
         },
       });
       if (!party) {
@@ -7107,7 +7143,8 @@ router.post(
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          text,
+          // suppli-58533: append the no-login reply CTA to the host DM.
+          withHostInboundCta(text),
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7122,7 +7159,9 @@ router.post(
       // `city_telegram_groups` via `sendToCityGroup` (adds the migration
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
+      const groupText = await buildGroupReminderText(party, text);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {
@@ -7174,6 +7213,8 @@ router.post(
           inviteCode: true,
           name: true,
           hostTelegramChatId: true,
+          // suppli-58533: needed to build the group-only tap-to-DM deeplink.
+          hostTelegramLinkToken: true,
         },
       });
       if (!party) {
@@ -7188,7 +7229,8 @@ router.post(
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          text,
+          // suppli-58533: append the no-login reply CTA to the host DM.
+          withHostInboundCta(text),
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7203,7 +7245,9 @@ router.post(
       // `city_telegram_groups` via `sendToCityGroup` (adds the migration
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, text);
+      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
+      const groupText = await buildGroupReminderText(party, text);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {

--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -1,0 +1,354 @@
+/**
+ * suppli-58533: host DM submissions to Molto Benny.
+ *
+ *   POST /api/telegram/host-inbound
+ *     Called by moltobene when a host REPLIES to the bot in Telegram (sends a
+ *     photo, or types a number). moltobene forwards the inbound DM here; we
+ *     resolve which party the chatId belongs to and add the submission to it:
+ *       - photo → OCR'd; if it looks like a receipt it's added as a
+ *         payout_documents receipt, otherwise as an event photo (gallery).
+ *       - text  → a bare positive integer sets the party's estimated attendance.
+ *
+ *     Auth: header `x-api-key` must equal `TELEGRAM_LINK_CALLBACK_SECRET`
+ *       (the exact pattern from telegram-link-callback.routes.ts):
+ *         - env unset → 503 { ok:false, reason:'not configured' }
+ *         - mismatch  → 401
+ *
+ *     Body: { chatId, kind:'photo'|'text', fileId?, fileUniqueId?,
+ *             imageBase64?, text? }
+ *     Returns: { ok, action:'receipt'|'photo'|'attendance'|'ignored',
+ *                partyName?, reason? }
+ *
+ *     Mounted at /api/telegram (same router family as /link-host) in index.ts.
+ */
+import { Router, Request, Response, NextFunction } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import { Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { prisma } from '../config/database.js';
+import {
+  resolveHostPartyByChatId,
+  downloadTelegramFile,
+  type HostInboundParty,
+} from '../services/hostInboundResolve.js';
+import { sendTelegramMessage } from '../services/telegramSend.js';
+import { analyzeReceipt } from '../services/ocr.service.js';
+import { convertToUSD } from '../services/fx.service.js';
+import { sanitizePgString, sanitizeForPg } from '../lib/sanitizePg.js';
+
+const router = Router();
+
+// suppli-58533: minimum OCR confidence for a host-DM image to be treated as a
+// receipt (rather than an event photo). Combined with amount>0 AND a merchant
+// or line items so a blurry guess doesn't get filed as a reimbursement claim.
+const RECEIPT_OCR_CONFIDENCE_MIN = 0.4;
+
+const STORAGE_BUCKET = 'event-images';
+
+let _supabase: ReturnType<typeof createClient> | null = null;
+function getSupabaseAdmin() {
+  if (_supabase) return _supabase;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  }
+  _supabase = createClient(url, key);
+  return _supabase;
+}
+
+/**
+ * Upload the downloaded buffer to the payouts folder for this party and return
+ * the public URL. Mirrors taxFormStorage.service.ts:50-62 (upload + getPublicUrl
+ * against the same `event-images` bucket); path matches the existing payout
+ * convention `payouts/{partyId}/{uniqueName}` so the receipt/photo flows that
+ * scope URLs to `payouts/{partyId}/` keep working.
+ */
+async function uploadPayoutBuffer(
+  buffer: Buffer,
+  partyId: string,
+  mimeType: string,
+): Promise<{ url: string; path: string }> {
+  const supabase = getSupabaseAdmin();
+  const ext = (mimeType.split('/')[1] || 'jpg').replace(/[^a-z0-9]/gi, '') || 'jpg';
+  const uniqueName = `tg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+  const path = `payouts/${partyId}/${uniqueName}`;
+  const { error } = await supabase.storage.from(STORAGE_BUCKET).upload(path, buffer, {
+    cacheControl: '3600',
+    upsert: false,
+    contentType: mimeType,
+  });
+  if (error) {
+    throw new Error(`Telegram inbound upload failed: ${error.message}`);
+  }
+  const { data } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(path);
+  return { url: data.publicUrl, path };
+}
+
+/** Event year for photoYear: event date year ?? null (upload-time fallback handled by NULL). */
+function partyEventYear(p: HostInboundParty): number | null {
+  return p.date ? p.date.getUTCFullYear() : null;
+}
+
+router.post(
+  '/host-inbound',
+  async (req: Request, res: Response, _next: NextFunction) => {
+    try {
+      // ---- Auth (exact pattern from telegram-link-callback.routes.ts) ----
+      const secret = process.env.TELEGRAM_LINK_CALLBACK_SECRET;
+      if (!secret) {
+        return res.status(503).json({ ok: false, action: 'ignored', reason: 'not configured' });
+      }
+      const provided = req.header('x-api-key') || '';
+      if (provided !== secret) {
+        return res.status(401).json({ ok: false, action: 'ignored', reason: 'unauthorized' });
+      }
+
+      const { chatId, kind, fileId, imageBase64, text } = (req.body || {}) as {
+        chatId?: number | string;
+        kind?: string;
+        fileId?: string;
+        fileUniqueId?: string;
+        imageBase64?: string;
+        text?: string;
+      };
+
+      // Validate chatId is integer-like before BigInt() (which throws).
+      if (chatId === undefined || chatId === null || `${chatId}`.trim() === '') {
+        return res.status(400).json({ ok: false, action: 'ignored', reason: 'chatId is required' });
+      }
+      const chatIdStr = `${chatId}`.trim();
+      if (!/^-?\d+$/.test(chatIdStr)) {
+        return res.status(400).json({ ok: false, action: 'ignored', reason: 'chatId must be an integer' });
+      }
+      if (kind !== 'photo' && kind !== 'text') {
+        return res.status(400).json({ ok: false, action: 'ignored', reason: "kind must be 'photo' or 'text'" });
+      }
+
+      // ---- Resolve the party ----
+      const resolved = await resolveHostPartyByChatId(BigInt(chatIdStr));
+
+      if (resolved.kind === 'none') {
+        // chatId not linked to any party → reply nothing.
+        return res.status(200).json({ ok: true, action: 'ignored', reason: 'no-party' });
+      }
+      if (resolved.kind === 'ambiguous') {
+        // Host runs several events — tell them to use the web link and stop.
+        const slug = resolved.slug;
+        if (slug) {
+          await sendTelegramMessage(
+            chatIdStr,
+            `You host a few events — please add this at rsv.pizza/host/${slug}/payments`,
+          );
+        }
+        return res.status(200).json({ ok: true, action: 'ignored', reason: 'ambiguous' });
+      }
+
+      const party = resolved.party;
+      const hostEmail = party.user?.email ?? null;
+
+      // =====================================================================
+      // TEXT → estimated attendance
+      // =====================================================================
+      if (kind === 'text') {
+        const trimmed = typeof text === 'string' ? text.trim() : '';
+        // Same validation as party.routes.ts attendance: a bare positive int.
+        if (!/^\d+$/.test(trimmed)) {
+          const slug = party.customUrl || party.inviteCode;
+          await sendTelegramMessage(
+            chatIdStr,
+            `I can add a receipt photo, an event photo, or a headcount number for ${party.name}. ` +
+              `For anything else, head to rsv.pizza/host/${slug}/payments`,
+          );
+          return res.status(200).json({
+            ok: true,
+            action: 'ignored',
+            partyName: party.name,
+            reason: 'non-numeric',
+          });
+        }
+        const n = Number(trimmed);
+        if (!Number.isInteger(n) || n < 1) {
+          return res.status(200).json({
+            ok: true,
+            action: 'ignored',
+            partyName: party.name,
+            reason: 'invalid-number',
+          });
+        }
+        await prisma.party.update({
+          where: { id: party.id },
+          data: { estimatedAttendance: n },
+        });
+        await sendTelegramMessage(chatIdStr, `✅ Set headcount for ${party.name} to ${n}.`);
+        return res.status(200).json({ ok: true, action: 'attendance', partyName: party.name });
+      }
+
+      // =====================================================================
+      // PHOTO → receipt or event photo
+      // =====================================================================
+      if (!fileId && !(typeof imageBase64 === 'string' && imageBase64.length > 0)) {
+        return res.status(400).json({
+          ok: false,
+          action: 'ignored',
+          reason: 'fileId or imageBase64 required for kind=photo',
+        });
+      }
+
+      // suppli-58533: idempotency by fileUniqueId is best-effort only. There is
+      // no column on payout_documents / photos to persist a Telegram file marker,
+      // so we deliberately SKIP the dedupe here rather than add a migration (this
+      // feature ships with no DB changes). Albums arrive as separate calls; a
+      // host re-sending the same photo would create a second row — acceptable.
+
+      let downloaded;
+      try {
+        downloaded = await downloadTelegramFile(fileId || '', imageBase64);
+      } catch (err: any) {
+        console.error('[suppli-58533][host-inbound] download failed:', err?.message || err);
+        await sendTelegramMessage(
+          chatIdStr,
+          `I couldn't download that image — please try again, or add it at ` +
+            `rsv.pizza/host/${party.customUrl || party.inviteCode}/payments`,
+        );
+        return res.status(200).json({ ok: false, action: 'ignored', reason: 'download-failed' });
+      }
+
+      const { url } = await uploadPayoutBuffer(downloaded.buffer, party.id, downloaded.mimeType);
+
+      // ---- OCR the image to decide receipt vs. event photo ----
+      let ocr:
+        | Awaited<ReturnType<typeof analyzeReceipt>>
+        | null = null;
+      try {
+        ocr = await analyzeReceipt({ imageUrl: url, partyCountry: party.country });
+      } catch (err: any) {
+        console.warn('[suppli-58533][host-inbound] OCR failed; treating as photo:', err?.message || err);
+        ocr = null;
+      }
+
+      const looksLikeReceipt =
+        ocr != null &&
+        ocr.amount > 0 &&
+        ocr.confidence >= RECEIPT_OCR_CONFIDENCE_MIN &&
+        (!!ocr.merchant || (Array.isArray(ocr.lineItems) && ocr.lineItems.length > 0));
+
+      if (looksLikeReceipt && ocr) {
+        // ---- RECEIPT path: mirror payout.routes.ts:731-796 column mapping ----
+        const fx = await convertToUSD(ocr.amount, ocr.currency);
+        const unresolved = fx.source === 'unresolved' || fx.usdAmount == null;
+
+        // Attach to an existing pending payout for the party if one exists; else null
+        // (the receipt is party-scoped via partyId and surfaces in the receipts library).
+        const pendingPayout = await prisma.payout.findFirst({
+          where: { partyId: party.id, status: 'pending' },
+          orderBy: { createdAt: 'desc' },
+          select: { id: true },
+        });
+
+        // sortOrder = (max existing doc sortOrder for this party) + 1.
+        const maxAgg = await prisma.payoutDocument.aggregate({
+          where: { partyId: party.id },
+          _max: { sortOrder: true },
+        });
+        const sortOrder = (maxAgg._max.sortOrder ?? -1) + 1;
+
+        await prisma.payoutDocument.create({
+          data: {
+            partyId: party.id,
+            payoutId: pendingPayout?.id ?? null,
+            kind: 'receipt',
+            url,
+            fileName: sanitizePgString(downloaded.fileName),
+            fileSize: downloaded.buffer.length,
+            mimeType: downloaded.mimeType,
+            ocrAmount: unresolved ? null : new Decimal(fx.usdAmount!),
+            ocrCurrency: unresolved
+              ? null
+              : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : fx.originalCurrency),
+            ocrConfidence: new Decimal(ocr.confidence),
+            originalAmount: new Decimal(fx.originalAmount),
+            originalCurrency: unresolved
+              ? null
+              : (fx.originalCurrency ? sanitizePgString(fx.originalCurrency) : null),
+            exchangeRate: unresolved
+              ? null
+              : (fx.exchangeRate != null ? new Decimal(fx.exchangeRate) : null),
+            ocrRaw: sanitizeForPg({
+              ocr: ocr.raw,
+              fx: { source: fx.source, rate: fx.exchangeRate },
+            } as Prisma.InputJsonValue),
+            ocrLineItems:
+              ocr.lineItems && ocr.lineItems.length > 0
+                ? sanitizeForPg(ocr.lineItems as unknown as Prisma.InputJsonValue)
+                : Prisma.JsonNull,
+            ocrError: unresolved ? 'CURRENCY_UNRESOLVED' : null,
+            ocrAttemptedAt: new Date(),
+            ocrAttemptCount: 1,
+            ocrLanguage: ocr.language ? sanitizePgString(ocr.language) : null,
+            ocrSummary: ocr.summary ? sanitizePgString(ocr.summary) : null,
+            uploadedByEmail: hostEmail,
+            sortOrder,
+          },
+        });
+
+        const receiptCount = await prisma.payoutDocument.count({
+          where: { partyId: party.id, kind: 'receipt' },
+        });
+
+        const amountLabel = unresolved
+          ? `${ocr.amount.toLocaleString()} ${ocr.currency ?? ''}`.trim()
+          : `$${fx.usdAmount!.toFixed(2)}`;
+        await sendTelegramMessage(
+          chatIdStr,
+          `✅ Got your receipt for ${party.name} — ${amountLabel}. ` +
+            `That's ${receiptCount} receipt${receiptCount === 1 ? '' : 's'} on file.`,
+        );
+        return res.status(200).json({ ok: true, action: 'receipt', partyName: party.name });
+      }
+
+      // ---- EVENT PHOTO path: mirror photo.routes.ts:459-650 (host auto-approve) ----
+      // payout_role stays NULL: 'group'/'box_stack'/'pizza' are the only designated
+      // roles (partial unique index), and getPayoutSubmissionReadiness counts any
+      // non-role photo dated >= party.date as an "additional" event photo. A photo
+      // uploaded now only counts toward readiness when now >= the event start.
+      const now = new Date();
+      await prisma.photo.create({
+        data: {
+          partyId: party.id,
+          url,
+          fileName: sanitizePgString(downloaded.fileName),
+          fileSize: downloaded.buffer.length,
+          mimeType: downloaded.mimeType,
+          uploadedBy: null,
+          uploaderName: null,
+          uploaderEmail: hostEmail ? hostEmail.toLowerCase() : null,
+          status: 'approved',
+          starred: true,
+          starredAt: now,
+          reviewedAt: now,
+          reviewedBy: party.user?.id ?? null,
+          photoYear: partyEventYear(party),
+        },
+      });
+
+      // Cutoff note: if the upload is before the event start it still stores but
+      // won't count toward the host's submission readiness.
+      const beforeEventStart = party.date != null && now < party.date;
+      const cutoffNote = beforeEventStart
+        ? " (note: it's before your event start, so it won't count toward your submission yet)"
+        : '';
+      await sendTelegramMessage(
+        chatIdStr,
+        `✅ Added your event photo for ${party.name}.${cutoffNote}`,
+      );
+      return res.status(200).json({ ok: true, action: 'photo', partyName: party.name });
+    } catch (err: any) {
+      console.error('[suppli-58533][host-inbound] error:', err?.message || err);
+      // Never 500 to moltobene — it's a fire-and-forward; surface a soft ignore.
+      return res.status(200).json({ ok: false, action: 'ignored', reason: 'internal error' });
+    }
+  },
+);
+
+export default router;

--- a/backend/src/services/hostInboundResolve.ts
+++ b/backend/src/services/hostInboundResolve.ts
@@ -1,0 +1,228 @@
+/**
+ * suppli-58533: host DM submissions to Molto Benny.
+ *
+ * A host can REPLY to the bot in Telegram (send a photo, or type a number) and
+ * have it added to their event. moltobene captures the inbound DM and forwards
+ * `{ chatId, fileId|text }` to POST /api/telegram/host-inbound, which uses the
+ * helpers in this file to (1) resolve which party the chatId belongs to, and
+ * (2) download the photo bytes from Telegram (RSV.Pizza holds the same
+ * TELEGRAM_BOT_TOKEN as the bot, so it can call getFile + download itself).
+ */
+import { prisma } from '../config/database.js';
+
+/**
+ * Result of resolving a chatId to a party.
+ *
+ *  - `{ kind: 'party', party }`     → unambiguous single host party.
+ *  - `{ kind: 'ambiguous', slug? }` → ≥2 plausible parties (the handler tells
+ *                                     the host to use the web link and stops).
+ *  - `{ kind: 'none' }`             → no party matches the chatId (reply nothing).
+ */
+export type ResolvedHostParty =
+  | { kind: 'party'; party: HostInboundParty }
+  | { kind: 'ambiguous'; slug: string | null }
+  | { kind: 'none' };
+
+export interface HostInboundParty {
+  id: string;
+  name: string;
+  customUrl: string | null;
+  inviteCode: string;
+  country: string | null;
+  date: Date | null;
+  underbossStatus: string;
+  receiptsReminderSentAt: Date | null;
+  photoReminderSentAt: Date | null;
+  walletReminderSentAt: Date | null;
+  attendanceReminderSentAt: Date | null;
+  hostTelegramLinkToken: string | null;
+  user: { id: string; email: string } | null;
+}
+
+const PARTY_SELECT = {
+  id: true,
+  name: true,
+  customUrl: true,
+  inviteCode: true,
+  country: true,
+  date: true,
+  underbossStatus: true,
+  receiptsReminderSentAt: true,
+  photoReminderSentAt: true,
+  walletReminderSentAt: true,
+  attendanceReminderSentAt: true,
+  hostTelegramLinkToken: true,
+  user: { select: { id: true, email: true } },
+} as const;
+
+/** Most-recent reminder timestamp across all four reminder kinds (or null). */
+function maxReminder(p: HostInboundParty): number | null {
+  const ts = [
+    p.receiptsReminderSentAt,
+    p.photoReminderSentAt,
+    p.walletReminderSentAt,
+    p.attendanceReminderSentAt,
+  ]
+    .filter((d): d is Date => d != null)
+    .map((d) => d.getTime());
+  return ts.length > 0 ? Math.max(...ts) : null;
+}
+
+function slugOf(p: HostInboundParty): string | null {
+  return p.customUrl || p.inviteCode || null;
+}
+
+/**
+ * Resolve the party a host's Telegram chatId belongs to.
+ *
+ * `parties.host_telegram_chat_id` is NOT unique — one chatId can map to many
+ * parties (a host running multiple cities/years). Selection order:
+ *   1. If exactly one party matches → that party.
+ *   2. Pick the party with the MOST RECENT reminder
+ *      (max of receipts/photo/wallet/attendance reminder timestamps).
+ *   3. If none have a reminder timestamp, pick the most recent APPROVED party
+ *      (by event date desc, then createdAt desc).
+ *   4. If still a genuine tie (≥2 equally-ranked) → ambiguous.
+ *   5. No party matches the chatId at all → none.
+ */
+export async function resolveHostPartyByChatId(
+  chatId: number | bigint,
+): Promise<ResolvedHostParty> {
+  let chatIdBig: bigint;
+  try {
+    chatIdBig = BigInt(chatId);
+  } catch {
+    return { kind: 'none' };
+  }
+
+  const parties = (await prisma.party.findMany({
+    where: { hostTelegramChatId: chatIdBig },
+    select: PARTY_SELECT,
+    orderBy: { createdAt: 'desc' },
+  })) as unknown as HostInboundParty[];
+
+  if (parties.length === 0) return { kind: 'none' };
+  if (parties.length === 1) return { kind: 'party', party: parties[0] };
+
+  // (2) Prefer the party with the most recent reminder.
+  const withReminder = parties
+    .map((p) => ({ p, r: maxReminder(p) }))
+    .filter((x): x is { p: HostInboundParty; r: number } => x.r != null);
+
+  if (withReminder.length > 0) {
+    const maxR = Math.max(...withReminder.map((x) => x.r));
+    const top = withReminder.filter((x) => x.r === maxR);
+    if (top.length === 1) return { kind: 'party', party: top[0].p };
+    // Genuine tie on reminder timestamp → ambiguous.
+    return { kind: 'ambiguous', slug: slugOf(top[0].p) };
+  }
+
+  // (3) No reminders anywhere → most recent APPROVED party.
+  const approved = parties.filter((p) => p.underbossStatus === 'approved');
+  const pool = approved.length > 0 ? approved : parties;
+
+  const sorted = [...pool].sort((a, b) => {
+    const ad = a.date ? a.date.getTime() : 0;
+    const bd = b.date ? b.date.getTime() : 0;
+    return bd - ad; // most recent event date first
+  });
+
+  // If the top two share the same event date we can't disambiguate cleanly —
+  // call it ambiguous so we don't guess and add a photo to the wrong event.
+  if (
+    sorted.length >= 2 &&
+    (sorted[0].date?.getTime() ?? 0) === (sorted[1].date?.getTime() ?? 0)
+  ) {
+    return { kind: 'ambiguous', slug: slugOf(sorted[0]) };
+  }
+
+  return { kind: 'party', party: sorted[0] };
+}
+
+export interface DownloadedTelegramFile {
+  buffer: Buffer;
+  mimeType: string;
+  fileName: string;
+}
+
+/**
+ * Download a Telegram file by `fileId` using the bot token.
+ *
+ *   GET https://api.telegram.org/bot{TOKEN}/getFile?file_id=... → result.file_path
+ *   GET https://api.telegram.org/file/bot{TOKEN}/{file_path}     → raw bytes
+ *
+ * If `imageBase64` is supplied instead, decode that and skip the network round
+ * trips (cheap hedge — moltobene can inline small images).
+ *
+ * Throws on misconfiguration / Telegram errors so the caller can surface a
+ * graceful failure to the host.
+ */
+export async function downloadTelegramFile(
+  fileId: string,
+  imageBase64?: string,
+): Promise<DownloadedTelegramFile> {
+  // Fast path: caller already inlined the bytes.
+  if (typeof imageBase64 === 'string' && imageBase64.length > 0) {
+    // Strip an optional data-URL prefix ("data:image/jpeg;base64,...").
+    let mimeType = 'image/jpeg';
+    let b64 = imageBase64;
+    const dataUrlMatch = /^data:([^;,]+)?(?:;base64)?,(.*)$/s.exec(imageBase64);
+    if (dataUrlMatch) {
+      if (dataUrlMatch[1]) mimeType = dataUrlMatch[1];
+      b64 = dataUrlMatch[2];
+    }
+    const buffer = Buffer.from(b64, 'base64');
+    if (buffer.length === 0) {
+      throw new Error('imageBase64 decoded to zero bytes');
+    }
+    const ext = mimeType.split('/')[1] || 'jpg';
+    return { buffer, mimeType, fileName: `tg-${Date.now()}.${ext}` };
+  }
+
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    throw new Error('TELEGRAM_BOT_TOKEN not configured');
+  }
+
+  const getFileResp = await fetch(
+    `https://api.telegram.org/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`,
+    { signal: AbortSignal.timeout(10000) },
+  );
+  if (!getFileResp.ok) {
+    throw new Error(`Telegram getFile returned ${getFileResp.status}`);
+  }
+  const getFileJson = (await getFileResp.json()) as {
+    ok?: boolean;
+    result?: { file_path?: string };
+  };
+  const filePath = getFileJson?.result?.file_path;
+  if (!getFileJson?.ok || !filePath) {
+    throw new Error('Telegram getFile returned no file_path');
+  }
+
+  const fileResp = await fetch(
+    `https://api.telegram.org/file/bot${token}/${filePath}`,
+    { signal: AbortSignal.timeout(20000) },
+  );
+  if (!fileResp.ok) {
+    throw new Error(`Telegram file download returned ${fileResp.status}`);
+  }
+  const arrayBuf = await fileResp.arrayBuffer();
+  const buffer = Buffer.from(arrayBuf);
+  if (buffer.length === 0) {
+    throw new Error('Telegram file download returned zero bytes');
+  }
+
+  // Infer mime/extension from the file_path suffix (Telegram preserves it).
+  const lowerPath = filePath.toLowerCase();
+  let mimeType = 'image/jpeg';
+  if (lowerPath.endsWith('.png')) mimeType = 'image/png';
+  else if (lowerPath.endsWith('.webp')) mimeType = 'image/webp';
+  else if (lowerPath.endsWith('.heic')) mimeType = 'image/heic';
+  else if (lowerPath.endsWith('.heif')) mimeType = 'image/heif';
+  else if (lowerPath.endsWith('.gif')) mimeType = 'image/gif';
+  const ext = filePath.split('.').pop() || 'jpg';
+  const fileName = `tg-${Date.now()}.${ext}`;
+
+  return { buffer, mimeType, fileName };
+}

--- a/backend/src/services/telegramSend.ts
+++ b/backend/src/services/telegramSend.ts
@@ -1,0 +1,54 @@
+/**
+ * suppli-58533: shared Telegram send helper for the Molto Benny bot.
+ *
+ * MOVED verbatim from admin-payout.routes.ts (where it was an inline
+ * `sendTelegramMessage`) so the new host-inbound handler can reuse the exact
+ * same send path — including the `withBennySignature` sign-off and the
+ * `disable_web_page_preview` flag. Behavior is unchanged; admin-payout.routes.ts
+ * now imports it from here.
+ *
+ * Uses `TELEGRAM_BOT_TOKEN` (the same token moltobene owns). Never throws —
+ * returns a discriminated result so callers can surface per-channel success/
+ * failure exactly as before.
+ */
+import { withBennySignature } from '../lib/bennySignature.js';
+
+export async function sendTelegramMessage(
+  chatId: string,
+  text: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    return { ok: false, reason: 'TELEGRAM_BOT_TOKEN not configured' };
+  }
+  try {
+    const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: withBennySignature(text),
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!resp.ok) {
+      let detail = '';
+      try {
+        const body = await resp.text();
+        detail = body.slice(0, 200);
+      } catch {
+        // ignore — surface just the status
+      }
+      return {
+        ok: false,
+        reason: `Telegram API returned ${resp.status}${detail ? `: ${detail}` : ''}`,
+      };
+    }
+    return { ok: true };
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: `Telegram fetch failed: ${err?.message || String(err)}`,
+    };
+  }
+}


### PR DESCRIPTION
## What

Lets a host **reply to the Molto Benny bot in Telegram** — send a photo, or type a headcount number — and have it added to their event. A separate service (**moltobene**) captures the inbound DM and forwards `{ chatId, kind, fileId|text }` to a new endpoint here. RSV.Pizza holds the same `TELEGRAM_BOT_TOKEN`, so it downloads the image itself.

## Endpoint

`POST /api/telegram/host-inbound` (mounted at `/api/telegram`, same family as `/link-host`)
- Auth: `x-api-key` must equal `TELEGRAM_LINK_CALLBACK_SECRET` (503 if unset, 401 on mismatch) — exact pattern copied from `telegram-link-callback.routes.ts`.
- Body: `{ chatId, kind:'photo'|'text', fileId?, fileUniqueId?, imageBase64?, text? }`
- Returns: `{ ok, action:'receipt'|'photo'|'attendance'|'ignored', partyName?, reason? }`

Flow:
- **photo** → downloaded via bot token (or inline `imageBase64`), uploaded to `event-images/payouts/{partyId}/...`, OCR'd. If it looks like a receipt (`amount>0 && confidence>=0.4 && (merchant || lineItems)`) it's filed as a `payout_documents` receipt (attached to the party's pending payout if one exists), converting to USD via `convertToUSD` and mirroring the exact host-receipt column mapping. Otherwise it's filed as an approved/starred gallery `photos` row (event photo).
- **text** → a bare positive integer sets `parties.estimated_attendance`. Non-numeric text → gentle pointer to the web link.
- Confirmation DM sent back via the shared `sendTelegramMessage` (with a running receipts-on-file count where cheap).

## Party resolver

`resolveHostPartyByChatId` (new `services/hostInboundResolve.ts`): `host_telegram_chat_id` is **not unique**, so one chatId → many parties. Picks the party with the most recent reminder (receipts/photo/wallet/attendance), else the most recent **approved** party; a genuine tie or no match → ambiguous/none (replies a web-link pointer or nothing).

## Reminder copy + group deeplink

Appended a no-login CTA to **both** DM and group bodies of all four TG reminders (`tg-receipts-/wallet-/photo-/attendance-reminder`):
> 📸 No need to log in — just reply with your receipt photo, an event photo, or type your headcount and I'll add it for you.

For the **group** message only, also append a tap-to-DM deeplink `https://t.me/{TELEGRAM_BOT_USERNAME}?start=submit_{token}`, minting `host_telegram_link_token` (nanoid(10), mirroring `host-telegram.routes.ts`) if absent. Existing reminder text + timestamp logic unchanged.

## Refactor

Moved the inline `sendTelegramMessage` out of `admin-payout.routes.ts` into `services/telegramSend.ts` (behavior identical, incl. `withBennySignature`); admin-payout imports it from there.

## Notes
- **No DB migration** — all columns already exist.
- **Pairs with a moltobene PR** (the inbound-DM capture side).
- **Backend auto-deploys from master** on merge.
- Idempotency by `fileUniqueId` is skipped (no column to persist a Telegram marker; documented in-code) to avoid a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)