### PR TITLE
stracciatella-58546: mobile-friendly /payments page shell (Phase 3)

### DIFF
--- a/frontend/src/components/payments-admin/BulkActionsBar.tsx
+++ b/frontend/src/components/payments-admin/BulkActionsBar.tsx
@@ -71,7 +71,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
           type="button"
           onClick={onApprove}
           disabled={busy}
-          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
+          className="inline-flex items-center justify-center gap-1 px-4 min-h-11 sm:min-h-0 sm:px-3 sm:py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium disabled:opacity-50"
         >
           {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
           Approve
@@ -80,7 +80,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
           type="button"
           onClick={onReject}
           disabled={busy}
-          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
+          className="inline-flex items-center justify-center gap-1 px-4 min-h-11 sm:min-h-0 sm:px-3 sm:py-1.5 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium disabled:opacity-50"
         >
           <X size={14} />
           Reject
@@ -90,7 +90,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
             type="button"
             onClick={onMarkPaid}
             disabled={busy}
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+            className="inline-flex items-center justify-center gap-1 px-4 min-h-11 sm:min-h-0 sm:px-3 sm:py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
           >
             <DollarSign size={14} />
             Mark paid
@@ -101,7 +101,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
             type="button"
             onClick={onBulkSend}
             disabled={busy || eligibleBulkSendCount === 0}
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            className="inline-flex items-center justify-center gap-1 px-4 min-h-11 sm:min-h-0 sm:px-3 sm:py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             title={
               eligibleBulkSendCount === 0
                 ? 'No eligible USDC payouts selected (need approved or failed + valid 0x wallet)'
@@ -117,7 +117,7 @@ export const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
             type="button"
             onClick={onExportSafeJson}
             disabled={busy}
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-violet-500 hover:bg-violet-600 text-white text-sm font-medium disabled:opacity-50"
+            className="inline-flex items-center justify-center gap-1 px-4 min-h-11 sm:min-h-0 sm:px-3 sm:py-1.5 rounded-lg bg-violet-500 hover:bg-violet-600 text-white text-sm font-medium disabled:opacity-50"
             title="Bundle selected USDC payouts as a Gnosis Safe Transaction Builder batch"
           >
             <FileJson size={14} />

--- a/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
+++ b/frontend/src/components/payments-admin/PayoutsFilterBar.tsx
@@ -307,7 +307,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
         <div
           role="tablist"
           aria-label="Payments view mode"
-          className="inline-flex rounded-lg overflow-hidden border border-theme-stroke bg-theme-surface"
+          className="flex flex-nowrap whitespace-nowrap overflow-x-auto max-w-full rounded-lg border border-theme-stroke bg-theme-surface md:inline-flex md:overflow-hidden"
         >
           {VIEW_MODE_TABS.map((tab) => {
             const active = viewMode === tab.value;
@@ -318,7 +318,7 @@ export const PayoutsFilterBar: React.FC<PayoutsFilterBarProps> = ({
                 role="tab"
                 aria-selected={active}
                 onClick={() => onViewModeChange(tab.value)}
-                className={`px-3 py-1.5 text-sm font-medium ${
+                className={`shrink-0 px-3 py-1.5 text-sm font-medium ${
                   active
                     ? 'bg-emerald-600 text-white'
                     : 'text-theme-text-muted hover:bg-theme-surface-hover'

--- a/frontend/src/pages/PaymentsAdminPage.tsx
+++ b/frontend/src/pages/PaymentsAdminPage.tsx
@@ -1158,7 +1158,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             <button
               type="button"
               onClick={() => setExternalModalState({ open: true })}
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium"
+              className="shrink-0 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium"
             >
               <Plus size={14} />
               Record External Payment
@@ -1168,7 +1168,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
             type="button"
             onClick={handleExportCsv}
             disabled={exporting}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke hover:bg-theme-surface-hover text-sm text-theme-text disabled:opacity-50"
+            className="shrink-0 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-theme-surface border border-theme-stroke hover:bg-theme-surface-hover text-sm text-theme-text disabled:opacity-50"
           >
             {exporting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
             Export CSV
@@ -2230,7 +2230,7 @@ export function PaymentsAdminPage({ regionFilter, portalSlug }: PaymentsAdminPag
 
         {/* siciliana-69183: toast stack (bottom-right, 3s auto-dismiss). */}
         {toasts.length > 0 && (
-          <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 max-w-sm pointer-events-none">
+          <div className="fixed z-50 flex flex-col gap-2 pointer-events-none max-sm:left-2 max-sm:right-2 max-sm:bottom-2 max-sm:max-w-[calc(100vw-1rem)] sm:right-6 sm:bottom-6 sm:max-w-sm">
             {toasts.map((t) => (
               <div
                 key={t.id}


### PR DESCRIPTION
## Phase 3 of /payments mobile overhaul (plan: stracciatella-58546)

Mobile fixes to the page shell. Desktop unchanged. Frontend-only (`+10/-10`, 3 files).

- **View-switcher tabs** ("By city / By payment / Payments") now horizontally scroll on mobile (`flex-nowrap whitespace-nowrap overflow-x-auto` + `shrink-0`), reverting to the original `inline-flex` at `md:`+. *(Note: these tabs were refactored into `PayoutsFilterBar.tsx` since the audit, so the fix lives there.)*
- **Header action buttons** got `shrink-0` so they wrap cleanly instead of being crushed.
- **Toast stack** is viewport-bounded on mobile (`max-sm:left-2/right-2/bottom-2/max-w-[calc(100vw-1rem)]`), keeping `sm:` desktop sizing.
- **BulkActionsBar** — all 5 action buttons now ≥44px (`min-h-11 px-4`) on mobile, compact `sm:` look on desktop.

Verify on preview at 375px: tabs scroll, no overflow, bulk-action targets tappable; desktop unchanged.

Preview: https://rsvpizza-git-stracciatella-58546-pay-shell-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)