### PR TITLE
focaccina-58550: customizable one sheet (pricing + details)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -224,6 +224,12 @@ model Party {
   // empty goal bar + "Set goal" affordance when null.
   hostGoals Json? @map("host_goals")
 
+  // focaccina-58550: host-customizable one-sheet config (headline/blurb,
+  // sponsorship pricing tiers, custom detail sections). Rendered read-only on
+  // the public /onesheet/:slug page. Nullable; unconfigured events render the
+  // fixed default one-sheet.
+  oneSheetConfig Json? @map("one_sheet_config")
+
   // Quiz settings
   quizEnabled Boolean @default(false) @map("quiz_enabled")
 

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -112,6 +112,7 @@ router.get('/:slug', optionalAuth, async (req: AuthRequest, res: Response, next:
         turtleRolesEnabled: true,
         underbossStatus: true,
         reimbursementCapUsd: true,
+        oneSheetConfig: true, // focaccina-58550
         password: true, // Just to check if it exists
         userId: true,
         user: {
@@ -194,6 +195,7 @@ router.get('/:slug', optionalAuth, async (req: AuthRequest, res: Response, next:
           turtleRolesEnabled: true,
           underbossStatus: true,
           reimbursementCapUsd: true,
+          oneSheetConfig: true, // focaccina-58550
           password: true,
           userId: true,
           user: {
@@ -422,6 +424,8 @@ router.get('/:slug', optionalAuth, async (req: AuthRequest, res: Response, next:
         sponsors,
         pageViewStats,
         reimbursementCapUsd: party.reimbursementCapUsd != null ? Number(party.reimbursementCapUsd) : null,
+        // focaccina-58550: host-customizable one-sheet config (read-only on public page).
+        oneSheetConfig: party.oneSheetConfig ?? null,
         // arugula-38633 v2 follow-up: numeric-tag fallback when no
         // underboss-validated cap exists. See helpers/reimbursementCap.ts.
         effectiveReimbursementCapUsd: computeEffectiveCapUsd({

--- a/backend/src/routes/party.routes.ts
+++ b/backend/src/routes/party.routes.ts
@@ -514,6 +514,8 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       taxFormRequired,
       // quattro-71244: gamified dashboard goals (JSONB) — per-KPI host targets.
       hostGoals,
+      // focaccina-58550: host-customizable one-sheet config (JSONB).
+      oneSheetConfig,
       // porchetta-81402: host can edit the free-text cancellation reason
       // without re-cancelling. Cancel/reinstate themselves go through their
       // dedicated POST endpoints — NOT through this PATCH whitelist.
@@ -716,6 +718,71 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
       }
     }
 
+    // focaccina-58550: sanitize the host-customizable one-sheet config. Never
+    // store the raw body — build a clean object with capped strings + arrays,
+    // dropping unknown keys. `null` clears the config. Mirrors the externalLinks
+    // validation pattern above.
+    let oneSheetConfigToWrite: any | undefined = undefined;
+    if (oneSheetConfig !== undefined) {
+      if (oneSheetConfig === null) {
+        oneSheetConfigToWrite = null;
+      } else if (typeof oneSheetConfig !== 'object' || Array.isArray(oneSheetConfig)) {
+        throw new AppError('Invalid one sheet config', 400, 'VALIDATION_ERROR');
+      } else {
+        const capStr = (v: any, max: number): string | undefined => {
+          if (typeof v !== 'string') return undefined;
+          const trimmed = v.trim();
+          return trimmed ? trimmed.slice(0, max) : undefined;
+        };
+        const clean: {
+          headline?: string;
+          blurb?: string;
+          tiers?: Array<{ id: string; name: string; price?: string; benefits: string[] }>;
+          sections?: Array<{ id: string; heading: string; body: string }>;
+        } = {};
+
+        const headline = capStr(oneSheetConfig.headline, 120);
+        if (headline !== undefined) clean.headline = headline;
+        const blurb = capStr(oneSheetConfig.blurb, 2000);
+        if (blurb !== undefined) clean.blurb = blurb;
+
+        if (Array.isArray(oneSheetConfig.tiers)) {
+          clean.tiers = oneSheetConfig.tiers
+            .filter((t: any) => t && typeof t === 'object' && !Array.isArray(t))
+            .slice(0, 12)
+            .map((t: any) => {
+              const benefits = Array.isArray(t.benefits)
+                ? t.benefits
+                    .filter((b: any) => typeof b === 'string')
+                    .slice(0, 20)
+                    .map((b: string) => b.slice(0, 200))
+                : [];
+              const tier: { id: string; name: string; price?: string; benefits: string[] } = {
+                id: typeof t.id === 'string' && t.id ? t.id.slice(0, 64) : crypto.randomUUID(),
+                name: capStr(t.name, 120) ?? '',
+                benefits,
+              };
+              const price = capStr(t.price, 60);
+              if (price !== undefined) tier.price = price;
+              return tier;
+            });
+        }
+
+        if (Array.isArray(oneSheetConfig.sections)) {
+          clean.sections = oneSheetConfig.sections
+            .filter((s: any) => s && typeof s === 'object' && !Array.isArray(s))
+            .slice(0, 12)
+            .map((s: any) => ({
+              id: typeof s.id === 'string' && s.id ? s.id.slice(0, 64) : crypto.randomUUID(),
+              heading: capStr(s.heading, 120) ?? '',
+              body: capStr(s.body, 4000) ?? '',
+            }));
+        }
+
+        oneSheetConfigToWrite = clean;
+      }
+    }
+
     // tigella-58513: authoritative guard — GPP events are capped at 3 hours.
     // The frontend block is UX only; this also covers the NL Event Assistant
     // path (arancini-58492), which writes through this same PATCH endpoint.
@@ -834,6 +901,7 @@ router.patch('/:id', async (req: AuthRequest, res: Response, next: NextFunction)
         ...(reimbursementCapUsdToWrite !== undefined && { reimbursementCapUsd: reimbursementCapUsdToWrite }),
         ...(taxFormRequiredToWrite !== undefined && { taxFormRequired: taxFormRequiredToWrite }),
         ...(hostGoalsToWrite !== undefined && { hostGoals: hostGoalsToWrite }),
+        ...(oneSheetConfigToWrite !== undefined && { oneSheetConfig: oneSheetConfigToWrite }),
         // porchetta-81402: allow editing the cancellation reason (truncated to
         // 500 chars to match the cancel-handler limit). Empty string clears it.
         ...(cancellationReason !== undefined && {

--- a/frontend/src/components/sponsors/OneSheetEditor.tsx
+++ b/frontend/src/components/sponsors/OneSheetEditor.tsx
@@ -1,0 +1,339 @@
+import React, { useState } from 'react';
+import {
+  Plus,
+  X,
+  Trash2,
+  Save,
+  Check,
+  ExternalLink,
+  Type,
+  FileText,
+  Tag,
+  DollarSign,
+  ListChecks,
+} from 'lucide-react';
+import { IconInput } from '../IconInput';
+import { updateParty } from '../../lib/supabase';
+import { uuid } from '../../lib/utils';
+import type { Party, OneSheetConfig, OneSheetTier, OneSheetSection } from '../../types';
+
+interface OneSheetEditorProps {
+  party: Party;
+  onSaved?: (config: OneSheetConfig) => void;
+}
+
+// focaccina-58550: host editor for the customizable public one-sheet
+// (/onesheet/:slug). Edits headline/blurb, sponsorship pricing tiers, and
+// free-text detail sections; the public page renders them read-only.
+export function OneSheetEditor({ party, onSaved }: OneSheetEditorProps) {
+  const initial = party.oneSheetConfig ?? {};
+  const [headline, setHeadline] = useState<string>(initial.headline ?? '');
+  const [blurb, setBlurb] = useState<string>(initial.blurb ?? '');
+  const [tiers, setTiers] = useState<OneSheetTier[]>(
+    (initial.tiers ?? []).map((t) => ({
+      id: t.id || uuid(),
+      name: t.name ?? '',
+      price: t.price ?? '',
+      benefits: Array.isArray(t.benefits) ? [...t.benefits] : [],
+    }))
+  );
+  const [sections, setSections] = useState<OneSheetSection[]>(
+    (initial.sections ?? []).map((s) => ({
+      id: s.id || uuid(),
+      heading: s.heading ?? '',
+      body: s.body ?? '',
+    }))
+  );
+
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Tier helpers
+  const addTier = () =>
+    setTiers((prev) => [...prev, { id: uuid(), name: '', price: '', benefits: [] }]);
+  const removeTier = (id: string) => setTiers((prev) => prev.filter((t) => t.id !== id));
+  const updateTier = (id: string, patch: Partial<OneSheetTier>) =>
+    setTiers((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  const addBenefit = (tierId: string) =>
+    updateTierBenefits(tierId, (b) => [...b, '']);
+  const removeBenefit = (tierId: string, index: number) =>
+    updateTierBenefits(tierId, (b) => b.filter((_, i) => i !== index));
+  const setBenefit = (tierId: string, index: number, value: string) =>
+    updateTierBenefits(tierId, (b) => b.map((x, i) => (i === index ? value : x)));
+  function updateTierBenefits(tierId: string, fn: (benefits: string[]) => string[]) {
+    setTiers((prev) =>
+      prev.map((t) => (t.id === tierId ? { ...t, benefits: fn(t.benefits) } : t))
+    );
+  }
+
+  // Section helpers
+  const addSection = () =>
+    setSections((prev) => [...prev, { id: uuid(), heading: '', body: '' }]);
+  const removeSection = (id: string) =>
+    setSections((prev) => prev.filter((s) => s.id !== id));
+  const updateSection = (id: string, patch: Partial<OneSheetSection>) =>
+    setSections((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+
+  // Build a cleaned config: drop empty strings/benefits and fully-empty entries.
+  const buildConfig = (): OneSheetConfig => {
+    const cfg: OneSheetConfig = {};
+    const h = headline.trim();
+    const b = blurb.trim();
+    if (h) cfg.headline = h;
+    if (b) cfg.blurb = b;
+
+    const cleanTiers = tiers
+      .map((t) => ({
+        id: t.id,
+        name: (t.name ?? '').trim(),
+        price: (t.price ?? '').trim(),
+        benefits: t.benefits.map((x) => x.trim()).filter(Boolean),
+      }))
+      .filter((t) => t.name || t.price || t.benefits.length > 0)
+      .map((t) => {
+        const tier: OneSheetTier = { id: t.id, name: t.name, benefits: t.benefits };
+        if (t.price) tier.price = t.price;
+        return tier;
+      });
+    if (cleanTiers.length > 0) cfg.tiers = cleanTiers;
+
+    const cleanSections = sections
+      .map((s) => ({
+        id: s.id,
+        heading: (s.heading ?? '').trim(),
+        body: (s.body ?? '').trim(),
+      }))
+      .filter((s) => s.heading || s.body);
+    if (cleanSections.length > 0) cfg.sections = cleanSections;
+
+    return cfg;
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const config = buildConfig();
+      const ok = await updateParty(party.id, { one_sheet_config: config });
+      if (!ok) {
+        setError('Could not save. Please try again.');
+        return;
+      }
+      onSaved?.(config);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2500);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not save. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const oneSheetUrl = `/onesheet/${party.customUrl || party.inviteCode}`;
+
+  return (
+    <div className="card bg-theme-header border-theme-stroke p-4 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-theme-text">One Sheet</h2>
+          <p className="text-xs text-theme-text-faint mt-0.5">
+            Customize your public sponsorship one sheet — headline, pricing packages, and detail sections.
+          </p>
+        </div>
+        <a
+          href={oneSheetUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-white/5 hover:bg-white/10 text-theme-text transition-colors shrink-0"
+        >
+          <ExternalLink size={16} />
+          <span className="hidden sm:inline">View one sheet</span>
+        </a>
+      </div>
+
+      {/* Intro headline + blurb */}
+      <div className="space-y-3">
+        <IconInput
+          icon={Type}
+          type="text"
+          placeholder="Headline (e.g. Partner with us this year)"
+          value={headline}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setHeadline(e.target.value)}
+          maxLength={120}
+        />
+        <IconInput
+          icon={FileText}
+          multiline
+          rows={3}
+          placeholder="Intro blurb — a short paragraph shown under the flyer"
+          value={blurb}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBlurb(e.target.value)}
+          maxLength={2000}
+        />
+      </div>
+
+      {/* Pricing tiers */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-theme-text">Sponsorship packages</h3>
+          <button
+            type="button"
+            onClick={addTier}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm rounded-lg bg-white/5 hover:bg-white/10 text-theme-text transition-colors"
+          >
+            <Plus size={16} />
+            Add package
+          </button>
+        </div>
+
+        {tiers.map((tier) => (
+          <div
+            key={tier.id}
+            className="rounded-xl bg-white/5 border border-theme-stroke p-3 space-y-3"
+          >
+            <div className="flex items-start gap-2">
+              <div className="flex-1 space-y-3">
+                <IconInput
+                  icon={Tag}
+                  type="text"
+                  placeholder="Package name (e.g. Gold)"
+                  value={tier.name}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateTier(tier.id, { name: e.target.value })
+                  }
+                  maxLength={120}
+                />
+                <IconInput
+                  icon={DollarSign}
+                  type="text"
+                  placeholder="Price (e.g. $500, In-kind, Contact us)"
+                  value={tier.price ?? ''}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateTier(tier.id, { price: e.target.value })
+                  }
+                  maxLength={60}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removeTier(tier.id)}
+                title="Remove package"
+                className="p-2 rounded-lg text-theme-text-muted hover:text-red-400 hover:bg-white/5 transition-colors shrink-0"
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+
+            {/* Benefits */}
+            <div className="space-y-2 pl-1">
+              {tier.benefits.map((benefit, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <div className="flex-1">
+                    <IconInput
+                      icon={ListChecks}
+                      type="text"
+                      placeholder="Benefit (e.g. Logo on flyer)"
+                      value={benefit}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        setBenefit(tier.id, i, e.target.value)
+                      }
+                      maxLength={200}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeBenefit(tier.id, i)}
+                    title="Remove benefit"
+                    className="p-2 rounded-lg text-theme-text-muted hover:text-red-400 hover:bg-white/5 transition-colors shrink-0"
+                  >
+                    <X size={16} />
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => addBenefit(tier.id)}
+                className="flex items-center gap-1.5 text-xs text-theme-text-muted hover:text-theme-text transition-colors"
+              >
+                <Plus size={14} />
+                Add benefit
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Detail sections */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-theme-text">Detail sections</h3>
+          <button
+            type="button"
+            onClick={addSection}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm rounded-lg bg-white/5 hover:bg-white/10 text-theme-text transition-colors"
+          >
+            <Plus size={16} />
+            Add section
+          </button>
+        </div>
+
+        {sections.map((section) => (
+          <div
+            key={section.id}
+            className="rounded-xl bg-white/5 border border-theme-stroke p-3 space-y-3"
+          >
+            <div className="flex items-start gap-2">
+              <div className="flex-1 space-y-3">
+                <IconInput
+                  icon={Tag}
+                  type="text"
+                  placeholder="Section heading (e.g. About the event)"
+                  value={section.heading}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateSection(section.id, { heading: e.target.value })
+                  }
+                  maxLength={120}
+                />
+                <IconInput
+                  icon={FileText}
+                  multiline
+                  rows={3}
+                  placeholder="Section body — free text shown on the one sheet"
+                  value={section.body}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    updateSection(section.id, { body: e.target.value })
+                  }
+                  maxLength={4000}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removeSection(section.id)}
+                title="Remove section"
+                className="p-2 rounded-lg text-theme-text-muted hover:text-red-400 hover:bg-white/5 transition-colors shrink-0"
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Save */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#ff393a] hover:bg-[#ff393a]/80 text-white font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saved ? <Check size={18} /> : <Save size={18} />}
+          {saving ? 'Saving…' : saved ? 'Saved' : 'Save one sheet'}
+        </button>
+        {error && <span className="text-sm text-red-400">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/sponsors/index.ts
+++ b/frontend/src/components/sponsors/index.ts
@@ -6,3 +6,4 @@ export type { PartnerFormData } from './PartnerForm';
 export { PartnerIntakeButton } from './PartnerIntakeButton';
 export { PartnerFlyerGenerator } from './PartnerFlyerGenerator';
 export { MercuryReconcilePanel } from './MercuryReconcilePanel';
+export { OneSheetEditor } from './OneSheetEditor';

--- a/frontend/src/contexts/PizzaContext.tsx
+++ b/frontend/src/contexts/PizzaContext.tsx
@@ -200,6 +200,8 @@ export function dbPartyToParty(dbParty: db.DbParty, guests: Guest[]): Party {
     parkingNotes: dbParty.parking_notes ?? null,
     // quattro-71244: gamified-dashboard goal targets.
     hostGoals: dbParty.host_goals ?? null,
+    // focaccina-58550: host-customizable one-sheet config.
+    oneSheetConfig: dbParty.one_sheet_config ?? null,
     // porchetta-81402: soft-cancel state.
     cancelledAt: dbParty.cancelled_at ?? null,
     cancelledBy: dbParty.cancelled_by ?? null,

--- a/frontend/src/i18n/locales/de/partner.json
+++ b/frontend/src/i18n/locales/de/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "Event nicht gefunden",
     "eventNotFoundDesc": "Das gesuchte Event existiert nicht oder wurde entfernt.",
     "partnersHeader": "Partner",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "Vielen Dank!",
     "thankYouDesc": "Wir haben Ihr Interesse erhalten und werden uns in Kürze bei Ihnen melden.",
     "interestedInPartnering": "Interesse an einer Partnerschaft?",

--- a/frontend/src/i18n/locales/en/partner.json
+++ b/frontend/src/i18n/locales/en/partner.json
@@ -184,6 +184,7 @@
     "eventNotFound": "Event Not Found",
     "eventNotFoundDesc": "The event you're looking for doesn't exist or has been removed.",
     "partnersHeader": "Partners",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "Thank you!",
     "thankYouDesc": "We've received your interest and will be in touch soon.",
     "interestedInPartnering": "Interested in Partnering?",

--- a/frontend/src/i18n/locales/es/partner.json
+++ b/frontend/src/i18n/locales/es/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "Evento No Encontrado",
     "eventNotFoundDesc": "El evento que buscas no existe o ha sido eliminado.",
     "partnersHeader": "Socios",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "¡Gracias!",
     "thankYouDesc": "Hemos recibido tu interés y nos pondremos en contacto pronto.",
     "interestedInPartnering": "¿Interesado en asociarte?",

--- a/frontend/src/i18n/locales/fr/partner.json
+++ b/frontend/src/i18n/locales/fr/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "Événement introuvable",
     "eventNotFoundDesc": "L'événement que vous recherchez n'existe pas ou a été supprimé.",
     "partnersHeader": "Partenaires",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "Merci !",
     "thankYouDesc": "Nous avons reçu votre intérêt et vous contacterons bientôt.",
     "interestedInPartnering": "Intéressé par un partenariat ?",

--- a/frontend/src/i18n/locales/ja/partner.json
+++ b/frontend/src/i18n/locales/ja/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "イベントが見つかりません",
     "eventNotFoundDesc": "お探しのイベントは存在しないか、削除されました。",
     "partnersHeader": "パートナー",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "ありがとうございます！",
     "thankYouDesc": "ご関心をお寄せいただきありがとうございます。近日中にご連絡いたします。",
     "interestedInPartnering": "パートナーになりませんか？",

--- a/frontend/src/i18n/locales/ko/partner.json
+++ b/frontend/src/i18n/locales/ko/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "이벤트를 찾을 수 없습니다",
     "eventNotFoundDesc": "찾으시는 이벤트가 존재하지 않거나 삭제되었습니다.",
     "partnersHeader": "파트너",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "감사합니다!",
     "thankYouDesc": "관심을 받았으며 곧 연락드리겠습니다.",
     "interestedInPartnering": "파트너십에 관심이 있으신가요?",

--- a/frontend/src/i18n/locales/pt/partner.json
+++ b/frontend/src/i18n/locales/pt/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "Evento Não Encontrado",
     "eventNotFoundDesc": "O evento que você está procurando não existe ou foi removido.",
     "partnersHeader": "Parceiros",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "Obrigado!",
     "thankYouDesc": "Recebemos seu interesse e entraremos em contato em breve.",
     "interestedInPartnering": "Interessado em ser parceiro?",

--- a/frontend/src/i18n/locales/zh/partner.json
+++ b/frontend/src/i18n/locales/zh/partner.json
@@ -173,6 +173,7 @@
     "eventNotFound": "未找到活动",
     "eventNotFoundDesc": "您查找的活动不存在或已被删除。",
     "partnersHeader": "合作伙伴",
+    "pricingHeader": "Sponsorship Packages",
     "thankYou": "谢谢！",
     "thankYouDesc": "我们已收到您的意向，将尽快与您联系。",
     "interestedInPartnering": "有兴趣成为合作伙伴吗？",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem, PayoutDocument, PayoutStatus, TaxForm, TaxFormType, TaxFormStatus, Invoice, CreateInvoiceData, UpdateInvoiceData, Mou, CreateMouData, UpdateMouData, MercuryWireMatch, MercuryReconcileResult } from '../types';
+import { Pizzeria, Donation, DonationPublicStats, Photo, PhotoStats, Sponsor, SponsorStats, SponsorStatus, SponsorshipType, VenueStatus, Venue, VenuePhoto, VenuePhotoCategory, VenueReport, Performer, PerformersResponse, EventReport, SocialPost, NotableAttendee, Staff, StaffStats, StaffStatus, Display, DisplayContentType, DisplayContentConfig, DisplayViewerData, Raffle, RafflePrize, RaffleEntry, RaffleWinner, BudgetOverview, BudgetItem, BudgetCategory, BudgetStatus, PartyKit, KitTier, ChecklistItem, ChecklistData, PageViewStats, LinkClickStats, UnderbossDashboardData, GPPRegion, AdminUser, UnderbossAdmin, ShippingKit, ShippingKitStats, ShippingCoordinator, ShippingMeResponse, SponsorUser, SponsorMeResponse, SponsorDashboardData, ConsolidatedReport, SponsorChecklistItem, UnifiedPartner, GraphicsAdmin, FakeDetectionResponse, Payout, AdminPayout, AdminPayoutDetail, AdminPayoutFilters, AdminPayoutsResponse, BankDetails, PayoutMethod, OcrPreviewResult, ExternalPaymentInput, HostGoals, OneSheetTier, OneSheetSection, OneSheetConfig, PrepayQueueRow, WalletPaidTotal, ReceiptLibraryEntry, PartyPayoutsResponse, ReceiptLineItem, PayoutDocument, PayoutStatus, TaxForm, TaxFormType, TaxFormStatus, Invoice, CreateInvoiceData, UpdateInvoiceData, Mou, CreateMouData, UpdateMouData, MercuryWireMatch, MercuryReconcileResult } from '../types';
 // pancetta-92103: region portal → underlying parties.region slug map. Used by
 // `buildPayoutQuery` to expand the /payments admin Regions multi-select into
 // the existing `?regions=` query the backend already accepts.
@@ -279,10 +279,17 @@ export interface UpdatePartyData {
   parkingNotes?: string | null;
   // quattro-71244: Gamified dashboard host-set goals (JSONB).
   hostGoals?: HostGoals | null;
+  // focaccina-58550: host-customizable one-sheet config (JSONB).
+  oneSheetConfig?: OneSheetConfig | null;
   // porchetta-81402: edit cancellation reason via PATCH (cancel/reinstate go
   // through dedicated POST endpoints).
   cancellationReason?: string | null;
 }
+
+// focaccina-58550: host-customizable one-sheet content. Defined in ../types to
+// avoid a circular import (api.ts already imports from ../types); re-exported
+// here so existing callers can keep importing from lib/api.
+export type { OneSheetTier, OneSheetSection, OneSheetConfig } from '../types';
 
 export async function createPartyApi(data: CreatePartyData) {
   return apiRequest<{ party: any }>('/api/parties', {
@@ -408,6 +415,8 @@ export async function updatePartyApi(partyId: string, data: UpdatePartyData) {
       parkingNotes: data.parkingNotes,
       // quattro-71244: gamified-dashboard goal targets.
       hostGoals: data.hostGoals,
+      // focaccina-58550: host-customizable one-sheet config.
+      oneSheetConfig: data.oneSheetConfig,
       // porchetta-81402: edit cancellation reason via PATCH.
       cancellationReason: data.cancellationReason,
     },
@@ -1110,6 +1119,9 @@ export interface PublicEvent {
   // shows a cancelled banner + replaces the RSVP button with a notice card.
   cancelledAt?: string | null;
   cancellationReason?: string | null;
+  // focaccina-58550: host-customizable one-sheet config, rendered read-only on
+  // the public /onesheet/:slug page. Null/absent = the fixed default one-sheet.
+  oneSheetConfig?: OneSheetConfig | null;
 }
 
 // Public Event API (no auth required)

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -11,6 +11,7 @@ import {
   uncheckInGuestApi,
   promoteGuestApi,
 } from './api';
+import type { OneSheetConfig } from './api';
 import { uuid } from './utils';
 import { sanitizeCoHosts } from './sanitizeCoHosts';
 import type { HostGoals } from '../types';
@@ -957,6 +958,8 @@ export interface DbParty {
   tax_form_required?: boolean;
   // quattro-71244: gamified-dashboard goal targets (JSONB on parties).
   host_goals?: HostGoals | null;
+  // focaccina-58550: host-customizable one-sheet config (JSONB on parties).
+  one_sheet_config?: OneSheetConfig | null;
   // porchetta-81402: soft-cancel columns. cancelledAt null = active event.
   cancelled_at?: string | null;
   cancelled_by?: string | null;
@@ -1034,6 +1037,7 @@ export const SAFE_PARTY_COLUMNS = `
   rollup_image_url, rollup_generated_at,
   reimbursement_cap_usd, reimbursement_cap_appeal_note, reimbursement_cap_appealed_at,
   tax_form_required,
+  one_sheet_config,
   cancelled_at, cancelled_by, cancellation_reason
 `;
 
@@ -2125,6 +2129,8 @@ export async function updateParty(
     tax_form_required?: boolean;
     // quattro-71244: gamified-dashboard goal targets.
     host_goals?: HostGoals | null;
+    // focaccina-58550: host-customizable one-sheet config.
+    one_sheet_config?: OneSheetConfig | null;
     // porchetta-81402: edit cancellation reason via PATCH. Cancel/reinstate
     // themselves go through `cancelParty()` / `reinstateParty()`.
     cancellation_reason?: string | null;
@@ -2217,6 +2223,8 @@ export async function updateParty(
         parkingNotes: updates.parking_notes,
         // quattro-71244: gamified-dashboard goal targets.
         hostGoals: updates.host_goals,
+        // focaccina-58550: host-customizable one-sheet config.
+        oneSheetConfig: updates.one_sheet_config,
         // porchetta-81402: edit cancellation reason via PATCH.
         cancellationReason: updates.cancellation_reason,
       });

--- a/frontend/src/pages/HostPage.tsx
+++ b/frontend/src/pages/HostPage.tsx
@@ -24,7 +24,7 @@ import { uuid } from '../lib/utils';
 import { fetchXAvatarToSupabase } from '../utils/avatarUtils';
 import { CoHost } from '../types';
 import { AppsHub } from '../components/AppsHub';
-import { SponsorCRM } from '../components/sponsors';
+import { SponsorCRM, OneSheetEditor } from '../components/sponsors';
 import { VenueWidget } from '../components/venue';
 import { VenueReportWidget } from '../components/venue-report';
 import { MusicWidget } from '../components/music';
@@ -355,7 +355,13 @@ function HostPageContent() {
         ) : activeTab === 'apps' && party ? (
           <AppsHub inviteCode={party.inviteCode} pinnedApps={party.pinnedApps ?? []} partyId={party.id} />
         ) : activeTab === 'partners' && party ? (
-          <SponsorCRM
+          <div className="space-y-4">
+            {/* focaccina-58550: host editor for the customizable public one sheet */}
+            <OneSheetEditor
+              party={party}
+              onSaved={(config) => mergeParty({ oneSheetConfig: config })}
+            />
+            <SponsorCRM
             partyId={party.id}
             onAddAsCoHost={async (data) => {
               // Use manually-provided avatar if available, otherwise auto-fetch from socials
@@ -392,6 +398,7 @@ function HostPageContent() {
               mergeParty({ coHosts: updated });
             }}
           />
+          </div>
         ) : activeTab !== 'apps' && activeTab !== 'dashboard' && activeTab !== 'party-guide' && activeTab !== 'partners' && (
           <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
             <div className="xl:col-span-2 space-y-3">

--- a/frontend/src/pages/OneSheetPage.tsx
+++ b/frontend/src/pages/OneSheetPage.tsx
@@ -124,6 +124,10 @@ export function OneSheetPage() {
   const partnerCount = event.sponsors?.length ?? 0;
   const sponsorsWithLogos = (event.sponsors || []).filter(s => s.logoUrl);
 
+  // focaccina-58550: host-customizable one-sheet content. Every block below is
+  // conditional so an unconfigured event renders exactly as the fixed default.
+  const cfg = event.oneSheetConfig;
+
   const ogDescription = [
     event.venueName,
     event.address,
@@ -177,6 +181,14 @@ export function OneSheetPage() {
               <Calendar size={18} className="flex-shrink-0 text-white/40" />
               <span>{formatEventDateTime()}</span>
             </div>
+          )}
+
+          {/* focaccina-58550: host-customizable intro headline + blurb */}
+          {cfg?.headline && (
+            <h2 className="text-2xl font-bold text-white pt-2">{cfg.headline}</h2>
+          )}
+          {cfg?.blurb && (
+            <p className="whitespace-pre-line text-white/70">{cfg.blurb}</p>
           )}
         </div>
 
@@ -240,6 +252,54 @@ export function OneSheetPage() {
             extraGppPhotos={event.extraGppPhotos}
           />
         )}
+
+        {/* focaccina-58550: host-customizable detail sections */}
+        {cfg?.sections?.length ? (
+          <div className="space-y-6">
+            {cfg.sections.map((section) => (
+              <div key={section.id} className="space-y-2">
+                {section.heading && (
+                  <h2 className="text-lg font-semibold text-white/80">{section.heading}</h2>
+                )}
+                {section.body && (
+                  <p className="whitespace-pre-line text-white/70">{section.body}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {/* focaccina-58550: host-customizable sponsorship pricing tiers */}
+        {cfg?.tiers?.length ? (
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-white/80">{t('oneSheet.pricingHeader')}</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {cfg.tiers.map((tier) => (
+                <div
+                  key={tier.id}
+                  className="bg-white/80 border border-black/10 rounded-xl p-4 flex flex-col"
+                >
+                  {tier.name && (
+                    <div className="text-lg font-bold text-white">{tier.name}</div>
+                  )}
+                  {tier.price && (
+                    <div className="text-2xl font-bold text-white mt-1">{tier.price}</div>
+                  )}
+                  {tier.benefits?.length ? (
+                    <ul className="mt-3 space-y-1.5">
+                      {tier.benefits.map((benefit, i) => (
+                        <li key={i} className="flex items-start gap-2 text-sm text-white/70">
+                          <CheckCircle size={16} className="mt-0.5 flex-shrink-0 text-green-400" />
+                          <span>{benefit}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         {/* Interest Form */}
         <div className="bg-white/80 border border-black/10 rounded-xl p-6 space-y-5">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -226,6 +226,29 @@ export type HostGoals = Partial<{
   pageViews: number;
 }>;
 
+// focaccina-58550: host-customizable one-sheet content. Rendered read-only on
+// the public /onesheet/:slug page; edited from the host dashboard Partners tab.
+// `id` is a client-generated uuid used only for React keys. All fields optional.
+export interface OneSheetTier {
+  id: string;
+  name: string;
+  price?: string;
+  benefits: string[];
+}
+
+export interface OneSheetSection {
+  id: string;
+  heading: string;
+  body: string;
+}
+
+export interface OneSheetConfig {
+  headline?: string;
+  blurb?: string;
+  tiers?: OneSheetTier[];
+  sections?: OneSheetSection[];
+}
+
 export interface MomentumDelta {
   lastHour?: number;
   today?: number;
@@ -366,6 +389,9 @@ export interface Party {
   // quattro-71244: Gamified host dashboard KPIs — host-private goal targets
   // keyed by ReportKPIs stat key. Lives in the `host_goals` JSONB column.
   hostGoals?: HostGoals | null;
+  // focaccina-58550: host-customizable one-sheet config. Lives in the
+  // `one_sheet_config` JSONB column. Rendered read-only on /onesheet/:slug.
+  oneSheetConfig?: OneSheetConfig | null;
   // porchetta-81402: soft-cancel state. cancelledAt non-null = host has
   // cancelled the event. EventPage renders a cancelled banner + replaces
   // the RSVP form with a cancellation notice. Hosts can reinstate.


### PR DESCRIPTION
## What

Makes the public partner one-sheet at `/onesheet/:slug` **host-customizable**. From the **Partners tab** of the host dashboard, a host can now add:

- **Intro headline + blurb** (rendered under the flyer)
- **Sponsorship pricing tiers** — repeatable cards (name, price, benefit list), shown as a grid directly above the interest form
- **Custom detail sections** — repeatable heading + body blocks

The public page renders everything **read-only**. An event with nothing configured renders **exactly** as before (every block is presence-guarded).

## How

- One new nullable JSONB column `parties.one_sheet_config` (same pattern as `hostGoals`) — no new table, no new endpoint.
- Read: surfaced through the existing `GET /api/events/:slug` → `PublicEvent` path (added to both `select` blocks + response).
- Write: through the existing `PATCH /api/parties/:id` (already gated by `canUserEditParty`), with a server-side **sanitize/clamp** step that never stores the raw body (headline ≤120, blurb ≤2000, ≤12 tiers, ≤12 sections, etc.).
- New host editor: `frontend/src/components/sponsors/OneSheetEditor.tsx` (uses `IconInput` only — no raw inputs), wired into the Partners tab above `SponsorCRM`.

## ⚠️ Before merge

Apply the additive column to prod (backend auto-deploys from master and Prisma SELECTs every declared field; also un-blocks the schema-drift CI check):

```sql
ALTER TABLE parties ADD COLUMN IF NOT EXISTS one_sheet_config jsonb;
```

## Verification

- `frontend`: `tsc --noEmit` → clean (0 errors).
- `backend`: `prisma validate` → OK. Backend typecheck pending prod column + `prisma generate` on master.
- Note: the Vercel preview hits the **production** backend, so save/render of the new field won't fully function on the preview until this is merged + the column applied (standard for backend-touching changes here). The **editor UI and page layout** are reviewable on the preview now.

Plan: `plans/focaccina-58550-onesheet-customize.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)