### PR TITLE
suppli-58533: PDF receipt support for Telegram host-inbound (rasterize page 1 for OCR)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.100.1",
+    "@napi-rs/canvas": "^0.1.100",
     "@prisma/client": "^6.8.2",
     "@privy-io/server-auth": "^1.32.5",
     "@supabase/supabase-js": "^2.49.1",
@@ -33,6 +34,7 @@
     "nanoid": "^5.0.5",
     "openai": "^6.38.0",
     "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^4.10.38",
     "pg": "^8.21.0",
     "sharp": "^0.33.5",
     "swagger-jsdoc": "^6.2.8",

--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -35,6 +35,7 @@ import { sendTelegramMessage } from '../services/telegramSend.js';
 import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
 import { sanitizePgString, sanitizeForPg } from '../lib/sanitizePg.js';
+import { rasterizePdfFirstPage } from '../services/pdfRasterize.js';
 
 const router = Router();
 
@@ -104,13 +105,17 @@ router.post(
         return res.status(401).json({ ok: false, action: 'ignored', reason: 'unauthorized' });
       }
 
-      const { chatId, kind, fileId, imageBase64, text } = (req.body || {}) as {
+      const { chatId, kind, fileId, imageBase64, text, mimeType } = (req.body || {}) as {
         chatId?: number | string;
         kind?: string;
         fileId?: string;
         fileUniqueId?: string;
         imageBase64?: string;
         text?: string;
+        // suppli-58533: the bot now forwards PDF receipts with kind:'photo' and
+        // a mimeType of 'application/pdf'. Optional; we also sniff the downloaded
+        // file extension as a belt-and-suspenders PDF check below.
+        mimeType?: string;
       };
 
       // Validate chatId is integer-like before BigInt() (which throws).
@@ -214,6 +219,47 @@ router.post(
         return res.status(200).json({ ok: false, action: 'ignored', reason: 'download-failed' });
       }
 
+      // suppli-58533: PDF receipts. The bot forwards PDFs with kind:'photo' +
+      // mimeType 'application/pdf'; also sniff the downloaded extension as a
+      // belt-and-suspenders check when mimeType is absent. gpt-4o vision can't
+      // read a PDF via image_url, so rasterize page 1 to a PNG and feed THAT
+      // into the same receipt path (so it OCRs and renders in the /payments
+      // <img> grids). PDFs are ALWAYS filed as receipts, never event photos.
+      const claimedPdf =
+        typeof mimeType === 'string' && mimeType.trim().toLowerCase() === 'application/pdf';
+      const looksLikePdf =
+        downloaded.mimeType.toLowerCase() === 'application/pdf' ||
+        /\.pdf$/i.test(downloaded.fileName);
+      const isPdf = claimedPdf || looksLikePdf;
+
+      if (isPdf) {
+        let raster: Awaited<ReturnType<typeof rasterizePdfFirstPage>>;
+        try {
+          raster = await rasterizePdfFirstPage(downloaded.buffer);
+        } catch (err: any) {
+          console.error('[suppli-58533][host-inbound] PDF rasterize failed:', err?.message || err);
+          await sendTelegramMessage(
+            chatIdStr,
+            "I couldn't read that PDF — try sending a photo of the receipt instead.",
+          );
+          return res.status(200).json({ ok: false, action: 'ignored', reason: 'pdf_rasterize_failed' });
+        }
+        if (raster.pageCount > 1) {
+          console.warn(
+            `[suppli-58533] PDF has ${raster.pageCount} pages; only page 1 rasterized`,
+          );
+        }
+        // Swap the image bytes/metadata to the rasterized PNG. Keep the original
+        // .pdf base filename for traceability but as a .png so the upload + the
+        // /payments <img> grid treat it as an image.
+        const pngFileName = downloaded.fileName.replace(/\.pdf$/i, '') + '.png';
+        downloaded = {
+          buffer: raster.pngBuffer,
+          mimeType: 'image/png',
+          fileName: pngFileName,
+        };
+      }
+
       const { url } = await uploadPayoutBuffer(downloaded.buffer, party.id, downloaded.mimeType);
 
       // ---- OCR the image to decide receipt vs. event photo ----
@@ -233,7 +279,31 @@ router.post(
         ocr.confidence >= RECEIPT_OCR_CONFIDENCE_MIN &&
         (!!ocr.merchant || (Array.isArray(ocr.lineItems) && ocr.lineItems.length > 0));
 
-      if (looksLikeReceipt && ocr) {
+      // suppli-58533: a PDF is ALWAYS filed as a receipt even when OCR threw or
+      // read nothing. Synthesize an empty OCR result so the receipt-persist block
+      // below (which dereferences ocr.*) is null-safe; the row stores with no
+      // amount/currency (host can fix it on /payments) but the PDF is preserved.
+      if (isPdf && ocr == null) {
+        ocr = {
+          amount: 0,
+          currency: null,
+          confidence: 0,
+          items: undefined,
+          lineItems: [],
+          merchant: null,
+          receiptDate: null,
+          boundingHint: null,
+          language: null,
+          summary: null,
+          raw: { receipts: [], note: 'pdf_ocr_failed' },
+        };
+      }
+
+      // suppli-58533: a PDF is ALWAYS a receipt — file it as one even if OCR
+      // confidence is low / no amount was read (store with whatever OCR fields
+      // it got). Never route a PDF to the event-photo branch below. For PDFs
+      // `ocr` is guaranteed non-null by the synthesize-empty guard above.
+      if ((isPdf || looksLikeReceipt) && ocr) {
         // ---- RECEIPT path: mirror payout.routes.ts:731-796 column mapping ----
         const fx = await convertToUSD(ocr.amount, ocr.currency);
         const unresolved = fx.source === 'unresolved' || fx.usdAmount == null;
@@ -296,12 +366,16 @@ router.post(
           where: { partyId: party.id, kind: 'receipt' },
         });
 
+        // suppli-58533: when no amount was read (e.g. a PDF whose OCR found no
+        // total), omit the amount fragment so the confirmation still reads
+        // cleanly ("Got your receipt for {party} — that's N receipts on file.").
         const amountLabel = unresolved
-          ? `${ocr.amount.toLocaleString()} ${ocr.currency ?? ''}`.trim()
+          ? (ocr.amount > 0 ? `${ocr.amount.toLocaleString()} ${ocr.currency ?? ''}`.trim() : '')
           : `$${fx.usdAmount!.toFixed(2)}`;
+        const amountFragment = amountLabel ? ` — ${amountLabel}` : '';
         await sendTelegramMessage(
           chatIdStr,
-          `✅ Got your receipt for ${party.name} — ${amountLabel}. ` +
+          `✅ Got your receipt for ${party.name}${amountFragment}. ` +
             `That's ${receiptCount} receipt${receiptCount === 1 ? '' : 's'} on file.`,
         );
         return res.status(200).json({ ok: true, action: 'receipt', partyName: party.name });

--- a/backend/src/services/pdfRasterize.ts
+++ b/backend/src/services/pdfRasterize.ts
@@ -1,0 +1,118 @@
+/**
+ * suppli-58533: rasterize the first page of a PDF receipt to a PNG buffer.
+ *
+ * WHY: hosts can now DM PDF receipts to Molto Benny (the Telegram bot forwards
+ * them to POST /api/telegram/host-inbound with mimeType 'application/pdf').
+ * gpt-4o vision CANNOT read a PDF via image_url — a PDF must be rasterized to a
+ * raster image first. We render page 1 to a PNG and feed THAT into the exact
+ * same receipt path every other image takes (upload PNG → analyzeReceipt → store
+ * as a payout_documents receipt). The PNG also displays in the /payments receipt
+ * <img> grids, where a raw PDF url would not render.
+ *
+ * LIBRARY CHOICE: `pdfjs-dist` (Mozilla's pdf.js, the `legacy/build` CommonJS-
+ * friendly bundle) + `@napi-rs/canvas` (a PREBUILT native canvas). We
+ * deliberately do NOT use:
+ *   - the `canvas` npm package — it needs system libs (cairo/pango) that aren't
+ *     present on Vercel's serverless Linux Node runtime.
+ *   - `pdf-to-png-converter` (a pdfjs+canvas wrapper) — it builds a cmaps URL
+ *     from a raw filesystem path and, on Windows, pdf.js rejects it with
+ *     "Invalid factory url ... must include trailing slash"; it also hides the
+ *     pdfjs options we need. Driving pdfjs directly lets us pass proper
+ *     `file://` URLs (with trailing slash) for the standard fonts + cmaps so
+ *     text and CJK receipts render.
+ * `@napi-rs/canvas` ships prebuilt .node binaries per platform (incl. linux-x64
+ * which Vercel uses), so there's no system-library/build-from-source dependency.
+ *
+ * RUNTIME CAVEAT: the native @napi-rs/canvas binary builds + runs locally, but
+ * it must also load on Vercel's serverless Node runtime — that can only be truly
+ * verified post-deploy. If it ever fails to load there, the caller's try/catch
+ * surfaces a graceful "send a photo instead" reply rather than a 500.
+ */
+
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+// pdfjs's `legacy/build` is the Node-safe bundle (no DOM worker assumptions).
+// Imported lazily inside the function so a load failure is caught by the caller.
+const require = createRequire(import.meta.url);
+
+/** Render scale. ~2x keeps small receipt text legible for the vision model. */
+const RASTER_SCALE = 2;
+
+export interface RasterizedPdf {
+  pngBuffer: Buffer;
+  pageCount: number;
+}
+
+/**
+ * Rasterize page 1 of a PDF to a PNG buffer.
+ *
+ * Returns `{ pngBuffer, pageCount }`. Callers should log a warning when
+ * pageCount > 1 (only page 1 is rendered) and treat a thrown error as
+ * "couldn't read the PDF" (reply to the host, don't 500).
+ */
+export async function rasterizePdfFirstPage(
+  pdfBuffer: Buffer,
+): Promise<RasterizedPdf> {
+  // Lazy ESM import of the legacy build (works under NodeNext + native fetch).
+  const pdfjsLib: any = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const { createCanvas } = await import('@napi-rs/canvas');
+
+  // Point pdf.js at the standard fonts + cmaps that ship inside pdfjs-dist, as
+  // proper file:// URLs WITH a trailing slash (pdf.js requires the slash). This
+  // lets standard-font and CJK receipts render glyphs instead of blanks.
+  const pdfjsPkgDir = path.dirname(require.resolve('pdfjs-dist/package.json'));
+  const standardFontDataUrl = pathToFileURL(
+    path.join(pdfjsPkgDir, 'standard_fonts') + path.sep,
+  ).href;
+  const cMapUrl = pathToFileURL(path.join(pdfjsPkgDir, 'cmaps') + path.sep).href;
+
+  const loadingTask = pdfjsLib.getDocument({
+    // pdf.js wants a Uint8Array; copy out of the Node Buffer.
+    data: new Uint8Array(pdfBuffer),
+    standardFontDataUrl,
+    cMapUrl,
+    cMapPacked: true,
+    // disableFontFace: render via the path generator (no DOM FontFace API on
+    // the native canvas); isEvalSupported off for safety in a server context.
+    disableFontFace: true,
+    isEvalSupported: false,
+  });
+
+  const pdf = await loadingTask.promise;
+  try {
+    const pageCount: number = pdf.numPages;
+
+    const page = await pdf.getPage(1);
+    const viewport = page.getViewport({ scale: RASTER_SCALE });
+    const width = Math.max(1, Math.ceil(viewport.width));
+    const height = Math.max(1, Math.ceil(viewport.height));
+
+    const canvas = createCanvas(width, height);
+    const ctx = canvas.getContext('2d');
+    // White backdrop so transparent PDFs don't OCR as black-on-black.
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, width, height);
+
+    await page.render({
+      canvasContext: ctx as unknown as CanvasRenderingContext2D,
+      viewport,
+      // pdf.js v4 also accepts the canvas itself; pass it for forward-compat.
+      canvas: canvas as unknown as HTMLCanvasElement,
+    }).promise;
+
+    const pngBuffer = canvas.toBuffer('image/png');
+    if (!pngBuffer || pngBuffer.length === 0) {
+      throw new Error('rasterized PNG was empty');
+    }
+    return { pngBuffer, pageCount };
+  } finally {
+    // Free pdf.js worker resources.
+    try {
+      await pdf.cleanup();
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
+        "@napi-rs/canvas": "^0.1.100",
         "@prisma/client": "^6.8.2",
         "@privy-io/server-auth": "^1.32.5",
         "@supabase/supabase-js": "^2.49.1",
@@ -34,6 +35,7 @@
         "nanoid": "^5.0.5",
         "openai": "^6.38.0",
         "pdf-lib": "^1.17.1",
+        "pdfjs-dist": "^4.10.38",
         "pg": "^8.21.0",
         "sharp": "^0.33.5",
         "swagger-jsdoc": "^6.2.8",
@@ -162,6 +164,18 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "backend/node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
       }
     },
     "backend/node_modules/readable-stream": {


### PR DESCRIPTION
The Molto Benny bot now forwards **PDF** receipts (host DMs a PDF) to `POST /api/telegram/host-inbound` with `kind:'photo'` + a new `mimeType: 'application/pdf'`. gpt-4o vision **can't** read a PDF via `image_url`, so this rasterizes **page 1** to a PNG, uploads the PNG (so it renders in the `/payments` receipt `<img>` grids), OCRs the PNG, and files it as a `payout_documents` **receipt** (never an event photo, even on low/failed OCR).

### What changed
- **New `backend/src/services/pdfRasterize.ts`** — `rasterizePdfFirstPage(pdfBuffer)` using `pdfjs-dist` (legacy build) + `@napi-rs/canvas` (prebuilt native canvas; no system libs, unlike the `canvas` pkg). Renders page 1 at 2x; returns `{ pngBuffer, pageCount }`.
- **`telegram-inbound.routes.ts`** — accepts optional `mimeType`; also sniffs a `.pdf` extension (belt-and-suspenders). When PDF: rasterize page 1 → swap in the PNG bytes → existing upload + `analyzeReceipt` + receipt-persist path (reused, not duplicated). `pageCount>1` logs a warning and still processes page 1. Rasterize failure replies "send a photo instead" and returns `action:'ignored', reason:'pdf_rasterize_failed'` — never 500s to moltobene.
- Adds 2 deps: `pdfjs-dist`, `@napi-rs/canvas`.

### Lib choice
Chose **direct `pdfjs-dist` + `@napi-rs/canvas`** over the `pdf-to-png-converter` wrapper: the wrapper builds a cmaps URL from a raw path and pdf.js rejects it on Windows ("Invalid factory url ... must include trailing slash"), and it hides the pdfjs options needed for standard-font/CJK rendering. Driving pdfjs directly lets us pass proper `file://` font/cmap URLs.

### ⚠️ Vercel-runtime risk
`@napi-rs/canvas` is a **native** dep. It builds + runs locally (verified: rasterizes a multi-page PDF to a valid PNG, reports correct page count), but the prebuilt `.node` binary must also load on **Vercel's serverless Node runtime** — that can only be truly verified **post-deploy**. Backend auto-deploys from master; verify the rasterizer works on a real PDF after merge. If the native binary ever fails to load there, the route's try/catch surfaces the graceful "send a photo instead" reply rather than a 500.

Pairs with moltobene #8 (the bot side that forwards PDFs). No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)