### PR TITLE
fix(telegram): verify editor co-hosts as hosts in link-host (crostata-58533)

### DIFF
--- a/backend/src/routes/telegram-link-callback.routes.ts
+++ b/backend/src/routes/telegram-link-callback.routes.ts
@@ -87,7 +87,7 @@ router.post('/link-host', async (req: Request, res: Response, _next: NextFunctio
 
     const party = await prisma.party.findUnique({
       where: { hostTelegramLinkToken: token },
-      select: { id: true, name: true, user: { select: { telegram: true } } },
+      select: { id: true, name: true, coHosts: true, user: { select: { telegram: true } } },
     });
 
     if (!party) {
@@ -95,19 +95,40 @@ router.post('/link-host', async (req: Request, res: Response, _next: NextFunctio
       return res.status(200).json({ ok: false, reason: 'invalid token' });
     }
 
-    // suppli-58533: verify the tapper IS the party host before linking.
-    const hostHandle = party.user?.telegram ?? null;
+    // suppli-58533 (crostata-58533): verify the tapper is the party host OR an
+    // editor co-host before linking. Co-hosts live in parties.co_hosts (JSON);
+    // only entries with canEdit===true count, and only their `telegram` field is
+    // matched (never twitter/instagram — display-only partners have canEdit:false
+    // and no telegram, so they're excluded).
     const tapperHandle = typeof username === 'string' ? username : null;
+    const authorizedHandles: string[] = [];
+    if (party.user?.telegram) authorizedHandles.push(party.user.telegram);
+    const coHosts = Array.isArray(party.coHosts) ? (party.coHosts as unknown[]) : [];
+    for (const ch of coHosts) {
+      if (
+        ch &&
+        typeof ch === 'object' &&
+        (ch as Record<string, unknown>).canEdit === true &&
+        typeof (ch as Record<string, unknown>).telegram === 'string'
+      ) {
+        authorizedHandles.push((ch as Record<string, unknown>).telegram as string);
+      }
+    }
+    const normalizedTapper = normalizeTgHandle(tapperHandle);
     const isHost =
-      !!hostHandle &&
-      !!tapperHandle &&
-      normalizeTgHandle(hostHandle) === normalizeTgHandle(tapperHandle);
+      normalizedTapper !== '' &&
+      authorizedHandles.some((h) => normalizeTgHandle(h) === normalizedTapper);
 
     if (isHost) {
-      // Verified host — set/refresh the host link (the legacy behavior).
+      // Verified host (primary or editor co-host) — set/refresh the host link.
       await prisma.party.update({
         where: { id: party.id },
         data: { hostTelegramChatId: BigInt(chatIdStr) },
+      });
+      // Clear any stale photo-only contributor row for this chat so it doesn't
+      // shadow the host binding in resolveSubmitterContext ("most recent wins").
+      await prisma.partyTelegramContributor.deleteMany({
+        where: { partyId: party.id, chatId: BigInt(chatIdStr) },
       });
       return res.status(200).json({ ok: true, role: 'host', partyName: party.name });
     }

--- a/plans/crostata-58533-cohost-verify.md
+++ b/plans/crostata-58533-cohost-verify.md
@@ -1,0 +1,44 @@
+# crostata-58533 — Verify editor co-hosts as hosts in `link-host`
+
+A suppli-58533 follow-up. Backend-only (rsvpizza), no migration.
+
+## Problem
+
+`POST /api/telegram/link-host` (`backend/src/routes/telegram-link-callback.routes.ts`)
+verified the tapper's Telegram @handle ONLY against the party's **primary** host
+(`party.user.telegram`). Co-hosts — stored in `parties.co_hosts` JSON (Prisma
+field `coHosts`) — were never considered, so an editor co-host who tapped the
+connect link was wrongly downgraded to a photo-only contributor and couldn't
+submit receipts/attendance via DM.
+
+Confirmed live: Philadelphia primary host is `Saucysaucier`, but editor co-host
+`@snack_man` got bounced to contributor.
+
+## Fix
+
+In the `link-host` handler:
+
+1. Add `coHosts: true` to the party `select`.
+2. Build a set of authorized host handles = primary host telegram + every
+   co-host with `canEdit === true` and a string `telegram` field. Only the
+   `telegram` field is matched — display-only partners have `canEdit:false` and
+   no telegram, so they're excluded (twitter/instagram are never matched).
+   Match the normalized tapper handle against that set.
+3. On a host match, also `deleteMany` any stale `party_telegram_contributors`
+   row for this `(partyId, chatId)` so it can't shadow the host binding in
+   `resolveSubmitterContext` ("most-recent-action-wins").
+
+The contributor (`linkPurpose === 'submit'`) and `not_host` branches are
+unchanged. `normalizeTgHandle` is unchanged.
+
+## Scope
+
+- rsvpizza only, single file: `backend/src/routes/telegram-link-callback.routes.ts`.
+- No migration (reads existing `co_hosts` JSON; deletes existing contributor rows).
+- Backend auto-deploys from `master` on merge.
+
+## Test plan
+
+After deploy: an editor co-host taps the connect link / pastes
+`/start submit_<token>` → bot replies "connected as host" → their
+headcount/receipt is attributed to the event.


### PR DESCRIPTION
## Problem
`/api/telegram/link-host` verified the tapper's Telegram @handle only against the **primary** host (`party.user.telegram`). Editor co-hosts (in `parties.co_hosts`, `canEdit=true`) were downgraded to photo-only contributors and couldn't submit receipts/attendance by DM. Confirmed live: Philadelphia primary host `Saucysaucier`, co-host `@snack_man` bounced to contributor.

## Fix
Match the tapper against the primary host **or** any `canEdit:true` co-host's `telegram` field (only that field — display-only partners have `canEdit:false`/no telegram, so they're excluded). On a host match, also delete any stale `party_telegram_contributors` row for that chat so the "most-recent-action-wins" resolver can't let an old contributor row shadow the host binding. Backend-only, no migration.

## Test plan
After deploy: an editor co-host taps the connect link / pastes `/start submit_<token>` → bot replies "connected as host" → their headcount/receipt is attributed to the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)