### PR TITLE
suppli-58533: reply when an inbound DM can't be linked to an event (don't leave the user on 'processing…')

### DIFF
--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -160,7 +160,12 @@ router.post(
       const ctx = await resolveSubmitterContext(BigInt(chatIdStr));
 
       if (!ctx) {
-        // chatId not linked to any party → reply nothing.
+        // chatId not linked to any party → tell the user how to connect so
+        // they aren't left on moltobene's "📥 processing…" ack forever.
+        await sendTelegramMessage(
+          chatIdStr,
+          `I'm not sure which event this is for yet! 🍕 Tap the "DM them to me" link in your event's reminder (in your city's Telegram group) to connect, then send it again and I'll add it.`,
+        );
         return res.status(200).json({ ok: true, action: 'ignored', reason: 'no-party' });
       }
 


### PR DESCRIPTION
When `resolveSubmitterContext` returns null (the inbound chatId isn't linked to any party), the bot was silent — but moltobene already sent the user a 📥 "Got it, processing…" ack, leaving them hanging forever. Now the bot DMs them to tap the "DM them to me" link in their event's reminder to connect, then resend. Return shape unchanged (`{ ok: true, action: 'ignored', reason: 'no-party' }`). One-branch change; backend auto-deploys from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)