### PR TITLE
napoletana-58547: pluggable map-provider layer (Google ↔ keyless OSM/MapLibre)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,6 +8,12 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 # Enable the "Places API" for your project
 VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
+# Map provider switch (napoletana-58547)
+#   google = use the Google Maps key above (maps, autocomplete, static thumbnails)
+#   osm    = keyless fallback (MapLibre + OpenFreeMap tiles, Photon/Nominatim
+#            autocomplete). Default while the Google key is down.
+VITE_MAP_PROVIDER=osm
+
 # Backend API URL
 # For production, this should be your deployed backend URL
 VITE_API_URL=http://localhost:3006

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@stripe/stripe-js": "^8.6.1",
     "@supabase/supabase-js": "^2.90.1",
     "@tanstack/react-query": "^5.90.20",
+    "@tmcw/togeojson": "^7.1.2",
     "@wagmi/connectors": "^5.11.2",
     "connectkit": "^1.9.1",
     "date-fns": "^4.1.0",
@@ -25,6 +26,7 @@
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.344.0",
+    "maplibre-gl": "^5.24.0",
     "pdfjs-dist": "^5.7.284",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -35,6 +37,7 @@
     "recharts": "^2.13.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "tz-lookup": "^6.1.25",
     "use-places-autocomplete": "^4.0.1",
     "viem": "^2.44.4",
     "wagmi": "^2.19.5"

--- a/frontend/src/components/GPPEventsMap.tsx
+++ b/frontend/src/components/GPPEventsMap.tsx
@@ -1,6 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { MarkerClusterer } from '@googlemaps/markerclusterer';
 import { GPPEventMapItem, updateUnderbossStatus } from '../lib/api';
+import { isGoogleMaps } from '../lib/maps/provider';
+import { loadMapLibre, DEFAULT_MAP_STYLE } from '../lib/maps/loadMapLibre';
+import type { Map as MlMap, Marker as MlMarker, Popup as MlPopup } from 'maplibre-gl';
+
+// Inner SVG for a status-colored circle pin (shared by the osm marker path).
+function statusCircleSvg(status?: string | null): string {
+  const color = statusColor(status);
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">` +
+    `<circle cx="16" cy="16" r="11" fill="${color}" stroke="white" stroke-width="3"/>` +
+    `</svg>`
+  );
+}
 
 // Lucide "send" icon SVG, inlined for use inside the InfoWindow HTML string.
 const SEND_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>`;
@@ -87,6 +100,11 @@ export default function GPPEventsMap({
     null
   );
   const mapClickListenerRef = useRef<google.maps.MapsEventListener | null>(null);
+  // napoletana-58547: keyless MapLibre (`osm`) refs.
+  const osmMapRef = useRef<MlMap | null>(null);
+  const osmMarkersRef = useRef<MlMarker[]>([]);
+  const osmMarkerElByIdRef = useRef<Map<string, HTMLElement>>(new Map());
+  const osmPopupRef = useRef<MlPopup | null>(null);
   const [error, setError] = useState(false);
 
   // Filter out events with no valid coordinates
@@ -102,6 +120,8 @@ export default function GPPEventsMap({
   );
 
   useEffect(() => {
+    if (!isGoogleMaps()) return; // osm handled by the effect below
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     if (!apiKey) {
       setError(true);
@@ -503,6 +523,299 @@ export default function GPPEventsMap({
     script.onerror = () => setError(true);
     document.head.appendChild(script);
   }, [validEvents, cityChats, canModerate, isModerator, iconUrl, iconWidth, iconHeight, iconAnchorX, iconAnchorY, cluster]);
+
+  // ── osm: keyless MapLibre implementation ────────────────────────────────────
+  // A parallel port of the Google map above. No native clustering — markers are
+  // rendered individually (acceptable for the temporary keyless bridge).
+  useEffect(() => {
+    if (isGoogleMaps()) return;
+    if (validEvents.length === 0) return;
+
+    let cancelled = false;
+
+    // Popup HTML is identical to the Google InfoWindow content.
+    function buildInfoContent(event: GPPEventMapItem) {
+      const dateHtml = event.date
+        ? `<p style="color:#555;font-size:12px;margin:2px 0;font-weight:500">${new Date(
+            event.date
+          ).toLocaleDateString('en-US', {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          })}</p>`
+        : '';
+
+      const venueHtml = event.venueName
+        ? `<p style="color:#555;font-size:12px;margin:2px 0">${event.venueName}</p>`
+        : '';
+
+      const addressHtml = event.address
+        ? `<p style="color:#888;font-size:11px;margin:2px 0">${event.address}</p>`
+        : '';
+
+      const safeName = event.name
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      const nameLinkHtml = `<a href="/${event.slug}" target="_blank" rel="noopener noreferrer" style="display:block;margin:0 0 4px;font-size:15px;font-weight:700;color:#1a1a1a;text-decoration:none;line-height:1.25">${safeName}</a>`;
+
+      const flyerHtml = event.eventImageUrl
+        ? `<img src="${event.eventImageUrl}" alt="" loading="lazy" style="width:100%;height:120px;object-fit:cover;border-radius:8px;display:block;margin:0 0 8px;background:#f3f4f6" onerror="this.style.display='none'" />`
+        : '';
+
+      const cityKey = event.name.replace(/^Global Pizza Party\s*/i, '').trim().toLowerCase();
+      const telegramUrlRaw = event.telegramGroup || cityChats.get(cityKey) || null;
+      const telegramUrl = telegramUrlRaw ? telegramUrlRaw.replace(/"/g, '&quot;') : null;
+      const telegramHtml = telegramUrl
+        ? `<a href="${telegramUrl}" target="_blank" rel="noopener noreferrer" title="Join the Telegram chat" style="display:inline-flex;align-items:center;text-decoration:none;line-height:0">${TELEGRAM_LOGO_SVG}</a>`
+        : '';
+
+      const sanitizeHandle = (raw: string | null | undefined): string | null => {
+        if (!raw) return null;
+        const stripped = raw.trim().replace(/^@/, '');
+        if (!/^[A-Za-z0-9_]{3,40}$/.test(stripped)) return null;
+        return stripped;
+      };
+
+      const hostTgHandles: string[] = [];
+      if (canModerate) {
+        const primary = sanitizeHandle(event.hostTelegram);
+        if (primary) hostTgHandles.push(primary);
+        for (const raw of event.coHostTelegrams || []) {
+          if (hostTgHandles.length >= 2) break;
+          const h = sanitizeHandle(raw);
+          if (h && !hostTgHandles.includes(h)) hostTgHandles.push(h);
+        }
+      }
+
+      const hostTgIconsHtml = hostTgHandles
+        .map(
+          (h) =>
+            `<a href="https://t.me/${h}" target="_blank" rel="noopener noreferrer" title="DM @${h} on Telegram" style="color:#29B6F6;display:inline-flex;align-items:center;text-decoration:none">${SEND_ICON_SVG}</a>`
+        )
+        .join('');
+
+      let actionsHtml = '';
+      if (canModerate) {
+        const statusKey = event.underbossStatus || 'pending';
+        const statusColorHex = statusColor(statusKey);
+        const statusPillHtml = `<span style="background:${statusColorHex}1a;color:${statusColorHex};font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:600;text-transform:capitalize">${statusKey}</span>`;
+        const rsvpPillHtml = `<span style="background:#fef2f2;color:#E52828;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:500">${event.rsvpCount.toLocaleString()} RSVPs</span>`;
+        if (statusKey === 'approved') {
+          actionsHtml = `
+            ${statusPillHtml}
+            ${hostTgIconsHtml}
+            ${rsvpPillHtml}
+            <button data-action="reject" data-event-id="${event.id}" style="background:none;border:none;color:#dc2626;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark rejected</button>
+          `;
+        } else if (statusKey === 'rejected') {
+          actionsHtml = `
+            ${statusPillHtml}
+            ${hostTgIconsHtml}
+            ${rsvpPillHtml}
+            <button data-action="approve" data-event-id="${event.id}" style="background:none;border:none;color:#16a34a;font-size:11px;text-decoration:underline;cursor:pointer;padding:0">Mark approved</button>
+          `;
+        } else {
+          actionsHtml = `
+            ${statusPillHtml}
+            ${hostTgIconsHtml}
+            ${rsvpPillHtml}
+            <button data-action="approve" data-event-id="${event.id}" style="background:#16a34a;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Approve</button>
+            <button data-action="reject" data-event-id="${event.id}" style="background:#dc2626;color:white;border:none;font-size:12px;padding:4px 12px;border-radius:8px;font-weight:600;cursor:pointer">Reject</button>
+          `;
+        }
+      }
+
+      const actionsRowHtml = canModerate
+        ? `<div style="margin-top:8px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">${actionsHtml}</div>`
+        : '';
+
+      const telegramRowHtml = telegramHtml
+        ? `<div style="margin-top:6px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">${telegramHtml}</div>`
+        : '';
+
+      return `
+        <div style="max-width:260px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:4px">
+          ${flyerHtml}
+          ${nameLinkHtml}
+          ${dateHtml}
+          ${venueHtml}
+          ${addressHtml}
+          ${telegramRowHtml}
+          ${actionsRowHtml}
+        </div>
+      `;
+    }
+
+    loadMapLibre()
+      .then((maplibregl) => {
+        if (cancelled || !containerRef.current) return;
+
+        // Populate event lookup ref
+        const eventIndex = new Map<string, GPPEventMapItem>();
+        for (const ev of validEvents) eventIndex.set(ev.id, ev);
+        eventByIdRef.current = eventIndex;
+
+        // Tear down any previous markers
+        osmMarkersRef.current.forEach((m) => m.remove());
+        osmMarkersRef.current = [];
+        osmMarkerElByIdRef.current.clear();
+
+        if (!osmMapRef.current) {
+          osmMapRef.current = new maplibregl.Map({
+            container: containerRef.current,
+            style: DEFAULT_MAP_STYLE,
+            center: [0, 20],
+            zoom: 3,
+            minZoom: 2,
+            maxZoom: 18,
+            attributionControl: { compact: true },
+          });
+          osmMapRef.current.addControl(
+            new maplibregl.NavigationControl({ showCompass: false }),
+            'top-right'
+          );
+        }
+        const map = osmMapRef.current;
+
+        if (!osmPopupRef.current) {
+          osmPopupRef.current = new maplibregl.Popup({
+            maxWidth: '280px',
+            closeButton: true,
+          });
+        }
+        const popup = osmPopupRef.current;
+
+        async function onOsmActionClick(e: Event) {
+          const button = e.currentTarget as HTMLButtonElement;
+          const action = button.dataset.action as 'approve' | 'reject';
+          const eventId = button.dataset.eventId;
+          if (!action || !eventId) return;
+
+          const popupEl = popup.getElement();
+          const actionButtons = popupEl
+            ? popupEl.querySelectorAll<HTMLButtonElement>('[data-action][data-event-id]')
+            : ([] as unknown as NodeListOf<HTMLButtonElement>);
+          const originalText = button.textContent;
+          actionButtons.forEach((b) => {
+            b.disabled = true;
+          });
+          button.textContent = 'Saving…';
+
+          try {
+            await updateUnderbossStatus(
+              eventId,
+              action === 'approve' ? 'approved' : 'rejected'
+            );
+          } catch (err) {
+            alert((err as Error).message || 'Failed to update');
+            actionButtons.forEach((b) => {
+              b.disabled = false;
+            });
+            button.textContent = originalText;
+            return;
+          }
+
+          const current = eventByIdRef.current.get(eventId);
+          if (!current) return;
+          const updated: GPPEventMapItem = {
+            ...current,
+            underbossStatus: action === 'approve' ? 'approved' : 'rejected',
+          };
+          eventByIdRef.current.set(eventId, updated);
+
+          renderPopupContent(updated);
+
+          if (isModerator) {
+            const elm = osmMarkerElByIdRef.current.get(eventId);
+            if (elm) elm.innerHTML = statusCircleSvg(updated.underbossStatus);
+          }
+        }
+
+        function attachActionHandlers() {
+          if (!canModerate) return;
+          const popupEl = popup.getElement();
+          if (!popupEl) return;
+          popupEl
+            .querySelectorAll<HTMLButtonElement>('[data-action][data-event-id]')
+            .forEach((b) => b.addEventListener('click', onOsmActionClick));
+        }
+
+        function renderPopupContent(event: GPPEventMapItem) {
+          popup.setHTML(buildInfoContent(event));
+          attachActionHandlers();
+        }
+
+        const bounds = new maplibregl.LngLatBounds();
+
+        for (const event of validEvents) {
+          const lng = event.longitude as number;
+          const lat = event.latitude as number;
+          bounds.extend([lng, lat]);
+
+          let el: HTMLElement;
+          let anchor: 'bottom' | 'center';
+          if (isModerator) {
+            el = document.createElement('div');
+            el.style.width = '32px';
+            el.style.height = '32px';
+            el.innerHTML = statusCircleSvg(event.underbossStatus);
+            anchor = 'center';
+          } else {
+            const img = document.createElement('img');
+            img.src = iconUrl;
+            img.width = iconWidth;
+            img.height = iconHeight;
+            img.style.width = `${iconWidth}px`;
+            img.style.height = `${iconHeight}px`;
+            img.alt = event.name;
+            el = img;
+            anchor = 'bottom';
+          }
+          el.style.cursor = 'pointer';
+
+          const marker = new maplibregl.Marker({ element: el, anchor })
+            .setLngLat([lng, lat])
+            .addTo(map);
+
+          const eventId = event.id;
+          el.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            const latest = eventByIdRef.current.get(eventId) ?? event;
+            popup.setLngLat([lng, lat]).addTo(map);
+            renderPopupContent(latest);
+          });
+
+          osmMarkersRef.current.push(marker);
+          osmMarkerElByIdRef.current.set(event.id, el);
+        }
+
+        map.on('click', () => popup.remove());
+
+        if (osmMarkersRef.current.length > 0) {
+          map.fitBounds(bounds, { padding: 48, maxZoom: 15, animate: false });
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load MapLibre events map:', err);
+        if (!cancelled) setError(true);
+      });
+
+    return () => {
+      cancelled = true;
+      osmMarkersRef.current.forEach((m) => m.remove());
+      osmMarkersRef.current = [];
+      osmMarkerElByIdRef.current.clear();
+      if (osmPopupRef.current) {
+        osmPopupRef.current.remove();
+      }
+      if (osmMapRef.current) {
+        osmMapRef.current.remove();
+        osmMapRef.current = null;
+      }
+    };
+  }, [validEvents, cityChats, canModerate, isModerator, iconUrl, iconWidth, iconHeight, cluster]);
 
   if (error) {
     return (

--- a/frontend/src/components/GPPMap.tsx
+++ b/frontend/src/components/GPPMap.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { kml } from '@tmcw/togeojson';
+import { isGoogleMaps } from '../lib/maps/provider';
+import MapLibreMap from '../lib/maps/MapLibreMap';
 
 const KML_URL = 'https://www.google.com/maps/d/kml?mid=1ixyD2QbCZcz9IdK2gFKCNCz92hDDzEA';
 
@@ -18,8 +21,16 @@ function GPPMap({
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
   const [error, setError] = useState(false);
+  // napoletana-58547: MapLibre has no KmlLayer. Under `osm` we fetch the same
+  // KML, convert it to GeoJSON with @tmcw/togeojson, and hand it to MapLibreMap
+  // as an overlay. NOTE: Google My Maps' `kml?mid=` endpoint does not send CORS
+  // headers, so a browser fetch may be blocked — in that case we degrade to the
+  // "View map on Google Maps" link fallback (setError).
+  const [kmlGeojson, setKmlGeojson] = useState<unknown | null>(null);
 
   useEffect(() => {
+    if (!isGoogleMaps()) return; // osm path handled by the effect below
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     if (!apiKey) {
       setError(true);
@@ -94,6 +105,28 @@ function GPPMap({
     document.head.appendChild(script);
   }, [initialZoom, minZoom, maxZoom]);
 
+  // osm: fetch + convert the KML to GeoJSON for the MapLibre overlay.
+  useEffect(() => {
+    if (isGoogleMaps()) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(KML_URL);
+        if (!res.ok) throw new Error(`KML ${res.status}`);
+        const text = await res.text();
+        const dom = new DOMParser().parseFromString(text, 'text/xml');
+        const geojson = kml(dom);
+        if (!cancelled) setKmlGeojson(geojson);
+      } catch (err) {
+        console.error('Failed to load GPP KML overlay:', err);
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   if (error) {
     return (
       <div style={{ height }} className="flex items-center justify-center bg-gray-100 rounded-2xl">
@@ -106,6 +139,21 @@ function GPPMap({
           View map on Google Maps
         </a>
       </div>
+    );
+  }
+
+  if (!isGoogleMaps()) {
+    return (
+      <MapLibreMap
+        center={{ lat: 20, lng: 0 }}
+        zoom={initialZoom}
+        minZoom={minZoom}
+        maxZoom={maxZoom}
+        geojson={kmlGeojson ?? undefined}
+        className="rounded-2xl"
+        style={{ height, width: '100%' }}
+        dataTestId="gpp-map"
+      />
     );
   }
 

--- a/frontend/src/components/GPPPizzeriasMap.tsx
+++ b/frontend/src/components/GPPPizzeriasMap.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { MarkerClusterer } from '@googlemaps/markerclusterer';
 import { GPPPizzeriaMapItem, saveGppPizzeriaPhoto } from '../lib/api';
+import { isGoogleMaps } from '../lib/maps/provider';
+import { loadMapLibre, DEFAULT_MAP_STYLE } from '../lib/maps/loadMapLibre';
+import type { Map as MlMap, Marker as MlMarker, Popup as MlPopup } from 'maplibre-gl';
 
 interface GPPPizzeriasMapProps {
   pizzerias: GPPPizzeriaMapItem[];
@@ -16,6 +19,10 @@ export default function GPPPizzeriasMap({
   const markersRef = useRef<google.maps.Marker[]>([]);
   const clustererRef = useRef<MarkerClusterer | null>(null);
   const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
+  // napoletana-58547: keyless MapLibre (`osm`) refs.
+  const osmMapRef = useRef<MlMap | null>(null);
+  const osmMarkersRef = useRef<MlMarker[]>([]);
+  const osmPopupRef = useRef<MlPopup | null>(null);
   const [error, setError] = useState(false);
 
   // Filter out pizzerias with no valid coordinates
@@ -30,6 +37,8 @@ export default function GPPPizzeriasMap({
   );
 
   useEffect(() => {
+    if (!isGoogleMaps()) return; // osm handled by the effect below
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     if (!apiKey) {
       setError(true);
@@ -250,6 +259,133 @@ export default function GPPPizzeriasMap({
     script.onload = () => initMap();
     script.onerror = () => setError(true);
     document.head.appendChild(script);
+  }, [validPizzerias]);
+
+  // ── osm: keyless MapLibre implementation ────────────────────────────────────
+  // No native clustering and no on-demand Google Places photo fetch (Overpass
+  // ids are not Google place ids). We still show a persisted `photoUrl` when the
+  // backend has one cached.
+  useEffect(() => {
+    if (isGoogleMaps()) return;
+    if (validPizzerias.length === 0) return;
+
+    let cancelled = false;
+
+    function buildInfoContent(pizzeria: GPPPizzeriaMapItem, photoUrl?: string) {
+      let photoHtml = '';
+      if (photoUrl) {
+        photoHtml = `<img src="${photoUrl}" alt="${pizzeria.name}" referrerpolicy="no-referrer" style="width:100%;height:120px;object-fit:cover;border-radius:8px;margin-bottom:8px" />`;
+      }
+
+      let ratingHtml = '';
+      if (pizzeria.rating) {
+        const fullStars = Math.floor(pizzeria.rating);
+        const halfStar = pizzeria.rating - fullStars >= 0.5;
+        let stars = '';
+        for (let i = 0; i < fullStars; i++) stars += '★';
+        if (halfStar) stars += '½';
+        const reviewText = pizzeria.reviewCount ? ` (${pizzeria.reviewCount})` : '';
+        ratingHtml = `<div style="color:#f59e0b;font-size:14px;margin:2px 0">${stars} <span style="color:#666;font-size:12px">${pizzeria.rating}${reviewText}</span></div>`;
+      }
+
+      let descHtml = '';
+      if (pizzeria.description) {
+        const truncated =
+          pizzeria.description.length > 120
+            ? pizzeria.description.slice(0, 120) + '...'
+            : pizzeria.description;
+        descHtml = `<p style="color:#555;font-size:12px;margin:4px 0;line-height:1.4">${truncated}</p>`;
+      }
+
+      let linkHtml = '';
+      if (pizzeria.url) {
+        linkHtml = `<a href="${pizzeria.url}" target="_blank" rel="noopener noreferrer" style="color:#E52828;font-size:12px;text-decoration:none;font-weight:500">Visit Website &rarr;</a>`;
+      }
+
+      return `
+        <div style="max-width:260px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:4px">
+          ${photoHtml}
+          <h3 style="margin:0 0 4px;font-size:15px;font-weight:700;color:#1a1a1a">${pizzeria.name}</h3>
+          ${ratingHtml}
+          <p style="color:#888;font-size:12px;margin:2px 0">${pizzeria.address || ''}</p>
+          ${descHtml}
+          <div style="margin-top:6px;display:flex;align-items:center;gap:8px">
+            ${linkHtml}
+            <span style="background:#fef2f2;color:#E52828;font-size:11px;padding:2px 8px;border-radius:9999px;font-weight:500">${pizzeria.eventCity}</span>
+          </div>
+        </div>
+      `;
+    }
+
+    loadMapLibre()
+      .then((maplibregl) => {
+        if (cancelled || !containerRef.current) return;
+
+        osmMarkersRef.current.forEach((m) => m.remove());
+        osmMarkersRef.current = [];
+
+        if (!osmMapRef.current) {
+          osmMapRef.current = new maplibregl.Map({
+            container: containerRef.current,
+            style: DEFAULT_MAP_STYLE,
+            center: [0, 20],
+            zoom: 3,
+            minZoom: 2,
+            maxZoom: 18,
+            attributionControl: { compact: true },
+          });
+          osmMapRef.current.addControl(
+            new maplibregl.NavigationControl({ showCompass: false }),
+            'top-right'
+          );
+        }
+        const map = osmMapRef.current;
+
+        if (!osmPopupRef.current) {
+          osmPopupRef.current = new maplibregl.Popup({ maxWidth: '280px', closeButton: true });
+        }
+        const popup = osmPopupRef.current;
+
+        for (const pizzeria of validPizzerias) {
+          const el = document.createElement('div');
+          el.textContent = '\u{1F355}';
+          el.style.fontSize = '22px';
+          el.style.lineHeight = '1';
+          el.style.cursor = 'pointer';
+
+          const marker = new maplibregl.Marker({ element: el, anchor: 'center' })
+            .setLngLat([pizzeria.location.lng, pizzeria.location.lat])
+            .addTo(map);
+
+          el.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            const cachedUrl = pizzeria.photoUrl || undefined;
+            popup
+              .setLngLat([pizzeria.location.lng, pizzeria.location.lat])
+              .setHTML(buildInfoContent(pizzeria, cachedUrl))
+              .addTo(map);
+          });
+
+          osmMarkersRef.current.push(marker);
+        }
+
+        map.on('click', () => popup.remove());
+      })
+      .catch((err) => {
+        console.error('Failed to load MapLibre pizzerias map:', err);
+        if (!cancelled) setError(true);
+      });
+
+    return () => {
+      cancelled = true;
+      osmMarkersRef.current.forEach((m) => m.remove());
+      osmMarkersRef.current = [];
+      if (osmPopupRef.current) osmPopupRef.current.remove();
+      if (osmMapRef.current) {
+        osmMapRef.current.remove();
+        osmMapRef.current = null;
+      }
+    };
   }, [validPizzerias]);
 
   if (error) {

--- a/frontend/src/components/LocationAutocomplete.tsx
+++ b/frontend/src/components/LocationAutocomplete.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MapPin } from 'lucide-react';
+import { isGoogleMaps } from '../lib/maps/provider';
+import { IconInput } from './IconInput';
+import {
+  searchAddresses,
+  AddressResult,
+  AUTOCOMPLETE_DEBOUNCE_MS,
+  AUTOCOMPLETE_MIN_CHARS,
+} from '../lib/maps/photonAutocomplete';
 
 export interface CityData {
   cityName: string;      // "New York"
@@ -49,6 +57,10 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [autocomplete, setAutocomplete] = useState<google.maps.places.Autocomplete | null>(null);
+  // napoletana-58547: keyless (`osm`) autocomplete state.
+  const [suggestions, setSuggestions] = useState<AddressResult[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const justSelectedRef = useRef(false);
 
   // Use refs to avoid stale closures in the event listener
   const onChangeRef = useRef(onChange);
@@ -68,6 +80,12 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   }, [onChange, onVenueNameChange, onTimezoneChange, onPlaceSelected, onLocationSelected, onCitySelected]);
 
   useEffect(() => {
+    // osm provider: skip Google entirely (handled by the search effect below).
+    if (!isGoogleMaps()) {
+      setIsLoaded(true);
+      return;
+    }
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
     // If no API key, fall back to regular text input
@@ -256,6 +274,110 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
       }
     };
   }, []);
+
+  // ── osm: debounced, abortable keyless search on the controlled `value` ───────
+  useEffect(() => {
+    if (isGoogleMaps()) return;
+    // Suppress the search that would otherwise fire right after a selection
+    // (selecting sets `value` to the formatted address).
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      return;
+    }
+    const q = value.trim();
+    if (q.length < AUTOCOMPLETE_MIN_CHARS) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const results = await searchAddresses(q, controller.signal);
+        setSuggestions(results);
+        setShowDropdown(true);
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') setSuggestions([]);
+      }
+    }, AUTOCOMPLETE_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [value]);
+
+  const handleOsmSelect = (r: AddressResult) => {
+    justSelectedRef.current = true;
+    setShowDropdown(false);
+    setSuggestions([]);
+
+    const selectedAddress = r.formattedName;
+    onChangeRef.current(selectedAddress);
+    // osm has no reliable distinct "venue name" — leave it to the address.
+    onVenueNameChangeRef.current?.(null);
+    // Set coords + timezone BEFORE onPlaceSelected (callers may read them).
+    if (r.timezone) onTimezoneChangeRef.current?.(r.timezone);
+    onLocationSelectedRef.current?.({ lat: r.lat, lng: r.lng });
+    onCitySelectedRef.current?.({
+      cityName: r.cityName,
+      country: r.country,
+      countryCode: r.countryCode,
+      state: r.state,
+      street: r.street,
+      postalCode: r.postalCode,
+      lat: r.lat,
+      lng: r.lng,
+      formattedName: selectedAddress,
+    });
+    // placeId is null under osm (callers already accept null).
+    onPlaceSelectedRef.current?.(selectedAddress, null, null);
+  };
+
+  if (!isGoogleMaps()) {
+    return (
+      <div className="relative">
+        <IconInput
+          icon={MapPin}
+          iconSize={18}
+          type="text"
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+            setShowDropdown(true);
+          }}
+          onFocus={() => {
+            if (suggestions.length > 0) setShowDropdown(true);
+          }}
+          onBlur={() => {
+            // Delay so a click on a suggestion registers first.
+            setTimeout(() => setShowDropdown(false), 150);
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={`text-left ${className}`}
+        />
+        {showDropdown && suggestions.length > 0 && (
+          <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-xl border border-theme-stroke bg-theme-header shadow-xl py-1">
+            {suggestions.map((s, i) => (
+              <li key={`${s.lat},${s.lng},${i}`}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => {
+                    // onMouseDown (not onClick) so it fires before input blur.
+                    e.preventDefault();
+                    handleOsmSelect(s);
+                  }}
+                  className="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-start gap-2"
+                >
+                  <MapPin size={14} className="text-theme-text-muted mt-0.5 flex-shrink-0" />
+                  <span className="truncate">{s.formattedName}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="relative">

--- a/frontend/src/components/ParticipatingPizzeriasMap.tsx
+++ b/frontend/src/components/ParticipatingPizzeriasMap.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Pizzeria } from '../types';
+import { isGoogleMaps } from '../lib/maps/provider';
+import MapLibreMap, { MapLibreMarker } from '../lib/maps/MapLibreMap';
 
 interface ParticipatingPizzeriasMapProps {
   pizzerias: Pizzeria[];
@@ -34,7 +36,67 @@ export default function ParticipatingPizzeriasMap({
     [pizzerias]
   );
 
+  // napoletana-58547: markers for the keyless MapLibre (`osm`) render path.
+  // Pizzeria pins are the 🍕 emoji with the name label below; the venue is the
+  // Molto Benny mascot — mirroring the Google markers.
+  const osmMarkers = useMemo<MapLibreMarker[]>(() => {
+    if (isGoogleMaps()) return [];
+
+    const buildPizzeriaPin = (name: string): HTMLElement => {
+      const wrap = document.createElement('div');
+      wrap.style.display = 'flex';
+      wrap.style.flexDirection = 'column';
+      wrap.style.alignItems = 'center';
+      wrap.style.transform = 'translateY(-50%)';
+      const emoji = document.createElement('div');
+      emoji.textContent = '\u{1F355}';
+      emoji.style.fontSize = '24px';
+      emoji.style.lineHeight = '1';
+      const label = document.createElement('div');
+      label.textContent = name;
+      label.style.color = '#ffffff';
+      label.style.fontSize = '11px';
+      label.style.fontWeight = '600';
+      label.style.textShadow = '0 1px 2px rgba(0,0,0,0.85)';
+      label.style.whiteSpace = 'nowrap';
+      wrap.appendChild(emoji);
+      wrap.appendChild(label);
+      return wrap;
+    };
+
+    const buildVenuePin = (title: string): HTMLElement => {
+      const img = document.createElement('img');
+      img.src = '/molto-benny.png';
+      img.width = 45;
+      img.height = 45;
+      img.style.width = '45px';
+      img.style.height = '45px';
+      img.alt = title;
+      return img;
+    };
+
+    const list: MapLibreMarker[] = validPizzerias.map((p) => ({
+      lat: p.location.lat,
+      lng: p.location.lng,
+      element: buildPizzeriaPin(p.name),
+      title: p.name,
+    }));
+
+    if (venueLocation) {
+      list.push({
+        lat: venueLocation.lat,
+        lng: venueLocation.lng,
+        element: buildVenuePin(venueName || 'Venue'),
+        title: venueName || 'Venue',
+      });
+    }
+    return list;
+  }, [validPizzerias, venueLocation, venueName]);
+
   useEffect(() => {
+    // osm renders declaratively via <MapLibreMap> below — skip Google loading.
+    if (!isGoogleMaps()) return;
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     if (!apiKey) {
       setError(true);
@@ -172,6 +234,23 @@ export default function ParticipatingPizzeriasMap({
   // collapse the grid.
   if (validPizzerias.length === 0) {
     return null;
+  }
+
+  // ── osm branch: keyless MapLibre map ────────────────────────────────────────
+  if (!isGoogleMaps()) {
+    return (
+      <MapLibreMap
+        center={validPizzerias[0]?.location || { lat: 40, lng: -100 }}
+        zoom={14}
+        markers={osmMarkers}
+        fitToMarkers
+        fitPadding={48}
+        fitMaxZoom={16}
+        className="rounded-2xl overflow-hidden border border-theme-stroke"
+        style={{ height, width: '100%' }}
+        dataTestId="participating-pizzerias-map"
+      />
+    );
   }
 
   if (error) {

--- a/frontend/src/components/PizzeriaSearch.tsx
+++ b/frontend/src/components/PizzeriaSearch.tsx
@@ -24,6 +24,8 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { LocationAutocomplete } from './LocationAutocomplete';
+import { isGoogleMaps } from '../lib/maps/provider';
+import MapLibreMap, { MapLibreMarker } from '../lib/maps/MapLibreMap';
 
 interface PizzeriaRanking {
   id: string;
@@ -319,10 +321,15 @@ export const PizzeriaSearch: React.FC<PizzeriaSearchProps> = ({
       ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${pizzeria.name} ${pizzeria.address}`)}${pizzeria.placeId?.startsWith('ChIJ') ? `&query_place_id=${pizzeria.placeId}` : ''}`
       : null;
 
-    // Construct static map URL (only for valid coords)
-    const staticMapUrl = apiKey && hasValidCoords
+    // Construct static map URL (Google only; osm renders a MapLibre thumbnail).
+    const staticMapUrl = isGoogleMaps() && apiKey && hasValidCoords
       ? `https://maps.googleapis.com/maps/api/staticmap?center=${pizzeria.location.lat},${pizzeria.location.lng}&zoom=15&size=200x200&scale=2&markers=color:red%7C${pizzeria.location.lat},${pizzeria.location.lng}&key=${apiKey}`
       : null;
+
+    const osmThumbMarkers: MapLibreMarker[] | null =
+      !isGoogleMaps() && hasValidCoords
+        ? [{ lat: pizzeria.location.lat, lng: pizzeria.location.lng, color: '#ff393a' }]
+        : null;
 
     return (
       <div
@@ -407,6 +414,15 @@ export const PizzeriaSearch: React.FC<PizzeriaSearchProps> = ({
                   src={staticMapUrl}
                   alt="Map"
                   className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
+                />
+              ) : osmThumbMarkers ? (
+                <MapLibreMap
+                  center={pizzeria.location}
+                  zoom={15}
+                  interactive={false}
+                  markers={osmThumbMarkers}
+                  className="w-full h-full"
+                  style={{ width: '100%', height: '100%' }}
                 />
               ) : (
                 <>

--- a/frontend/src/components/PlaceAutocomplete.tsx
+++ b/frontend/src/components/PlaceAutocomplete.tsx
@@ -2,6 +2,14 @@ import React, { useEffect, useRef, useState } from 'react';
 import { MapPin, Loader2 } from 'lucide-react';
 import { Pizzeria } from '../types';
 import { uuid } from '../lib/utils';
+import { isGoogleMaps } from '../lib/maps/provider';
+import { IconInput } from './IconInput';
+import {
+  searchAddresses,
+  AddressResult,
+  AUTOCOMPLETE_DEBOUNCE_MS,
+  AUTOCOMPLETE_MIN_CHARS,
+} from '../lib/maps/photonAutocomplete';
 
 interface PlaceAutocompleteProps {
   onPlaceSelected: (pizzeria: Partial<Pizzeria>) => void;
@@ -21,12 +29,21 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
   const [loading, setLoading] = useState(false);
   const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
   const onPlaceSelectedRef = useRef(onPlaceSelected);
+  // napoletana-58547: keyless (`osm`) autocomplete state.
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<AddressResult[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
 
   useEffect(() => {
     onPlaceSelectedRef.current = onPlaceSelected;
   }, [onPlaceSelected]);
 
   useEffect(() => {
+    if (!isGoogleMaps()) {
+      setIsLoaded(true);
+      return;
+    }
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
     if (!apiKey) {
@@ -154,6 +171,88 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
       }
     };
   }, []);
+
+  // ── osm: debounced keyless establishment search ─────────────────────────────
+  useEffect(() => {
+    if (isGoogleMaps()) return;
+    const q = query.trim();
+    if (q.length < AUTOCOMPLETE_MIN_CHARS) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const results = await searchAddresses(q, controller.signal);
+        setSuggestions(results);
+        setShowDropdown(true);
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') setSuggestions([]);
+      }
+    }, AUTOCOMPLETE_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query]);
+
+  const handleOsmSelect = (r: AddressResult) => {
+    const pizzeria: Partial<Pizzeria> = {
+      id: `custom-${uuid()}`,
+      placeId: '', // no Google place id under osm
+      name: r.name || r.formattedName,
+      address: r.formattedName,
+      location: { lat: r.lat, lng: r.lng },
+      orderingOptions: [],
+    };
+    onPlaceSelectedRef.current(pizzeria);
+    setQuery('');
+    setSuggestions([]);
+    setShowDropdown(false);
+  };
+
+  if (!isGoogleMaps()) {
+    return (
+      <div className="relative">
+        <IconInput
+          icon={MapPin}
+          iconSize={18}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setShowDropdown(true);
+          }}
+          onFocus={() => {
+            if (suggestions.length > 0) setShowDropdown(true);
+          }}
+          onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+          placeholder={placeholder}
+          autoFocus={autoFocus}
+          className={`text-left ${className}`}
+        />
+        {showDropdown && suggestions.length > 0 && (
+          <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-xl border border-theme-stroke bg-theme-header shadow-xl py-1">
+            {suggestions.map((s, i) => (
+              <li key={`${s.lat},${s.lng},${i}`}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleOsmSelect(s);
+                  }}
+                  className="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-start gap-2"
+                >
+                  <MapPin size={14} className="text-theme-text-muted mt-0.5 flex-shrink-0" />
+                  <span className="truncate">{s.formattedName}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="relative">

--- a/frontend/src/components/VenueMap.tsx
+++ b/frontend/src/components/VenueMap.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { MapPin } from 'lucide-react';
 import { geocodeAddress } from '../lib/ordering';
+import { isGoogleMaps } from '../lib/maps/provider';
+import MapLibreMap, { MapLibreMarker } from '../lib/maps/MapLibreMap';
 
 interface VenueMapProps {
   address: string;
@@ -93,8 +95,9 @@ export default function VenueMap({
   }
 
   // Missing API key or geocoding failure → fallback placeholder that matches
-  // the visual language of the old static-map "no key" state.
-  if (error || !apiKey) {
+  // the visual language of the old static-map "no key" state. Under the keyless
+  // `osm` provider we don't need an API key, so only gate on the key for Google.
+  if (error || (isGoogleMaps() && !apiKey)) {
     return (
       <div
         className={`${className ?? ''} venue-map-thumbnail rounded-[inherit] bg-gradient-to-br from-[#ff393a]/20 to-[#ff6b35]/20 flex items-center justify-center`}
@@ -132,6 +135,55 @@ export default function VenueMap({
   const iconOrigin =
     typeof window !== 'undefined' ? window.location.origin : 'https://rsv.pizza';
   const iconUrl = `${iconOrigin}/molto-benny-pin.png`;
+
+  // Canonical Google Maps place card. We don't have a `ChIJ…` placeId in
+  // this component's prop surface, so use `query` alone (address preferred,
+  // fall back to lat/lng). A Google Maps deep link is fine even when the tiles
+  // themselves are OSM.
+  const googleMapsLink = address
+    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`
+    : `https://www.google.com/maps/search/?api=1&query=${center}`;
+
+  // ── osm branch: keyless non-interactive MapLibre thumbnail ──────────────────
+  // Keeps the same container className so layout is unchanged. A single Molto
+  // Benny pin sits on the venue coords.
+  if (!isGoogleMaps()) {
+    const buildBennyPin = (): HTMLElement => {
+      const img = document.createElement('img');
+      img.src = iconUrl;
+      img.width = 36;
+      img.height = 36;
+      img.style.width = '36px';
+      img.style.height = '36px';
+      img.style.display = 'block';
+      img.alt = venueName || 'Venue';
+      return img;
+    };
+    const osmMarkers: MapLibreMarker[] = [
+      { lat: location.lat, lng: location.lng, element: buildBennyPin() },
+    ];
+    return (
+      <a
+        href={googleMapsLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="venue-map"
+        className={`${className ?? ''} venue-map-thumbnail block rounded-[inherit] overflow-hidden bg-theme-surface`}
+        aria-label={`Open ${venueName || address} in Google Maps`}
+      >
+        <MapLibreMap
+          center={{ lat: location.lat, lng: location.lng }}
+          zoom={zoom}
+          interactive={false}
+          markers={osmMarkers}
+          className="w-full h-full"
+          style={{ width: '100%', height: '100%' }}
+        />
+      </a>
+    );
+  }
+
+  // ── google branch: cacheable Static Maps <img> (kept verbatim) ──────────────
   const staticMapUrl =
     `https://maps.googleapis.com/maps/api/staticmap` +
     `?center=${center}` +
@@ -141,13 +193,6 @@ export default function VenueMap({
     `&maptype=roadmap` +
     `&markers=anchor:bottom%7Cicon:${encodeURIComponent(iconUrl)}%7C${center}` +
     `&key=${apiKey}`;
-
-  // Canonical Google Maps place card. We don't have a `ChIJ…` placeId in
-  // this component's prop surface, so use `query` alone (address preferred,
-  // fall back to lat/lng).
-  const googleMapsLink = address
-    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`
-    : `https://www.google.com/maps/search/?api=1&query=${center}`;
 
   return (
     <a

--- a/frontend/src/components/kit/ShippingAddressAutocomplete.tsx
+++ b/frontend/src/components/kit/ShippingAddressAutocomplete.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MapPin } from 'lucide-react';
+import { isGoogleMaps } from '../../lib/maps/provider';
+import { IconInput } from '../IconInput';
+import {
+  searchAddresses,
+  AddressResult,
+  AUTOCOMPLETE_DEBOUNCE_MS,
+  AUTOCOMPLETE_MIN_CHARS,
+} from '../../lib/maps/photonAutocomplete';
 
 export interface AddressComponents {
   addressLine1: string;
@@ -41,6 +49,10 @@ export const ShippingAddressAutocomplete: React.FC<ShippingAddressAutocompletePr
   const inputRef = useRef<HTMLInputElement>(null);
   const [, setIsLoaded] = useState(false);
   const [autocomplete, setAutocomplete] = useState<google.maps.places.Autocomplete | null>(null);
+  // napoletana-58547: keyless (`osm`) autocomplete state.
+  const [suggestions, setSuggestions] = useState<AddressResult[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const justSelectedRef = useRef(false);
 
   // Use refs to avoid stale closures in the event listener
   const onChangeRef = useRef(onChange);
@@ -52,6 +64,11 @@ export const ShippingAddressAutocomplete: React.FC<ShippingAddressAutocompletePr
   }, [onChange, onAddressSelected]);
 
   useEffect(() => {
+    if (!isGoogleMaps()) {
+      setIsLoaded(true);
+      return;
+    }
+
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
     // If no API key, fall back to regular text input
@@ -206,6 +223,96 @@ export const ShippingAddressAutocomplete: React.FC<ShippingAddressAutocompletePr
       }
     };
   }, []);
+
+  // ── osm: debounced keyless address search ───────────────────────────────────
+  useEffect(() => {
+    if (isGoogleMaps()) return;
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      return;
+    }
+    const q = value.trim();
+    if (q.length < AUTOCOMPLETE_MIN_CHARS) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const results = await searchAddresses(q, controller.signal);
+        setSuggestions(results);
+        setShowDropdown(true);
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') setSuggestions([]);
+      }
+    }, AUTOCOMPLETE_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [value]);
+
+  const handleOsmSelect = (r: AddressResult) => {
+    justSelectedRef.current = true;
+    setShowDropdown(false);
+    setSuggestions([]);
+
+    const addressLine1 = r.street || r.name || '';
+    const components: AddressComponents = {
+      addressLine1,
+      city: r.cityName || '',
+      state: r.state || '',
+      postalCode: r.postalCode || '',
+      country: r.countryCode
+        ? COUNTRY_MAP[r.countryCode] || r.country || ''
+        : r.country || '',
+    };
+    if (addressLine1) onChangeRef.current(addressLine1);
+    onAddressSelectedRef.current?.(components);
+  };
+
+  if (!isGoogleMaps()) {
+    return (
+      <div className="relative">
+        <IconInput
+          icon={MapPin}
+          iconSize={16}
+          type="text"
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+            setShowDropdown(true);
+          }}
+          onFocus={() => {
+            if (suggestions.length > 0) setShowDropdown(true);
+          }}
+          onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+          placeholder={placeholder || t('kit.searchForAddress')}
+          disabled={disabled}
+          className={`text-sm ${className}`}
+        />
+        {showDropdown && suggestions.length > 0 && (
+          <ul className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-lg border border-theme-stroke bg-theme-header shadow-xl py-1">
+            {suggestions.map((s, i) => (
+              <li key={`${s.lat},${s.lng},${i}`}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleOsmSelect(s);
+                  }}
+                  className="w-full text-left px-3 py-2 text-sm text-theme-text hover:bg-theme-surface-hover flex items-start gap-2"
+                >
+                  <MapPin size={13} className="text-theme-text-muted mt-0.5 flex-shrink-0" />
+                  <span className="truncate">{s.formattedName}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="relative">

--- a/frontend/src/components/sponsor-dashboard/EventInfoCard.tsx
+++ b/frontend/src/components/sponsor-dashboard/EventInfoCard.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { MapPin, Calendar, Clock } from 'lucide-react';
+import { isGoogleMaps } from '../../lib/maps/provider';
+import MapLibreMap, { MapLibreMarker } from '../../lib/maps/MapLibreMap';
+import { geocodeAddress } from '../../lib/ordering';
 
 interface EventInfoCardProps {
   date: string | null;
@@ -44,26 +47,73 @@ function getStaticMapUrl(address: string): string {
   return `https://maps.googleapis.com/maps/api/staticmap?center=${encoded}&zoom=15&size=300x200&scale=2&maptype=roadmap&markers=color:red%7C${encoded}&key=${key}`;
 }
 
+// napoletana-58547: under the keyless `osm` provider we have no static-image
+// service, so geocode the address (Nominatim, via geocodeAddress) and render a
+// tiny non-interactive MapLibre map in the same 24x20 thumbnail slot.
+const OsmMapThumbnail: React.FC<{ address: string }> = ({ address }) => {
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await geocodeAddress(address);
+        if (!cancelled && result) setCoords(result);
+      } catch {
+        /* leave empty — thumbnail simply won't render */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  if (!coords) return null;
+
+  const markers: MapLibreMarker[] = [{ lat: coords.lat, lng: coords.lng, color: '#ff393a' }];
+  return (
+    <a
+      href={`https://maps.google.com/?q=${encodeURIComponent(address)}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex-shrink-0 w-24 h-20 rounded-lg overflow-hidden bg-theme-surface"
+    >
+      <MapLibreMap
+        center={coords}
+        zoom={14}
+        interactive={false}
+        markers={markers}
+        className="w-full h-full"
+        style={{ width: '100%', height: '100%' }}
+      />
+    </a>
+  );
+};
+
 export const EventInfoCard: React.FC<EventInfoCardProps> = ({ date, timezone, address, venueName }) => {
-  const mapUrl = address ? getStaticMapUrl(address) : '';
+  const mapUrl = isGoogleMaps() && address ? getStaticMapUrl(address) : '';
 
   return (
     <div className="flex gap-3">
-      {/* Map thumbnail */}
-      {mapUrl && (
-        <a
-          href={`https://maps.google.com/?q=${encodeURIComponent(address!)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex-shrink-0 w-24 h-20 rounded-lg overflow-hidden bg-theme-surface"
-        >
-          <img
-            src={mapUrl}
-            alt="Map"
-            className="w-full h-full object-cover"
-            loading="lazy"
-          />
-        </a>
+      {/* Map thumbnail — Google static image, or keyless MapLibre under osm */}
+      {isGoogleMaps() ? (
+        mapUrl && (
+          <a
+            href={`https://maps.google.com/?q=${encodeURIComponent(address!)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-shrink-0 w-24 h-20 rounded-lg overflow-hidden bg-theme-surface"
+          >
+            <img
+              src={mapUrl}
+              alt="Map"
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          </a>
+        )
+      ) : (
+        address && <OsmMapThumbnail address={address} />
       )}
 
       {/* Info */}

--- a/frontend/src/components/venue/VenueForm.tsx
+++ b/frontend/src/components/venue/VenueForm.tsx
@@ -6,6 +6,7 @@ import { Venue, VenueStatus } from '../../types';
 import { VenueCreateData } from '../../lib/api';
 import { IconInput } from '../IconInput';
 import { LocationAutocomplete } from '../LocationAutocomplete';
+import { isGoogleMaps } from '../../lib/maps/provider';
 
 interface VenueFormProps {
   venue?: Venue;
@@ -71,12 +72,15 @@ const AddVenueModal: React.FC<{ onSave: VenueFormProps['onSave']; onClose: Venue
     setSaving(true);
     setError(null);
 
-    // Try to fetch additional details (website, phone) via Places text search
+    // Try to fetch additional details (website, phone) via Places text search.
+    // napoletana-58547: Google-only — Photon/Nominatim don't expose website or
+    // phone, so under the keyless `osm` provider we skip enrichment and create
+    // the venue from the name/address/coords the autocomplete already provided.
     let website: string | undefined;
     let contactPhone: string | undefined;
 
     try {
-      if (window.google?.maps?.places && venueName) {
+      if (isGoogleMaps() && window.google?.maps?.places && venueName) {
         const searchQuery = venueName + (address ? ' ' + address : '');
         const details = await new Promise<google.maps.places.PlaceResult | null>((resolve) => {
           const div = document.createElement('div');

--- a/frontend/src/lib/maps/MapLibreMap.tsx
+++ b/frontend/src/lib/maps/MapLibreMap.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Map as MlMap, Marker as MlMarker } from 'maplibre-gl';
+import { loadMapLibre, DEFAULT_MAP_STYLE } from './loadMapLibre';
+
+export interface MapLibreMarker {
+  lat: number;
+  lng: number;
+  /** Custom pin element. When omitted, MapLibre's default teardrop pin is used. */
+  element?: HTMLElement;
+  /** Color for the default pin (ignored when `element` is provided). */
+  color?: string;
+  /** HTML popup shown when the marker is clicked. */
+  popupHTML?: string;
+  /** Called when the marker element is clicked (in addition to any popup). */
+  onClick?: () => void;
+  title?: string;
+}
+
+interface MapLibreMapProps {
+  center?: { lat: number; lng: number };
+  zoom?: number;
+  minZoom?: number;
+  maxZoom?: number;
+  markers?: MapLibreMarker[];
+  /** Optional GeoJSON overlay (FeatureCollection/Feature) drawn as line+fill+circle. */
+  geojson?: unknown;
+  /** Disable all interaction (pan/zoom) — used for "static" thumbnails. */
+  interactive?: boolean;
+  /** Fit the viewport to all markers after they are added. */
+  fitToMarkers?: boolean;
+  fitPadding?: number;
+  fitMaxZoom?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  mapStyle?: string;
+  dataTestId?: string;
+  onMapClick?: () => void;
+}
+
+const OVERLAY_SOURCE_ID = 'ml-overlay';
+
+/**
+ * napoletana-58547: generic MapLibre GL map wrapper for the keyless `osm`
+ * provider path. Handles interactive maps, static (interaction-disabled)
+ * thumbnails, custom HTML markers with popups, fit-to-markers, and an optional
+ * GeoJSON overlay. The Google equivalents live in the individual components
+ * behind `isGoogleMaps()`.
+ */
+export default function MapLibreMap({
+  center = { lat: 20, lng: 0 },
+  zoom = 3,
+  minZoom,
+  maxZoom,
+  markers = [],
+  geojson,
+  interactive = true,
+  fitToMarkers = false,
+  fitPadding = 48,
+  fitMaxZoom = 15,
+  className,
+  style,
+  mapStyle = DEFAULT_MAP_STYLE,
+  dataTestId,
+  onMapClick,
+}: MapLibreMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<MlMap | null>(null);
+  const markerObjsRef = useRef<MlMarker[]>([]);
+  const mlRef = useRef<Awaited<ReturnType<typeof loadMapLibre>> | null>(null);
+  const [ready, setReady] = useState(false);
+
+  // ── Init map once ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+
+    loadMapLibre()
+      .then((maplibregl) => {
+        if (cancelled || !containerRef.current || mapRef.current) return;
+        mlRef.current = maplibregl;
+
+        const map = new maplibregl.Map({
+          container: containerRef.current,
+          style: mapStyle,
+          center: [center.lng, center.lat],
+          zoom,
+          minZoom,
+          maxZoom,
+          interactive,
+          attributionControl: { compact: true },
+        });
+
+        if (interactive) {
+          map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+        }
+
+        if (onMapClick) {
+          map.on('click', () => onMapClick());
+        }
+
+        mapRef.current = map;
+        setReady(true);
+      })
+      .catch((err) => {
+        console.error('Failed to load MapLibre map:', err);
+      });
+
+    return () => {
+      cancelled = true;
+      markerObjsRef.current.forEach((m) => m.remove());
+      markerObjsRef.current = [];
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+      }
+    };
+    // Intentionally init-once; content is synced by the effects below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync markers + fit bounds ───────────────────────────────────────────────
+  useEffect(() => {
+    const map = mapRef.current;
+    const maplibregl = mlRef.current;
+    if (!ready || !map || !maplibregl) return;
+
+    // Clear previous markers
+    markerObjsRef.current.forEach((m) => m.remove());
+    markerObjsRef.current = [];
+
+    const bounds = new maplibregl.LngLatBounds();
+
+    for (const mk of markers) {
+      const marker = mk.element
+        ? new maplibregl.Marker({ element: mk.element, anchor: 'bottom' })
+        : new maplibregl.Marker({ color: mk.color });
+      marker.setLngLat([mk.lng, mk.lat]);
+
+      if (mk.popupHTML) {
+        marker.setPopup(new maplibregl.Popup({ offset: 24 }).setHTML(mk.popupHTML));
+      }
+      if (mk.onClick) {
+        marker.getElement().style.cursor = 'pointer';
+        marker.getElement().addEventListener('click', mk.onClick);
+      }
+      marker.addTo(map);
+      markerObjsRef.current.push(marker);
+      bounds.extend([mk.lng, mk.lat]);
+    }
+
+    if (fitToMarkers && markers.length > 1) {
+      map.fitBounds(bounds, { padding: fitPadding, maxZoom: fitMaxZoom, animate: false });
+    } else if (fitToMarkers && markers.length === 1) {
+      map.setCenter([markers[0].lng, markers[0].lat]);
+    } else {
+      map.setCenter([center.lng, center.lat]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, markers, fitToMarkers, fitPadding, fitMaxZoom, center.lat, center.lng]);
+
+  // ── Sync GeoJSON overlay ─────────────────────────────────────────────────────
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!ready || !map || !geojson) return;
+
+    const apply = () => {
+      const existing = map.getSource(OVERLAY_SOURCE_ID) as
+        | { setData: (d: unknown) => void }
+        | undefined;
+      if (existing) {
+        existing.setData(geojson as never);
+        return;
+      }
+      map.addSource(OVERLAY_SOURCE_ID, { type: 'geojson', data: geojson as never });
+      map.addLayer({
+        id: `${OVERLAY_SOURCE_ID}-fill`,
+        type: 'fill',
+        source: OVERLAY_SOURCE_ID,
+        filter: ['==', ['geometry-type'], 'Polygon'],
+        paint: { 'fill-color': '#ff393a', 'fill-opacity': 0.15 },
+      });
+      map.addLayer({
+        id: `${OVERLAY_SOURCE_ID}-line`,
+        type: 'line',
+        source: OVERLAY_SOURCE_ID,
+        paint: { 'line-color': '#ff393a', 'line-width': 2 },
+      });
+      map.addLayer({
+        id: `${OVERLAY_SOURCE_ID}-point`,
+        type: 'circle',
+        source: OVERLAY_SOURCE_ID,
+        filter: ['==', ['geometry-type'], 'Point'],
+        paint: {
+          'circle-radius': 5,
+          'circle-color': '#ff393a',
+          'circle-stroke-color': '#ffffff',
+          'circle-stroke-width': 2,
+        },
+      });
+    };
+
+    if (map.isStyleLoaded()) {
+      apply();
+    } else {
+      map.once('load', apply);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, geojson]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={style}
+      data-testid={dataTestId}
+    />
+  );
+}

--- a/frontend/src/lib/maps/loadMapLibre.ts
+++ b/frontend/src/lib/maps/loadMapLibre.ts
@@ -1,0 +1,38 @@
+// napoletana-58547: lazy-load MapLibre GL JS + its CSS.
+//
+// Mirrors the script-injection pattern of the Google loader (load once, share
+// the instance across every map component) — but MapLibre is an npm package,
+// so we use a dynamic `import()` to keep the (large) library out of the initial
+// bundle and only pull it when a map is actually rendered under the `osm` path.
+
+// Keyless vector style. OpenFreeMap is truly keyless (no signup / rate-limit
+// token) and MIT-licensed. If it is ever unavailable, swap to the Carto
+// Voyager basemap below — same MapLibre code, just a different style URL.
+export const OPENFREEMAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+export const CARTO_VOYAGER_STYLE =
+  'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json';
+
+// The generic map style used everywhere unless a caller overrides it.
+export const DEFAULT_MAP_STYLE = OPENFREEMAP_STYLE;
+
+type MapLibreModule = typeof import('maplibre-gl');
+
+let modPromise: Promise<MapLibreModule['default']> | null = null;
+
+/**
+ * Resolve the maplibre-gl default export, loading the library + its stylesheet
+ * on first use. Safe to call from multiple components — the underlying import
+ * is memoized so the library is only fetched once.
+ */
+export async function loadMapLibre(): Promise<MapLibreModule['default']> {
+  if (!modPromise) {
+    modPromise = (async () => {
+      // Side-effect CSS import (static literal so Vite can bundle it). Loaded
+      // alongside the JS the first time any MapLibre map mounts.
+      await import('maplibre-gl/dist/maplibre-gl.css');
+      const mod = await import('maplibre-gl');
+      return mod.default;
+    })();
+  }
+  return modPromise;
+}

--- a/frontend/src/lib/maps/photonAutocomplete.ts
+++ b/frontend/src/lib/maps/photonAutocomplete.ts
@@ -1,0 +1,185 @@
+// napoletana-58547: keyless address autocomplete for the `osm` provider path.
+//
+// Primary: Photon (https://photon.komoot.io) — autocomplete-optimized, keyless,
+// returns coords + a structured address. Fallback: Nominatim with
+// addressdetails=1 when Photon is unreachable or returns nothing.
+//
+// Results are mapped to the existing `CityData` shape (exported from
+// LocationAutocomplete.tsx) so callers need no changes, plus a locally-derived
+// IANA timezone (Google's path got tz from the place; here we compute it offline
+// from lat/lng via tz-lookup).
+
+import tzlookup from 'tz-lookup';
+import type { CityData } from '../../components/LocationAutocomplete';
+
+export interface AddressResult extends CityData {
+  timezone: string | null;
+  // The most specific label (venue / street / city name). Useful for
+  // establishment searches (e.g. pizzerias) where the caller wants a name
+  // distinct from the city.
+  name: string;
+}
+
+export const AUTOCOMPLETE_DEBOUNCE_MS = 300;
+export const AUTOCOMPLETE_MIN_CHARS = 3;
+
+const PHOTON_URL = 'https://photon.komoot.io/api';
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+
+function safeTimezone(lat: number, lng: number): string | null {
+  try {
+    return tzlookup(lat, lng);
+  } catch {
+    return null;
+  }
+}
+
+// ── Photon ────────────────────────────────────────────────────────────────
+interface PhotonProps {
+  name?: string;
+  housenumber?: string;
+  street?: string;
+  city?: string;
+  district?: string;
+  county?: string;
+  state?: string;
+  country?: string;
+  countrycode?: string;
+  postcode?: string;
+  type?: string;
+}
+
+interface PhotonFeature {
+  geometry?: { coordinates?: [number, number] };
+  properties?: PhotonProps;
+}
+
+function mapPhotonFeature(f: PhotonFeature): AddressResult | null {
+  const coords = f.geometry?.coordinates;
+  const p = f.properties;
+  if (!coords || !p) return null;
+  const lng = coords[0];
+  const lat = coords[1];
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+
+  const city = p.city || p.district || p.county || '';
+  const street = [p.housenumber, p.street].filter(Boolean).join(' ') || undefined;
+
+  // Build a human-readable label. Photon `name` is the most specific label
+  // (venue / street / city name); append the broader context.
+  const label = [p.name, city && city !== p.name ? city : null, p.state, p.country]
+    .filter((s): s is string => !!s && s.length > 0)
+    .join(', ');
+
+  return {
+    cityName: city || p.name || '',
+    country: p.country || '',
+    countryCode: (p.countrycode || '').toUpperCase(),
+    state: p.state || undefined,
+    street,
+    postalCode: p.postcode || undefined,
+    lat,
+    lng,
+    formattedName: label || p.name || '',
+    timezone: safeTimezone(lat, lng),
+    name: p.name || city || '',
+  };
+}
+
+async function searchPhoton(query: string, signal?: AbortSignal): Promise<AddressResult[]> {
+  const url = `${PHOTON_URL}?q=${encodeURIComponent(query)}&limit=5`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`Photon ${res.status}`);
+  const data = (await res.json()) as { features?: PhotonFeature[] };
+  return (data.features || [])
+    .map(mapPhotonFeature)
+    .filter((r): r is AddressResult => r !== null);
+}
+
+// ── Nominatim (fallback) ────────────────────────────────────────────────────
+interface NominatimAddress {
+  house_number?: string;
+  road?: string;
+  city?: string;
+  town?: string;
+  village?: string;
+  municipality?: string;
+  county?: string;
+  state?: string;
+  country?: string;
+  country_code?: string;
+  postcode?: string;
+}
+
+interface NominatimResult {
+  lat: string;
+  lon: string;
+  display_name?: string;
+  name?: string;
+  address?: NominatimAddress;
+}
+
+function mapNominatimResult(r: NominatimResult): AddressResult | null {
+  const lat = parseFloat(r.lat);
+  const lng = parseFloat(r.lon);
+  if (Number.isNaN(lat) || Number.isNaN(lng)) return null;
+  const a = r.address || {};
+  const city = a.city || a.town || a.village || a.municipality || a.county || '';
+  const street = [a.house_number, a.road].filter(Boolean).join(' ') || undefined;
+
+  return {
+    cityName: city || r.name || '',
+    country: a.country || '',
+    countryCode: (a.country_code || '').toUpperCase(),
+    state: a.state || undefined,
+    street,
+    postalCode: a.postcode || undefined,
+    lat,
+    lng,
+    formattedName: r.display_name || r.name || '',
+    timezone: safeTimezone(lat, lng),
+    name: r.name || city || '',
+  };
+}
+
+async function searchNominatim(query: string, signal?: AbortSignal): Promise<AddressResult[]> {
+  const url =
+    `${NOMINATIM_URL}?format=json&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`;
+  const res = await fetch(url, {
+    signal,
+    headers: { 'User-Agent': 'RSV.Pizza/1.0' },
+  });
+  if (!res.ok) throw new Error(`Nominatim ${res.status}`);
+  const data = (await res.json()) as NominatimResult[];
+  return (data || [])
+    .map(mapNominatimResult)
+    .filter((r): r is AddressResult => r !== null);
+}
+
+/**
+ * Keyless address search. Tries Photon first, falls back to Nominatim on error
+ * or empty result. Pass an AbortSignal to cancel an in-flight request when the
+ * query changes. Aborts propagate (the caller should ignore AbortError).
+ */
+export async function searchAddresses(
+  query: string,
+  signal?: AbortSignal,
+): Promise<AddressResult[]> {
+  const q = query.trim();
+  if (q.length < AUTOCOMPLETE_MIN_CHARS) return [];
+
+  try {
+    const photon = await searchPhoton(q, signal);
+    if (photon.length > 0) return photon;
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') throw err;
+    // fall through to Nominatim
+  }
+
+  try {
+    return await searchNominatim(q, signal);
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') throw err;
+    return [];
+  }
+}

--- a/frontend/src/lib/maps/provider.ts
+++ b/frontend/src/lib/maps/provider.ts
@@ -1,0 +1,17 @@
+// napoletana-58547: single map-provider switch.
+//
+// The Google Maps key is currently down, which breaks every map surface at
+// once (autocomplete, interactive maps, static thumbnails, pizzeria search).
+// This selector lets us run a keyless OpenStreetMap/MapLibre path by default
+// while keeping every Google implementation intact behind `isGoogleMaps()`,
+// so we can flip back to Google with zero code changes:
+//
+//   VITE_MAP_PROVIDER=google  → use the Google Maps key
+//   VITE_MAP_PROVIDER=osm      → keyless fallback (default while the key is down)
+
+export type MapProvider = 'google' | 'osm';
+
+export const MAP_PROVIDER: MapProvider =
+  (import.meta.env.VITE_MAP_PROVIDER as MapProvider) || 'osm';
+
+export const isGoogleMaps = () => MAP_PROVIDER === 'google';

--- a/frontend/src/lib/maps/tz-lookup.d.ts
+++ b/frontend/src/lib/maps/tz-lookup.d.ts
@@ -1,0 +1,5 @@
+// napoletana-58547: tz-lookup ships no bundled types. It default-exports a
+// single synchronous fn: (lat, lng) => IANA timezone id (e.g. "America/New_York").
+declare module 'tz-lookup' {
+  export default function tzlookup(lat: number, lng: number): string;
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,6 +4,10 @@ import '@testing-library/jest-dom';
 Object.defineProperty(import.meta, 'env', {
   value: {
     VITE_GOOGLE_MAPS_API_KEY: 'test-api-key',
+    // napoletana-58547: force the Google branch in tests so the osm-branch
+    // components (which lazy-load maplibre-gl / call out to Photon) aren't
+    // exercised in jsdom. Set to 'osm' to test the keyless path explicitly.
+    VITE_MAP_PROVIDER: 'google',
     VITE_API_URL: 'http://localhost:3001',
     VITE_SUPABASE_URL: 'https://test.supabase.co',
     VITE_SUPABASE_ANON_KEY: 'test-anon-key',

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,7 @@
         "@stripe/stripe-js": "^8.6.1",
         "@supabase/supabase-js": "^2.90.1",
         "@tanstack/react-query": "^5.90.20",
+        "@tmcw/togeojson": "^7.1.2",
         "@wagmi/connectors": "^5.11.2",
         "connectkit": "^1.9.1",
         "date-fns": "^4.1.0",
@@ -260,6 +261,7 @@
         "i18next": "^26.0.8",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.344.0",
+        "maplibre-gl": "^5.24.0",
         "pdfjs-dist": "^5.7.284",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -270,6 +272,7 @@
         "recharts": "^2.13.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
+        "tz-lookup": "^6.1.25",
         "use-places-autocomplete": "^4.0.1",
         "viem": "^2.44.4",
         "wagmi": "^2.19.5"
@@ -2596,6 +2599,15 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
@@ -2616,6 +2628,110 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+      "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.0.tgz",
+      "integrity": "sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
@@ -8773,6 +8889,15 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tmcw/togeojson": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@tmcw/togeojson/-/togeojson-7.1.2.tgz",
+      "integrity": "sha512-QKnFs9DAuqqBVj4d6c69tV1Dj2TspSBTqffivoN0YoBCVdP/JY1+WaYCJbzU49RkoU5NOSOJ3jtFHCdEUVh21A==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
@@ -13118,6 +13243,12 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -14553,6 +14684,12 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -15669,6 +15806,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -16285,6 +16428,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -17311,6 +17488,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -17387,6 +17573,12 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -17999,6 +18191,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
@@ -18592,6 +18796,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/preact": {
       "version": "10.24.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
@@ -18716,6 +18926,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -18859,6 +19075,12 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/radix3": {
       "version": "1.1.2",
@@ -19367,6 +19589,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/reusify": {
@@ -20709,6 +20940,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -21477,6 +21714,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
+      "license": "CC0-1.0"
     },
     "node_modules/ufo": {
       "version": "1.6.4",

--- a/plans/napoletana-58547-map-provider-abstraction.md
+++ b/plans/napoletana-58547-map-provider-abstraction.md
@@ -1,0 +1,229 @@
+# napoletana-58547 — Pluggable map-provider layer (Google ↔ keyless OSM, switchable on demand)
+
+## Problem
+
+Our Google Maps API key is currently not working, which breaks every user-visible
+map surface at once: address autocomplete, interactive maps, static venue
+thumbnails, and pizzeria discovery. We need a **temporary** fallback to a keyless
+open-source provider so the site keeps working — **without deleting any Google
+code**, so we can flip back to Google (or to a paid provider later) on demand via
+a single switch.
+
+## Goal
+
+Introduce a thin **provider abstraction** at each of the 4 map seams. Google stays
+as one implementation; a keyless OpenStreetMap-based implementation is added and
+becomes the default while the key is down. A single env var per surface selects the
+active provider at build/deploy time — no code change required to switch back.
+
+**Non-goals:** removing Google code, achieving Google-parity POI quality, changing
+any data model. This is a resilience/switchability layer, not a redesign.
+
+## What already works (do not touch)
+
+- **Geocoding (address → lat/lng)** is *already* off Google:
+  - `frontend/src/lib/ordering.ts` `geocodeAddress()` → Nominatim only.
+  - `backend/src/lib/geocode.ts` `geocodeCity()` → Nominatim-first, Google only as
+    fallback (`GOOGLE_GEOCODING_API_KEY`). Dead key just means it stops at Nominatim.
+  - **Keep both as-is.** They are the coordinate source the new components reuse.
+
+## The switch
+
+One provider selector, defaulting to the keyless path while Google is down:
+
+- **Frontend:** `VITE_MAP_PROVIDER` = `google` | `osm` (default `osm`).
+  Read once in a new `frontend/src/lib/maps/provider.ts`:
+  ```ts
+  export type MapProvider = 'google' | 'osm';
+  export const MAP_PROVIDER: MapProvider =
+    (import.meta.env.VITE_MAP_PROVIDER as MapProvider) || 'osm';
+  export const isGoogleMaps = () => MAP_PROVIDER === 'google';
+  ```
+- **Edge function (pizzeria search):** `MAP_PROVIDER` Supabase secret = `google` | `osm`
+  (default `osm`). Read in `search-pizzerias/index.ts`.
+
+To restore Google later: set `VITE_MAP_PROVIDER=google` in Vercel (+ redeploy) and
+`MAP_PROVIDER=google` in Supabase secrets. Zero code changes.
+
+## Keyless provider choices (the `osm` path)
+
+| Seam | Keyless replacement | Notes |
+|---|---|---|
+| Interactive maps | **MapLibre GL JS** (`maplibre-gl`) + **OpenFreeMap** vector style (`https://tiles.openfreemap.org/styles/liberty`) | Truly keyless, no rate-limit signup, MIT. Fallback style: Carto `voyager` basemap. Avoid raw `tile.openstreetmap.org` (usage policy forbids app-scale use). |
+| Static map images | **Non-interactive MapLibre map** (interaction disabled) in place of the `<img>` | No keyless static-image service is reliable; a locked-down MapLibre instance is the simplest keyless equivalent. Keep the Google `<img>` branch behind `isGoogleMaps()`. |
+| Address autocomplete | **Photon** (`https://photon.komoot.io/api?q=`) primary, **Nominatim** fallback | Photon is autocomplete-optimized and keyless; returns coords + structured address. |
+| Pizzeria POI search | **Overpass API** (`amenity=restaurant`/`fast_food` + `cuisine~pizza` around lat/lng) | Keyless. Coverage/quality drops outside major metros — acceptable "for now", flagged in UI copy is not needed but note in PR. |
+| Timezone (from autocomplete) | **`tz-lookup`** npm (offline lat/lng → IANA tz) | Google path derived tz from the place; keyless path computes it locally. |
+
+## Architecture — new `frontend/src/lib/maps/` module
+
+Create wrapper components that internally branch on `MAP_PROVIDER`, keeping each
+Google implementation intact as the `google` branch:
+
+```
+frontend/src/lib/maps/
+  provider.ts            # MAP_PROVIDER + helpers (above)
+  MapLibreMap.tsx        # generic interactive MapLibre map (markers, popups, fitBounds, GeoJSON)
+  loadMapLibre.ts        # lazy-load maplibre-gl + css (mirrors existing loadGoogleMaps pattern)
+  photonAutocomplete.ts  # debounced Photon→Nominatim search returning CityData[]
+  overpassPizzerias.ts   # (shared types) Overpass query→Pizzeria[] mapper (used by edge fn logic ref)
+```
+
+### Seam 1 — Interactive maps (4 components)
+
+Files: `GPPEventsMap.tsx`, `GPPPizzeriasMap.tsx`, `GPPMap.tsx`, `ParticipatingPizzeriasMap.tsx`.
+
+Pattern per file: at the top of the render/effect, branch on `isGoogleMaps()`.
+- `google` branch → the **existing** `new google.maps.Map` + `loadGoogleMaps` code
+  (unchanged, kept verbatim).
+- `osm` branch → new MapLibre code:
+  - `new maplibregl.Map({ style: OPENFREEMAP_STYLE, ... })`
+  - Markers → `new maplibregl.Marker({ element })` (custom pin element for the
+    Molto Benny / status icons).
+  - InfoWindow → `new maplibregl.Popup()`.
+  - `LatLngBounds`/`fitBounds` → `maplibregl.LngLatBounds` + `map.fitBounds(bounds, {padding})`.
+  - **`GPPMap.tsx` uses `KmlLayer`** — MapLibre has none. Convert the KML to GeoJSON
+    with `@tmcw/togeojson` (fetch the KML, parse, `map.addSource`/`addLayer`).
+    This is the one non-mechanical port; budget extra time.
+
+Cleanest structure: extract each component's marker/data logic into a shared helper
+and have the two branches only differ in the map primitive calls.
+
+### Seam 2 — Static map images (3 spots)
+
+Files: `VenueMap.tsx`, `PizzeriaSearch.tsx` (line ~324 static URL),
+`sponsor-dashboard/EventInfoCard.tsx` (line ~44 static URL).
+
+- Keep the Google `staticmap` `<img>` branch exactly as-is behind `isGoogleMaps()`.
+- Add an `osm` branch that renders a small `<MapLibreMap>` with interaction disabled
+  (`interactive:false`, `dragPan/scrollZoom` off), single marker at center, same
+  container `className` so layout is unchanged. Tap-through link: keep the existing
+  `google.com/maps/search` deep link (a link is fine even when tiles are OSM), or
+  switch to `https://www.openstreetmap.org/?mlat=..&mlon=..#map=17/..` under `osm`.
+- `VenueMap.tsx` already has a `MapPin` fallback for missing key/geocode-fail — reuse
+  it as the loading/empty state.
+
+### Seam 3 — Address autocomplete (4 components)
+
+Files: `LocationAutocomplete.tsx`, `PlaceAutocomplete.tsx`,
+`kit/ShippingAddressAutocomplete.tsx`, `venue/VenueForm.tsx` (`PlacesService`).
+
+- Keep the Google `Autocomplete`/`PlacesService` code behind `isGoogleMaps()`.
+- Add an `osm` branch built on the existing `IconInput` (per CLAUDE.md — no raw
+  inputs) + a results dropdown, wired to `photonAutocomplete.ts`:
+  - Debounce (~300ms), min 3 chars, abortable fetch.
+  - Map Photon/Nominatim result → the existing `CityData` shape
+    (`cityName/country/countryCode/state/street/postalCode/lat/lng/formattedName`).
+    Photon `properties` covers city/country/countrycode/state/street/postcode;
+    fall back to Nominatim `addressdetails=1` when a field is missing.
+  - Derive `onTimezoneChange` from `tz-lookup(lat, lng)` (Google path got tz from
+    the place; keep the same callback contract).
+  - Fire the same callbacks (`onPlaceSelected`, `onLocationSelected`, `onCitySelected`)
+    so **no caller changes**. `placeId` → `null` under `osm` (callers already accept null).
+- Match the existing dropdown look to `LocationModal`/existing modal patterns.
+
+### Seam 4 — Pizzeria POI discovery (edge function)
+
+File: `supabase/functions/search-pizzerias/index.ts` (+ helper `scripts/backfill-place-ids.js`
+left on Google; it's an offline one-shot, not runtime — leave as-is, note in PR).
+
+- Branch `searchGooglePlaces` vs new `searchOverpassPizzerias(lat, lng, radius)` on
+  the `MAP_PROVIDER` secret.
+- Overpass query:
+  ```
+  [out:json][timeout:15];
+  ( node["amenity"~"restaurant|fast_food"]["cuisine"~"pizza",i](around:RADIUS,LAT,LNG);
+    way ["amenity"~"restaurant|fast_food"]["cuisine"~"pizza",i](around:RADIUS,LAT,LNG); );
+  out center 20;
+  ```
+  Endpoint: `https://overpass-api.de/api/interpreter` (POST, `data=`). Map each element
+  → the existing `Pizzeria` shape (id = `osm/{type}/{id}`, name = `tags.name`,
+  address from `addr:*` tags, `location` from `lat/lon` or `center`, phone =
+  `tags.phone`, url = `tags.website`; rating/priceLevel/isOpen → undefined).
+- **Keep the in-memory response cache** (already there) — Overpass is slower and
+  rate-limited, so caching matters more, not less. Consider extending TTL under `osm`.
+- Preserve the existing sort; with no ratings it degenerates to insertion order —
+  acceptable "for now".
+
+## Dependencies to add (frontend)
+
+- `maplibre-gl` (interactive + static maps)
+- `@tmcw/togeojson` (KML → GeoJSON for GPPMap)
+- `tz-lookup` (offline timezone from lat/lng)
+
+All MIT/BSD, no keys. `maplibre-gl` ships its own CSS — import in `loadMapLibre.ts`.
+
+## Env / config changes
+
+- `frontend/.env.example`: add `VITE_MAP_PROVIDER=osm` with a comment ("`google` to
+  use the Google key; `osm` for the keyless fallback").
+- **Vercel:** add `VITE_MAP_PROVIDER=osm` (Production + Preview). Keep
+  `VITE_GOOGLE_MAPS_API_KEY` set so flipping back is instant.
+- **Supabase secrets:** add `MAP_PROVIDER=osm`. Keep `GOOGLE_PLACES_API_KEY`.
+
+## Rollout (respect prod-shared-backend ordering, per CLAUDE.md)
+
+1. Land the frontend abstraction (previews auto-deploy per branch). Verify on the
+   preview URL with `VITE_MAP_PROVIDER=osm`.
+2. Deploy the `search-pizzerias` edge function **and** set `MAP_PROVIDER=osm` secret
+   (edge functions deploy independently of `master`).
+3. Set `VITE_MAP_PROVIDER=osm` in Vercel Production, redeploy frontend.
+4. Rollback = set both back to `google` (assuming the key is restored).
+
+## Testing / verification
+
+- Existing tests reference `VITE_GOOGLE_MAPS_API_KEY` (`test/setup.ts`,
+  `VenueForm.test.tsx`, `RSVPModal.test.tsx`). Add `VITE_MAP_PROVIDER` to
+  `test/setup.ts`; make the `osm`-branch components render without a Google global.
+- Manual matrix (both provider values) on: create-event location autocomplete
+  (→ tz + coords populate), EventPage venue thumbnail, `/gpp` events map + KML map,
+  participating-pizzerias map, pizzeria search (Overpass results appear), kit
+  shipping autocomplete, sponsor dashboard event card.
+- `npx tsc --noEmit` in `frontend/` (vite build does **not** typecheck — per repo memory).
+
+## Risks / caveats
+
+- **Overpass coverage/quality** is materially worse than Google Places outside big
+  cities (missing pizzerias, no ratings/hours/photos). This is the weakest seam;
+  acceptable only as a temporary bridge. The `sicilian-25988` pizzeria-photos work
+  assumes Google `place.id` — those photos won't exist under `osm` (Overpass ids
+  aren't Google place ids). Flag but don't block.
+- **Public tile/geocoder rate limits** (OpenFreeMap, Photon, Overpass are community
+  services with fair-use policies). Fine for current traffic; if we stay on `osm`
+  long-term, move to self-hosted or a free-tier key provider (MapTiler/Geoapify) —
+  same abstraction, new branch.
+- **`GPPMap` KML→GeoJSON** is the only non-mechanical port; verify the KML actually
+  fetches from its current source and renders.
+- Keep all Google branches compiling — don't let the `osm` default bit-rot the
+  Google path (it's the rollback).
+
+## File checklist
+
+New:
+- `frontend/src/lib/maps/provider.ts`
+- `frontend/src/lib/maps/loadMapLibre.ts`
+- `frontend/src/lib/maps/MapLibreMap.tsx`
+- `frontend/src/lib/maps/photonAutocomplete.ts`
+- `frontend/src/lib/maps/overpassPizzerias.ts` (shared mapper/types)
+
+Edited (add `osm` branch, keep Google branch):
+- `frontend/src/components/GPPEventsMap.tsx`
+- `frontend/src/components/GPPPizzeriasMap.tsx`
+- `frontend/src/components/GPPMap.tsx`
+- `frontend/src/components/ParticipatingPizzeriasMap.tsx`
+- `frontend/src/components/VenueMap.tsx`
+- `frontend/src/components/PizzeriaSearch.tsx`
+- `frontend/src/components/sponsor-dashboard/EventInfoCard.tsx`
+- `frontend/src/components/LocationAutocomplete.tsx`
+- `frontend/src/components/PlaceAutocomplete.tsx`
+- `frontend/src/components/kit/ShippingAddressAutocomplete.tsx`
+- `frontend/src/components/venue/VenueForm.tsx`
+- `supabase/functions/search-pizzerias/index.ts`
+- `frontend/.env.example`
+- `frontend/src/test/setup.ts`
+- `frontend/package.json` (deps)
+
+Untouched (already keyless / intentionally left on Google):
+- `frontend/src/lib/ordering.ts` (`geocodeAddress` — Nominatim)
+- `backend/src/lib/geocode.ts` (Nominatim-first)
+- `scripts/backfill-place-ids.js` (offline one-shot)


### PR DESCRIPTION
## napoletana-58547 — Pluggable map-provider abstraction (part 1 of 2)

The Google Maps key is currently down, breaking autocomplete, interactive maps, and static thumbnails at once. This adds a **provider abstraction** so all of it works keyless — **without deleting any Google code**. Every Google implementation is kept behind `isGoogleMaps()`; a keyless `osm` path is added and defaulted. Flip back anytime via one env var.

(Part 2 = the edge-function Overpass pizzeria swap, PR #1039.)

### The switch
`VITE_MAP_PROVIDER` = `google` | `osm` (default `osm`), read in `frontend/src/lib/maps/provider.ts`. Set `VITE_MAP_PROVIDER=google` in Vercel + redeploy to restore Google with zero code change. Keep `VITE_GOOGLE_MAPS_API_KEY` set for that.

### `osm` path (keyless)
- **Interactive maps** → MapLibre GL + OpenFreeMap vector tiles (`GPPEventsMap`, `GPPPizzeriasMap`, `GPPMap`, `ParticipatingPizzeriasMap`). `maplibre-gl` code-splits into its own lazy chunk — Google users never download it.
- **Static thumbnails** → non-interactive MapLibre map (`VenueMap`, `PizzeriaSearch`, `EventInfoCard`).
- **Autocomplete** → Photon → Nominatim, mapped to the existing `CityData` shape (timezone via `tz-lookup`). No caller signature changes (`LocationAutocomplete`, `PlaceAutocomplete`, `ShippingAddressAutocomplete`, `VenueForm`).

New deps: `maplibre-gl`, `@tmcw/togeojson`, `tz-lookup`. `tsc --noEmit` clean; `npm run build` green.

### Deploy
Set `VITE_MAP_PROVIDER=osm` in Vercel (Production + Preview) + redeploy. Geocoding (`ordering.ts`, `backend/geocode.ts`) was already Nominatim — untouched.

### ⚠️ Needs preview verification / known gaps
- **GPPMap KML→GeoJSON**: Google My Maps' KML endpoint likely sends no CORS headers, so the browser fetch may be blocked — degrades to the "View map on Google Maps" link. May need a CORS proxy / server-side fetch. **Verify on preview.**
- `VenueForm` osm path skips website/phone enrichment (Photon/Nominatim don't expose them); venue still created from name/address/coords.
- Marker clustering not ported under osm (individual markers — heavier for large event counts, fine as a temporary bridge).
- `GPPPizzeriasMap` shows only persisted `photoUrl` under osm (Overpass ids ≠ Google place ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)