### PR TITLE
fix(pangrattato-58543): inline PDF receipt thumbnails on /payments

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -28,6 +28,7 @@ import {
   Wallet,
   Camera,
   Users,
+  FileText,
 } from 'lucide-react';
 import { IconInput } from '../IconInput';
 import type {
@@ -54,6 +55,7 @@ import { AdminAddAttachment } from './AdminAddAttachment';
 import { AdminAddPhotosModal } from './AdminAddPhotosModal';
 import { isSwcHubParty } from '../../utils/swcHub';
 import { isVideoFile } from '../../lib/mediaUtils';
+import { isPdfFile, derivePdfThumbnailUrl } from '../../lib/pdfUtils';
 import {
   updatePayoutDocument,
   markReceiptDuplicate,
@@ -2541,11 +2543,28 @@ function CityExpansion({
                       : ''
                   }`}
                 >
+                  {/* pangrattato-58543: PDF receipts thumbnail off their
+                      sibling `.thumb.png` (same derivation as
+                      PayoutReviewModal). Legacy PDFs uploaded before the
+                      thumbnail feature have no sibling → the derived URL
+                      404s; the onError below hides the broken <img> and
+                      reveals the FileText placeholder layered beneath. */}
+                  {isPdfFile(e.doc) && (
+                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-0.5 text-theme-text-muted pointer-events-none">
+                      <FileText size={20} />
+                      <span className="text-[8px] uppercase font-bold tracking-wide">
+                        PDF
+                      </span>
+                    </div>
+                  )}
                   <img
-                    src={e.doc.url}
+                    src={isPdfFile(e.doc) ? derivePdfThumbnailUrl(e.doc.url) : e.doc.url}
                     alt={e.doc.fileName}
-                    className="w-full h-full object-cover"
+                    className="relative w-full h-full object-cover bg-theme-surface"
                     loading="lazy"
+                    onError={(ev) => {
+                      ev.currentTarget.style.display = 'none';
+                    }}
                   />
                   {/* coppa-92105: 8px alternating dark/transparent diagonal
                       stripes laid over the thumbnail. Reinforces "do not


### PR DESCRIPTION
## Problem
On the `/payments` by-city merged receipt grid, each receipt thumbnail rendered as `<img src={e.doc.url}>`. For a PDF receipt that `src` is the raw PDF URL, which browsers can't render in an `<img>` — so PDF receipts showed a broken tile and had to be downloaded to view.

## Fix (one file, frontend-only)
`frontend/src/components/payments-admin/PayoutsByPartyTable.tsx`:
- Point the thumbnail `src` at the PDF's sibling `.thumb.png` for PDFs, via the existing `isPdfFile` / `derivePdfThumbnailUrl` helpers in `frontend/src/lib/pdfUtils.ts`. This is the exact same pattern already used in `PayoutReviewModal.tsx:2267`. Image receipts are unchanged.
- **Legacy-PDF fallback:** PDF receipts uploaded before the `.thumb.png` feature shipped have no sibling, so the derived URL 404s. Added a state-free fallback — a `FileText` (lucide) + "PDF" placeholder layered behind the `<img>` (only rendered for PDFs), plus a solid `bg-theme-surface` on the img and an `onError` that hides the broken img to reveal the placeholder. No React state, pure CSS layering + `onError`.

## Scope
- Frontend-only. **No backend, no migration.** Reuses existing `pdfUtils` infrastructure.
- Only the receipt grid `<img>` touched — lightbox, event/pizza photo grids, and all other files untouched. Image receipts are visually identical.

## Verification
- `npm run build` passes (no TS errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)