### PR TITLE
bucatini-58547: declare heic2any dep (fix root/worktree builds)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@wagmi/connectors": "^5.11.2",
     "connectkit": "^1.9.1",
     "date-fns": "^4.1.0",
+    "heic2any": "^0.0.4",
     "html5-qrcode": "^2.3.8",
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -256,6 +256,7 @@
         "@wagmi/connectors": "^5.11.2",
         "connectkit": "^1.9.1",
         "date-fns": "^4.1.0",
+        "heic2any": "^0.0.4",
         "html5-qrcode": "^2.3.8",
         "i18next": "^26.0.8",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -14807,6 +14808,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hey-listen": {
       "version": "1.0.8",


### PR DESCRIPTION
## Fix undeclared `heic2any` dependency

`frontend/src/lib/supabase.ts` uses `heic2any` via dynamic import, but it was undeclared in `frontend/package.json` and absent from the **root workspaces** `package-lock.json`. Result: `npm ci` from the repo root failed (`Missing: heic2any@0.0.4 from lock file`), breaking `vite build` in fresh installs and agent worktrees.

**Not a prod bug:** Vercel builds from `frontend/` using the (vestigial) `frontend/package-lock.json`, which already had heic2any — so prod and all preview builds were green. This purely fixes root/local/worktree builds.

### Change (2 files, +8)
- `frontend/package.json` — declare `"heic2any": "^0.0.4"` (alphabetical).
- `package-lock.json` (root) — sync via `npm install ... --package-lock-only` (+7 lines, surgical).
- `frontend/package-lock.json` left untouched (Vercel relies on it).

### Verified
- root `npm ci` → success (previously failed).
- `cd frontend && npx vite build` → success, heic2any resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)