### PR TITLE
malfatti-58532: surface party.date to admin Add-photo modal (re-enable photo cutoff)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -900,6 +900,9 @@ function serializePayout(row: any): any {
           name: row.party.name,
           inviteCode: row.party.inviteCode,
           customUrl: row.party.customUrl,
+          // malfatti-58532: event start, so the admin "Add photo" modal can apply
+          // the same post-event-start photo cutoff hosts use (RolePhotoPicker).
+          date: row.party.date ? row.party.date.toISOString() : null,
           // bruschetta-58291: surface the party's country on the wire so the
           // /payments queue can render it as a subtitle and populate the
           // Country filter dropdown.
@@ -2209,6 +2212,9 @@ router.get(
             name: b.partyMeta.name,
             customUrl: b.partyMeta.customUrl ?? null,
             inviteCode: b.partyMeta.inviteCode ?? null,
+            // malfatti-58532: event start, so the admin "Add photo" modal can apply
+            // the same post-event-start photo cutoff hosts use (RolePhotoPicker).
+            date: b.partyMeta.date ? b.partyMeta.date.toISOString() : null,
             country: b.partyMeta.country ?? null,
             // provatura-92107: region now selected via PAYOUT_PARTY_SELECT so
             // the by-city "Hide US cities" toggle can filter party.region.
@@ -2374,6 +2380,8 @@ router.get(
               name: partyMeta.name,
               customUrl: partyMeta.customUrl ?? null,
               inviteCode: partyMeta.inviteCode ?? null,
+              // malfatti-58532: keep field-for-field parity with the real row.
+              date: partyMeta.date ? partyMeta.date.toISOString() : null,
               country: partyMeta.country ?? null,
               region: (partyMeta.region as string | null) ?? null,
               effectiveReimbursementCapUsd: computeEffectiveCapUsd({

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -4326,12 +4326,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       />
 
       {/* provolone-58531: admin/underboss Add-photos modal (host-style role
-          slots + additional photos). AdminPayout.party carries no date field,
-          so the event-start cutoff is disabled (eventStart={null}). */}
+          slots + additional photos). malfatti-58532: pass the event start so the
+          role-picker applies the same post-event-start cutoff hosts get. */}
       {showAddPhotos && (
         <AdminAddPhotosModal
           partyId={payout.partyId}
-          eventStart={null}
+          eventStart={payout.party.date ?? null}
           partyName={payout.party.name}
           onClose={() => setShowAddPhotos(false)}
           onAdded={handlePhotosAdded}

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -2787,12 +2787,12 @@ function CityExpansion({
       />
 
       {/* provolone-58531: admin/underboss "Add photo" modal (host-style role
-          slots + additional photos). row.party has no date field, so the
-          event-start cutoff is disabled (eventStart={null}). */}
+          slots + additional photos). malfatti-58532: pass the event start so the
+          role-picker applies the same post-event-start cutoff hosts get. */}
       {showAddPhotos && (
         <AdminAddPhotosModal
           partyId={row.party.id}
-          eventStart={null}
+          eventStart={row.party.date ?? null}
           partyName={row.party.name}
           onClose={() => setShowAddPhotos(false)}
           onAdded={handlePhotosAdded}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2179,6 +2179,8 @@ export interface AdminPayout extends Payout, FlaggedReadyFields {
     name: string;
     inviteCode: string;
     customUrl: string | null;
+    /** malfatti-58532: event start ISO; drives the admin Add-photo modal cutoff. */
+    date: string | null;
     /**
      * bruschetta-58291: surface country on the /payments admin queue.
      * Free-form string from `parties.country` (e.g. 'USA', 'Spain').
@@ -2619,6 +2621,8 @@ export interface PartyPayoutsRow {
     customUrl: string | null;
     /** Mirrors `party.inviteCode` so the frontend can build `/host/:slug` links. */
     inviteCode: string | null;
+    /** malfatti-58532: event start ISO; drives the admin Add-photo modal cutoff. */
+    date: string | null;
     country: string | null;
     /** Optional — backend currently surfaces null since the value isn't on PAYOUT_PARTY_SELECT. */
     region: string | null;


### PR DESCRIPTION
## What
Follow-up polish to **provolone-58531**. The admin/underboss **"+ Add photo"** modal was passing `eventStart={null}` because the /payments by-party row and the `AdminPayout` detail projections didn't carry the event start. That disabled the *client-side* role-picker cutoff, so the picker listed ineligible **pre-event** photos as selectable — and the backend then rejected designating them (a confusing dead-end).

`date` is already in `PAYOUT_PARTY_SELECT`, so this just surfaces it onto the wire.

## Changes
**Backend — `admin-payout.routes.ts`** (no migration)
- Add `date` (ISO string) to: `serializePayout()`'s `party` (powers `AdminPayout`/PayoutReviewModal), the by-party **real** row, and the synthetic **TBD** row (keeps field-for-field parity so tsc + the frontend stay consistent).

**Frontend**
- `types.ts`: add `date: string | null` to `AdminPayout.party` and `PartyPayoutsRow.party`.
- `PayoutsByPartyTable` + `PayoutReviewModal`: pass `eventStart={…party.date ?? null}` to `AdminAddPhotosModal` (was `null`).

## Effect
The admin modal now applies the **same post-event-start cutoff hosts get** — ineligible pre-event photos are hidden from the role picker, so admins can't pick one and hit a backend rejection. Uploading fresh photos was already fine; this only tightens the existing-photo picker.

## Deploy / preview
Backend auto-deploys from master on merge; the new `date` field won't appear on the preview branch (shared prod backend) until merge + redeploy, so on preview the modal still behaves as `eventStart=null` until then.

## Test checklist
- [ ] Vercel preview builds green (no local node_modules → gated on Vercel).
- [ ] Admin opens Add-photo modal on a past event → role picker only lists post-event photos.
- [ ] A pre-event gallery photo is NOT selectable in the role picker.
- [ ] By-party AND PayoutReviewModal both pass the real date.
- [ ] Parties with null date → cutoff disabled (all photos selectable), no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)