### PR TITLE
feat(reminders): connect buttons on group reminders (bocconcini-58533)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -7018,12 +7018,14 @@ async function sendCityGroupReminder(
   // suppli-58533: optional parse_mode so the per-type reminder copy can embed an
   // inline <a> "DM them to me" link in the GROUP message. Default plain.
   parseMode?: string,
+  // bocconcini-58533: optional inline keyboard (URL + copy_text connect buttons).
+  replyMarkup?: Record<string, unknown>,
 ): Promise<{ groupSent: boolean; groupReason?: string }> {
   const cityKey = cityKeyFromPartyName(partyName) ?? partyName.toLowerCase().trim();
   if (!cityKey) {
     return { groupSent: false, groupReason: 'no city TG group set' };
   }
-  const result = await sendToCityGroup(cityKey, text, parseMode);
+  const result = await sendToCityGroup(cityKey, text, parseMode, replyMarkup);
   return result.ok
     ? { groupSent: true }
     : { groupSent: false, groupReason: result.reason };
@@ -7065,7 +7067,7 @@ function escapeHtml(s: string): string {
 async function resolveSubmitDeeplink(party: {
   id: string;
   hostTelegramLinkToken: string | null;
-}): Promise<string | null> {
+}): Promise<{ deeplink: string; token: string } | null> {
   const botUsername = process.env.TELEGRAM_BOT_USERNAME || '';
   if (!botUsername) return null;
 
@@ -7083,7 +7085,22 @@ async function resolveSubmitDeeplink(party: {
       return null;
     }
   }
-  return `https://t.me/${botUsername}?start=submit_${token}`;
+  return { deeplink: `https://t.me/${botUsername}?start=submit_${token}`, token };
+}
+
+/**
+ * suppli-58533 FU5: inline keyboard for the GROUP reminder. A URL button opens
+ * the connect deeplink; a copy_text button (Bot API 7.11+) copies the literal
+ * `/start submit_<token>` so a host whose tap didn't fire the payload can paste
+ * it into the DM and still bind. `verb` matches the per-type inline-link label.
+ */
+function buildSubmitKeyboard(deeplink: string, token: string, verb: string) {
+  return {
+    inline_keyboard: [
+      [{ text: verb, url: deeplink }],
+      [{ text: '📋 Copy connect code', copy_text: { text: `/start submit_${token}` } }],
+    ],
+  };
 }
 
 /**
@@ -7160,8 +7177,10 @@ router.post(
       const slug = party.customUrl || party.inviteCode;
       // suppli-58533: per-type copy. GROUP gets an inline HTML "DM them to me"
       // link; DM says "just reply here".
-      const deeplink = await resolveSubmitDeeplink(party);
+      const submit = await resolveSubmitDeeplink(party);
+      const deeplink = submit?.deeplink ?? null;
       const { groupText, groupHtml, dmText } = buildReminderCopy('receipts', slug, deeplink);
+      const groupKeyboard = submit ? buildSubmitKeyboard(submit.deeplink, submit.token, 'DM them to me') : undefined;
 
       // Host DM — only when the party has a linked Telegram chat id.
       let hostDmSent = false;
@@ -7189,6 +7208,7 @@ router.post(
         party.name,
         groupText,
         groupHtml ? 'HTML' : undefined,
+        groupKeyboard,
       );
 
       // Record when the reminder was sent (if at least one message succeeded).
@@ -7254,8 +7274,10 @@ router.post(
 
       const slug = party.customUrl || party.inviteCode;
       // suppli-58533: per-type copy (wallet).
-      const deeplink = await resolveSubmitDeeplink(party);
+      const submit = await resolveSubmitDeeplink(party);
+      const deeplink = submit?.deeplink ?? null;
       const { groupText, groupHtml, dmText } = buildReminderCopy('wallet', slug, deeplink);
+      const groupKeyboard = submit ? buildSubmitKeyboard(submit.deeplink, submit.token, 'DM it to me') : undefined;
 
       let hostDmSent = false;
       let hostDmReason: string | undefined;
@@ -7282,6 +7304,7 @@ router.post(
         party.name,
         groupText,
         groupHtml ? 'HTML' : undefined,
+        groupKeyboard,
       );
 
       // Record when the reminder was sent (if at least one message succeeded).
@@ -7344,8 +7367,10 @@ router.post(
 
       const slug = party.customUrl || party.inviteCode;
       // suppli-58533: per-type copy (photos).
-      const deeplink = await resolveSubmitDeeplink(party);
+      const submit = await resolveSubmitDeeplink(party);
+      const deeplink = submit?.deeplink ?? null;
       const { groupText, groupHtml, dmText } = buildReminderCopy('photos', slug, deeplink);
+      const groupKeyboard = submit ? buildSubmitKeyboard(submit.deeplink, submit.token, 'DM them to me') : undefined;
 
       let hostDmSent = false;
       let hostDmReason: string | undefined;
@@ -7372,6 +7397,7 @@ router.post(
         party.name,
         groupText,
         groupHtml ? 'HTML' : undefined,
+        groupKeyboard,
       );
 
       // Record when the reminder was sent (if at least one message succeeded).
@@ -7434,8 +7460,10 @@ router.post(
 
       const slug = party.customUrl || party.inviteCode;
       // suppli-58533: per-type copy (attendance).
-      const deeplink = await resolveSubmitDeeplink(party);
+      const submit = await resolveSubmitDeeplink(party);
+      const deeplink = submit?.deeplink ?? null;
       const { groupText, groupHtml, dmText } = buildReminderCopy('attendance', slug, deeplink);
+      const groupKeyboard = submit ? buildSubmitKeyboard(submit.deeplink, submit.token, 'DM me the number') : undefined;
 
       let hostDmSent = false;
       let hostDmReason: string | undefined;
@@ -7462,6 +7490,7 @@ router.post(
         party.name,
         groupText,
         groupHtml ? 'HTML' : undefined,
+        groupKeyboard,
       );
 
       // Record when the reminder was sent (if at least one message succeeded).

--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -164,7 +164,7 @@ router.post(
         // they aren't left on moltobene's "📥 processing…" ack forever.
         await sendTelegramMessage(
           chatIdStr,
-          `I'm not sure which event this is for yet! 🍕 Tap the "DM them to me" link in your event's reminder (in your city's Telegram group) to connect, then send it again and I'll add it.`,
+          `I'm not sure which event this is for yet! 🍕 Open your city's Telegram group, tap "📋 Copy connect code" on the reminder and paste it here (or tap the "DM them to me" link), then send your photo/number again and I'll add it.`,
         );
         return res.status(200).json({ ok: true, action: 'ignored', reason: 'no-party' });
       }

--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -182,7 +182,7 @@ router.post(
           await sendTelegramMessage(
             chatIdStr,
             `Only the event host can submit receipts or attendance for ${party.name}. ` +
-              `Photos are welcome though 📸`,
+              `Photos are welcome though 📸 — if you're the host, add your Telegram @handle on your rsv.pizza profile so I can verify you.`,
           );
           return res.status(200).json({
             ok: true,
@@ -332,7 +332,7 @@ router.post(
         await sendTelegramMessage(
           chatIdStr,
           `Only the event host can submit receipts or attendance for ${party.name}. ` +
-            `Photos are welcome though 📸`,
+            `Photos are welcome though 📸 — if you're the host, add your Telegram @handle on your rsv.pizza profile so I can verify you.`,
         );
         return res.status(200).json({
           ok: true,

--- a/backend/src/services/cityTelegramGroup.ts
+++ b/backend/src/services/cityTelegramGroup.ts
@@ -87,11 +87,14 @@ export interface SendToCityGroupResult {
  * @param cityKey  Already-normalized city key (caller should pass `lower(trim(city))`).
  * @param text     Message body.
  * @param parseMode Optional Telegram parse_mode ('HTML' | 'Markdown'); omit/None for plain.
+ * @param replyMarkup Optional Telegram reply_markup (e.g. an inline_keyboard);
+ *   bocconcini-58533 uses this to attach URL + copy_text connect buttons.
  */
 export async function sendToCityGroup(
   cityKey: string,
   text: string,
   parseMode?: string,
+  replyMarkup?: Record<string, unknown>,
 ): Promise<SendToCityGroupResult> {
   const key = (cityKey || '').toLowerCase().trim();
   if (!key) {
@@ -135,6 +138,7 @@ export async function sendToCityGroup(
         text: withBennySignature(text),
         disable_web_page_preview: true,
         ...(effectiveParseMode && { parse_mode: effectiveParseMode }),
+        ...(replyMarkup && { reply_markup: replyMarkup }),
       }),
     });
     return resp.json() as Promise<any>;

--- a/plans/bocconcini-58533-connect-buttons.md
+++ b/plans/bocconcini-58533-connect-buttons.md
@@ -1,0 +1,42 @@
+# bocconcini-58533 — connect buttons on group reminders
+
+Follow-up to suppli-58533 (host DM submissions to Molto Benny).
+
+## Problem
+Group Telegram reminders link hosts to the connect deeplink
+(`https://t.me/<bot>?start=submit_<token>`) via an inline HTML `<a>` "DM them to me"
+link. Telegram does NOT reliably re-send the `/start <payload>` for a bot the host
+has already started, so the host taps the link, lands in a DM that doesn't re-bind,
+and dead-ends at "I'm not sure which event this is for yet!" when they send a
+photo/number.
+
+## Change
+Add an inline keyboard to every group reminder (receipts / photos / attendance /
+wallet) with two buttons:
+1. **URL button** → the same `submit_<token>` deeplink (more reliable than an inline
+   text link).
+2. **📋 Copy connect code** (`copy_text`, Bot API 7.11+) → copies the literal
+   `/start submit_<token>` so the host can paste it into the DM and bind regardless
+   of whether the tap fired the payload.
+
+moltobene already binds a pasted `/start submit_<token>` — no bot change needed.
+
+Also update the dead-end DM reply to point hosts at the copy button.
+
+## Files touched (rsvpizza-only, backend-only, no migration, no frontend)
+- `backend/src/services/cityTelegramGroup.ts` — `sendToCityGroup` gains an optional
+  4th `replyMarkup` param, spread into the `sendMessage` body (covers both the
+  initial send and the supergroup-migration retry, which share the `send` closure).
+- `backend/src/routes/admin-payout.routes.ts`
+  - `resolveSubmitDeeplink` now returns `{ deeplink, token }` (or `null`) so the
+    raw token is available for the copy button.
+  - New `buildSubmitKeyboard(deeplink, token, verb)` helper.
+  - `sendCityGroupReminder` gains an optional 4th `replyMarkup` param, passed through.
+  - All four reminder routes build a `groupKeyboard` and pass it as the 4th arg.
+    Per-type URL-button verb: receipts/photos = "DM them to me",
+    attendance = "DM me the number", wallet = "DM it to me".
+- `backend/src/routes/telegram-inbound.routes.ts` — dead-end "not sure which event"
+  reply now points at the "📋 Copy connect code" button.
+
+`buildReminderCopy` still takes the deeplink STRING (or null); body copy / inline
+`<a>` link unchanged — the buttons are additive.


### PR DESCRIPTION
## Summary
Makes the host tap-to-connect on group reminders reliable even when Telegram won't re-fire the `/start <payload>` for an already-started bot.

- Group reminders (receipts / photos / attendance / wallet) now carry an inline keyboard: a **URL button** to the `submit_<token>` deeplink + a **📋 Copy connect code** button (`copy_text`, Bot API 7.11+) that copies `/start submit_<token>` for a paste-to-bind fallback.
- Dead-end DM reply now points hosts at the copy button.
- rsvpizza-only — moltobene already binds a pasted `/start submit_<token>`. No DB migration, no frontend.

## Test plan
- `tsc --noEmit` clean.
- Post-merge (backend auto-deploys from master): send an attendance reminder from `/payments`, confirm both buttons render in the city group and the copy button pastes a `/start submit_<token>` that binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)