### PR TITLE
Send payment modal falls back to host profile wallet (gorgonzola-58544)

### DIFF
--- a/backend/src/routes/admin-payout.routes.ts
+++ b/backend/src/routes/admin-payout.routes.ts
@@ -1095,7 +1095,15 @@ router.get(
           // party is picked. Frontend-only guardrail — no backend gating.
           country: true,
           eventTags: true,
-          user: { select: { id: true, name: true, email: true } },
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              payoutWalletAddress: true,
+              preferredPayoutMethod: true,
+            },
+          },
         },
         orderBy: { createdAt: 'desc' },
         take: 20,
@@ -1116,10 +1124,25 @@ router.get(
       const cohostUsers = allCohostEmails.size
         ? await prisma.user.findMany({
             where: { email: { in: Array.from(allCohostEmails) } },
-            select: { id: true, name: true, email: true },
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              payoutWalletAddress: true,
+              preferredPayoutMethod: true,
+            },
           })
         : [];
-      const cohostUserByEmail = new Map<string, { id: string; name: string | null; email: string }>();
+      const cohostUserByEmail = new Map<
+        string,
+        {
+          id: string;
+          name: string | null;
+          email: string;
+          payoutWalletAddress: string | null;
+          preferredPayoutMethod: string | null;
+        }
+      >();
       for (const u of cohostUsers) {
         cohostUserByEmail.set(u.email.toLowerCase(), u);
       }
@@ -1161,6 +1184,8 @@ router.get(
             name: string | null;
             email: string | null;
             role: 'host' | 'cohost';
+            profileWalletAddress: string | null;
+            profilePayoutMethod: string | null;
           }> = [];
 
           // Main host always first — unless they're an org insider (admin /
@@ -1171,6 +1196,8 @@ router.get(
               name: p.user!.name,
               email: p.user!.email,
               role: 'host',
+              profileWalletAddress: p.user!.payoutWalletAddress ?? null,
+              profilePayoutMethod: p.user!.preferredPayoutMethod ?? null,
             });
           }
 
@@ -1196,6 +1223,8 @@ router.get(
               name: u.name,
               email: u.email,
               role: 'cohost',
+              profileWalletAddress: u.payoutWalletAddress ?? null,
+              profilePayoutMethod: u.preferredPayoutMethod ?? null,
             });
           }
 

--- a/frontend/src/components/payments-admin/SendPaymentModal.tsx
+++ b/frontend/src/components/payments-admin/SendPaymentModal.tsx
@@ -233,16 +233,23 @@ export const SendPaymentModal: React.FC<SendPaymentModalProps> = ({
   const [mercuryCardId, setMercuryCardId] = useState('');
   const [wireReference, setWireReference] = useState('');
 
-  // Pre-fill the USDC wallet with the address the selected host submitted on
-  // their receipt payouts for this city (passed down per-recipient by the
-  // parent). Re-runs whenever the recipient changes so switching hosts pulls
-  // in that host's wallet; an empty mapping clears the field. `hostWalletByUserId`
-  // is a stable snapshot for the modal's lifetime, so this only fires on an
+  // Pre-fill the USDC wallet for the selected recipient. The city-submitted
+  // wallet (the address the host put on a receipt payout for THIS city, passed
+  // down per-recipient by the parent) is preferred. gorgonzola-58544: when the
+  // city has no payout rows yet (e.g. Surat/Split), fall back to the host's
+  // profile wallet (User.payout_wallet_address) returned per-candidate by
+  // /parties/search. Re-runs whenever the recipient changes so switching hosts
+  // pulls in that host's wallet; an empty result clears the field. The sources
+  // are stable snapshots for the modal's lifetime, so this only fires on an
   // actual recipient change — a manual edit for the same recipient is kept.
   useEffect(() => {
     if (!recipientUserId) return;
-    setWalletAddress(hostWalletByUserId?.[recipientUserId] ?? '');
-  }, [recipientUserId, hostWalletByUserId]);
+    const cityWallet = hostWalletByUserId?.[recipientUserId];
+    const profileWallet = partyMeta?.hostCandidates.find(
+      (c) => c.userId === recipientUserId,
+    )?.profileWalletAddress;
+    setWalletAddress((cityWallet || profileWallet || '').trim());
+  }, [recipientUserId, hostWalletByUserId, partyMeta]);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6187,6 +6187,14 @@ export interface ApprovedPartySearchResult {
     name: string | null;
     email: string | null;
     role: 'host' | 'cohost';
+    /**
+     * gorgonzola-58544: the candidate's profile-level payout wallet/method
+     * (User.payout_wallet_address / preferred_payout_method). Used by the Send
+     * payment modal as a fallback wallet when a city has no payout rows yet.
+     * Optional for rolling-deploy backward-compat (like country/eventTags).
+     */
+    profileWalletAddress?: string | null;
+    profilePayoutMethod?: string | null;
   }>;
   /**
    * parmigiana-92104: surfaced so the ExternalPaymentModal can render the


### PR DESCRIPTION
On /payments, the Send payment modal pre-fills the USDC wallet field. Previously it only pre-filled from a wallet the host submitted on an existing payout row for that city, so cities with no payout rows yet (e.g. Surat, Split) showed a blank wallet even when the host has a wallet on their profile.

This adds a fallback to the host's profile wallet (User.payout_wallet_address): city-submitted wallet is still preferred, else the host's profile wallet.

- Backend GET /api/admin/payouts/parties/search now returns per-candidate profileWalletAddress / profilePayoutMethod.
- Frontend ApprovedPartySearchResult.hostCandidates gains optional profileWalletAddress / profilePayoutMethod (rolling-deploy backward-compat).
- SendPaymentModal pre-fill effect falls back to the selected candidate's profile wallet.

No migration (columns already exist). Default payout method unchanged.

Preview: https://rsvpizza-git-gorgonzola-58544-profile-wallet-fallback-pizza-dao.vercel.app/payments