### PR TITLE
feat(payments): inline-edit estimated attendance on /payments by-city rows (bucatini-58546)

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -47,6 +47,7 @@ import {
   formatUsd,
   computePartyTotals,
   CapInlineEditor,
+  EstimatedAttendanceInlineEditor,
   SubmittedForReviewBadge,
 } from '../payments-shared';
 import { ClickableEmail } from '../ClickableEmail';
@@ -213,6 +214,8 @@ interface PayoutsByPartyTableProps {
   onUnapprove?: (id: string) => void;
   onHostClick?: (userId: string) => void;
   onCapUpdated?: (partyId: string) => void;
+  /** bucatini-58546: refresh hook called after editing estimated attendance. */
+  onEstimatedAttendanceUpdated?: (partyId: string) => void;
   /**
    * schiacciata-58503: refresh hook called after an admin adds a receipt or
    * photo to the city's primary payout via the in-panel AdminAddAttachment
@@ -3011,6 +3014,7 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
   onSendPayment,
   onScamFlagChanged,
   onCapUpdated,
+  onEstimatedAttendanceUpdated,
   onDocumentsChanged,
   onTagsChanged,
   onTgReminderResult,
@@ -3627,7 +3631,18 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                       {/* cappelletti-58525: est. attendance + RSVP + check-in
                           counts as a compact sub-line on each city row. */}
                       <div className="text-xs text-theme-text-muted mt-0.5 flex flex-wrap items-center gap-x-2">
-                        <span title="Host-estimated attendance">Est. {row.party.estimatedAttendance ?? '—'}</span>
+                        <span
+                          title="Host-estimated attendance"
+                          className="inline-flex items-center gap-1"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Est.{' '}
+                          <EstimatedAttendanceInlineEditor
+                            partyId={row.party.id}
+                            currentAttendance={row.party.estimatedAttendance ?? null}
+                            onUpdated={() => onEstimatedAttendanceUpdated?.(row.party.id)}
+                          />
+                        </span>
                         <span aria-hidden>·</span>
                         <span title="RSVPs (non-invited guests)">{row.party.rsvpCount ?? 0} RSVP{(row.party.rsvpCount ?? 0) === 1 ? '' : 's'}</span>
                         <span aria-hidden>·</span>

--- a/frontend/src/components/payments-shared/EstimatedAttendanceInlineEditor.tsx
+++ b/frontend/src/components/payments-shared/EstimatedAttendanceInlineEditor.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { Check, X, Pencil, Loader2 } from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { updatePartyApi } from '../../lib/api';
+
+interface EstimatedAttendanceInlineEditorProps {
+  partyId: string;
+  /** Current host-estimated attendance (whole number) or null. */
+  currentAttendance: number | null;
+  /** Called after a successful save so the parent can refresh its data. */
+  onUpdated?: (newAttendance: number | null) => void;
+}
+
+/**
+ * bucatini-58546: shared inline editor for the per-event host-estimated
+ * attendance, used on the `/payments` admin dashboard by-city sub-line.
+ *
+ * Clones `CapInlineEditor` but edits an integer (not currency): click the
+ * value (or pencil) to edit, Enter saves, Escape cancels, empty clears to
+ * null. Saves to `parties.estimated_attendance` via PATCH /api/parties/:id
+ * (same auth path as the cap editor: admins + scoped underbosses on GPP).
+ */
+export const EstimatedAttendanceInlineEditor: React.FC<
+  EstimatedAttendanceInlineEditorProps
+> = ({ partyId, currentAttendance, onUpdated }) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(
+    currentAttendance != null ? String(currentAttendance) : ''
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function startEditing(e: React.MouseEvent) {
+    e.stopPropagation();
+    setDraft(currentAttendance != null ? String(currentAttendance) : '');
+    setError(null);
+    setEditing(true);
+  }
+
+  function cancel() {
+    setEditing(false);
+    setError(null);
+    setDraft(currentAttendance != null ? String(currentAttendance) : '');
+  }
+
+  async function save() {
+    const trimmed = draft.trim();
+    let value: number | null;
+    if (trimmed === '') {
+      value = null;
+    } else {
+      const n = Number(trimmed);
+      if (!Number.isInteger(n) || n < 0 || n > 1000000) {
+        setError('Enter a whole number 0–1000000');
+        return;
+      }
+      value = n;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await updatePartyApi(partyId, { estimatedAttendance: value });
+      setEditing(false);
+      onUpdated?.(value);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <div
+        className="inline-flex flex-col gap-1"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="inline-flex items-center gap-1">
+          <IconInput
+            type="number"
+            step="1"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                save();
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                cancel();
+              }
+            }}
+            disabled={saving}
+            placeholder="#"
+            className="!pl-2 py-1 text-xs w-[70px] bg-theme-surface border border-theme-stroke rounded text-theme-text"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving}
+            className="p-1 rounded text-emerald-500 hover:bg-emerald-500/10 disabled:opacity-40"
+            title="Save"
+          >
+            {saving ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Check size={12} />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={cancel}
+            disabled={saving}
+            className="p-1 rounded text-theme-text-faint hover:text-theme-text-muted hover:bg-theme-surface-hover disabled:opacity-40"
+            title="Cancel"
+          >
+            <X size={12} />
+          </button>
+        </div>
+        {error && (
+          <span className="text-[10px] text-red-400" title={error}>
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  const display = currentAttendance != null ? String(currentAttendance) : '—';
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      className="inline-flex items-center gap-1 text-theme-text hover:text-[#E52828] group"
+      title="Edit estimated attendance"
+    >
+      <span>{display}</span>
+      <Pencil
+        size={11}
+        className="text-theme-text-faint group-hover:text-[#E52828]"
+      />
+    </button>
+  );
+};

--- a/frontend/src/components/payments-shared/index.ts
+++ b/frontend/src/components/payments-shared/index.ts
@@ -3,6 +3,7 @@ export { SubmittedForReviewBadge } from './SubmittedForReviewBadge';
 export { PayoutMethodIcon, PAYOUT_METHOD_LABELS } from './PayoutMethodIcon';
 export { PayoutRow } from './PayoutRow';
 export { CapInlineEditor } from './CapInlineEditor';
+export { EstimatedAttendanceInlineEditor } from './EstimatedAttendanceInlineEditor';
 export { formatPayoutAmount, formatUsd, formatOriginalCurrency } from './formatPayoutAmount';
 export { ReceiptLightbox } from './ReceiptLightbox';
 export type { ReceiptLightboxImage } from './ReceiptLightbox';

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1377,6 +1377,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             onUnapprove={handleRowUnapprove}
             onHostClick={(userId) => setHostDetailUserId(userId)}
             onCapUpdated={() => refresh()}
+            onEstimatedAttendanceUpdated={() => refresh()}
             // schiacciata-58503: refetch after an admin adds a receipt/photo
             // in the by-party panel. New docs aren't on `row.payouts` yet, so
             // the local receiptOverrides merge can't surface them.

--- a/plans/bucatini-58546-est-attendance.md
+++ b/plans/bucatini-58546-est-attendance.md
@@ -1,0 +1,42 @@
+# bucatini-58546 — Inline-edit estimated attendance on /payments by-city rows
+
+## Goal
+On the `/payments` admin page, the per-city ("by-party") row shows a read-only
+"Est. {n}" sub-line (host-estimated attendance). Make that value EDITABLE inline
+for admins and scoped underbosses, exactly mirroring the existing inline
+reimbursement-cap editor (`CapInlineEditor`) on the same row.
+
+## Why this is frontend-only (no migration, no backend change)
+- `estimatedAttendance` is `Int?` on the `Party` model (`@map("estimated_attendance")`).
+  The column already exists in prod. **No migration.**
+- `PATCH /api/parties/:id` (`backend/src/routes/party.routes.ts`) already accepts
+  `estimatedAttendance` and writes it. Its auth gate is `canUserEditParty`, which
+  grants edit to super_admin, party owner, canEdit co-hosts, and — for GPP events —
+  admins + scoped underbosses. `/payments` shows GPP cities, so admins + scoped
+  underbosses can already PATCH this field.
+- This is the **same path** the existing `CapInlineEditor` uses (`updatePartyApi`),
+  so auth/scope behavior is identical to the cap editor already shipping on this row.
+- `frontend/src/lib/api.ts` already has `updatePartyApi(partyId, data)` and
+  `UpdatePartyData.estimatedAttendance?: number | null`.
+
+## Files touched (frontend only)
+1. **NEW** `frontend/src/components/payments-shared/EstimatedAttendanceInlineEditor.tsx`
+   — clone of `CapInlineEditor.tsx`. Differences: integer validation
+   (`Number.isInteger(n) && 0 <= n <= 1000000`, empty clears to null),
+   `<IconInput type="number" step="1">`, no `$` prefix on display, saves via
+   `updatePartyApi(partyId, { estimatedAttendance: value })`, title
+   "Edit estimated attendance", error "Enter a whole number 0–1000000".
+2. `frontend/src/components/payments-shared/index.ts` — export the new editor
+   from the barrel (the cap editor is imported from `../payments-shared`).
+3. `frontend/src/components/payments-admin/PayoutsByPartyTable.tsx` — import the
+   editor; replace the read-only `Est. {row.party.estimatedAttendance ?? '—'}`
+   with the inline editor (kept the `Est.` prefix + `title`, wrapped in a span
+   with `onClick stopPropagation` so editing doesn't toggle the row expand);
+   added optional prop `onEstimatedAttendanceUpdated?: (partyId: string) => void`
+   and destructured it.
+4. `frontend/src/pages/PaymentsAdminPage.tsx` — wired
+   `onEstimatedAttendanceUpdated={() => refresh()}` at both
+   `<PayoutsByPartyTable>` usages, next to the existing `onCapUpdated`.
+
+## No migration needed
+The `estimated_attendance` column and the PATCH endpoint already exist in prod.


### PR DESCRIPTION
## What
Makes the **estimated attendance** value editable inline on the `/payments` by-city rows. Previously it was read-only (`Est. {n}`); now admins + scoped underbosses can click it (pencil/value), edit, and save — mirroring the existing `CapInlineEditor` that already sits on the same row.

## Why it's frontend-only (no backend / no migration)
- `estimatedAttendance` already exists on the `Party` model (`@map("estimated_attendance")`).
- `PATCH /api/parties/:id` already accepts and writes `estimatedAttendance`.
- Its auth gate (`canUserEditParty`) already grants edit to admins + scoped underbosses on **GPP** events — which is exactly what `/payments` shows. This is the **same path** `CapInlineEditor` uses (`updatePartyApi`), so auth/scope behavior is identical to a control already shipping on this row.

## Changes
- **NEW** `payments-shared/EstimatedAttendanceInlineEditor.tsx` — clone of `CapInlineEditor`, integer validation (`0–1000000`, empty clears to `null`), no `$` prefix.
- `payments-shared/index.ts` — barrel export.
- `PayoutsByPartyTable.tsx` — swap read-only `Est.` display for the editor (wrapped in a `stopPropagation` span so editing doesn't toggle row-expand); add optional `onEstimatedAttendanceUpdated` prop.
- `PaymentsAdminPage.tsx` — wire `onEstimatedAttendanceUpdated={() => refresh()}`.
- `plans/bucatini-58546-est-attendance.md`.

## Verify on preview
https://rsvpizza-git-bucatini-58546-est-attendance-pizza-dao.vercel.app → `/payments` → by-city view → click an `Est.` value, change it, Enter to save; Escape cancels; empty clears.

> Note: `vite build` currently fails repo-wide on a pre-existing missing `heic2any` dep (absent from `frontend/package.json` on `master`), unrelated to this change. Touched files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)