### PR TITLE
fix(ciabatta-58920): /partners filter triggers visible on light bg

### DIFF
--- a/frontend/src/components/PartnersFilterBar.tsx
+++ b/frontend/src/components/PartnersFilterBar.tsx
@@ -28,6 +28,13 @@ const SORT_OPTIONS: { value: PartnersSortValue; label: string }[] = [
 const FIELD_CLASS =
   'rounded-lg border bg-white/90 px-3 py-2 text-sm text-[#1a1a1a] placeholder:text-[#555]/60 focus:outline-none focus:border-black/30';
 
+// TriStateFilterDropdown ships with dark-theme trigger tokens
+// (text-theme-text-secondary etc.) which render near-white and vanish on this
+// light sky-blue page. Override the trigger button to match the white pills
+// above via arbitrary `[&>button]:` variants (panel stays the shared dark popover).
+const TRISTATE_LIGHT =
+  '[&>button]:!bg-white/90 [&>button]:!text-[#1a1a1a] [&>button]:!border-black/10 [&>button:hover]:!border-black/30';
+
 interface PartnersFilterBarProps {
   filters: PartnersFilters;
   onChange: (next: PartnersFilters) => void;
@@ -104,6 +111,7 @@ export function PartnersFilterBar({
 
         {/* City */}
         <TriStateFilterDropdown
+          className={TRISTATE_LIGHT}
           label="City"
           items={cities}
           includes={filters.cityIncludes}
@@ -120,6 +128,7 @@ export function PartnersFilterBar({
 
         {/* Region */}
         <TriStateFilterDropdown
+          className={TRISTATE_LIGHT}
           label="Region"
           items={regions}
           includes={filters.regionIncludes}
@@ -138,6 +147,7 @@ export function PartnersFilterBar({
 
         {/* Country */}
         <TriStateFilterDropdown
+          className={TRISTATE_LIGHT}
           label="Country"
           items={countries}
           includes={filters.countryIncludes}


### PR DESCRIPTION
## Problem
On `/partners`, the City / Region / Country filter dropdown **triggers were invisible** — the shared `TriStateFilterDropdown` uses dark-theme tokens (`text-theme-text-secondary`) which render near-white against the light sky-blue page background.

(The "no regions in the dropdown" report was a timing artifact — the backend hadn't auto-deployed the `region`/`country` payload fields yet at screenshot time. Confirmed live `GET /api/gpp/partners` now returns them, and every region slug maps into a `PAYMENTS_REGION_LABELS` bucket.)

## Fix
Override the trigger button to the white-pill style (matching the Search / category / sort fields) via arbitrary `[&>button]:` Tailwind variants passed through the existing `className` prop. **No change to the shared component** — the dark popover panel is untouched and already readable.

Frontend-only, no backend/migration.

## Verify
- [ ] On `/partners` as admin: City/Region/Country trigger labels are dark and readable
- [ ] Region & Country dropdowns list options; filtering narrows the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)