### PR TITLE
fix(crostino): make filter/picker dropdown panels opaque

### DIFF
--- a/frontend/src/components/TimezonePickerInput.tsx
+++ b/frontend/src/components/TimezonePickerInput.tsx
@@ -121,7 +121,7 @@ export function TimezonePickerInput({ value, onChange }: TimezonePickerInputProp
       </button>
 
       {isOpen && (
-        <div className="absolute top-full right-0 mt-1 w-80 bg-theme-card border border-theme-stroke-hover rounded-lg shadow-xl z-50 overflow-hidden">
+        <div className="absolute top-full right-0 mt-1 w-80 bg-theme-header border border-theme-stroke-hover rounded-lg shadow-xl z-50 overflow-hidden">
           {/* Search Input */}
           <div className="p-3 border-b border-theme-stroke">
             <input

--- a/frontend/src/components/TriStateFilterDropdown.tsx
+++ b/frontend/src/components/TriStateFilterDropdown.tsx
@@ -116,7 +116,7 @@ export function TriStateFilterDropdown({
       {open && (
         <>
           <div className="fixed inset-0 z-40" onClick={closePanel} />
-          <div className="absolute top-full left-0 mt-1 z-50 w-64 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1">
+          <div className="absolute top-full left-0 mt-1 z-50 w-64 bg-theme-header border border-theme-stroke rounded-lg shadow-xl py-1">
             {(includes.length > 0 || excludes.length > 0) && (
               <div className="flex items-center justify-end px-3 py-1.5 border-b border-theme-stroke">
                 <button onClick={clear} className="text-xs text-red-500/70 hover:text-red-500 transition-colors">{clearLabel}</button>

--- a/frontend/src/components/payments-admin/CurrencyPicker.tsx
+++ b/frontend/src/components/payments-admin/CurrencyPicker.tsx
@@ -128,7 +128,7 @@ export const CurrencyPicker: React.FC<CurrencyPickerProps> = ({
       </div>
 
       {open && (
-        <div className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border border-theme-stroke bg-theme-surface shadow-xl">
+        <div className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border border-theme-stroke bg-theme-header shadow-xl">
           {filtered.length === 0 && (
             <div className="px-3 py-2 text-xs text-theme-text-muted">
               No currencies match "{query}".

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -371,7 +371,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
               {regionsOpen && (
                 <div
                   role="listbox"
-                  className="absolute left-0 right-0 mt-1 z-50 rounded-lg border border-theme-stroke bg-theme-surface shadow-lg py-2 min-w-[200px]"
+                  className="absolute left-0 right-0 mt-1 z-50 rounded-lg border border-theme-stroke bg-theme-header shadow-lg py-2 min-w-[200px]"
                 >
                   {PAYMENTS_REGION_DISPLAY_ORDER.map((slug) => {
                     const checked = selectedRegionPortals.includes(slug);

--- a/frontend/src/components/payouts/tax/CountryPicker.tsx
+++ b/frontend/src/components/payouts/tax/CountryPicker.tsx
@@ -151,7 +151,7 @@ export const CountryPicker: React.FC<CountryPickerProps> = ({
       />
 
       {open && (
-        <div className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border border-theme-stroke bg-theme-surface shadow-xl">
+        <div className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border border-theme-stroke bg-theme-header shadow-xl">
           {filtered.length === 0 && (
             <div className="px-3 py-2 text-xs text-theme-text-muted">
               No countries match "{query}".

--- a/frontend/src/components/underboss/CitiesTable.tsx
+++ b/frontend/src/components/underboss/CitiesTable.tsx
@@ -566,7 +566,7 @@ export function CitiesTable({ events, selectedRegions, meData, onTelegramBroadca
               {showActionDropdown && (
                 <>
                   <div className="fixed inset-0 z-40" onClick={() => setShowActionDropdown(false)} />
-                  <div className="absolute top-full left-0 mt-1 z-50 bg-theme-card border border-theme-stroke rounded-xl shadow-2xl py-1 min-w-[180px]">
+                  <div className="absolute top-full left-0 mt-1 z-50 bg-theme-header border border-theme-stroke rounded-xl shadow-2xl py-1 min-w-[180px]">
                     <button onClick={() => handleBulkStatus('created')} className="w-full text-left px-4 py-2 text-sm text-green-600 hover:bg-theme-surface transition-colors">
                       {t('cities.setCreated')}
                     </button>

--- a/frontend/src/components/underboss/EventRow.tsx
+++ b/frontend/src/components/underboss/EventRow.tsx
@@ -113,7 +113,7 @@ function HostStatusBadge({
       {isOpen && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute top-full left-0 mt-1 z-50 bg-theme-card border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[80px]">
+          <div className="absolute top-full left-0 mt-1 z-50 bg-theme-header border border-theme-stroke rounded-lg shadow-xl py-1 min-w-[80px]">
             {HOST_STATUS_OPTIONS.map((opt) => (
               <button
                 key={opt.value}

--- a/frontend/src/components/underboss/TelegramBroadcast.tsx
+++ b/frontend/src/components/underboss/TelegramBroadcast.tsx
@@ -826,7 +826,7 @@ export function TelegramBroadcast({ onClose, preSelectedCities, events, allHosts
                     {regionDropdownOpen && (
                       <>
                         <div className="fixed inset-0 z-40" onClick={() => setRegionDropdownOpen(false)} />
-                        <div className="absolute top-full right-0 mt-1 z-50 bg-theme-card border border-theme-stroke rounded-xl shadow-2xl py-1 min-w-[160px]">
+                        <div className="absolute top-full right-0 mt-1 z-50 bg-theme-header border border-theme-stroke rounded-xl shadow-2xl py-1 min-w-[160px]">
                           <button
                             onClick={() => { setRegionFilter('all'); setRegionDropdownOpen(false); }}
                             className={`w-full text-left px-3 py-2 text-sm transition-colors ${


### PR DESCRIPTION
## Problem
On **/payments**, the **Country** and **Tags** dropdowns rendered with `bg-theme-card`, which in the dark theme is `rgba(255, 255, 255, 0.07)` — only 7% opaque. The payouts table behind the panel showed through, making the options unreadable (see report).

## Fix
Switched every **floating dropdown panel** that used the translucent `bg-theme-card` / `bg-theme-surface` tokens to **`bg-theme-header`** — the solid token (`#1a1a2e` dark / `rgba(255,255,255,0.8)` light) already used by the `SavedViewsMenu` and `TimePickerInput` dropdowns, which render correctly. Same component pattern, so it stays theme-aware (dark + GPP light).

Panels fixed (audited all `absolute z-50` dropdown panels):
- `TriStateFilterDropdown` — **Country + Tags on /payments** (reported)
- `PayoutsFilterBar` Regions multi-select (/payments)
- `payments-admin/CurrencyPicker`
- `payouts/tax/CountryPicker`
- `TimezonePickerInput`
- `underboss/CitiesTable`, `underboss/EventRow`, `underboss/TelegramBroadcast` region menus

Panels already opaque and left untouched: `SavedViewsMenu`, `TimePickerInput` (`bg-theme-header`), `AddToCalendarPopup` (`bg-theme-card` + `backdrop-blur-xl`), `DisplaysWidget` (`bg-black/90`).

## Scope
Frontend-only, 8 one-line class swaps. No backend / DB / migration. No logic change.

## Verify on preview
https://rsvpizza-git-crostino-opaque-dropdowns-pizza-dao.vercel.app/payments — open the Country / Tags dropdowns; the panel should be solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)