### PR TITLE
feat(rigatoni-58919): 'side' event type for conference side events

### DIFF
--- a/backend/prisma/migrations/20260622000000_add_side_agreement_clauses/migration.sql
+++ b/backend/prisma/migrations/20260622000000_add_side_agreement_clauses/migration.sql
@@ -1,0 +1,38 @@
+-- rigatoni-58919: side-event (PizzaDAO conference side-event) agreement clauses.
+-- Exact mirror of gpp_agreement_clauses. Seed copy below is PLACEHOLDER —
+-- final copy is DB-editable (UPDATE the rows / add a new version + flip active).
+
+CREATE TABLE IF NOT EXISTS "side_agreement_clauses" (
+  "id"           UUID         NOT NULL DEFAULT gen_random_uuid(),
+  "version"      TEXT         NOT NULL,
+  "sort_order"   INTEGER      NOT NULL,
+  "heading"      TEXT,
+  "body"         TEXT         NOT NULL,
+  "requires_ack" BOOLEAN      NOT NULL DEFAULT true,
+  "active"       BOOLEAN      NOT NULL DEFAULT true,
+  "created_at"   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  "updated_at"   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT "side_agreement_clauses_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "side_agreement_clauses_active_version_sort_order_idx"
+  ON "side_agreement_clauses" ("active", "version", "sort_order");
+
+-- Placeholder seed clauses (version '1.0'). Final copy is DB-editable.
+INSERT INTO "side_agreement_clauses" ("version", "sort_order", "heading", "body", "requires_ack", "active")
+VALUES
+  (
+    '1.0', 1, 'Code of Conduct',
+    E'I agree that my side event will:\n- Be **welcoming, safe, and inclusive** for all attendees.\n- Follow the **PizzaDAO community code of conduct** and any rules of the host conference/venue.\n- Have **no tolerance** for harassment, discrimination, or unsafe behavior.',
+    true, true
+  ),
+  (
+    '1.0', 2, 'Reimbursement Rules',
+    E'I understand that:\n- Only **pizza costs** are eligible for reimbursement, and a **valid receipt** is required.\n- **I will confirm** my approved maximum reimbursement amount before my event is listed.\n- Reimbursement is typically processed within **2–3 weeks**, and at least **~7 days after submission**.',
+    true, true
+  ),
+  (
+    '1.0', 3, 'Hosting Requirements',
+    E'I understand that:\n- I must provide required event documentation, including **a group photo of attendees, a photo of the pizza box stack, and a photo of the pizza**.\n- **Fraud or dishonest behavior** may result in reimbursement being denied or revoked.',
+    true, true
+  );

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1666,6 +1666,23 @@ model GppAgreementClause {
   @@map("gpp_agreement_clauses")
 }
 
+// rigatoni-58919: side-event (conference side-event) agreement clauses. Exact
+// field-for-field mirror of GppAgreementClause; its own table + clause copy.
+model SideAgreementClause {
+  id          String   @id @default(uuid()) @db.Uuid
+  version     String
+  sortOrder   Int      @map("sort_order")
+  heading     String?
+  body        String
+  requiresAck Boolean  @default(true) @map("requires_ack")
+  active      Boolean  @default(true)
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([active, version, sortOrder])
+  @@map("side_agreement_clauses")
+}
+
 // ============================================
 // Experiment Flags (kill switches)
 // ============================================

--- a/backend/src/helpers/side.ts
+++ b/backend/src/helpers/side.ts
@@ -1,0 +1,98 @@
+import { AppError } from '../middleware/error.js';
+import { getUnderbossScope, partyMatchesScope, UnderbossScope } from './underbossScope.js';
+
+/**
+ * rigatoni-58919 — "side" (PizzaDAO conference side-event) helpers.
+ *
+ * Side events are a clone-and-adapt of the GPP27 create flow (helpers/gpp27.ts),
+ * but they are NOT city-based: the host enters the event's own name, date/time
+ * and venue. The public slug is derived from the event name and money keeps the
+ * full payout machinery, except there are no city tiers — the reimbursement cap
+ * is admin/UB-set and clamped to the configured ceiling.
+ *
+ * The create flow is admin/underboss-gated and reuses the existing `parties`
+ * table with `event_type = 'side'`. Two cross-cutting concerns live here:
+ *   1. Event-name → slug normalization (shared with the create handler).
+ *   2. The "is this viewer allowed to see a gated side event" check used by the
+ *      public resolver (event.routes.ts) and the create endpoint.
+ */
+
+/**
+ * eventTags marker stamped on pre-launch side parties so the public resolver
+ * can hide them from anonymous/out-of-scope viewers until launch. Removed by
+ * the publish endpoint once the gates pass. This is the INTERNAL control tag —
+ * the public `'side'` taxonomy tag stays public.
+ */
+export const SIDE_TAG = 'side-prelaunch';
+
+/**
+ * Master kill-switch for pre-launch gating. While false, side events are only
+ * visible to admins + the relevant underboss. Set the env var SIDE_PUBLIC=true
+ * (or edit this default) to make side events public at launch.
+ */
+export function isSidePublic(): boolean {
+  return process.env.SIDE_PUBLIC === 'true';
+}
+
+/**
+ * Normalize an event name into a public slug: strip diacritics, lowercase, drop
+ * non-alphanumerics. Mirrors gpp27.ts `citySlugFromCityName` but applied to the
+ * host-entered event name instead of a city.
+ */
+export function slugFromName(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Is the given (already-resolved) event gated behind the side pre-launch wall
+ * for this viewer? Returns true when the viewer should be treated as if the
+ * event does not exist (404).
+ *
+ * A side event is gated when:
+ *   - side is not yet public (isSidePublic() === false), AND
+ *   - the event is a side event (eventType === 'side' OR carries SIDE_TAG), AND
+ *   - the viewer is neither an admin nor an underboss in scope for the event.
+ *
+ * Signature mirrors gpp27.ts `isGpp27Hidden` so it slots into event.routes.ts
+ * the same way (year is accepted but unused — side has no year gate).
+ */
+export async function isSideHidden(
+  match: { eventType?: string | null; eventTags: string[]; region: string | null; city: string | null },
+  viewerEmail: string | null | undefined,
+): Promise<boolean> {
+  const isSide = match.eventType === 'side' || (match.eventTags || []).includes(SIDE_TAG);
+  if (!isSide) return false;
+  if (isSidePublic()) return false;
+
+  // Gated — only admins + in-scope underbosses may see it.
+  const scope = await getUnderbossScope(viewerEmail);
+  if (scope.isAdmin) return false;
+  return !partyMatchesScope(
+    { region: match.region, city: match.city, eventType: 'side' },
+    scope,
+  );
+}
+
+/**
+ * Resolve the caller's underboss scope and assert they may act on the given
+ * city/region (admin OR in-scope underboss). Throws when out of scope.
+ */
+export async function assertSideAuthorized(
+  viewerEmail: string | null | undefined,
+  target: { region?: string | null; city?: string | null },
+): Promise<UnderbossScope> {
+  const scope = await getUnderbossScope(viewerEmail);
+  if (scope.isAdmin) return scope;
+  const ok = partyMatchesScope(
+    { region: target.region ?? null, city: target.city ?? null, eventType: 'side' },
+    scope,
+  );
+  if (!ok) {
+    throw new AppError('You are not authorized to manage side events for this region.', 403, 'SIDE_FORBIDDEN');
+  }
+  return scope;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -24,6 +24,7 @@ import heicRoutes from './routes/heic.routes.js'; // taleggio-71042: server-side
 import kitRoutes from './routes/kit.routes.js';
 import gppRoutes from './routes/gpp.routes.js';
 import gpp27Routes from './routes/gpp27.routes.js'; // soppressata-50927: admin-gated GPP27 (2027) create flow
+import sideRoutes from './routes/side.routes.js'; // rigatoni-58919: admin-gated "side" (conference side-event) create flow
 import donationRoutes from './routes/donation.routes.js';
 import checkinRoutes from './routes/checkin.routes.js';
 import displayRoutes from './routes/display.routes.js';
@@ -227,6 +228,7 @@ app.use('/api/events', eventRoutes);
 app.use('/api/nft', nftRoutes);
 app.use('/api/gpp', gppRoutes);
 app.use('/api/gpp27', gpp27Routes); // soppressata-50927: GPP27 (2027) admin/UB-gated create flow, budget, agreement, publish gates
+app.use('/api/side', sideRoutes); // rigatoni-58919: side-event admin/UB-gated create flow, cap, agreement, publish gates
 app.use('/api/cities', citiesRoutes); // Public list of cities hosting GPP events
 app.use('/api/config', configRoutes); // marinara-71630 P5: admin/UB-gated city-tier + sponsorship-pricing + GPP27 reimbursement config
 app.use('/api/leaderboard', publicLeaderboardRoutes); // stromboli-71593: public /leaderboard ranking GPP parties + countries

--- a/backend/src/lib/eventTags.ts
+++ b/backend/src/lib/eventTags.ts
@@ -27,6 +27,9 @@ export const INTERNAL_EVENT_TAGS = new Set<string>([
   // exceeds capped receipt total) so admins can chase a refund. Admin-only —
   // must never surface on a public PublicEvent / GPP payload.
   'refund',
+  // rigatoni-58919: pre-launch control tag for "side" (conference side) events.
+  // The public 'side' taxonomy tag stays public; this gate marker must not leak.
+  'side-prelaunch',
 ]);
 
 const INTERNAL_TAG_PATTERNS: RegExp[] = [

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -5,6 +5,7 @@ import { isAdmin } from '../middleware/auth.js';
 import { getGppGlobalEditors } from '../lib/privateConfig.js';
 import { computeEffectiveCapUsd } from '../helpers/reimbursementCap.js';
 import { resolveGppByYear, isGpp27Hidden } from '../helpers/gpp27.js';
+import { isSideHidden } from '../helpers/side.js';
 import { optionalAuth, AuthRequest } from '../middleware/auth.js';
 import { publicTags } from '../lib/eventTags.js';
 
@@ -239,6 +240,25 @@ router.get('/:slug', optionalAuth, async (req: AuthRequest, res: Response, next:
       const hidden = await isGpp27Hidden(
         {
           year: partyYear,
+          eventTags: (party.eventTags as string[]) || [],
+          region: party.region ?? null,
+          city: party.city ?? null,
+        },
+        req.userEmail,
+      );
+      if (hidden) {
+        throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
+      }
+    }
+
+    // rigatoni-58919: pre-launch gate for "side" (conference side) events. Side
+    // events resolve via the normal customUrl/inviteCode lookup (no ?year=), so
+    // we only ADD the hide-gate here. A tagged-but-unpublished side event 404s
+    // for non-admin / out-of-scope viewers while SIDE_PUBLIC !== 'true'.
+    if (party.eventType === 'side' || ((party.eventTags as string[]) || []).includes('side-prelaunch')) {
+      const hidden = await isSideHidden(
+        {
+          eventType: party.eventType ?? null,
           eventTags: (party.eventTags as string[]) || [],
           region: party.region ?? null,
           city: party.city ?? null,

--- a/backend/src/routes/side.routes.ts
+++ b/backend/src/routes/side.routes.ts
@@ -1,0 +1,461 @@
+import { Router, Response, NextFunction } from 'express';
+import { prisma } from '../config/database.js';
+import { AppError } from '../middleware/error.js';
+import { requireAuth, AuthRequest } from '../middleware/auth.js';
+import { countryCodeToRegion, countryNameToRegion } from './gpp.routes.js';
+import { SIDE_TAG, slugFromName, assertSideAuthorized } from '../helpers/side.js';
+import { getReimbursementTiers } from '../lib/privateConfig.js';
+
+/**
+ * rigatoni-58919 — "side" (PizzaDAO conference side-event) admin/underboss-gated
+ * create flow + budget approval + side-event agreement.
+ *
+ * Clone-and-adapt of gpp27.routes.ts. Key differences:
+ *   - NOT city-based: host enters the event name, date + start/end time, venue.
+ *   - The public slug is derived from the event NAME (slugFromName).
+ *   - NO city tiers / budget-suggestion: the reimbursement cap is admin/UB-set
+ *     in the form, defaulting to + clamped at the configured ceiling.
+ *
+ * Every mutating endpoint is server-side gated to admins + the underboss in
+ * scope for the target region (assertSideAuthorized). Created events carry the
+ * SIDE_TAG so the public resolver (event.routes.ts) hides them from out-of-scope
+ * viewers until publish.
+ */
+
+const router = Router();
+
+const SIDE_DESCRIPTION = `A PizzaDAO conference side event — join us for pizza and good vibes alongside the main programming.
+
+What to expect:
+- Free pizza
+- Pizza & crypto community
+- Good conversations
+
+RSVP to secure your slice!`;
+
+/** Read the configured per-event reimbursement ceiling, fallback $625. */
+async function ceilingUsd(): Promise<number> {
+  const { ceilingUsd: c } = await getReimbursementTiers();
+  return typeof c === 'number' && Number.isFinite(c) && c > 0 ? c : 625;
+}
+
+// Convert a local wall-clock date+time in a timezone to a UTC Date.
+function localToUTC(year: number, month: number, day: number, hour: number, minute: number, tz: string): Date {
+  const utcGuess = new Date(Date.UTC(year, month, day, hour, minute, 0));
+  const fmt = (timeZone: string) => new Intl.DateTimeFormat('en-US', {
+    timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  });
+  const parse = (str: string) => {
+    const m = str.match(/(\d+)\/(\d+)\/(\d+),?\s*(\d+):(\d+):(\d+)/);
+    return m ? Date.UTC(+m[3], +m[1] - 1, +m[2], +m[4], +m[5], +m[6]) : 0;
+  };
+  const offset = parse(fmt(tz).format(utcGuess)) - parse(fmt('UTC').format(utcGuess));
+  return new Date(utcGuess.getTime() - offset);
+}
+
+/**
+ * Parse a `YYYY-MM-DD` date + `HH:MM` (24h) time into a UTC Date, interpreted in
+ * the given timezone. Returns null when either part is missing/malformed.
+ */
+function parseLocalDateTime(date: unknown, time: unknown, tz: string): Date | null {
+  if (typeof date !== 'string') return null;
+  const dm = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!dm) return null;
+  const t = typeof time === 'string' ? time : '';
+  const tm = t.match(/^(\d{1,2}):(\d{2})$/);
+  const hour = tm ? +tm[1] : 18;
+  const minute = tm ? +tm[2] : 0;
+  return localToUTC(+dm[1], +dm[2] - 1, +dm[3], hour, minute, tz);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/side/agreement — active side-event agreement clauses + version.
+// Auth-gated (admin/UB) since the whole side flow is gated pre-launch.
+// ---------------------------------------------------------------------------
+router.get('/agreement', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    await assertSideAuthorized(req.userEmail, {});
+    const clauses = await prisma.sideAgreementClause.findMany({
+      where: { active: true },
+      orderBy: { sortOrder: 'asc' },
+      select: { id: true, version: true, sortOrder: true, heading: true, body: true, requiresAck: true },
+    });
+    const version = clauses[0]?.version ?? null;
+    res.json({ version, clauses });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/side/events — mint a side party (admin/UB gated).
+// Body: { name, hostName, email, telegram, timezone?, date, startTime?,
+//         endTime?, formattedName?, lat?, lng?, country?, countryCode?,
+//         reimbursementCapUsd?, agreementVersion, acceptedClauseIds }
+// ---------------------------------------------------------------------------
+router.post('/events', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const {
+      name, hostName, email, telegram, timezone,
+      date, startTime, endTime,
+      formattedName, lat, lng, country, countryCode,
+      reimbursementCapUsd, agreementVersion, acceptedClauseIds,
+    } = req.body || {};
+
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new AppError('Event name is required', 400, 'VALIDATION_ERROR');
+    }
+    if (!hostName || typeof hostName !== 'string' || hostName.trim().length === 0) {
+      throw new AppError('Host name is required', 400, 'VALIDATION_ERROR');
+    }
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
+      throw new AppError('Valid email is required', 400, 'VALIDATION_ERROR');
+    }
+    if (!telegram || typeof telegram !== 'string' || telegram.trim().length === 0) {
+      throw new AppError('Telegram is required', 400, 'VALIDATION_ERROR');
+    }
+
+    const normalizedName = name.trim();
+
+    // The venue's country/countryCode drives the underboss scope (region).
+    const inferredRegion = (countryCode ? countryCodeToRegion(countryCode) : null)
+      || (country ? countryNameToRegion(country) : null);
+
+    // Server-side scope gate: admin OR underboss in scope for this region.
+    await assertSideAuthorized(req.userEmail, { region: inferredRegion });
+
+    // Confirm the side-event agreement BEFORE persisting any row. Validate the
+    // posted version + required clause acks up front so a stale client can never
+    // mint a hidden, half-configured event.
+    if (!agreementVersion || typeof agreementVersion !== 'string') {
+      throw new AppError('agreementVersion is required', 400, 'VALIDATION_ERROR');
+    }
+    if (!Array.isArray(acceptedClauseIds) || !acceptedClauseIds.every((id) => typeof id === 'string')) {
+      throw new AppError('acceptedClauseIds must be an array of strings', 400, 'VALIDATION_ERROR');
+    }
+
+    const activeClauses = await prisma.sideAgreementClause.findMany({
+      where: { active: true },
+      orderBy: { sortOrder: 'asc' },
+      select: { id: true, version: true, requiresAck: true },
+    });
+    if (activeClauses.length === 0) {
+      throw new AppError('No active agreement is configured', 409, 'NO_ACTIVE_AGREEMENT');
+    }
+    const currentAgreementVersion = activeClauses[0].version;
+    if (agreementVersion !== currentAgreementVersion) {
+      throw new AppError('The agreement has changed — please reload and re-confirm.', 409, 'AGREEMENT_VERSION_STALE');
+    }
+    const ackedSet = new Set(acceptedClauseIds);
+    const allRequiredAcked = activeClauses
+      .filter((c) => c.requiresAck === true)
+      .every((c) => ackedSet.has(c.id));
+    if (!allRequiredAcked) {
+      throw new AppError('All required agreement clauses must be confirmed.', 409, 'AGREEMENT_NOT_ACCEPTED');
+    }
+
+    // Clamp the operator-approved reimbursement cap to the configured ceiling.
+    // Omitted / 0 / non-number → 0 (a side event legitimately starts pending).
+    const ceiling = await ceilingUsd();
+    const rawCap = reimbursementCapUsd;
+    const clampedCapUsd = (typeof rawCap === 'number' && Number.isFinite(rawCap) && rawCap > 0)
+      ? Math.min(Math.round(rawCap), ceiling)
+      : 0;
+
+    const normalizedEmail = email.toLowerCase().trim();
+    const normalizedHostName = hostName.trim();
+    const normalizedTelegram = typeof telegram === 'string' ? telegram.trim().replace(/^@/, '') || null : null;
+
+    const eventTimezone = (typeof timezone === 'string' && timezone.trim()) || 'America/New_York';
+    const venueAddress = (typeof formattedName === 'string' && formattedName.trim()) || normalizedName;
+
+    // Host-chosen date + start/end time. Default to a 3-hour block when only the
+    // start is provided; fall back to "now" when no date is supplied at all.
+    const startDate = parseLocalDateTime(date, startTime, eventTimezone) || new Date();
+    const endDate = parseLocalDateTime(date, endTime, eventTimezone)
+      || new Date(startDate.getTime() + 3 * 60 * 60 * 1000);
+
+    const resolvedLat = typeof lat === 'number' && lat >= -90 && lat <= 90 ? lat : null;
+    const resolvedLng = typeof lng === 'number' && lng >= -180 && lng <= 180 ? lng : null;
+
+    // Derive a unique customUrl from the event name. Prefer the bare slug; on
+    // collision append an incrementing numeric suffix (slug-2, slug-3, …).
+    const baseSlug = slugFromName(normalizedName);
+    let customUrl: string | null = null;
+    if (baseSlug.length > 0) {
+      const candidates = [baseSlug];
+      for (let i = 2; i <= 50; i++) candidates.push(`${baseSlug}-${i}`);
+      for (const cand of candidates) {
+        const existing = await prisma.party.findUnique({ where: { customUrl: cand }, select: { id: true } });
+        if (!existing) { customUrl = cand; break; }
+      }
+    }
+
+    // Seed hidden underboss co-hosts for the inferred region (mirror GPP flow).
+    let underbossCoHosts: any[] = [];
+    if (inferredRegion) {
+      const underbosses = await prisma.underboss.findMany({
+        where: { isActive: true, OR: [{ region: inferredRegion }, { regions: { has: inferredRegion } }] },
+        select: { name: true, email: true },
+      });
+      underbossCoHosts = underbosses.map((ub) => ({
+        id: crypto.randomUUID(),
+        name: ub.name,
+        email: ub.email.toLowerCase(),
+        showOnEvent: false,
+        canEdit: true,
+        isUnderboss: true,
+      }));
+    }
+
+    // Find or create the host user.
+    let user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
+    if (!user) {
+      user = await prisma.user.create({
+        data: { email: normalizedEmail, name: normalizedHostName, telegram: normalizedTelegram },
+      });
+    } else if (normalizedTelegram) {
+      await prisma.user.update({ where: { id: user.id }, data: { telegram: normalizedTelegram } });
+    }
+
+    const party = await prisma.party.create({
+      data: {
+        name: normalizedName,
+        description: SIDE_DESCRIPTION,
+        eventType: 'side',
+        // SIDE_TAG drives the pre-launch public-resolver gate. 'side' is the
+        // public taxonomy tag.
+        eventTags: ['side', SIDE_TAG],
+        requireApproval: true,
+        hideGuests: false,
+        photosEnabled: true,
+        photosPublic: true,
+        customUrl,
+        date: startDate,
+        endTime: endDate,
+        duration: 3,
+        timezone: eventTimezone,
+        region: inferredRegion,
+        country: country || null,
+        // city/region drive underboss scope; use the venue's country as the
+        // "city" surrogate for scope-matching (side events aren't city-based).
+        city: country || null,
+        address: venueAddress,
+        latitude: resolvedLat,
+        longitude: resolvedLng,
+        availableBeverages: [],
+        availableToppings: [],
+        coHosts: [
+          { id: crypto.randomUUID(), name: 'PizzaDAO', email: 'hello@rarepizzas.com', showOnEvent: true },
+          { id: crypto.randomUUID(), name: normalizedHostName, email: normalizedEmail, showOnEvent: false, canEdit: true },
+          ...underbossCoHosts,
+        ],
+        userId: user.id,
+        agreementAcceptedAt: new Date(),
+        agreementVersion: currentAgreementVersion,
+        reimbursementCapUsd: clampedCapUsd,
+      },
+    });
+
+    // Add the host as an approved guest (mirror GPP flow).
+    await prisma.guest.create({
+      data: {
+        name: normalizedHostName,
+        email: normalizedEmail,
+        dietaryRestrictions: [],
+        likedToppings: [],
+        dislikedToppings: [],
+        likedBeverages: [],
+        dislikedBeverages: [],
+        submittedVia: 'host',
+        partyId: party.id,
+        approved: true,
+      },
+    });
+
+    const publicSlug = customUrl || party.inviteCode;
+    res.status(201).json({
+      success: true,
+      event: {
+        id: party.id,
+        name: party.name,
+        inviteCode: party.inviteCode,
+        customUrl: party.customUrl,
+        city: party.city,
+        region: party.region,
+      },
+      // Side events resolve via the NORMAL slug (no ?year=).
+      eventPageUrl: `/${publicSlug}`,
+      hostPageUrl: `/host/${party.inviteCode}`,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/side/parties/:partyId/budget — set the approved reimbursement cap
+// (admin/UB). Clamped to the configured ceiling.
+// ---------------------------------------------------------------------------
+router.patch('/parties/:partyId/budget', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, city: true, region: true, eventType: true },
+    });
+    if (!party) throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
+
+    await assertSideAuthorized(req.userEmail, { city: party.city, region: party.region });
+
+    const raw = req.body?.reimbursementCapUsd;
+    if (raw == null || typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0) {
+      throw new AppError('reimbursementCapUsd must be a non-negative number', 400, 'VALIDATION_ERROR');
+    }
+    const ceiling = await ceilingUsd();
+    const capped = Math.min(Math.round(raw), ceiling);
+
+    await prisma.party.update({
+      where: { id: partyId },
+      data: { reimbursementCapUsd: capped },
+    });
+
+    res.json({ success: true, reimbursementCapUsd: capped, ceilingUsd: ceiling });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/side/parties/:partyId/agreement/accept — persist the host's
+// sign-off. Records agreement_accepted_at + the CURRENT active version.
+// ---------------------------------------------------------------------------
+router.post('/parties/:partyId/agreement/accept', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { id: true, city: true, region: true },
+    });
+    if (!party) throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
+
+    await assertSideAuthorized(req.userEmail, { city: party.city, region: party.region });
+
+    const current = await prisma.sideAgreementClause.findFirst({
+      where: { active: true },
+      orderBy: { sortOrder: 'asc' },
+      select: { version: true },
+    });
+    if (!current) throw new AppError('No active agreement is configured', 409, 'NO_ACTIVE_AGREEMENT');
+
+    await prisma.party.update({
+      where: { id: partyId },
+      data: { agreementAcceptedAt: new Date(), agreementVersion: current.version },
+    });
+
+    res.json({ success: true, agreementVersion: current.version, agreementAcceptedAt: new Date().toISOString() });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/side/parties/:partyId/publish-status — report which publish gates
+// are satisfied (agreement signed for current version + valid merch address).
+// ---------------------------------------------------------------------------
+router.get('/parties/:partyId/publish-status', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const status = await computePublishStatus(partyId, req.userEmail);
+    res.json(status);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/side/parties/:partyId/publish — flip the event public, but only
+// when BOTH gates pass (server-enforced): the host has signed the CURRENT
+// agreement version AND a valid merch delivery address exists.
+// ---------------------------------------------------------------------------
+router.post('/parties/:partyId/publish', requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { partyId } = req.params;
+    const status = await computePublishStatus(partyId, req.userEmail);
+
+    if (!status.canPublish) {
+      throw new AppError(
+        'Cannot publish: agreement must be signed for the current version and a valid merch delivery address must be provided.',
+        409,
+        'PUBLISH_GATE_BLOCKED',
+      );
+    }
+
+    // Remove the pre-launch gate tag so the public resolver exposes the event.
+    const party = await prisma.party.findUnique({
+      where: { id: partyId },
+      select: { eventTags: true },
+    });
+    const newTags = (party?.eventTags || []).filter((t) => t !== SIDE_TAG);
+    await prisma.party.update({ where: { id: partyId }, data: { eventTags: newTags } });
+
+    res.json({ success: true, published: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+interface PublishStatus {
+  partyId: string;
+  agreementSigned: boolean;
+  agreementVersionMatches: boolean;
+  hasMerchAddress: boolean;
+  currentAgreementVersion: string | null;
+  signedAgreementVersion: string | null;
+  canPublish: boolean;
+}
+
+async function computePublishStatus(partyId: string, viewerEmail: string | null | undefined): Promise<PublishStatus> {
+  const party = await prisma.party.findUnique({
+    where: { id: partyId },
+    select: {
+      id: true,
+      city: true,
+      region: true,
+      agreementAcceptedAt: true,
+      agreementVersion: true,
+      partyKit: { select: { addressLine1: true, city: true, postalCode: true } },
+    },
+  });
+  if (!party) throw new AppError('Event not found', 404, 'EVENT_NOT_FOUND');
+
+  await assertSideAuthorized(viewerEmail, { city: party.city, region: party.region });
+
+  const current = await prisma.sideAgreementClause.findFirst({
+    where: { active: true },
+    orderBy: { sortOrder: 'asc' },
+    select: { version: true },
+  });
+  const currentVersion = current?.version ?? null;
+
+  const agreementSigned = !!party.agreementAcceptedAt;
+  const agreementVersionMatches = agreementSigned && !!currentVersion && party.agreementVersion === currentVersion;
+
+  // A "valid merch delivery address" reuses the existing party_kits shipping
+  // record (address_line1 + city + postal_code).
+  const kit = party.partyKit;
+  const hasMerchAddress = !!(kit && kit.addressLine1?.trim() && kit.city?.trim() && kit.postalCode?.trim());
+
+  return {
+    partyId: party.id,
+    agreementSigned,
+    agreementVersionMatches,
+    hasMerchAddress,
+    currentAgreementVersion: currentVersion,
+    signedAgreementVersion: party.agreementVersion,
+    canPublish: agreementVersionMatches && hasMerchAddress,
+  };
+}
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { NewEventPage } from './pages/NewEventPage';
 import { AccountPage } from './pages/AccountPage';
 import { GPPLandingPage } from './pages/GPPLandingPage';
 import { GPP27CreatePage } from './pages/GPP27CreatePage';
+import { SideCreatePage } from './pages/SideCreatePage';
 import { CheckInPage } from './pages/CheckInPage';
 import { DJPage } from './pages/DJPage';
 import { PublicReportPage } from './pages/PublicReportPage';
@@ -80,6 +81,8 @@ function App() {
             <Route path="/gpp" element={<GPPLandingPage />} />
             {/* soppressata-50927: admin/UB-gated 2027 create flow; must come before /:slug */}
             <Route path="/gpp27" element={<GPP27CreatePage />} />
+            {/* rigatoni-58919: admin/UB-gated side-event create flow; must come before /:slug */}
+            <Route path="/side" element={<SideCreatePage />} />
             <Route path="/gpp/pizzerias" element={<GPPPizzeriasPage />} />
             {/* /map must come before /:slug */}
             <Route path="/map" element={<EventsMapPage />} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7770,6 +7770,104 @@ export async function publishGpp27Event(partyId: string): Promise<{ success: boo
   return apiRequest(`/api/gpp27/parties/${partyId}/publish`, { method: 'POST' });
 }
 
+// ---------------------------------------------------------------------------
+// rigatoni-58919: "side" (PizzaDAO conference side-event) admin/UB create flow.
+// Clones of the gpp27 functions pointed at /api/side/*. NOT city-based: the host
+// enters the event name + date/time + venue; the cap is admin/UB-set (no tiers).
+// ---------------------------------------------------------------------------
+export interface SideAgreementClause {
+  id: string;
+  version: string;
+  sortOrder: number;
+  heading?: string | null;
+  body: string;
+  requiresAck: boolean;
+}
+
+export interface SideAgreementResponse {
+  version: string | null;
+  clauses: SideAgreementClause[];
+}
+
+export async function fetchSideAgreement(): Promise<SideAgreementResponse> {
+  return apiRequest<SideAgreementResponse>('/api/side/agreement');
+}
+
+export interface SideCreateEventInput {
+  name: string;
+  hostName: string;
+  email: string;
+  telegram: string;
+  timezone?: string;
+  date?: string;       // YYYY-MM-DD (event-local)
+  startTime?: string;  // HH:MM 24h
+  endTime?: string;    // HH:MM 24h
+  // Venue (from LocationAutocomplete).
+  formattedName?: string;
+  lat?: number;
+  lng?: number;
+  country?: string;
+  countryCode?: string;
+  reimbursementCapUsd?: number;
+  agreementVersion: string;
+  acceptedClauseIds: string[];
+}
+
+export interface SideCreateEventResponse {
+  success: boolean;
+  event: {
+    id: string;
+    name: string;
+    inviteCode: string;
+    customUrl: string | null;
+    city: string | null;
+    region: string | null;
+  };
+  eventPageUrl: string;
+  hostPageUrl: string;
+}
+
+export async function createSideEvent(input: SideCreateEventInput): Promise<SideCreateEventResponse> {
+  return apiRequest<SideCreateEventResponse>('/api/side/events', {
+    method: 'POST',
+    body: input,
+  });
+}
+
+export async function patchSideBudget(
+  partyId: string,
+  reimbursementCapUsd: number,
+): Promise<{ success: boolean; reimbursementCapUsd: number; ceilingUsd: number }> {
+  return apiRequest(`/api/side/parties/${partyId}/budget`, {
+    method: 'PATCH',
+    body: { reimbursementCapUsd },
+  });
+}
+
+export async function acceptSideAgreement(
+  partyId: string,
+): Promise<{ success: boolean; agreementVersion: string; agreementAcceptedAt: string }> {
+  return apiRequest(`/api/side/parties/${partyId}/agreement/accept`, { method: 'POST' });
+}
+
+export interface SidePublishStatus {
+  partyId: string;
+  agreementSigned: boolean;
+  agreementVersionMatches: boolean;
+  hasMerchAddress: boolean;
+  currentAgreementVersion: string | null;
+  signedAgreementVersion: string | null;
+  canPublish: boolean;
+}
+
+export async function fetchSidePublishStatus(partyId: string): Promise<SidePublishStatus> {
+  return apiRequest<SidePublishStatus>(`/api/side/parties/${partyId}/publish-status`);
+}
+
+export async function publishSideEvent(partyId: string): Promise<{ success: boolean; published: boolean }> {
+  return apiRequest(`/api/side/parties/${partyId}/publish`, { method: 'POST' });
+}
+
 // scarpetta-58472: site-wide suggestions list (admin / underboss view-only).
 export interface Suggestion {
   id: string; createdAt: string; body: string;

--- a/frontend/src/pages/SideCreatePage.tsx
+++ b/frontend/src/pages/SideCreatePage.tsx
@@ -1,0 +1,505 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
+import {
+  Shield, ShieldCheck, Loader2, MapPin, User, Mail, Send, DollarSign,
+  Pizza, CheckCircle, ExternalLink, AlertTriangle, ArrowLeft, ArrowRight,
+  Calendar, Clock, Tag,
+} from 'lucide-react';
+import { Layout } from '../components/Layout';
+import { IconInput } from '../components/IconInput';
+import { Checkbox } from '../components/Checkbox';
+import { LocationAutocomplete, CityData } from '../components/LocationAutocomplete';
+import { TimezonePickerInput } from '../components/TimezonePickerInput';
+import {
+  fetchAdminMe, fetchUnderbossMe,
+  createSideEvent, fetchSideAgreement,
+  fetchSidePublishStatus, publishSideEvent,
+  type SideCreateEventResponse,
+  type SideAgreementClause, type SidePublishStatus,
+} from '../lib/api';
+
+// --- Agreement clause body rendering (cloned from GPP27CreatePage) ----------
+// Parse inline `**bold**` markers: split on `**` and wrap odd-index segments
+// in <strong>. Returns React nodes with stable index keys.
+function renderInline(text: string): React.ReactNode[] {
+  return text.split('**').map((seg, i) =>
+    i % 2 === 1 ? <strong key={i}>{seg}</strong> : <React.Fragment key={i}>{seg}</React.Fragment>
+  );
+}
+
+// Render a clause body: lines starting with `- ` become bullets grouped into a
+// single <ul>; other lines render as <p>. Inline **bold** is parsed per line.
+function renderClauseBody(body: string): React.ReactNode {
+  const lines = body.split('\n');
+  const out: React.ReactNode[] = [];
+  let bullets: string[] = [];
+
+  const flushBullets = () => {
+    if (bullets.length === 0) return;
+    out.push(
+      <ul key={`ul-${out.length}`} className="list-disc ml-5 space-y-1">
+        {bullets.map((b, i) => (
+          <li key={i}>{renderInline(b)}</li>
+        ))}
+      </ul>
+    );
+    bullets = [];
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('- ')) {
+      bullets.push(line.slice(2));
+    } else {
+      flushBullets();
+      if (line.trim().length > 0) {
+        out.push(
+          <p key={`p-${out.length}`} className="mb-1">
+            {renderInline(line)}
+          </p>
+        );
+      }
+    }
+  }
+  flushBullets();
+  return out;
+}
+
+export function SideCreatePage() {
+  // --- All hooks declared ABOVE any conditional return (rules-of-hooks). ---
+  const [loading, setLoading] = useState(true);
+  const [authorized, setAuthorized] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  // Create form. 2-step wizard — step 1 collects details, step 2 reviews the
+  // cap + confirms the agreement, and ONLY the step-2 confirm persists the
+  // party. `step` toggles 1 | 2 (no router change).
+  const [step, setStep] = useState<1 | 2>(1);
+  const [name, setName] = useState('');
+  const [hostName, setHostName] = useState('');
+  const [email, setEmail] = useState('');
+  const [telegram, setTelegram] = useState('');
+  const [eventDate, setEventDate] = useState('');     // YYYY-MM-DD
+  const [startTime, setStartTime] = useState('');     // HH:MM 24h
+  const [endTime, setEndTime] = useState('');         // HH:MM 24h
+  const [timezone, setTimezone] = useState<string>('America/New_York');
+  const [cityData, setCityData] = useState<CityData | null>(null);
+  const [venue, setVenue] = useState('');
+  const [loadingReview, setLoadingReview] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [created, setCreated] = useState<SideCreateEventResponse | null>(null);
+
+  // Reimbursement cap (admin/UB-set; clamped server-side to the config ceiling).
+  const [capInput, setCapInput] = useState<string>('');
+
+  // Agreement (pre-fetched in step 1, confirmed in step 2 before create)
+  const [agreementVersion, setAgreementVersion] = useState<string | null>(null);
+  const [clauses, setClauses] = useState<SideAgreementClause[]>([]);
+  const [acked, setAcked] = useState<Record<string, boolean>>({});
+
+  // Publish gates
+  const [publishStatus, setPublishStatus] = useState<SidePublishStatus | null>(null);
+  const [publishing, setPublishing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function gate() {
+      try {
+        const me = await fetchAdminMe();
+        if (me.isAdmin) {
+          if (!cancelled) { setAuthorized(true); setLoading(false); }
+          return;
+        }
+        // Not a full admin — allow active underbosses.
+        const ub = await fetchUnderbossMe().catch(() => null);
+        if (!cancelled) {
+          setAuthorized(!!(ub && (ub.isAdmin || ub.isUnderboss)));
+          setLoading(false);
+        }
+      } catch (err: any) {
+        if (!cancelled) { setAuthError(err?.message || 'Failed to verify access'); setLoading(false); }
+      }
+    }
+    gate();
+    return () => { cancelled = true; };
+  }, []);
+
+  const renderedClauses = useMemo(() => clauses.map((c) => ({ ...c, text: c.body })), [clauses]);
+  const allAcked = renderedClauses.length > 0 && renderedClauses.every((c) => acked[c.id]);
+
+  // Step 1 → 2: validate the details, then fetch the agreement clauses (NO party
+  // row exists yet — agreement is auth-scoped). Nothing is persisted here.
+  async function handleProceedToReview(e: React.FormEvent) {
+    e.preventDefault();
+    setCreateError(null);
+    if (!name.trim() || !hostName.trim() || !email.trim() || !telegram.trim()) {
+      setCreateError('Event name, host name, email, and Telegram are required.');
+      return;
+    }
+    if (!eventDate.trim()) {
+      setCreateError('Please pick an event date.');
+      return;
+    }
+    setLoadingReview(true);
+    try {
+      const a = await fetchSideAgreement();
+      setAgreementVersion(a.version);
+      setClauses(a.clauses);
+      setAcked({});
+      setStep(2);
+    } catch (err: any) {
+      setCreateError(err?.message || 'Failed to load the agreement. Please try again.');
+    } finally {
+      setLoadingReview(false);
+    }
+  }
+
+  // Step 2 confirm: persist the event with the approved cap + confirmed
+  // agreement. This is the FIRST write to the parties table in the flow.
+  async function handleCreate() {
+    setCreateError(null);
+    if (!allAcked || !agreementVersion) return;
+    setSubmitting(true);
+    try {
+      const resp = await createSideEvent({
+        name: name.trim(),
+        hostName: hostName.trim(),
+        email: email.trim(),
+        telegram: telegram.trim(),
+        timezone,
+        date: eventDate || undefined,
+        startTime: startTime || undefined,
+        endTime: endTime || undefined,
+        reimbursementCapUsd: Number(capInput) || 0,
+        agreementVersion,
+        acceptedClauseIds: Object.keys(acked).filter((id) => acked[id]),
+        ...(cityData && {
+          country: cityData.country,
+          countryCode: cityData.countryCode,
+          formattedName: cityData.formattedName,
+          lat: cityData.lat,
+          lng: cityData.lng,
+        }),
+      });
+      setCreated(resp);
+
+      // Load publish status for the freshly-created party.
+      const ps = await fetchSidePublishStatus(resp.event.id).catch(() => null);
+      if (ps) setPublishStatus(ps);
+    } catch (err: any) {
+      setCreateError(err?.message || 'Failed to create event.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handlePublish() {
+    if (!created) return;
+    setPublishing(true);
+    try {
+      await publishSideEvent(created.event.id);
+      const ps = await fetchSidePublishStatus(created.event.id);
+      setPublishStatus(ps);
+    } catch (err: any) {
+      setCreateError(err?.message || 'Cannot publish yet — check the gates below.');
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  // ---- Conditional returns (all hooks above this point) ----
+  if (loading) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center py-32">
+          <Loader2 size={32} className="animate-spin text-theme-text-muted" />
+        </div>
+      </Layout>
+    );
+  }
+
+  if (!authorized || authError) {
+    return (
+      <Layout>
+        <div className="flex flex-col items-center justify-center px-4 py-32">
+          <Shield size={48} className="text-red-400/60 mb-4" />
+          <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
+          <p className="text-theme-text-muted text-center max-w-md">
+            {authError || 'The side-event create flow is limited to admins and underbosses.'}
+          </p>
+        </div>
+      </Layout>
+    );
+  }
+
+  const capValue = Number(capInput);
+  const capPending = !(Number.isFinite(capValue) && capValue > 0);
+
+  return (
+    <Layout>
+      <Helmet><title>Create a Side Event | RSV.Pizza</title></Helmet>
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
+        <div className="rounded-2xl p-6 sm:p-8 bg-theme-surface border border-theme-stroke">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-10 h-10 rounded-xl bg-red-500/20 flex items-center justify-center">
+              <ShieldCheck size={20} className="text-red-500" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold">Create a Side Event</h1>
+              <p className="text-sm text-theme-text-muted">
+                Admin / underboss only. New side events are hidden from the public until you publish them.
+              </p>
+            </div>
+          </div>
+
+          {/* Step 1 — Details */}
+          {!created && step === 1 && (
+            <form onSubmit={handleProceedToReview} className="space-y-4">
+              <IconInput
+                icon={Tag}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Event name"
+              />
+              <IconInput
+                icon={User}
+                value={hostName}
+                onChange={(e) => setHostName(e.target.value)}
+                placeholder="Host name"
+              />
+              <IconInput
+                icon={Mail}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Host email"
+              />
+              <IconInput
+                icon={Send}
+                value={telegram}
+                onChange={(e) => setTelegram(e.target.value)}
+                placeholder="Host Telegram"
+              />
+
+              <LocationAutocomplete
+                value={venue}
+                onChange={(v) => { setVenue(v); setCityData(null); }}
+                onTimezoneChange={setTimezone}
+                onLocationSelected={() => { /* lat/lng captured via onCitySelected */ }}
+                onCitySelected={(d) => { setCityData(d); setVenue(d.formattedName || d.cityName); }}
+                placeholder="Venue / location (start typing, then pick from the list)"
+              />
+
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <IconInput
+                  icon={Calendar}
+                  type="date"
+                  value={eventDate}
+                  onChange={(e) => setEventDate(e.target.value)}
+                  placeholder="Date"
+                />
+                <IconInput
+                  icon={Clock}
+                  type="time"
+                  value={startTime}
+                  onChange={(e) => setStartTime(e.target.value)}
+                  placeholder="Start time"
+                />
+                <IconInput
+                  icon={Clock}
+                  type="time"
+                  value={endTime}
+                  onChange={(e) => setEndTime(e.target.value)}
+                  placeholder="End time"
+                />
+              </div>
+
+              <TimezonePickerInput value={timezone} onChange={setTimezone} />
+
+              {createError && (
+                <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2">
+                  {createError}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={loadingReview}
+                className="w-full flex items-center justify-center gap-2 bg-red-500 hover:bg-red-600 disabled:opacity-60 text-white font-semibold rounded-xl py-3 transition-colors"
+              >
+                {loadingReview ? <Loader2 size={18} className="animate-spin" /> : <ArrowRight size={18} />}
+                {loadingReview ? 'Loading…' : 'Next: review & confirm'}
+              </button>
+            </form>
+          )}
+
+          {/* Step 2 — Review cap + confirm the agreement (nothing persisted yet) */}
+          {!created && step === 2 && (
+            <div className="space-y-8">
+              <button
+                type="button"
+                onClick={() => { setStep(1); setCreateError(null); }}
+                className="inline-flex items-center gap-1 text-sm text-red-400 hover:underline"
+              >
+                <ArrowLeft size={14} /> Back to details
+              </button>
+
+              <div className="text-sm text-theme-text-secondary">
+                Creating <strong>{name.trim()}</strong> for{' '}
+                <strong>{hostName.trim()}</strong> ({email.trim()}).
+              </div>
+
+              {/* pizza-only + reimbursement-model host messaging */}
+              <section className="rounded-2xl p-5 bg-red-500/15 border border-red-500/30">
+                <div className="flex items-center gap-2 font-bold text-lg">
+                  <Pizza size={20} /> We reimburse pizza only
+                </div>
+                <p className="mt-2 text-sm text-theme-text-secondary">
+                  This is a <strong>reimbursement model</strong>: the host pays for pizza first, then
+                  PizzaDAO reimburses the pizza cost — it is not an upfront grant, and only pizza is covered.
+                </p>
+                <p className="mt-3 text-sm">
+                  {capPending ? (
+                    <>The approved amount is <strong>pending</strong>. You can still create the event —
+                    the pizza reimbursement budget can be confirmed shortly.</>
+                  ) : (
+                    <>Approved to spend up to <strong>${capValue}</strong> on pizza.</>
+                  )}
+                </p>
+              </section>
+
+              {/* reimbursement cap — admin/UB-editable, no tiers */}
+              <section>
+                <h2 className="flex items-center gap-2 text-lg font-bold mb-3">
+                  <DollarSign size={18} /> Reimbursement cap
+                </h2>
+                <div className="rounded-xl border border-theme-stroke bg-theme-surface p-4 space-y-3">
+                  <IconInput
+                    icon={DollarSign}
+                    type="number"
+                    min={0}
+                    value={capInput}
+                    onChange={(e) => setCapInput(e.target.value)}
+                    placeholder="Approved reimbursement cap (USD)"
+                  />
+                  <p className="text-xs text-theme-text-muted">
+                    Set the approved pizza reimbursement cap for this event. Amounts above the configured
+                    ceiling are clamped on save. Leave at 0 to start pending.
+                  </p>
+                </div>
+              </section>
+
+              {/* Side-event agreement (data-driven) — must be confirmed before create */}
+              <section>
+                <h2 className="text-lg font-bold mb-1">Host Agreement</h2>
+                <p className="text-sm text-theme-text-secondary mb-3">
+                  Confirm every condition below before creating this event
+                  {agreementVersion ? ` (${agreementVersion})` : ''}:
+                </p>
+                <div className="space-y-4">
+                  {renderedClauses.map((c) => (
+                    <div key={c.id} className="space-y-1">
+                      <Checkbox
+                        checked={!!acked[c.id]}
+                        onChange={() => setAcked((prev) => ({ ...prev, [c.id]: !prev[c.id] }))}
+                        label={c.heading ?? ''}
+                        labelClassName="text-base font-semibold"
+                      />
+                      <div className="ml-7 text-sm text-theme-text-secondary">{renderClauseBody(c.text)}</div>
+                    </div>
+                  ))}
+                  {renderedClauses.length === 0 && (
+                    <p className="text-sm text-theme-text-muted">No active agreement configured.</p>
+                  )}
+                </div>
+              </section>
+
+              {createError && (
+                <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2">
+                  {createError}
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={handleCreate}
+                disabled={submitting || !allAcked}
+                className="w-full flex items-center justify-center gap-2 bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-semibold rounded-xl py-3 transition-colors"
+              >
+                {submitting ? <Loader2 size={18} className="animate-spin" /> : <MapPin size={18} />}
+                {submitting ? 'Creating…' : 'Create side event'}
+              </button>
+              {!allAcked && renderedClauses.length > 0 && (
+                <p className="text-xs text-theme-text-muted -mt-4">
+                  Confirm every agreement condition above to enable creation.
+                </p>
+              )}
+            </div>
+          )}
+
+          {created && (
+            <div className="space-y-8">
+              {/* Created confirmation */}
+              <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+                <div className="flex items-center gap-2 text-emerald-400 font-semibold mb-1">
+                  <CheckCircle size={18} /> Event created: {created.event.name}
+                </div>
+                <div className="text-sm text-theme-text-secondary flex flex-wrap items-center gap-3">
+                  <Link to={created.hostPageUrl} className="inline-flex items-center gap-1 text-red-400 hover:underline">
+                    Host dashboard <ExternalLink size={14} />
+                  </Link>
+                  <Link to={created.eventPageUrl} className="inline-flex items-center gap-1 text-red-400 hover:underline">
+                    Event page (gated preview) <ExternalLink size={14} />
+                  </Link>
+                </div>
+              </div>
+
+              {/* Publish gates */}
+              <section className="rounded-xl border border-theme-stroke bg-theme-surface p-4">
+                <h2 className="text-lg font-bold mb-3">Publish</h2>
+                <ul className="space-y-2 text-sm">
+                  <li className="flex items-center gap-2">
+                    {publishStatus?.agreementVersionMatches
+                      ? <CheckCircle size={16} className="text-emerald-400" />
+                      : <AlertTriangle size={16} className="text-amber-500" />}
+                    Host Agreement signed (current version)
+                  </li>
+                  <li className="flex items-center gap-2">
+                    {publishStatus?.hasMerchAddress
+                      ? <CheckCircle size={16} className="text-emerald-400" />
+                      : <AlertTriangle size={16} className="text-amber-500" />}
+                    Valid merch delivery address provided
+                    {!publishStatus?.hasMerchAddress && (
+                      <span className="text-theme-text-muted"> — add it in the host dashboard's kit/shipping section.</span>
+                    )}
+                  </li>
+                </ul>
+                <button
+                  type="button"
+                  onClick={handlePublish}
+                  disabled={publishing || !publishStatus?.canPublish}
+                  className="mt-4 bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white font-semibold rounded-xl px-4 py-2.5 transition-colors"
+                >
+                  {publishing ? 'Publishing…' : 'Publish event (make public)'}
+                </button>
+                {!publishStatus?.canPublish && (
+                  <p className="text-xs text-theme-text-muted mt-2">
+                    Both gates must pass. Publishing is also enforced server-side.
+                  </p>
+                )}
+              </section>
+
+              {createError && (
+                <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2">
+                  {createError}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/plans/rigatoni-58919-side-events.md
+++ b/plans/rigatoni-58919-side-events.md
@@ -1,0 +1,81 @@
+# rigatoni-58919 — "side" (PizzaDAO conference side-event) create flow
+
+Clone-and-adapt of the GPP27 create flow for PizzaDAO conference **side events** at
+`rsv.pizza/side`. Admin/UB-gated, hidden behind a `SIDE_PUBLIC` env flag until launch.
+
+## What a "side" event is (vs GPP)
+- **NOT city-based.** Host enters the event's own **name**, **date + start/end time**,
+  and **venue** (LocationAutocomplete). The public slug is derived from the **event name**
+  (`slugFromName`, same NFD/lowercase/alphanumeric normalization as GPP's `citySlugFromCityName`),
+  with a numeric `-2`, `-3`… suffix on collision.
+- **Full payout machinery kept** (cap, receipts, payouts) but **NO city tiers** — the
+  reimbursement cap is admin/UB-set in the form, clamped to the configured ceiling
+  (`private.reimbursement_tiers.ceilingUsd`, fallback **625**). GPP's budget-suggestion /
+  tier helpers were NOT cloned.
+- **Admin/UB-gated** create (`assertSideAuthorized`) + **`SIDE_PUBLIC`** launch env
+  (`isSidePublic()` → `process.env.SIDE_PUBLIC === 'true'`).
+- **Side-specific agreement** in a new `side_agreement_clauses` table (mirror of
+  `gpp_agreement_clauses`), same acknowledgment flow.
+
+## Files created
+- `backend/src/helpers/side.ts` — `SIDE_TAG='side-prelaunch'`, `isSidePublic()`,
+  `slugFromName()`, `isSideHidden()`, `assertSideAuthorized()` (throws `SIDE_FORBIDDEN`).
+  No tier/year/computeReimbursementCap helpers.
+- `backend/src/routes/side.routes.ts` — `/api/side` endpoints:
+  `GET /agreement`, `POST /events`, `PATCH /parties/:id/budget`,
+  `POST /parties/:id/agreement/accept`, `GET /parties/:id/publish-status`,
+  `POST /parties/:id/publish`. All `requireAuth` + `assertSideAuthorized`.
+  Scope `region`/`city` are inferred from the venue's country/countryCode
+  (side events aren't city-based, so `city` is set to the country surrogate).
+- `backend/prisma/migrations/20260622000000_add_side_agreement_clauses/migration.sql` —
+  CREATE TABLE + index + 3 placeholder v1.0 seed clauses (code-of-conduct,
+  reimbursement-rules, hosting-requirements; markdown bullets + bold; requires_ack true).
+  Final copy is DB-editable.
+- `frontend/src/pages/SideCreatePage.tsx` — 2-step wizard (Details → Review & confirm),
+  **standard dark theme** via `Layout` (no GPP clouds/confetti). Step 1: name, host name,
+  email, telegram, venue (LocationAutocomplete), date + start/end time, TimezonePickerInput.
+  Step 2: admin/UB cap (IconInput) + agreement clauses (reused `renderClauseBody`/`renderInline`)
+  + publish gates. Reuses GPP admin/UB gate effect. Only reusable components, placeholders not labels.
+
+## Files modified (minimal shared-file edits)
+- `backend/src/index.ts` — import + mount `sideRoutes` at `/api/side`.
+- `backend/src/lib/eventTags.ts` — add `'side-prelaunch'` to `INTERNAL_EVENT_TAGS`
+  (the public `'side'` taxonomy tag stays public).
+- `backend/src/routes/event.routes.ts` — import `isSideHidden`; add a parallel hide-gate
+  after the GPP block so a tagged-but-unpublished side event 404s for non-admin/out-of-scope
+  viewers while `SIDE_PUBLIC !== 'true'`. Side events resolve via the NORMAL customUrl/inviteCode
+  lookup (no `?year=`), so only the gate was added.
+- `backend/prisma/schema.prisma` — add `SideAgreementClause` model (mirror of `GppAgreementClause`,
+  `@@map("side_agreement_clauses")`).
+- `frontend/src/lib/api.ts` — `fetchSideAgreement`, `createSideEvent`, `patchSideBudget`,
+  `acceptSideAgreement`, `fetchSidePublishStatus`, `publishSideEvent` + `Side*` interfaces.
+- `frontend/src/App.tsx` — import + `<Route path="/side" element={<SideCreatePage />} />`
+  (before the `/:slug` catch-all).
+
+## POST /api/side/events request body
+```jsonc
+{
+  "name": "PizzaDAO @ Devcon",        // required → event name + slug source
+  "hostName": "Jane Host",            // required
+  "email": "jane@example.com",        // required
+  "telegram": "@janehost",            // required
+  "timezone": "America/New_York",     // optional, default America/New_York
+  "date": "2027-05-20",               // optional YYYY-MM-DD (event-local)
+  "startTime": "18:00",               // optional HH:MM 24h
+  "endTime": "21:00",                 // optional HH:MM 24h (default = start + 3h)
+  "formattedName": "Venue, City, US", // optional (venue) — from LocationAutocomplete
+  "lat": 40.0, "lng": -74.0,          // optional
+  "country": "United States",         // optional → drives region/scope
+  "countryCode": "US",                // optional → drives region/scope
+  "reimbursementCapUsd": 500,         // optional, clamped to ceiling (else 0/pending)
+  "agreementVersion": "1.0",          // required
+  "acceptedClauseIds": ["<uuid>"]     // required (all requiresAck clauses)
+}
+```
+Response: `{ success, event:{id,name,inviteCode,customUrl,city,region}, eventPageUrl, hostPageUrl }`.
+
+## Launch / deploy notes
+- Run the migration in prod BEFORE merging the Prisma schema change (backend auto-deploys
+  from master quickly). The created table + seed clauses must exist before `/api/side/*` runs.
+- Set `SIDE_PUBLIC=true` (backend env) + redeploy to make side events public at launch.
+- EventPage badge intentionally skipped — side events use the standard dark theme.


### PR DESCRIPTION
## Summary
New admin/UB-gated event type **`side`** at **`rsv.pizza/side`**, for PizzaDAO conference side events. Clone-and-adapt of the GPP27 create flow (GPP27 code untouched).

**Key differences from GPP:**
- **Not city-based** — host picks the event **name + date/time + venue** (LocationAutocomplete); public slug derives from the event name.
- **Full payout machinery kept** (receipts/payouts/`/payments` — payout-gated + type-agnostic, no payments changes), but **no city tiers**: the reimbursement cap is **admin/UB-set**, defaulting to + clamped at the configured ceiling ($625).
- **Admin/UB-gated** create; events hidden behind a new **`SIDE_PUBLIC`** env until launch (mirrors `GPP27_PUBLIC`).
- **Side-specific agreement** — new `side_agreement_clauses` table + DB-editable clauses.

## Changes
**Backend:** `helpers/side.ts` (SIDE_TAG, isSidePublic, slugFromName, isSideHidden, assertSideAuthorized) · `routes/side.routes.ts` mounted at `/api/side` · `isSideHidden` gate in `event.routes.ts` · `side-prelaunch` added to `INTERNAL_EVENT_TAGS` · `SideAgreementClause` model + migration.
**Frontend:** `SideCreatePage.tsx` (2-step wizard) at `/side` · 6 `Side*` client fns in `api.ts` · route registered before `/:slug`. EventPage uses the standard theme (no GPP clouds).

## Migration — already applied to prod ✅
`side_agreement_clauses` table + 3 placeholder v1.0 clauses applied to prod via Supabase MCP **before** this PR (required: schema-add 500s + the schema-drift CI check needs the table to exist). Final clause copy is DB-editable.

## Verification
- Backend `tsc --noEmit`: side code clean (only pre-existing repo errors remain).
- Frontend hooks-lint: all hooks declared above early returns.
- **Note:** the backend (`/api/side/*`) only deploys from `master`, so the Vercel **preview** can show the gated `/side` UI shell but a full create round-trips only **after merge**. Backend auto-deploys on merge.

## To launch (post-merge)
Set `SIDE_PUBLIC=true` on the backend Vercel project + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)