### PR TITLE
feat(farinata-58536): rotate control in the receipt editor

### DIFF
--- a/backend/src/lib/privateConfig.test.ts
+++ b/backend/src/lib/privateConfig.test.ts
@@ -274,10 +274,46 @@ describe('getLlmModels', () => {
 
     const models = await getLlmModels();
 
-    expect(models).toEqual(seeded);
+    // farinata-58536: the seeded blob omits `ocrCheap` (a field added after the
+    // prod blob was last written). getConfig returns the blob verbatim, so
+    // getLlmModels coalesces each field against the code default — the seeded
+    // values pass through and the missing `ocrCheap` is backfilled.
+    expect(models).toEqual({ ...seeded, ocrCheap: 'gpt-4o-mini' });
     expect(mockPrisma.appConfig.findUnique).toHaveBeenCalledWith({
       where: { key: PRIVATE_CONFIG_KEYS.llmModels },
     });
+  });
+
+  it('backfills a field missing from the stored blob (e.g. ocrCheap) from the default', async () => {
+    // farinata-58536 regression: the OCR "400 you must provide a model
+    // parameter" outage — a prod blob seeded before `ocrCheap` existed left it
+    // undefined, which reached OpenAI as `model: undefined`. getLlmModels must
+    // never let a missing OR blank key through.
+    mockPrisma.appConfig.findUnique.mockResolvedValue({
+      value: JSON.stringify({
+        ocr: 'gpt-4o',
+        visionPrimary: 'gpt-4o',
+        assistant: 'gpt-4o-mini',
+        visionSecondOpinion: 'claude-3-5-sonnet-latest',
+        // ocrCheap intentionally absent
+      }),
+    });
+    expect((await getLlmModels()).ocrCheap).toBe('gpt-4o-mini');
+  });
+
+  it('backfills a BLANK field from the default (empty string must not reach the model param)', async () => {
+    mockPrisma.appConfig.findUnique.mockResolvedValue({
+      value: JSON.stringify({
+        ocr: '',
+        ocrCheap: '',
+        visionPrimary: 'gpt-4o',
+        assistant: 'gpt-4o-mini',
+        visionSecondOpinion: 'claude-3-5-sonnet-latest',
+      }),
+    });
+    const models = await getLlmModels();
+    expect(models.ocr).toBe('gpt-4o');
+    expect(models.ocrCheap).toBe('gpt-4o-mini');
   });
 
   it('falls back to the CURRENT production models when the row is absent', async () => {

--- a/backend/src/lib/privateConfig.ts
+++ b/backend/src/lib/privateConfig.ts
@@ -498,8 +498,8 @@ export interface LlmModels {
  * per-use-case tier distinction is intentional: the assistant deliberately runs
  * on the cheaper `gpt-4o-mini` and must NOT be collapsed into one global model.
  */
-export function getLlmModels(): Promise<LlmModels> {
-  return getConfig<LlmModels>(KEYS.llmModels, {
+export async function getLlmModels(): Promise<LlmModels> {
+  const defaults: LlmModels = {
     ocr: 'gpt-4o',
     // bruschetta-58519: cheap first-pass OCR (cost routing). Set equal to `ocr`
     // in app_config to disable routing (no escalation) without a deploy.
@@ -507,7 +507,21 @@ export function getLlmModels(): Promise<LlmModels> {
     visionPrimary: 'gpt-4o',
     assistant: 'gpt-4o-mini',
     visionSecondOpinion: 'claude-3-5-sonnet-latest',
-  });
+  };
+  const cfg = await getConfig<Partial<LlmModels>>(KEYS.llmModels, defaults);
+  // farinata-58536: getConfig returns the stored blob VERBATIM (no deep-merge),
+  // so a prod blob seeded before a field was added (e.g. `ocrCheap`, shipped by
+  // bruschetta-58519) leaves that key undefined → it reaches OpenAI as
+  // `model: undefined` → 400 "you must provide a model parameter", which broke
+  // ALL receipt OCR until the blob was re-seeded. Coalesce every field against
+  // the code default so a missing OR blank key can never reach the model param.
+  return {
+    ocr: cfg.ocr || defaults.ocr,
+    ocrCheap: cfg.ocrCheap || defaults.ocrCheap,
+    visionPrimary: cfg.visionPrimary || defaults.visionPrimary,
+    assistant: cfg.assistant || defaults.assistant,
+    visionSecondOpinion: cfg.visionSecondOpinion || defaults.visionSecondOpinion,
+  };
 }
 
 export { KEYS as PRIVATE_CONFIG_KEYS };

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -16,6 +16,8 @@
  */
 import { Router, Request, Response, NextFunction } from 'express';
 import { customAlphabet } from 'nanoid';
+import sharp from 'sharp';
+import { createClient } from '@supabase/supabase-js';
 import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../config/database.js';
@@ -6441,6 +6443,121 @@ router.post(
         ranInline,
         inlineError,
       });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ============================================
+// farinata-58536: POST /api/admin/payouts/documents/:docId/rotate
+//
+// Admin-only: rotate a sideways receipt image so it's readable AND so the next
+// "Re-run OCR" reads the corrected orientation. The rotation is PERSISTED to
+// storage (not CSS-only), because OCR re-reads `payout_documents.url` from
+// storage. We write a NEW rotated object to a fresh path (cache-safe) and
+// repoint `doc.url`. Only changes `url` — never amount/currency/USD/line items.
+//
+// Body: { degrees: 90 | -90 | 180 }
+// Returns: { document: { id, url } }
+// ============================================
+router.post(
+  '/documents/:docId/rotate',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { docId } = req.params;
+      const body = (req.body || {}) as { degrees?: unknown };
+      const degrees = Number(body.degrees);
+      if (degrees !== 90 && degrees !== -90 && degrees !== 180) {
+        throw new AppError('degrees must be 90, -90, or 180', 400, 'INVALID_ROTATION');
+      }
+
+      const existing = await prisma.payoutDocument.findUnique({
+        where: { id: docId },
+        select: { id: true, url: true, kind: true, fileName: true, partyId: true },
+      });
+      if (!existing) {
+        throw new AppError('Document not found', 404, 'NOT_FOUND');
+      }
+
+      // Fetch the bytes (Node 18+ global fetch).
+      const resp = await fetch(existing.url);
+      if (!resp.ok) {
+        throw new AppError('Could not fetch the receipt image', 502, 'ROTATE_FETCH_FAILED');
+      }
+      const contentType = resp.headers.get('content-type') || '';
+
+      // Reject non-raster formats — sharp cannot decode HEIC on Vercel and PDFs
+      // aren't raster. Check both the content-type and the url/fileName extension.
+      const lowerUrl = (existing.url || '').toLowerCase();
+      const lowerName = (existing.fileName || '').toLowerCase();
+      const isUnsupported =
+        contentType.includes('pdf') ||
+        contentType.includes('heic') ||
+        contentType.includes('heif') ||
+        /\.(pdf|heic|heif)$/.test(lowerUrl.split('?')[0]) ||
+        /\.(pdf|heic|heif)$/.test(lowerName);
+      if (isUnsupported) {
+        throw new AppError(
+          'Rotation is only supported for JPG/PNG images',
+          400,
+          'ROTATE_UNSUPPORTED_FORMAT',
+        );
+      }
+
+      // Rotate clockwise by `degrees` and bake it into the pixels. No format
+      // method preserves the input format.
+      const inputBuf = Buffer.from(await resp.arrayBuffer());
+      const rotated = await sharp(inputBuf).rotate(degrees).toBuffer();
+
+      // Upload a NEW object (do NOT overwrite — a fresh path avoids CDN/browser
+      // cache staleness). Mirror logoAudit.routes.ts's admin client pattern.
+      const supabaseAdmin = createClient(
+        process.env.SUPABASE_URL!,
+        process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      );
+      const ROTATE_BUCKET = 'event-images';
+
+      // Derive the storage path from the public URL. Fall back to a synthesized
+      // path under payouts/{partyId}/ so it still passes the OCR url guard.
+      let newPath: string;
+      const marker = '/object/public/event-images/';
+      const markerIdx = existing.url.indexOf(marker);
+      if (markerIdx !== -1) {
+        let rawPath = existing.url.slice(markerIdx + marker.length);
+        // Strip any query string off the object path.
+        rawPath = rawPath.split('?')[0];
+        const dotIdx = rawPath.lastIndexOf('.');
+        const pathWithoutExt = dotIdx === -1 ? rawPath : rawPath.slice(0, dotIdx);
+        const ext = dotIdx === -1 ? '.jpg' : rawPath.slice(dotIdx);
+        newPath = `${pathWithoutExt}-r${Date.now()}${ext}`;
+      } else {
+        newPath = `payouts/${existing.partyId}/${existing.id}-r${Date.now()}.jpg`;
+      }
+
+      const { error: uploadError } = await supabaseAdmin.storage
+        .from(ROTATE_BUCKET)
+        .upload(newPath, rotated, {
+          contentType: contentType || 'image/jpeg',
+          upsert: false,
+        });
+      if (uploadError) {
+        throw new AppError('Failed to upload rotated image', 502, 'ROTATE_UPLOAD_FAILED');
+      }
+
+      const { data: urlData } = supabaseAdmin.storage
+        .from(ROTATE_BUCKET)
+        .getPublicUrl(newPath);
+      const newUrl = urlData.publicUrl;
+
+      await prisma.payoutDocument.update({
+        where: { id: docId },
+        data: { url: newUrl },
+      });
+
+      res.json({ document: { id: existing.id, url: newUrl } });
     } catch (err) {
       next(err);
     }

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '../Checkbox';
 import { ClickableEmail } from '../ClickableEmail';
 import { SwcHubWarning } from './SwcHubWarning';
 import { isSwcHubParty } from '../../utils/swcHub';
-import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, summarizePayoutDocument, markReceiptDuplicate, markReceiptIneligible, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
+import { updatePartyApi, updatePayoutDocument, retryPayoutDocumentOcr, rotatePayoutDocument, summarizePayoutDocument, markReceiptDuplicate, markReceiptIneligible, getImageAuthenticityCheck, type ImageAuthenticityCheck } from '../../lib/api';
 import { isVideoFile } from '../../lib/mediaUtils';
 import { usePayoutCaps } from '../../hooks/usePayoutCaps';
 import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
@@ -567,6 +567,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     // show the new summary/language immediately without a parent refetch.
     ocrLanguage?: string | null;
     ocrSummary?: string | null;
+    // farinata-58536: post-rotate url so the lightbox image re-renders rotated
+    // immediately (backend repoints the doc url to a fresh storage object).
+    url?: string;
   };
   const [receiptOverrides, setReceiptOverrides] = useState<Record<string, ReceiptOverride>>({});
   // Per-row save state.
@@ -601,6 +604,12 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
   // ocrError from `payout.documents` once retry succeeds. We only set true
   // on success; failures still surface a per-row error chip.
   const [retryClearedErrors, setRetryClearedErrors] = useState<Record<string, boolean>>({});
+
+  // farinata-58536: per-row "Rotate" state. Admin can rotate a sideways receipt
+  // image so it's readable + so the next Re-run OCR reads the corrected
+  // orientation. Mirrors the retry-OCR state shape.
+  const [rotatingDocId, setRotatingDocId] = useState<string | null>(null);
+  const [rotateErrors, setRotateErrors] = useState<Record<string, string>>({});
 
   // bruschetta-58519: per-row "Summarize" backfill state (language + English
   // summary). Mirrors the retry-OCR state shape — one in-flight docId + a
@@ -707,6 +716,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               ov.ocrLanguage !== undefined ? ov.ocrLanguage : d.ocrLanguage,
             ocrSummary:
               ov.ocrSummary !== undefined ? ov.ocrSummary : d.ocrSummary,
+            // farinata-58536: layer the rotated url so the lightbox shows the
+            // corrected orientation immediately.
+            url: ov.url !== undefined ? ov.url : d.url,
           };
         }),
     [payout.documents, receiptOverrides],
@@ -1010,6 +1022,32 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
       }));
     } finally {
       setRetryingDocId(null);
+    }
+  }
+
+  // farinata-58536: rotate a sideways receipt image. The backend persists the
+  // rotation to a new storage object and repoints the doc url; we merge the new
+  // url into receiptOverrides so the lightbox image re-renders upright in place.
+  async function rotateDoc(docId: string, degrees: 90 | -90 | 180) {
+    setRotatingDocId(docId);
+    setRotateErrors((m) => {
+      const next = { ...m };
+      delete next[docId];
+      return next;
+    });
+    try {
+      const res = await rotatePayoutDocument(docId, degrees);
+      setReceiptOverrides((m) => ({
+        ...m,
+        [docId]: { ...m[docId], url: res.document.url },
+      }));
+    } catch (err: any) {
+      setRotateErrors((m) => ({
+        ...m,
+        [docId]: err?.message ? String(err.message) : 'Rotate failed',
+      }));
+    } finally {
+      setRotatingDocId(null);
     }
   }
 
@@ -1615,6 +1653,9 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
         retrying={retryingDocId === r.id}
         retryError={retryErrors[r.id]}
         onRetryOcr={() => retryOcr(r.id)}
+        onRotate={(deg) => rotateDoc(r.id, deg)}
+        rotating={rotatingDocId === r.id}
+        rotateError={rotateErrors[r.id]}
         onSummarize={() => summarizeDoc(r.id)}
         summarizing={summarizingDocId === r.id}
         summarizeError={summarizeErrors[r.id]}
@@ -1654,6 +1695,8 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
     retryingDocId,
     retryErrors,
     retryClearedErrors,
+    rotatingDocId,
+    rotateErrors,
     summarizingDocId,
     summarizeErrors,
     authChecks,

--- a/frontend/src/components/payments-admin/ReceiptEditor.tsx
+++ b/frontend/src/components/payments-admin/ReceiptEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw, Receipt, Languages, Sparkles } from 'lucide-react';
+import { Loader2, Plus, Trash2, Copy, DollarSign, AlertTriangle, RefreshCw, Receipt, Languages, Sparkles, RotateCcw, RotateCw } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { CurrencyPicker } from './CurrencyPicker';
@@ -108,6 +108,16 @@ interface ReceiptEditorProps {
   onRetryOcr?: () => void;
 
   /**
+   * farinata-58536: optional rotate affordance. When provided, the editor
+   * header shows rotate-left (−90°) / rotate-right (+90°) icon buttons. The
+   * parent persists the rotation server-side and repoints the doc url. Same
+   * spinner/disabled-in-flight + inline-error pattern as retry-OCR.
+   */
+  onRotate?: (degrees: 90 | -90 | 180) => void;
+  rotating?: boolean;
+  rotateError?: string;
+
+  /**
    * bruschetta-58519: on-demand "Summarize" backfill. When the receipt has no
    * `ocrSummary` yet (historical rows predating the feature), the editor shows
    * a Summarize button wired to this callback. The parent calls
@@ -198,6 +208,9 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
   retrying,
   retryError,
   onRetryOcr,
+  onRotate,
+  rotating,
+  rotateError,
   onSummarize,
   summarizing,
   summarizeError,
@@ -337,16 +350,58 @@ export const ReceiptEditor: React.FC<ReceiptEditorProps> = ({
             </p>
           )}
         </div>
-        {conf > 0 && (
-          <span
-            className={`text-xs whitespace-nowrap ${
-              lowConf ? 'text-amber-500' : 'text-theme-text-faint'
-            }`}
-            title="OCR confidence"
-          >
-            {(conf * 100).toFixed(0)}% confidence
-          </span>
-        )}
+        <div className="flex flex-col items-end gap-1 flex-shrink-0">
+          <div className="flex items-center gap-2">
+            {/* farinata-58536: rotate a sideways receipt. Persisted server-side
+                so the next Re-run OCR reads the corrected orientation. Same
+                style/disabled/spinner pattern as the Re-run OCR button. */}
+            {onRotate && (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => onRotate(-90)}
+                  disabled={rotating}
+                  title="Rotate left 90°"
+                  className="px-1.5 py-1 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center justify-center flex-shrink-0"
+                >
+                  {rotating ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : (
+                    <RotateCcw size={12} />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRotate(90)}
+                  disabled={rotating}
+                  title="Rotate right 90°"
+                  className="px-1.5 py-1 rounded border border-theme-stroke text-theme-text text-xs disabled:opacity-40 inline-flex items-center justify-center flex-shrink-0"
+                >
+                  {rotating ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : (
+                    <RotateCw size={12} />
+                  )}
+                </button>
+              </div>
+            )}
+            {conf > 0 && (
+              <span
+                className={`text-xs whitespace-nowrap ${
+                  lowConf ? 'text-amber-500' : 'text-theme-text-faint'
+                }`}
+                title="OCR confidence"
+              >
+                {(conf * 100).toFixed(0)}% confidence
+              </span>
+            )}
+          </div>
+          {onRotate && rotateError && (
+            <div className="text-xs text-red-300 text-right max-w-[200px]">
+              {rotateError}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* bruschetta-58519: compact Summary block. Shows the OCR English summary

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5554,6 +5554,21 @@ export async function retryPayoutDocumentOcr(
 }
 
 /**
+ * farinata-58536: admin rotates a sideways receipt image. The backend persists
+ * the rotation to a NEW storage object and repoints the doc's url (so a
+ * subsequent "Re-run OCR" reads the corrected orientation). Only changes url.
+ */
+export async function rotatePayoutDocument(
+  docId: string,
+  degrees: 90 | -90 | 180,
+): Promise<{ document: { id: string; url: string } }> {
+  return apiRequest(
+    `/api/admin/payouts/documents/${docId}/rotate`,
+    { method: 'POST', body: { degrees } },
+  );
+}
+
+/**
  * bruschetta-58519: admin on-demand "Summarize" backfill. Re-runs OCR on a
  * single receipt and updates ONLY `ocrLanguage` + `ocrSummary` (preserving any
  * admin-edited amount/currency/lineItems). Used to populate the new language +

--- a/plans/farinata-58536-rotate-receipt.md
+++ b/plans/farinata-58536-rotate-receipt.md
@@ -1,0 +1,128 @@
+# farinata-58536: Rotate control in the receipt editor
+
+**Branch**: `farinata-58536-rotate-receipt` (off `origin/master`)
+**Preview**: `https://rsvpizza-git-farinata-58536-rotate-receipt-pizza-dao.vercel.app`
+
+## Context
+Some receipts are uploaded sideways (e.g. the Santiago de Chile receipt
+`1000271295.jpg`, doc `51c2def9`). gpt-4o reads rotated text inconsistently, and
+the deployed OCR pipeline only honors **EXIF** orientation (sharp `.rotate()` with
+no arg in `imageUrlToBase64DataUrl`), which does nothing for a scan with no/incorrect
+EXIF. Admins need a way to rotate a receipt so it's readable **and** so the next
+"Re-run OCR" reads the corrected orientation.
+
+Decision: the rotation must be **persisted to the stored image** (not a CSS-only
+display transform), because OCR re-reads `payout_documents.url` from storage. We
+rotate by writing a **new** rotated object to storage and repointing `doc.url` — a
+new path avoids CDN/browser cache staleness, and rotation is itself reversible
+(rotate back). No DB migration (the `url` column already exists).
+
+## What already exists (reuse, don't rebuild)
+- **sharp** is a backend dependency (`backend/package.json`, `^0.33.5`).
+- **Storage upload pattern**: `backend/src/routes/logoAudit.routes.ts:347` /
+  `:465` — `createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)` then
+  `supabaseAdmin.storage.from(BUCKET).upload(path, buffer, { contentType, upsert })`
+  + `.getPublicUrl(path)`. Mirror this. `taxFormStorage.service.ts` is another example.
+- **Bucket**: receipts live in the **`event-images`** bucket under
+  `payouts/{partyId}/` (see `payout.routes.ts:230,270,276`). Write the rotated copy
+  under the same `payouts/{partyId}/` prefix so it satisfies the OCR URL guard.
+- **Retry-OCR endpoint** (`admin-payout.routes.ts:6118`,
+  `POST /documents/:docId/retry-ocr`) — mirror its auth
+  (`requireAuth` + `requireAnyAdminOrPaymentAdmin`), the `findUnique` doc lookup, and
+  the `{ document: {...} }` response shape.
+- **Frontend optimistic plumbing**: `receiptOverrides` merge in
+  `PayoutReviewModal.tsx:651-686` (the `ReceiptOverride` type is at `:539-555`) and
+  the `retryOcr` success handler at `:925-960` — mirror both.
+- **Editor buttons**: the "Re-run OCR" button row in
+  `ReceiptEditor.tsx:534-554` is the model for a compact icon button with a
+  `Loader2` spinner + disabled in-flight state + inline error.
+
+## Changes
+
+### 1. Backend — `backend/src/routes/admin-payout.routes.ts` (new endpoint)
+Add `POST /documents/:docId/rotate`, placed near the retry-ocr handler (~6118):
+- Auth: `requireAuth`, `requireAnyAdminOrPaymentAdmin` (same as retry-ocr).
+- Body: `{ degrees: 90 | -90 | 180 }`. Validate it's one of those three; else
+  `AppError('degrees must be 90, -90, or 180', 400, 'INVALID_ROTATION')`.
+- `prisma.payoutDocument.findUnique({ where: { id: docId }, select: { id, url, kind, fileName, partyId } })`;
+  404 if missing.
+- **Guard the input format.** Fetch the bytes: `const resp = await fetch(existing.url)`.
+  Determine content type from the response `content-type` header (fallback: extension).
+  Reject non-raster: if it's a PDF (`application/pdf` / `.pdf`) or HEIC
+  (`image/heic`/`image/heif`/`.heic`/`.heif`) → `AppError('Rotation is only supported
+  for JPG/PNG images', 400, 'ROTATE_UNSUPPORTED_FORMAT')`. (sharp can't decode HEIC on
+  Vercel — see `architecture_heic_decode_limits`; PDFs aren't raster.)
+- Rotate: `import sharp from 'sharp'` (top-level import is fine; it's already a dep).
+  `const rotated = await sharp(Buffer.from(await resp.arrayBuffer())).rotate(degrees).toBuffer();`
+  (`.rotate(angle)` with an explicit angle rotates clockwise by that many degrees and
+  bakes orientation into the pixels; no format method preserves the input format.)
+- Upload a **new** object (cache-safe). Build the storage path from the existing URL:
+  take the path segment after `/object/public/event-images/` and insert a suffix
+  before the extension, e.g. `payouts/{partyId}/{base}-r{Date.now()}{ext}`. Use the
+  `event-images` bucket + the `createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)`
+  admin client (mirror logoAudit). `upload(newPath, rotated, { contentType, upsert: false })`,
+  then `getPublicUrl(newPath)`.
+- `prisma.payoutDocument.update({ where: { id: docId }, data: { url: newUrl } })`.
+- Respond `{ document: { id, url: newUrl } }`.
+- Do **NOT** delete the old object (it may be the original upload / referenced
+  elsewhere). Leaving an orphan is acceptable; note it as a possible future cleanup.
+- Do **NOT** re-run OCR here — keep rotate and OCR as separate explicit admin actions
+  (admin clicks "Re-run OCR" after rotating). Same single-responsibility contract as
+  retry-ocr / the per-receipt PATCH.
+
+### 2. Frontend API — `frontend/src/lib/api.ts`
+Add `rotatePayoutDocument(docId: string, degrees: 90 | -90 | 180): Promise<{ document: { id: string; url: string } }>`
+next to `retryPayoutDocumentOcr` (~`:4542`). POST to
+`/admin/payouts/documents/${docId}/rotate` with `{ degrees }`.
+
+### 3. Modal handler — `frontend/src/components/payments-admin/PayoutReviewModal.tsx`
+- Add `url?: string` to the `ReceiptOverride` type (`:539`) and merge it in the
+  `receipts` memo (`:664-683`): `url: ov.url !== undefined ? ov.url : d.url`.
+- Add per-row rotate state mirroring retry-OCR: `rotatingDocId`, `rotateErrors`.
+- Add `async function rotateDoc(docId, degrees)` mirroring `retryOcr` (`:925`):
+  set rotating, call `rotatePayoutDocument`, on success
+  `setReceiptOverrides((m) => ({ ...m, [docId]: { ...m[docId], url: res.document.url } }))`
+  so the lightbox image re-renders rotated; clear on error into `rotateErrors`.
+- Pass `onRotate`, `rotating`, `rotateError` down to `ReceiptEditor` at the
+  lightbox render site (where `onRetryOcr` is wired, ~`:1547`).
+
+### 4. Editor buttons — `frontend/src/components/payments-admin/ReceiptEditor.tsx`
+- Add props: `onRotate?: (degrees: 90 | -90 | 180) => void; rotating?: boolean; rotateError?: string;`
+- Render two compact icon buttons (lucide `RotateCcw` = rotate left / `-90`,
+  `RotateCw` = rotate right / `90`) in the header row (`:300-335`), next to the
+  confidence chip. Same spinner/disabled pattern as the Re-run OCR button; show
+  `rotateError` inline. Honor the literal ask ("in the receipt editor"); an overlay
+  on the lightbox image is an optional nice-to-have, out of scope here.
+
+## Constraints / gotchas
+- **Backend deploys from master only**; previews hit the prod backend, so the new
+  `/rotate` endpoint is NOT live on the preview until merged + backend deploys from
+  `master`. The frontend buttons will 404 against the current prod backend until then
+  — verify end-to-end only after merge.
+- **No migration** — `url` already exists on `payout_documents`. (No schema change =
+  no pre-merge DB step.)
+- **HEIC/PDF**: explicitly rejected with a clear 400 (sharp can't decode HEIC on
+  Vercel; PDFs aren't raster). Don't silently no-op.
+- **New URL, not overwrite** — repointing to a fresh path avoids the CDN/browser
+  caching the pre-rotation pixels under the same URL.
+- **Money path untouched** — rotate only changes `url`; it does not write
+  amount/currency/USD. OCR re-read remains the only path that sets those.
+
+## Verification
+1. `cd frontend && npm run build` passes; `cd backend && npx tsc --noEmit` passes.
+2. After backend deploy from master: open receipt `51c2def9` (Santiago de Chile,
+   `1000271295.jpg`) in the review lightbox. Click rotate-left (−90°) → the image
+   re-renders upright in place (no full refetch).
+3. Click **Re-run OCR** → line items/amount/currency populate from the now-readable
+   image (requires the `llm.models.ocrCheap` config fix to be live, separately).
+4. Rotating a PDF/HEIC receipt surfaces the `ROTATE_UNSUPPORTED_FORMAT` 400 inline,
+   not a generic 500.
+5. Reload the page → the rotation persists (url repointed in the DB).
+
+## Related
+- Separate prod-config fix (NOT part of this PR): `app_config.llm.models` is missing
+  the `ocrCheap` key, so the deployed OCR routing calls OpenAI with
+  `model: undefined` → "400 you must provide a model parameter". Re-seed the blob to
+  add `"ocrCheap":"gpt-4o-mini"`. Without that, Re-run OCR fails regardless of
+  rotation. (Also worth a code follow-up: `getLlmModels` should tolerate a missing
+  key, e.g. `ocrCheap || ocr`, since `getConfig` doesn't merge defaults.)


### PR DESCRIPTION
## What
Two related changes:

**1. Rotate control in the receipt editor** — rotate-left / rotate-right buttons in the payments review lightbox, so admins can fix sideways receipts (e.g. Santiago de Chile `1000271295.jpg`). The rotation is **persisted to storage** — the backend rotates the image with `sharp`, uploads it as a **new** object (cache-safe), and repoints `payout_documents.url`. So the next **Re-run OCR** reads the corrected orientation, not just the on-screen display.

**2. OCR resilience fix** — `getLlmModels` now coalesces every field against the code default. `getConfig` returns the stored `app_config` blob verbatim (no deep-merge), so a prod blob seeded before `ocrCheap` was added (bruschetta-58519) left it `undefined` → reached OpenAI as `model: undefined` → **400 "you must provide a model parameter", which broke ALL receipt OCR**. After this merges + deploys, OCR self-heals regardless of the stored blob.

## Changes
- **Backend** — `POST /api/admin/payouts/documents/:docId/rotate` `{ degrees: 90 | -90 | 180 }`. Fetch → `sharp().rotate()` → re-upload under `event-images/payouts/{partyId}/…-r{ts}` → repoint `url`. Rejects PDF/HEIC with a clear 400. Only mutates `url`.
- **Backend** — `getLlmModels` coalesces missing/blank keys (`cfg.ocrCheap || defaults.ocrCheap`, etc.) + regression tests.
- **Frontend** — `rotatePayoutDocument()` API; rotate buttons in `ReceiptEditor` header (same spinner/disabled/inline-error pattern as Re-run OCR); optimistic `receiptOverrides.url` swap so the lightbox image re-renders upright in place.

## Notes
- **No DB migration** (`url` column already exists).
- **Backend deploys from master only** — the `/rotate` endpoint and the OCR fix are NOT live on this preview until merged + backend deploys; the rotate buttons will 404 against the current prod backend until then.
- **Stopgap before merge:** OCR is broken in prod *now*; re-seed the blob to restore it immediately without waiting for this deploy: `UPDATE app_config SET value = '{"ocr":"gpt-4o","ocrCheap":"gpt-4o-mini","visionPrimary":"gpt-4o","assistant":"gpt-4o-mini","visionSecondOpinion":"claude-3-5-sonnet-latest"}' WHERE key = 'llm.models';`
- Plan: `plans/farinata-58536-rotate-receipt.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)