### PR TITLE
feat(tortellini): redesign /payments filter section

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Search, X, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
+import { Search, X, SlidersHorizontal, ChevronDown } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import { Checkbox } from '../Checkbox';
 import { TriStateFilterDropdown } from '../TriStateFilterDropdown';
@@ -14,11 +14,28 @@ import {
 // panuozzo-92114: canonical filter VALUE lists live in the React-free options
 // module so PayoutsFilterBar and the URL (de)serializer can't drift.
 import type { SortValue, StatusTabValue } from './paymentsFilterOptions';
+import type { ViewMode } from './paymentsUrlState';
+import { getActiveFilterChips } from './activeFilterChips';
 
 interface PayoutsFilterBarProps {
   filters: AdminPayoutFilters;
   onChange: (next: AdminPayoutFilters) => void;
   onReset: () => void;
+  /**
+   * tortellini: the By city / By payment / Payments segmented control is now
+   * the primary control at the TOP of the filter section (moved up from a
+   * standalone row below the bar). The parent stays the state owner.
+   */
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  /** tortellini: row-count label ("52 cities" / "…") shown in the header row. */
+  rowLabel?: string;
+  /**
+   * tortellini: the parent's configured `<SavedViewsMenu>` element, rendered
+   * in the header row. Passed as a slot so the bar doesn't have to re-thread
+   * `scope`/`currentParams`/`onApply` or re-derive URL params.
+   */
+  savedViewsSlot?: React.ReactNode;
   /**
    * mascarpone-49102: distinct event-tag values across the currently-loaded
    * payouts (flattened from each `party.eventTags` array). Derived in
@@ -145,48 +162,18 @@ const SORT_OPTIONS: Array<{ value: SortValue; label: string }> = [
   { value: 'outstanding_desc', label: 'Most outstanding' },
   { value: 'outstanding_asc', label: 'Least outstanding' },
 ];
-const SORT_LABEL: Record<SortValue, string> = SORT_OPTIONS.reduce(
+// tortellini: exported so activeFilterChips.ts can label the non-default sort
+// chip from the same source (chip list + count can't drift).
+export const SORT_LABEL: Record<SortValue, string> = SORT_OPTIONS.reduce(
   (acc, opt) => ({ ...acc, [opt.value]: opt.label }),
   {} as Record<SortValue, string>,
 );
 
-/**
- * regina-89172: count active (non-default) filter fields. Status tab strip is
- * NOT counted here — it's always visible above the collapsible section, so
- * counting it would double-render the signal. Cursor/limit are pagination
- * plumbing, not user-facing filters.
- */
-function countActiveFilters(filters: AdminPayoutFilters): number {
-  let n = 0;
-  if (filters.search && filters.search.trim()) n += 1;
-  if (filters.partyId && filters.partyId.trim()) n += 1;
-  if (filters.payoutMethod && filters.payoutMethod !== 'all') n += 1;
-  if (filters.country && filters.country !== 'all') n += 1;
-  // pancetta-92103: regions multi-select counts as a single active filter
-  // when at least one portal is selected (regardless of how many).
-  if (Array.isArray(filters.regionPortals) && filters.regionPortals.length > 0) n += 1;
-  if (filters.tag && filters.tag !== 'all') n += 1;
-  // cornetto-58510: tri-state tag/country (by-city view) each count as one
-  // active filter when any include/exclude is selected.
-  if ((filters.tagIncludes?.length ?? 0) + (filters.tagExcludes?.length ?? 0) > 0) n += 1;
-  if ((filters.countryIncludes?.length ?? 0) + (filters.countryExcludes?.length ?? 0) > 0) n += 1;
-  if (filters.dateFrom) n += 1;
-  if (filters.dateTo) n += 1;
-  // arancino-92103: count sort as an active filter when it differs from
-  // the default `created_desc` (newest first).
-  if (filters.sort && filters.sort !== 'created_desc') n += 1;
-  // pinsa-92103: count Hide closed cities so admins see they've hidden rows.
-  if (filters.hideClosed) n += 1;
-  // stracchino-92108: count Hide possible scams alongside Hide closed cities.
-  if (filters.hideScams) n += 1;
-  // provatura-92107: count Hide US cities alongside the other hide toggles.
-  if (filters.hideUsCities) n += 1;
-  // tigella-58512: count Show TBD (no submission) when the admin turns it on.
-  if (filters.showTbdUnsubmitted) n += 1;
-  // farinata-58532: count Has submitted receipts when the admin turns it on.
-  if (filters.hasReceipts) n += 1;
-  return n;
-}
+const VIEW_MODE_TABS: Array<{ value: ViewMode; label: string }> = [
+  { value: 'by-city', label: 'By city' },
+  { value: 'by-payment', label: 'By payment' },
+  { value: 'payments', label: 'Payments' },
+];
 
 /**
  * Sticky filter bar at the top of the admin payouts dashboard. All updates are
@@ -195,15 +182,24 @@ function countActiveFilters(filters: AdminPayoutFilters): number {
  * Cursor is intentionally NOT a prop here — when filters change the parent
  * should reset cursor to undefined.
  *
- * regina-89172: on mobile (<640px) the filter controls collapse behind a
- * "Filters (N)" toggle button so the payouts table stays above the fold.
- * The status tab strip stays visible at all times. On `sm:` and up the
- * controls are always expanded (existing desktop behavior).
+ * tortellini: restructured into a single cohesive card —
+ *   1. View-mode segmented control + row count + Saved Views (header row),
+ *   2. Search + ⚙ Filters (N) popover + Sort,
+ *   3. Status pills (hidden when showStatusTabs === false),
+ *   4. Active-filter chips (one removable chip per non-default filter).
+ * Advanced controls (Method, Regions, Tags, Country, Party ID, dates, the five
+ * visibility toggles) live behind the ⚙ Filters popover. The old mobile-only
+ * `expanded` collapse (regina-89172) is superseded by this panel on all
+ * viewports.
  */
 export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   filters,
   onChange,
   onReset,
+  viewMode,
+  onViewModeChange,
+  rowLabel,
+  savedViewsSlot,
   availableTags,
   availableCountries,
   showTriStateFilters,
@@ -215,8 +211,21 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
   showRegionsFilter,
   showStatusTabs = true,
 }) => {
-  const [expanded, setExpanded] = useState(false);
-  const activeCount = countActiveFilters(filters);
+  // tortellini: chips are the single source of truth for "what's active" — the
+  // (N) badge is just their count. View-specific chips are gated by the same
+  // `show*` flags that gate their controls, so By-payment / Payments views
+  // don't surface non-actionable By-city-only chips.
+  const chips = getActiveFilterChips(filters, {
+    showTriStateFilters,
+    showRegionsFilter,
+    showStatusTabs,
+    showHideClosedToggle,
+    showHideScamsToggle,
+    showHideUsToggle,
+    showTbdToggle,
+    showReceiptsToggle,
+  });
+  const activeCount = chips.length;
 
   const update = (patch: Partial<AdminPayoutFilters>) => {
     onChange({ ...filters, ...patch, cursor: undefined });
@@ -240,6 +249,22 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
     return () => document.removeEventListener('mousedown', onDocClick);
   }, [regionsOpen]);
 
+  // tortellini: Filters popover open/close — modeled on the regionsOpen
+  // click-outside pattern above.
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const filtersRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!filtersOpen) return;
+    function onDocClick(e: MouseEvent) {
+      if (!filtersRef.current) return;
+      if (!filtersRef.current.contains(e.target as Node)) {
+        setFiltersOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [filtersOpen]);
+
   const selectedRegionPortals = useMemo<string[]>(
     () => (Array.isArray(filters.regionPortals) ? filters.regionPortals : []),
     [filters.regionPortals],
@@ -259,14 +284,352 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
       ? current.filter((s) => s !== slug)
       : [...current, slug];
     // Empty array = no filter (treat same as undefined so the URL/query stays
-    // clean and `countActiveFilters` doesn't count an empty selection).
+    // clean and no empty-selection chip is emitted).
     update({ regionPortals: next.length > 0 ? next : undefined });
   }
 
+  // tortellini: render the Visibility group only when at least one of its
+  // toggles is enabled (i.e. by-city view).
+  const showVisibilityGroup =
+    !!showHideClosedToggle ||
+    !!showHideScamsToggle ||
+    !!showHideUsToggle ||
+    !!showTbdToggle ||
+    !!showReceiptsToggle;
+
   return (
     <div className="sticky top-0 z-20 bg-theme-surface/95 backdrop-blur-sm border border-theme-stroke rounded-xl p-4 mb-4 shadow-sm">
-      {/* Status tab strip — always visible (mobile + desktop). Hidden in the
-          coppa-92106 Payments-ledger view, which forces status server-side. */}
+      {/* Row 1 — view-mode segmented control + row count + Saved Views.
+          etruria-92103 / coppa-92106: by-city default; the third "Payments"
+          tab shows the actual payments ledger. tortellini moved this UP from a
+          standalone row below the bar (it governs which filters appear). */}
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div
+          role="tablist"
+          aria-label="Payments view mode"
+          className="inline-flex rounded-lg overflow-hidden border border-theme-stroke bg-theme-surface"
+        >
+          {VIEW_MODE_TABS.map((tab) => {
+            const active = viewMode === tab.value;
+            return (
+              <button
+                key={tab.value}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => onViewModeChange(tab.value)}
+                className={`px-3 py-1.5 text-sm font-medium ${
+                  active
+                    ? 'bg-emerald-600 text-white'
+                    : 'text-theme-text-muted hover:bg-theme-surface-hover'
+                }`}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex items-center gap-2">
+          {rowLabel && (
+            <span className="text-sm font-medium text-theme-text-muted">{rowLabel}</span>
+          )}
+          {/* montanara-58497: per-account saved filter views (passed via slot). */}
+          {savedViewsSlot}
+        </div>
+      </div>
+
+      {/* Row 2 — unified search (grows) + ⚙ Filters (N) popover + Sort. */}
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        {/* salame-83472: unified search — host email|name OR party name. */}
+        <div className="flex-1 min-w-[200px]">
+          <IconInput
+            icon={Search}
+            type="search"
+            placeholder="Search hosts and parties"
+            value={filters.search || ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ search: e.target.value })}
+          />
+        </div>
+
+        {/* tortellini: ⚙ Filters (N) popover trigger + opaque panel. */}
+        <div className="relative" ref={filtersRef}>
+          <button
+            type="button"
+            onClick={() => setFiltersOpen((v) => !v)}
+            className="h-11 inline-flex items-center gap-2 px-3 rounded-lg border border-theme-stroke bg-theme-surface-hover text-sm font-medium text-theme-text hover:bg-theme-stroke"
+            aria-haspopup="dialog"
+            aria-expanded={filtersOpen}
+          >
+            <SlidersHorizontal size={14} />
+            Filters{activeCount > 0 ? ` (${activeCount})` : ''}
+            <ChevronDown size={14} className="text-theme-text-muted" />
+          </button>
+
+          {filtersOpen && (
+            <div
+              role="dialog"
+              aria-label="Filters"
+              className="
+                bg-theme-header border border-theme-stroke rounded-lg shadow-xl z-50
+                max-sm:fixed max-sm:inset-x-2 max-sm:bottom-2 max-sm:top-auto
+                sm:absolute sm:right-0 sm:mt-1 sm:w-[360px] sm:max-w-[90vw]
+                p-4 max-h-[80vh] overflow-y-auto
+              "
+            >
+              {/* — Attributes — */}
+              <div className="mb-4">
+                <h4 className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">Attributes</h4>
+                <div className="flex flex-col gap-2">
+                  {/* Method dropdown */}
+                  <select
+                    value={filters.payoutMethod ?? 'all'}
+                    onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
+                    className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+                    aria-label="Filter by payment method"
+                  >
+                    {METHOD_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+
+                  {/* pancetta-92103: Regions multi-select — each region maps to
+                      a fixed list of `parties.region` slugs (PAYMENTS_REGION_SCOPES);
+                      the backend `?regions=` query filters `parties.region IN (...)`.
+                      Hidden on regional sub-portals (hard-scoped by their
+                      parent's `regionFilter` prop). */}
+                  {showRegionsFilter && (
+                    <div className="relative" ref={regionsRef}>
+                      <button
+                        type="button"
+                        onClick={() => setRegionsOpen((v) => !v)}
+                        className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text inline-flex items-center justify-between gap-2"
+                        aria-haspopup="listbox"
+                        aria-expanded={regionsOpen}
+                        aria-label="Filter by region"
+                      >
+                        <span className="truncate">{regionsButtonLabel}</span>
+                        <ChevronDown size={14} className="flex-shrink-0 text-theme-text-muted" />
+                      </button>
+                      {regionsOpen && (
+                        <div
+                          role="listbox"
+                          className="absolute left-0 right-0 mt-1 z-50 rounded-lg border border-theme-stroke bg-theme-header shadow-lg py-2 min-w-[200px]"
+                        >
+                          {PAYMENTS_REGION_DISPLAY_ORDER.map((slug) => {
+                            const checked = selectedRegionPortals.includes(slug);
+                            const scopeCount = PAYMENTS_REGION_SCOPES[slug].length;
+                            return (
+                              <div key={slug} className="px-3 py-1.5 hover:bg-theme-surface-hover">
+                                <Checkbox
+                                  checked={checked}
+                                  onChange={() => toggleRegionPortal(slug)}
+                                  label={`${PAYMENTS_REGION_LABELS[slug]} (${scopeCount})`}
+                                  labelClassName="text-sm text-theme-text"
+                                  size={16}
+                                />
+                              </div>
+                            );
+                          })}
+                          {selectedRegionPortals.length > 0 && (
+                            <div className="border-t border-theme-stroke mt-1 pt-1 px-3">
+                              <button
+                                type="button"
+                                onClick={() => update({ regionPortals: undefined })}
+                                className="text-xs text-theme-text-muted hover:text-theme-text py-1"
+                              >
+                                Clear regions
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* cornetto-58510: by-city view uses tri-state Tag + Country
+                      dropdowns (client-side filtering). Other views keep the
+                      legacy single-select Tag dropdown (mascarpone-49102),
+                      filtered server-side via Prisma `{ has: tag }`. */}
+                  {showTriStateFilters ? (
+                    <>
+                      <TriStateFilterDropdown
+                        label="Tags"
+                        className="w-full"
+                        items={availableTags}
+                        includes={filters.tagIncludes ?? []}
+                        excludes={filters.tagExcludes ?? []}
+                        onChange={({ includes, excludes }) => update({ tagIncludes: includes, tagExcludes: excludes })}
+                        // paccheri-58541: friendly label for the refund-due tag.
+                        labelFor={(t) => (t === 'refund' ? 'Refund due' : t)}
+                        searchPlaceholder="Search tags…"
+                        noMatchesLabel="No tags"
+                        clearLabel="Clear"
+                        includeLabel="Include (must have)"
+                        excludeLabel="Exclude (must not have)"
+                      />
+                      <TriStateFilterDropdown
+                        label="Country"
+                        className="w-full"
+                        items={availableCountries}
+                        includes={filters.countryIncludes ?? []}
+                        excludes={filters.countryExcludes ?? []}
+                        onChange={({ includes, excludes }) => update({ countryIncludes: includes, countryExcludes: excludes })}
+                        searchPlaceholder="Search countries…"
+                        noMatchesLabel="No countries"
+                        clearLabel="Clear"
+                        includeLabel="Include (must have)"
+                        excludeLabel="Exclude (must not have)"
+                      />
+                    </>
+                  ) : (
+                    <select
+                      value={filters.tag ?? 'all'}
+                      onChange={(e) => update({ tag: e.target.value })}
+                      className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+                      aria-label="Filter by tag"
+                    >
+                      <option value="all">All tags</option>
+                      {availableTags.map((t) => (
+                        <option key={t} value={t}>{t === 'refund' ? 'Refund due' : t}</option>
+                      ))}
+                    </select>
+                  )}
+
+                  {/* Party ID search — moved here from the top row (power field). */}
+                  <IconInput
+                    icon={Search}
+                    type="search"
+                    placeholder="Party ID"
+                    value={filters.partyId || ''}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ partyId: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              {/* — Date range — */}
+              <div className="mb-4">
+                <h4 className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">Date range</h4>
+                <div className="flex flex-wrap items-center gap-2">
+                  <label className="text-xs text-theme-text-muted">From</label>
+                  <input
+                    type="date"
+                    value={filters.dateFrom || ''}
+                    onChange={(e) => update({ dateFrom: e.target.value })}
+                    className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+                    aria-label="Date from"
+                  />
+                  <label className="text-xs text-theme-text-muted">To</label>
+                  <input
+                    type="date"
+                    value={filters.dateTo || ''}
+                    onChange={(e) => update({ dateTo: e.target.value })}
+                    className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+                    aria-label="Date to"
+                  />
+                </div>
+              </div>
+
+              {/* — Visibility (by-city only) — */}
+              {showVisibilityGroup && (
+                <div className="mb-4">
+                  <h4 className="text-xs uppercase tracking-wide text-theme-text-muted mb-2">Visibility</h4>
+                  <div className="flex flex-col gap-2">
+                    {/* pinsa-92103: Hide closed cities (`paymentsClosedAt`). */}
+                    {showHideClosedToggle && (
+                      <Checkbox
+                        checked={!!filters.hideClosed}
+                        onChange={() => update({ hideClosed: !filters.hideClosed })}
+                        label="Hide closed cities"
+                        labelClassName="text-sm text-theme-text-secondary"
+                        size={16}
+                      />
+                    )}
+                    {/* stracchino-92108: Hide possible-scam-flagged cities. */}
+                    {showHideScamsToggle && (
+                      <Checkbox
+                        checked={!!filters.hideScams}
+                        onChange={() => update({ hideScams: !filters.hideScams })}
+                        label="Hide possible scams"
+                        labelClassName="text-sm text-theme-text-secondary"
+                        size={16}
+                      />
+                    )}
+                    {/* provatura-92107: Hide US cities (party.region === 'usa'). */}
+                    {showHideUsToggle && (
+                      <Checkbox
+                        checked={!!filters.hideUsCities}
+                        onChange={() => update({ hideUsCities: !filters.hideUsCities })}
+                        label="Hide US cities"
+                        labelClassName="text-sm text-theme-text-secondary"
+                        size={16}
+                      />
+                    )}
+                    {/* tigella-58512: Show approved `tbd` events that submitted
+                        nothing yet (zero payouts + zero documents). */}
+                    {showTbdToggle && (
+                      <Checkbox
+                        checked={!!filters.showTbdUnsubmitted}
+                        onChange={() => update({ showTbdUnsubmitted: !filters.showTbdUnsubmitted })}
+                        label="Show unsubmitted cities"
+                        labelClassName="text-sm text-theme-text-secondary"
+                        size={16}
+                      />
+                    )}
+                    {/* farinata-58532: show only cities with ≥1 submitted receipt. */}
+                    {showReceiptsToggle && (
+                      <Checkbox
+                        checked={!!filters.hasReceipts}
+                        onChange={() => update({ hasReceipts: !filters.hasReceipts })}
+                        label="Has submitted receipts"
+                        labelClassName="text-sm text-theme-text-secondary"
+                        size={16}
+                      />
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* — Footer — */}
+              <div className="flex items-center justify-between gap-2 border-t border-theme-stroke pt-3">
+                <button
+                  type="button"
+                  onClick={onReset}
+                  className="inline-flex items-center gap-1 text-sm text-theme-text-muted hover:text-theme-text px-3 py-2 rounded-lg hover:bg-theme-surface-hover"
+                >
+                  <X size={14} />
+                  Reset filters
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFiltersOpen(false)}
+                  className="inline-flex items-center text-sm font-medium text-theme-text px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white"
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* arancino-92103: Sort dropdown — controls the row order of the
+            payouts table. Default `created_desc` (newest submitted first).
+            Hidden in the Payments-ledger view (sort forced server-side). */}
+        {showStatusTabs && (
+          <select
+            value={filters.sort ?? 'created_desc'}
+            onChange={(e) => update({ sort: e.target.value as SortValue })}
+            className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
+            aria-label="Sort payouts"
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>Sort: {opt.label}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Row 3 — status tab strip. Hidden in the coppa-92106 Payments-ledger
+          view, which forces status server-side. */}
       {showStatusTabs && (
         <div className="flex flex-wrap gap-1.5 mb-3">
           {STATUS_TABS.map((tab) => {
@@ -289,289 +652,37 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         </div>
       )}
 
-      {/* regina-89172: mobile-only collapse toggle. Hidden on sm:+ via `sm:hidden`. */}
-      <div className="sm:hidden mb-3">
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="w-full inline-flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-theme-stroke bg-theme-surface-hover text-sm font-medium text-theme-text"
-          aria-expanded={expanded}
-          aria-controls="payouts-filter-controls"
-        >
-          <span className="inline-flex items-center gap-2">
-            <SlidersHorizontal size={14} />
-            Filters{activeCount > 0 ? ` (${activeCount})` : ''}
-          </span>
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-        </button>
-      </div>
-
-      {/* Controls. Hidden on mobile when collapsed; force-visible on sm:+. */}
-      <div
-        id="payouts-filter-controls"
-        className={`${expanded ? 'block' : 'hidden'} sm:block`}
-      >
-        <div className="grid grid-cols-1 md:grid-cols-9 gap-2 items-start">
-          {/* salame-83472: unified search — host email|name OR party name. */}
-          <div className="md:col-span-2">
-            <IconInput
-              icon={Search}
-              type="search"
-              placeholder="Search hosts and parties"
-              value={filters.search || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ search: e.target.value })}
-            />
-          </div>
-
-          {/* Party ID search */}
-          <div>
-            <IconInput
-              icon={Search}
-              type="search"
-              placeholder="Party ID"
-              value={filters.partyId || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => update({ partyId: e.target.value })}
-            />
-          </div>
-
-          {/* Method dropdown */}
-          <div>
-            <select
-              value={filters.payoutMethod ?? 'all'}
-              onChange={(e) => update({ payoutMethod: e.target.value as PayoutMethod | 'all' })}
-              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Filter by payment method"
+      {/* Row 4 — active-filter chips. One removable chip per non-default
+          filter (including the default-on visibility hides, for transparency).
+          Clicking ✕ resets just that field; "Reset all" clears everything. */}
+      {chips.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {chips.map((chip) => (
+            <span
+              key={chip.key}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-theme-surface-hover text-xs text-theme-text"
             >
-              {METHOD_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </div>
-
-          {/* pancetta-92103: Regions multi-select — replaces the prior
-              bruschetta-58291 single-country dropdown. Each region maps to a
-              fixed list of `parties.region` slugs (PAYMENTS_REGION_SCOPES);
-              the backend `?regions=` query filters `parties.region IN (...)`.
-              Selecting zero regions = no filter (same as the old "All
-              countries"). Hidden on regional sub-portals which are already
-              hard-scoped by their parent's `regionFilter` prop. */}
-          {showRegionsFilter && (
-            <div className="relative" ref={regionsRef}>
+              {chip.label}
               <button
                 type="button"
-                onClick={() => setRegionsOpen((v) => !v)}
-                className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text inline-flex items-center justify-between gap-2"
-                aria-haspopup="listbox"
-                aria-expanded={regionsOpen}
-                aria-label="Filter by region"
+                onClick={() => update(chip.patch)}
+                className="text-theme-text-muted hover:text-theme-text"
+                aria-label={`Remove filter ${chip.label}`}
               >
-                <span className="truncate">{regionsButtonLabel}</span>
-                <ChevronDown size={14} className="flex-shrink-0 text-theme-text-muted" />
+                <X size={12} />
               </button>
-              {regionsOpen && (
-                <div
-                  role="listbox"
-                  className="absolute left-0 right-0 mt-1 z-50 rounded-lg border border-theme-stroke bg-theme-header shadow-lg py-2 min-w-[200px]"
-                >
-                  {PAYMENTS_REGION_DISPLAY_ORDER.map((slug) => {
-                    const checked = selectedRegionPortals.includes(slug);
-                    const scopeCount = PAYMENTS_REGION_SCOPES[slug].length;
-                    return (
-                      <div key={slug} className="px-3 py-1.5 hover:bg-theme-surface-hover">
-                        <Checkbox
-                          checked={checked}
-                          onChange={() => toggleRegionPortal(slug)}
-                          label={`${PAYMENTS_REGION_LABELS[slug]} (${scopeCount})`}
-                          labelClassName="text-sm text-theme-text"
-                          size={16}
-                        />
-                      </div>
-                    );
-                  })}
-                  {selectedRegionPortals.length > 0 && (
-                    <div className="border-t border-theme-stroke mt-1 pt-1 px-3">
-                      <button
-                        type="button"
-                        onClick={() => update({ regionPortals: undefined })}
-                        className="text-xs text-theme-text-muted hover:text-theme-text py-1"
-                      >
-                        Clear regions
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* cornetto-58510: by-city view uses tri-state Tag + Country dropdowns
-              (client-side filtering). Other views keep the legacy single-select
-              Tag dropdown (mascarpone-49102), which is filtered server-side via
-              Prisma `{ has: tag }`. */}
-          {showTriStateFilters ? (
-            <>
-              <div>
-                <TriStateFilterDropdown
-                  label="Tags"
-                  className="w-full"
-                  items={availableTags}
-                  includes={filters.tagIncludes ?? []}
-                  excludes={filters.tagExcludes ?? []}
-                  onChange={({ includes, excludes }) => update({ tagIncludes: includes, tagExcludes: excludes })}
-                  // paccheri-58541: friendly label for the refund-due tag.
-                  labelFor={(t) => (t === 'refund' ? 'Refund due' : t)}
-                  searchPlaceholder="Search tags…"
-                  noMatchesLabel="No tags"
-                  clearLabel="Clear"
-                  includeLabel="Include (must have)"
-                  excludeLabel="Exclude (must not have)"
-                />
-              </div>
-              <div>
-                <TriStateFilterDropdown
-                  label="Country"
-                  className="w-full"
-                  items={availableCountries}
-                  includes={filters.countryIncludes ?? []}
-                  excludes={filters.countryExcludes ?? []}
-                  onChange={({ includes, excludes }) => update({ countryIncludes: includes, countryExcludes: excludes })}
-                  searchPlaceholder="Search countries…"
-                  noMatchesLabel="No countries"
-                  clearLabel="Clear"
-                  includeLabel="Include (must have)"
-                  excludeLabel="Exclude (must not have)"
-                />
-              </div>
-            </>
-          ) : (
-            <div>
-              <select
-                value={filters.tag ?? 'all'}
-                onChange={(e) => update({ tag: e.target.value })}
-                className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-                aria-label="Filter by tag"
-              >
-                <option value="all">All tags</option>
-                {availableTags.map((t) => (
-                  <option key={t} value={t}>{t === 'refund' ? 'Refund due' : t}</option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* arancino-92103: Sort dropdown — controls the row order of the
-              payouts table. Default is `created_desc` (newest submitted
-              first), matching the prior implicit backend ordering. */}
-          <div>
-            <select
-              value={filters.sort ?? 'created_desc'}
-              onChange={(e) => update({ sort: e.target.value as SortValue })}
-              className="w-full h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Sort payouts"
-            >
-              {SORT_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>Sort: {opt.label}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        <div className="flex flex-col md:flex-row md:items-end gap-2 mt-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <label className="text-xs text-theme-text-muted">From</label>
-            <input
-              type="date"
-              value={filters.dateFrom || ''}
-              onChange={(e) => update({ dateFrom: e.target.value })}
-              className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Date from"
-            />
-            <label className="text-xs text-theme-text-muted">To</label>
-            <input
-              type="date"
-              value={filters.dateTo || ''}
-              onChange={(e) => update({ dateTo: e.target.value })}
-              className="h-11 rounded-lg border border-theme-stroke bg-theme-surface px-3 text-sm text-theme-text"
-              aria-label="Date to"
-            />
-            {/* arancino-92103: surface non-default sort as a small chip so
-                admins notice the list is reordered. The dropdown above is
-                the canonical control; this chip is a read-only summary. */}
-            {filters.sort && filters.sort !== 'created_desc' && (
-              <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-[#E52828]/10 text-[#E52828] text-xs font-medium">
-                Sort: {SORT_LABEL[filters.sort]}
-              </span>
-            )}
-            {/* pinsa-92103: Hide closed cities toggle. Only rendered on the
-                by-city view (`paymentsClosedAt` is a party-level signal so
-                the by-payment view has nothing to hide). Backend honors
-                `hideClosed=true` on the /by-party endpoint. */}
-            {showHideClosedToggle && (
-              <Checkbox
-                checked={!!filters.hideClosed}
-                onChange={() => update({ hideClosed: !filters.hideClosed })}
-                label="Hide closed cities"
-                labelClassName="text-xs text-theme-text-secondary"
-                size={14}
-              />
-            )}
-            {/* stracchino-92108: Hide possible-scam-flagged cities. By-city view only,
-                same as Hide closed cities. */}
-            {showHideScamsToggle && (
-              <Checkbox
-                checked={!!filters.hideScams}
-                onChange={() => update({ hideScams: !filters.hideScams })}
-                label="Hide possible scams"
-                labelClassName="text-xs text-theme-text-secondary"
-                size={14}
-              />
-            )}
-            {/* provatura-92107: Hide US cities (party.region === 'usa'). By-city
-                + admin dashboard only, same gating as the other hide toggles. */}
-            {showHideUsToggle && (
-              <Checkbox
-                checked={!!filters.hideUsCities}
-                onChange={() => update({ hideUsCities: !filters.hideUsCities })}
-                label="Hide US cities"
-                labelClassName="text-xs text-theme-text-secondary"
-                size={14}
-              />
-            )}
-            {/* tigella-58512: Show approved `tbd` events that have submitted
-                nothing yet (zero payouts + zero documents). By-city view only;
-                OFF by default. The backend injects synthetic rows on /by-party
-                when `showTbdUnsubmitted` is set. */}
-            {showTbdToggle && (
-              <Checkbox
-                checked={!!filters.showTbdUnsubmitted}
-                onChange={() => update({ showTbdUnsubmitted: !filters.showTbdUnsubmitted })}
-                label="Show unsubmitted cities"
-                labelClassName="text-xs text-theme-text-secondary"
-                size={14}
-              />
-            )}
-            {/* farinata-58532: show only cities with ≥1 submitted receipt
-                (aggregates.totalReceiptCount > 0). By-city view only; OFF by default. */}
-            {showReceiptsToggle && (
-              <Checkbox
-                checked={!!filters.hasReceipts}
-                onChange={() => update({ hasReceipts: !filters.hasReceipts })}
-                label="Has submitted receipts"
-                labelClassName="text-xs text-theme-text-secondary"
-                size={14}
-              />
-            )}
-          </div>
+            </span>
+          ))}
           <button
             type="button"
             onClick={onReset}
-            className="md:ml-auto inline-flex items-center gap-1 text-sm text-theme-text-muted hover:text-theme-text px-3 py-2 rounded-lg hover:bg-theme-surface-hover"
+            className="inline-flex items-center gap-1 text-xs text-theme-text-muted hover:text-theme-text px-2 py-1"
           >
-            <X size={14} />
-            Reset filters
+            <X size={12} />
+            Reset all
           </button>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/payments-admin/activeFilterChips.ts
+++ b/frontend/src/components/payments-admin/activeFilterChips.ts
@@ -1,0 +1,180 @@
+// tortellini: React-free helper that turns the active (non-default) fields of
+// an `AdminPayoutFilters` into a flat list of removable chip descriptors. This
+// is the single source of truth for "what filters are active": PayoutsFilterBar
+// renders these chips AND derives the `(N)` badge from `chips.length`, so the
+// row and the badge can never drift.
+import type { AdminPayoutFilters, PayoutMethod } from '../../types';
+import { PAYOUT_METHOD_LABELS } from '../payments-shared';
+import { PAYMENTS_REGION_LABELS, type PaymentsRegionPortal } from '../../utils/regions';
+import { SORT_LABEL } from './PayoutsFilterBar';
+import type { SortValue } from './paymentsFilterOptions';
+
+export interface ActiveFilterChip {
+  /** Stable key for React list rendering. */
+  key: string;
+  /** Human-readable chip label. */
+  label: string;
+  /** Partial patch that resets just this field to its default when removed. */
+  patch: Partial<AdminPayoutFilters>;
+}
+
+/**
+ * tortellini: which filter controls are actually rendered for the current view
+ * (mirrors the `show*` capability flags on `PayoutsFilterBar`). A chip is only
+ * emitted for a filter whose control is visible — otherwise a By-city-only
+ * filter (e.g. "Hiding US") would show a non-actionable chip in the By-payment
+ * / Payments views, where that filter has no effect. Any flag left `undefined`
+ * is treated as applicable (`?? true`), so omitting `caps` yields every chip.
+ */
+export interface ActiveFilterChipCaps {
+  showTriStateFilters?: boolean;
+  showRegionsFilter?: boolean;
+  showStatusTabs?: boolean;
+  showHideClosedToggle?: boolean;
+  showHideScamsToggle?: boolean;
+  showHideUsToggle?: boolean;
+  showTbdToggle?: boolean;
+  showReceiptsToggle?: boolean;
+}
+
+/** paccheri-58541: friendly label for the refund-due tag. */
+function tagLabel(t: string): string {
+  return t === 'refund' ? 'Refund due' : t;
+}
+
+/**
+ * Build the removable-chip list for the currently active filters. This is the
+ * single source of truth for "what filters are active" — the `(N)` badge is
+ * just `getActiveFilterChips(...).length`. Each chip's `patch` resets only that
+ * field (or removes only that one value, for the multi-value tri-state / region
+ * filters). View-specific chips are gated by `caps` so they only appear when
+ * their control is actually rendered.
+ */
+export function getActiveFilterChips(
+  filters: AdminPayoutFilters,
+  caps: ActiveFilterChipCaps = {},
+): ActiveFilterChip[] {
+  const triState = caps.showTriStateFilters ?? true;
+  const regions = caps.showRegionsFilter ?? true;
+  const statusTabs = caps.showStatusTabs ?? true;
+  const chips: ActiveFilterChip[] = [];
+
+  // salame-83472: unified search.
+  if (filters.search && filters.search.trim()) {
+    chips.push({ key: 'search', label: `Search: "${filters.search}"`, patch: { search: '' } });
+  }
+
+  // Party ID search.
+  if (filters.partyId && filters.partyId.trim()) {
+    chips.push({ key: 'partyId', label: `Party: ${filters.partyId}`, patch: { partyId: '' } });
+  }
+
+  // Method.
+  if (filters.payoutMethod && filters.payoutMethod !== 'all') {
+    const m = filters.payoutMethod as PayoutMethod;
+    chips.push({
+      key: 'payoutMethod',
+      label: `Method: ${PAYOUT_METHOD_LABELS[m] ?? m}`,
+      patch: { payoutMethod: 'all' },
+    });
+  }
+
+  // bruschetta-58291: single-select country (non-tri-state views).
+  if (filters.country && filters.country !== 'all') {
+    chips.push({ key: 'country', label: `Country: ${filters.country}`, patch: { country: 'all' } });
+  }
+
+  // mascarpone-49102: single-select tag (non-tri-state views only).
+  if (!triState && filters.tag && filters.tag !== 'all') {
+    chips.push({ key: 'tag', label: `Tag: ${tagLabel(filters.tag)}`, patch: { tag: 'all' } });
+  }
+
+  // cornetto-58510: tri-state tag + country include/exclude — one chip per
+  // value. By-city view only (the tri-state controls only render there).
+  if (triState) {
+    for (const t of filters.tagIncludes ?? []) {
+      chips.push({
+        key: `tagInclude:${t}`,
+        label: `Tag: ${tagLabel(t)}`,
+        patch: { tagIncludes: (filters.tagIncludes ?? []).filter((x) => x !== t) },
+      });
+    }
+    for (const t of filters.tagExcludes ?? []) {
+      chips.push({
+        key: `tagExclude:${t}`,
+        label: `Tag ≠ ${tagLabel(t)}`,
+        patch: { tagExcludes: (filters.tagExcludes ?? []).filter((x) => x !== t) },
+      });
+    }
+    for (const c of filters.countryIncludes ?? []) {
+      chips.push({
+        key: `countryInclude:${c}`,
+        label: `Country: ${c}`,
+        patch: { countryIncludes: (filters.countryIncludes ?? []).filter((x) => x !== c) },
+      });
+    }
+    for (const c of filters.countryExcludes ?? []) {
+      chips.push({
+        key: `countryExclude:${c}`,
+        label: `Country ≠ ${c}`,
+        patch: { countryExcludes: (filters.countryExcludes ?? []).filter((x) => x !== c) },
+      });
+    }
+  }
+
+  // pancetta-92103: region portals — one chip per selected portal. Empty array
+  // collapses to undefined (matches toggleRegionPortal's "no filter" shape).
+  // Hidden on regional sub-portals (Regions control isn't rendered there).
+  if (regions && Array.isArray(filters.regionPortals) && filters.regionPortals.length > 0) {
+    for (const slug of filters.regionPortals) {
+      const next = filters.regionPortals.filter((s) => s !== slug);
+      chips.push({
+        key: `region:${slug}`,
+        label: `Region: ${PAYMENTS_REGION_LABELS[slug as PaymentsRegionPortal] ?? slug}`,
+        patch: { regionPortals: next.length > 0 ? next : undefined },
+      });
+    }
+  }
+
+  // Date range.
+  if (filters.dateFrom) {
+    chips.push({ key: 'dateFrom', label: `From ${filters.dateFrom}`, patch: { dateFrom: '' } });
+  }
+  if (filters.dateTo) {
+    chips.push({ key: 'dateTo', label: `To ${filters.dateTo}`, patch: { dateTo: '' } });
+  }
+
+  // arancino-92103: non-default sort. Hidden in the Payments-ledger view
+  // (sort forced server-side), so gate on the same flag as the Sort control.
+  if (statusTabs && filters.sort && filters.sort !== 'created_desc') {
+    chips.push({
+      key: 'sort',
+      label: `Sort: ${SORT_LABEL[filters.sort as SortValue]}`,
+      patch: { sort: 'created_desc' },
+    });
+  }
+
+  // Visibility toggles — surfaced as chips (incl. the default-on hides, for
+  // transparency), but only when their control is rendered (by-city view).
+  if ((caps.showHideClosedToggle ?? true) && filters.hideClosed) {
+    chips.push({ key: 'hideClosed', label: 'Hiding closed', patch: { hideClosed: false } });
+  }
+  if ((caps.showHideScamsToggle ?? true) && filters.hideScams) {
+    chips.push({ key: 'hideScams', label: 'Hiding scams', patch: { hideScams: false } });
+  }
+  if ((caps.showHideUsToggle ?? true) && filters.hideUsCities) {
+    chips.push({ key: 'hideUsCities', label: 'Hiding US', patch: { hideUsCities: false } });
+  }
+  if ((caps.showTbdToggle ?? true) && filters.showTbdUnsubmitted) {
+    chips.push({
+      key: 'showTbdUnsubmitted',
+      label: 'Incl. unsubmitted',
+      patch: { showTbdUnsubmitted: false },
+    });
+  }
+  if ((caps.showReceiptsToggle ?? true) && filters.hasReceipts) {
+    chips.push({ key: 'hasReceipts', label: 'Has receipts', patch: { hasReceipts: false } });
+  }
+
+  return chips;
+}

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1261,6 +1261,22 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
         <PayoutsFilterBar
           filters={filters}
           onChange={setFilters}
+          // tortellini: the view-mode segmented control + row count + Saved
+          // Views now live INSIDE the filter bar's header row.
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+          rowLabel={loading ? '…' : visibleRowLabel}
+          savedViewsSlot={
+            <SavedViewsMenu
+              scope="payments"
+              currentParams={filtersToSearchParams(filters, viewMode).toString()}
+              onApply={(p) => {
+                const { filters: f, viewMode: vm } = searchParamsToFilters(new URLSearchParams(p), regions);
+                setFilters((prev) => ({ ...prev, ...f }));
+                if (vm) setViewMode(vm);
+              }}
+            />
+          }
           // panuozzo-92114: re-inject the hard `regions` scope on regional
           // portals so Reset can't silently widen a regional underboss's view.
           // The URL sync effect then clears the query string automatically.
@@ -1299,75 +1315,8 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
           showStatusTabs={viewMode !== 'payments'}
         />
 
-        {/* etruria-92103: by-city / by-payment view toggle. by-city is the
-            default; the choice persists in localStorage. Lives on its own
-            row above the bulk-actions bar so it doesn't fight the filter
-            bar's sticky position.
-            coppa-92106: third "Payments" tab shows the actual payments ledger
-            (status=paid|completed, proven-only, sorted by paid_at DESC). */}
-        <div className="flex items-center justify-between gap-2 mb-3">
-          <span className="text-sm font-medium text-theme-text-muted">
-            {loading ? '…' : visibleRowLabel}
-          </span>
-          <div className="flex items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-theme-text-muted">View:</span>
-          <div
-            role="tablist"
-            aria-label="Payments view mode"
-            className="inline-flex rounded-lg overflow-hidden border border-theme-stroke bg-theme-surface"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={viewMode === 'by-city'}
-              onClick={() => setViewMode('by-city')}
-              className={`px-3 py-1.5 text-sm font-medium ${
-                viewMode === 'by-city'
-                  ? 'bg-emerald-600 text-white'
-                  : 'text-theme-text-muted hover:bg-theme-surface-hover'
-              }`}
-            >
-              By city
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={viewMode === 'by-payment'}
-              onClick={() => setViewMode('by-payment')}
-              className={`px-3 py-1.5 text-sm font-medium ${
-                viewMode === 'by-payment'
-                  ? 'bg-emerald-600 text-white'
-                  : 'text-theme-text-muted hover:bg-theme-surface-hover'
-              }`}
-            >
-              By payment
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={viewMode === 'payments'}
-              onClick={() => setViewMode('payments')}
-              className={`px-3 py-1.5 text-sm font-medium ${
-                viewMode === 'payments'
-                  ? 'bg-emerald-600 text-white'
-                  : 'text-theme-text-muted hover:bg-theme-surface-hover'
-              }`}
-            >
-              Payments
-            </button>
-          </div>
-          {/* montanara-58497: per-account saved filter views */}
-          <SavedViewsMenu
-            scope="payments"
-            currentParams={filtersToSearchParams(filters, viewMode).toString()}
-            onApply={(p) => {
-              const { filters: f, viewMode: vm } = searchParamsToFilters(new URLSearchParams(p), regions);
-              setFilters((prev) => ({ ...prev, ...f }));
-              if (vm) setViewMode(vm);
-            }}
-          />
-          </div>
-        </div>
+        {/* tortellini: the view-mode toggle + row count + Saved Views row that
+            used to live here has moved into PayoutsFilterBar's header row. */}
 
         {/* coppa-92106: breadcrumb under the toggle when the Payments-ledger
             view is active. Surfaces the forced status + sort so the admin

--- a/plans/tortellini-payments-filter-redesign.md
+++ b/plans/tortellini-payments-filter-redesign.md
@@ -1,0 +1,170 @@
+# tortellini — Redesign the /payments dashboard filter section
+
+## Context
+
+The Host Payments admin dashboard (`/payments`) crams its entire filter
+surface into a flat, dense block (see the current layout):
+
+- **Row 1:** 10 status pills (All, Pending, Approved, Queued, Paid, Rejected,
+  Failed, Withdrawn, Completed, Closed).
+- **Row 2:** Search · Party ID · Methods · Regions · Tags · Country · Sort —
+  seven controls jammed into a 9-column grid. "Sort: Newest first" gets clipped.
+- **Row 3:** From/To dates · five hide/show checkboxes · Reset.
+- **A separate row *below* the bar:** the View toggle (By city / By payment /
+  Payments) + Saved Views.
+
+Two structural problems drive the redesign:
+
+1. **The View toggle sits below the filters, yet governs which filters appear.**
+   The tri-state Tags/Country dropdowns, the Regions multi-select, and all five
+   hide/show toggles only render in **By city** view (`viewMode === 'by-city'`,
+   wired in `PaymentsAdminPage.tsx:1261-1300`). A control that changes the whole
+   filter set should come first, not last.
+2. **Silent default hiding.** Four of the five toggles are **on by default**
+   (`hideClosed`, `hideScams`, `hideUsCities`, `hasReceipts` — see
+   `DEFAULT_FILTERS`, `PaymentsAdminPage.tsx:101`). The default view hides closed,
+   scam-flagged, and US cities plus anything with no receipts, and nothing on
+   screen makes that obvious.
+
+**Outcome:** a compact, scannable filter header where the view mode is the
+primary control, advanced filters live behind one "Filters" button, and active
+filters (including the default-on hides) are visible and one-click removable.
+
+### Decisions (confirmed with Snax)
+- **Layout:** compact always-visible bar + a grouped **Filters panel** popover.
+- **Toggles:** consolidate the five hide/show checkboxes into one **Visibility**
+  group (inside the panel), keeping current defaults.
+- **View mode:** promote the By city / By payment / Payments selector to the
+  **top** of the section as the primary control.
+
+### Critical constraint — presentation-only
+This is a pure **UI restructuring** over the existing `AdminPayoutFilters`
+shape (`frontend/src/types.ts`). No filter values, defaults, or semantics
+change. Therefore **do not touch**: `paymentsUrlState.ts`, `paymentsFilterOptions.ts`,
+`paymentsUrlState.test.ts`, `lib/api.ts` query builder, or any backend. The URL
+remains shareable and the existing round-trip test keeps passing. **No backend,
+no DB, no migration.**
+
+## New layout
+
+The filter section becomes a single cohesive card, top → bottom:
+
+1. **Mode + Views header row**
+   `[ By city | By payment | Payments ]`  (segmented control, moved up from
+   below) … right-aligned: row-count label ("52 cities") + `Views ▾`
+   (`SavedViewsMenu`).
+2. **Search + Filters + Sort row**
+   `🔍 Search hosts & parties` (grows) · `⚙ Filters (N)` button · `Sort ▾`.
+   The Party-ID search is a power field → moved **into** the Filters panel.
+3. **Status pills row** — unchanged set; still hidden in the Payments-ledger
+   view (`showStatusTabs === false`).
+4. **Active-filter chips row** — one removable chip per active, non-default
+   filter (method, each region, each tag include/exclude, each country
+   include/exclude, date range, and each ON visibility toggle). Clicking ✕
+   resets that field to its default; a "Reset all" appears when any chip is
+   present. This is what makes the default-on hides visible.
+
+**Filters panel** (popover anchored to the `⚙ Filters` button; full-width
+bottom sheet on `<640px`). Opaque background using `bg-theme-header` (the token
+used by `SavedViewsMenu` / `TimePickerInput`, and the one we standardized on in
+PR #1017). Grouped sections:
+- **Attributes:** Method (`<select>`), Region multi-select (admin only,
+  `showRegionsFilter`), Tags (tri-state in by-city, single `<select>` elsewhere),
+  Country (tri-state, by-city only), Party ID.
+- **Date range:** From / To.
+- **Visibility** (by-city only): the five consolidated toggles — Hide closed /
+  Hide possible scams / Hide US cities / Show unsubmitted cities / Has submitted
+  receipts — as a labeled `Checkbox` group.
+- **Footer:** "Reset filters" + "Done".
+
+## Implementation
+
+All changes are frontend-only and centered on the payments-admin filter bar.
+
+### 1. `frontend/src/components/payments-admin/PayoutsFilterBar.tsx` (main rework)
+- Restructure JSX into the four rows above. Keep the component as the single
+  filter surface but accept new props so `PaymentsAdminPage` stays the state
+  owner:
+  - `viewMode` + `onViewModeChange` — render the segmented control (move the
+    markup from `PaymentsAdminPage.tsx:1309-1360`).
+  - `rowLabel?: string` — the "52 cities" / "…" count (currently `visibleRowLabel`).
+  - `savedViews` slot: simplest is a `savedViewsSlot?: React.ReactNode` prop so
+    the page passes its configured `<SavedViewsMenu .../>` straight through
+    (avoids threading `scope`/`currentParams`/`onApply` and re-deriving URL
+    params inside the bar).
+- **Reuse** the existing click-outside pattern (`regionsRef` + `useEffect`,
+  lines ~228-246) for the Filters popover open/close. Add it as a new
+  `filtersOpen` state. **Place all new hooks above any early return**
+  (CLAUDE.md hooks-rules gate — `eslint.hooks.config.js` runs in CI).
+- **Reuse** `countActiveFilters` (already in this file) for the `(N)` badge.
+- Replace the existing mobile-only `expanded`/"Filters (N)" collapse
+  (regina-89172) — the new panel supersedes it on all viewports.
+- The status pill strip, the `<select>` Method/Sort, `TriStateFilterDropdown`
+  (Tags/Country), the Regions multi-select, the date inputs, and the `Checkbox`
+  toggles are all **kept as-is** and relocated into their new rows/panel
+  sections — minimal change to each control, only their container moves.
+
+### 2. New `frontend/src/components/payments-admin/activeFilterChips.ts` (helper)
+- Pure function `getActiveFilterChips(filters, opts): { key, label, onRemove }[]`
+  that mirrors `countActiveFilters`' field list and returns a removable
+  descriptor per active filter. Visibility toggles render their human label
+  ("Hide US cities", etc.). `onRemove` produces the reset patch for that field
+  (e.g. `{ country: 'all' }`, `{ hideUsCities: false }`, `{ tagIncludes: [], ... }`).
+- Keep it React-free and next to `paymentsFilterOptions.ts` so the chip list and
+  the count can't drift.
+
+### 3. New `frontend/src/components/payments-admin/FiltersPanel.tsx` (optional extraction)
+- PayoutsFilterBar is already large; extracting the popover body
+  (Attributes / Date range / Visibility groups + footer) keeps it readable.
+  Receives `filters`, `update`, and the same `show*` capability flags.
+- If extraction balloons the diff, inline it in PayoutsFilterBar instead — the
+  grouping/markup is what matters, not the file boundary.
+
+### 4. `frontend/src/pages/PaymentsAdminPage.tsx`
+- Pass `viewMode`, `setViewMode`, `visibleRowLabel`, and a `savedViewsSlot`
+  (the existing `<SavedViewsMenu .../>`) into `<PayoutsFilterBar>`.
+- **Remove** the now-duplicated standalone view-toggle + count + SavedViews row
+  (the `<div className="flex items-center justify-between …">` block at
+  ~1309-1372). Leave the `viewMode === 'payments'` breadcrumb (~1375) where it is.
+- All existing capability flags (`showTriStateFilters`, `showHide*Toggle`,
+  `showTbdToggle`, `showReceiptsToggle`, `showRegionsFilter`, `showStatusTabs`)
+  stay wired exactly as today.
+
+### Reused components / utilities
+- `Checkbox`, `IconInput`, `TriStateFilterDropdown` (per CLAUDE.md reusable-
+  component rules — no raw inputs/checkboxes).
+- `SavedViewsMenu` (relocated via slot, not rewritten).
+- `SORT_OPTIONS` / `SORT_LABEL`, `STATUS_TABS`, `METHOD_OPTIONS` (already in
+  PayoutsFilterBar).
+- `bg-theme-header` for the opaque popover (matches PR #1017 convention).
+
+## Verification
+
+Frontend-only → verify on the Vercel preview for the branch
+(`https://rsvpizza-git-tortellini-payments-filter-redesign-pizza-dao.vercel.app/payments`).
+
+1. **View mode is primary:** segmented control is at the top; switching to
+   By payment / Payments correctly hides the by-city-only filters; Payments
+   view still hides the status strip.
+2. **Filters panel:** `⚙ Filters (N)` opens the grouped popover; setting Method,
+   Region, Tags, Country, Party ID, dates, and each Visibility toggle all apply;
+   panel is opaque in both dark and GPP light themes; on a narrow viewport it
+   renders as a usable bottom sheet; click-outside / Done closes it.
+3. **Active chips:** every non-default filter (including the four default-on
+   hides) shows a chip; ✕ removes just that filter; "Reset all" clears everything
+   to `DEFAULT_FILTERS`; the `(N)` badge matches the chip count.
+4. **URL + Saved Views unchanged:** apply filters → URL query updates and is
+   shareable/reloadable; create/apply a Saved View still works; regional portals
+   (`/payments/latam` etc.) still hard-scope and Reset doesn't widen them.
+5. **Regressions:** run `npm --prefix frontend test` (or vitest) — the
+   `paymentsUrlState.test.ts` round-trip must still pass (proof nothing in the
+   filter shape changed). Confirm the hooks-rules lint job is green
+   (`frontend/eslint.hooks.config.js`).
+
+## Out of scope / notes
+- The `purpose` filter (`salumi-89172`) exists in the type but isn't rendered in
+  the current bar; leave it unrendered unless we want to add it (separate ask).
+- Whether to *also* surface the default-on visibility toggles as chips (done
+  here, for transparency) vs. relying solely on the panel's count badge is the
+  one spot where the chosen "consolidate into a menu" and "compact bar + chips"
+  answers overlap — flag for Snax to confirm during review.


### PR DESCRIPTION
## Why
The Host Payments filter section crammed everything into a flat block: 10 status pills, a 7-control row (Search/Party/Method/Regions/Tags/Country/Sort — Sort got clipped), a row of dates + 5 checkboxes, and the **View toggle stranded on a separate row *below*** — even though it governs which filters appear. Four of the five toggles are also **on by default**, so the default view silently hides closed/scam/US/no-receipt cities with nothing on screen to say so.

## What
Restructured `PayoutsFilterBar` into one cohesive card:
1. **View-mode segmented control** (`By city / By payment / Payments`) moved to the **top** as the primary control, with the row count + Saved Views.
2. **Search** (grows) + a single **`⚙ Filters (N)`** popover + **Sort**.
3. **Status pill strip** (unchanged; still hidden in the Payments-ledger view).
4. **Active-filter chips** — one removable ✕ chip per active filter, *including the default-on hides*, so the narrowing is finally visible. "Reset all" clears everything.

The advanced controls (Method, Regions, Tags, Country, Party ID, dates, and the five toggles consolidated into a **Visibility** group) live behind the Filters popover — opaque `bg-theme-header`, anchored under the button on desktop, full-width bottom sheet on mobile. The old mobile-only `expanded` collapse (regina-89172) is superseded.

New **`activeFilterChips.ts`** is the single source of truth for "what's active": the bar renders the chips **and** derives the `(N)` badge from `chips.length` (replacing the old `countActiveFilters`), so the row and badge can't drift. View-specific chips are gated by the same `show*` flags as their controls, so By-payment / Payments don't surface non-actionable By-city-only chips.

## Scope / safety
**Presentation-only** over the existing `AdminPayoutFilters` shape — **no** filter values, defaults, semantics, URL serialization, or backend calls change. `paymentsUrlState.ts`, `paymentsFilterOptions.ts`, `lib/api.ts`, `types.ts`, and the backend are untouched. **No DB / migration.** Frontend-only.

## Notes for review
- **Sort hidden in Payments view:** the `showStatusTabs` prop is *documented* as hiding "the status tab strip **+ sort dropdown**", but the old code only hid the tabs. This now also hides Sort in the Payments-ledger view (which forces sort server-side) — matching the documented intent. Confirm that's desired.
- **Default-on hides as chips:** the four default-on visibility filters show as chips on first load (by-city). This is the transparency we wanted, but it's the spot where your two answers ("consolidate into a menu" + "compact bar + chips") overlap — easy to drop the visibility chips and rely on the panel's `(N)` badge instead if it reads as noisy.
- **Import cycle** `activeFilterChips ↔ PayoutsFilterBar` (for `SORT_LABEL`): safe — `SORT_LABEL` is only read inside the function body at render time, never at module-eval; Vite/Rollup handle the lazy cycle. Can hoist `SORT_LABEL` into `paymentsFilterOptions.ts` later if we want to remove the cycle entirely.

## Verify on preview
https://rsvpizza-git-tortellini-filters-pizza-dao.vercel.app/payments

- View mode at top; switching to By payment / Payments hides the by-city-only filters; Payments view hides the status strip + Sort.
- `⚙ Filters (N)` opens the grouped popover; opaque in dark + GPP light themes; usable bottom-sheet on mobile; click-outside / Done closes.
- Each non-default filter shows a removable chip; ✕ removes just that one; "Reset all" → defaults; badge matches chip count.
- URL updates + is shareable; Saved Views still apply; regional portals still hard-scope and Reset doesn't widen them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)