### PR TITLE
polenta-58540: GPP27 City Host Agreement 2-section redesign

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1651,6 +1651,7 @@ model GppAgreementClause {
   id          String   @id @default(uuid()) @db.Uuid
   version     String
   sortOrder   Int      @map("sort_order")
+  heading     String?
   body        String
   requiresAck Boolean  @default(true) @map("requires_ack")
   active      Boolean  @default(true)

--- a/backend/src/routes/gpp27.routes.ts
+++ b/backend/src/routes/gpp27.routes.ts
@@ -89,7 +89,7 @@ router.get('/agreement', requireAuth, async (req: AuthRequest, res: Response, ne
     const clauses = await prisma.gppAgreementClause.findMany({
       where: { active: true },
       orderBy: { sortOrder: 'asc' },
-      select: { id: true, version: true, sortOrder: true, body: true, requiresAck: true },
+      select: { id: true, version: true, sortOrder: true, heading: true, body: true, requiresAck: true },
     });
     const version = clauses[0]?.version ?? null;
     res.json({ version, clauses });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7616,6 +7616,7 @@ export interface Gpp27AgreementClause {
   id: string;
   version: string;
   sortOrder: number;
+  heading?: string | null;
   body: string;
   requiresAck: boolean;
 }

--- a/frontend/src/pages/GPP27CreatePage.tsx
+++ b/frontend/src/pages/GPP27CreatePage.tsx
@@ -31,6 +31,52 @@ const TIMELINE_COPY =
 // override (index.css) — use the arbitrary-value class text-[#ffffff].
 const WHITE = 'text-[#ffffff]';
 
+// --- Agreement clause body rendering (polenta-58540) -----------------------
+// Parse inline `**bold**` markers: split on `**` and wrap odd-index segments
+// in <strong>. Returns React nodes with stable index keys.
+function renderInline(text: string): React.ReactNode[] {
+  return text.split('**').map((seg, i) =>
+    i % 2 === 1 ? <strong key={i}>{seg}</strong> : <React.Fragment key={i}>{seg}</React.Fragment>
+  );
+}
+
+// Render a clause body: lines starting with `- ` become bullets grouped into a
+// single <ul>; other lines render as <p>. Inline **bold** is parsed per line.
+function renderClauseBody(body: string): React.ReactNode {
+  const lines = body.split('\n');
+  const out: React.ReactNode[] = [];
+  let bullets: string[] = [];
+
+  const flushBullets = () => {
+    if (bullets.length === 0) return;
+    out.push(
+      <ul key={`ul-${out.length}`} className="list-disc ml-5 space-y-1">
+        {bullets.map((b, i) => (
+          <li key={i}>{renderInline(b)}</li>
+        ))}
+      </ul>
+    );
+    bullets = [];
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('- ')) {
+      bullets.push(line.slice(2));
+    } else {
+      flushBullets();
+      if (line.trim().length > 0) {
+        out.push(
+          <p key={`p-${out.length}`} className="mb-1">
+            {renderInline(line)}
+          </p>
+        );
+      }
+    }
+  }
+  flushBullets();
+  return out;
+}
+
 export function GPP27CreatePage() {
   // --- All hooks declared ABOVE any conditional return (rules-of-hooks). ---
   const [loading, setLoading] = useState(true);
@@ -395,15 +441,17 @@ export function GPP27CreatePage() {
                   Before this RSVP page can be published, confirm the following
                   {agreementVersion ? ` (${agreementVersion})` : ''}:
                 </p>
-                <div className="space-y-3">
+                <div className="space-y-4">
                   {renderedClauses.map((c) => (
-                    <Checkbox
-                      key={c.id}
-                      checked={!!acked[c.id]}
-                      onChange={() => setAcked((prev) => ({ ...prev, [c.id]: !prev[c.id] }))}
-                      label={c.text}
-                      labelClassName="text-sm text-gray-800"
-                    />
+                    <div key={c.id} className="space-y-1">
+                      <Checkbox
+                        checked={!!acked[c.id]}
+                        onChange={() => setAcked((prev) => ({ ...prev, [c.id]: !prev[c.id] }))}
+                        label={c.heading ?? ''}
+                        labelClassName="text-base font-semibold text-gray-900"
+                      />
+                      <div className="ml-7 text-sm text-gray-800">{renderClauseBody(c.text)}</div>
+                    </div>
                   ))}
                   {renderedClauses.length === 0 && (
                     <p className="text-sm text-gray-500">No active agreement configured.</p>


### PR DESCRIPTION
## Summary
Redesigns the GPP27 City Host Agreement on `/gpp27` from 7 flat checkboxes into **two grouped sections**, each with its own checkbox + bold heading, an "I understand that:" intro, and a bulleted list with inline **bold**.

- **Reimbursement Rules** — pizza-cost eligibility + receipt requirement, confirm max reimbursement before listing, processing timeline.
- **Hosting Requirements** — required event documentation (group / box-stack / pizza photos), fraud/dishonesty consequences.

## Changes
- `backend/prisma/schema.prisma` — `GppAgreementClause` gains `heading String?`.
- `backend/src/routes/gpp27.routes.ts` — GET `/api/gpp27/agreement` select now includes `heading`.
- `frontend/src/lib/api.ts` — `Gpp27AgreementClause` gains `heading?: string | null`.
- `frontend/src/pages/GPP27CreatePage.tsx` — per-clause render now puts the `heading` in the `Checkbox` label and renders the body (bullets + inline bold) below it via new module-level `renderClauseBody`/`renderInline` helpers. `{tier amount}` interpolation and `allAcked` logic unchanged (now requires both checkboxes).

## DB / deploy notes
- The nullable `heading` column is **already applied to prod**.
- The **v2 clause reseed runs post-merge from the main session** (not in this PR).

## Verification
- `frontend` `tsc --noEmit` clean.
- Backend changes are mechanical (field + select key) following existing patterns; backend toolchain (prisma/tsc) is not installed in the worktree sandbox so it was verified by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)