### PR TITLE
sfoglia-58543: /photos type filter + slideshow thumbs-up

### DIFF
--- a/backend/src/routes/photo-feed.routes.ts
+++ b/backend/src/routes/photo-feed.routes.ts
@@ -174,6 +174,11 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
       ? partnerTagRaw.trim()
       : null;
 
+    // sfoglia-58543: `type` filters the feed by the photo's designated
+    // payout_role (group / box_stack / pizza). Whitelist to the three known
+    // roles so a bad value can't reach the ANY() bind.
+    const roles = parseCsv(req.query.type).filter((r) => ['group', 'box_stack', 'pizza'].includes(r));
+
     // sicilian-58195: random shuffle sort. When sort=random, the seed deter-
     // mines the order so cursor pagination + filters stay consistent across
     // requests. Order is MD5(id::text || seed::text) ASC (tiebreak: id ASC).
@@ -189,7 +194,7 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
     const year = parseYear(req.query.year);
 
     if (sort === 'random' && seed !== null) {
-      return await handleRandomFeed(req, res, { limit, regions, countries, partnerTag, seed, year });
+      return await handleRandomFeed(req, res, { limit, regions, countries, partnerTag, seed, year, roles });
     }
 
     const cursor = parseCursor(req.query.cursor);
@@ -218,6 +223,18 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
       : Prisma.empty;
     const partnerTagFilter = partnerTag
       ? Prisma.sql`AND ${partnerTag} = ANY(pa.event_tags)`
+      : Prisma.empty;
+    // sfoglia-58543: photos-side role filter (parameter-bound).
+    const roleFilter = roles.length > 0
+      ? Prisma.sql`AND p.payout_role = ANY(${roles}::text[])`
+      : Prisma.empty;
+    // sfoglia-58543: payout_documents have no payout_role column. The only role
+    // a payout pizza doc could represent is 'pizza', so when a role filter is
+    // active include the payout side only if 'pizza' is among the roles; else
+    // exclude it entirely (mostly defensive — this UNION side is effectively
+    // empty in practice per napoletana-58211).
+    const payoutRoleFilter = roles.length > 0
+      ? (roles.includes('pizza') ? Prisma.empty : Prisma.sql`AND FALSE`)
       : Prisma.empty;
 
     // cannoli-58292: keyset predicate. The boundary row's id orders within the
@@ -305,6 +322,7 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
           ${regionFilter}
           ${countryFilter}
           ${partnerTagFilter}
+          ${roleFilter}
 
         UNION ALL
 
@@ -350,6 +368,7 @@ router.get('/feed', optionalAuth, async (req: AuthRequest, res: Response, next: 
           ${regionFilter}
           ${countryFilter}
           ${partnerTagFilter}
+          ${payoutRoleFilter}
       ) u
       ${cursorPredicate}
       ORDER BY u.created_at DESC, u.id DESC
@@ -426,9 +445,10 @@ async function handleRandomFeed(
     partnerTag: string | null;
     seed: string;
     year: number; // cannoli-58292
+    roles: string[]; // sfoglia-58543
   },
 ): Promise<void> {
-  const { limit, regions, countries, partnerTag, seed, year } = opts;
+  const { limit, regions, countries, partnerTag, seed, year, roles } = opts;
   const cursor = parseRandomCursor(req.query.cursor);
   const fetchSize = limit + 1;
 
@@ -442,6 +462,10 @@ async function handleRandomFeed(
     : Prisma.empty;
   const partnerTagFilter = partnerTag
     ? Prisma.sql`AND ${partnerTag} = ANY(pa.event_tags)`
+    : Prisma.empty;
+  // sfoglia-58543: role filter (random mode already skips the payout union).
+  const roleFilter = roles.length > 0
+    ? Prisma.sql`AND p.payout_role = ANY(${roles}::text[])`
     : Prisma.empty;
   const cursorFilter = cursor
     ? Prisma.sql`AND (
@@ -468,6 +492,7 @@ async function handleRandomFeed(
       ${regionFilter}
       ${countryFilter}
       ${partnerTagFilter}
+      ${roleFilter}
       ${cursorFilter}
     ORDER BY MD5(p.id::text || ${seed}::text) ASC, p.id::text ASC
     LIMIT ${fetchSize}
@@ -677,6 +702,8 @@ router.get('/feed/download', requireAuth, async (req: AuthRequest, res: Response
       : null;
     // cannoli-58292: ZIP honors the same year + cutoff as the feed.
     const year = parseYear(req.query.year);
+    // sfoglia-58543: ZIP honors the same role filter as the on-screen feed.
+    const roles = parseCsv(req.query.type).filter((r) => ['group', 'box_stack', 'pizza'].includes(r));
 
     const regionFilter = regions.length > 0
       ? Prisma.sql`AND pa.region = ANY(${regions}::text[])`
@@ -686,6 +713,10 @@ router.get('/feed/download', requireAuth, async (req: AuthRequest, res: Response
       : Prisma.empty;
     const partnerTagFilter = partnerTag
       ? Prisma.sql`AND ${partnerTag} = ANY(pa.event_tags)`
+      : Prisma.empty;
+    // sfoglia-58543: photos-side role filter (ZIP is photos-table only).
+    const roleFilter = roles.length > 0
+      ? Prisma.sql`AND p.payout_role = ANY(${roles}::text[])`
       : Prisma.empty;
 
     // cannoli-58292: raw SQL so the ZIP mirrors /feed exactly — effective_year
@@ -727,6 +758,7 @@ router.get('/feed/download', requireAuth, async (req: AuthRequest, res: Response
         ${regionFilter}
         ${countryFilter}
         ${partnerTagFilter}
+        ${roleFilter}
       ORDER BY p.created_at DESC, p.id DESC
       LIMIT ${DOWNLOAD_MAX_PHOTOS}
     `);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7229,6 +7229,8 @@ export interface PhotosFeedFilters {
   // cannoli-58292: event-year filter. Backend defaults to the current calendar
   // year when omitted; only photos uploaded after their event's start show.
   year?: number;
+  // sfoglia-58543: filter by designated photo role (group / box_stack / pizza).
+  type?: string[];
 }
 
 export async function getPhotosFeed(
@@ -7256,6 +7258,10 @@ export async function getPhotosFeed(
     // cannoli-58292: event-year filter.
     if (typeof filters?.year === 'number') {
       params.append('year', String(filters.year));
+    }
+    // sfoglia-58543: photo-role type filter (CSV).
+    if (filters?.type && filters.type.length > 0) {
+      params.append('type', filters.type.join(','));
     }
     return await apiRequest<PhotosFeedResponse>(
       `/api/photos/feed?${params.toString()}`,

--- a/frontend/src/pages/PhotosFeedPage.tsx
+++ b/frontend/src/pages/PhotosFeedPage.tsx
@@ -55,6 +55,9 @@ export function PhotosFeedPage() {
     return Number.isFinite(n) ? n : CURRENT_YEAR;
   });
 
+  // sfoglia-58543: photo-role type filter (multi-select). Initialized from URL.
+  const [activeType, setActiveType] = useState<string[]>(() => parseCsvParam(searchParams.get('type')));
+
   // Facets + partner tags
   const [facetCountries, setFacetCountries] = useState<Array<{ name: string; count: number }>>([]);
   const [facetYears, setFacetYears] = useState<number[]>([]);
@@ -82,12 +85,14 @@ export function PhotosFeedPage() {
   const sortModeRef = useRef(sortMode);
   const seedRef = useRef(seed);
   const yearRef = useRef(activeYear); // cannoli-58292
+  const typeRef = useRef(activeType); // sfoglia-58543
   countriesRef.current = activeCountries;
   regionsRef.current = activeRegions;
   partnerTagRef.current = activePartnerTag;
   sortModeRef.current = sortMode;
   seedRef.current = seed;
   yearRef.current = activeYear;
+  typeRef.current = activeType;
 
   // Sync filter state -> URL so refresh / sharing work.
   useEffect(() => {
@@ -102,10 +107,12 @@ export function PhotosFeedPage() {
     // cannoli-58292: only put year in the URL when it differs from the current
     // calendar default, so a fresh /photos link stays clean.
     if (activeYear !== CURRENT_YEAR) next.set('year', String(activeYear));
+    // sfoglia-58543: persist the type filter in the URL when active.
+    if (activeType.length > 0) next.set('type', activeType.join(','));
     // Replace (don't push) to keep history clean.
     setSearchParams(next, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeCountries, activeRegions, activePartnerTag, sortMode, seed, activeYear]);
+  }, [activeCountries, activeRegions, activePartnerTag, sortMode, seed, activeYear, activeType]);
 
   // Build the raw-country list to send to the backend by expanding each
   // selected alpha-2 to all known locale variants intersected with what
@@ -141,6 +148,7 @@ export function PhotosFeedPage() {
         sort: sortModeRef.current,
         seed: seedRef.current,
         year: yearRef.current, // cannoli-58292
+        type: typeRef.current, // sfoglia-58543
       };
       const res = await getPhotosFeed(cursorRef.current, 24, filters);
       if (!res) {
@@ -165,8 +173,8 @@ export function PhotosFeedPage() {
   // + seed so picking Shuffle (or reshuffling with a new seed) re-pages.
   // cannoli-58292: include year so changing it resets the cursor + re-pages.
   const filterKey = useMemo(
-    () => `${activeCountries.slice().sort().join(',')}|${activeRegions.slice().sort().join(',')}|${activePartnerTag || ''}|${sortMode}|${seed || ''}|${activeYear}`,
-    [activeCountries, activeRegions, activePartnerTag, sortMode, seed, activeYear]
+    () => `${activeCountries.slice().sort().join(',')}|${activeRegions.slice().sort().join(',')}|${activePartnerTag || ''}|${sortMode}|${seed || ''}|${activeYear}|${activeType.slice().sort().join(',')}`,
+    [activeCountries, activeRegions, activePartnerTag, sortMode, seed, activeYear, activeType]
   );
 
   useEffect(() => {
@@ -266,6 +274,8 @@ export function PhotosFeedPage() {
     setSeed(null);
     // cannoli-58292: reset to the default (current calendar) year.
     setActiveYear(CURRENT_YEAR);
+    // sfoglia-58543: clear the type filter.
+    setActiveType([]);
   };
 
   // sicilian-58195: shuffle handler. Generates a new seed and switches to
@@ -302,8 +312,10 @@ export function PhotosFeedPage() {
     }
     // cannoli-58292: ZIP download honors the selected event year.
     params.append('year', String(activeYear));
+    // sfoglia-58543: ZIP download honors the type filter.
+    if (activeType.length > 0) params.append('type', activeType.join(','));
     return params.toString();
-  }, [activeCountries, activeRegions, activePartnerTag, sortMode, seed, activeYear, buildCountriesForBackend]);
+  }, [activeCountries, activeRegions, activePartnerTag, sortMode, seed, activeYear, activeType, buildCountriesForBackend]);
 
   const handleDownloadZip = async () => {
     if (downloading || !activePartnerTag) return;
@@ -352,7 +364,7 @@ export function PhotosFeedPage() {
     []
   );
 
-  const anyFiltersActive = activeCountries.length > 0 || activeRegions.length > 0 || !!activePartnerTag || sortMode === 'random' || activeYear !== CURRENT_YEAR;
+  const anyFiltersActive = activeCountries.length > 0 || activeRegions.length > 0 || !!activePartnerTag || sortMode === 'random' || activeYear !== CURRENT_YEAR || activeType.length > 0;
 
   return (
     <ThemeProvider theme="gpp">
@@ -380,6 +392,11 @@ export function PhotosFeedPage() {
             options={yearOptions}
             selected={activeYear}
             onChange={setActiveYear}
+          />
+          {/* sfoglia-58543: photo-role type selector (group / box_stack / pizza). */}
+          <TypeFilterButton
+            selected={activeType}
+            onChange={setActiveType}
           />
           <CountryFilterButton
             options={countryOptions}
@@ -682,6 +699,68 @@ function YearFilterButton({
               {isSel && <Check size={12} className="text-white" />}
             </div>
             <span className="flex-1">{y}</span>
+          </button>
+        );
+      })}
+    </FilterDropdownShell>
+  );
+}
+
+// sfoglia-58543: multi-select photo-role type dropdown. Built on
+// FilterDropdownShell like RegionFilterButton — a user may want Group OR Pizza.
+// Options map to the payout_role values gated on the backend.
+const TYPE_OPTIONS: Array<{ id: string; label: string }> = [
+  { id: 'group', label: 'Group' },
+  { id: 'box_stack', label: 'Box stack' },
+  { id: 'pizza', label: 'Pizza' },
+];
+
+function TypeFilterButton({
+  selected, onChange,
+}: {
+  selected: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = (id: string) => {
+    if (selected.includes(id)) onChange(selected.filter((t) => t !== id));
+    else onChange([...selected, id]);
+  };
+
+  return (
+    <FilterDropdownShell
+      label="Type"
+      count={selected.length}
+      open={open}
+      onToggle={() => setOpen((o) => !o)}
+    >
+      {selected.length > 0 && (
+        <button
+          onClick={() => onChange([])}
+          className="w-full text-left px-4 py-2 text-xs text-gray-600 hover:bg-gray-100 transition-colors"
+        >
+          Clear ({selected.length})
+        </button>
+      )}
+      {TYPE_OPTIONS.map((opt) => {
+        const isSel = selected.includes(opt.id);
+        return (
+          <button
+            key={opt.id}
+            onClick={() => toggle(opt.id)}
+            className={`w-full text-left px-4 py-2.5 text-sm transition-colors flex items-center gap-2 ${
+              isSel
+                ? 'text-red-600 font-medium'
+                : 'text-gray-900 hover:bg-gray-100'
+            }`}
+          >
+            <div className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 ${
+              isSel ? 'bg-red-500 border-red-500' : 'border-black/20'
+            }`}>
+              {isSel && <Check size={12} className="text-white" />}
+            </div>
+            {opt.label}
           </button>
         );
       })}

--- a/frontend/src/pages/PhotosSlideshowPage.tsx
+++ b/frontend/src/pages/PhotosSlideshowPage.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import { Loader2, X, Pause, Play, MapPin } from 'lucide-react';
+import { Loader2, X, Pause, Play, MapPin, ThumbsUp } from 'lucide-react';
 import { cdnUrl } from '../lib/supabase';
-import { getPhotosFeed, FeedPhoto } from '../lib/api';
+import { getPhotosFeed, togglePhotoVote, togglePayoutPhotoVote, FeedPhoto } from '../lib/api';
+import { useAuth } from '../contexts/AuthContext';
 import { countryNameToAlpha2, alpha2ToCountryNames } from '../utils/countryFlag';
 import { gppCityBySlug } from '../utils/gppCity';
 import { CircleFlag } from '../components/CircleFlag';
@@ -40,6 +41,8 @@ export function PhotosSlideshowPage() {
   const countryCodes = parseCsvParam(searchParams.get('countries'));
   const regions = parseCsvParam(searchParams.get('regions'));
   const partnerTag = searchParams.get('partnerTag') || null;
+  // sfoglia-58543: honor the /photos type (payout_role) filter in the slideshow.
+  const types = parseCsvParam(searchParams.get('type'));
   const yearParam = searchParams.get('year');
   const year = yearParam && Number.isFinite(parseInt(yearParam, 10)) ? parseInt(yearParam, 10) : undefined;
   const backendCountries = Array.from(
@@ -51,6 +54,12 @@ export function PhotosSlideshowPage() {
   const [paused, setPaused] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // sfoglia-58543: thumbs-up (vote) support, mirroring the /photos feed
+  // lightbox. Anon users can't vote (button disabled); logged-in users toggle
+  // via the source-appropriate endpoint.
+  const { user } = useAuth();
+  const [voting, setVoting] = useState(false);
 
   // Refs mirror the state that the interval / prefetch logic reads, so the
   // timer callback never goes stale.
@@ -65,8 +74,8 @@ export function PhotosSlideshowPage() {
 
   // Filters are stable for the life of the page; capture them in a ref so
   // loadPage stays a stable callback.
-  const filtersRef = useRef({ countries: backendCountries, regions, partnerTag, year });
-  filtersRef.current = { countries: backendCountries, regions, partnerTag, year };
+  const filtersRef = useRef({ countries: backendCountries, regions, partnerTag, year, type: types });
+  filtersRef.current = { countries: backendCountries, regions, partnerTag, year, type: types };
 
   const loadPage = useCallback(async (isInitial: boolean) => {
     if (loadingRef.current) return;
@@ -81,6 +90,7 @@ export function PhotosSlideshowPage() {
         regions: filtersRef.current.regions,
         partnerTag: filtersRef.current.partnerTag,
         year: filtersRef.current.year,
+        type: filtersRef.current.type, // sfoglia-58543
       });
       if (!res) {
         if (isInitial) setError('Could not load photos right now.');
@@ -167,6 +177,23 @@ export function PhotosSlideshowPage() {
   const current = photos[idx];
   const isVideo = current?.mimeType?.startsWith('video/');
 
+  // sfoglia-58543: toggle a vote on the current photo. Source-aware dispatch
+  // (same as the /photos FeedLightbox). On success, patch the loaded deck so
+  // the count/fill persist as the slideshow advances or loops.
+  const handleVote = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!current || voting || !user) return;
+    setVoting(true);
+    const res = current.source === 'payout' && current.payoutId
+      ? await togglePayoutPhotoVote(current.payoutId, current.id)
+      : await togglePhotoVote(current.party.id, current.id);
+    setVoting(false);
+    if (res) {
+      setPhotos((prev) => prev.map((p) =>
+        p.id === current.id ? { ...p, voteCount: res.voteCount, votedByMe: res.voted } : p));
+    }
+  };
+
   const gpp = current ? gppCityBySlug(current.party.slug) : undefined;
   const displayCity = gpp?.name ?? current?.party.city;
   const displayCountry = gpp?.country ?? current?.party.country;
@@ -186,6 +213,24 @@ export function PhotosSlideshowPage() {
       >
         <X size={24} />
       </Link>
+
+      {/* sfoglia-58543: thumbs-up (vote) — bottom-right, left of Pause/Play.
+          Styled like the other overlay controls. Anon users see the count but
+          can't vote (disabled). */}
+      {photos.length > 0 && current && (
+        <button
+          onClick={handleVote}
+          disabled={!user || voting}
+          aria-label={current.votedByMe ? 'Remove vote' : 'Thumbs up'}
+          title={user ? (current.votedByMe ? 'Remove vote' : 'Thumbs up') : 'Log in to vote'}
+          className={`absolute bottom-4 right-16 z-20 inline-flex items-center gap-1.5 px-3 py-2 rounded-full bg-black/40 hover:bg-black/70 text-white transition-colors ${
+            !user || voting ? 'opacity-60 cursor-not-allowed' : ''
+          }`}
+        >
+          <ThumbsUp size={20} fill={current.votedByMe ? 'white' : 'none'} />
+          <span className="text-sm font-medium">{current.voteCount}</span>
+        </button>
+      )}
 
       {/* Pause / play */}
       {photos.length > 0 && (

--- a/plans/sfoglia-58543-photos-type-and-slideshow-vote.md
+++ b/plans/sfoglia-58543-photos-type-and-slideshow-vote.md
@@ -1,0 +1,123 @@
+# sfoglia-58543 — /photos type selector (group/pizza) + /photos/play slideshow thumbs-up
+
+## Goal
+Two related enhancements to the public Photos feature (both layer on top of the already-merged
+crespelle-58543 slideshow + cannoli-58292 year selector, all on `master`):
+
+1. **Slideshow thumbs-up** — add a working thumbs-up (vote) button to the `/photos/play` fullscreen
+   slideshow (`PhotosSlideshowPage.tsx`), reusing the existing end-to-end vote feature
+   (salame-58195 / napoletana-58210). Frontend-only, works on preview immediately.
+2. **Type selector on /photos** — add a "Type" filter to the `/photos` feed filter bar that filters
+   photos by `payout_role` (`group` / `box_stack` / `pizza`). Requires a backend feed change +
+   frontend wiring.
+
+## Base
+Fresh branch off `origin/master`. Branch name: `sfoglia-58543-photos-type-vote`.
+Do NOT reuse the recycled agent worktree — branch clean from master.
+
+## Important caveats (read before implementing)
+- **`payout_role` semantics**: it's a *single designated photo per role per event* (partial unique
+  index on `(party_id, payout_role)`), used to gate payout submission — not a category on every
+  uploaded photo. Values: `'group' | 'box_stack' | 'pizza'` (see `schema.prisma` Photo model,
+  `RolePhotoPicker.tsx:9`).
+- **Feed intersection**: the feed only surfaces `photos WHERE starred = true AND status = 'approved'`.
+  A photo's `payout_role` is set independently of starring, so the type filter shows only starred
+  photos that ALSO have a role. Expect sparse results for many year/type combos. This is expected /
+  accepted scope — note it on the PR.
+- **Backend deploy ordering**: the `type` query param is a NEW backend param. Preview branches share
+  the PROD backend, which won't understand `type` until this merges to `master` (backend auto-deploys
+  from master). So on the preview URL the Type filter will appear to do nothing (prod ignores the
+  unknown param and returns unfiltered) until merge. The slideshow thumbs-up (frontend-only) works on
+  preview right away. Call this out in the PR description.
+- No DB migration needed (`payout_role` column already exists).
+
+---
+
+## Part 1 — Slideshow thumbs-up (frontend only)
+
+File: `frontend/src/pages/PhotosSlideshowPage.tsx`
+
+Mirror the existing vote logic from `PhotosFeedPage.tsx` `FeedLightbox` (lines ~908-923, 963-977):
+1. Imports: add `ThumbsUp` from `lucide-react`; add `togglePhotoVote, togglePayoutPhotoVote` from
+   `../lib/api`; add `useAuth` from `../contexts/AuthContext`.
+2. State: `const { user } = useAuth();` and `const [voting, setVoting] = useState(false);`
+3. `handleVote` (source-aware, same dispatch as the lightbox):
+   ```ts
+   const res = current.source === 'payout' && current.payoutId
+     ? await togglePayoutPhotoVote(current.payoutId, current.id)
+     : await togglePhotoVote(current.party.id, current.id);
+   ```
+   On success, update the loaded deck so the count/fill persist:
+   `setPhotos(prev => prev.map(p => p.id === current.id ? { ...p, voteCount: res.voteCount, votedByMe: res.voted } : p));`
+   Guard `if (!current || voting) return;` and no-op for anon (`!user`) — the slideshow has no lightbox
+   to defer to, so for anon just disable the button (show count, `cursor-not-allowed`, title "Log in to vote").
+4. Button placement: bottom-right control cluster next to Pause/Play (lines ~191-199). Add a pill/icon
+   button styled like the existing overlay controls (`bg-black/40 hover:bg-black/70 text-white`,
+   `rounded-full`), showing `<ThumbsUp>` (filled white when `current.votedByMe`) + `current.voteCount`.
+   Keep it visually consistent with the existing exit / pause controls. Guard render on `photos.length > 0 && current`.
+5. Don't let the button clicks bubble to any pause toggle; `e.stopPropagation()`.
+
+No backend/API change — `getPhotosFeed` already returns `voteCount`/`votedByMe`/`source`/`payoutId`.
+
+## Part 2 — Type selector on /photos
+
+### 2a. Backend — `backend/src/routes/photo-feed.routes.ts`
+- Parse the new param near the other filters in `GET /feed` (and in the ZIP `GET /feed/download`
+  handler): `const roles = parseCsv(req.query.type).filter(r => ['group','box_stack','pizza'].includes(r));`
+- **Newest handler** (raw UNION SQL, ~line 268): add a parameter-bound fragment
+  `const roleFilter = roles.length > 0 ? Prisma.sql\`AND p.payout_role = ANY(${roles}::text[])\` : Prisma.empty;`
+  Insert it in the **photos** SELECT WHERE block (alongside `regionFilter`/`countryFilter`/`partnerTagFilter`,
+  ~line 305-307). For the **payout_documents** UNION side (which has no `payout_role`): when
+  `roles.length > 0`, gate it — include it only if `'pizza' ∈ roles`, else add `AND FALSE`
+  (it's "effectively empty in practice" per the napoletana-58211 comment, so this is mostly defensive).
+- **Random handler** `handleRandomFeed` (~line 419): thread `roles` through `opts`, build the same
+  `roleFilter`, and add it to the ids query WHERE (~line 468-470). Random mode already skips the payout union.
+- **ZIP download handler** (`GET /feed/download`): apply the same `roleFilter` for parity so a filtered
+  ZIP matches the on-screen filter. Find it and mirror the fragment.
+- No change to `FeedItem` shape or the JSON response — this is filter-only, not a new output field.
+
+### 2b. Frontend API — `frontend/src/lib/api.ts`
+- Add `type?: string[];` to the `PhotosFeedFilters` interface (~lines 6750-6761).
+- In `getPhotosFeed` (~6763-6797), append `type` as a CSV query param when non-empty
+  (mirror how `regions`/`countries` are serialized).
+
+### 2c. Frontend page — `frontend/src/pages/PhotosFeedPage.tsx`
+Follow the `activeYear` / `YearFilterButton` pattern exactly (it's the closest analog), but multi-select
+(like `RegionFilterButton`) since a user may want group OR pizza:
+- State: `const [activeType, setActiveType] = useState<string[]>(() => parseCsvParam(searchParams.get('type')));`
+- Ref: `const typeRef = useRef(activeType); typeRef.current = activeType;`
+- URL sync effect: `if (activeType.length > 0) next.set('type', activeType.join(','));`
+  (add `activeType` to the effect dep array).
+- `loadPage` filters object: add `type: typeRef.current`.
+- `filterKey` memo: append `|${activeType.slice().sort().join(',')}` and add `activeType` to deps.
+- `clearAllFilters`: `setActiveType([]);`
+- `anyFiltersActive`: `|| activeType.length > 0`.
+- `buildDownloadParams`: append `type` CSV when non-empty.
+- Render a new `<TypeFilterButton>` in the sticky filter bar, right after `<YearFilterButton>`
+  (~line 383). Build it on `FilterDropdownShell` like `RegionFilterButton`, multi-select checkboxes:
+  options `[{id:'group',label:'Group'},{id:'box_stack',label:'Box stack'},{id:'pizza',label:'Pizza'}]`,
+  label `"Type"`, `count={selected.length}`.
+  (Include all three roles — box_stack is a valid role and cheap to expose; Snax's ask was "group or pizza".)
+- The existing Play/slideshow `<Link>` already serializes `searchParams` (~line 429), so `type`
+  propagates into the slideshow automatically.
+
+### 2d. Slideshow honors the type filter — `frontend/src/pages/PhotosSlideshowPage.tsx`
+- Read `type` from the URL once (like the other filters, ~lines 40-44):
+  `const types = parseCsvParam(searchParams.get('type'));`
+- Add `type: types` to `filtersRef` (~line 68) and pass `type: filtersRef.current.type` into the
+  `getPhotosFeed(...)` call (~lines 77-84).
+
+---
+
+## Verification
+- Frontend typecheck: `cd frontend && npx tsc --noEmit` (vite build does NOT typecheck — see repo memory).
+- Backend: `cd backend && npx tsc --noEmit` for the route change.
+- Manual on preview: slideshow thumbs-up toggles + count updates + persists across advance/loop; logged-out
+  user sees the count but can't vote. Type filter UI renders + updates URL (`?type=pizza`) — note it won't
+  actually filter on preview until merged (prod backend). Confirm no regressions to year/shuffle/country/region.
+
+## PR
+- Draft PR off master. Title: `sfoglia-58543: /photos type filter + slideshow thumbs-up`.
+- In the body, call out: (1) type filter needs master merge before it filters on preview (new backend
+  param); (2) `payout_role`×`starred` intersection means sparse results are expected; (3) frontend-only
+  slideshow vote works on preview immediately; (4) no migration.


### PR DESCRIPTION
## What
Two enhancements to the public Photos feature (layered on the merged crespelle-58543 slideshow + cannoli-58292 year selector):

1. **Slideshow thumbs-up** — `/photos/play` gets a working thumbs-up button (bottom-right, next to Pause/Play), reusing the existing salame-58195 / napoletana-58210 vote feature. Source-aware (photo vs payout doc); the loaded deck updates on click so the count/fill persist across advances and reshuffles. Anon users see the count but can't vote.
2. **"Type" filter on /photos** — a multi-select filter (Group / Box stack / Pizza) keyed on `photos.payout_role`. Wired through the feed query (newest + random), the ZIP download, and forwarded into the slideshow URL. Follows the existing Year/Region filter patterns.

## Files
- `backend/src/routes/photo-feed.routes.ts` — new `type` CSV param + parameter-bound `payout_role` filter on newest/random/ZIP paths (filter-only, no response-shape change).
- `frontend/src/lib/api.ts` — `type` added to `PhotosFeedFilters` + serialized in `getPhotosFeed`.
- `frontend/src/pages/PhotosFeedPage.tsx` — `activeType` state/URL-sync/filterKey/clearAll + new `TypeFilterButton`.
- `frontend/src/pages/PhotosSlideshowPage.tsx` — vote button + reads `type` from URL.

## ⚠️ Notes for review / testing
- **The Type filter won't actually filter on the preview URL until this merges to `master`.** It adds a NEW backend query param, and preview branches share the prod backend (which ignores the unknown param and returns unfiltered) until the backend auto-deploys from master on merge. The slideshow thumbs-up is frontend-only and **works on the preview immediately**.
- **Sparse results are expected.** `payout_role` tags only ~one designated photo per role per event, and the feed only surfaces `starred = true` photos — so many year/type combinations will show few or no photos. This is the accepted scope.
- **No DB migration** (the `payout_role` column already exists).
- Backend `tsc --noEmit` is clean for the changed file; 3 pre-existing errors in untouched files (`@types` drift, no backend lockfile) are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)