### PR TITLE
stracciatella-58546: surface hover-only info on /payments mobile cards (Phase 2)

### DIFF
--- a/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
+++ b/frontend/src/components/payments-admin/PayoutsByPartyTable.tsx
@@ -4347,6 +4347,21 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
             outstandingUsd,
           } = computePartyTotals(row);
 
+          // stracciatella-58546: replicate the desktop "last Molto Benny
+          // reminder" computation (tortellini-58542) so the card can surface
+          // the same line that's hover-only / absent on mobile.
+          const reminders = [
+            { label: 'Receipts', at: row.party.receiptsReminderSentAt },
+            { label: 'Wallet', at: row.party.walletReminderSentAt },
+            { label: 'Photo', at: row.party.photoReminderSentAt },
+            { label: 'Attendance', at: row.party.attendanceReminderSentAt },
+          ].filter((r) => r.at);
+          const lastReminder = reminders.reduce(
+            (best, r) =>
+              !best || new Date(r.at!) > new Date(best.at!) ? r : best,
+            null as null | { label: string; at: string },
+          );
+
           return (
             <div
               key={row.party.id}
@@ -4399,6 +4414,14 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                       </span>
                     )}
                   </span>
+                  {/* stracciatella-58546: surface the Closed pill's hover-only
+                      reason (desktop `title="Closed out …"`) inline on the card.
+                      Same toLocaleString() value as the desktop title=. */}
+                  {isClosed && (
+                    <span className="block mt-1 text-xs text-theme-text-secondary break-words">
+                      Closed out {new Date(closedAt!).toLocaleString()}
+                    </span>
+                  )}
                 </span>
               </button>
 
@@ -4450,6 +4473,31 @@ export const PayoutsByPartyTable: React.FC<PayoutsByPartyTableProps> = ({
                     {outstandingUsd > 0 ? formatUsd(outstandingUsd) : '—'}
                   </div>
                 </div>
+              </div>
+
+              {/* stracciatella-58546: Last activity — absent from the card in
+                  Phase 1. Desktop shows relativeTime() with the precise
+                  localized timestamp in title= (hover-only). Surface BOTH the
+                  relative time and the precise timestamp inline, plus the last
+                  Molto Benny reminder line. Reuses the exact same expressions
+                  as the desktop cell (relativeTime + toLocaleString). */}
+              <div className="mt-3 text-xs text-theme-text-secondary break-words">
+                {row.aggregates.lastActivityAt ? (
+                  <span>
+                    Last activity{' '}
+                    {relativeTime(new Date(row.aggregates.lastActivityAt))} ·{' '}
+                    {new Date(row.aggregates.lastActivityAt).toLocaleString()}
+                  </span>
+                ) : (
+                  <span className="text-theme-text-faint">No activity yet</span>
+                )}
+                {lastReminder && (
+                  <div className="mt-0.5 text-theme-text-faint break-words">
+                    🔔 {lastReminder.label} reminder ·{' '}
+                    {relativeTime(new Date(lastReminder.at!))} ·{' '}
+                    {new Date(lastReminder.at!).toLocaleString()}
+                  </div>
+                )}
               </div>
 
               {partySlug && (


### PR DESCRIPTION
## Phase 2 (final) of /payments mobile overhaul (plan: stracciatella-58546)

Surfaces info that was only in desktop `title=` hover tooltips as visible inline text in the `md:hidden` mobile card view. Desktop table + all `title=` attrs unchanged. Frontend-only, additions-only (`+48/-0`, 1 file).

- **Last activity** — was entirely absent from the Phase 1 card; now shows "Last activity {relative} · {precise}" plus the last Molto Benny reminder sub-line (same `relativeTime()`/`toLocaleString()` exprs as desktop).
- **Closed-out date** — was hover-only on desktop; now inline "Closed out {date}" beneath the pill strip.
- Already-covered items (labeled action buttons, custom-tag/pending/scam pills whose text is visible) intentionally skipped to avoid noise.

Verify on preview at 375px: expand a city card — last-activity timestamp and closed-out date are visible without hovering.

Preview: https://rsvpizza-git-stracciatella-58546-pay-tooltips-pizza-dao.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)