### PR TITLE
fix(telegram): host-connect time in submitter recency (panforte-58533)

### DIFF
--- a/backend/src/services/hostInboundResolve.ts
+++ b/backend/src/services/hostInboundResolve.ts
@@ -185,7 +185,7 @@ export async function resolveSubmitterContext(
     prisma.partyTelegramHost.findMany({
       where: { chatId: chatIdBig },
       orderBy: { updatedAt: 'desc' },
-      select: { party: { select: PARTY_SELECT } },
+      select: { updatedAt: true, party: { select: PARTY_SELECT } },
     }),
     prisma.partyTelegramContributor.findMany({
       where: { chatId: chatIdBig },
@@ -209,8 +209,14 @@ export async function resolveSubmitterContext(
   for (const row of hostRows) {
     const p = row.party as unknown as HostInboundParty | null;
     if (!p) continue;
-    // Host recency: most recent reminder, else event date, else 0.
-    const r = maxReminder(p) ?? (p.date ? p.date.getTime() : 0);
+    // Host recency = the most recent of the host-link connect (row.updatedAt),
+    // any reminder, or the event date. Using the connect time makes a freshly
+    // linked host outrank a stale contributor row for a different event —
+    // symmetric with how contributor recency uses its own row.updatedAt.
+    const r = Math.max(
+      row.updatedAt ? row.updatedAt.getTime() : 0,
+      maxReminder(p) ?? (p.date ? p.date.getTime() : 0),
+    );
     candidates.push({ role: 'host', party: p, recency: r, contributorUsername: null });
   }
 

--- a/plans/panforte-58533-host-connect-recency.md
+++ b/plans/panforte-58533-host-connect-recency.md
@@ -1,0 +1,24 @@
+# panforte-58533 — Host-connect recency in submitter resolution
+
+## Bug
+In `backend/src/services/hostInboundResolve.ts`, `resolveSubmitterContext` ranks
+all candidate parties for a Telegram chatId by "most recent action wins".
+Contributor candidates use their own row's `updatedAt`, but HOST candidates
+computed recency from `maxReminder(p) ?? eventDate` and **ignored the
+`party_telegram_hosts` row's `updatedAt`** (the actual connect time). So a host
+who just connected could lose to a stale contributor row for a different event
+and get their receipt/headcount rejected.
+
+## Repro
+Chat `706681092` connected as host of **Philadelphia** today, but its `100`
+headcount resolved to **Moscow** (a 4-day-old contributor row) and was rejected.
+
+## Fix
+Two small edits, both inside `resolveSubmitterContext`:
+1. Add `updatedAt: true` to the host `partyTelegramHost.findMany` `select`.
+2. Fold the host-link connect time into host recency:
+   `Math.max(row.updatedAt, maxReminder(p) ?? eventDate)` — symmetric with how
+   contributor recency already uses its own `row.updatedAt`.
+
+No DB migration (`party_telegram_hosts.updatedAt` already exists). Did not touch
+`resolveHostPartyByChatId`, the contributor loop, or the tie-break.


### PR DESCRIPTION
## Problem
`resolveSubmitterContext` ranks a chatId's candidate parties by "most recent action wins", but host candidates used `maxReminder/eventDate` and ignored the `party_telegram_hosts` row `updatedAt` (the actual connect). So a freshly-connected host could lose to a stale contributor row for a different event. Live repro: a chat connected as host of Philadelphia, but its headcount resolved to a 4-day-old Moscow contributor row and was rejected.

## Fix
Fold the host-link `updatedAt` into host recency (`Math.max(row.updatedAt, maxReminder ?? eventDate)`), symmetric with how contributor recency already uses its row `updatedAt`.

## Test plan
Connect as host of event A while having an older contributor row for event B → a DM headcount now routes to A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)