### PR TITLE
test(gnocco-58537): fix stale getPayoutCaps low-fallback assertion

### DIFF
--- a/backend/src/lib/privateConfig.test.ts
+++ b/backend/src/lib/privateConfig.test.ts
@@ -53,12 +53,21 @@ describe('getPayoutCaps', () => {
 
     const caps = await getPayoutCaps();
 
-    // Fallback must be present, non-zero, and LOW — every value well under the
-    // real production caps so a missing row caps payouts low (safe), never high.
-    for (const v of Object.values(caps)) {
+    // Fallback must be present, non-zero, and LOW — every DISBURSEMENT cap well
+    // under the real production caps so a missing row caps payouts low (safe),
+    // never high.
+    //
+    // gnocco-58537: `underbossOverPartyCapMaxUsd` (margherita-58526) is a policy
+    // CEILING — the max an underboss may override a per-party cap to ($675), not
+    // a per-payout disbursement amount — so it legitimately exceeds the $200
+    // low-fallback bound and must be excluded from this loop. It's asserted
+    // separately below.
+    const { underbossOverPartyCapMaxUsd, ...disbursementCaps } = caps;
+    for (const v of Object.values(disbursementCaps)) {
       expect(v).toBeGreaterThan(0);
       expect(v).toBeLessThanOrEqual(200);
     }
+    expect(underbossOverPartyCapMaxUsd).toBeGreaterThan(0);
     // Ordering invariant the consumers rely on: per-address / hard ceiling are
     // not below the per-tx / per-submission caps.
     expect(caps.perAddressHardCapUsd).toBeGreaterThanOrEqual(caps.hardPerTxCeilingUsd);


### PR DESCRIPTION
## What
Fixes a stale unit test in `backend/src/lib/privateConfig.test.ts` — `getPayoutCaps > returns the fail-safe LOW fallback when the row is absent`.

The test loops over **every** value in the caps fallback asserting each is `≤ 200` (so a missing `payout_caps` row caps payouts low/safe). But `margherita-58526` added a 7th field, `underbossOverPartyCapMaxUsd: 675` — a **policy ceiling** (the max an underboss may override a per-party cap to), not a per-payout disbursement amount. It legitimately exceeds $200, so the blanket loop failed.

## Fix
Destructure `underbossOverPartyCapMaxUsd` out of the low-bound loop and assert it separately (`> 0`). Test-only; no behavior change.

## Notes
- Not a real bug — the fallback only fires if the DB row is absent, and the field is a ceiling-bound, not a disbursable amount.
- These vitest backend tests aren't in CI here (Vercel builds only the frontend), so this never blocked a merge — it just failed locally. Verified the file passes (26/26) after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)