### PR TITLE
feat(ciabatta-58918): filters on /partners (admin/UB only)

### DIFF
--- a/backend/src/routes/gpp.routes.ts
+++ b/backend/src/routes/gpp.routes.ts
@@ -1097,6 +1097,8 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
             customUrl: true,
             inviteCode: true,
             name: true,
+            country: true,
+            region: true,
           },
         },
       },
@@ -1129,7 +1131,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
       brandInstagram: string | null;
       category: string | null;
       eventCount: number;
-      events: { slug: string; city: string; sponsorId: string }[];
+      events: { slug: string; city: string; sponsorId: string; country: string | null; region: string | null }[];
       // tie-break tracking
       bestSortOrder: number;
       bestCreatedAt: Date;
@@ -1149,6 +1151,8 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
       const city =
         partyName.replace(/^Global Pizza Party\s*/i, '').trim() || partyName || 'Unknown';
       const slug = s.party?.customUrl || s.party?.inviteCode || '';
+      const country = s.party?.country ?? null;
+      const region = s.party?.region ?? null;
 
       // Find existing aggregate via logoKey first, then nameKey fallback.
       let agg = byLogoKey.get(logoKey);
@@ -1168,7 +1172,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
           agg.eventCount += 1;
           // Cap events array at 500 to defend against pathological payload size.
           if (agg.events.length < 500 && slug) {
-            agg.events.push({ slug, city, sponsorId: s.id });
+            agg.events.push({ slug, city, sponsorId: s.id, country, region });
           }
         }
         // Tie-break: prefer the representative row with lowest sortOrder; if tied,
@@ -1200,7 +1204,7 @@ router.get('/partners', async (_req: Request, res: Response, next: NextFunction)
           brandInstagram: s.brandInstagram,
           category: s.category,
           eventCount: 1,
-          events: slug ? [{ slug, city, sponsorId: s.id }] : [],
+          events: slug ? [{ slug, city, sponsorId: s.id, country, region }] : [],
           bestSortOrder: s.sortOrder,
           bestCreatedAt: s.createdAt,
         };

--- a/frontend/src/components/PartnersFilterBar.tsx
+++ b/frontend/src/components/PartnersFilterBar.tsx
@@ -1,0 +1,170 @@
+import { Search, X } from 'lucide-react';
+import { IconInput } from './IconInput';
+import { TriStateFilterDropdown } from './TriStateFilterDropdown';
+import {
+  PartnersFilters,
+  PartnersSortValue,
+  DEFAULT_FILTERS,
+  activeFilterCount,
+} from '../pages/partnersUrlState';
+import { PAYMENTS_REGION_LABELS, PaymentsRegionPortal } from '../utils/regions';
+
+/* ── colour tokens (mirror PartnersPage `C`) ─────────────── */
+const C = {
+  darkText: '#1a1a1a',
+  mutedText: '#555',
+  cardBorder: 'rgba(0,0,0,0.12)',
+};
+
+const SORT_OPTIONS: { value: PartnersSortValue; label: string }[] = [
+  { value: 'events_desc', label: 'Most events' },
+  { value: 'name_asc', label: 'Name A → Z' },
+  { value: 'name_desc', label: 'Name Z → A' },
+  { value: 'eventcount_asc', label: 'Fewest events' },
+];
+
+// Tailwind classes shared by the search box + native selects so they all match
+// the page's light theme (white card on the sky-blue gradient).
+const FIELD_CLASS =
+  'rounded-lg border bg-white/90 px-3 py-2 text-sm text-[#1a1a1a] placeholder:text-[#555]/60 focus:outline-none focus:border-black/30';
+
+interface PartnersFilterBarProps {
+  filters: PartnersFilters;
+  onChange: (next: PartnersFilters) => void;
+  categories: string[];
+  cities: string[];
+  /** region PORTAL keys present in the data (e.g. 'latam', 'westafrica') */
+  regions: string[];
+  countries: string[];
+}
+
+/** Human-readable category label: 'hardware_wallet' → 'Hardware wallet'. */
+function categoryLabel(cat: string): string {
+  return cat
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function PartnersFilterBar({
+  filters,
+  onChange,
+  categories,
+  cities,
+  regions,
+  countries,
+}: PartnersFilterBarProps) {
+  const count = activeFilterCount(filters);
+
+  return (
+    <div
+      className="mb-6 rounded-2xl border shadow-sm p-3 sm:p-4"
+      style={{ background: 'rgba(255,255,255,0.85)', borderColor: C.cardBorder }}
+    >
+      <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+        {/* Search */}
+        <div className="flex-1 min-w-[200px]">
+          <IconInput
+            icon={Search}
+            iconSize={18}
+            value={filters.search}
+            onChange={(e) => onChange({ ...filters, search: e.target.value })}
+            placeholder="Search partners…"
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        {/* Category (single-select) */}
+        <select
+          value={filters.category}
+          onChange={(e) => onChange({ ...filters, category: e.target.value })}
+          className={FIELD_CLASS}
+          aria-label="Category"
+        >
+          <option value="all">All categories</option>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {categoryLabel(cat)}
+            </option>
+          ))}
+        </select>
+
+        {/* Sort */}
+        <select
+          value={filters.sort}
+          onChange={(e) => onChange({ ...filters, sort: e.target.value as PartnersSortValue })}
+          className={FIELD_CLASS}
+          aria-label="Sort"
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+
+        {/* City */}
+        <TriStateFilterDropdown
+          label="City"
+          items={cities}
+          includes={filters.cityIncludes}
+          excludes={filters.cityExcludes}
+          onChange={({ includes, excludes }) =>
+            onChange({ ...filters, cityIncludes: includes, cityExcludes: excludes })
+          }
+          searchPlaceholder="Search cities…"
+          noMatchesLabel="No cities"
+          clearLabel="Clear"
+          includeLabel="Include"
+          excludeLabel="Exclude"
+        />
+
+        {/* Region */}
+        <TriStateFilterDropdown
+          label="Region"
+          items={regions}
+          includes={filters.regionIncludes}
+          excludes={filters.regionExcludes}
+          onChange={({ includes, excludes }) =>
+            onChange({ ...filters, regionIncludes: includes, regionExcludes: excludes })
+          }
+          searchPlaceholder="Search regions…"
+          noMatchesLabel="No regions"
+          clearLabel="Clear"
+          includeLabel="Include"
+          excludeLabel="Exclude"
+          labelFor={(item) =>
+            PAYMENTS_REGION_LABELS[item as PaymentsRegionPortal] ?? item}
+        />
+
+        {/* Country */}
+        <TriStateFilterDropdown
+          label="Country"
+          items={countries}
+          includes={filters.countryIncludes}
+          excludes={filters.countryExcludes}
+          onChange={({ includes, excludes }) =>
+            onChange({ ...filters, countryIncludes: includes, countryExcludes: excludes })
+          }
+          searchPlaceholder="Search countries…"
+          noMatchesLabel="No countries"
+          clearLabel="Clear"
+          includeLabel="Include"
+          excludeLabel="Exclude"
+        />
+
+        {/* Active count + clear all */}
+        {count > 0 && (
+          <button
+            type="button"
+            onClick={() => onChange({ ...DEFAULT_FILTERS })}
+            className="flex items-center gap-1 rounded-lg border px-3 py-2 text-sm font-semibold transition-colors hover:bg-black/5"
+            style={{ borderColor: C.cardBorder, color: C.mutedText }}
+          >
+            <X size={14} />
+            Clear all ({count})
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4790,7 +4790,7 @@ export interface GPPPartner {
   brandInstagram: string | null;
   category: string | null;
   eventCount: number;
-  events: { slug: string; city: string; sponsorId: string }[];
+  events: { slug: string; city: string; sponsorId: string; country: string | null; region: string | null }[];
 }
 
 export interface GPPPartnersResponse {

--- a/frontend/src/pages/PartnersPage.tsx
+++ b/frontend/src/pages/PartnersPage.tsx
@@ -1,9 +1,42 @@
-import { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { Loader2, X } from 'lucide-react';
 import { GPPClouds } from '../components/GPPClouds';
 import { fetchGppPartners, fetchUnderbossMe, GPPPartner } from '../lib/api';
+import { PartnersFilterBar } from '../components/PartnersFilterBar';
+import {
+  PartnersFilters,
+  filtersToSearchParams,
+  searchParamsToFilters,
+} from './partnersUrlState';
+import {
+  PAYMENTS_REGION_SCOPES,
+  PAYMENTS_REGION_DISPLAY_ORDER,
+  PaymentsRegionPortal,
+} from '../utils/regions';
+
+// Reverse map: a party.region slug (e.g. 'west-africa') → its portal key
+// (e.g. 'westafrica'). Built once from PAYMENTS_REGION_SCOPES so the Region
+// filter operates on the PAYMENTS_REGION_LABELS buckets.
+const REGION_SLUG_TO_PORTAL: Record<string, PaymentsRegionPortal> = (() => {
+  const map: Record<string, PaymentsRegionPortal> = {};
+  // Iterate in display order; the Africa overlap (south-africa appears in both
+  // 'africa' and 'southafrica') resolves to the most specific single-country
+  // portal because the specific ones come later in PAYMENTS_REGION_DISPLAY_ORDER.
+  for (const portal of PAYMENTS_REGION_DISPLAY_ORDER) {
+    for (const slug of PAYMENTS_REGION_SCOPES[portal]) {
+      map[slug] = portal;
+    }
+  }
+  return map;
+})();
+
+/** Map a party.region slug to its portal key (or null if unknown/empty). */
+function regionPortalFor(region: string | null | undefined): PaymentsRegionPortal | null {
+  if (!region) return null;
+  return REGION_SLUG_TO_PORTAL[region] ?? null;
+}
 
 /* ── colour tokens (from the 2026 flyer) ────────────────── */
 const C = {
@@ -26,9 +59,24 @@ const C = {
 
 export function PartnersPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [partners, setPartners] = useState<GPPPartner[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Lazy-init filters from the URL once on mount (mirrors PaymentsAdminPage).
+  // The ref captures the initial searchParams so a later setSearchParams (from
+  // the serialize effect) doesn't re-seed state.
+  const initialSearchParamsRef = useRef(searchParams);
+  const [filters, setFilters] = useState<PartnersFilters>(() =>
+    searchParamsToFilters(initialSearchParamsRef.current)
+  );
+
+  // Serialize filters → URL (diff-against-defaults keeps URLs short).
+  useEffect(() => {
+    setSearchParams(filtersToSearchParams(filters), { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters]);
 
   // Role detection (default to all-false — 401 / network errors are silent)
   const [roles, setRoles] = useState<{ isAdmin: boolean; isUnderboss: boolean; isGraphicsAdmin: boolean }>({
@@ -103,6 +151,139 @@ export function PartnersPage() {
     () => new Set(partners.flatMap((p) => p.events.map((e) => e.slug))).size,
     [partners]
   );
+
+  // ── Filter option lists (derived from the loaded partners) ──────────────
+  const categoryOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          partners
+            .map((p) => p.category)
+            .filter((c): c is string => !!c && c.trim().length > 0)
+        )
+      ).sort(),
+    [partners]
+  );
+
+  const cityOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          partners.flatMap((p) =>
+            p.events.map((e) => e.city).filter((c): c is string => !!c && c.trim().length > 0)
+          )
+        )
+      ).sort(),
+    [partners]
+  );
+
+  const countryOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          partners.flatMap((p) =>
+            p.events
+              .map((e) => e.country)
+              .filter((c): c is string => !!c && c.trim().length > 0)
+          )
+        )
+      ).sort(),
+    [partners]
+  );
+
+  // Region options = the PAYMENTS_REGION_LABELS portal keys actually present in
+  // the data (derived from each event's region slug). Ordered by the canonical
+  // display order.
+  const regionOptions = useMemo(() => {
+    const present = new Set<string>();
+    for (const p of partners) {
+      for (const e of p.events) {
+        const portal = regionPortalFor(e.region);
+        if (portal) present.add(portal);
+      }
+    }
+    return PAYMENTS_REGION_DISPLAY_ORDER.filter((portal) => present.has(portal));
+  }, [partners]);
+
+  // ── Visible (filtered + sorted) partners ────────────────────────────────
+  const visiblePartners = useMemo(() => {
+    const q = filters.search.trim().toLowerCase();
+
+    const matches = partners.filter((p) => {
+      // Search: name + description + twitter + instagram (case-insensitive).
+      if (q) {
+        const hay = [p.name, p.brandDescription, p.brandTwitter, p.brandInstagram]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+
+      // Category equality.
+      if (filters.category !== 'all' && p.category !== filters.category) return false;
+
+      // any-event include / none-exclude semantics for city.
+      if (filters.cityIncludes.length || filters.cityExcludes.length) {
+        const cities = p.events.map((e) => e.city).filter(Boolean) as string[];
+        if (filters.cityExcludes.length && cities.some((c) => filters.cityExcludes.includes(c))) {
+          return false;
+        }
+        if (filters.cityIncludes.length && !cities.some((c) => filters.cityIncludes.includes(c))) {
+          return false;
+        }
+      }
+
+      // Region (portal-key buckets).
+      if (filters.regionIncludes.length || filters.regionExcludes.length) {
+        const portals = p.events
+          .map((e) => regionPortalFor(e.region))
+          .filter((r): r is PaymentsRegionPortal => !!r);
+        if (filters.regionExcludes.length && portals.some((r) => filters.regionExcludes.includes(r))) {
+          return false;
+        }
+        if (filters.regionIncludes.length && !portals.some((r) => filters.regionIncludes.includes(r))) {
+          return false;
+        }
+      }
+
+      // Country.
+      if (filters.countryIncludes.length || filters.countryExcludes.length) {
+        const countries = p.events.map((e) => e.country).filter(Boolean) as string[];
+        if (filters.countryExcludes.length && countries.some((c) => filters.countryExcludes.includes(c))) {
+          return false;
+        }
+        if (filters.countryIncludes.length && !countries.some((c) => filters.countryIncludes.includes(c))) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    // Sort. Default 'events_desc' reproduces the backend order (eventCount
+    // DESC, then name ASC).
+    const sorted = [...matches];
+    switch (filters.sort) {
+      case 'name_asc':
+        sorted.sort((a, b) => a.name.localeCompare(b.name));
+        break;
+      case 'name_desc':
+        sorted.sort((a, b) => b.name.localeCompare(a.name));
+        break;
+      case 'eventcount_asc':
+        sorted.sort((a, b) =>
+          a.eventCount !== b.eventCount ? a.eventCount - b.eventCount : a.name.localeCompare(b.name)
+        );
+        break;
+      case 'events_desc':
+      default:
+        sorted.sort((a, b) =>
+          b.eventCount !== a.eventCount ? b.eventCount - a.eventCount : a.name.localeCompare(b.name)
+        );
+        break;
+    }
+    return sorted;
+  }, [partners, filters]);
 
   return (
     <div
@@ -218,9 +399,40 @@ export function PartnersPage() {
           </div>
         )}
 
-        {!loading && !error && partners.length > 0 && (
+        {/* Filter bar — admin / underboss / graphics-admin only. Public and
+            logged-out viewers never see it. */}
+        {!loading && !error && partners.length > 0 && canClick && (
+          <>
+            <PartnersFilterBar
+              filters={filters}
+              onChange={setFilters}
+              categories={categoryOptions}
+              cities={cityOptions}
+              regions={regionOptions}
+              countries={countryOptions}
+            />
+            <div className="mb-4 text-sm font-medium" style={{ color: C.mutedText }}>
+              {visiblePartners.length.toLocaleString()} of {partners.length.toLocaleString()} partners
+            </div>
+          </>
+        )}
+
+        {!loading && !error && partners.length > 0 && canClick && visiblePartners.length === 0 && (
+          <div className="flex items-center justify-center py-16 px-6">
+            <div
+              className="rounded-2xl px-6 py-5 border shadow-sm text-center"
+              style={{ background: C.cardBg, borderColor: C.cardBorder }}
+            >
+              <p className="text-sm" style={{ color: C.mutedText }}>
+                No partners match your filters — try clearing some.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && partners.length > 0 && !(canClick && visiblePartners.length === 0) && (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-            {partners.map((partner) => {
+            {(canClick ? visiblePartners : partners).map((partner) => {
               const tile = (
                 <div
                   className="aspect-square flex items-center justify-center p-4 rounded-2xl border shadow-lg transition-transform duration-200 hover:scale-105"

--- a/frontend/src/pages/partnersUrlState.ts
+++ b/frontend/src/pages/partnersUrlState.ts
@@ -1,0 +1,126 @@
+// ciabatta-58918: pure (no-React) (de)serializer for the /partners filter bar
+// <-> URL query string. Wired into PartnersPage via react-router's
+// useSearchParams so a refresh / shared link restores the exact filtered view.
+// Kept React-free so it can be unit-tested in isolation.
+//
+// Design: diff-against-defaults (mirrors paymentsUrlState.ts). We only emit a
+// query key when its value differs from DEFAULT_FILTERS, so the default view
+// produces an empty query string and shared URLs stay short.
+
+export type PartnersSortValue =
+  | 'events_desc'
+  | 'name_asc'
+  | 'name_desc'
+  | 'eventcount_asc';
+
+export const PARTNERS_SORT_VALUES: PartnersSortValue[] = [
+  'events_desc',
+  'name_asc',
+  'name_desc',
+  'eventcount_asc',
+];
+
+export interface PartnersFilters {
+  /** case-insensitive substring over name + description + twitter + instagram */
+  search: string;
+  /** 'all' or one of the distinct category values present in the data */
+  category: string;
+  sort: PartnersSortValue;
+  cityIncludes: string[];
+  cityExcludes: string[];
+  /** region portal keys (see regions.ts PAYMENTS_REGION_LABELS) */
+  regionIncludes: string[];
+  regionExcludes: string[];
+  countryIncludes: string[];
+  countryExcludes: string[];
+}
+
+export const DEFAULT_FILTERS: PartnersFilters = {
+  search: '',
+  category: 'all',
+  sort: 'events_desc',
+  cityIncludes: [],
+  cityExcludes: [],
+  regionIncludes: [],
+  regionExcludes: [],
+  countryIncludes: [],
+  countryExcludes: [],
+};
+
+const SORT_VALUE_SET = new Set<string>(PARTNERS_SORT_VALUES);
+
+/**
+ * Serialize the active filters to a URLSearchParams. A key is written ONLY when
+ * its value differs from the default, so the default view produces an empty
+ * query string.
+ */
+export function filtersToSearchParams(filters: PartnersFilters): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (filters.search && filters.search.trim()) params.set('q', filters.search.trim());
+  if (filters.category && filters.category !== DEFAULT_FILTERS.category) {
+    params.set('category', filters.category);
+  }
+  if (filters.sort && filters.sort !== DEFAULT_FILTERS.sort) params.set('sort', filters.sort);
+
+  if (filters.cityIncludes.length) params.set('cityInc', filters.cityIncludes.join(','));
+  if (filters.cityExcludes.length) params.set('cityExc', filters.cityExcludes.join(','));
+  if (filters.regionIncludes.length) params.set('regionInc', filters.regionIncludes.join(','));
+  if (filters.regionExcludes.length) params.set('regionExc', filters.regionExcludes.join(','));
+  if (filters.countryIncludes.length) params.set('countryInc', filters.countryIncludes.join(','));
+  if (filters.countryExcludes.length) params.set('countryExc', filters.countryExcludes.join(','));
+
+  return params;
+}
+
+/**
+ * Parse a URLSearchParams back into a PartnersFilters object. Starts from
+ * DEFAULT_FILTERS and overlays each present param, validating the sort enum so
+ * a hand-mangled URL can't crash the page.
+ */
+export function searchParamsToFilters(params: URLSearchParams): PartnersFilters {
+  const parseList = (key: string): string[] => {
+    const raw = params.get(key);
+    return raw ? raw.split(',').map((s) => s.trim()).filter(Boolean) : [];
+  };
+
+  const filters: PartnersFilters = {
+    ...DEFAULT_FILTERS,
+    cityIncludes: [],
+    cityExcludes: [],
+    regionIncludes: [],
+    regionExcludes: [],
+    countryIncludes: [],
+    countryExcludes: [],
+  };
+
+  const q = params.get('q');
+  if (q) filters.search = q;
+
+  const category = params.get('category');
+  if (category) filters.category = category;
+
+  const sortRaw = params.get('sort');
+  if (sortRaw && SORT_VALUE_SET.has(sortRaw)) filters.sort = sortRaw as PartnersSortValue;
+
+  filters.cityIncludes = parseList('cityInc');
+  filters.cityExcludes = parseList('cityExc');
+  filters.regionIncludes = parseList('regionInc');
+  filters.regionExcludes = parseList('regionExc');
+  filters.countryIncludes = parseList('countryInc');
+  filters.countryExcludes = parseList('countryExc');
+
+  return filters;
+}
+
+/** True when `filters` differs from DEFAULT_FILTERS in any user-facing field. */
+export function activeFilterCount(filters: PartnersFilters): number {
+  let n = 0;
+  if (filters.search.trim()) n += 1;
+  if (filters.category !== DEFAULT_FILTERS.category) n += 1;
+  if (filters.sort !== DEFAULT_FILTERS.sort) n += 1;
+  n += filters.cityIncludes.length + filters.cityExcludes.length;
+  n += filters.regionIncludes.length + filters.regionExcludes.length;
+  n += filters.countryIncludes.length + filters.countryExcludes.length;
+  return n;
+}

--- a/plans/ciabatta-58918-partners-filters.md
+++ b/plans/ciabatta-58918-partners-filters.md
@@ -1,0 +1,70 @@
+# ciabatta-58918 — Filters for /partners (admin/UB only)
+
+## Goal
+Add a filter bar to the `/partners` page, visible **only to admin / underboss / graphics-admin** viewers (public continues to see the plain logo wall). Filters:
+1. **Search by name** (substring over partner name; also description/socials)
+2. **Category** (e.g. `hardware_wallet`, `software_wallet`, `cex`, `blockchain`, `dex`, `community`, ...)
+3. **Sort** (most events / A–Z / Z–A / newest)
+4. **City / event** (partner sponsored a given city)
+5. **Region** (PAYMENTS_REGION_LABELS buckets)
+6. **Country**
+
+Filters 1–4 are achievable **frontend-only** with today's payload. Filters 5–6 (**region, country**) require a **backend payload change** because the partner record does not currently carry country/region.
+
+## Current state (verified)
+- Page: `frontend/src/pages/PartnersPage.tsx` — loads all partners via `fetchGppPartners()`, renders a responsive logo grid; admins/UB/graphics-admin get a clickable pill → events modal. Role flags already resolved: `roles.isAdmin/isUnderboss/isGraphicsAdmin`, combined as `canClick` (`PartnersPage.tsx:77`). **Reuse `canClick` to gate the filter bar.**
+- Route: `frontend/src/App.tsx` — `<Route path="/partners" element={<PartnersPage />} />` (before `/:slug`).
+- Type: `GPPPartner` in `frontend/src/lib/api.ts` — `{ name, logoUrl, website, brandDescription, brandTwitter, brandInstagram, category, eventCount, events: { slug; city; sponsorId }[] }`. **No country/region.**
+- Backend: `GET /api/gpp/partners` in `backend/src/routes/gpp.routes.ts:1073` — selects `party.{customUrl, inviteCode, name}` only; builds `events[]` as `{ slug, city, sponsorId }`. The `party` model has `country` and `region` (used on /payments: `row.party.country`, `party.region === 'usa'`).
+- Reuse patterns from /payments:
+  - `frontend/src/components/TriStateFilterDropdown.tsx` — searchable include/exclude dropdown (used for tag/country on /payments).
+  - `frontend/src/components/payments-admin/paymentsUrlState.ts` — `filtersToSearchParams` / `searchParamsToFilters` diff-against-defaults URL serialization pattern.
+  - `frontend/src/utils/regions.ts` — `PAYMENTS_REGION_LABELS`, country→region mapping (reuse for the region filter).
+  - `IconInput` (Search icon) for the search box; `Checkbox` for any toggles.
+
+## Backend change (required for region + country) — must deploy to prod first
+In `backend/src/routes/gpp.routes.ts` `/partners` handler:
+1. Add to the `party` select: `country: true`, `region: true`.
+2. Extend the per-event object pushed into `events[]` to `{ slug, city, sponsorId, country, region }` (both nullable). Update the `Aggregate.events` interface type accordingly.
+3. (Optional convenience) Add aggregated distinct sets on the response: `countries: string[]`, `regions: string[]` per partner — or let the frontend derive them from `events[]`. Deriving on the frontend keeps the backend diff minimal; recommend **derive on frontend** to avoid widening the response contract.
+
+> ⚠️ Preview deploys share the prod backend (CLAUDE.md). The new fields must be live on the master backend before the preview branch can filter by them. No DB migration needed — `country`/`region` already exist on `party`. Sequence: merge → backend auto-deploys from master (~1 min) → preview works.
+
+## Frontend changes
+1. **`frontend/src/lib/api.ts`** — extend `GPPPartner.events[]` element type to include `country: string | null; region: string | null`.
+2. **New `frontend/src/components/PartnersFilterBar.tsx`** (modeled on PayoutsFilterBar, much simpler):
+   - `IconInput` search box (Search icon) — substring over name (+ description, twitter, instagram).
+   - Category dropdown — options derived from `Array.from(new Set(partners.map(p => p.category).filter(Boolean)))`, single-select `all | <category>`.
+   - Sort dropdown — `events_desc` (default, current backend order) | `name_asc` | `name_desc` | `eventcount_asc`.
+   - City filter — `TriStateFilterDropdown` (or single-select) over distinct cities from `partners.flatMap(p => p.events.map(e => e.city))`.
+   - Region filter — `TriStateFilterDropdown` over `PAYMENTS_REGION_LABELS` keys present in the data.
+   - Country filter — `TriStateFilterDropdown` over distinct countries from events.
+   - An "active filter count" badge + a Clear-all button (match PayoutsFilterBar UX).
+3. **New `frontend/src/pages/partnersUrlState.ts`** — `filtersToSearchParams` / `searchParamsToFilters` (copy the diff-against-defaults approach from `paymentsUrlState.ts`). Persist: `q`, `category`, `sort`, `city`, `regionInc/regionExc`, `countryInc/countryExc`.
+4. **`PartnersPage.tsx`** wiring:
+   - Add `const [searchParams, setSearchParams] = useSearchParams()`; lazy-init a `filters` state from URL via a `useRef` captured once on mount (PaymentsAdminPage pattern). Sync `filters → setSearchParams(..., { replace: true })`.
+   - Compute `visiblePartners = useMemo(...)` applying search + category + city/region/country include/exclude, then sort. A partner matches a city/region/country filter if **any** of its `events[]` matches (include) and **no** event matches an exclude.
+   - Render `<PartnersFilterBar .../>` **only when `canClick`**; render the grid over `visiblePartners`. Update the header count (`uniqueEventCount` / partner count) to reflect the filtered set, or show "X of Y partners".
+   - Empty-state message when filters match nothing.
+
+## Out of scope (note, don't silently drop)
+- Saved views (`SavedViewsMenu`) — could be added later (scope `'partners'`); not in this pass unless requested.
+- Public-facing filters — explicitly admin/UB-only per decision.
+
+## Testing / verification
+- Local: load `/partners` as admin → filter bar visible; as logged-out → no filter bar, plain grid.
+- Search narrows by name; category/city/region/country narrow correctly (any-event match semantics); sort reorders; Clear resets; URL reflects state and survives refresh/share.
+- Confirm region/country only populate after the backend field addition is deployed (or test against local backend).
+
+## Sequencing
+1. Branch `ciabatta-58918-partners-filters` off `origin/master` (worktree).
+2. Backend payload change + frontend changes in one PR (frontend gracefully treats missing country/region as null until backend deploys).
+3. Merge → backend auto-deploys from master → verify on preview/prod.
+
+## Files
+- `backend/src/routes/gpp.routes.ts` (partners handler)
+- `frontend/src/lib/api.ts` (GPPPartner type)
+- `frontend/src/pages/PartnersPage.tsx`
+- `frontend/src/components/PartnersFilterBar.tsx` (new)
+- `frontend/src/pages/partnersUrlState.ts` (new)
+- Reuse: `TriStateFilterDropdown.tsx`, `utils/regions.ts`, `IconInput`, `Checkbox`


### PR DESCRIPTION
## What
Adds a filter bar to the **/partners** page, visible **only to admin / underboss / graphics-admin** viewers. Public and logged-out visitors see the unchanged logo grid.

Filters:
- **Search by name** (also matches description / twitter / instagram)
- **Category** (single-select, derived from data)
- **Sort** — most events (default, matches current order) / A–Z / Z–A / fewest events
- **City** / **Region** / **Country** — tri-state include/exclude via `TriStateFilterDropdown`

Filter state is **URL-persisted** (diff-against-defaults, shareable/refresh-safe), mirroring /payments.

## Backend
`GET /api/gpp/partners` now includes `party.country` and `party.region` per event. **No DB migration** — both columns already exist on `party`.

> ⚠️ Previews share the prod backend — **region/country filters only populate once this merges and the master backend auto-deploys.** Search/category/sort/city work on the preview immediately.

## Files
- `backend/src/routes/gpp.routes.ts` — add country/region to partner payload
- `frontend/src/lib/api.ts` — extend `GPPPartner.events[]` type
- `frontend/src/pages/PartnersPage.tsx` — wire filters (gated on `canClick`)
- `frontend/src/components/PartnersFilterBar.tsx` *(new)*
- `frontend/src/pages/partnersUrlState.ts` *(new)*
- Reuses `TriStateFilterDropdown`, `IconInput`, `utils/regions`

## Verification
- [ ] Vercel preview build green (local typecheck not run — worktree has no node_modules)
- [ ] As admin: filter bar shows, all filters narrow correctly, URL updates & survives refresh
- [ ] As logged-out: no filter bar, plain grid unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)