### PR TITLE
suppli-58533: per-type reminder copy (inline DM link) + wallet-via-DM + migration hygiene

### DIFF
--- a/backend/src/lib/escapeHtml.ts
+++ b/backend/src/lib/escapeHtml.ts
@@ -1,0 +1,16 @@
+/**
+ * suppli-58533: minimal HTML escape for values interpolated into a Telegram
+ * `parse_mode: 'HTML'` message (or any HTML body).
+ *
+ * Telegram's HTML mode only requires `<`, `>` and `&` to be escaped inside text
+ * and `"` inside attribute values, so we cover all four. Kept as a tiny shared
+ * helper so the per-type reminder builders (and any future HTML Telegram copy)
+ * don't each hand-roll their own.
+ */
+export function escapeHtml(s: string): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -59,6 +59,8 @@ import { sendToCityGroup } from '../services/cityTelegramGroup.js';
 import { sendTelegramMessage } from '../services/telegramSend.js';
 import { cityKeyFromPartyName } from '../helpers/underbossScope.js';
 import { sanitizePgString, sanitizeForPg } from '../lib/sanitizePg.js';
+// suppli-58533: HTML-escape dynamic values in parse_mode:'HTML' reminder copy.
+import { escapeHtml } from '../lib/escapeHtml.js';
 
 const router = Router();
 
@@ -7015,32 +7017,33 @@ router.post(
 async function sendCityGroupReminder(
   partyName: string,
   text: string,
+  // suppli-58533: optional parse_mode so the HTML reminder copy (inline
+  // "DM them to me" link) renders in the group; default stays plain text.
+  parseMode?: string,
 ): Promise<{ groupSent: boolean; groupReason?: string }> {
   const cityKey = cityKeyFromPartyName(partyName) ?? partyName.toLowerCase().trim();
   if (!cityKey) {
     return { groupSent: false, groupReason: 'no city TG group set' };
   }
-  const result = await sendToCityGroup(cityKey, text);
+  const result = await sendToCityGroup(cityKey, text, parseMode);
   return result.ok
     ? { groupSent: true }
     : { groupSent: false, groupReason: result.reason };
 }
 
-// suppli-58533: host DM submissions to Molto Benny.
+// suppli-58533: host DM submissions to Molto Benny — per-type reminder copy.
 //
-// A host can now REPLY to the bot (photo or a headcount number) and we add it
-// to their event. Append a no-login CTA to both the host-DM and city-group
-// reminder bodies — but with DIFFERENT wording. In the DM, the host can "just
-// reply here" (moltobene processes private-chat replies). In the GROUP, an
-// in-group reply is NOT processed (moltobene only forwards private-chat DMs),
-// so the group copy must point at the tap-to-DM deeplink instead of implying an
-// in-group reply. For the GROUP message we also append a deeplink the host can
-// tap to open a DM with the bot (?start=submit_<token>) — moltobene routes that
-// payload back to the host-inbound flow.
-const HOST_INBOUND_CTA_DM =
-  "📸 No need to log in — just reply here with your receipt photo, an event photo, or type your headcount and I'll add it for you.";
-const HOST_INBOUND_CTA_GROUP =
-  "📸 No login needed — tap below to DM me your receipt photo, an event photo, or your headcount and I'll add it for you:";
+// A host can REPLY to the bot (photo / PDF / a headcount number / a wallet
+// address) and we add it to their event. Each reminder now ships custom
+// per-type copy where "DM them to me" is an INLINE hyperlink (Telegram HTML
+// mode). Two variants:
+//   - GROUP: an in-group reply is NOT processed (moltobene only forwards
+//     private-chat DMs), so the copy links to the bot deeplink
+//     (?start=submit_<token>) the host taps to open a DM.
+//   - DM: a linked host is already in the bot DM, so the copy says "just reply
+//     here" with no link.
+// Both go through parse_mode:'HTML'; every dynamic value (slug especially) is
+// HTML-escaped via escapeHtml before interpolation.
 
 // nanoid(10) mint mirrors host-telegram.routes.ts:25-67 (same URL-safe alphabet
 // + length). Used to lazily mint a host_telegram_link_token when one is absent
@@ -7050,27 +7053,44 @@ const generateHostTelegramToken = customAlphabet(
   10,
 );
 
+type ReminderType = 'photos' | 'receipts' | 'attendance' | 'wallet';
+
 /**
- * suppli-58533: append the no-login CTA to a host-DM reminder body.
+ * suppli-58533: build the DM-variant HTML reminder body for a given type. The
+ * host is already in the bot DM, so the copy says "just reply here" with no
+ * link. `slug` is HTML-escaped by the caller-facing helper below.
  */
-function withHostInboundCta(text: string): string {
-  return `${text}\n\n${HOST_INBOUND_CTA_DM}`;
+function buildHostDmReminderHtml(type: ReminderType, slug: string): string {
+  const s = escapeHtml(slug);
+  switch (type) {
+    case 'photos':
+      return `Make sure you've uploaded your event photos! Just reply here with them or upload them to rsv.pizza/${s}`;
+    case 'receipts':
+      return `Make sure you've uploaded your receipts! Just reply here with them or upload them to rsv.pizza/${s}`;
+    case 'attendance':
+      return `How many people came to your event? Just reply here with the number or enter it at rsv.pizza/${s}`;
+    case 'wallet':
+      return `We need your payout wallet to reimburse you! Just reply here with it or add it at rsv.pizza/host/${s}/payments`;
+  }
 }
 
 /**
- * suppli-58533: build the GROUP reminder body: base text + CTA + a tap-to-DM
- * deeplink. Mints the party's host_telegram_link_token if it's missing (mirrors
- * the host-telegram.routes.ts mint). Returns the group text; the deeplink is
- * omitted when TELEGRAM_BOT_USERNAME is unset (no usable link to offer).
+ * suppli-58533: build the GROUP-variant HTML reminder body for a given type.
+ * "DM them to me" (etc.) is an inline <a> link to the bot deeplink. Mints the
+ * party's host_telegram_link_token if it's missing (mirrors the
+ * host-telegram.routes.ts mint). When TELEGRAM_BOT_USERNAME is unset (no usable
+ * link) we fall back to the DM-variant copy so the message still makes sense.
  */
-async function buildGroupReminderText(party: {
-  id: string;
-  hostTelegramLinkToken: string | null;
-}, baseText: string): Promise<string> {
-  let body = `${baseText}\n\n${HOST_INBOUND_CTA_GROUP}`;
+async function buildGroupReminderText(
+  party: { id: string; hostTelegramLinkToken: string | null },
+  type: ReminderType,
+  slug: string,
+): Promise<string> {
+  const s = escapeHtml(slug);
   const botUsername = process.env.TELEGRAM_BOT_USERNAME || '';
-  if (!botUsername) return body;
 
+  // Mint a token if absent so the deeplink resolves; on any failure (or no bot
+  // username) fall back to the link-free DM copy.
   let token = party.hostTelegramLinkToken;
   if (!token) {
     token = generateHostTelegramToken();
@@ -7082,11 +7102,25 @@ async function buildGroupReminderText(party: {
     } catch (err) {
       // Non-fatal — if the mint write fails we just skip the deeplink.
       console.warn('[suppli-58533] failed to mint host_telegram_link_token:', err);
-      return body;
+      token = null;
     }
   }
-  body += `\n👉 https://t.me/${botUsername}?start=submit_${token}`;
-  return body;
+
+  if (!botUsername || !token) {
+    return buildHostDmReminderHtml(type, slug);
+  }
+
+  const deeplink = escapeHtml(`https://t.me/${botUsername}?start=submit_${token}`);
+  switch (type) {
+    case 'photos':
+      return `Make sure you've uploaded your event photos! <a href="${deeplink}">DM them to me</a> or upload them to rsv.pizza/${s}`;
+    case 'receipts':
+      return `Make sure you've uploaded your receipts! <a href="${deeplink}">DM them to me</a> or upload them to rsv.pizza/${s}`;
+    case 'attendance':
+      return `How many people came to your event? <a href="${deeplink}">DM me the number</a> or enter it at rsv.pizza/${s}`;
+    case 'wallet':
+      return `We need your payout wallet to reimburse you! <a href="${deeplink}">DM it to me</a> or add it at rsv.pizza/host/${s}/payments`;
+  }
 }
 
 router.post(
@@ -7116,16 +7150,17 @@ router.post(
       // Prefer custom_url for the public link; fall back to invite_code so
       // the URL always resolves even on parties without a custom slug.
       const slug = party.customUrl || party.inviteCode;
-      const text = `Make sure you've uploaded your receipts to rsv.pizza/${slug}`;
 
       // Host DM — only when the party has a linked Telegram chat id.
+      // suppli-58533: per-type HTML copy; the DM variant has no link (the host
+      // is already in the bot DM), so it can "just reply here".
       let hostDmSent = false;
       let hostDmReason: string | undefined;
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          // suppli-58533: append the no-login reply CTA to the host DM.
-          withHostInboundCta(text),
+          buildHostDmReminderHtml('receipts', slug),
+          'HTML',
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7140,9 +7175,10 @@ router.post(
       // chat_id from `city_telegram_groups` via `sendToCityGroup` (which also
       // persists supergroup migrations). FIX #4: falls back to the raw party
       // name as cityKey so non-GPP-named parties aren't silently skipped.
-      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
-      const groupText = await buildGroupReminderText(party, text);
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
+      // suppli-58533: group body = per-type HTML copy with an inline tap-to-DM
+      // <a> link; sent with parse_mode:'HTML'.
+      const groupText = await buildGroupReminderText(party, 'receipts', slug);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText, 'HTML');
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {
@@ -7206,15 +7242,16 @@ router.post(
       }
 
       const slug = party.customUrl || party.inviteCode;
-      const text = `Please submit your payout wallet address so we can reimburse you: rsv.pizza/host/${slug}/payments`;
 
+      // suppli-58533: per-type HTML copy; DM variant has no link ("just reply
+      // here with it"), group variant has the inline tap-to-DM <a> link.
       let hostDmSent = false;
       let hostDmReason: string | undefined;
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          // suppli-58533: append the no-login reply CTA to the host DM.
-          withHostInboundCta(text),
+          buildHostDmReminderHtml('wallet', slug),
+          'HTML',
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7229,9 +7266,9 @@ router.post(
       // `city_telegram_groups` via `sendToCityGroup` (adds the migration
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
-      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
-      const groupText = await buildGroupReminderText(party, text);
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
+      // suppli-58533: group body = per-type HTML copy with an inline tap-to-DM link.
+      const groupText = await buildGroupReminderText(party, 'wallet', slug);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText, 'HTML');
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {
@@ -7292,15 +7329,16 @@ router.post(
       }
 
       const slug = party.customUrl || party.inviteCode;
-      const text = `Make sure you've uploaded your event photos to rsv.pizza/${slug}`;
 
+      // suppli-58533: per-type HTML copy; DM variant has no link, group variant
+      // has the inline tap-to-DM <a> link.
       let hostDmSent = false;
       let hostDmReason: string | undefined;
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          // suppli-58533: append the no-login reply CTA to the host DM.
-          withHostInboundCta(text),
+          buildHostDmReminderHtml('photos', slug),
+          'HTML',
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7315,9 +7353,9 @@ router.post(
       // `city_telegram_groups` via `sendToCityGroup` (adds the migration
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
-      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
-      const groupText = await buildGroupReminderText(party, text);
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
+      // suppli-58533: group body = per-type HTML copy with an inline tap-to-DM link.
+      const groupText = await buildGroupReminderText(party, 'photos', slug);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText, 'HTML');
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {
@@ -7378,15 +7416,16 @@ router.post(
       }
 
       const slug = party.customUrl || party.inviteCode;
-      const text = `Please submit your event's estimated attendance at rsv.pizza/${slug}`;
 
+      // suppli-58533: per-type HTML copy; DM variant has no link, group variant
+      // has the inline DM-me-the-number <a> link.
       let hostDmSent = false;
       let hostDmReason: string | undefined;
       if (party.hostTelegramChatId) {
         const result = await sendTelegramMessage(
           party.hostTelegramChatId.toString(),
-          // suppli-58533: append the no-login reply CTA to the host DM.
-          withHostInboundCta(text),
+          buildHostDmReminderHtml('attendance', slug),
+          'HTML',
         );
         if (result.ok) {
           hostDmSent = true;
@@ -7401,9 +7440,9 @@ router.post(
       // `city_telegram_groups` via `sendToCityGroup` (adds the migration
       // retry+persist this endpoint previously lacked). FIX #4: shared helper
       // with the raw-party-name cityKey fallback so non-GPP names aren't skipped.
-      // suppli-58533: group body = base text + no-login CTA + tap-to-DM deeplink.
-      const groupText = await buildGroupReminderText(party, text);
-      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText);
+      // suppli-58533: group body = per-type HTML copy with an inline tap-to-DM link.
+      const groupText = await buildGroupReminderText(party, 'attendance', slug);
+      const { groupSent, groupReason } = await sendCityGroupReminder(party.name, groupText, 'HTML');
 
       // Record when the reminder was sent (if at least one message succeeded).
       if (hostDmSent || groupSent) {

--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -7,7 +7,10 @@
  *     resolve which party the chatId belongs to and add the submission to it:
  *       - photo → OCR'd; if it looks like a receipt it's added as a
  *         payout_documents receipt, otherwise as an event photo (gallery).
- *       - text  → a bare positive integer sets the party's estimated attendance.
+ *       - text  → a bare integer (1–6 digits) sets the party's estimated
+ *         attendance; a 0x… EVM address (or an ENS name) is saved as the host's
+ *         payout wallet via the website's exact save+re-stamp path
+ *         (suppli-58533); anything else gets a gentle pointer.
  *
  *     Auth: header `x-api-key` must equal `TELEGRAM_LINK_CALLBACK_SECRET`
  *       (the exact pattern from telegram-link-callback.routes.ts):
@@ -36,6 +39,9 @@ import { analyzeReceipt } from '../services/ocr.service.js';
 import { convertToUSD } from '../services/fx.service.js';
 import { sanitizePgString, sanitizeForPg } from '../lib/sanitizePg.js';
 import { rasterizePdfFirstPage } from '../services/pdfRasterize.js';
+// suppli-58533: reuse the website's exact wallet-save + rolling-row re-stamp.
+import { saveHostPayoutWalletAndRestamp } from '../services/payout-snapshot.js';
+import { looksLikeEnsName } from '../services/ens.service.js';
 
 const router = Router();
 
@@ -89,6 +95,16 @@ async function uploadPayoutBuffer(
 /** Event year for photoYear: event date year ?? null (upload-time fallback handled by NULL). */
 function partyEventYear(p: HostInboundParty): number | null {
   return p.date ? p.date.getUTCFullYear() : null;
+}
+
+/**
+ * suppli-58533: mask the middle of a 0x wallet for the confirmation DM, e.g.
+ * `0x1234abcd…wxyz` → `0x1234…wxyz`. Short/odd inputs are returned as-is.
+ */
+function maskWalletAddress(addr: string): string {
+  const a = (addr || '').trim();
+  if (!/^0x[0-9a-fA-F]{40}$/.test(a)) return a;
+  return `${a.slice(0, 6)}…${a.slice(-4)}`;
 }
 
 router.post(
@@ -153,40 +169,94 @@ router.post(
       const hostEmail = party.user?.email ?? null;
 
       // =====================================================================
-      // TEXT → estimated attendance
+      // TEXT → estimated attendance (bare number) | payout wallet (0x / ENS)
       // =====================================================================
       if (kind === 'text') {
         const trimmed = typeof text === 'string' ? text.trim() : '';
-        // Same validation as party.routes.ts attendance: a bare positive int.
-        if (!/^\d+$/.test(trimmed)) {
-          const slug = party.customUrl || party.inviteCode;
+        const slug = party.customUrl || party.inviteCode;
+
+        // --- (a) bare positive integer → estimated attendance (existing) -----
+        // Tighter than a wallet match: a 1–6 digit run can only be a headcount.
+        if (/^\d{1,6}$/.test(trimmed)) {
+          const n = Number(trimmed);
+          if (!Number.isInteger(n) || n < 1) {
+            return res.status(200).json({
+              ok: true,
+              action: 'ignored',
+              partyName: party.name,
+              reason: 'invalid-number',
+            });
+          }
+          await prisma.party.update({
+            where: { id: party.id },
+            data: { estimatedAttendance: n },
+          });
+          await sendTelegramMessage(chatIdStr, `✅ Set headcount for ${party.name} to ${n}.`);
+          return res.status(200).json({ ok: true, action: 'attendance', partyName: party.name });
+        }
+
+        // --- (b) payout wallet → save to the host's profile + re-stamp rows ---
+        // EVM 0x…40-hex, OR an ENS name (the website's wallet-submit accepts ENS
+        // via resolveWalletInput, so we accept it here too — both go through the
+        // SAME save path). HOST-ONLY: the chatId resolves to the host's own
+        // party (parties.host_telegram_chat_id), so a resolved sender IS the host.
+        const isEvm = /^0x[0-9a-fA-F]{40}$/.test(trimmed);
+        const isEns = looksLikeEnsName(trimmed);
+        if (isEvm || isEns) {
+          const hostUserId = party.user?.id ?? null;
+          if (!hostUserId) {
+            // No host User to attach the wallet to — point them at the web page.
+            await sendTelegramMessage(
+              chatIdStr,
+              `I couldn't save that wallet — please add it at rsv.pizza/host/${slug}/payments`,
+            );
+            return res.status(200).json({
+              ok: true,
+              action: 'ignored',
+              partyName: party.name,
+              reason: 'wallet_no_host_user',
+            });
+          }
+          let resolved: string;
+          try {
+            resolved = await saveHostPayoutWalletAndRestamp(hostUserId, trimmed);
+          } catch (err: any) {
+            console.warn(
+              '[suppli-58533][host-inbound] wallet save failed:',
+              err?.message || err,
+            );
+            await sendTelegramMessage(
+              chatIdStr,
+              `That doesn't look like a valid wallet address. Send a 0x… address ` +
+                `(or an ENS name like alice.eth), or add it at rsv.pizza/host/${slug}/payments`,
+            );
+            return res.status(200).json({
+              ok: true,
+              action: 'ignored',
+              partyName: party.name,
+              reason: 'wallet_invalid',
+            });
+          }
           await sendTelegramMessage(
             chatIdStr,
-            `I can add a receipt photo, an event photo, or a headcount number for ${party.name}. ` +
-              `For anything else, head to rsv.pizza/host/${slug}/payments`,
+            `✅ Saved your payout wallet (${maskWalletAddress(resolved)}) for ${party.name}.`,
           );
-          return res.status(200).json({
-            ok: true,
-            action: 'ignored',
-            partyName: party.name,
-            reason: 'non-numeric',
-          });
+          return res.status(200).json({ ok: true, action: 'wallet', partyName: party.name });
         }
-        const n = Number(trimmed);
-        if (!Number.isInteger(n) || n < 1) {
-          return res.status(200).json({
-            ok: true,
-            action: 'ignored',
-            partyName: party.name,
-            reason: 'invalid-number',
-          });
-        }
-        await prisma.party.update({
-          where: { id: party.id },
-          data: { estimatedAttendance: n },
+
+        // --- (c) anything else → gentle pointer (existing) -------------------
+        await sendTelegramMessage(
+          chatIdStr,
+          `I can add a receipt photo, an event photo, a headcount number, or your ` +
+            `payout wallet for ${party.name}. ` +
+            `For anything else, head to rsv.pizza/host/${slug}/payments`,
+        );
+        return res.status(200).json({
+          ok: true,
+          action: 'ignored',
+          partyName: party.name,
+          reason: 'non-numeric',
         });
-        await sendTelegramMessage(chatIdStr, `✅ Set headcount for ${party.name} to ${n}.`);
-        return res.status(200).json({ ok: true, action: 'attendance', partyName: party.name });
       }
 
       // =====================================================================

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -5,7 +5,7 @@ import { resolveWalletInput } from '../services/ens.service.js';
 import { canUserEditParty } from '../helpers/partyAccess.js';
 import { getReimbursementRules } from '../lib/privateConfig.js';
 import { resolvePartyReimbursementOptions } from '../lib/reimbursementOptions.js';
-import { payoutRowSnapshotFromUser, NON_TERMINAL_PAYOUT_STATUSES } from '../services/payout-snapshot.js';
+import { restampHostRollingPayoutRows } from '../services/payout-snapshot.js';
 
 const router = Router();
 
@@ -172,37 +172,18 @@ router.patch('/me', async (req: AuthRequest, res: Response, next: NextFunction) 
     // path reads the payout ROW (no host fallback), so without this a host who
     // fixes their wallet AFTER the rolling row exists (incl. after an admin has
     // approved it) stays un-payable.
-    // tortano-58516: re-stamp across ALL non-terminal statuses
-    // (NON_TERMINAL_PAYOUT_STATUSES = pending/approved/queued), now INCLUDING
-    // 'queued'. This matches the receipt-upload snapshot path in
-    // payout.routes.ts (which already uses NON_TERMINAL_PAYOUT_STATUSES), so an
-    // admin who marks a payout 'queued' before the host has finalized their
-    // wallet/method no longer strands it un-payable when the host later fixes
-    // their profile. Terminal rows (paid/completed/withdrawn/rejected/failed)
-    // stay excluded because NON_TERMINAL_PAYOUT_STATUSES lists only the three
-    // non-terminal statuses. The mercury_card guard avoids clobbering an
-    // admin-issued Mercury card with the host's self-serve prefs.
+    // tortano-58516 / suppli-58533: re-stamp across ALL non-terminal statuses
+    // (NON_TERMINAL_PAYOUT_STATUSES = pending/approved/queued, incl. 'queued').
+    // Extracted into restampHostRollingPayoutRows so the wallet-via-DM path
+    // (telegram-inbound.routes.ts) re-stamps via the identical code. The helper
+    // re-reads the just-updated profile, applies the mercury_card guard, and is
+    // best-effort (never throws). Terminal rows stay excluded.
     if (
       preferredPayoutMethod !== undefined
       || payoutWalletAddress !== undefined
       || payoutBankDetails !== undefined
     ) {
-      try {
-        const snap = payoutRowSnapshotFromUser(user);
-        await prisma.payout.updateMany({
-          where: {
-            hostUserId: req.userId,
-            purpose: 'event',
-            status: { in: [...NON_TERMINAL_PAYOUT_STATUSES] },
-            NOT: { payoutMethod: 'mercury_card' },
-          },
-          data: snap,
-        });
-      } catch (err) {
-        // Non-fatal — the profile save itself succeeded; the row sync is a
-        // best-effort convenience so a stale rolling row doesn't strand a host.
-        console.warn('[user] failed to sync payout prefs onto rolling rows:', err);
-      }
+      await restampHostRollingPayoutRows(req.userId!, user);
     }
 
     res.json({ user });

--- a/backend/src/services/payout-snapshot.ts
+++ b/backend/src/services/payout-snapshot.ts
@@ -13,6 +13,8 @@
  * to avoid a require cycle between those two route files.
  */
 import { Prisma } from '@prisma/client';
+import { prisma } from '../config/database.js';
+import { resolveWalletInput } from './ens.service.js';
 
 // Non-terminal statuses: a rolling record is "active" while in one of these.
 // Terminal = paid | completed | withdrawn | rejected | failed.
@@ -39,4 +41,85 @@ export function payoutRowSnapshotFromUser(u: {
         ? (u.payoutBankDetails as Prisma.InputJsonValue)
         : Prisma.JsonNull,
   };
+}
+
+/**
+ * suppli-58533 / tortano-58516: re-stamp the host's CURRENT profile payout
+ * prefs onto their non-terminal rolling `event` payout rows.
+ *
+ * EXTRACTED verbatim from the PATCH /api/user/me handler (user.routes.ts) so the
+ * wallet-via-DM path (telegram-inbound.routes.ts) writes the row snapshot via
+ * the identical code — the execute/send path reads the payout ROW with no host
+ * fallback, so a wallet saved only on the User profile leaves the host
+ * un-payable (ricotta-58512 incident). The mercury_card guard avoids clobbering
+ * an admin-issued Mercury card with the host's self-serve prefs. Best-effort:
+ * never throws — the caller's profile save already succeeded.
+ */
+export async function restampHostRollingPayoutRows(
+  userId: string,
+  // Optional already-loaded profile snapshot. user.routes.ts passes the user it
+  // just updated (no extra query); the DM path omits it so we re-read here.
+  preloaded?: {
+    preferredPayoutMethod: string | null;
+    payoutWalletAddress: string | null;
+    payoutBankDetails: Prisma.JsonValue | null;
+  },
+): Promise<void> {
+  try {
+    const user =
+      preloaded ??
+      (await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          preferredPayoutMethod: true,
+          payoutWalletAddress: true,
+          payoutBankDetails: true,
+        },
+      }));
+    if (!user) return;
+    const snap = payoutRowSnapshotFromUser(user);
+    await prisma.payout.updateMany({
+      where: {
+        hostUserId: userId,
+        purpose: 'event',
+        status: { in: [...NON_TERMINAL_PAYOUT_STATUSES] },
+        NOT: { payoutMethod: 'mercury_card' },
+      },
+      data: snap,
+    });
+  } catch (err) {
+    console.warn('[payout-snapshot] failed to re-stamp rolling payout rows:', err);
+  }
+}
+
+/**
+ * suppli-58533: save a host's payout wallet exactly like the website does
+ * (PATCH /api/user/me wallet path) and re-stamp their rolling payout rows.
+ *
+ *   1. Resolve the input via the SAME `resolveWalletInput` (accepts a 0x… EVM
+ *      address OR an ENS name; throws on anything else — caller surfaces a
+ *      friendly message).
+ *   2. Persist the resolved 0x onto `User.payoutWalletAddress`.
+ *   3. Re-stamp non-terminal rolling rows (the un-payable-without-this step).
+ *
+ * Returns the resolved 0x address. Throws (with the resolver's message) on an
+ * unresolvable input so the DM handler can reply a helpful rejection.
+ */
+export async function saveHostPayoutWalletAndRestamp(
+  userId: string,
+  walletInput: string,
+): Promise<string> {
+  // (1) Resolve — identical boundary to user.routes.ts (ENS → 0x or 0x verbatim).
+  const resolved = await resolveWalletInput(String(walletInput));
+
+  // (2) Persist onto the host profile (the website's source of truth).
+  await prisma.user.update({
+    where: { id: userId },
+    data: { payoutWalletAddress: resolved },
+  });
+
+  // (3) Re-stamp the rolling rows so the wallet is actually payable.
+  await restampHostRollingPayoutRows(userId);
+
+  return resolved;
 }

--- a/backend/src/services/telegramSend.ts
+++ b/backend/src/services/telegramSend.ts
@@ -16,11 +16,16 @@ import { withBennySignature } from '../lib/bennySignature.js';
 export async function sendTelegramMessage(
   chatId: string,
   text: string,
+  // suppli-58533: optional Telegram parse_mode ('HTML' | 'Markdown'). Default
+  // stays plain text so existing callers are unchanged; the per-type reminder
+  // builders pass 'HTML' so the inline "DM them to me" link renders.
+  parseMode?: string,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
   const token = process.env.TELEGRAM_BOT_TOKEN;
   if (!token) {
     return { ok: false, reason: 'TELEGRAM_BOT_TOKEN not configured' };
   }
+  const effectiveParseMode = parseMode && parseMode !== 'None' ? parseMode : undefined;
   try {
     const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: 'POST',
@@ -29,6 +34,7 @@ export async function sendTelegramMessage(
         chat_id: chatId,
         text: withBennySignature(text),
         disable_web_page_preview: true,
+        ...(effectiveParseMode && { parse_mode: effectiveParseMode }),
       }),
     });
     if (!resp.ok) {

--- a/supabase/migrations/20260611_party_telegram_contributors.sql
+++ b/supabase/migrations/20260611_party_telegram_contributors.sql
@@ -1,0 +1,21 @@
+-- suppli-58533: per-type Telegram host authz — non-host "contributors" that a
+-- city group has authorized to submit on the host's behalf.
+--
+-- The table already exists in production (it was created out-of-band). This
+-- file exists for migration HISTORY and the schema-drift CI check
+-- (scripts/check-schema-drift.js), which expects supabase/migrations/ to be the
+-- source of truth — NOT backend/prisma/migrations/. Hence the idempotent
+-- IF NOT EXISTS guards: re-applying against prod is a no-op.
+
+CREATE TABLE IF NOT EXISTS party_telegram_contributors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id uuid NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  chat_id bigint NOT NULL,
+  telegram_user_id bigint,
+  username text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT party_telegram_contributors_party_chat_unique UNIQUE (party_id, chat_id)
+);
+
+CREATE INDEX IF NOT EXISTS party_telegram_contributors_chat_id_idx ON party_telegram_contributors (chat_id);


### PR DESCRIPTION
## Part 1 — per-type reminder copy with an inline HTML "DM them to me" link
The four `/payments` Telegram reminders (receipts / photo / attendance / wallet) now send **custom per-type copy** where "DM them to me" is an **inline `<a>` hyperlink** (`parse_mode: 'HTML'`) in the GROUP variant, and a link-free "just reply here" in the host-DM variant (a linked host is already in the bot DM). Threaded an optional `parseMode` through `sendTelegramMessage` + `sendCityGroupReminder` → `sendToCityGroup` (default stays plain text, so other callers are unchanged). All dynamic values (slug, deeplink) are HTML-escaped via a new shared `escapeHtml` helper. `disable_web_page_preview: true` and the `withBennySignature` footer (emoji-only, HTML-safe) are preserved. Removed the now-dead `HOST_INBOUND_CTA_DM/_GROUP` constants + `withHostInboundCta`.

## Part 2 — wallet-via-DM
The host-inbound TEXT path now classifies a `0x…40-hex` EVM address (or an ENS name — the website's wallet-submit accepts ENS via `resolveWalletInput`, so we mirror it) and saves it as the host's payout wallet via the **same path the website uses**. Extracted the `PATCH /api/user/me` re-stamp logic into `restampHostRollingPayoutRows` + `saveHostPayoutWalletAndRestamp` (in `services/payout-snapshot.ts`): resolve → `User.payoutWalletAddress` → re-stamp non-terminal rolling payout rows (pending/approved/queued, mercury_card guard). Both `user.routes.ts` and the DM path call it, so the two are identical. Confirmation DM masks the address (`0x1234…abcd`); invalid input replies a helpful message with `action:'ignored', reason:'wallet_invalid'`; never 500s. HOST-ONLY by construction: the chatId resolves to the host's own party (`parties.host_telegram_chat_id`).

## Part 3 — migration hygiene
Added `supabase/migrations/20260611_party_telegram_contributors.sql` (idempotent `IF NOT EXISTS` CREATE TABLE + `chat_id` index) as the schema-drift-check source of truth. No `backend/prisma/migrations/suppli-58533-party-telegram-contributors.sql` existed on `origin/master` to remove (the contributor/authz work referenced in the brief is not merged on master).

## Notes
- Pairs with a moltobene PR that forwards wallet-address text to `/api/telegram/host-inbound`.
- Backend auto-deploys from master; the `party_telegram_contributors` table already exists in prod (the migration file is for history + the drift check).
- Build: `npm run build` compiles clean apart from 3 pre-existing unrelated tsc errors (`auth.test.ts:38`, `admin-payout.routes.ts:2381` [was 2379 on master — my added lines shifted it], `payout.routes.ts:2273/2274`) — verified identical on `origin/master`; none reference my files.
- `src/routes/user.routes.test.ts` (7 tests) passes; the 7 other src test failures (privateConfig/photo/rsvp) are pre-existing on `origin/master` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)