### PR TITLE
paccheri-58541: /payments Pending tile = capped receipts − paid (open cities) + refund tag

### DIFF
--- a/backend/src/lib/eventTags.ts
+++ b/backend/src/lib/eventTags.ts
@@ -23,6 +23,10 @@ export const INTERNAL_EVENT_TAGS = new Set<string>([
   // 'nonpres' — used only in the payments-admin UI + swcHub helper, never
   // surfaced publicly.
   'nonhub',
+  // paccheri-58541: 'refund' marks an open city that has been OVERPAID (paid
+  // exceeds capped receipt total) so admins can chase a refund. Admin-only —
+  // must never surface on a public PublicEvent / GPP payload.
+  'refund',
 ]);
 
 const INTERNAL_TAG_PATTERNS: RegExp[] = [

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -53,6 +53,11 @@ import {
 } from '../middleware/regionalUnderboss.js';
 import { scorePartiesByIds } from '../lib/fakeDetectionScan.js';
 import { withPaidTag, withoutPaidTag } from '../lib/eventTags.js';
+// paccheri-58541: refund-tag recompute (wired into every payment-record +
+// receipt-change path). Note the intentional runtime-only circular import:
+// refundTag.ts imports `fetchPaidTotalsByParty` from THIS module; both are
+// referenced only at call time so the ESM cycle resolves cleanly.
+import { recomputeRefundTags, REFUND_CAP_USD } from '../services/refundTag.js';
 import { sendToCityGroup } from '../services/cityTelegramGroup.js';
 // suppli-58533: sendTelegramMessage moved to a shared service so the host-inbound
 // handler can reuse the exact same send path (withBennySignature + preview off).
@@ -157,6 +162,22 @@ const PAID_HAS_PROOF_WHERE: Prisma.PayoutWhereInput = {
     { externalProofUrl: { not: null, notIn: [''] } },
   ],
 };
+
+/**
+ * paccheri-58541: fire-and-forget refund-tag recompute after a mutation that
+ * changes a party's paid total or receipt total. ALWAYS awaited AFTER the
+ * surrounding $transaction commits, and wrapped so a tag-recompute failure can
+ * never 500 the underlying action. Pass the affected partyId(s).
+ */
+async function safeRecomputeRefundTags(partyIds: Array<string | null | undefined>): Promise<void> {
+  try {
+    const ids = partyIds.filter((id): id is string => typeof id === 'string' && id.length > 0);
+    if (ids.length === 0) return;
+    await recomputeRefundTags(prisma, ids);
+  } catch (err) {
+    console.error('[paccheri-58541] recomputeRefundTags failed', err);
+  }
+}
 
 /**
  * JS-side proof check (mirror of PAID_HAS_PROOF_WHERE) for use after rows are
@@ -454,7 +475,7 @@ function escapeCSV(value: string): string {
  * no paid payouts are simply absent from the map — callers should default to
  * `{ paidUsd: 0, paidCount: 0 }` for those.
  */
-async function fetchPaidTotalsByParty(
+export async function fetchPaidTotalsByParty(
   partyIds: string[],
 ): Promise<Map<string, { paidUsd: number; paidCount: number }>> {
   if (partyIds.length === 0) return new Map();
@@ -1667,6 +1688,73 @@ router.get(
 //     Mirrors the bismarck-92103 prepay admin override. When override is used,
 //     the audit row's `note` records "Recipient overridden to {email}".
 // ============================================
+// paccheri-58541: one-time backfill — recompute the 'refund' event_tag across
+// ALL open cities that have ≥1 non-excluded receipt. Run ONCE after the backend
+// deploys this code. Admin-guarded (same guard as the other mutation POSTs) and
+// declared among the literal POST routes (NOT after GET /:id) so the path isn't
+// shadowed. Pages in batches; returns { scanned, tagged, untagged }.
+router.post(
+  '/recompute-refund-tags',
+  requireAuth,
+  requireAnyAdminOrPaymentAdmin,
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const BATCH = 200;
+      let scanned = 0;
+      let tagged = 0;
+      let untagged = 0;
+      let cursor: string | undefined;
+      // Iterate over all OPEN cities with ≥1 non-excluded receipt. Cursor by id.
+      for (;;) {
+        const parties = await prisma.party.findMany({
+          where: {
+            paymentsClosedAt: null,
+            payoutDocuments: {
+              some: { kind: 'receipt', isDuplicate: false, ineligible: false },
+            },
+          },
+          select: { id: true, eventTags: true },
+          orderBy: { id: 'asc' },
+          take: BATCH,
+          ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+        });
+        if (parties.length === 0) break;
+
+        const ids = parties.map((p) => p.id);
+        // Snapshot tag membership BEFORE the recompute to report tagged/untagged.
+        const hadTagById = new Map<string, boolean>();
+        for (const p of parties) {
+          hadTagById.set(
+            p.id,
+            Array.isArray(p.eventTags) && p.eventTags.includes('refund'),
+          );
+        }
+
+        await recomputeRefundTags(prisma, ids);
+
+        const after = await prisma.party.findMany({
+          where: { id: { in: ids } },
+          select: { id: true, eventTags: true },
+        });
+        for (const p of after) {
+          const has = Array.isArray(p.eventTags) && p.eventTags.includes('refund');
+          const had = hadTagById.get(p.id) === true;
+          scanned += 1;
+          if (has && !had) tagged += 1;
+          else if (!has && had) untagged += 1;
+        }
+
+        cursor = parties[parties.length - 1].id;
+        if (parties.length < BATCH) break;
+      }
+
+      res.json({ scanned, tagged, untagged });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
 router.post(
   '/external',
   requireAuth,
@@ -1915,6 +2003,9 @@ router.post(
           audits: { orderBy: { createdAt: 'desc' } },
         },
       });
+
+      // paccheri-58541: external payment changed this party's paid total.
+      await safeRecomputeRefundTags([partyId]);
 
       res.status(201).json({ payout: serializePayout(full || created) });
     } catch (error) {
@@ -2819,7 +2910,10 @@ router.get(
         byMethod[methodKey] = (byMethod[methodKey] || 0) + 1;
         const usd = Number(r.finalAmountUsd);
         if (r.status === 'pending') {
-          totalUsdPending += usd;
+          // paccheri-58541: totalUsdPending NO LONGER sums pending payout-row
+          // amounts. It is recomputed below as Σ max(0, min(625, receiptTotal)
+          // − paid) over OPEN cities with receipts (see below). awaitingReview
+          // (the count of pending rows) is UNCHANGED and still tallied here.
           awaitingReview += 1;
         } else if (r.status === 'paid') {
           // prosciutto-92106: only proven-paid rows (have transaction_hash /
@@ -2902,6 +2996,97 @@ router.get(
           closedPaidSum += partyTotals.get(pid)?.totalPaidUsd ?? 0;
         }
         avgUsd = closedPaidSum / closedPartyIds.size;
+      }
+
+      // paccheri-58541: REDEFINED "Pending" tile. It NO LONGER sums
+      // status='pending' payout-row amounts. New meaning = total reimbursement
+      // money STILL OWED to hosts, across OPEN cities that have submitted at
+      // least one receipt:
+      //
+      //   totalUsdPending = Σ over qualifying events E of
+      //                       max(0, min(625, receiptTotal(E)) − paid(E))
+      //
+      // - qualifying E = Party with paymentsClosedAt IS NULL AND ≥1 submitted
+      //   receipt (payout_documents kind='receipt', NOT is_duplicate, NOT
+      //   ineligible).
+      // - receiptTotal(E) = Σ ocr_amount over those receipt docs (NULL → 0).
+      // - cap = literal 625 (NOT computeEffectiveCapUsd).
+      // - paid(E) = proof-backed status='paid' only (fetchPaidTotalsByParty;
+      //   'completed' rows are intentionally excluded so mark_pending_complete
+      //   close-outs don't double-count).
+      // - per-event floor at $0 (an event never contributes negative).
+      //
+      // SCOPE: "all open cities with receipts" includes events with ZERO payout
+      // rows, so this CANNOT be derived from `allFiltered`. We run a party-level
+      // query scoped ONLY by the party-level portion of the active filter
+      // (where.party + the search partyId set) — payout-level filters
+      // (status/method/currency/date) are intentionally excluded. Extraction
+      // mirrors the showTbdUnsubmitted block above field-for-field.
+      // (`totalUsdPending` is declared with the other totals above and was left
+      // at 0 by the loop — the pending branch no longer adds to it.)
+      {
+        const pendingPartyScope: any = { ...(where.party ?? {}) };
+        const pendingAndParts: any[] = [
+          { paymentsClosedAt: null },
+          // ≥1 non-excluded receipt doc.
+          {
+            payoutDocuments: {
+              some: { kind: 'receipt', isDuplicate: false, ineligible: false },
+            },
+          },
+        ];
+        if (Array.isArray(where.OR)) {
+          const searchPartyIds = where.OR
+            .map((o: any) => o?.partyId?.in)
+            .find((v: any) => Array.isArray(v));
+          if (Array.isArray(searchPartyIds)) {
+            pendingAndParts.push({ id: { in: searchPartyIds } });
+          }
+        }
+        if (typeof where.partyId === 'string' && where.partyId.length > 0) {
+          pendingAndParts.push({ id: where.partyId });
+        }
+        pendingPartyScope.AND = [
+          ...(Array.isArray(pendingPartyScope.AND) ? pendingPartyScope.AND : []),
+          ...pendingAndParts,
+        ];
+
+        const pendingParties = await prisma.party.findMany({
+          where: pendingPartyScope,
+          select: { id: true },
+        });
+        const pendingPartyIds = pendingParties.map((p) => p.id);
+
+        if (pendingPartyIds.length > 0) {
+          // receiptTotal per party (non-excluded receipt docs; NULL ocr → 0).
+          const receiptAgg = await prisma.payoutDocument.groupBy({
+            by: ['partyId'],
+            where: {
+              partyId: { in: pendingPartyIds },
+              kind: 'receipt',
+              isDuplicate: false,
+              ineligible: false,
+            },
+            _sum: { ocrAmount: true },
+          });
+          const receiptByParty = new Map<string, number>();
+          for (const r of receiptAgg) {
+            receiptByParty.set(
+              r.partyId,
+              r._sum.ocrAmount ? Number(r._sum.ocrAmount.toString()) : 0,
+            );
+          }
+          // proof-backed paid per party (shared helper).
+          const pendingPaidTotals = await fetchPaidTotalsByParty(pendingPartyIds);
+          for (const pid of pendingPartyIds) {
+            const receiptTotal = receiptByParty.get(pid) ?? 0;
+            const paid = pendingPaidTotals.get(pid)?.paidUsd ?? 0;
+            totalUsdPending += Math.max(
+              0,
+              Math.min(REFUND_CAP_USD, receiptTotal) - paid,
+            );
+          }
+        }
       }
 
       // taleggio-49183: the parmigiana-58291 top-level `byParty` aggregate
@@ -4362,6 +4547,9 @@ router.post(
         return row;
       });
 
+      // paccheri-58541: mark-paid changed this party's paid total.
+      await safeRecomputeRefundTags([existing.partyId]);
+
       res.json({ payout: serializePayout(updated) });
     } catch (error) {
       next(error);
@@ -4402,7 +4590,8 @@ router.post(
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true },
+        // paccheri-58541: include partyId so we can recompute the refund tag.
+        select: { id: true, status: true, hostUserId: true, partyId: true },
       });
 
       if (!existing) {
@@ -4457,6 +4646,9 @@ router.post(
 
         return row;
       });
+
+      // paccheri-58541: revert-paid changed this party's paid total.
+      await safeRecomputeRefundTags([existing.partyId]);
 
       res.json({ payout: serializePayout(updated) });
     } catch (error) {
@@ -5125,7 +5317,8 @@ router.post(
       const actor = await loadActor(req);
       const existing = await prisma.payout.findUnique({
         where: { id: req.params.id },
-        select: { id: true, status: true, hostUserId: true },
+        // paccheri-58541: include partyId so we can recompute the refund tag.
+        select: { id: true, status: true, hostUserId: true, partyId: true },
       });
       if (!existing) {
         throw new AppError('Payout not found', 404, 'NOT_FOUND');
@@ -5151,6 +5344,10 @@ router.post(
         // itself (requireAnyAdminOrPaymentAdmin above).
         allowOverPartyCap: !!(req.body && req.body.allowOverPartyCap),
       });
+
+      // paccheri-58541: execution (success → paid) changed this party's paid
+      // total. Safe even on a failed send — recompute is idempotent.
+      await safeRecomputeRefundTags([existing.partyId]);
 
       res.json({ payout: serializePayout(updated) });
     } catch (error) {
@@ -5383,6 +5580,9 @@ router.post(
         }
       }
 
+      // paccheri-58541: the batch changed paid totals for every touched party.
+      await safeRecomputeRefundTags(eligible.map((r) => r.partyId));
+
       // bottarga-58513: include the skipped (no-receipt) ids so the UI can tell
       // the admin which rows were not sent and need a receipt / individual send.
       res.json({ results, skippedNoReceipt });
@@ -5460,6 +5660,9 @@ router.patch(
           id: true,
           kind: true,
           payoutId: true,
+          // paccheri-58541: partyId so we can recompute the refund tag after a
+          // receipt ocr-amount edit or duplicate/ineligible toggle.
+          partyId: true,
           ocrAmount: true,
           ocrCurrency: true,
           // mortadella-92103: pull the existing original-amount + raw OCR
@@ -6053,6 +6256,10 @@ router.patch(
 
         return row;
       });
+
+      // paccheri-58541: an ocr-amount edit or duplicate/ineligible toggle on a
+      // receipt changes the party's receipt total → recompute the refund tag.
+      await safeRecomputeRefundTags([doc.partyId]);
 
       res.json({
         document: {
@@ -6925,6 +7132,10 @@ router.post(
 
         return row;
       });
+
+      // paccheri-58541: admin added a document — if it's a receipt the party's
+      // receipt total changed → recompute the refund tag (no-op for photos).
+      await safeRecomputeRefundTags([partyId]);
 
       res.json({
         document: {
@@ -8017,6 +8228,8 @@ partyMarkPaidRouter.post(
             },
             select: { id: true, name: true, paymentsClosedAt: true },
           });
+          // paccheri-58541: city just closed → drop the refund tag.
+          await safeRecomputeRefundTags([partyId]);
           res.json({
             count: 0,
             party: {
@@ -8256,6 +8469,11 @@ partyMarkPaidRouter.post(
         select: { id: true, name: true, paymentsClosedAt: true },
       });
 
+      // paccheri-58541: paid totals changed (and the city may have just
+      // closed) → recompute the refund tag. If the city closed, the tag is
+      // dropped; otherwise it reflects the new paid-vs-receipts math.
+      await safeRecomputeRefundTags([partyId]);
+
       res.json({
         count: updatedIds.length,
         mode: resolvedMode,
@@ -8368,6 +8586,10 @@ partyMarkPaidRouter.post(
           },
         });
       });
+
+      // paccheri-58541: city reopened → re-add the refund tag if it's still
+      // overpaid (recomputeRefundTags keys on the now-null paymentsClosedAt).
+      await safeRecomputeRefundTags([partyId]);
 
       res.json({
         party: { id: party.id, name: party.name, paymentsClosedAt: null },

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -36,8 +36,24 @@ import {
   NON_TERMINAL_PAYOUT_STATUSES,
   payoutRowSnapshotFromUser,
 } from '../services/payout-snapshot.js';
+import { recomputeRefundTags } from '../services/refundTag.js';
 
 const router = Router();
+
+/**
+ * paccheri-58541: fire-and-forget refund-tag recompute after a host-side
+ * receipt change (create / edit / delete). Always runs AFTER the mutation
+ * commits and never throws — a tag-recompute failure must not 500 the host's
+ * receipt submission.
+ */
+async function safeRecomputeRefundTags(partyId: string | null | undefined): Promise<void> {
+  try {
+    if (typeof partyId !== 'string' || partyId.length === 0) return;
+    await recomputeRefundTags(prisma, [partyId]);
+  } catch (err) {
+    console.error('[paccheri-58541] recomputeRefundTags failed', err);
+  }
+}
 
 // Path-scope auth on /:partyId/payouts ONLY. The router is mounted at
 // /api/parties (alongside many sibling routers including partyRoutes after
@@ -1748,6 +1764,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       }
     }
 
+    // paccheri-58541: a new host receipt changes the party's receipt total.
+    await safeRecomputeRefundTags(req.params.partyId);
+
     res.status(201).json({ payout: serializePayout(payout) });
   } catch (error) {
     // tortellini-58520: structured capture so the next prod 500 on payout
@@ -2595,6 +2614,10 @@ router.patch('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respon
       return row;
     });
 
+    // paccheri-58541: PATCH deletes + recreates receipt docs, changing the
+    // party's receipt total → recompute the refund tag.
+    await safeRecomputeRefundTags(req.params.partyId);
+
     res.json({ payout: serializePayout(updated) });
   } catch (error) {
     next(error);
@@ -2669,6 +2692,10 @@ router.delete('/:partyId/payouts/:payoutId', async (req: AuthRequest, res: Respo
         },
       });
     });
+
+    // paccheri-58541: host withdrew the payout request — recompute the refund
+    // tag (paid/committed totals may have shifted).
+    await safeRecomputeRefundTags(req.params.partyId);
 
     res.json({ success: true });
   } catch (error) {
@@ -3155,6 +3182,10 @@ router.post('/:partyId/reimbursement/receipts', async (req: AuthRequest, res: Re
       // Non-fatal — the upload succeeded.
     }
 
+    // paccheri-58541: forwarded-payload receipt create changes the party's
+    // receipt total → recompute the refund tag.
+    await safeRecomputeRefundTags(req.params.partyId);
+
     res.status(201).json({
       reimbursement: serializePayout(updated),
       receipts: updated.documents.filter((d) => d.kind === 'receipt').map(serializeDocument),
@@ -3223,6 +3254,10 @@ router.delete('/:partyId/reimbursement/receipts/:docId', async (req: AuthRequest
         },
       });
     });
+
+    // paccheri-58541: host deleted a receipt → receipt total changed →
+    // recompute the refund tag.
+    await safeRecomputeRefundTags(req.params.partyId);
 
     res.json({
       reimbursement: serializePayout(updated),

--- a/backend/src/routes/telegram-inbound.routes.ts
+++ b/backend/src/routes/telegram-inbound.routes.ts
@@ -32,6 +32,7 @@ import { createClient } from '@supabase/supabase-js';
 import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../config/database.js';
+import { recomputeRefundTags } from '../services/refundTag.js';
 import {
   resolveSubmitterContext,
   downloadTelegramFile,
@@ -520,6 +521,14 @@ router.post(
           `✅ Got your receipt for ${party.name}${amountFragment}. ` +
             `That's ${receiptCount} receipt${receiptCount === 1 ? '' : 's'} on file.`,
         );
+        // paccheri-58541: host DM'd a receipt to Molto Benny → receipt total
+        // changed → recompute the refund tag (non-fatal).
+        try {
+          await recomputeRefundTags(prisma, [party.id]);
+        } catch (err) {
+          console.error('[paccheri-58541][host-inbound] recomputeRefundTags failed', err);
+        }
+
         return res.status(200).json({ ok: true, action: 'receipt', partyName: party.name });
       }
 

--- a/backend/src/services/refundTag.ts
+++ b/backend/src/services/refundTag.ts
@@ -1,0 +1,137 @@
+/**
+ * paccheri-58541: single source of truth for the 'refund' event_tag.
+ *
+ * A city is "refund due" when it is OPEN (paymentsClosedAt IS NULL), has at
+ * least one submitted (non-duplicate, non-ineligible) receipt, AND the
+ * proof-backed PAID total exceeds the capped receipt total — i.e. PizzaDAO
+ * over-reimbursed and is owed money back.
+ *
+ * The 'refund' tag is INTERNAL (see backend/src/lib/eventTags.ts +
+ * frontend/src/lib/eventTags.ts): it is stripped from every public payload and
+ * suppressed on guest-facing surfaces. It stays visible on /payments and
+ * /underboss admin surfaces.
+ *
+ * `recomputeRefundTags` is batched + idempotent: it only writes rows whose tag
+ * membership actually changes. Wire it AFTER any mutation that changes a
+ * party's paid total or receipt total (payment-record + receipt-change paths),
+ * outside the surrounding $transaction, wrapped in try/catch so a tag-recompute
+ * failure never 500s the underlying action.
+ */
+import { PrismaClient } from '@prisma/client';
+import { fetchPaidTotalsByParty } from '../routes/admin-payout.routes.js';
+
+export const REFUND_TAG = 'refund';
+
+// paccheri-58541: literal cap. Matches the /payments Pending tile formula —
+// deliberately NOT computeEffectiveCapUsd (per-event numeric-tag caps do not
+// raise the refund ceiling).
+export const REFUND_CAP_USD = 625;
+
+export interface PartyReimbursementState {
+  receiptTotalUsd: number;
+  capUsd: number;
+  paidUsd: number;
+  owedUsd: number;
+  isRefund: boolean;
+}
+
+/**
+ * Per-party reimbursement state for the given partyIds. Parties with no
+ * receipts still appear in the map (receiptTotalUsd 0, isRefund false) when
+ * loaded, but callers typically pass an id set already known to have receipts.
+ */
+export async function computePartyReimbursementState(
+  db: PrismaClient,
+  partyIds: string[],
+): Promise<Map<string, PartyReimbursementState>> {
+  const result = new Map<string, PartyReimbursementState>();
+  if (partyIds.length === 0) return result;
+
+  // receiptTotal: Σ ocr_amount over non-excluded receipt docs (NULL → 0).
+  const receiptRows = await db.payoutDocument.groupBy({
+    by: ['partyId'],
+    where: {
+      partyId: { in: partyIds },
+      kind: 'receipt',
+      isDuplicate: false,
+      ineligible: false,
+    },
+    _sum: { ocrAmount: true },
+  });
+  const receiptTotals = new Map<string, number>();
+  for (const r of receiptRows) {
+    receiptTotals.set(
+      r.partyId,
+      r._sum.ocrAmount ? Number(r._sum.ocrAmount.toString()) : 0,
+    );
+  }
+
+  // paid: proof-backed status='paid' only (reuse the shared helper — do NOT
+  // duplicate the proof logic; 'completed' rows are intentionally excluded so
+  // mark_pending_complete close-outs don't double-count).
+  const paidTotals = await fetchPaidTotalsByParty(partyIds);
+
+  // closed-state: a closed city is never a refund (the tag is cleared on
+  // close), regardless of the math.
+  const parties = await db.party.findMany({
+    where: { id: { in: partyIds } },
+    select: { id: true, paymentsClosedAt: true },
+  });
+  const closedById = new Map<string, boolean>();
+  for (const p of parties) closedById.set(p.id, p.paymentsClosedAt != null);
+
+  for (const partyId of partyIds) {
+    const receiptTotalUsd = receiptTotals.get(partyId) ?? 0;
+    const paidUsd = paidTotals.get(partyId)?.paidUsd ?? 0;
+    const cappedReceipts = Math.min(REFUND_CAP_USD, receiptTotalUsd);
+    const owedUsd = Math.max(0, cappedReceipts - paidUsd);
+    const isClosed = closedById.get(partyId) === true;
+    const hasReceipts = receiptTotals.has(partyId);
+    const isRefund = !isClosed && hasReceipts && paidUsd > cappedReceipts;
+    result.set(partyId, {
+      receiptTotalUsd,
+      capUsd: REFUND_CAP_USD,
+      paidUsd,
+      owedUsd,
+      isRefund,
+    });
+  }
+  return result;
+}
+
+/**
+ * Add / remove REFUND_TAG in party.event_tags to match `isRefund`. Only writes
+ * rows whose membership actually changes (no-op when already correct). Closed
+ * parties always have the tag REMOVED (computePartyReimbursementState forces
+ * isRefund=false for closed cities).
+ */
+export async function recomputeRefundTags(
+  db: PrismaClient,
+  partyIds: string[],
+): Promise<void> {
+  const ids = Array.from(new Set(partyIds.filter((id) => typeof id === 'string' && id.length > 0)));
+  if (ids.length === 0) return;
+
+  const states = await computePartyReimbursementState(db, ids);
+
+  const parties = await db.party.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, eventTags: true },
+  });
+
+  for (const party of parties) {
+    const desired = states.get(party.id)?.isRefund === true;
+    const current = Array.isArray(party.eventTags) ? party.eventTags : [];
+    const has = current.includes(REFUND_TAG);
+    if (desired === has) continue; // already correct — no-op
+
+    const next = desired
+      ? Array.from(new Set([...current, REFUND_TAG])) // add + dedupe
+      : current.filter((t) => t !== REFUND_TAG);       // remove
+
+    await db.party.update({
+      where: { id: party.id },
+      data: { eventTags: next },
+    });
+  }
+}

--- a/frontend/src/components/TriStateFilterDropdown.tsx
+++ b/frontend/src/components/TriStateFilterDropdown.tsx
@@ -22,6 +22,13 @@ interface TriStateFilterDropdownProps {
   excludeLabel: string;
   /** applied to the outer `relative` wrapper */
   className?: string;
+  /**
+   * paccheri-58541: optional friendly display label for a raw item value (e.g.
+   * map 'refund' → 'Refund due'). The underlying filter value is unchanged; the
+   * label is used for rendering AND type-ahead matching. Items without a mapping
+   * render as-is.
+   */
+  labelFor?: (item: string) => string;
 }
 
 export function TriStateFilterDropdown({
@@ -36,7 +43,9 @@ export function TriStateFilterDropdown({
   includeLabel,
   excludeLabel,
   className,
+  labelFor,
 }: TriStateFilterDropdownProps) {
+  const displayLabel = (item: string) => (labelFor ? labelFor(item) : item);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   // touchOrder floats recently-interacted items to the top of the dropdown.
@@ -57,7 +66,11 @@ export function TriStateFilterDropdown({
   }, [availableSorted, touchOrder, includes, excludes]);
 
   const visibleItems = search.trim()
-    ? orderedItems.filter((x) => x.toLowerCase().includes(search.trim().toLowerCase()))
+    ? orderedItems.filter((x) => {
+        const q = search.trim().toLowerCase();
+        // paccheri-58541: match the raw value OR the friendly display label.
+        return x.toLowerCase().includes(q) || displayLabel(x).toLowerCase().includes(q);
+      })
     : orderedItems;
 
   function getState(item: string): 'neutral' | 'include' | 'exclude' {
@@ -131,7 +144,7 @@ export function TriStateFilterDropdown({
                   <React.Fragment key={item}>
                     {showDivider && <div className="border-t border-theme-stroke my-1" />}
                     <div className="flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-theme-surface transition-colors">
-                      <span className="text-sm text-theme-text truncate">{item}</span>
+                      <span className="text-sm text-theme-text truncate">{displayLabel(item)}</span>
                       <div className="flex items-center gap-1 shrink-0">
                         <button
                           onClick={() => setState(item, state === 'include' ? 'neutral' : 'include')}

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -418,6 +418,8 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
                   includes={filters.tagIncludes ?? []}
                   excludes={filters.tagExcludes ?? []}
                   onChange={({ includes, excludes }) => update({ tagIncludes: includes, tagExcludes: excludes })}
+                  // paccheri-58541: friendly label for the refund-due tag.
+                  labelFor={(t) => (t === 'refund' ? 'Refund due' : t)}
                   searchPlaceholder="Search tags…"
                   noMatchesLabel="No tags"
                   clearLabel="Clear"
@@ -451,7 +453,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               >
                 <option value="all">All tags</option>
                 {availableTags.map((t) => (
-                  <option key={t} value={t}>{t}</option>
+                  <option key={t} value={t}>{t === 'refund' ? 'Refund due' : t}</option>
                 ))}
               </select>
             </div>

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -6,6 +6,7 @@ import { generateWaveRecommendations } from '../utils/waveAlgorithm';
 import { TOPPINGS, DRINK_CATEGORIES, DIETARY_OPTIONS, PIZZA_STYLES, PIZZA_SIZES } from '../constants/options';
 import * as db from '../lib/supabase';
 import { computeEffectiveCapUsd } from '../lib/reimbursementCap';
+import { REFUND_TAG } from '../lib/eventTags';
 
 interface PizzaContextType {
   // Party management
@@ -159,7 +160,11 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     rollupImageUrl: dbParty.rollup_image_url || null,
     rollupGeneratedAt: dbParty.rollup_generated_at || null,
     eventType: dbParty.event_type || null,
-    eventTags: dbParty.event_tags || [],
+    // paccheri-58541: strip the internal 'refund' tag from the host-facing
+    // party. Other internal tags ('go', numeric caps) are deliberately KEPT —
+    // HostPage's cap-gating + reimbursementCap math rely on them. The raw
+    // dbParty.event_tags is still used directly for the cap computation below.
+    eventTags: (dbParty.event_tags || []).filter((t) => t !== REFUND_TAG),
     canEdit: dbParty.can_edit || false,
     allowedTabs: dbParty.allowed_tabs,
     hiddenGppPhotos: (dbParty.hidden_gpp_photos as string[]) || [],

--- a/frontend/src/hooks/useRSVPForm.ts
+++ b/frontend/src/hooks/useRSVPForm.ts
@@ -9,6 +9,7 @@ import { uuid } from '../lib/utils';
 import { findActiveRegion } from '../lib/optinAbRegions';
 import { getOrCreateVisitorSessionId } from '../lib/visitorSession';
 import { rankPizzerias } from '../lib/pizzeriaRank';
+import { publicEventTags } from '../lib/eventTags';
 
 // ---- Types ----
 
@@ -66,7 +67,9 @@ export function publicEventToRSVPData(event: PublicEvent): RSVPEventData {
     customUrl: event.customUrl,
     address: event.address,
     eventType: event.eventType,
-    eventTags: event.eventTags,
+    // paccheri-58541: belt-and-suspenders — the API already strips internal
+    // tags, but re-filter so 'refund'/'paid' never reach the public RSVP form.
+    eventTags: publicEventTags(event.eventTags),
     nftEnabled: event.nftEnabled,
     nftChain: event.nftChain,
     eventImageUrl: event.eventImageUrl,
@@ -91,7 +94,10 @@ export function dbPartyToRSVPData(party: DbParty): RSVPEventData {
     customUrl: party.custom_url,
     address: party.address,
     eventType: party.event_type,
-    eventTags: party.event_tags,
+    // paccheri-58541: Supabase-direct boundary — strip internal/control tags
+    // ('refund', 'paid', etc.) so they never reach the public RSVP form /
+    // checkbox list. Tag-based row filtering only uses public taxonomy tags.
+    eventTags: publicEventTags(party.event_tags),
     nftEnabled: party.nft_enabled,
     nftChain: party.nft_chain,
     eventImageUrl: party.event_image_url,

--- a/frontend/src/lib/eventTags.ts
+++ b/frontend/src/lib/eventTags.ts
@@ -1,0 +1,54 @@
+/**
+ * paccheri-58541: frontend mirror of `backend/src/lib/eventTags.ts`.
+ *
+ * `parties.event_tags` is overloaded as both a public taxonomy (season /
+ * program markers like 'gpp2026', 'swc', 'SWC Hub') AND a private control
+ * channel for admin / underboss / payments workflows (scam flags, payout
+ * state, the new 'refund' refund-due marker, reimbursement caps). Control
+ * tags must never reach a guest-facing surface.
+ *
+ * Pages that load a Party through the backend public payloads
+ * (`/api/gpp/events`, `/api/events/:id`) already get tags filtered by the
+ * backend `publicTags()` boundary. Pages that load the Party DIRECTLY from
+ * Supabase (RSVPPage, the host PizzaContext) bypass that boundary, so they
+ * call `publicEventTags()` here at the mapping boundary.
+ *
+ * Keep INTERNAL_EVENT_TAGS in sync with the backend set.
+ */
+
+export const REFUND_TAG = 'refund';
+
+export const INTERNAL_EVENT_TAGS = new Set<string>([
+  'possible-scam', // manual /payments scam flag
+  'paid',          // payout closed out (auto-tagged on mark-paid close-out)
+  'prepay',        // payout workflow state
+  'go',            // payout workflow state
+  'nonpres',       // admin-only "not a presidential/SWC city" gate marker
+  'missed',        // payout workflow state
+  'nonhub',        // admin-only SWC-Hub-gate opt-out
+  REFUND_TAG,      // paccheri-58541: refund-due (overpaid open city) marker
+]);
+
+const INTERNAL_TAG_PATTERNS: RegExp[] = [
+  // numeric reimbursement-cap tags ('200', '500', '350.50').
+  /^\d+(\.\d{1,2})?$/,
+  // party-kit cap tags ('k40', 'k200.50').
+  /^k\d+(\.\d{1,2})?$/i,
+  /^gpp2027$/i, // pre-launch year gate marker
+];
+
+export function isInternalEventTag(tag: string): boolean {
+  if (typeof tag !== 'string') return false;
+  const t = tag.trim();
+  if (INTERNAL_EVENT_TAGS.has(t) || INTERNAL_EVENT_TAGS.has(t.toLowerCase())) return true;
+  return INTERNAL_TAG_PATTERNS.some((re) => re.test(t));
+}
+
+/**
+ * Strip internal/control tags from a tag list for guest-facing rendering.
+ * Used at the Supabase-direct public mapping boundaries only.
+ */
+export function publicEventTags(tags: string[] | null | undefined): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags.filter((t) => !isInternalEventTag(t));
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -611,6 +611,9 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         }
       }
     }
+    // paccheri-58541: always offer the 'refund' (refund-due) tag as a filter
+    // option even when no loaded row carries it yet, so admins can discover it.
+    set.add('refund');
     return Array.from(set).sort();
   }, [payouts]);
 
@@ -639,6 +642,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         }
       }
     }
+    // paccheri-58541: always offer the 'refund' (refund-due) tag (see above).
+    set.add('refund');
     return Array.from(set).sort();
   }, [byPartyRows]);
 

--- a/frontend/src/pages/RSVPPage.tsx
+++ b/frontend/src/pages/RSVPPage.tsx
@@ -7,6 +7,7 @@ import { DonationForm } from '../components/DonationForm';
 import { PublicEvent, getDonationStats, trackRsvpFunnel } from '../lib/api';
 import { DonationPublicStats } from '../types';
 import { useRSVPForm, dbPartyToRSVPData } from '../hooks/useRSVPForm';
+import { publicEventTags } from '../lib/eventTags';
 // GPP theme applied conditionally
 import { GPPClouds } from '../components/GPPClouds';
 import { useConfetti } from '../hooks/useConfetti';
@@ -45,7 +46,9 @@ function dbPartyToPublicEvent(party: DbParty, inviteCode: string): PublicEvent {
     userId: party.user_id,
     selectedPizzerias: party.selected_pizzerias as any,
     eventType: party.event_type,
-    eventTags: party.event_tags,
+    // paccheri-58541: strip internal/control tags (e.g. 'refund', 'paid') at
+    // this Supabase-direct public boundary so they never leak to RSVPers.
+    eventTags: publicEventTags(party.event_tags),
     donationEnabled: party.donation_enabled,
     donationRecipient: party.donation_recipient,
     donationRecipientUrl: party.donation_recipient_url,


### PR DESCRIPTION
## Summary

Redefines the **/payments "Pending"** KPI tile and introduces a persisted, internal **`refund`** event tag for over-reimbursed open cities.

### A. Pending tile redefined (response key `totalUsdPending` unchanged)
Old: Σ `finalAmountUsd` over `status='pending'` payout rows.
New (money still OWED to hosts):
```
totalUsdPending = Σ over qualifying open cities E of  max(0, min(625, receiptTotal(E)) − paid(E))
```
- **Qualifying E** = `paymentsClosedAt IS NULL` AND ≥1 submitted receipt (`payout_documents kind='receipt'`, NOT `is_duplicate`, NOT `ineligible`).
- **receiptTotal(E)** = Σ `ocr_amount` over those docs (NULL → 0).
- **cap** = literal **625** (NOT `computeEffectiveCapUsd`).
- **paid(E)** = proof-backed `status='paid'` only via the existing `fetchPaidTotalsByParty` (`completed` rows excluded to avoid double-counting `mark_pending_complete` close-outs).
- Per-event `max(0, …)` floor.
- Scoped by the party-level portion of the active filter only (mirrors the `showTbdUnsubmitted` extraction). Includes cities with zero payout rows → runs a party-level query, NOT over `allFiltered`.
- `awaitingReview` and all other `totals.*` are unchanged. The `status==='pending'` branch only lost its `totalUsdPending +=`.

### B. New service `backend/src/services/refundTag.ts`
`REFUND_TAG`, `computePartyReimbursementState`, `recomputeRefundTags` — batched + idempotent (only writes rows whose membership changes). `isRefund` = open AND has receipts AND `paid > min(625, receiptTotal)`. Reuses `fetchPaidTotalsByParty` (now exported) for the proof logic — no duplication. Closed cities always have the tag removed.

### C. Wired `recomputeRefundTags` into every mutation path (post-commit, try/catch — never 500s the action)
- `admin-payout.routes.ts`: `POST /external`, `POST /:id/mark-paid`, `POST /:id/revert-paid`, `POST /:id/execute`, `POST /bulk-execute`, `POST /:id/documents`, `PATCH /documents/:docId`, party `POST /:partyId/mark-paid` (covers close) + `POST /:partyId/reopen` (covers re-add).
- `payout.routes.ts`: `POST /:partyId/payouts`, `PATCH /:partyId/payouts/:payoutId`, `DELETE /:partyId/payouts/:payoutId` (host withdraw), `POST /:partyId/reimbursement/receipts` (forwarded create), `DELETE /:partyId/reimbursement/receipts/:docId` (host receipt delete).
- `telegram-inbound.routes.ts`: Molto Benny `POST /host-inbound` receipt path.

### D. One-time backfill endpoint
`POST /api/admin/payouts/recompute-refund-tags` (admin-guarded, declared among literal POSTs). Pages over ALL open cities with ≥1 non-excluded receipt, returns `{ scanned, tagged, untagged }`. **Must be run once after the backend deploys this code.**

### E. Suppress `refund` from public/guest-facing surfaces
- Backend: added `refund` to `INTERNAL_EVENT_TAGS` in `backend/src/lib/eventTags.ts` → stripped by the existing `publicTags()` boundary on all backend public payloads (`/api/gpp/events` → EventsMapPage, `/api/events/:id`).
- Frontend: new `frontend/src/lib/eventTags.ts` (`publicEventTags` / `REFUND_TAG`), applied at the Supabase-direct boundaries (`RSVPPage` mapper, `useRSVPForm` `dbPartyToRSVPData` + `publicEventToRSVPData`). `PizzaContext` strips ONLY `refund` (keeps `go`/numeric caps that HostPage cap-gating relies on).
- Kept VISIBLE on /payments + /underboss admin surfaces.

### F. Payments tag filter chip
`refund` is always offered in the /payments tag filter (`PaymentsAdminPage` `availableTags` + `availableTagsByParty`), with friendly label **"Refund due"** via a new optional `labelFor` prop on `TriStateFilterDropdown` (and the legacy single-select).

## Notes
- **No DB migration** (`event_tags` exists; `refund` is just a new string value).
- Intentional runtime-only ESM circular import: `refundTag.ts` imports `fetchPaidTotalsByParty` from `admin-payout.routes.ts`; both referenced only at call time.
- `paid = proof-backed paid only` (not `completed`) is a deliberate decision to avoid double-counting close-outs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)