### PR TITLE
feat(crostata-58532): default 'Has submitted receipts' filter to ON on /payments

### DIFF
--- a/frontend/src/components/payments-admin/paymentsUrlState.test.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.test.ts
@@ -16,6 +16,8 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   purpose: 'all',
   hideClosed: true,
   hideScams: true,
+  // crostata-58532: default-TRUE — mirrors PaymentsAdminPage DEFAULT_FILTERS.
+  hasReceipts: true,
   sort: 'created_desc',
 };
 
@@ -85,6 +87,14 @@ describe('filtersToSearchParams', () => {
       filtersToSearchParams({ ...DEFAULT_FILTERS, showTbdUnsubmitted: true }, 'by-city').get('tbd'),
     ).toBe('1');
   });
+
+  // crostata-58532: default-TRUE toggle — emit `receipts=0` only when OFF.
+  it('hasReceipts: emits receipts=0 only when OFF, nothing by default', () => {
+    expect(filtersToSearchParams(DEFAULT_FILTERS, 'by-city').get('receipts')).toBeNull();
+    expect(
+      filtersToSearchParams({ ...DEFAULT_FILTERS, hasReceipts: false }, 'by-city').get('receipts'),
+    ).toBe('0');
+  });
 });
 
 describe('searchParamsToFilters', () => {
@@ -128,9 +138,18 @@ describe('searchParamsToFilters', () => {
     expect(filters.status).toBe('all');
     expect(filters.payoutMethod).toBe('all');
     expect(filters.hideClosed).toBe(true);
+    expect(filters.hasReceipts).toBe(true);
     expect(filters.hideScams).toBe(true);
     expect(filters.sort).toBe('created_desc');
     expect(viewMode).toBeNull();
+  });
+
+  // crostata-58532: default-TRUE toggle — receipts=0 parses to false.
+  it('hasReceipts: receipts=0 parses to false; absent stays true', () => {
+    const { filters } = searchParamsToFilters(new URLSearchParams('receipts=0'), undefined);
+    expect(filters.hasReceipts).toBe(false);
+    const { filters: f2 } = searchParamsToFilters(new URLSearchParams(''), undefined);
+    expect(f2.hasReceipts).toBe(true);
   });
 
   it('default-TRUE boolean: =0 parses to false', () => {

--- a/frontend/src/components/payments-admin/paymentsUrlState.ts
+++ b/frontend/src/components/payments-admin/paymentsUrlState.ts
@@ -36,8 +36,9 @@ const DEFAULTS = {
   hideUsCities: true,
   // tigella-58512: default-FALSE — only emitted (as `tbd=1`) when turned ON.
   showTbdUnsubmitted: false,
-  // farinata-58532: default-FALSE — only emitted (as `receipts=1`) when turned ON.
-  hasReceipts: false,
+  // farinata-58532 + crostata-58532: default-TRUE — only emitted (as
+  // `receipts=0`) when the admin turns the filter OFF.
+  hasReceipts: true,
 };
 const DEFAULT_VIEW: ViewMode = 'by-city';
 
@@ -101,8 +102,8 @@ export function filtersToSearchParams(
   // tigella-58512: default-FALSE toggle — only emit when turned ON.
   if (filters.showTbdUnsubmitted === true) params.set('tbd', '1');
 
-  // farinata-58532: default-FALSE toggle — only emit when turned ON.
-  if (filters.hasReceipts === true) params.set('receipts', '1');
+  // farinata-58532 + crostata-58532: default-TRUE toggle — only emit when OFF.
+  if (filters.hasReceipts === false) params.set('receipts', '0');
 
   if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
 
@@ -216,9 +217,9 @@ export function searchParamsToFilters(
   // leave the default (false). Any non-`1` value is treated as false.
   if (params.has('tbd')) filters.showTbdUnsubmitted = params.get('tbd') === '1';
 
-  // farinata-58532: default-FALSE toggle — present `receipts=1` => true; absent
-  // => leave the default (false). Any non-`1` value is treated as false.
-  if (params.has('receipts')) filters.hasReceipts = params.get('receipts') === '1';
+  // farinata-58532 + crostata-58532: default-TRUE toggle — present `receipts=0`
+  // => false; absent => leave the default (true). Any non-`0` value => true.
+  if (params.has('receipts')) filters.hasReceipts = params.get('receipts') !== '0';
 
   const viewRaw = params.get('view');
   const viewMode: ViewMode | null =

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -124,6 +124,9 @@ const DEFAULT_FILTERS: AdminPayoutFilters = {
   // tigella-58512: surface approved `tbd` events with zero submissions —
   // OFF by default so the default request is byte-identical to before.
   showTbdUnsubmitted: false,
+  // crostata-58532: only show cities that have submitted receipts by default.
+  // Admin un-ticks "Has submitted receipts" to also see not-yet-submitted ones.
+  hasReceipts: true,
   // arancino-92103: sort order default — newest submitted first. Matches the
   // prior implicit backend ordering, so non-sorting callers see no change.
   sort: 'created_desc',


### PR DESCRIPTION
## What
The **"Has submitted receipts"** filter on the admin `/payments` **by-city** view now defaults to **checked/ON**.

Previously it was a default-FALSE toggle (added in farinata-58532 / #985). This converts `hasReceipts` to the default-TRUE pattern used by `hideClosed` / `hideScams` / `hideUsCities` — emit `receipts=0` in the URL only when an admin turns it OFF; absent param parses back to `true`.

## Effect
By default the by-city view now **hides cities that haven't submitted receipts yet**. Admins un-tick "Has submitted receipts" to bring them back. Filtering is client-side (`PaymentsAdminPage.tsx`, `r.aggregates.totalReceiptCount > 0`) — no backend/migration.

## Files
- `frontend/src/pages/PaymentsAdminPage.tsx` — add `hasReceipts: true` to `DEFAULT_FILTERS`
- `frontend/src/components/payments-admin/paymentsUrlState.ts` — flip serialize/parse to default-TRUE
- `frontend/src/components/payments-admin/paymentsUrlState.test.ts` — mirror default + 2 new round-trip tests (17/17 pass)

## Verify on preview
`/payments` → By city: the "Has submitted receipts" box is ticked on load and only submitted cities show; un-tick it to reveal the rest. Shareable URL stays clean by default and only adds `?receipts=0` when toggled off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)