### PR TITLE
cannelloni-58543: host can submit payout without photos via acknowledgment checkbox

### DIFF
--- a/backend/prisma/migrations/cannelloni-58543-photos-waived-at.sql
+++ b/backend/prisma/migrations/cannelloni-58543-photos-waived-at.sql
@@ -1,0 +1,3 @@
+-- cannelloni-58543: host can submit payout for review without required event
+-- photos via an acknowledgment checkbox. Nullable timestamp recording that waiver.
+ALTER TABLE "payouts" ADD COLUMN IF NOT EXISTS "photos_waived_at" TIMESTAMPTZ;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1981,6 +1981,10 @@ model Payout {
   // receipts until an admin acts).
   submittedForReviewAt DateTime? @map("submitted_for_review_at") @db.Timestamptz
 
+  // cannelloni-58543: set when the host submits for review without the required
+  // event photos via the acknowledgment checkbox. Null on photo-complete submits.
+  photosWaivedAt DateTime? @map("photos_waived_at") @db.Timestamptz
+
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 

--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -843,6 +843,9 @@ function serializePayout(row: any): any {
     submittedForReviewAt: row.submittedForReviewAt
       ? row.submittedForReviewAt.toISOString()
       : null,
+    // cannelloni-58543: non-null when the host submitted without the required
+    // event photos; /payments surfaces a "Submitted without photos" pill.
+    photosWaivedAt: row.photosWaivedAt ? row.photosWaivedAt.toISOString() : null,
     payoutMethod: row.payoutMethod,
     payoutWalletAddress: row.payoutWalletAddress,
     // caciotta-92104: original ENS input (e.g. `puebla.eth`) when the

--- a/backend/src/routes/payout.routes.ts
+++ b/backend/src/routes/payout.routes.ts
@@ -195,6 +195,9 @@ function serializePayout(p: any) {
     // ziti-58300: host "Submit for review" toggle timestamp on the rolling
     // reimbursement record. Null until the host signals ready.
     submittedForReviewAt: p.submittedForReviewAt ? p.submittedForReviewAt.toISOString() : null,
+    // cannelloni-58543: non-null when the host submitted without the required
+    // event photos via the acknowledgment checkbox.
+    photosWaivedAt: p.photosWaivedAt ? p.photosWaivedAt.toISOString() : null,
     createdAt: p.createdAt.toISOString(),
     updatedAt: p.updatedAt.toISOString(),
     documents: Array.isArray(p.documents) ? p.documents.map(serializeDocument) : undefined,
@@ -885,6 +888,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
       // porchetta-58296: host must affirm "I have submitted all my receipts and
       // they are itemized." before the payout can be created.
       receiptAttested,
+      // cannelloni-58543: host acknowledges submitting without the required event
+      // photos. Waives ONLY the photo gates (receipt + attestation stay required).
+      photosWaived,
       // bismarck-92103: admin-only override so the resulting Payout row is
       // credited to the chosen cohost (not the admin creating it). When set
       // AND the caller is an admin, `recipientHostUserId` replaces the
@@ -1074,34 +1080,39 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           'RECEIPTS_REQUIRED',
         );
       }
-      if (!submissionReadiness.hasGroupPhoto) {
-        throw new AppError(
-          'Designate a group photo before submitting.',
-          400,
-          'GROUP_PHOTO_REQUIRED',
-        );
-      }
-      if (!submissionReadiness.hasBoxStackPhoto) {
-        throw new AppError(
-          'Designate a box stack photo before submitting.',
-          400,
-          'BOX_STACK_PHOTO_REQUIRED',
-        );
-      }
-      if (!submissionReadiness.hasPizzaPhoto) {
-        throw new AppError(
-          'Designate a pizza photo before submitting.',
-          400,
-          'PIZZA_PHOTO_REQUIRED',
-        );
-      }
-      // tiramisu-58530: beyond the 3 role photos, require >=5 additional event photos.
-      if (submissionReadiness.additionalPhotoCount < REQUIRED_ADDITIONAL_PHOTOS) {
-        throw new AppError(
-          `Upload at least ${REQUIRED_ADDITIONAL_PHOTOS} additional event photos before submitting.`,
-          400,
-          'ADDITIONAL_PHOTOS_REQUIRED',
-        );
+      // cannelloni-58543: the host may waive ALL photo gates (3 role photos +
+      // the >=5 additional) via an acknowledgment checkbox. Receipt + attestation
+      // gates above stay unconditional.
+      if (photosWaived !== true) {
+        if (!submissionReadiness.hasGroupPhoto) {
+          throw new AppError(
+            'Designate a group photo before submitting.',
+            400,
+            'GROUP_PHOTO_REQUIRED',
+          );
+        }
+        if (!submissionReadiness.hasBoxStackPhoto) {
+          throw new AppError(
+            'Designate a box stack photo before submitting.',
+            400,
+            'BOX_STACK_PHOTO_REQUIRED',
+          );
+        }
+        if (!submissionReadiness.hasPizzaPhoto) {
+          throw new AppError(
+            'Designate a pizza photo before submitting.',
+            400,
+            'PIZZA_PHOTO_REQUIRED',
+          );
+        }
+        // tiramisu-58530: beyond the 3 role photos, require >=5 additional event photos.
+        if (submissionReadiness.additionalPhotoCount < REQUIRED_ADDITIONAL_PHOTOS) {
+          throw new AppError(
+            `Upload at least ${REQUIRED_ADDITIONAL_PHOTOS} additional event photos before submitting.`,
+            400,
+            'ADDITIONAL_PHOTOS_REQUIRED',
+          );
+        }
       }
     }
 
@@ -1794,6 +1805,9 @@ router.post('/:partyId/payouts', async (req: AuthRequest, res: Response, next: N
           // time (W-9 / W-8BEN / W-8BEN-E). Null on shipping-purpose receipts
           // and on admin-prepay rows where the gate is skipped.
           taxFormId: taxFormSnapshotId,
+          // cannelloni-58543: stamp the photo waiver when the host explicitly
+          // submitted without the required event photos.
+          photosWaivedAt: photosWaived === true ? new Date() : null,
           documents: { create: docsToCreateStamped },
         },
         include: {
@@ -2941,6 +2955,12 @@ async function getReimbursementReadiness(partyId: string, userId: string) {
     photoReadiness.additionalPhotoCount >= REQUIRED_ADDITIONAL_PHOTOS &&
     paymentMethodValid;
 
+  // cannelloni-58543: everything required EXCEPT the photo gates. Drives the
+  // "submit anyway with a waiver checkbox" path. readyToSubmit keeps its full
+  // meaning (still includes photos) so existing labels/behavior don't shift.
+  const readyToSubmitWithoutPhotos =
+    attendanceSet && photoReadiness.hasReceipt && paymentMethodValid;
+
   return {
     attendanceSet,
     hasGroupPhoto: photoReadiness.hasGroupPhoto,
@@ -2951,6 +2971,7 @@ async function getReimbursementReadiness(partyId: string, userId: string) {
     additionalPhotoCount: photoReadiness.additionalPhotoCount,
     paymentMethodValid,
     readyToSubmit,
+    readyToSubmitWithoutPhotos,
   };
 }
 
@@ -3460,7 +3481,10 @@ router.delete('/:partyId/reimbursement/receipts/:docId', async (req: AuthRequest
 router.post('/:partyId/reimbursement/submit', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const { partyId } = req.params;
-    const { attested } = req.body || {};
+    // cannelloni-58543: `photosWaived` lets the host submit without the required
+    // event photos (acknowledged via a checkbox). Receipt/attestation/method/
+    // attendance gates stay required.
+    const { attested, photosWaived } = req.body || {};
     const canEdit = await canUserEditParty(partyId, req.userId, req.userEmail);
     if (!canEdit) {
       throw new AppError('Party not found', 404, 'NOT_FOUND');
@@ -3484,7 +3508,20 @@ router.post('/:partyId/reimbursement/submit', async (req: AuthRequest, res: Resp
     }
 
     const readiness = await getReimbursementReadiness(partyId, req.userId);
-    if (!readiness.readyToSubmit) {
+    if (photosWaived === true) {
+      // cannelloni-58543: photo gates waived — require only the non-photo gates.
+      if (!readiness.readyToSubmitWithoutPhotos) {
+        let missing = 'unknown';
+        if (!readiness.attendanceSet) missing = 'attendance';
+        else if (!readiness.hasReceipt) missing = 'receipt';
+        else if (!readiness.paymentMethodValid) missing = 'paymentMethod';
+        throw new AppError(
+          `Your reimbursement is not ready to submit (missing: ${missing}).`,
+          400,
+          'NOT_READY',
+        );
+      }
+    } else if (!readiness.readyToSubmit) {
       // Report the first missing requirement so the client can highlight it.
       let missing = 'unknown';
       if (!readiness.attendanceSet) missing = 'attendance';
@@ -3517,6 +3554,9 @@ router.post('/:partyId/reimbursement/submit', async (req: AuthRequest, res: Resp
       where: { id: record.id },
       data: {
         submittedForReviewAt: new Date(),
+        // cannelloni-58543: stamp/clear the photo waiver. A re-submit with photos
+        // (photosWaived !== true) un-waives a previously waived record.
+        photosWaivedAt: photosWaived === true ? new Date() : null,
         ...(submitter ? payoutRowSnapshotFromUser(submitter) : {}),
       },
       include: {
@@ -3560,7 +3600,9 @@ router.post('/:partyId/reimbursement/unsubmit', async (req: AuthRequest, res: Re
 
     const updated = await prisma.payout.update({
       where: { id: record.id },
-      data: { submittedForReviewAt: null },
+      // cannelloni-58543: reopening drops any stale photo waiver alongside the
+      // submitted-for-review flag.
+      data: { submittedForReviewAt: null, photosWaivedAt: null },
       include: {
         host: { select: { id: true, name: true, email: true } },
         documents: {

--- a/frontend/src/components/payments-admin/PayoutReviewModal.tsx
+++ b/frontend/src/components/payments-admin/PayoutReviewModal.tsx
@@ -1948,7 +1948,10 @@ export const PayoutReviewModal: React.FC<PayoutReviewModalProps> = ({
               {/* ziti-58300: amber "Submitted {date}" pill in the review header
                   so the reviewer sees the co-host explicitly marked their
                   rolling reimbursement ready for review. */}
-              <SubmittedForReviewBadge submittedForReviewAt={payout.submittedForReviewAt} />
+              <SubmittedForReviewBadge
+                submittedForReviewAt={payout.submittedForReviewAt}
+                photosWaivedAt={payout.photosWaivedAt}
+              />
               <PayoutMethodIcon method={payout.payoutMethod} showLabel />
             </div>
             <div className="text-xs text-theme-text-muted mt-0.5">

--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -1485,7 +1485,14 @@ function CityExpansion({
   const hosts = useMemo(() => {
     const seen = new Map<
       string,
-      { id: string; name: string | null; email: string | null; submittedForReviewAt: string | null }
+      {
+        id: string;
+        name: string | null;
+        email: string | null;
+        submittedForReviewAt: string | null;
+        // cannelloni-58543: most-recent photo waiver across active records.
+        photosWaivedAt: string | null;
+      }
     >();
     for (const p of row.payouts) {
       const h = p.host;
@@ -1495,11 +1502,17 @@ function CityExpansion({
         !TERMINAL_STATUSES.includes(p.status) && p.submittedForReviewAt
           ? p.submittedForReviewAt
           : null;
+      // cannelloni-58543: track the waiver on the same active-record basis.
+      const waived =
+        !TERMINAL_STATUSES.includes(p.status) && p.photosWaivedAt
+          ? p.photosWaivedAt
+          : null;
       const existing = seen.get(h.id);
       if (existing) {
         // Keep the latest submitted timestamp if more than one active record.
         if (submitted && (!existing.submittedForReviewAt || submitted > existing.submittedForReviewAt)) {
           existing.submittedForReviewAt = submitted;
+          existing.photosWaivedAt = waived;
         }
         continue;
       }
@@ -1508,6 +1521,7 @@ function CityExpansion({
         name: h.name,
         email: h.email,
         submittedForReviewAt: submitted,
+        photosWaivedAt: waived,
       });
     }
     return Array.from(seen.values());
@@ -2193,7 +2207,11 @@ function CityExpansion({
                       flipped their rolling reimbursement's "Submit for review"
                       toggle — distinguishes host-ready co-hosts from those
                       still rolling. */}
-                  <SubmittedForReviewBadge submittedForReviewAt={h.submittedForReviewAt} compact />
+                  <SubmittedForReviewBadge
+                    submittedForReviewAt={h.submittedForReviewAt}
+                    photosWaivedAt={h.photosWaivedAt}
+                    compact
+                  />
                 </span>
               ))}
             </div>
@@ -2390,6 +2408,7 @@ function CityExpansion({
                           the per-payout ledger row inside the expansion. */}
                       <SubmittedForReviewBadge
                         submittedForReviewAt={p.submittedForReviewAt}
+                        photosWaivedAt={p.photosWaivedAt}
                         compact
                       />
                       <span className="text-theme-text-secondary text-xs min-w-[5.5rem] shrink-0">

--- a/frontend/src/components/payments-shared/PayoutRow.tsx
+++ b/frontend/src/components/payments-shared/PayoutRow.tsx
@@ -290,7 +290,11 @@ export const PayoutRow: React.FC<PayoutRowProps> = ({
           {/* ziti-58300: amber "Submitted" pill when the co-host has flipped
               their rolling reimbursement's "Submit for review" toggle. Helps
               admins prioritise host-ready records over still-rolling ones. */}
-          <SubmittedForReviewBadge submittedForReviewAt={payout.submittedForReviewAt} compact />
+          <SubmittedForReviewBadge
+            submittedForReviewAt={payout.submittedForReviewAt}
+            photosWaivedAt={payout.photosWaivedAt}
+            compact
+          />
           {/* argentina-92103: green Flag icon when a regional underboss (or
               admin) has marked the row "ready for payment". Tooltip carries
               the actor email + timestamp. Sticky until the row is paid /

--- a/frontend/src/components/payments-shared/SubmittedForReviewBadge.tsx
+++ b/frontend/src/components/payments-shared/SubmittedForReviewBadge.tsx
@@ -8,6 +8,12 @@ interface SubmittedForReviewBadgeProps {
    * hasn't signalled their reimbursement is ready for review yet.
    */
   submittedForReviewAt?: string | null;
+  /**
+   * cannelloni-58543: when set, the host submitted for review WITHOUT the
+   * required event photos via the acknowledgment checkbox. The pill switches
+   * to "Submitted without photos" so reviewers know photos are missing.
+   */
+  photosWaivedAt?: string | null;
   /** Compact variant drops the date text and shows just the check + label. */
   compact?: boolean;
   className?: string;
@@ -25,18 +31,29 @@ interface SubmittedForReviewBadgeProps {
  */
 export const SubmittedForReviewBadge: React.FC<SubmittedForReviewBadgeProps> = ({
   submittedForReviewAt,
+  photosWaivedAt,
   compact = false,
   className = '',
 }) => {
   if (!submittedForReviewAt) return null;
   const abs = new Date(submittedForReviewAt).toLocaleString();
-  const label = compact
-    ? 'Submitted'
-    : `Submitted ${new Date(submittedForReviewAt).toLocaleDateString()}`;
+  // cannelloni-58543: photo-waived submissions read differently so reviewers
+  // can spot photo-less submissions at a glance.
+  const waived = !!photosWaivedAt;
+  const label = waived
+    ? compact
+      ? 'Submitted without photos'
+      : `Submitted without photos ${new Date(submittedForReviewAt).toLocaleDateString()}`
+    : compact
+      ? 'Submitted'
+      : `Submitted ${new Date(submittedForReviewAt).toLocaleDateString()}`;
+  const title = waived
+    ? `Host submitted this reimbursement WITHOUT the required event photos on ${abs}`
+    : `Host marked this reimbursement ready for review on ${abs}`;
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full font-medium border px-2 py-0.5 text-xs bg-amber-100 text-amber-800 border-amber-300 ${className}`}
-      title={`Host marked this reimbursement ready for review on ${abs}`}
+      title={title}
     >
       <CheckCircle2 size={12} className="shrink-0" />
       {label}

--- a/frontend/src/components/payouts/PayoutsTab.tsx
+++ b/frontend/src/components/payouts/PayoutsTab.tsx
@@ -159,6 +159,10 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   // porchetta-58296: receipts-itemized attestation (re-used key).
   const [attested, setAttested] = useState(false);
 
+  // cannelloni-58543: host acknowledges submitting without the required event
+  // photos. Only sent when photos are actually missing.
+  const [photosWaived, setPhotosWaived] = useState(false);
+
   // Submit / reopen action state.
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -474,14 +478,23 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
   // --- Submit / reopen -------------------------------------------------------
 
   const readyToSubmit = readiness?.readyToSubmit === true;
-  const canSubmit = readyToSubmit && attested && !submitting;
+  // cannelloni-58543: everything required except photos. With the waiver ticked,
+  // a host missing photos can still submit.
+  const readyWithWaiver = readiness?.readyToSubmitWithoutPhotos === true;
+  const allPhotosDesignated =
+    !!readiness?.hasGroupPhoto && !!readiness?.hasBoxStackPhoto &&
+    !!readiness?.hasPizzaPhoto &&
+    (readiness?.additionalPhotoCount ?? 0) >= REQUIRED_ADDITIONAL_PHOTOS;
+  const canSubmit =
+    (readyToSubmit || (photosWaived && readyWithWaiver)) && attested && !submitting;
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const res = await submitReimbursement(partyId, true);
+      // Only stamp a waiver when photos are actually missing.
+      const res = await submitReimbursement(partyId, true, photosWaived && !allPhotosDesignated);
       setData((prev) =>
         prev
           ? {
@@ -906,6 +919,17 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
           </div>
         ) : (
           <div className="flex flex-col gap-2">
+            {/* cannelloni-58543: when the required event photos are missing, the
+                host can acknowledge and submit without them. */}
+            {!photosAllDesignated && (
+              <div className="mb-1">
+                <Checkbox
+                  checked={photosWaived}
+                  onChange={() => setPhotosWaived((v) => !v)}
+                  label={t('payouts.photoWaiverAck')}
+                />
+              </div>
+            )}
             <button
               type="button"
               onClick={handleSubmit}
@@ -915,10 +939,15 @@ export const PayoutsTab: React.FC<PayoutsTabProps> = ({
               {submitting && <Loader2 size={16} className="animate-spin" />}
               {t('payouts.submitForReview')}
             </button>
-            {!readyToSubmit && (
+            {/* When only photos are missing, point the host at the waiver box
+                instead of the generic "not ready" message. */}
+            {!readyToSubmit && readyWithWaiver && !photosWaived && (
+              <p className="text-xs text-theme-text-muted">{t('payouts.submitNeedsPhotoWaiver')}</p>
+            )}
+            {!readyToSubmit && !readyWithWaiver && (
               <p className="text-xs text-theme-text-muted">{t('payouts.submitDisabledHelp')}</p>
             )}
-            {readyToSubmit && !attested && (
+            {(readyToSubmit || (photosWaived && readyWithWaiver)) && !attested && (
               <p className="text-xs text-theme-text-muted">{t('payouts.submitNeedsAttestation')}</p>
             )}
           </div>

--- a/frontend/src/i18n/locales/de/host.json
+++ b/frontend/src/i18n/locales/de/host.json
@@ -893,6 +893,8 @@
     "submitForReview": "Zur Prüfung einreichen",
     "submitDisabledHelp": "Schließe die obigen Schritte ab, um das Einreichen zur Prüfung zu aktivieren.",
     "submitNeedsAttestation": "Bestätige die obige Erklärung, um einzureichen.",
+    "photoWaiverAck": "Ich reiche ohne die erforderlichen Event-Fotos ein und verstehe, dass meine Erstattung wegen der fehlenden Fotos verzögert oder zurückgewiesen werden kann.",
+    "submitNeedsPhotoWaiver": "Aktiviere das Kästchen oben, um ohne die erforderlichen Fotos einzureichen.",
     "eventRollupTitle": "Alle Belege der Veranstaltung",
     "eventRollupSubtitle": "Alle Belege jedes Co-Gastgebers für diese Veranstaltung, gruppiert nach Einreichendem.",
     "unknownCohost": "Unbekannter Co-Gastgeber",

--- a/frontend/src/i18n/locales/en/host.json
+++ b/frontend/src/i18n/locales/en/host.json
@@ -1015,6 +1015,8 @@
     "submitForReview": "Submit for review",
     "submitDisabledHelp": "Complete the steps above to enable submitting for review.",
     "submitNeedsAttestation": "Tick the attestation above to submit.",
+    "photoWaiverAck": "I'm submitting without the required event photos and understand my reimbursement may be delayed or returned for the missing photos.",
+    "submitNeedsPhotoWaiver": "Tick the box above to submit without the required photos.",
     "eventRollupTitle": "All event receipts",
     "eventRollupSubtitle": "Every co-host's receipts for this event, grouped by who submitted them.",
     "unknownCohost": "Unknown co-host",

--- a/frontend/src/i18n/locales/es/host.json
+++ b/frontend/src/i18n/locales/es/host.json
@@ -892,6 +892,8 @@
     "submitForReview": "Enviar para revisión",
     "submitDisabledHelp": "Completa los pasos anteriores para habilitar el envío para revisión.",
     "submitNeedsAttestation": "Marca la declaración de arriba para enviar.",
+    "photoWaiverAck": "Estoy enviando sin las fotos del evento requeridas y entiendo que mi reembolso puede retrasarse o devolverse por las fotos faltantes.",
+    "submitNeedsPhotoWaiver": "Marca la casilla de arriba para enviar sin las fotos requeridas.",
     "eventRollupTitle": "Todos los recibos del evento",
     "eventRollupSubtitle": "Todos los recibos de cada coanfitrión de este evento, agrupados por quién los envió.",
     "unknownCohost": "Coanfitrión desconocido",

--- a/frontend/src/i18n/locales/fr/host.json
+++ b/frontend/src/i18n/locales/fr/host.json
@@ -892,6 +892,8 @@
     "submitForReview": "Soumettre pour examen",
     "submitDisabledHelp": "Terminez les étapes ci-dessus pour activer la soumission pour examen.",
     "submitNeedsAttestation": "Cochez l'attestation ci-dessus pour soumettre.",
+    "photoWaiverAck": "Je soumets sans les photos d'événement requises et je comprends que mon remboursement peut être retardé ou retourné en raison des photos manquantes.",
+    "submitNeedsPhotoWaiver": "Cochez la case ci-dessus pour soumettre sans les photos requises.",
     "eventRollupTitle": "Tous les reçus de l'événement",
     "eventRollupSubtitle": "Tous les reçus de chaque co-hôte pour cet événement, regroupés selon qui les a soumis.",
     "unknownCohost": "Co-hôte inconnu",

--- a/frontend/src/i18n/locales/ja/host.json
+++ b/frontend/src/i18n/locales/ja/host.json
@@ -892,6 +892,8 @@
     "submitForReview": "審査のため提出",
     "submitDisabledHelp": "上記の手順を完了すると、審査への提出が有効になります。",
     "submitNeedsAttestation": "提出するには上記の確認にチェックを入れてください。",
+    "photoWaiverAck": "必要なイベント写真なしで提出します。写真が不足しているため、払い戻しが遅れたり差し戻されたりする可能性があることを理解しています。",
+    "submitNeedsPhotoWaiver": "必要な写真なしで提出するには、上のチェックボックスをオンにしてください。",
     "eventRollupTitle": "イベントのすべての領収書",
     "eventRollupSubtitle": "このイベントの各共同ホストの領収書を、提出者ごとにまとめたものです。",
     "unknownCohost": "不明な共同ホスト",

--- a/frontend/src/i18n/locales/ko/host.json
+++ b/frontend/src/i18n/locales/ko/host.json
@@ -848,6 +848,8 @@
     "submitForReview": "검토를 위해 제출",
     "submitDisabledHelp": "위 단계를 완료하면 검토 제출이 활성화됩니다.",
     "submitNeedsAttestation": "제출하려면 위의 확인란에 체크하세요.",
+    "photoWaiverAck": "필수 행사 사진 없이 제출하며, 누락된 사진으로 인해 환급이 지연되거나 반려될 수 있음을 이해합니다.",
+    "submitNeedsPhotoWaiver": "필수 사진 없이 제출하려면 위의 체크박스를 선택하세요.",
     "eventRollupTitle": "이벤트의 모든 영수증",
     "eventRollupSubtitle": "이 이벤트의 모든 공동 호스트 영수증을 제출자별로 그룹화했습니다.",
     "unknownCohost": "알 수 없는 공동 호스트",

--- a/frontend/src/i18n/locales/pt/host.json
+++ b/frontend/src/i18n/locales/pt/host.json
@@ -892,6 +892,8 @@
     "submitForReview": "Enviar para revisão",
     "submitDisabledHelp": "Conclua as etapas acima para habilitar o envio para revisão.",
     "submitNeedsAttestation": "Marque a declaração acima para enviar.",
+    "photoWaiverAck": "Estou enviando sem as fotos do evento exigidas e entendo que meu reembolso pode ser atrasado ou devolvido devido às fotos ausentes.",
+    "submitNeedsPhotoWaiver": "Marque a caixa acima para enviar sem as fotos exigidas.",
     "eventRollupTitle": "Todos os recibos do evento",
     "eventRollupSubtitle": "Todos os recibos de cada coanfitrião deste evento, agrupados por quem os enviou.",
     "unknownCohost": "Coanfitrião desconhecido",

--- a/frontend/src/i18n/locales/zh/host.json
+++ b/frontend/src/i18n/locales/zh/host.json
@@ -892,6 +892,8 @@
     "submitForReview": "提交审核",
     "submitDisabledHelp": "完成上述步骤即可提交审核。",
     "submitNeedsAttestation": "请勾选上方的声明以提交。",
+    "photoWaiverAck": "我在没有所需活动照片的情况下提交，并理解由于照片缺失，我的报销可能会被延迟或退回。",
+    "submitNeedsPhotoWaiver": "勾选上方复选框即可在没有所需照片的情况下提交。",
     "eventRollupTitle": "活动的所有收据",
     "eventRollupSubtitle": "本活动每位联合主办人的收据，按提交人分组。",
     "unknownCohost": "未知联合主办人",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6592,6 +6592,11 @@ export interface ReimbursementReadiness {
   paymentMethodValid: boolean;
   /** All of the above — the "Submit for review" toggle is enabled when true. */
   readyToSubmit: boolean;
+  /**
+   * cannelloni-58543: everything required EXCEPT the photo gates. Enables the
+   * "submit anyway" path once the host ticks the photo-waiver acknowledgment.
+   */
+  readyToSubmitWithoutPhotos: boolean;
 }
 
 export interface MyReimbursementResponse extends ReimbursementReadiness {
@@ -6702,14 +6707,17 @@ export async function removeReimbursementReceipt(
 /**
  * Flip the host "Submit for review" toggle. Backend enforces `readyToSubmit`
  * AND `attested === true` (NOT_READY / ATTESTATION_REQUIRED otherwise).
+ * cannelloni-58543: pass `photosWaived` to submit without the required event
+ * photos (gated on `readyToSubmitWithoutPhotos` server-side).
  */
 export async function submitReimbursement(
   partyId: string,
-  attested: boolean
+  attested: boolean,
+  photosWaived?: boolean
 ): Promise<{ reimbursement: Payout }> {
   return apiRequest<{ reimbursement: Payout }>(
     `/api/parties/${partyId}/reimbursement/submit`,
-    { method: 'POST', body: { attested }, requireAuth: true }
+    { method: 'POST', body: { attested, photosWaived }, requireAuth: true }
   );
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2055,6 +2055,11 @@ export interface Payout {
    * Optional on the wire for backward-compat with cached payloads.
    */
   submittedForReviewAt?: string | null;
+  /**
+   * cannelloni-58543: set when the host submitted without the required event
+   * photos via the acknowledgment checkbox. Null on photo-complete submits.
+   */
+  photosWaivedAt?: string | null;
 }
 
 // ============================================

--- a/plans/cannelloni-58543-photo-waiver.md
+++ b/plans/cannelloni-58543-photo-waiver.md
@@ -1,0 +1,145 @@
+# cannelloni-58543 — Host can submit payout without photos via acknowledgment checkbox
+
+## Goal
+Let a host submit their reimbursement **for review/payment** on /payments even when the
+required event photos are missing, **provided they tick an acknowledgment checkbox** that
+they understand they are submitting without the required photos. The receipt + attestation
++ payment-method + attendance gates are **unchanged** — only the photo gates are waivable.
+
+Decisions (confirmed with Snax):
+- **Waive ALL photo requirements** — the 3 role photos (group / box_stack / pizza) AND the
+  ≥5 additional event photos (tiramisu-58530). Not a partial relaxation.
+- **Persist + surface to admins** — record `photos_waived_at` on the payout row at submit
+  time and show a "Submitted without photos" badge on /payments (by-party row + review modal)
+  so reviewers know they approved a photo-less submission.
+
+## Background — the two gated submit paths (both must change)
+1. `POST /:partyId/reimbursement/submit` (payout.routes.ts ~3460) — the **modern** rolling
+   "Submit for review" toggle used by `PayoutsTab`. Gates via `getReimbursementReadiness()`
+   → `readyToSubmit` → throws `NOT_READY` with `missing: groupPhoto/boxStackPhoto/pizzaPhoto`
+   (and the additional-photo count feeds `readyToSubmit`).
+2. `POST /:partyId/payouts` (payout.routes.ts ~868) — the legacy one-shot create flow.
+   Throws `GROUP_PHOTO_REQUIRED` / `BOX_STACK_PHOTO_REQUIRED` / `PIZZA_PHOTO_REQUIRED` /
+   `ADDITIONAL_PHOTOS_REQUIRED` (lines ~1078-1107).
+
+Clone the existing `submittedForReviewAt` (ziti-58300) plumbing end-to-end — it is the exact
+template for a new nullable timestamp that flows schema → serializers → admin projection →
+frontend types → UI badge.
+
+## Landmines (from ship-payout-change)
+- **Backend auto-deploys from master ~1 min after merge.** Apply the migration to PROD
+  **before** merging or every query touching the Payout model 500s.
+- Receipt OCR preview ≠ persistence; don't touch the receipt gate — it stays required.
+- Rolling payouts snapshot wallet/method onto the row at submit; keep that snapshot logic
+  intact (the submit handler already does `payoutRowSnapshotFromUser`).
+
+---
+
+## Changes
+
+### 1. Migration (apply to PROD before merge)
+New file `backend/prisma/migrations/cannelloni-58543-photos-waived-at.sql`:
+```sql
+ALTER TABLE "payouts" ADD COLUMN IF NOT EXISTS "photos_waived_at" TIMESTAMPTZ;
+```
+Table is `payouts` (verified `@@map("payouts")`). Apply via `mcp__supabase-pizzadao__apply_migration`
+from the main session, then verify with `execute_sql`.
+
+### 2. `backend/prisma/schema.prisma` (model Payout, ~line 1982 next to submittedForReviewAt)
+```prisma
+photosWaivedAt DateTime? @map("photos_waived_at") @db.Timestamptz
+```
+
+### 3. `backend/src/routes/payout.routes.ts`
+- **serializePayout (~line 197)** — add next to `submittedForReviewAt`:
+  ```ts
+  photosWaivedAt: p.photosWaivedAt ? p.photosWaivedAt.toISOString() : null,
+  ```
+- **`POST /:partyId/payouts` create handler**
+  - Destructure `photosWaived` from `req.body` (~line 900, near `receiptAttested`).
+  - In the photo-gate block (~1078-1107), wrap the four photo throws so they are skipped
+    when `photosWaived === true`. Keep the receipt + attestation throws unconditional.
+    Cleanest: `if (photosWaived !== true) { ...the four photo gates... }`.
+  - When creating the payout row, set `photosWaivedAt: photosWaived === true ? new Date() : null`.
+- **`getReimbursementReadiness` (~2907)** — add a derived flag that callers can use without
+  changing `readyToSubmit`'s meaning. Return an extra:
+  ```ts
+  // Everything required EXCEPT photos — drives the "submit anyway with waiver" path.
+  readyToSubmitWithoutPhotos: attendanceSet && photoReadiness.hasReceipt && paymentMethodValid,
+  ```
+  Leave `readyToSubmit` as-is (still includes photos) so existing behavior/labels don't shift.
+- **`POST /:partyId/reimbursement/submit` (~3460)**
+  - Destructure `photosWaived` alongside `attested`.
+  - Keep the `attested !== true` → `ATTESTATION_REQUIRED` throw.
+  - Replace the readiness gate: if `photosWaived === true`, require
+    `readiness.readyToSubmitWithoutPhotos` (else `NOT_READY` reporting the first non-photo
+    miss: attendance / receipt / paymentMethod). If not waived, keep the existing
+    `readiness.readyToSubmit` gate exactly.
+  - In the `prisma.payout.update`, set `photosWaivedAt: photosWaived === true ? new Date() : null`
+    (clearing it on a normal submit is correct — a re-submit with photos un-waives).
+- **`GET /:partyId/reimbursement/me` (~2980)** — the response already spreads `...readiness`,
+  so `readyToSubmitWithoutPhotos` flows automatically. `photosWaivedAt` flows via
+  `serializePayout(record)`. No extra work beyond confirming.
+- **`POST /:partyId/reimbursement/unsubmit`** — when clearing `submittedForReviewAt`, also
+  clear `photosWaivedAt: null` so reopening drops the stale waiver.
+
+### 4. `backend/src/routes/admin-payout.routes.ts`
+- **serializePayout (~837)** — add next to `submittedForReviewAt` (~843):
+  ```ts
+  photosWaivedAt: row.photosWaivedAt ? row.photosWaivedAt.toISOString() : null,
+  ```
+  (Confirm the Prisma selects/includes for the by-party + review queries don't use a
+  narrow `select` that omits the new column — `submittedForReviewAt` is already returned,
+  so the same query should include `photosWaivedAt` for free once it's in the model.)
+
+### 5. `frontend/src/lib/api.ts`
+- `ReimbursementReadiness` (~6581): add `readyToSubmitWithoutPhotos: boolean;`.
+- `submitReimbursement` (~6706): add a `photosWaived?: boolean` param and include it in the
+  POST body: `body: { attested, photosWaived }`.
+
+### 6. `frontend/src/types.ts`
+- `Payout` interface (~2057, next to `submittedForReviewAt`): add
+  `photosWaivedAt?: string | null;`.
+
+### 7. `frontend/src/components/payouts/PayoutsTab.tsx`
+- New state `const [photosWaived, setPhotosWaived] = useState(false);`.
+- `photosAllDesignated` already computed (~581). When `!photosAllDesignated`, render a
+  **photo-waiver checkbox** in the submit card (section 7, near the attestation):
+  label e.g. *"I'm submitting without the required event photos and understand my
+  reimbursement may be delayed or returned for the missing photos."* Use the `Checkbox`
+  component (per CLAUDE.md reusable-components rule).
+- Recompute submit-enable:
+  ```ts
+  const readyWithWaiver = readiness?.readyToSubmitWithoutPhotos === true;
+  const canSubmit = ((readyToSubmit) || (photosWaived && readyWithWaiver)) && attested && !submitting;
+  ```
+- `handleSubmit` → `submitReimbursement(partyId, attested, photosWaived)`.
+- Update the disabled-help text: when `!readyToSubmit` but `readyWithWaiver`, prompt them to
+  tick the waiver instead of the generic "not ready" message. Keep the `missing` list visible
+  so they still see what's absent.
+- Only pass `photosWaived: true` when photos are actually missing (avoid stamping a waiver on
+  a complete submission). i.e. send `photosWaived && !photosAllDesignated`.
+
+### 8. Admin badge — `frontend/src/components/payments-shared/PayoutRow.tsx` + `payments-admin/PayoutReviewModal.tsx`
+- Where `submittedForReviewAt` is surfaced (the "Submitted" badge), add a small amber pill /
+  note "Submitted without photos" when `payout.photosWaivedAt` is set. Reuse existing
+  badge/pill styling next to the Submitted badge. (Find current usage by grepping
+  `submittedForReviewAt` in `frontend/src/components/payments-*`.)
+
+### 9. i18n
+- Add the new copy keys to `frontend/src/i18n/locales/en/host.json` (and mirror to the other
+  locale files alongside the existing `payouts.*` keys — at minimum add the English string to
+  all 8 so `t()` doesn't render the raw key). Keys: `payouts.photoWaiverAck`,
+  `payouts.submitNeedsPhotoWaiver` (the "tick the box to submit without photos" helper).
+
+## Verify
+- Preview: `https://rsvpizza-git-cannelloni-58543-photo-waiver-pizza-dao.vercel.app`
+- As a host on a city with **no** event photos but with a receipt + valid method + attendance:
+  Submit is disabled; ticking the waiver enables it; submit succeeds.
+- Admin /payments shows the "Submitted without photos" badge on that city's row + review modal.
+- A host **with** all photos submits normally and gets **no** waiver badge (photosWaivedAt null).
+- Reopen (unsubmit) clears both submittedForReviewAt and photosWaivedAt.
+
+## Out of scope
+- Receipt / attestation / payment-method / attendance gates stay required.
+- The `/payouts` legacy create flow keeps all non-photo gates; only photo gates become waivable.


### PR DESCRIPTION
## Summary
Lets a host submit their reimbursement **for payment** on /payments even when the required event photos are missing — provided they tick an acknowledgment checkbox confirming they understand they're submitting without the required photos.

Receipt, attestation, payment-method and attendance gates are **unchanged** — only the photo gates (group / box_stack / pizza role photos **and** the ≥5 additional event photos, tiramisu-58530) become waivable.

## Behavior
- **Host (PayoutsTab):** when photos are missing, an acknowledgment `Checkbox` appears in the submit card. Ticking it enables **Submit for review**. The missing-requirements list stays visible.
- **Persisted + surfaced to admins:** a new nullable `payouts.photos_waived_at` is stamped at submit/create when waived, and cleared on unsubmit or a photo-complete submit. The amber `SubmittedForReviewBadge` reads **"Submitted without photos"** on the by-city row, co-host chip, ledger row and review modal so reviewers know photos are missing.

## Backend
- `schema.prisma`: `Payout.photosWaivedAt` (`photos_waived_at` timestamptz, nullable).
- `getReimbursementReadiness` gains `readyToSubmitWithoutPhotos` (everything except photos); `readyToSubmit` keeps its full meaning.
- `POST /reimbursement/submit` + legacy `POST /payouts`: accept `photosWaived`; when true, skip the photo gates and gate on the non-photo requirements; stamp/clear `photosWaivedAt`. `POST /reimbursement/unsubmit` clears it.
- Both `serializePayout`s emit `photosWaivedAt`.

## Frontend
- `Payout.photosWaivedAt` type (inherited by `AdminPayout`); `ReimbursementReadiness.readyToSubmitWithoutPhotos`; `submitReimbursement(partyId, attested, photosWaived?)`.
- `SubmittedForReviewBadge` `photosWaivedAt` prop + 4 call sites wired.
- i18n keys `payouts.photoWaiverAck` / `payouts.submitNeedsPhotoWaiver` in all 8 locales.

## DB / deploy
- ✅ Migration **already applied to prod** (`payouts.photos_waived_at`, nullable timestamptz) — verified. Safe to merge; backend auto-deploys from master.

## Verify on preview
- https://rsvpizza-git-cannelloni-58543-photo-waiver-pizza-dao.vercel.app
- Host on a city with **no** photos + a receipt + valid method + attendance: Submit disabled → tick waiver → submit succeeds.
- Admin /payments shows the "Submitted without photos" pill on that city.
- A fully-photo'd submit shows the normal "Submitted" pill (no waiver).

Plan: `plans/cannelloni-58543-photo-waiver.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)