### PR TITLE
feat(telegram): multi-host submission auth (panettone-58533)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -327,6 +327,7 @@ model Party {
   // suppli-58533: non-host Telegram contributors (photo-only submitters) who
   // tapped a `submit_<token>` group link. Verified hosts use host_telegram_chat_id.
   telegramContributors    PartyTelegramContributor[]
+  telegramHosts           PartyTelegramHost[]
 
   @@index([coHosts(ops: JsonbPathOps)], type: Gin, map: "idx_parties_co_hosts_gin")
   @@map("parties")
@@ -2532,4 +2533,24 @@ model PartyTelegramContributor {
   @@unique([partyId, chatId])
   @@index([chatId])
   @@map("party_telegram_contributors")
+}
+
+// panettone-58533: VERIFIED host Telegram chats (multi-host). Replaces the
+// single parties.host_telegram_chat_id as the auth source for inbound host
+// submissions, so multiple co-hosts can each submit. host_telegram_chat_id is
+// retained as the single primary OUTBOUND DM target. Table ALREADY applied to
+// prod separately — do NOT auto-apply a migration.
+model PartyTelegramHost {
+  id             String   @id @default(uuid()) @db.Uuid
+  partyId        String   @map("party_id") @db.Uuid
+  party          Party    @relation(fields: [partyId], references: [id], onDelete: Cascade)
+  chatId         BigInt   @map("chat_id")
+  telegramUserId BigInt?  @map("telegram_user_id")
+  username       String?
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  @@unique([partyId, chatId])
+  @@index([chatId])
+  @@map("party_telegram_hosts")
 }

--- a/backend/src/routes/host-telegram.routes.ts
+++ b/backend/src/routes/host-telegram.routes.ts
@@ -90,6 +90,9 @@ router.delete(
           hostTelegramLinkToken: null,
         },
       });
+      // panettone-58533: disconnect must also revoke inbound submission auth by
+      // removing all verified host chat rows for this party.
+      await prisma.partyTelegramHost.deleteMany({ where: { partyId } });
 
       res.json({ success: true });
     } catch (error) {

--- a/backend/src/routes/telegram-link-callback.routes.ts
+++ b/backend/src/routes/telegram-link-callback.routes.ts
@@ -119,14 +119,35 @@ router.post('/link-host', async (req: Request, res: Response, _next: NextFunctio
       normalizedTapper !== '' &&
       authorizedHandles.some((h) => normalizeTgHandle(h) === normalizedTapper);
 
+    // panettone-58533: parse telegramUserId once so BOTH the host and
+    // contributor branches can persist it.
+    const tgUserId =
+      telegramUserId !== undefined &&
+      telegramUserId !== null &&
+      /^-?\d+$/.test(`${telegramUserId}`.trim())
+        ? BigInt(`${telegramUserId}`.trim())
+        : null;
+
     if (isHost) {
-      // Verified host (primary or editor co-host) — set/refresh the host link.
+      // panettone-58533: multi-host. Record this chat in party_telegram_hosts
+      // (the auth source for inbound submissions) so multiple co-hosts can each
+      // submit. Keep host_telegram_chat_id as the single primary OUTBOUND DM
+      // target (last verified host wins that slot).
+      await prisma.partyTelegramHost.upsert({
+        where: { partyId_chatId: { partyId: party.id, chatId: BigInt(chatIdStr) } },
+        create: {
+          partyId: party.id,
+          chatId: BigInt(chatIdStr),
+          telegramUserId: tgUserId,
+          username: tapperHandle,
+        },
+        update: { username: tapperHandle, telegramUserId: tgUserId, updatedAt: new Date() },
+      });
       await prisma.party.update({
         where: { id: party.id },
         data: { hostTelegramChatId: BigInt(chatIdStr) },
       });
-      // Clear any stale photo-only contributor row for this chat so it doesn't
-      // shadow the host binding in resolveSubmitterContext ("most recent wins").
+      // Clear any stale photo-only contributor row so it can't shadow this host.
       await prisma.partyTelegramContributor.deleteMany({
         where: { partyId: party.id, chatId: BigInt(chatIdStr) },
       });
@@ -137,13 +158,8 @@ router.post('/link-host', async (req: Request, res: Response, _next: NextFunctio
     // CRITICAL: never set host_telegram_chat_id here — that was the hijack.
     if (linkPurpose === 'submit') {
       // Photo-only contributor: register them so host-inbound can route their
-      // photos to this party's gallery (pending review).
-      const tgUserId =
-        telegramUserId !== undefined &&
-        telegramUserId !== null &&
-        /^-?\d+$/.test(`${telegramUserId}`.trim())
-          ? BigInt(`${telegramUserId}`.trim())
-          : null;
+      // photos to this party's gallery (pending review). Reuses the hoisted
+      // `tgUserId` parsed above (panettone-58533).
       await prisma.partyTelegramContributor.upsert({
         where: { partyId_chatId: { partyId: party.id, chatId: BigInt(chatIdStr) } },
         create: {

--- a/backend/src/services/hostInboundResolve.ts
+++ b/backend/src/services/hostInboundResolve.ts
@@ -40,9 +40,9 @@ export interface HostInboundParty {
 }
 
 /**
- * suppli-58533: per-type authorization. A Telegram chatId can be either the
- * VERIFIED host of a party (parties.host_telegram_chat_id) or a photo-only
- * CONTRIBUTOR (party_telegram_contributors). resolveSubmitterContext picks the
+ * suppli-58533: per-type authorization. A Telegram chatId can be either a
+ * VERIFIED host of a party (party_telegram_hosts rows where chat_id = chatId) or
+ * a photo-only CONTRIBUTOR (party_telegram_contributors). resolveSubmitterContext picks the
  * single most-recently-active candidate across BOTH sets and returns its role.
  */
 export interface SubmitterContext {
@@ -88,8 +88,9 @@ function slugOf(p: HostInboundParty): string | null {
 /**
  * Resolve the party a host's Telegram chatId belongs to.
  *
- * `parties.host_telegram_chat_id` is NOT unique — one chatId can map to many
- * parties (a host running multiple cities/years). Selection order:
+ * party_telegram_hosts rows where chat_id = chatId are NOT unique per chatId —
+ * one chatId can map to many parties (a host running multiple cities/years).
+ * Selection order:
  *   1. If exactly one party matches → that party.
  *   2. Pick the party with the MOST RECENT reminder
  *      (max of receipts/photo/wallet/attendance reminder timestamps).
@@ -108,11 +109,14 @@ export async function resolveHostPartyByChatId(
     return { kind: 'none' };
   }
 
-  const parties = (await prisma.party.findMany({
-    where: { hostTelegramChatId: chatIdBig },
-    select: PARTY_SELECT,
+  const hostRows = await prisma.partyTelegramHost.findMany({
+    where: { chatId: chatIdBig },
+    select: { party: { select: PARTY_SELECT } },
     orderBy: { createdAt: 'desc' },
-  })) as unknown as HostInboundParty[];
+  });
+  const parties = hostRows
+    .map((r) => r.party as unknown as HostInboundParty | null)
+    .filter((p): p is HostInboundParty => p != null);
 
   if (parties.length === 0) return { kind: 'none' };
   if (parties.length === 1) return { kind: 'party', party: parties[0] };
@@ -156,7 +160,7 @@ export async function resolveHostPartyByChatId(
  * suppli-58533: resolve a chatId to a SINGLE submitter context (host OR
  * contributor), choosing by "most recent action wins":
  *
- *  - Host candidates: parties where host_telegram_chat_id = chatId. Recency =
+ *  - Host candidates: party_telegram_hosts rows where chat_id = chatId. Recency =
  *    max(receipts/photo/wallet/attendance reminder timestamps), falling back to
  *    the event date so a host always has *some* ordering key.
  *  - Contributor candidates: party_telegram_contributors where chat_id = chatId.
@@ -177,12 +181,12 @@ export async function resolveSubmitterContext(
     return null;
   }
 
-  const [hostParties, contributorRows] = await Promise.all([
-    prisma.party.findMany({
-      where: { hostTelegramChatId: chatIdBig },
-      select: PARTY_SELECT,
-      orderBy: { createdAt: 'desc' },
-    }) as unknown as Promise<HostInboundParty[]>,
+  const [hostRows, contributorRows] = await Promise.all([
+    prisma.partyTelegramHost.findMany({
+      where: { chatId: chatIdBig },
+      orderBy: { updatedAt: 'desc' },
+      select: { party: { select: PARTY_SELECT } },
+    }),
     prisma.partyTelegramContributor.findMany({
       where: { chatId: chatIdBig },
       orderBy: { updatedAt: 'desc' },
@@ -202,7 +206,9 @@ export async function resolveSubmitterContext(
   };
   const candidates: Candidate[] = [];
 
-  for (const p of hostParties) {
+  for (const row of hostRows) {
+    const p = row.party as unknown as HostInboundParty | null;
+    if (!p) continue;
     // Host recency: most recent reminder, else event date, else 0.
     const r = maxReminder(p) ?? (p.date ? p.date.getTime() : 0);
     candidates.push({ role: 'host', party: p, recency: r, contributorUsername: null });

--- a/plans/panettone-58533-multihost-hosts-table.md
+++ b/plans/panettone-58533-multihost-hosts-table.md
@@ -1,0 +1,60 @@
+# panettone-58533 — Multi-host Telegram submission auth (`party_telegram_hosts`)
+
+Follow-up to suppli-58533 (host DM submissions to Molto Benny).
+
+## Problem
+Inbound host submission auth keyed off the single `parties.host_telegram_chat_id`
+column. That's one slot per party — last-writer-wins. When two co-hosts each
+tapped the connect link, the second overwrote the first, so only one co-host
+could ever submit a receipt/photo/headcount via Telegram. The other silently
+fell through to "no party matches this chat".
+
+## Scope (decided)
+- New `party_telegram_hosts` table is the auth source for **INBOUND** submissions
+  only (one row per verified host chat, many per party).
+- `host_telegram_chat_id` **STAYS** as the single primary **OUTBOUND** DM target
+  (reminders / notifications / coverage). No outbound/reminder code touched.
+
+## The table (ALREADY applied + backfilled in prod via MCP, 2026-06-15)
+```sql
+CREATE TABLE party_telegram_hosts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id uuid NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  chat_id bigint NOT NULL,
+  telegram_user_id bigint,
+  username text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (party_id, chat_id)
+);
+CREATE INDEX party_telegram_hosts_chat_id_idx ON party_telegram_hosts (chat_id);
+```
+8 existing host bindings were backfilled from `host_telegram_chat_id`. No
+migration runs on merge — `supabase/migrations/20260615_create_party_telegram_hosts.sql`
+exists only for repo record + the schema drift guard (uses `IF NOT EXISTS`).
+
+## Code touch-points (4)
+1. **`backend/prisma/schema.prisma`** — new `PartyTelegramHost` model mirroring
+   `PartyTelegramContributor`, plus `telegramHosts PartyTelegramHost[]`
+   back-relation on `Party`.
+2. **`backend/src/routes/telegram-link-callback.routes.ts`** (`POST /link-host`) —
+   `telegramUserId`→`tgUserId` BigInt parse hoisted above the `isHost` branch so
+   both branches share it. The `isHost` branch now **upserts** the host chat into
+   `party_telegram_hosts` (the inbound auth source), still sets
+   `host_telegram_chat_id` (the outbound slot), and still clears a stale
+   contributor row.
+3. **`backend/src/services/hostInboundResolve.ts`** — both `resolveHostPartyByChatId`
+   and `resolveSubmitterContext` now source host candidates from
+   `party_telegram_hosts WHERE chat_id = chatId` (joined to the party) instead of
+   `parties WHERE host_telegram_chat_id = chatId`. All recency / ambiguity /
+   approved-fallback logic unchanged.
+4. **`backend/src/routes/host-telegram.routes.ts`** (`DELETE /:partyId/host-telegram`) —
+   disconnect now also `deleteMany`s the party's `party_telegram_hosts` rows so it
+   genuinely revokes inbound submission auth (not just the outbound slot).
+
+## Follow-up (out of scope)
+The auto-unlink-on-failed-send sites in `backend/src/routes/telegram.routes.ts`
+null `host_telegram_chat_id` when a DM bounces. They do **not** clear
+`party_telegram_hosts` rows. A bounced outbound DM doesn't necessarily mean the
+inbound binding is invalid, so this was intentionally left alone; revisit if we
+want failed sends to also revoke inbound.

--- a/supabase/migrations/20260615_create_party_telegram_hosts.sql
+++ b/supabase/migrations/20260615_create_party_telegram_hosts.sql
@@ -1,0 +1,12 @@
+-- panettone-58533: applied to prod via MCP on 2026-06-15; file is for repo record + drift guard.
+CREATE TABLE IF NOT EXISTS party_telegram_hosts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  party_id uuid NOT NULL REFERENCES parties(id) ON DELETE CASCADE,
+  chat_id bigint NOT NULL,
+  telegram_user_id bigint,
+  username text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (party_id, chat_id)
+);
+CREATE INDEX IF NOT EXISTS party_telegram_hosts_chat_id_idx ON party_telegram_hosts (chat_id);


### PR DESCRIPTION
## Summary
Makes Telegram host-submission auth multi-host. A new `party_telegram_hosts` table (one row per verified host chat) replaces the single `parties.host_telegram_chat_id` as the auth source for inbound DM submissions, so several co-hosts can each submit without displacing each other.

- `link-host`: on a verified host match, upserts the chat into `party_telegram_hosts` (+ keeps `host_telegram_chat_id` as the single primary OUTBOUND DM target, + clears any stale contributor row).
- `hostInboundResolve`: host candidates now come from `party_telegram_hosts` (both resolver functions).
- disconnect (`DELETE /:partyId/host-telegram`): also clears the table so it actually revokes inbound.
- Outbound reminders/notifications/coverage are unchanged (still use `host_telegram_chat_id`).

Table already applied + backfilled in prod (8 existing bindings). No migration to run on merge.

Follow-up (out of scope): the auto-unlink-on-failed-send sites in `telegram.routes.ts` could also clear table rows.

## Test plan
Two co-hosts of the same event each tap the connect link -> each gets "connected as host" -> each can submit a headcount/receipt and it lands on the event (neither displaces the other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)